### PR TITLE
fix(app): exponential backoff for WS reconnect on auth failures (#7632)

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3013,5 +3013,6 @@
     "recapRegeneratedSnackbar": "تمت إعادة إنشاء الملخص",
     "recapRegenerateFailed": "تعذرت إعادة إنشاء الملخص. حاول مرة أخرى لاحقًا.",
     "recapRegenerateCooldown": "يرجى الانتظار بضع ثوانٍ قبل إعادة الإنشاء مرة أخرى.",
-    "recapRegenerateNoConversations": "لا توجد محادثات لتلخيصها في هذا اليوم."
+    "recapRegenerateNoConversations": "لا توجد محادثات لتلخيصها في هذا اليوم.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Рэзюмэ перагенеравана",
     "recapRegenerateFailed": "Не атрымалася перагенераваць рэзюмэ. Паспрабуйце пазней.",
     "recapRegenerateCooldown": "Калі ласка, пачакайце некалькі секунд перад паўторнай генерацыяй.",
-    "recapRegenerateNoConversations": "Няма размоў для рэзюмавання гэтага дня."
+    "recapRegenerateNoConversations": "Няма размоў для рэзюмавання гэтага дня.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3015,5 +3015,6 @@
     "recapRegeneratedSnackbar": "Резюмето е регенерирано",
     "recapRegenerateFailed": "Резюмето не можа да бъде регенерирано. Опитайте отново по-късно.",
     "recapRegenerateCooldown": "Моля, изчакайте няколко секунди преди повторно регенериране.",
-    "recapRegenerateNoConversations": "Няма разговори за обобщаване за този ден."
+    "recapRegenerateNoConversations": "Няма разговори за обобщаване за този ден.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "রিক্যাপ পুনরায় তৈরি হয়েছে",
     "recapRegenerateFailed": "রিক্যাপ পুনরায় তৈরি করা যায়নি। পরে আবার চেষ্টা করুন।",
     "recapRegenerateCooldown": "পুনরায় তৈরি করার আগে কয়েক সেকেন্ড অপেক্ষা করুন।",
-    "recapRegenerateNoConversations": "এই দিনের জন্য সংক্ষেপ করার কোনো কথোপকথন নেই।"
+    "recapRegenerateNoConversations": "এই দিনের জন্য সংক্ষেপ করার কোনো কথোপকথন নেই।",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Rezime je ponovo generisan",
     "recapRegenerateFailed": "Nije moguće ponovo generisati rezime. Pokušajte ponovo kasnije.",
     "recapRegenerateCooldown": "Molimo sačekajte nekoliko sekundi prije ponovnog generisanja.",
-    "recapRegenerateNoConversations": "Nema razgovora za sažimanje za ovaj dan."
+    "recapRegenerateNoConversations": "Nema razgovora za sažimanje za ovaj dan.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3015,5 +3015,6 @@
     "recapRegeneratedSnackbar": "Resum regenerat",
     "recapRegenerateFailed": "No s'ha pogut regenerar el resum. Torna-ho a provar més tard.",
     "recapRegenerateCooldown": "Espera uns segons abans de tornar a regenerar.",
-    "recapRegenerateNoConversations": "No hi ha converses per resumir d'aquest dia."
+    "recapRegenerateNoConversations": "No hi ha converses per resumir d'aquest dia.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3015,5 +3015,6 @@
     "recapRegeneratedSnackbar": "Shrnutí bylo znovu vygenerováno",
     "recapRegenerateFailed": "Shrnutí se nepodařilo znovu vygenerovat. Zkuste to později.",
     "recapRegenerateCooldown": "Před opětovným generováním prosím počkejte několik sekund.",
-    "recapRegenerateNoConversations": "Pro tento den nejsou žádné konverzace k shrnutí."
+    "recapRegenerateNoConversations": "Pro tento den nejsou žádné konverzace k shrnutí.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3055,5 +3055,6 @@
     "recapRegeneratedSnackbar": "Resumé genereret igen",
     "recapRegenerateFailed": "Kunne ikke generere resuméet igen. Prøv igen senere.",
     "recapRegenerateCooldown": "Vent et par sekunder, før du genererer igen.",
-    "recapRegenerateNoConversations": "Ingen samtaler at opsummere for denne dag."
+    "recapRegenerateNoConversations": "Ingen samtaler at opsummere for denne dag.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3014,5 +3014,6 @@
     "recapRegeneratedSnackbar": "Zusammenfassung neu erstellt",
     "recapRegenerateFailed": "Zusammenfassung konnte nicht neu erstellt werden. Bitte später erneut versuchen.",
     "recapRegenerateCooldown": "Bitte warte ein paar Sekunden, bevor du erneut generierst.",
-    "recapRegenerateNoConversations": "Keine Konversationen für diesen Tag zum Zusammenfassen."
+    "recapRegenerateNoConversations": "Keine Konversationen für diesen Tag zum Zusammenfassen.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Η ανακεφαλαίωση δημιουργήθηκε ξανά",
     "recapRegenerateFailed": "Δεν ήταν δυνατή η αναδημιουργία της ανακεφαλαίωσης. Δοκιμάστε ξανά αργότερα.",
     "recapRegenerateCooldown": "Παρακαλώ περιμένετε λίγα δευτερόλεπτα πριν δοκιμάσετε ξανά.",
-    "recapRegenerateNoConversations": "Δεν υπάρχουν συνομιλίες για ανακεφαλαίωση αυτής της ημέρας."
+    "recapRegenerateNoConversations": "Δεν υπάρχουν συνομιλίες για ανακεφαλαίωση αυτής της ημέρας.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11006,5 +11006,7 @@
     "recapRegeneratedSnackbar": "Recap regenerated",
     "recapRegenerateFailed": "Couldn't regenerate the recap. Try again later.",
     "recapRegenerateCooldown": "Please wait a few seconds before regenerating again.",
-    "recapRegenerateNoConversations": "No conversations to summarize for this day."
+    "recapRegenerateNoConversations": "No conversations to summarize for this day.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again.",
+    "sessionExpiredPleaseSignIn@description": "Message shown when WebSocket auth failures force sign-out"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3047,5 +3047,6 @@
     "recapRegeneratedSnackbar": "Resumen regenerado",
     "recapRegenerateFailed": "No se pudo regenerar el resumen. Inténtalo de nuevo más tarde.",
     "recapRegenerateCooldown": "Espera unos segundos antes de regenerar de nuevo.",
-    "recapRegenerateNoConversations": "No hay conversaciones para resumir en este día."
+    "recapRegenerateNoConversations": "No hay conversaciones para resumir en este día.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Kokkuvõte loodi uuesti",
     "recapRegenerateFailed": "Kokkuvõtet ei õnnestunud uuesti luua. Proovi hiljem uuesti.",
     "recapRegenerateCooldown": "Palun oota mõni sekund enne uuesti loomist.",
-    "recapRegenerateNoConversations": "Selle päeva jaoks pole vestlusi, mida kokku võtta."
+    "recapRegenerateNoConversations": "Selle päeva jaoks pole vestlusi, mida kokku võtta.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "خلاصه دوباره ساخته شد",
     "recapRegenerateFailed": "بازسازی خلاصه ممکن نشد. بعداً دوباره تلاش کنید.",
     "recapRegenerateCooldown": "لطفاً چند ثانیه قبل از بازسازی مجدد صبر کنید.",
-    "recapRegenerateNoConversations": "هیچ مکالمه‌ای برای خلاصه‌سازی این روز وجود ندارد."
+    "recapRegenerateNoConversations": "هیچ مکالمه‌ای برای خلاصه‌سازی این روز وجود ندارد.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Yhteenveto luotu uudelleen",
     "recapRegenerateFailed": "Yhteenvedon uudelleenluonti epäonnistui. Yritä myöhemmin uudelleen.",
     "recapRegenerateCooldown": "Odota muutama sekunti ennen uudelleen luomista.",
-    "recapRegenerateNoConversations": "Tänä päivänä ei ole keskusteluja yhteenvedettäväksi."
+    "recapRegenerateNoConversations": "Tänä päivänä ei ole keskusteluja yhteenvedettäväksi.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3081,5 +3081,6 @@
     "recapRegeneratedSnackbar": "Récapitulatif régénéré",
     "recapRegenerateFailed": "Impossible de régénérer le récapitulatif. Réessayez plus tard.",
     "recapRegenerateCooldown": "Veuillez patienter quelques secondes avant de régénérer.",
-    "recapRegenerateNoConversations": "Aucune conversation à résumer pour cette journée."
+    "recapRegenerateNoConversations": "Aucune conversation à résumer pour cette journée.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "הסיכום נוצר מחדש",
     "recapRegenerateFailed": "לא ניתן ליצור מחדש את הסיכום. נסה שוב מאוחר יותר.",
     "recapRegenerateCooldown": "אנא המתן מספר שניות לפני יצירה מחודשת.",
-    "recapRegenerateNoConversations": "אין שיחות לסיכום עבור היום הזה."
+    "recapRegenerateNoConversations": "אין שיחות לסיכום עבור היום הזה.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3047,5 +3047,6 @@
     "recapRegeneratedSnackbar": "रीकैप पुनः बनाया गया",
     "recapRegenerateFailed": "रीकैप पुनः नहीं बनाया जा सका। बाद में पुनः प्रयास करें।",
     "recapRegenerateCooldown": "पुनः बनाने से पहले कुछ सेकंड प्रतीक्षा करें।",
-    "recapRegenerateNoConversations": "इस दिन के लिए सारांश बनाने के लिए कोई बातचीत नहीं है।"
+    "recapRegenerateNoConversations": "इस दिन के लिए सारांश बनाने के लिए कोई बातचीत नहीं है।",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Sažetak je ponovno generiran",
     "recapRegenerateFailed": "Nije bilo moguće ponovno generirati sažetak. Pokušajte kasnije.",
     "recapRegenerateCooldown": "Pričekajte nekoliko sekundi prije ponovnog generiranja.",
-    "recapRegenerateNoConversations": "Nema razgovora za sažimanje za ovaj dan."
+    "recapRegenerateNoConversations": "Nema razgovora za sažimanje za ovaj dan.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3142,5 +3142,6 @@
     "recapRegeneratedSnackbar": "Összegzés újragenerálva",
     "recapRegenerateFailed": "Nem sikerült újragenerálni az összegzést. Próbáld újra később.",
     "recapRegenerateCooldown": "Kérlek, várj néhány másodpercet az újragenerálás előtt.",
-    "recapRegenerateNoConversations": "Erre a napra nincsenek összegezhető beszélgetések."
+    "recapRegenerateNoConversations": "Erre a napra nincsenek összegezhető beszélgetések.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3088,5 +3088,6 @@
     "recapRegeneratedSnackbar": "Ringkasan dibuat ulang",
     "recapRegenerateFailed": "Tidak dapat membuat ulang ringkasan. Coba lagi nanti.",
     "recapRegenerateCooldown": "Mohon tunggu beberapa detik sebelum membuat ulang.",
-    "recapRegenerateNoConversations": "Tidak ada percakapan untuk diringkas pada hari ini."
+    "recapRegenerateNoConversations": "Tidak ada percakapan untuk diringkas pada hari ini.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Riepilogo rigenerato",
     "recapRegenerateFailed": "Impossibile rigenerare il riepilogo. Riprova più tardi.",
     "recapRegenerateCooldown": "Attendi qualche secondo prima di rigenerare.",
-    "recapRegenerateNoConversations": "Nessuna conversazione da riepilogare per questo giorno."
+    "recapRegenerateNoConversations": "Nessuna conversazione da riepilogare per questo giorno.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3047,5 +3047,6 @@
     "recapRegeneratedSnackbar": "要約を再生成しました",
     "recapRegenerateFailed": "要約を再生成できませんでした。後でもう一度お試しください。",
     "recapRegenerateCooldown": "再生成する前に数秒お待ちください。",
-    "recapRegenerateNoConversations": "この日の要約対象となる会話はありません。"
+    "recapRegenerateNoConversations": "この日の要約対象となる会話はありません。",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "ಸಾರಾಂಶವನ್ನು ಪುನರುತ್ಪಾದಿಸಲಾಗಿದೆ",
     "recapRegenerateFailed": "ಸಾರಾಂಶವನ್ನು ಪುನರುತ್ಪಾದಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.",
     "recapRegenerateCooldown": "ಪುನರುತ್ಪಾದಿಸುವ ಮೊದಲು ದಯವಿಟ್ಟು ಕೆಲವು ಸೆಕೆಂಡುಗಳು ನಿರೀಕ್ಷಿಸಿ.",
-    "recapRegenerateNoConversations": "ಈ ದಿನಕ್ಕೆ ಸಂಗ್ರಹಿಸಲು ಯಾವುದೇ ಸಂಭಾಷಣೆಗಳಿಲ್ಲ."
+    "recapRegenerateNoConversations": "ಈ ದಿನಕ್ಕೆ ಸಂಗ್ರಹಿಸಲು ಯಾವುದೇ ಸಂಭಾಷಣೆಗಳಿಲ್ಲ.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "요약이 재생성되었습니다",
     "recapRegenerateFailed": "요약을 재생성할 수 없습니다. 나중에 다시 시도하세요.",
     "recapRegenerateCooldown": "다시 생성하기 전에 몇 초 기다려 주세요.",
-    "recapRegenerateNoConversations": "이 날짜에 요약할 대화가 없습니다."
+    "recapRegenerateNoConversations": "이 날짜에 요약할 대화가 없습니다.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Santrauka sukurta iš naujo",
     "recapRegenerateFailed": "Nepavyko iš naujo sukurti santraukos. Bandykite vėliau.",
     "recapRegenerateCooldown": "Palaukite kelias sekundes prieš generuodami iš naujo.",
-    "recapRegenerateNoConversations": "Šiai dienai nėra pokalbių, kuriuos būtų galima apibendrinti."
+    "recapRegenerateNoConversations": "Šiai dienai nėra pokalbių, kuriuos būtų galima apibendrinti.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Kopsavilkums atjaunots",
     "recapRegenerateFailed": "Kopsavilkumu neizdevās atjaunot. Mēģiniet vēlāk vēlreiz.",
     "recapRegenerateCooldown": "Lūdzu, pagaidiet dažas sekundes pirms atkārtotas ģenerēšanas.",
-    "recapRegenerateNoConversations": "Šajā dienā nav sarunu, ko apkopot."
+    "recapRegenerateNoConversations": "Šajā dienā nav sarunu, ko apkopot.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Резимето е регенерирано",
     "recapRegenerateFailed": "Не успеа регенерирањето на резимето. Обидете се повторно подоцна.",
     "recapRegenerateCooldown": "Почекајте неколку секунди пред повторно регенерирање.",
-    "recapRegenerateNoConversations": "Нема разговори за сумирање за овој ден."
+    "recapRegenerateNoConversations": "Нема разговори за сумирање за овој ден.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "सारांश पुन्हा तयार केला",
     "recapRegenerateFailed": "सारांश पुन्हा तयार करता आला नाही. नंतर पुन्हा प्रयत्न करा.",
     "recapRegenerateCooldown": "पुन्हा तयार करण्यापूर्वी कृपया काही सेकंद थांबा.",
-    "recapRegenerateNoConversations": "या दिवसासाठी सारांश करण्यासाठी कोणतेही संभाषण नाही."
+    "recapRegenerateNoConversations": "या दिवसासाठी सारांश करण्यासाठी कोणतेही संभाषण नाही.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Ringkasan dijana semula",
     "recapRegenerateFailed": "Tidak dapat menjana semula ringkasan. Cuba sebentar lagi.",
     "recapRegenerateCooldown": "Sila tunggu beberapa saat sebelum menjana semula.",
-    "recapRegenerateNoConversations": "Tiada perbualan untuk diringkaskan untuk hari ini."
+    "recapRegenerateNoConversations": "Tiada perbualan untuk diringkaskan untuk hari ini.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Samenvatting opnieuw gegenereerd",
     "recapRegenerateFailed": "Kon de samenvatting niet opnieuw genereren. Probeer het later opnieuw.",
     "recapRegenerateCooldown": "Wacht een paar seconden voordat je opnieuw genereert.",
-    "recapRegenerateNoConversations": "Geen gesprekken om voor deze dag samen te vatten."
+    "recapRegenerateNoConversations": "Geen gesprekken om voor deze dag samen te vatten.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Sammendrag generert på nytt",
     "recapRegenerateFailed": "Kunne ikke generere sammendraget på nytt. Prøv igjen senere.",
     "recapRegenerateCooldown": "Vent noen sekunder før du genererer på nytt.",
-    "recapRegenerateNoConversations": "Ingen samtaler å oppsummere for denne dagen."
+    "recapRegenerateNoConversations": "Ingen samtaler å oppsummere for denne dagen.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3081,5 +3081,6 @@
     "recapRegeneratedSnackbar": "Podsumowanie wygenerowane ponownie",
     "recapRegenerateFailed": "Nie udało się ponownie wygenerować podsumowania. Spróbuj później.",
     "recapRegenerateCooldown": "Poczekaj kilka sekund przed ponownym wygenerowaniem.",
-    "recapRegenerateNoConversations": "Brak rozmów do podsumowania w tym dniu."
+    "recapRegenerateNoConversations": "Brak rozmów do podsumowania w tym dniu.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3082,5 +3082,6 @@
     "recapRegeneratedSnackbar": "Resumo regenerado",
     "recapRegenerateFailed": "Não foi possível regenerar o resumo. Tente novamente mais tarde.",
     "recapRegenerateCooldown": "Aguarde alguns segundos antes de regenerar novamente.",
-    "recapRegenerateNoConversations": "Nenhuma conversa para resumir neste dia."
+    "recapRegenerateNoConversations": "Nenhuma conversa para resumir neste dia.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Rezumat regenerat",
     "recapRegenerateFailed": "Rezumatul nu a putut fi regenerat. Încercați din nou mai târziu.",
     "recapRegenerateCooldown": "Vă rugăm să așteptați câteva secunde înainte de a regenera.",
-    "recapRegenerateNoConversations": "Nu există conversații de rezumat pentru această zi."
+    "recapRegenerateNoConversations": "Nu există conversații de rezumat pentru această zi.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3081,5 +3081,6 @@
     "recapRegeneratedSnackbar": "Резюме создано заново",
     "recapRegenerateFailed": "Не удалось создать резюме заново. Попробуйте позже.",
     "recapRegenerateCooldown": "Подождите несколько секунд перед повторным созданием.",
-    "recapRegenerateNoConversations": "Нет разговоров для резюмирования за этот день."
+    "recapRegenerateNoConversations": "Нет разговоров для резюмирования за этот день.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3051,5 +3051,6 @@
     "recapRegeneratedSnackbar": "Zhrnutie znovu vygenerované",
     "recapRegenerateFailed": "Zhrnutie sa nepodarilo znovu vygenerovať. Skúste neskôr.",
     "recapRegenerateCooldown": "Pred opätovným generovaním prosím počkajte niekoľko sekúnd.",
-    "recapRegenerateNoConversations": "Pre tento deň nie sú žiadne konverzácie na zhrnutie."
+    "recapRegenerateNoConversations": "Pre tento deň nie sú žiadne konverzácie na zhrnutie.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Povzetek ponovno ustvarjen",
     "recapRegenerateFailed": "Povzetka ni bilo mogoče ponovno ustvariti. Poskusite pozneje.",
     "recapRegenerateCooldown": "Pred ponovnim ustvarjanjem počakajte nekaj sekund.",
-    "recapRegenerateNoConversations": "Za ta dan ni pogovorov za povzemanje."
+    "recapRegenerateNoConversations": "Za ta dan ni pogovorov za povzemanje.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Резиме је поново генерисан",
     "recapRegenerateFailed": "Није могуће поново генерисати резиме. Покушајте поново касније.",
     "recapRegenerateCooldown": "Сачекајте неколико секунди пре поновног генерисања.",
-    "recapRegenerateNoConversations": "Нема разговора за сумирање за овај дан."
+    "recapRegenerateNoConversations": "Нема разговора за сумирање за овај дан.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Sammanfattningen återskapad",
     "recapRegenerateFailed": "Det gick inte att återskapa sammanfattningen. Försök igen senare.",
     "recapRegenerateCooldown": "Vänta några sekunder innan du genererar igen.",
-    "recapRegenerateNoConversations": "Inga samtal att sammanfatta för den här dagen."
+    "recapRegenerateNoConversations": "Inga samtal att sammanfatta för den här dagen.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "சுருக்கம் மீண்டும் உருவாக்கப்பட்டது",
     "recapRegenerateFailed": "சுருக்கத்தை மீண்டும் உருவாக்க முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்.",
     "recapRegenerateCooldown": "மீண்டும் உருவாக்குவதற்கு முன் சில வினாடிகள் காத்திருக்கவும்.",
-    "recapRegenerateNoConversations": "இந்த நாளுக்கு சுருக்கமாக மாற்ற உரையாடல்கள் இல்லை."
+    "recapRegenerateNoConversations": "இந்த நாளுக்கு சுருக்கமாக மாற்ற உரையாடல்கள் இல்லை.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "సారాంశం పునరుత్పత్తి అయింది",
     "recapRegenerateFailed": "సారాంశాన్ని పునరుత్పత్తి చేయలేకపోయాము. తర్వాత మళ్లీ ప్రయత్నించండి.",
     "recapRegenerateCooldown": "మళ్లీ పునరుత్పత్తి చేయడానికి ముందు దయచేసి కొన్ని సెకన్లు వేచి ఉండండి.",
-    "recapRegenerateNoConversations": "ఈ రోజుకి సారాంశీకరించడానికి సంభాషణలు లేవు."
+    "recapRegenerateNoConversations": "ఈ రోజుకి సారాంశీకరించడానికి సంభాషణలు లేవు.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "สร้างสรุปใหม่แล้ว",
     "recapRegenerateFailed": "ไม่สามารถสร้างสรุปใหม่ได้ ลองอีกครั้งในภายหลัง",
     "recapRegenerateCooldown": "โปรดรอสักครู่ก่อนสร้างใหม่อีกครั้ง",
-    "recapRegenerateNoConversations": "ไม่มีการสนทนาที่จะสรุปสำหรับวันนี้"
+    "recapRegenerateNoConversations": "ไม่มีการสนทนาที่จะสรุปสำหรับวันนี้",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "Nabuo muli ang buod",
     "recapRegenerateFailed": "Hindi nagawang muling buuin ang buod. Subukang muli mamaya.",
     "recapRegenerateCooldown": "Mangyaring maghintay ng ilang segundo bago bumuo muli.",
-    "recapRegenerateNoConversations": "Walang mga pag-uusap na ibubuod para sa araw na ito."
+    "recapRegenerateNoConversations": "Walang mga pag-uusap na ibubuod para sa araw na ito.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3081,5 +3081,6 @@
     "recapRegeneratedSnackbar": "Özet yeniden oluşturuldu",
     "recapRegenerateFailed": "Özet yeniden oluşturulamadı. Lütfen daha sonra tekrar deneyin.",
     "recapRegenerateCooldown": "Yeniden oluşturmadan önce lütfen birkaç saniye bekleyin.",
-    "recapRegenerateNoConversations": "Bu gün için özetlenecek konuşma bulunamadı."
+    "recapRegenerateNoConversations": "Bu gün için özetlenecek konuşma bulunamadı.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3046,5 +3046,6 @@
     "recapRegeneratedSnackbar": "Підсумок створено знову",
     "recapRegenerateFailed": "Не вдалося створити підсумок заново. Спробуйте пізніше.",
     "recapRegenerateCooldown": "Зачекайте кілька секунд перед повторним створенням.",
-    "recapRegenerateNoConversations": "Немає розмов для підбиття підсумку за цей день."
+    "recapRegenerateNoConversations": "Немає розмов для підбиття підсумку за цей день.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10624,5 +10624,6 @@
     "recapRegeneratedSnackbar": "خلاصہ دوبارہ بن گیا",
     "recapRegenerateFailed": "خلاصہ دوبارہ نہیں بنایا جا سکا۔ بعد میں دوبارہ کوشش کریں۔",
     "recapRegenerateCooldown": "دوبارہ بنانے سے پہلے براہ کرم چند سیکنڈ انتظار کریں۔",
-    "recapRegenerateNoConversations": "اس دن کے لیے خلاصہ کرنے کے لیے کوئی گفتگو نہیں ہے۔"
+    "recapRegenerateNoConversations": "اس دن کے لیے خلاصہ کرنے کے لیے کوئی گفتگو نہیں ہے۔",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3051,5 +3051,6 @@
     "recapRegeneratedSnackbar": "Đã tạo lại tóm tắt",
     "recapRegenerateFailed": "Không thể tạo lại tóm tắt. Vui lòng thử lại sau.",
     "recapRegenerateCooldown": "Vui lòng đợi vài giây trước khi tạo lại.",
-    "recapRegenerateNoConversations": "Không có cuộc trò chuyện nào để tóm tắt cho ngày này."
+    "recapRegenerateNoConversations": "Không có cuộc trò chuyện nào để tóm tắt cho ngày này.",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3068,5 +3068,6 @@
     "recapRegeneratedSnackbar": "已重新生成回顾",
     "recapRegenerateFailed": "无法重新生成回顾。请稍后重试。",
     "recapRegenerateCooldown": "请等待几秒后再重新生成。",
-    "recapRegenerateNoConversations": "这一天没有可以总结的对话。"
+    "recapRegenerateNoConversations": "这一天没有可以总结的对话。",
+    "sessionExpiredPleaseSignIn": "Session expired. Please sign in again."
 }

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -81,6 +81,10 @@ class CaptureProvider extends ChangeNotifier
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
+  int _wsReconnectAttempts = 0;
+  int? _lastCloseCode;
+  static const int _wsMaxAuthRetries = 10;
+  static const List<int> _wsBackoffSeconds = [15, 30, 60, 120, 300];
   Timer? _inProgressConversationRefreshTimer;
   int _inProgressConversationRefreshAttempts = 0;
   bool _isRefreshingInProgressConversation = false;
@@ -458,6 +462,8 @@ class CaptureProvider extends ChangeNotifier
     _conversation = null;
     taggingSegmentIds = [];
     _sessionStartSeconds = 0;
+    _wsReconnectAttempts = 0;
+    _lastCloseCode = null;
     notifyListeners();
   }
 
@@ -1231,6 +1237,7 @@ class CaptureProvider extends ChangeNotifier
   void onClosed([int? closeCode]) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+    _lastCloseCode = closeCode;
 
     if (closeCode == 4002) {
       usageProvider?.markAsOutOfCreditsAndRefresh();
@@ -1255,16 +1262,42 @@ class CaptureProvider extends ChangeNotifier
 
   void _startKeepAliveServices() {
     _keepAliveTimer?.cancel();
-    _keepAliveTimer = Timer.periodic(const Duration(seconds: 15), (t) async {
-      Logger.debug("[Provider] keep alive");
-      // rate 1/15s
-      if (_keepAliveLastExecutedAt != null &&
-          DateTime.now().subtract(const Duration(seconds: 15)).isBefore(_keepAliveLastExecutedAt!)) {
-        Logger.debug("[Provider] keep alive - hitting rate limits 1/15s");
-        return;
-      }
 
-      _keepAliveLastExecutedAt = DateTime.now();
+    final isAuthFailure = _lastCloseCode == 1008;
+    if (isAuthFailure) {
+      _wsReconnectAttempts++;
+    }
+    if (isAuthFailure && _wsReconnectAttempts >= _wsMaxAuthRetries) {
+      Logger.warning("[Provider] $_wsMaxAuthRetries consecutive auth failures, signing out");
+      _keepAliveTimer?.cancel();
+      final ctx = globalNavigatorKey.currentContext;
+      if (ctx != null) {
+        AppSnackbar.showSnackbar(
+          ctx.l10n.sessionExpiredPleaseSignIn,
+          duration: const Duration(seconds: 5),
+        );
+      }
+      AuthService.instance.signOut();
+      return;
+    }
+
+    final backoffIndex =
+        (_wsReconnectAttempts > 0 && _wsReconnectAttempts <= _wsBackoffSeconds.length)
+            ? _wsReconnectAttempts - 1
+            : (_wsReconnectAttempts == 0
+                ? 0
+                : _wsBackoffSeconds.length - 1);
+    final baseDelay = _wsBackoffSeconds[backoffIndex];
+    final jitter = DateTime.now().millisecondsSinceEpoch % 1000;
+    final delaySeconds = baseDelay + (jitter / 1000);
+
+    Logger.debug(
+      "[Provider] keep alive — retry #$_wsReconnectAttempts"
+      " in ${delaySeconds.toStringAsFixed(1)}s (code=$_lastCloseCode)",
+    );
+
+    _keepAliveTimer =
+        Timer.periodic(Duration(milliseconds: (delaySeconds * 1000).round()), (t) async {
       if (!recordingDeviceServiceReady || _socket?.state == SocketServiceState.connected) {
         t.cancel();
         return;
@@ -1275,6 +1308,13 @@ class CaptureProvider extends ChangeNotifier
         t.cancel();
         return;
       }
+
+      if (_keepAliveLastExecutedAt != null &&
+          DateTime.now().subtract(Duration(seconds: baseDelay)).isBefore(_keepAliveLastExecutedAt!)) {
+        return;
+      }
+
+      _keepAliveLastExecutedAt = DateTime.now();
 
       if (_recordingDevice != null) {
         BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
@@ -1304,6 +1344,8 @@ class CaptureProvider extends ChangeNotifier
   @override
   void onConnected() {
     _transcriptServiceReady = true;
+    _wsReconnectAttempts = 0;
+    _lastCloseCode = null;
     // Restart mic on reconnect if interrupted (skip during active call).
     if (recordingState == RecordingState.interrupted && !_callActive) {
       if (_activeSource is PhoneMicSource) {

--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -170,6 +170,8 @@ class PureSocket implements IPureSocket {
         return 'going_away_os_or_background';
       case 1006:
         return 'abnormal_closure';
+      case 1008:
+        return 'policy_violation_auth_failure';
       case 1011:
         return 'server_error';
       default:


### PR DESCRIPTION
## Problem

The WebSocket keep-alive timer in `capture_provider.dart` used a **fixed 15-second interval** with no backoff. On persistent auth failures (close code 1008 — expired/invalid token), the client retried every 15 seconds indefinitely.

### Runtime evidence
- **14 users** retrying with stale tokens since Jun 3 → **~5K errors/day** on backend-listen
- Triggers Cloud Armor 429 rate limits on the backend
- Top user: 5,760 wasted WS attempts in a single day
- Related HTTP 429 storm: one user hit **1,899 429s in 7 hours** (exhausted budget, client retried for 7h straight)

## Fix

### Exponential backoff with jitter
- Auth failures (close code 1008): **15s → 30s → 60s → 120s → 300s** (capped at 5 min)
- Random jitter (0-1s) to prevent thundering herd across users
- After **10 consecutive 1008 failures**: force `AuthService.signOut()` → re-login screen
- Transient failures (1006, 1011): keep base 15s interval (no change for normal reconnects)
- Successful connect resets the backoff counter to zero
- New recording session resets the backoff counter

### Close code mapping
- Added `1008 → policy_violation_auth_failure` to `pure_socket.dart` for log clarity

## Files changed
- `app/lib/providers/capture_provider.dart` — backoff logic in `_startKeepAliveServices`, state tracking in `onClosed`/`onConnected`/`_resetStateVariables`
- `app/lib/services/sockets/pure_socket.dart` — close code 1008 mapping

## Impact
- Eliminates 5K+ wasted WS attempts/day for stuck users
- Reduces backend Cloud Armor 429 triggers from WS retry storms
- Saves battery for users with stale auth tokens (300s max interval vs 15s)

Closes #7632