### PR TITLE
fix(backend): skip+log invalid memories in dev API list instead of 500ing the page

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 import database.folders as folders_db
 import database.memories as memories_db
@@ -171,11 +171,24 @@ def get_memories(
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
     memories = memories_db.get_memories(uid, limit, offset, [c.value for c in category_list])
+    # Validate each record individually so a single malformed/legacy doc (e.g. missing a required
+    # field or an out-of-enum category) doesn't fail the whole page with a 500. Mirrors the
+    # hardening already applied to GET /v3/memories.
+    valid_memories = []
     for memory in memories:
         if memory.get('is_locked', False):
             content = memory.get('content', '')
             memory['content'] = (content[:70] + '...') if len(content) > 70 else content
-    return memories
+        try:
+            valid_memories.append(CleanerMemory.model_validate(memory))
+        except ValidationError as e:
+            missing_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(
+                f"Skipping invalid memory doc {memory.get('id', 'unknown')} for uid {uid}: "
+                f"missing/invalid fields {missing_fields}"
+            )
+            continue
+    return valid_memories
 
 
 @router.post("/v1/dev/user/memories", response_model=MemoryResponse, tags=["developer"])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -90,6 +90,7 @@ pytest tests/unit/test_async_tasks.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
+pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v

--- a/backend/tests/unit/test_dev_api_memories_pagination.py
+++ b/backend/tests/unit/test_dev_api_memories_pagination.py
@@ -9,7 +9,7 @@ failed). The handler now validates each record and skips+logs invalid ones, mirr
 import os
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
@@ -144,18 +144,18 @@ def _build():
 
 
 def test_invalid_record_is_skipped_not_500():
-    memories_db.get_memories = MagicMock(
-        return_value=[_valid_memory('good1'), _invalid_memory('bad1'), _valid_memory('good2')]
-    )
-    client = _build()
-    resp = client.get('/v1/dev/user/memories')
+    page = [_valid_memory('good1'), _invalid_memory('bad1'), _valid_memory('good2')]
+    with patch.object(memories_db, 'get_memories', return_value=page):
+        client = _build()
+        resp = client.get('/v1/dev/user/memories')
     assert resp.status_code == 200
     assert [m['id'] for m in resp.json()] == ['good1', 'good2']
 
 
 def test_all_valid_records_returned():
-    memories_db.get_memories = MagicMock(return_value=[_valid_memory('a'), _valid_memory('b')])
-    client = _build()
-    resp = client.get('/v1/dev/user/memories')
+    page = [_valid_memory('a'), _valid_memory('b')]
+    with patch.object(memories_db, 'get_memories', return_value=page):
+        client = _build()
+        resp = client.get('/v1/dev/user/memories')
     assert resp.status_code == 200
     assert len(resp.json()) == 2

--- a/backend/tests/unit/test_dev_api_memories_pagination.py
+++ b/backend/tests/unit/test_dev_api_memories_pagination.py
@@ -1,0 +1,161 @@
+"""Regression test for GET /v1/dev/user/memories resilience (issue #7492).
+
+The endpoint declares response_model=List[CleanerMemory] and returned raw Firestore dicts, so a
+single malformed/legacy record (missing a required field or an out-of-enum category) made FastAPI
+raise ResponseValidationError -> HTTP 500 for the whole page (only the offsets containing that record
+failed). The handler now validates each record and skips+logs invalid ones, mirroring GET /v3/memories.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.knowledge_graph',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.location',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.llm.knowledge_graph',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# utils.other.endpoints must expose real callables (used in route signatures); provide stand-ins.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'uid1'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_endpoints.get_user = MagicMock()
+sys.modules['utils.other.endpoints'] = _endpoints
+
+from datetime import datetime, timezone  # noqa: E402
+
+import database.memories as memories_db  # noqa: E402  (the stub)
+from models.memories import MemoryCategory  # noqa: E402  (real model; stubs prevent google init)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from routers.developer import router as developer_router  # noqa: E402
+from dependencies import get_uid_with_memories_read  # noqa: E402
+
+_VALID_CATEGORY = next(iter(MemoryCategory)).value
+
+
+def _valid_memory(mid):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return {
+        'id': mid,
+        'content': 'a memory',
+        'category': _VALID_CATEGORY,
+        'visibility': 'private',
+        'tags': [],
+        'created_at': now,
+        'updated_at': now,
+        'manually_added': False,
+        'scoring': None,
+        'reviewed': False,
+        'user_review': None,
+        'edited': False,
+    }
+
+
+def _invalid_memory(mid):
+    # Legacy/malformed record missing a required CleanerMemory field ('edited').
+    m = _valid_memory(mid)
+    del m['edited']
+    return m
+
+
+def _build():
+    app = FastAPI()
+    app.include_router(developer_router)
+    app.dependency_overrides[get_uid_with_memories_read] = lambda: 'uid1'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_invalid_record_is_skipped_not_500():
+    memories_db.get_memories = MagicMock(
+        return_value=[_valid_memory('good1'), _invalid_memory('bad1'), _valid_memory('good2')]
+    )
+    client = _build()
+    resp = client.get('/v1/dev/user/memories')
+    assert resp.status_code == 200
+    assert [m['id'] for m in resp.json()] == ['good1', 'good2']
+
+
+def test_all_valid_records_returned():
+    memories_db.get_memories = MagicMock(return_value=[_valid_memory('a'), _valid_memory('b')])
+    client = _build()
+    resp = client.get('/v1/dev/user/memories')
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2


### PR DESCRIPTION
Fixes #7492

## Summary

`GET /v1/dev/user/memories` returns HTTP 500 for specific pagination offsets when a single stored memory record fails response-model validation. This validates each record and skips + logs invalid ones, matching the behavior already in `GET /v3/memories`, so one bad record no longer breaks the whole page.

## Root cause

The endpoint declares `response_model=List[CleanerMemory]` and the handler returns raw Firestore dicts. FastAPI validates the whole returned list, so if any record is missing a required `CleanerMemory` field (`id`, `content`, `category`, `created_at`, `updated_at`, `manually_added`, `reviewed`, `edited`) or has a `category` outside the enum, FastAPI raises `ResponseValidationError` and the entire page 500s.

That explains the report exactly: only the offsets containing the bad record (offsets 7 and 8 in the issue) fail, while other offsets return fine. It is not the `order_by('scoring')` composite index, which would fail every offset, not just two.

File: `backend/routers/developer.py`, `get_memories` (`GET /v1/dev/user/memories`).

## Fix

Build each `CleanerMemory` individually; on `ValidationError`, log the record id and the offending fields, then skip that record. This mirrors the hardening already present in `backend/routers/memories.py` for `GET /v3/memories`, so the two memory-list endpoints now behave consistently. The bad record is logged (not silently dropped), and unrelated pagination keeps working, which matches the options suggested in the issue.

## Behavior change

- A page that contained an unparseable record: was `500`, now returns the valid records with `200`; invalid ones are logged and skipped.
- Pages with all-valid records: unchanged.

## Testing

Added `backend/tests/unit/test_dev_api_memories_pagination.py` (registered in `backend/test.sh`):

- a page containing a malformed record returns `200` with only the valid records (no `500`)
- an all-valid page returns everything

I verified the first test fails against current `main` (returns `500`) and passes with this change.

## Notes

Skip + log is the minimal fix and keeps this endpoint consistent with `/v3/memories`. A possible follow-up is to repair recoverable records (default missing booleans, fall back `updated_at` to `created_at`) so they are still returned rather than skipped, but I left that out to keep this change small and matching the existing pattern. No open PR touches this path as far as I can tell (#6946 is auth-router churn in this file; #7006 adds batch delete in the DB layer).
