### PR TITLE
fix(backend): cancel active Stripe subscription on account deletion

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -167,6 +167,19 @@ def delete_account(
             except Exception as e:
                 logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
 
+        # 1.5 Cancel any active paid Stripe subscription before wiping the account, so the user
+        #     isn't billed after deletion (they lose all access and can't self-serve a cancel).
+        #     Read the subscription while the user doc still exists. Best-effort: a Stripe hiccup
+        #     must never block account deletion, but log loudly so support can clean up manually.
+        try:
+            sub = users_db.get_user_subscription(uid)
+            if sub and sub.stripe_subscription_id:
+                canceled = stripe_utils.cancel_subscription(sub.stripe_subscription_id)
+                if not canceled:
+                    logger.error(f'delete_account stripe cancel returned None for {uid}')
+        except Exception as e:
+            logger.error(f'delete_account stripe cancel failed for {uid}: {sanitize(str(e))}')
+
         # 2. Revoke Firebase auth immediately so tokens are useless and the
         #    account cannot be logged back into while the data wipe runs.
         try:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -178,7 +178,9 @@ def delete_account(
                 if not canceled:
                     logger.error(f'delete_account stripe cancel returned None for {uid}')
         except Exception as e:
-            logger.error(f'delete_account stripe cancel failed for {uid}: {sanitize(str(e))}')
+            # cancel_subscription swallows its own Stripe errors (returns None), so this only
+            # fires on the subscription lookup (e.g. a Firestore read error).
+            logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
 
         # 2. Revoke Firebase auth immediately so tokens are useless and the
         #    account cannot be logged back into while the data wipe runs.

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -130,6 +130,7 @@ pytest tests/unit/test_tts.py -v
 pytest tests/unit/test_webhook_auto_disable.py -v
 pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
+pytest tests/unit/test_delete_account_stripe_cancel.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -58,23 +58,27 @@ def _should_stub(name: str) -> bool:
 
 
 class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def __init__(self):
+        self.created = set()
+
     def find_spec(self, name, path=None, target=None):
         if _should_stub(name):
             return importlib.machinery.ModuleSpec(name, self, is_package=True)
         return None
 
     def create_module(self, spec):
+        self.created.add(spec.name)
         return _AutoMockModule(spec.name)
 
     def exec_module(self, module):
         pass
 
 
-sys.meta_path.insert(0, _StubFinder())
-
-import firebase_admin.auth as _fa_auth  # stubbed
-
-_fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+# Install the stub finder only for the duration of importing routers.users, then remove it AND
+# the stub modules it created. This keeps the finder/stubs from leaking into other tests when the
+# whole suite runs in one process (pytest tests/unit/); routers.users keeps its own references.
+_finder = _StubFinder()
+sys.meta_path.insert(0, _finder)
 
 # Real shim for the auth dependency module (used in route signatures + as auth.delete_account).
 _endpoints = types.ModuleType('utils.other.endpoints')
@@ -84,7 +88,16 @@ _endpoints.delete_account = MagicMock()
 _endpoints.get_user = MagicMock()
 sys.modules['utils.other.endpoints'] = _endpoints
 
-from routers import users as users_router  # noqa: E402  (heavy import; deps stubbed above)
+try:
+    import firebase_admin.auth as _fa_auth  # stubbed
+
+    _fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+    from routers import users as users_router  # noqa: E402  (heavy import; deps stubbed above)
+finally:
+    if _finder in sys.meta_path:
+        sys.meta_path.remove(_finder)
+    for _name in list(_finder.created) + ['utils.other.endpoints']:
+        sys.modules.pop(_name, None)
 
 
 def _sub(stripe_subscription_id):

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -1,0 +1,132 @@
+"""Regression test for issue #6750 — delete-account must cancel the active Stripe subscription.
+
+Before the fix, DELETE /v1/users/delete-account revoked Firebase auth and wiped Firestore but never
+canceled the user's Stripe subscription, so a paying user kept getting billed with no way to log back
+in and cancel. The handler now cancels the subscription (best-effort) before the wipe.
+
+routers/users.py has a heavy import graph (star imports, `from database import (...)`), so we install
+a meta-path finder that auto-stubs the database/utils/external namespaces, then call delete_account()
+directly with the relevant collaborators patched.
+"""
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(types.ModuleType):
+    __path__ = []  # behave as a package so submodule imports resolve to stubs
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_STUB_PREFIXES = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google.cloud',
+    'google.api_core',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'twilio',
+)
+
+
+def _should_stub(name: str) -> bool:
+    if name == 'utils.other.endpoints':  # provided as a real shim below
+        return False
+    return any(name == p or name.startswith(p + '.') for p in _STUB_PREFIXES)
+
+
+class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _should_stub(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMockModule(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+sys.meta_path.insert(0, _StubFinder())
+
+import firebase_admin.auth as _fa_auth  # stubbed
+
+_fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# Real shim for the auth dependency module (used in route signatures + as auth.delete_account).
+_endpoints = types.ModuleType('utils.other.endpoints')
+_endpoints.get_current_user_uid = lambda: 'uid1'
+_endpoints.with_rate_limit = lambda dependency, _policy: dependency
+_endpoints.delete_account = MagicMock()
+_endpoints.get_user = MagicMock()
+sys.modules['utils.other.endpoints'] = _endpoints
+
+from routers import users as users_router  # noqa: E402  (heavy import; deps stubbed above)
+
+
+def _sub(stripe_subscription_id):
+    s = MagicMock()
+    s.stripe_subscription_id = stripe_subscription_id
+    return s
+
+
+def test_paid_user_subscription_is_canceled_before_wipe():
+    with patch.object(
+        users_router.users_db, 'get_user_subscription', return_value=_sub('sub_123')
+    ) as get_sub, patch.object(
+        users_router.stripe_utils, 'cancel_subscription', return_value=MagicMock()
+    ) as cancel, patch.object(
+        users_router.auth, 'delete_account'
+    ) as fb_delete, patch.object(
+        users_router, '_background_wipe_user_data'
+    ):
+        resp = users_router.delete_account(uid='uid1')
+    get_sub.assert_called_once_with('uid1')
+    cancel.assert_called_once_with('sub_123')
+    fb_delete.assert_called_once()  # deletion still proceeds
+    assert resp['status'] == 'ok'
+
+
+def test_free_user_does_not_call_stripe():
+    with patch.object(users_router.users_db, 'get_user_subscription', return_value=_sub(None)), patch.object(
+        users_router.stripe_utils, 'cancel_subscription'
+    ) as cancel, patch.object(users_router.auth, 'delete_account'), patch.object(
+        users_router, '_background_wipe_user_data'
+    ):
+        resp = users_router.delete_account(uid='uid1')
+    cancel.assert_not_called()
+    assert resp['status'] == 'ok'
+
+
+def test_stripe_error_does_not_block_deletion():
+    with patch.object(users_router.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
+        users_router.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
+    ), patch.object(users_router.auth, 'delete_account') as fb_delete, patch.object(
+        users_router, '_background_wipe_user_data'
+    ):
+        resp = users_router.delete_account(uid='uid1')
+    fb_delete.assert_called_once()  # best-effort: Stripe failure must not abort deletion
+    assert resp['status'] == 'ok'


### PR DESCRIPTION
Fixes #6750

## Summary

`DELETE /v1/users/delete-account` revokes Firebase auth and wipes Firestore but never cancels the user's Stripe subscription. A paying user who deletes their account keeps getting billed, and since their auth and data are gone they can't log back in to self-serve the cancellation. This cancels the active subscription (best-effort) before the wipe.

## Root cause

`delete_account` (`backend/routers/users.py`) does: store feedback -> `auth.delete_account(uid)` (Firebase revoke) -> background Firestore wipe (`_background_wipe_user_data` -> `delete_user_data`). None of those touch Stripe, so the subscription stays active. The delete-account redesign (#6669) explicitly deferred Pinecone/GCS but didn't mention Stripe, so this reads as an unintentional gap.

## Fix

Insert a best-effort cancel right after the feedback step and before the Firebase revoke, so the user doc (and `subscription.stripe_subscription_id`) is still readable:

```python
try:
    sub = users_db.get_user_subscription(uid)
    if sub and sub.stripe_subscription_id:
        canceled = stripe_utils.cancel_subscription(sub.stripe_subscription_id)
        if not canceled:
            logger.error(f'delete_account stripe cancel returned None for {uid}')
except Exception as e:
    logger.error(f'delete_account stripe cancel failed for {uid}: {sanitize(str(e))}')
```

It uses the existing `utils/stripe.py` `cancel_subscription` helper (`cancel_at_period_end=True`), which is idempotent and already error-tolerant. The try/except guarantees a Stripe outage can never strand an account half-deleted; a `None` return or exception is logged so support can clean up manually.

## Behavior change

- Paid user deletes account: subscription is now canceled (was: continued billing).
- Free user: no Stripe call.
- Stripe error: logged, deletion proceeds exactly as before.

## Testing

New `backend/tests/unit/test_delete_account_stripe_cancel.py` (registered in `backend/test.sh`):

- paid user -> `cancel_subscription` called with the subscription id, deletion still proceeds
- free user (`stripe_subscription_id is None`) -> Stripe not called
- Stripe raises -> deletion still returns `{'status': 'ok'}`

Verified the paid-user test fails against current `main` (no cancel happens) and passes with this change.

## Scope and possible follow-ups (kept out to keep this minimal)

- Timing: uses the existing `cancel_at_period_end=True` helper for consistency. If the intent is "deleted account means no active paid service," an immediate-cancel variant could be added.
- This cancels the user's own Omi subscription. Canceling app-marketplace / Connect subscriptions tied to the Stripe customer (discovered separately via the customer id) is a broader cleanup worth its own pass.
- `get_user_subscription` writes a default subscription doc if none exists. It's harmless here since the doc is wiped moments later, but a non-mutating read would be slightly cleaner.
