### PR TITLE
Tighten WebSocket auth close codes

### DIFF
--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -170,8 +170,14 @@ class PureSocket implements IPureSocket {
         return 'going_away_os_or_background';
       case 1006:
         return 'abnormal_closure';
+      case 1008:
+        return 'policy_violation_or_auth_error';
       case 1011:
         return 'server_error';
+      case 4001:
+        return 'auth_token_refresh_required';
+      case 4004:
+        return 'auth_relogin_required';
       default:
         return 'unknown';
     }

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -47,6 +47,9 @@ firebase_admin_stub.auth = firebase_auth_stub
 invalid_token_error = getattr(firebase_auth_stub, "InvalidIdTokenError", None)
 if not isinstance(invalid_token_error, type) or not issubclass(invalid_token_error, Exception):
     firebase_auth_stub.InvalidIdTokenError = type("InvalidIdTokenError", (Exception,), {})
+certificate_fetch_error = getattr(firebase_auth_stub, "CertificateFetchError", None)
+if not isinstance(certificate_fetch_error, type) or not issubclass(certificate_fetch_error, Exception):
+    firebase_auth_stub.CertificateFetchError = type("CertificateFetchError", (Exception,), {})
 firebase_auth_stub.verify_id_token = MagicMock(side_effect=firebase_auth_stub.InvalidIdTokenError("Invalid token"))
 if not hasattr(firebase_auth_stub, "get_user"):
     firebase_auth_stub.get_user = MagicMock()
@@ -55,7 +58,7 @@ redis_db_stub = sys.modules.setdefault("database.redis_db", types.ModuleType("da
 redis_db_stub.check_rate_limit = MagicMock(return_value=True)
 redis_db_stub.try_acquire_listen_lock = MagicMock(return_value=True)
 
-from firebase_admin.auth import InvalidIdTokenError
+from firebase_admin.auth import CertificateFetchError, InvalidIdTokenError
 
 existing_endpoints = sys.modules.get('utils.other.endpoints')
 if existing_endpoints is not None and not hasattr(existing_endpoints, 'get_current_user_uid_ws_listen'):
@@ -130,6 +133,17 @@ class TestWebSocketAuthListen(WebSocketAuthTestCase):
         """Certificate/key failures -> 4001 so clients can force-refresh the token."""
         with self.assertRaises(WebSocketDisconnect) as ctx:
             with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer stale_key_token"}):
+                self.fail("Expected WebSocket to be closed by server")
+        self.assertEqual(ctx.exception.code, 4001)
+
+    @patch(
+        'utils.other.endpoints.verify_token',
+        side_effect=CertificateFetchError('Certificate fetch failed', RuntimeError('network unavailable')),
+    )
+    def test_certificate_fetch_error_sends_close_4001(self, mock_verify):
+        """Real Firebase cert fetch failures -> 4001 so clients can refresh their token."""
+        with self.assertRaises(WebSocketDisconnect) as ctx:
+            with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer cert_fetch_token"}):
                 self.fail("Expected WebSocket to be closed by server")
         self.assertEqual(ctx.exception.code, 4001)
 

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -37,26 +37,25 @@ def _ensure_package(name, path):
     return module
 
 
-_ensure_package("database", BACKEND_DIR / "database")
+database_package = _ensure_package("database", BACKEND_DIR / "database")
 _ensure_package("utils", BACKEND_DIR / "utils")
 _ensure_package("utils.other", BACKEND_DIR / "utils" / "other")
 
 firebase_admin_stub = sys.modules.setdefault("firebase_admin", types.ModuleType("firebase_admin"))
 firebase_auth_stub = sys.modules.setdefault("firebase_admin.auth", types.ModuleType("firebase_admin.auth"))
 firebase_admin_stub.auth = firebase_auth_stub
-invalid_token_error = getattr(firebase_auth_stub, "InvalidIdTokenError", None)
-if not isinstance(invalid_token_error, type) or not issubclass(invalid_token_error, Exception):
-    firebase_auth_stub.InvalidIdTokenError = type("InvalidIdTokenError", (Exception,), {})
-certificate_fetch_error = getattr(firebase_auth_stub, "CertificateFetchError", None)
-if not isinstance(certificate_fetch_error, type) or not issubclass(certificate_fetch_error, Exception):
-    firebase_auth_stub.CertificateFetchError = type("CertificateFetchError", (Exception,), {})
+for error_name in (
+    "CertificateFetchError",
+    "ExpiredIdTokenError",
+    "InvalidIdTokenError",
+    "RevokedIdTokenError",
+):
+    auth_error = getattr(firebase_auth_stub, error_name, None)
+    if not isinstance(auth_error, type) or not issubclass(auth_error, Exception):
+        setattr(firebase_auth_stub, error_name, type(error_name, (Exception,), {}))
 firebase_auth_stub.verify_id_token = MagicMock(side_effect=firebase_auth_stub.InvalidIdTokenError("Invalid token"))
 if not hasattr(firebase_auth_stub, "get_user"):
     firebase_auth_stub.get_user = MagicMock()
-
-redis_db_stub = sys.modules.setdefault("database.redis_db", types.ModuleType("database.redis_db"))
-redis_db_stub.check_rate_limit = MagicMock(return_value=True)
-redis_db_stub.try_acquire_listen_lock = MagicMock(return_value=True)
 
 from firebase_admin.auth import CertificateFetchError, InvalidIdTokenError
 
@@ -67,10 +66,32 @@ if existing_endpoints is not None and not hasattr(existing_endpoints, 'get_curre
     if utils_other is not None and getattr(utils_other, 'endpoints', None) is existing_endpoints:
         delattr(utils_other, 'endpoints')
 
+database_client_stub = types.ModuleType('database._client')
+database_client_stub.db = MagicMock()
+database_client_stub.document_id_from_seed = MagicMock(return_value='doc-id')
+original_database_client = sys.modules.get('database._client')
+original_database_client_attr = getattr(database_package, '_client', None)
+original_database_client_attr_missing = not hasattr(database_package, '_client')
+sys.modules['database._client'] = database_client_stub
+database_package._client = database_client_stub
+
+database_redis_stub = types.ModuleType('database.redis_db')
+database_redis_stub.check_rate_limit = MagicMock(return_value=True)
+database_redis_stub.try_acquire_listen_lock = MagicMock(return_value=True)
+database_redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
+original_database_redis = sys.modules.get('database.redis_db')
+original_database_redis_attr = getattr(database_package, 'redis_db', None)
+original_database_redis_attr_missing = not hasattr(database_package, 'redis_db')
+sys.modules['database.redis_db'] = database_redis_stub
+database_package.redis_db = database_redis_stub
+
 database_users_stub = types.ModuleType('database.users')
 database_users_stub.record_user_platform = MagicMock()
 original_database_users = sys.modules.get('database.users')
+original_database_users_attr = getattr(database_package, 'users', None)
+original_database_users_attr_missing = not hasattr(database_package, 'users')
 sys.modules['database.users'] = database_users_stub
+database_package.users = database_users_stub
 
 try:
     endpoints = importlib.import_module('utils.other.endpoints')
@@ -79,10 +100,30 @@ try:
     get_current_user_uid_ws = endpoints.get_current_user_uid_ws
     get_current_user_uid = endpoints.get_current_user_uid
 finally:
+    if original_database_client is None:
+        sys.modules.pop('database._client', None)
+    else:
+        sys.modules['database._client'] = original_database_client
+    if original_database_client_attr_missing:
+        delattr(database_package, '_client')
+    else:
+        database_package._client = original_database_client_attr
+    if original_database_redis is None:
+        sys.modules.pop('database.redis_db', None)
+    else:
+        sys.modules['database.redis_db'] = original_database_redis
+    if original_database_redis_attr_missing:
+        delattr(database_package, 'redis_db')
+    else:
+        database_package.redis_db = original_database_redis_attr
     if original_database_users is None:
         sys.modules.pop('database.users', None)
     else:
         sys.modules['database.users'] = original_database_users
+    if original_database_users_attr_missing:
+        delattr(database_package, 'users')
+    else:
+        database_package.users = original_database_users_attr
 
 
 class WebSocketAuthTestCase(unittest.TestCase):

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -133,6 +133,14 @@ class TestWebSocketAuthListen(WebSocketAuthTestCase):
                 self.fail("Expected WebSocket to be closed by server")
         self.assertEqual(ctx.exception.code, 4001)
 
+    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('API key invalid'))
+    def test_non_certificate_key_error_sends_close_1008(self, mock_verify):
+        """Generic key errors should not be treated as token-refresh certificate failures."""
+        with self.assertRaises(WebSocketDisconnect) as ctx:
+            with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer invalid_key_token"}):
+                self.fail("Expected WebSocket to be closed by server")
+        self.assertEqual(ctx.exception.code, 1008)
+
     @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('Token revoked'))
     def test_revoked_token_sends_close_4004(self, mock_verify):
         """Revoked token -> WebSocketDisconnect with code 4004 so clients can re-login."""

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -109,13 +109,37 @@ class TestWebSocketAuthListen(WebSocketAuthTestCase):
                 self.fail("Expected WebSocket to be closed by server")
         self.assertEqual(ctx.exception.code, 1008)
 
-    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('Token expired'))
+    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('bad token'))
     def test_invalid_token_sends_close_1008(self, mock_verify):
         """Invalid token -> WebSocketDisconnect with code 1008."""
         with self.assertRaises(WebSocketDisconnect) as ctx:
             with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer invalid_token"}):
                 self.fail("Expected WebSocket to be closed by server")
         self.assertEqual(ctx.exception.code, 1008)
+
+    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('Token expired'))
+    def test_expired_token_sends_close_4001(self, mock_verify):
+        """Expired token -> WebSocketDisconnect with code 4001 so clients can refresh."""
+        with self.assertRaises(WebSocketDisconnect) as ctx:
+            with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer expired_token"}):
+                self.fail("Expected WebSocket to be closed by server")
+        self.assertEqual(ctx.exception.code, 4001)
+
+    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('Certificate key not found'))
+    def test_certificate_key_error_sends_close_4001(self, mock_verify):
+        """Certificate/key failures -> 4001 so clients can force-refresh the token."""
+        with self.assertRaises(WebSocketDisconnect) as ctx:
+            with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer stale_key_token"}):
+                self.fail("Expected WebSocket to be closed by server")
+        self.assertEqual(ctx.exception.code, 4001)
+
+    @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('Token revoked'))
+    def test_revoked_token_sends_close_4004(self, mock_verify):
+        """Revoked token -> WebSocketDisconnect with code 4004 so clients can re-login."""
+        with self.assertRaises(WebSocketDisconnect) as ctx:
+            with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer revoked_token"}):
+                self.fail("Expected WebSocket to be closed by server")
+        self.assertEqual(ctx.exception.code, 4004)
 
     def test_malformed_auth_header_sends_close_1008(self):
         """Malformed auth header -> WebSocketDisconnect with code 1008."""
@@ -230,12 +254,12 @@ class TestWebSocketAuthWithRateLimit(WebSocketAuthTestCase):
 
     @patch('utils.other.endpoints.try_acquire_listen_lock')
     @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('expired'))
-    def test_invalid_token_does_not_call_rate_limiter(self, mock_verify, mock_lock):
-        """Invalid token should short-circuit before rate limiter is called."""
+    def test_expired_token_does_not_call_rate_limiter(self, mock_verify, mock_lock):
+        """Expired token should short-circuit before rate limiter is called."""
         with self.assertRaises(WebSocketDisconnect) as ctx:
             with self.client.websocket_connect("/ws-ratelimited", headers={"Authorization": "Bearer bad"}):
                 pass
-        self.assertEqual(ctx.exception.code, 1008)
+        self.assertEqual(ctx.exception.code, 4001)
         mock_lock.assert_not_called()
 
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Header, HTTPException, WebSocketException
 from fastapi import Request
 from starlette.websockets import WebSocket
 from firebase_admin import auth
-from firebase_admin.auth import ExpiredIdTokenError, InvalidIdTokenError, RevokedIdTokenError
+from firebase_admin.auth import CertificateFetchError, ExpiredIdTokenError, InvalidIdTokenError, RevokedIdTokenError
 import logging
 import redis as redis_pkg
 
@@ -127,8 +127,10 @@ def get_current_user_uid_no_byok_validation(
 def _verify_ws_auth(authorization: str) -> str:
     """Common WebSocket auth — verifies token, returns uid.
 
-    Raises WebSocketException(code=1008) instead of HTTPException(401) so the
-    ASGI server sends a proper WebSocket close frame (not a handshake crash).
+    Raises WebSocketException instead of HTTPException(401) so the ASGI server
+    sends a proper WebSocket close frame (not a handshake crash). Auth failures
+    use 1008 by default, 4001 when the client should refresh its token, and
+    4004 when it should force re-login.
     """
     if not authorization:
         raise WebSocketException(code=1008, reason="Authorization header not found")
@@ -138,7 +140,7 @@ def _verify_ws_auth(authorization: str) -> str:
     try:
         token = authorization.split(' ')[1]
         return verify_token(token)
-    except InvalidIdTokenError as e:
+    except (InvalidIdTokenError, CertificateFetchError) as e:
         close_code, reason = _get_ws_auth_close(e)
         logger.error("WebSocket auth failed: code=%s error=%s", close_code, e)
         raise WebSocketException(code=close_code, reason=reason)
@@ -147,9 +149,11 @@ def _verify_ws_auth(authorization: str) -> str:
         raise WebSocketException(code=1008, reason="Auth error")
 
 
-def _get_ws_auth_close(error: InvalidIdTokenError) -> tuple[int, str]:
+def _get_ws_auth_close(error: Exception) -> tuple[int, str]:
     if isinstance(error, RevokedIdTokenError):
         return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
+    if isinstance(error, CertificateFetchError):
+        return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
     if isinstance(error, ExpiredIdTokenError):
         return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Header, HTTPException, WebSocketException
 from fastapi import Request
 from starlette.websockets import WebSocket
 from firebase_admin import auth
-from firebase_admin.auth import CertificateFetchError, ExpiredIdTokenError, InvalidIdTokenError, RevokedIdTokenError
+from firebase_admin.auth import ExpiredIdTokenError, InvalidIdTokenError, RevokedIdTokenError
 import logging
 import redis as redis_pkg
 
@@ -150,13 +150,13 @@ def _verify_ws_auth(authorization: str) -> str:
 def _get_ws_auth_close(error: InvalidIdTokenError) -> tuple[int, str]:
     if isinstance(error, RevokedIdTokenError):
         return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
-    if isinstance(error, (ExpiredIdTokenError, CertificateFetchError)):
+    if isinstance(error, ExpiredIdTokenError):
         return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
 
     message = str(error).lower()
     if 'revoked' in message:
         return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
-    if 'expired' in message or 'certificate' in message or 'key' in message:
+    if 'expired' in message or 'certificate' in message:
         return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
     return 1008, "Invalid authorization token"
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Header, HTTPException, WebSocketException
 from fastapi import Request
 from starlette.websockets import WebSocket
 from firebase_admin import auth
-from firebase_admin.auth import InvalidIdTokenError
+from firebase_admin.auth import CertificateFetchError, ExpiredIdTokenError, InvalidIdTokenError, RevokedIdTokenError
 import logging
 import redis as redis_pkg
 
@@ -17,6 +17,9 @@ from utils.executors import critical_executor, run_blocking
 from utils.rate_limit_config import RATE_POLICIES, RATE_LIMIT_SHADOW, get_effective_limit
 
 logger = logging.getLogger(__name__)
+
+WS_AUTH_CODE_TOKEN_REFRESH = 4001
+WS_AUTH_CODE_RELOGIN_REQUIRED = 4004
 
 
 def get_user(uid: str):
@@ -136,11 +139,26 @@ def _verify_ws_auth(authorization: str) -> str:
         token = authorization.split(' ')[1]
         return verify_token(token)
     except InvalidIdTokenError as e:
-        logger.error(f"WebSocket auth failed: {e}")
-        raise WebSocketException(code=1008, reason="Invalid or expired token")
+        close_code, reason = _get_ws_auth_close(e)
+        logger.error("WebSocket auth failed: code=%s error=%s", close_code, e)
+        raise WebSocketException(code=close_code, reason=reason)
     except Exception as e:
         logger.error(f"WebSocket auth error: {e}")
         raise WebSocketException(code=1008, reason="Auth error")
+
+
+def _get_ws_auth_close(error: InvalidIdTokenError) -> tuple[int, str]:
+    if isinstance(error, RevokedIdTokenError):
+        return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
+    if isinstance(error, (ExpiredIdTokenError, CertificateFetchError)):
+        return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
+
+    message = str(error).lower()
+    if 'revoked' in message:
+        return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
+    if 'expired' in message or 'certificate' in message or 'key' in message:
+        return WS_AUTH_CODE_TOKEN_REFRESH, "Token refresh required"
+    return 1008, "Invalid authorization token"
 
 
 async def get_current_user_uid_ws_listen(


### PR DESCRIPTION
## Summary
- distinguish WebSocket auth failures so clients can refresh expired/certificate-stale tokens or force re-login for revoked tokens
- keep generic invalid auth on policy violation code 1008
- add client-side socket close-code labels for 1008, 4001, and 4004
- add backend coverage for expired, revoked, certificate-key, certificate-fetch, and generic key auth failures
- keep the backend auth test isolated on Windows by stubbing Firebase/database imports before loading `utils.other.endpoints`

## Current status
- Rebased on `main` at `cc06c20fae75e88b15e220d57402f6f47591dd72`.
- Current head: `4127e6f7ac2a8c0a3885fe455f2db0c966599b6b`.
- GitHub compare reports this branch as ahead 6 / behind 0; PR is mergeable.
- Existing review threads are resolved/outdated after the certificate-fetch and generic-key follow-ups.

## Verification
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_ws_auth_handshake.py -q --tb=short`
  - 23 passed, 1 warning
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\utils\other\endpoints.py backend\tests\unit\test_ws_auth_handshake.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\utils\other\endpoints.py backend\tests\unit\test_ws_auth_handshake.py`
  - 2 files would be left unchanged
- `D:\codex-omi-work\.tools\dart-sdk\bin\dart.exe format --line-length 120 --set-exit-if-changed app\lib\services\sockets\pure_socket.dart`
  - Formatted 1 file (0 changed). Dart still reports a `flutter_lints` package-resolution warning because app package dependencies are not installed in this Windows worktree.
- `PYTHONUTF8=1 D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe backend\scripts\scan_async_blockers.py`
  - exit 0; existing async-blocker backlog reported, no new WebSocket auth blocker
- `git diff --check origin/main...HEAD` and `git diff --check`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`