### PR TITLE
fix flash page WAL null connection crash in getMissingWals

### DIFF
--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -127,6 +127,7 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
       int timerStart = DateTime.now().millisecondsSinceEpoch ~/ 1000 - estimatedSeconds;
 
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      if (connection == null) return [];
       var pd = await device.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Limitless";
 


### PR DESCRIPTION
## Crash

FlashPageWalSyncImpl._getMissingWals

FlutterError - Null check operator used on a null value

package:omi/services/wals/flash_page_wal_sync.dart:124

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/567d7aefe1b1be7cd6f64fc113b54376?time=7d&types=crash&sessionEventKey=69d5edf0af26432e91f7e4f4df8a497a_2225709665459050495

Logs:

```
Fatal Exception: FlutterError
0  ???  0x0 FlashPageWalSyncImpl._getMissingWals + 128 (flash_page_wal_sync.dart:128)
1  ???  0x0 FlashPageWalSyncImpl.setDevice + 586 (flash_page_wal_sync.dart:586)
```

## Fix

ensureConnection can return null if the device disconnects between the call and the result. getDeviceInfo was called with that potentially null connection, which crashes with null check operator inside. Added if (connection == null) return [] after ensureConnection, matching the same guard already present in _syncWal and other methods in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)