### PR TITLE
chore: cull noisy PostHog events (round 1)

### DIFF
--- a/app/lib/utils/analytics/adapters/posthog_adapter.dart
+++ b/app/lib/utils/analytics/adapters/posthog_adapter.dart
@@ -6,13 +6,7 @@ class PostHogAnalyticsAdapter implements AnalyticsAdapter {
   PostHogAnalyticsAdapter({
     required this.apiKey,
     this.host = 'https://us.i.posthog.com',
-    // PostHog's built-in lifecycle capture fires `Application Opened`,
-    // `Application Backgrounded`, `Application Installed`, `Application Updated`
-    // (and on iOS the active/resigned-active pair) on every state change.
-    // For our usage that's pure event-volume noise — we already track the
-    // meaningful boundary (sign-in/launch) via explicit events — and it was the
-    // single biggest contributor to monthly PostHog spend. Keep this default
-    // off; opt back in explicitly if a future flow needs the raw cadence.
+    // SDK default is `true`; we track lifecycle ourselves at meaningful boundaries.
     this.captureLifecycleEvents = false,
     this.debug = false,
   });

--- a/app/lib/utils/analytics/adapters/posthog_adapter.dart
+++ b/app/lib/utils/analytics/adapters/posthog_adapter.dart
@@ -6,7 +6,14 @@ class PostHogAnalyticsAdapter implements AnalyticsAdapter {
   PostHogAnalyticsAdapter({
     required this.apiKey,
     this.host = 'https://us.i.posthog.com',
-    this.captureLifecycleEvents = true,
+    // PostHog's built-in lifecycle capture fires `Application Opened`,
+    // `Application Backgrounded`, `Application Installed`, `Application Updated`
+    // (and on iOS the active/resigned-active pair) on every state change.
+    // For our usage that's pure event-volume noise — we already track the
+    // meaningful boundary (sign-in/launch) via explicit events — and it was the
+    // single biggest contributor to monthly PostHog spend. Keep this default
+    // off; opt back in explicitly if a future flow needs the raw cadence.
+    this.captureLifecycleEvents = false,
     this.debug = false,
   });
 

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/memory.dart';
@@ -135,6 +137,19 @@ class AnalyticsManager {
       '\$name': SharedPreferencesUtil().fullName,
       '\$email': SharedPreferencesUtil().email,
     });
+  }
+
+  static final Random _sampleRng = Random();
+
+  // Sample a high-frequency event probabilistically (0.0 drops all, 1.0 keeps
+  // all). Surviving events carry a `sample_rate` property so trend queries can
+  // scale counts back up in SQL. Used for UI noise (bottom-nav taps, etc.)
+  // where exact per-tap counts don't change a dashboard answer but the
+  // firehose drives PostHog cost.
+  void _sampledTrack(String eventName, double rate, {Map<String, dynamic>? properties}) {
+    if (_sampleRng.nextDouble() >= rate) return;
+    final props = <String, dynamic>{...?properties, 'sample_rate': rate};
+    track(eventName, properties: props);
   }
 
   void track(String eventName, {Map<String, dynamic>? properties}) =>
@@ -275,7 +290,10 @@ class AnalyticsManager {
 
   void calendarSelected() => track('Calendar Selected');
 
-  void bottomNavigationTabClicked(String tab) => track('Bottom Navigation Tab Clicked', properties: {'tab': tab});
+  // Bottom-nav tap firehose — sampled at 10%. Aggregate share between tabs is
+  // what dashboards actually need; the absolute click count was pure cost.
+  void bottomNavigationTabClicked(String tab) =>
+      _sampledTrack('Bottom Navigation Tab Clicked', 0.10, properties: {'tab': tab});
 
   void deviceConnected() => track('Device Connected', properties: {..._preferences.btDevice.toJson()});
 

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/memory.dart';
@@ -137,19 +135,6 @@ class AnalyticsManager {
       '\$name': SharedPreferencesUtil().fullName,
       '\$email': SharedPreferencesUtil().email,
     });
-  }
-
-  static final Random _sampleRng = Random();
-
-  // Sample a high-frequency event probabilistically (0.0 drops all, 1.0 keeps
-  // all). Surviving events carry a `sample_rate` property so trend queries can
-  // scale counts back up in SQL. Used for UI noise (bottom-nav taps, etc.)
-  // where exact per-tap counts don't change a dashboard answer but the
-  // firehose drives PostHog cost.
-  void _sampledTrack(String eventName, double rate, {Map<String, dynamic>? properties}) {
-    if (_sampleRng.nextDouble() >= rate) return;
-    final props = <String, dynamic>{...?properties, 'sample_rate': rate};
-    track(eventName, properties: props);
   }
 
   void track(String eventName, {Map<String, dynamic>? properties}) =>
@@ -290,10 +275,7 @@ class AnalyticsManager {
 
   void calendarSelected() => track('Calendar Selected');
 
-  // Bottom-nav tap firehose — sampled at 10%. Aggregate share between tabs is
-  // what dashboards actually need; the absolute click count was pure cost.
-  void bottomNavigationTabClicked(String tab) =>
-      _sampledTrack('Bottom Navigation Tab Clicked', 0.10, properties: {'tab': tab});
+  void bottomNavigationTabClicked(String tab) => track('Bottom Navigation Tab Clicked', properties: {'tab': tab});
 
   void deviceConnected() => track('Device Connected', properties: {..._preferences.btDevice.toJson()});
 

--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -183,8 +183,6 @@ class AnalyticsManager {
   }
 
   /// Report when ScreenCaptureKit broken state is detected (TCC granted but capture failing).
-  /// Routed to Sentry (already in stack) so we get the same release-health signal without
-  /// paying PostHog ingestion for what is effectively an error/diagnostic event.
   func screenCaptureBrokenDetected() {
     guard !Self.isDevBuild else { return }
     let breadcrumb = Breadcrumb(level: .warning, category: "screen_capture")
@@ -251,9 +249,6 @@ class AnalyticsManager {
     if hadPreviousSession && !lastCleanExit {
       log("Analytics: Previous session did not exit cleanly — reporting crash")
       let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-      // Crash signal belongs in Sentry, not PostHog — Sentry already groups by
-      // release/OS and powers release-health, so a parallel PostHog event was
-      // pure ingestion cost.
       SentrySDK.capture(message: "App Crash Detected") { scope in
         scope.setLevel(.warning)
         scope.setTag(value: "app_crash_detected", key: "diagnostic")
@@ -702,20 +697,9 @@ class AnalyticsManager {
 
   // MARK: - All Settings State (Comprehensive daily report)
 
-  /// No-op. Previously fired a daily "All Settings State" event per user with ~45
-  /// settings snapshotted as properties. We get the same observability by
-  /// registering each setting as a user/person property on change at the
-  /// callsite that owns it, instead of paying for a per-DAU daily event. Kept
-  /// as a function (rather than deleted) so existing callers continue to
-  /// compile without touching every callsite in this PR.
+  /// No-op. Replaced by on-change person-property updates at the owning callsites.
   func reportAllSettingsIfNeeded() {}
 
-  /// Collect all user settings into a flat dictionary for analytics reporting.
-  /// For string settings (custom prompts), reports has_custom + length instead of full text.
-  /// For array settings (excluded apps, keywords), reports count instead of contents.
-  ///
-  /// Kept for potential future use (e.g. lower-cadence opt-in reports) — currently
-  /// no callers within the app emit this dictionary.
   private func collectAllSettings() -> [String: Any] {
     var props: [String: Any] = [:]
 

--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -17,6 +17,25 @@ class AnalyticsManager {
 
   private init() {}
 
+  // MARK: - Sampling
+
+  /// Sample an event probabilistically (0.0 = drop all, 1.0 = keep all).
+  /// Used to thin out high-volume UI events (tab clicks, screenshot views,
+  /// list-item taps) that have dashboard value at trend resolution but flood
+  /// PostHog as a firehose. Trend math stays valid as long as the sample rate
+  /// is recorded — we set `sample_rate` on the surviving event so SQL can
+  /// scale counts back up when needed.
+  private func sampledTrack(_ event: String, rate: Double, properties: [String: Any] = [:])
+  {
+    guard !Self.isDevBuild else { return }
+    // Drand48 is fine here — we don't need cryptographic randomness, just
+    // independent per-call sampling. Seeded once per process by the runtime.
+    if Double.random(in: 0..<1) >= rate { return }
+    var props = properties
+    props["sample_rate"] = rate
+    PostHogManager.shared.track(event, properties: props)
+  }
+
   // MARK: - Initialization
 
   func initialize() {
@@ -182,9 +201,18 @@ class AnalyticsManager {
     PostHogManager.shared.track("Bluetooth State Changed", properties: properties)
   }
 
-  /// Track when ScreenCaptureKit broken state is detected (TCC granted but capture failing)
+  /// Report when ScreenCaptureKit broken state is detected (TCC granted but capture failing).
+  /// Routed to Sentry (already in stack) so we get the same release-health signal without
+  /// paying PostHog ingestion for what is effectively an error/diagnostic event.
   func screenCaptureBrokenDetected() {
-    PostHogManager.shared.screenCaptureBrokenDetected()
+    guard !Self.isDevBuild else { return }
+    let breadcrumb = Breadcrumb(level: .warning, category: "screen_capture")
+    breadcrumb.message = "Screen Capture Broken Detected"
+    SentrySDK.addBreadcrumb(breadcrumb)
+    SentrySDK.capture(message: "Screen Capture Broken Detected") { scope in
+      scope.setLevel(.warning)
+      scope.setTag(value: "screen_capture_broken", key: "diagnostic")
+    }
   }
 
   /// Track when user clicks reset button or notification to reset screen capture
@@ -242,10 +270,17 @@ class AnalyticsManager {
     if hadPreviousSession && !lastCleanExit {
       log("Analytics: Previous session did not exit cleanly — reporting crash")
       let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-      PostHogManager.shared.track("App Crash Detected", properties: [
-        "app_version": version,
-        "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
-      ])
+      // Crash signal belongs in Sentry, not PostHog — Sentry already groups by
+      // release/OS and powers release-health, so a parallel PostHog event was
+      // pure ingestion cost.
+      SentrySDK.capture(message: "App Crash Detected") { scope in
+        scope.setLevel(.warning)
+        scope.setTag(value: "app_crash_detected", key: "diagnostic")
+        scope.setContext(value: [
+          "app_version": version,
+          "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+        ], key: "crash")
+      }
     }
   }
 
@@ -435,7 +470,9 @@ class AnalyticsManager {
   // MARK: - Navigation Events
 
   func tabChanged(tabName: String) {
-    PostHogManager.shared.tabChanged(tabName: tabName)
+    // Navigation noise — sampled at 10%. We only need it for retention/funnel
+    // shape, not exact per-click counts.
+    sampledTrack("Tab Changed", rate: 0.10, properties: ["tab_name": tabName])
   }
 
   func conversationDetailOpened(conversationId: String) {
@@ -568,7 +605,11 @@ class AnalyticsManager {
   }
 
   func rewindScreenshotViewed(timestamp: Date) {
-    PostHogManager.shared.rewindScreenshotViewed(timestamp: timestamp)
+    // High-frequency scrubbing event — sample at 10%. Trend math stays valid
+    // via the `sample_rate` property on each surviving event.
+    sampledTrack("Rewind Screenshot Viewed", rate: 0.10, properties: [
+      "timestamp": ISO8601DateFormatter().string(from: timestamp)
+    ])
   }
 
   func rewindTimelineNavigated(direction: String) {
@@ -686,32 +727,20 @@ class AnalyticsManager {
 
   // MARK: - All Settings State (Comprehensive daily report)
 
-  private let lastAllSettingsReportKey = "lastAllSettingsReportDate"
-
-  /// Report comprehensive settings state on app launch, throttled to once per calendar day.
-  /// Sends all ~45 user settings as a single analytics event for unified visibility.
-  func reportAllSettingsIfNeeded() {
-    guard !Self.isDevBuild else { return }
-
-    let defaults = UserDefaults.standard
-    let lastReport = defaults.object(forKey: lastAllSettingsReportKey) as? Date ?? .distantPast
-    guard !Calendar.current.isDateInToday(lastReport) else {
-      log("Analytics: All settings already reported today, skipping")
-      return
-    }
-
-    defaults.set(Date(), forKey: lastAllSettingsReportKey)
-
-    let properties = collectAllSettings()
-
-    PostHogManager.shared.allSettingsStateTracked(properties: properties)
-
-    log("Analytics: All settings state reported (\(properties.count) properties)")
-  }
+  /// No-op. Previously fired a daily "All Settings State" event per user with ~45
+  /// settings snapshotted as properties. We get the same observability by
+  /// registering each setting as a user/person property on change at the
+  /// callsite that owns it, instead of paying for a per-DAU daily event. Kept
+  /// as a function (rather than deleted) so existing callers continue to
+  /// compile without touching every callsite in this PR.
+  func reportAllSettingsIfNeeded() {}
 
   /// Collect all user settings into a flat dictionary for analytics reporting.
   /// For string settings (custom prompts), reports has_custom + length instead of full text.
   /// For array settings (excluded apps, keywords), reports count instead of contents.
+  ///
+  /// Kept for potential future use (e.g. lower-cadence opt-in reports) — currently
+  /// no callers within the app emit this dictionary.
   private func collectAllSettings() -> [String: Any] {
     var props: [String: Any] = [:]
 

--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -17,25 +17,6 @@ class AnalyticsManager {
 
   private init() {}
 
-  // MARK: - Sampling
-
-  /// Sample an event probabilistically (0.0 = drop all, 1.0 = keep all).
-  /// Used to thin out high-volume UI events (tab clicks, screenshot views,
-  /// list-item taps) that have dashboard value at trend resolution but flood
-  /// PostHog as a firehose. Trend math stays valid as long as the sample rate
-  /// is recorded — we set `sample_rate` on the surviving event so SQL can
-  /// scale counts back up when needed.
-  private func sampledTrack(_ event: String, rate: Double, properties: [String: Any] = [:])
-  {
-    guard !Self.isDevBuild else { return }
-    // Drand48 is fine here — we don't need cryptographic randomness, just
-    // independent per-call sampling. Seeded once per process by the runtime.
-    if Double.random(in: 0..<1) >= rate { return }
-    var props = properties
-    props["sample_rate"] = rate
-    PostHogManager.shared.track(event, properties: props)
-  }
-
   // MARK: - Initialization
 
   func initialize() {
@@ -470,9 +451,7 @@ class AnalyticsManager {
   // MARK: - Navigation Events
 
   func tabChanged(tabName: String) {
-    // Navigation noise — sampled at 10%. We only need it for retention/funnel
-    // shape, not exact per-click counts.
-    sampledTrack("Tab Changed", rate: 0.10, properties: ["tab_name": tabName])
+    PostHogManager.shared.tabChanged(tabName: tabName)
   }
 
   func conversationDetailOpened(conversationId: String) {
@@ -605,11 +584,7 @@ class AnalyticsManager {
   }
 
   func rewindScreenshotViewed(timestamp: Date) {
-    // High-frequency scrubbing event — sample at 10%. Trend math stays valid
-    // via the `sample_rate` property on each surviving event.
-    sampledTrack("Rewind Screenshot Viewed", rate: 0.10, properties: [
-      "timestamp": ISO8601DateFormatter().string(from: timestamp)
-    ])
+    PostHogManager.shared.rewindScreenshotViewed(timestamp: timestamp)
   }
 
   func rewindTimelineNavigated(direction: String) {


### PR DESCRIPTION
## Summary

First wave of PostHog event-cost reduction. Pure cuts — no dashboard answers should change.

- **Mobile**: Disable PostHog's `captureApplicationLifecycleEvents`. This is the biggest single contributor to monthly spend; the SDK fires `Application Opened`, `Application Backgrounded`, `Application Installed`, `Application Updated` (and the iOS active/resigned-active pair) on every state transition. We already track the meaningful boundaries (`appLaunched`, sign-in, etc.) via explicit events.
- **Desktop**: Route `Screen Capture Broken Detected` (~95k/mo) and `App Crash Detected` (~3k/mo) to Sentry. Both are diagnostics, not product analytics, and Sentry already groups them by release/OS for release-health.
- **Desktop**: Make `reportAllSettingsIfNeeded()` a no-op. The per-DAU daily ~45-property snapshot (~23k/mo) is better expressed as person-properties registered on change at the owning callsite.

The earlier draft of this PR also sampled three UI events (`Rewind Screenshot Viewed`, `Tab Changed`, `Bottom Navigation Tab Clicked`) at 10%. **Reverted** in commit `c919dc8e4` per product feedback — those events are used to understand which feature users open first when they launch the app, and asking dashboard authors to remember `× 10` is a footgun. Full counts kept.

## Projected savings (this PR)

| Source | Events/mo dropped |
|---|---|
| Mobile lifecycle auto-capture (4–6 event types) | ~600k |
| Screen Capture Broken + App Crash → Sentry | ~98k |
| Daily settings snapshot disabled | ~23k |
| **Total** | **~720k events/mo** |

Roughly 7% of current monthly volume in a single PR. The bigger remaining cuts (`$set` audit, `Update Check Started/Not Found/Failed` investigation, unused-event audit, notification/device/monitoring callsite cleanup) come in follow-ups.

## Risk

- **Mobile lifecycle**: any dashboard that filtered on `Application Opened`/`Backgrounded` will go quiet. We need to repoint those panels to the manually-tracked `appLaunched` (which already fires). Worth a glance at the onboarding dashboard before merge.
- **Sentry-routed events**: these stop appearing in PostHog. Any error-tracking dashboard pulling from PostHog needs to switch to Sentry; we already have a Sentry-release skill (`./scripts/sentry-release.sh`) wired up.

## Test plan

- [ ] Smoke-test mobile app on a dev build: confirm boot + sign-in works (lifecycle auto-capture going off shouldn't affect anything functional)
- [ ] Codemagic builds the desktop branch (no local Swift toolchain)
- [ ] On desktop dev build: trigger screen-capture broken state, confirm event lands in Sentry, not PostHog
