### PR TITLE
fix audio player proxy server crash when widget disposed during setup

### DIFF
--- a/app/lib/widgets/conversation_audio_player_widget.dart
+++ b/app/lib/widgets/conversation_audio_player_widget.dart
@@ -29,6 +29,7 @@ class ConversationAudioPlayerWidget extends StatefulWidget {
 
 class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerWidget> {
   final AudioPlayer _audioPlayer = AudioPlayer();
+  bool _disposed = false;
   bool _isLoading = false;
   String? _errorMessage;
   double _playbackSpeed = 1.0;
@@ -52,6 +53,7 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
 
   @override
   void dispose() {
+    _disposed = true;
     _sequenceSubscription?.cancel();
     _errorSubscription?.cancel();
     _audioPlayer.dispose();
@@ -91,6 +93,7 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
 
     try {
       final headers = await getAudioHeaders();
+      if (_disposed) return;
 
       final audioFileIds = widget.conversation.audioFiles.map((af) => af.id).toList();
       final urls = getConversationAudioUrls(
@@ -109,22 +112,21 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
 
       // Listen for playback errors
       _errorSubscription?.cancel();
-      _errorSubscription = _audioPlayer.playbackEventStream
-          .handleError((error) {
-            Logger.debug('Playback error: $error');
-            if (mounted && _retryCount < _maxRetries) {
-              _retryCount++;
-              Future.delayed(const Duration(seconds: 1), () {
-                if (mounted) _setupAudioPlayer();
-              });
-            } else if (mounted) {
-              setState(() {
-                _errorMessage = 'Playback error: ${error.toString()}';
-              });
-            }
-          })
-          .listen((_) {});
+      _errorSubscription = _audioPlayer.playbackEventStream.handleError((error) {
+        Logger.debug('Playback error: $error');
+        if (mounted && _retryCount < _maxRetries) {
+          _retryCount++;
+          Future.delayed(const Duration(seconds: 1), () {
+            if (mounted) _setupAudioPlayer();
+          });
+        } else if (mounted) {
+          setState(() {
+            _errorMessage = 'Playback error: ${error.toString()}';
+          });
+        }
+      }).listen((_) {});
 
+      if (_disposed) return;
       await _audioPlayer.setAudioSource(playlist, preload: true);
 
       _retryCount = 0;
@@ -295,9 +297,9 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
                               ),
                               child: Slider(
                                 value: combinedPosition.inMilliseconds.toDouble().clamp(
-                                  0,
-                                  _totalDuration.inMilliseconds.toDouble(),
-                                ),
+                                      0,
+                                      _totalDuration.inMilliseconds.toDouble(),
+                                    ),
                                 max: _totalDuration.inMilliseconds.toDouble().clamp(1.0, double.infinity),
                                 activeColor: Colors.deepPurpleAccent,
                                 inactiveColor: Colors.grey.shade700,

--- a/app/lib/widgets/conversation_audio_player_widget.dart
+++ b/app/lib/widgets/conversation_audio_player_widget.dart
@@ -127,7 +127,14 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
       }).listen((_) {});
 
       if (_disposed) return;
-      await _audioPlayer.setAudioSource(playlist, preload: true);
+      try {
+        await _audioPlayer.setAudioSource(playlist, preload: true);
+      } catch (e) {
+        // If disposed mid-flight (proxy server started then player was killed),
+        // swallow the error silently — the widget is already gone.
+        if (_disposed) return;
+        rethrow;
+      }
 
       _retryCount = 0;
 


### PR DESCRIPTION
## Crash

_ProxyHttpServer.start.<fn>

FlutterError - Null check operator used on a null value

package:just_audio/just_audio.dart:2158

Logs:

```
Fatal Exception: FlutterError
0  ???  0x0 _ProxyHttpServer.start.<fn> + 2158 (just_audio.dart:2158)
```

## Fix

_setupAudioPlayer is called from initState and contains two awaits — getAudioHeaders and setAudioSource. If the widget is disposed while either await is in flight, dispose() kills the AudioPlayer, but the async method continues and calls setAudioSource on the dead player. just_audio's internal _ProxyHttpServer then fires a callback against the null player state and crashes.

Added a _disposed flag that is set to true at the top of dispose() before _audioPlayer.dispose() is called. Two guards added in _setupAudioPlayer: one after getAudioHeaders (stops before building the playlist) and one immediately before setAudioSource (the exact crash point), so the proxy server is never started on a disposed player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)