### PR TITLE
fix(backend): return 400 instead of 500 on malformed search dates

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -809,10 +809,16 @@ def search_conversations_endpoint(
     end_timestamp = None
 
     if search_request.start_date:
-        start_timestamp = int(datetime.fromisoformat(search_request.start_date).timestamp())
+        try:
+            start_timestamp = int(datetime.fromisoformat(search_request.start_date).timestamp())
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid start_date; expected an ISO 8601 datetime string")
 
     if search_request.end_date:
-        end_timestamp = int(datetime.fromisoformat(search_request.end_date).timestamp())
+        try:
+            end_timestamp = int(datetime.fromisoformat(search_request.end_date).timestamp())
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid end_date; expected an ISO 8601 datetime string")
 
     return search_conversations(
         query=search_request.query,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -130,6 +130,7 @@ pytest tests/unit/test_tts.py -v
 pytest tests/unit/test_webhook_auto_disable.py -v
 pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
+pytest tests/unit/test_conversation_search_date_validation.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -9,7 +9,7 @@ The handler now catches it and returns HTTP 400. These tests mount the conversat
 import os
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
@@ -113,11 +113,11 @@ def test_bad_end_date_returns_400_not_500():
 
 
 def test_valid_date_is_accepted_and_calls_search():
-    conv.search_conversations = MagicMock(return_value={'conversations': []})
-    client = _client()
-    resp = client.post(
-        '/v1/conversations/search',
-        json={'query': 'hi', 'start_date': '2026-01-01T00:00:00', 'end_date': '2026-02-01T00:00:00'},
-    )
-    assert resp.status_code == 200
-    assert conv.search_conversations.called
+    with patch.object(conv, 'search_conversations', return_value={'conversations': []}) as mock_search:
+        client = _client()
+        resp = client.post(
+            '/v1/conversations/search',
+            json={'query': 'hi', 'start_date': '2026-01-01T00:00:00', 'end_date': '2026-02-01T00:00:00'},
+        )
+        assert resp.status_code == 200
+        assert mock_search.called

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -1,0 +1,123 @@
+"""Regression test for POST /v1/conversations/search date validation.
+
+SearchRequest.start_date / end_date are free-form ISO strings. Before the fix, a malformed
+value made `datetime.fromisoformat(...)` raise an unhandled ValueError, returning HTTP 500.
+The handler now catches it and returns HTTP 400. These tests mount the conversations router
+(heavy deps stubbed, same pattern as the other router unit tests) and exercise the HTTP layer.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'database._client',
+    'database.conversations',
+    'database.action_items',
+    'database.memories',
+    'database.redis_db',
+    'database.users',
+    'database.vector_db',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.conversations.factory',
+    'utils.conversations.render',
+    'utils.conversations.process_conversation',
+    'utils.conversations.search',
+    'utils.conversations.calendar_linking',
+    'utils.conversations.calendar_utils',
+    'utils.conversations.location',
+    'utils.llm.conversation_processing',
+    'utils.speaker_identification',
+    'utils.app_integrations',
+    'utils.retrieval.tools.calendar_tools',
+    'utils.retrieval.tools.google_utils',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# utils.other.endpoints exposes the auth dependencies used in route signatures; FastAPI needs
+# real callables to build the dependants, so provide small stand-ins.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_endpoints.get_user = MagicMock()
+sys.modules['utils.other.endpoints'] = _endpoints
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from routers import conversations as conv  # noqa: E402
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(conv.router)
+    app.dependency_overrides[conv.auth.get_current_user_uid] = lambda: 'test-uid'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_bad_start_date_returns_400_not_500():
+    client = _client()
+    resp = client.post('/v1/conversations/search', json={'query': 'hi', 'start_date': 'not-a-date'})
+    assert resp.status_code == 400
+    assert 'start_date' in resp.json().get('detail', '')
+
+
+def test_bad_end_date_returns_400_not_500():
+    client = _client()
+    resp = client.post('/v1/conversations/search', json={'query': 'hi', 'end_date': 'nope'})
+    assert resp.status_code == 400
+    assert 'end_date' in resp.json().get('detail', '')
+
+
+def test_valid_date_is_accepted_and_calls_search():
+    conv.search_conversations = MagicMock(return_value={'conversations': []})
+    client = _client()
+    resp = client.post(
+        '/v1/conversations/search',
+        json={'query': 'hi', 'start_date': '2026-01-01T00:00:00', 'end_date': '2026-02-01T00:00:00'},
+    )
+    assert resp.status_code == 200
+    assert conv.search_conversations.called


### PR DESCRIPTION
## Summary

`POST /v1/conversations/search` returns HTTP 500 when a client sends a malformed `start_date` or `end_date`. This changes it to return HTTP 400 with a clear message, which is the correct response for bad input rather than a server error.

## Steps to reproduce

With any valid auth, POST to `/v1/conversations/search` with a non-ISO date:

```json
{ "query": "test", "start_date": "not-a-date" }
```

- Current behavior: `500 Internal Server Error`
- Expected: `400 Bad Request`

## Root cause

`SearchRequest.start_date` and `end_date` are `Optional[str]` (`backend/models/conversation.py`), so the handler receives raw client strings. The handler parsed them directly:

```python
start_timestamp = int(datetime.fromisoformat(search_request.start_date).timestamp())
```

`datetime.fromisoformat()` raises `ValueError` on a malformed string. There is no `try/except` around it and no global `ValueError` handler, so the request fails as an unhandled server error (500). `auth.with_rate_limit(...)` only wraps the auth/rate-limit dependency, not the handler body, so it does not catch this.

File: `backend/routers/conversations.py`, `search_conversations_endpoint`.

## Fix

Wrap each parse and raise `HTTPException(400)` on `ValueError`, with a message that names the bad field and the expected format. This matches how other routers validate date input.

## Behavior change

- Malformed `start_date` or `end_date`: was `500`, now `400` with a `detail` explaining the expected ISO 8601 format.
- Valid dates and the no-date case: unchanged.
- Success responses: unchanged.

## Testing

Added `backend/tests/unit/test_conversation_search_date_validation.py` (registered in `backend/test.sh`):

- bad `start_date` -> `400`
- bad `end_date` -> `400`
- valid dates -> `200`, and `search_conversations` is called

I verified the tests fail against current `main` (they return `500`) and pass with this change.

## Notes

Small, behavior-only change to a single endpoint. There may be a trivial textual overlap with the in-flight auth-router refactor (#6946), which moves route decorators in this file, but the change here is to the handler body and is independent of that work.
