### PR TITLE
Keep stale queued sync jobs queued

### DIFF
--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -88,6 +88,16 @@ def get_sync_job(job_id: str) -> Optional[dict]:
             job['completed_at'] = now
             # Persist the failure status
             r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+    elif job['status'] == 'queued':
+        updated_at = job.get('updated_at') or job.get('created_at', 0)
+        now = time.time()
+        if now - updated_at > STALE_THRESHOLD_SECONDS:
+            logger.warning(
+                "sync_job_stale_queued job_id=%s uid=%s age_seconds=%.0f",
+                job_id,
+                job.get('uid'),
+                now - updated_at,
+            )
 
     return job
 

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -70,13 +70,22 @@ def get_sync_job(job_id: str) -> Optional[dict]:
         return None
     job = json.loads(data)
 
-    # Stale-job detection: if processing for too long, mark failed
-    if job['status'] in ('queued', 'processing'):
+    # Stale-job detection: only jobs picked up by a worker can time out here.
+    # Queued jobs may simply be waiting behind saturated worker pools; leave
+    # them queued so clients do not treat backend capacity as content failure.
+    if job['status'] == 'processing':
         updated_at = job.get('updated_at') or job.get('created_at', 0)
-        if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
+        now = time.time()
+        if now - updated_at > STALE_THRESHOLD_SECONDS:
+            logger.warning(
+                "sync_job_stale_processing job_id=%s uid=%s age_seconds=%.0f",
+                job_id,
+                job.get('uid'),
+                now - updated_at,
+            )
             job['status'] = 'failed'
             job['error'] = 'Job timed out (background worker likely died)'
-            job['completed_at'] = time.time()
+            job['completed_at'] = now
             # Persist the failure status
             r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
 

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -329,9 +329,13 @@ class TestSyncJobsRedis:
         }
         mock_redis.get.return_value = json.dumps(stale_job).encode()
 
-        result = mod.get_sync_job('queued-stale-1')
+        with patch.object(mod.logger, 'warning') as mock_warning:
+            result = mod.get_sync_job('queued-stale-1')
+
         assert result['status'] == 'queued'
         assert result['error'] is None
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args[0][0] == "sync_job_stale_queued job_id=%s uid=%s age_seconds=%.0f"
         mock_redis.set.assert_not_called()
 
     def test_get_sync_job_does_not_mark_fresh_as_stale(self):

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -316,6 +316,24 @@ class TestSyncJobsRedis:
         assert result['status'] == 'failed'
         assert 'timed out' in result['error']
 
+    def test_get_sync_job_leaves_stale_queued_job_queued(self):
+        """Queued jobs can be delayed by capacity and must not be marked failed."""
+        mod, mock_redis = self._load_sync_jobs_module()
+        stale_job = {
+            'job_id': 'queued-stale-1',
+            'uid': 'uid',
+            'status': 'queued',
+            'updated_at': time.time() - 700,  # 700s ago > 600s threshold
+            'created_at': time.time() - 800,
+            'error': None,
+        }
+        mock_redis.get.return_value = json.dumps(stale_job).encode()
+
+        result = mod.get_sync_job('queued-stale-1')
+        assert result['status'] == 'queued'
+        assert result['error'] is None
+        mock_redis.set.assert_not_called()
+
     def test_get_sync_job_does_not_mark_fresh_as_stale(self):
         """Processing jobs within threshold should not be marked failed."""
         mod, mock_redis = self._load_sync_jobs_module()


### PR DESCRIPTION
## Summary
- only mark `processing` sync jobs as stale/failed after `STALE_THRESHOLD_SECONDS`
- leave stale `queued` jobs queued so backend capacity delays are not reported as content failures
- add a regression test for stale queued jobs and keep the existing processing-stale behavior

Addresses #7469

## Validation
- `black --line-length 120 --skip-string-normalization backend/database/sync_jobs.py backend/tests/unit/test_sync_v2.py`
- `python -m py_compile backend/database/sync_jobs.py backend/tests/unit/test_sync_v2.py`
- `PYTHONUTF8=1 python -m pytest tests/unit/test_sync_v2.py::TestSyncJobsRedis -q` -> 10 passed
- `git diff --check` (passes; Windows CRLF warnings only)

Note: full `tests/unit/test_sync_v2.py -q` was also attempted with `PYTHONUTF8=1`; the sync job tests passed, but the full file still fails in this lightweight Windows venv because `pytest-asyncio` and `numpy` are not installed, and one existing executor assertion expects `storage_executor` to be 96 while the current code reports 128.