### PR TITLE
[codex] Defer Typesense client setup for conversation search

### DIFF
--- a/backend/tests/unit/test_conversation_hybrid_search.py
+++ b/backend/tests/unit/test_conversation_hybrid_search.py
@@ -146,11 +146,13 @@ class TestSpeakerFilteredConversationSearch:
         search = MagicMock(return_value={'hits': []})
         collection = MagicMock()
         collection.documents.search = search
-        return search, {'conversations': collection}
+        client = MagicMock()
+        client.collections = {'conversations': collection}
+        return search, client
 
     def test_named_speaker_filter_combines_with_existing_filters(self):
-        search, collections = self._search_mock()
-        with patch.object(search_module.client, 'collections', collections, create=True):
+        search, client = self._search_mock()
+        with patch.object(search_module, '_get_typesense_client', return_value=client):
             search_conversations(
                 uid='uid1',
                 query='launch',
@@ -168,8 +170,8 @@ class TestSpeakerFilteredConversationSearch:
         )
 
     def test_user_speaker_filter_uses_is_user_field(self):
-        search, collections = self._search_mock()
-        with patch.object(search_module.client, 'collections', collections, create=True):
+        search, client = self._search_mock()
+        with patch.object(search_module, '_get_typesense_client', return_value=client):
             search_conversations(uid='uid1', query='', speaker_id='user')
 
         params = search.call_args.args[0]
@@ -177,16 +179,16 @@ class TestSpeakerFilteredConversationSearch:
         assert params['filter_by'] == 'userId:=uid1 && transcript_segments.is_user:=true'
 
     def test_empty_query_without_structured_filter_returns_empty_without_wildcard_search(self):
-        search, collections = self._search_mock()
-        with patch.object(search_module.client, 'collections', collections, create=True):
+        search, client = self._search_mock()
+        with patch.object(search_module, '_get_typesense_client', return_value=client):
             results = search_conversations(uid='uid1', query='   ')
 
         assert results == {'items': [], 'total_pages': 1, 'current_page': 1, 'per_page': 10}
         search.assert_not_called()
 
     def test_search_without_speaker_keeps_existing_filter_behavior(self):
-        search, collections = self._search_mock()
-        with patch.object(search_module.client, 'collections', collections, create=True):
+        search, client = self._search_mock()
+        with patch.object(search_module, '_get_typesense_client', return_value=client):
             search_conversations(uid='uid1', query='planning')
 
         params = search.call_args.args[0]

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -49,7 +49,7 @@ def test_search_requires_typesense_api_key_when_used(monkeypatch):
     monkeypatch.delenv('TYPESENSE_API_KEY', raising=False)
     search_module, client_configs = _import_search_module(monkeypatch)
 
-    with pytest.raises(Exception, match='TYPESENSE_API_KEY is required to search conversations'):
+    with pytest.raises(RuntimeError, match='TYPESENSE_API_KEY is required to search conversations'):
         search_module.search_conversations(uid='user-1', query='meeting')
 
     assert client_configs == []

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -73,6 +73,18 @@ def test_search_constructs_typesense_client_on_first_use(monkeypatch):
     ]
 
 
+def test_search_preserves_typesense_protocol_override(monkeypatch):
+    monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
+    monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')
+    monkeypatch.setenv('TYPESENSE_API_KEY', 'dev-key')
+    monkeypatch.setenv('TYPESENSE_PROTOCOL', 'http')
+    search_module, client_configs = _import_search_module(monkeypatch)
+
+    search_module.search_conversations(uid='user-1', query='meeting')
+
+    assert client_configs[0]['nodes'][0]['protocol'] == 'http'
+
+
 def test_typesense_client_initializes_once_for_concurrent_first_use(monkeypatch):
     monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
     monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -1,6 +1,8 @@
 import importlib
 import sys
+import time
 import types
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -14,11 +16,13 @@ def cleanup_search_module():
     sys.modules.pop(MODULE_NAME, None)
 
 
-def _import_search_module(monkeypatch):
+def _import_search_module(monkeypatch, client_delay=0):
     client_configs = []
 
     class FakeClient:
         def __init__(self, config):
+            if client_delay:
+                time.sleep(client_delay)
             client_configs.append(config)
             documents = types.SimpleNamespace(search=lambda _params: {'hits': []})
             self.collections = {'conversations': types.SimpleNamespace(documents=documents)}
@@ -67,3 +71,16 @@ def test_search_constructs_typesense_client_on_first_use(monkeypatch):
             'connection_timeout_seconds': 2,
         }
     ]
+
+
+def test_typesense_client_initializes_once_for_concurrent_first_use(monkeypatch):
+    monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
+    monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')
+    monkeypatch.setenv('TYPESENSE_API_KEY', 'dev-key')
+    search_module, client_configs = _import_search_module(monkeypatch, client_delay=0.02)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        clients = list(executor.map(lambda _: search_module._get_typesense_client(), range(8)))
+
+    assert len({id(client) for client in clients}) == 1
+    assert len(client_configs) == 1

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+MODULE_NAME = 'utils.conversations.search'
+
+
+@pytest.fixture(autouse=True)
+def cleanup_search_module():
+    sys.modules.pop(MODULE_NAME, None)
+    yield
+    sys.modules.pop(MODULE_NAME, None)
+
+
+def _import_search_module(monkeypatch):
+    client_configs = []
+
+    class FakeClient:
+        def __init__(self, config):
+            client_configs.append(config)
+            documents = types.SimpleNamespace(search=lambda _params: {'hits': []})
+            self.collections = {'conversations': types.SimpleNamespace(documents=documents)}
+
+    fake_typesense = types.ModuleType('typesense')
+    fake_typesense.Client = FakeClient
+    monkeypatch.setitem(sys.modules, 'typesense', fake_typesense)
+    sys.modules.pop(MODULE_NAME, None)
+    return importlib.import_module(MODULE_NAME), client_configs
+
+
+def test_import_does_not_require_typesense_env(monkeypatch):
+    for name in ('TYPESENSE_HOST', 'TYPESENSE_HOST_PORT', 'TYPESENSE_API_KEY'):
+        monkeypatch.delenv(name, raising=False)
+
+    _, client_configs = _import_search_module(monkeypatch)
+
+    assert client_configs == []
+
+
+def test_search_requires_typesense_api_key_when_used(monkeypatch):
+    monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
+    monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')
+    monkeypatch.delenv('TYPESENSE_API_KEY', raising=False)
+    search_module, client_configs = _import_search_module(monkeypatch)
+
+    with pytest.raises(Exception, match='TYPESENSE_API_KEY is required to search conversations'):
+        search_module.search_conversations(uid='user-1', query='meeting')
+
+    assert client_configs == []
+
+
+def test_search_constructs_typesense_client_on_first_use(monkeypatch):
+    monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
+    monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')
+    monkeypatch.setenv('TYPESENSE_API_KEY', 'dev-key')
+    search_module, client_configs = _import_search_module(monkeypatch)
+
+    result = search_module.search_conversations(uid='user-1', query='meeting')
+
+    assert result == {'items': [], 'total_pages': 1, 'current_page': 1, 'per_page': 10}
+    assert client_configs == [
+        {
+            'nodes': [{'host': 'localhost', 'port': '8108', 'protocol': 'https'}],
+            'api_key': 'dev-key',
+            'connection_timeout_seconds': 2,
+        }
+    ]

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -49,7 +49,7 @@ def test_search_requires_typesense_api_key_when_used(monkeypatch):
     monkeypatch.delenv('TYPESENSE_API_KEY', raising=False)
     search_module, client_configs = _import_search_module(monkeypatch)
 
-    with pytest.raises(RuntimeError, match='TYPESENSE_API_KEY is required to search conversations'):
+    with pytest.raises(Exception, match='TYPESENSE_API_KEY is required to search conversations'):
         search_module.search_conversations(uid='user-1', query='meeting')
 
     assert client_configs == []

--- a/backend/tests/unit/test_conversation_search_typesense_config.py
+++ b/backend/tests/unit/test_conversation_search_typesense_config.py
@@ -96,3 +96,15 @@ def test_typesense_client_initializes_once_for_concurrent_first_use(monkeypatch)
 
     assert len({id(client) for client in clients}) == 1
     assert len(client_configs) == 1
+
+
+def test_exposes_shared_lazy_typesense_client_for_other_indexes(monkeypatch):
+    monkeypatch.setenv('TYPESENSE_HOST', 'localhost')
+    monkeypatch.setenv('TYPESENSE_HOST_PORT', '8108')
+    monkeypatch.setenv('TYPESENSE_API_KEY', 'dev-key')
+    search_module, client_configs = _import_search_module(monkeypatch)
+
+    client = search_module.get_typesense_client()
+
+    assert search_module.get_typesense_client() is client
+    assert len(client_configs) == 1

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -457,10 +457,10 @@ class TestSearchRedaction:
             'found': 2,
         }
 
-        with patch('utils.conversations.search.client', mock_client):
-            from utils.conversations.search import search_conversations
+        from utils.conversations import search as search_module
 
-            result = search_conversations(uid='test-uid', query='test')
+        with patch.object(search_module, '_get_typesense_client', return_value=mock_client):
+            result = search_module.search_conversations(uid='test-uid', query='test')
 
         # Locked item must be excluded entirely (prevents inference leak)
         assert len(result['items']) == 1
@@ -497,10 +497,10 @@ class TestSearchRedaction:
             'found': 2,
         }
 
-        with patch('utils.conversations.search.client', mock_client):
-            from utils.conversations.search import search_conversations
+        from utils.conversations import search as search_module
 
-            result = search_conversations(uid='test-uid', query='test')
+        with patch.object(search_module, '_get_typesense_client', return_value=mock_client):
+            result = search_module.search_conversations(uid='test-uid', query='test')
 
         # Does not raise; only the well-formed hit survives, with ISO-string timestamps.
         assert len(result['items']) == 1
@@ -525,10 +525,10 @@ class TestSearchRedaction:
             'found': 2,
         }
 
-        with patch('utils.conversations.search.client', mock_client):
-            from utils.conversations.search import search_conversations
+        from utils.conversations import search as search_module
 
-            result = search_conversations(uid='test-uid', query='test', page=2)
+        with patch.object(search_module, '_get_typesense_client', return_value=mock_client):
+            result = search_module.search_conversations(uid='test-uid', query='test', page=2)
 
         assert result['items'] == []
         assert result['total_pages'] == 2  # falls back to the page param, not inflated
@@ -562,10 +562,10 @@ class TestSearchRedaction:
             'hits': hits,
             'found': 6,
         }
-        with patch('utils.conversations.search.client', mock_client):
-            from utils.conversations.search import search_conversations
+        from utils.conversations import search as search_module
 
-            result = search_conversations(uid='test-uid', query='test', per_page=5)
+        with patch.object(search_module, '_get_typesense_client', return_value=mock_client):
+            result = search_module.search_conversations(uid='test-uid', query='test', per_page=5)
 
         assert len(result['items']) == 1
         # total_pages derived from visible items (1 < per_page=5), not raw hits or found count
@@ -590,10 +590,10 @@ class TestSearchRedaction:
             'hits': hits,
             'found': 2,
         }
-        with patch('utils.conversations.search.client', mock_client):
-            from utils.conversations.search import search_conversations
+        from utils.conversations import search as search_module
 
-            result = search_conversations(uid='test-uid', query='test', per_page=5)
+        with patch.object(search_module, '_get_typesense_client', return_value=mock_client):
+            result = search_module.search_conversations(uid='test-uid', query='test', per_page=5)
 
         assert len(result['items']) == 0
         # Not a full page → total_pages = current page (1), not found/per_page

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import datetime, timezone
+from threading import Lock
 from typing import Any, Dict, List, Optional, cast
 
 import typesense
@@ -35,19 +36,50 @@ def _is_typesense_transient_error(exc: BaseException) -> bool:
     }
 
 
-client = typesense.Client(
-    {
-        'nodes': [
-            {
-                'host': os.getenv('TYPESENSE_HOST'),
-                'port': os.getenv('TYPESENSE_HOST_PORT'),
-                'protocol': os.getenv('TYPESENSE_PROTOCOL', 'https'),
-            }
-        ],
-        'api_key': os.getenv('TYPESENSE_API_KEY'),
-        'connection_timeout_seconds': 2,
-    }
-)
+_typesense_client = None
+_typesense_client_lock = Lock()
+
+
+def _get_required_env_var(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"{name} is required to search conversations")
+    return value
+
+
+def _create_typesense_client() -> Any:
+    return typesense.Client(
+        {
+            'nodes': [
+                {
+                    'host': _get_required_env_var('TYPESENSE_HOST'),
+                    'port': _get_required_env_var('TYPESENSE_HOST_PORT'),
+                    'protocol': os.getenv('TYPESENSE_PROTOCOL', 'https'),
+                }
+            ],
+            'api_key': _get_required_env_var('TYPESENSE_API_KEY'),
+            'connection_timeout_seconds': 2,
+        }
+    )
+
+
+def _get_typesense_client() -> Any:
+    global _typesense_client
+    client = _typesense_client
+    if client is not None:
+        return client
+
+    with _typesense_client_lock:
+        client = _typesense_client
+        if client is None:
+            client = _create_typesense_client()
+            _typesense_client = client
+        return client
+
+
+def get_typesense_client() -> Any:
+    """Return the shared lazy Typesense client for backend keyword indexes."""
+    return _get_typesense_client()
 
 
 def _utc_iso(ts: int) -> str:
@@ -81,6 +113,8 @@ def search_conversations(
                 'current_page': page,
                 'per_page': per_page,
             }
+
+        client = _get_typesense_client()
 
         filter_by = f'userId:={uid}'
         if not include_discarded:

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -53,9 +53,9 @@ def _payload_list(value: object) -> List[Payload]:
 
 
 def _typesense_client() -> Any:
-    from utils.conversations.search import client
+    from utils.conversations.search import get_typesense_client
 
-    return client
+    return get_typesense_client()
 
 
 def memories_collection_name() -> str:


### PR DESCRIPTION
## Summary
- Rebased the lazy Typesense client work onto current `main` (`45fe68b82f`).
- Keeps conversation search import-safe by constructing the Typesense client on first use behind a lock.
- Preserves current `main`'s transient Typesense error handling while keeping `TYPESENSE_PROTOCOL` override support.
- Exposes `get_typesense_client()` so the canonical atom keyword index can share the same lazy singleton instead of importing the removed eager `client` symbol.
- Updates the conversation search, hybrid-search, and lock-bypass tests to patch the lazy accessor path.

## Product invariants affected
- INV-MEM-1: `backend/utils/memory/atom_keyword_index.py` still gates canonical long-term atom keyword indexing through existing canonical/data-protection checks; this PR only changes how the shared Typesense client is acquired after lazy initialization.

## Why
`utils.conversations.search` previously built a Typesense client at import time, so importing conversation search required `TYPESENSE_HOST`, `TYPESENSE_HOST_PORT`, and `TYPESENSE_API_KEY` even in test paths that never searched. The refresh also fixes the backend typecheck regression where `utils.memory.atom_keyword_index` still imported the old eager `client` symbol.

## Validation
- `python -m py_compile utils\conversations\search.py utils\memory\atom_keyword_index.py tests\unit\test_conversation_search_typesense_config.py`
- `python -m black --check utils\conversations\search.py utils\memory\atom_keyword_index.py tests\unit\test_conversation_search_typesense_config.py tests\unit\test_conversation_hybrid_search.py tests\unit\test_lock_bypass_fixes.py`
- `python -m pytest tests\unit\test_conversation_search_typesense_config.py tests\unit\test_ws_m_atom_keyword_index.py -q --tb=short` -> 27 passed
- `python -m pytest tests\unit\test_conversation_hybrid_search.py tests\unit\test_lock_bypass_fixes.py -q --tb=short` -> 75 passed
- `python -m pyright -p pyrightconfig.json utils\conversations\search.py utils\memory\atom_keyword_index.py --pythonpath D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe` -> 0 errors, 1 existing warning
- `git diff --check`
