### PR TITLE
Fix desktop appcast parsing for two-part macOS versions

### DIFF
--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -24,17 +24,19 @@ def _xml_attr(value: str) -> str:
 def _parse_desktop_version(tag_name: str) -> Optional[Dict[str, str]]:
     """
     Parse desktop version from tag name.
-    Expected format: v1.0.77+464-desktop-cm or v1.0.77+464-macos-cm or v1.0.77+464-desktop-auto or v0.6.4+6004-macos
+    Expected format: v1.0.77+464-desktop-cm or v1.0.77+464-macos-cm or v1.0.77+464-desktop-auto or v0.6.4+6004-macos.
+    Newer desktop tags may omit the patch component, e.g. v11.3+11003-macos.
     Returns dict with version info or None if invalid.
     """
-    # Match pattern: v{major}.{minor}.{patch}+{build}-{platform}[-{cm|auto}]
-    pattern = r'^v?(\d+)\.(\d+)\.(\d+)\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
+    # Match pattern: v{major}.{minor}[.{patch}]+{build}-{platform}[-{cm|auto}]
+    pattern = r'^v?(\d+)\.(\d+)(?:\.(\d+))?\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
     match = re.match(pattern, tag_name, re.IGNORECASE)
 
     if not match:
         return None
 
     major, minor, patch, build = match.groups()
+    patch = patch or "0"
 
     return {
         'major': major,

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -59,6 +59,15 @@ class TestParseDesktopVersion:
         assert result is not None
         assert result["version"] == "1.2.3+100"
 
+    def test_two_component_macos_tag_defaults_patch_to_zero(self):
+        result = _parse_desktop_version("v11.3+11003-macos")
+        assert result is not None
+        assert result["major"] == "11"
+        assert result["minor"] == "3"
+        assert result["patch"] == "0"
+        assert result["build"] == "11003"
+        assert result["version"] == "11.3.0+11003"
+
     def test_desktop_auto_tag(self):
         result = _parse_desktop_version("v1.2.3+100-desktop-auto")
         assert result is not None
@@ -364,6 +373,18 @@ class TestGetLiveDesktopReleases:
         with patch("routers.updates.get_omi_github_releases", new_callable=AsyncMock, return_value=releases):
             result = await _get_live_desktop_releases("macos")
         assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_component_macos_tag_accepted(self):
+        from routers.updates import _get_live_desktop_releases
+
+        releases = [
+            _make_github_release("v11.3+11003-macos", body_kv={"isLive": "true"}),
+        ]
+        with patch("routers.updates.get_omi_github_releases", new_callable=AsyncMock, return_value=releases):
+            result = await _get_live_desktop_releases("macos")
+        assert len(result) == 1
+        assert result[0]["version_info"]["version"] == "11.3.0+11003"
 
 
 # --- Appcast XML endpoint ---


### PR DESCRIPTION
## Summary
- allow desktop appcast release tags without an explicit patch component, e.g. `v11.3+11003-macos`
- default missing patch versions to `0` so appcast version metadata stays three-component
- add parser and live release filtering tests for the new tag format

## Validation
- `python -m pytest tests/unit/test_desktop_updates.py -q`
- `git diff origin/main..HEAD --check`

Fixes #5285