### PR TITLE
fix transcription service crash on invalid STT URL port placeholder

### DIFF
--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -449,7 +449,7 @@ class TranscriptSocketServiceFactory {
     if (params.isEmpty) return baseUrl;
     final uri = Uri.tryParse(baseUrl);
     if (uri == null) {
-      Logger.debug('[STTFactory] Invalid URL, cannot append params: $baseUrl');
+      Logger.warning('[STTFactory] Invalid URL, cannot append params: $baseUrl');
       return baseUrl;
     }
     return uri.replace(queryParameters: {...uri.queryParameters, ...params}).toString();

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -447,9 +447,12 @@ class TranscriptSocketServiceFactory {
   /// Build URL with query parameters
   static String _buildUrlWithParams(String baseUrl, Map<String, String> params) {
     if (params.isEmpty) return baseUrl;
-    final uri = Uri.parse(baseUrl);
-    final newUri = uri.replace(queryParameters: {...uri.queryParameters, ...params});
-    return newUri.toString();
+    final uri = Uri.tryParse(baseUrl);
+    if (uri == null) {
+      Logger.debug('[STTFactory] Invalid URL, cannot append params: $baseUrl');
+      return baseUrl;
+    }
+    return uri.replace(queryParameters: {...uri.queryParameters, ...params}).toString();
   }
 
   /// Create composite service: primary STT socket + Omi backend for conversation processing


### PR DESCRIPTION
TranscriptSocketServiceFactory._buildUrlWithParams
`FlutterError - FormatException: Invalid port (at character 31) wss://<address>.tailb6a000.ts.net:<capture-port>/stt ^`

package:omi/services/sockets/transcription_service.dart:450

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/85254b13a6a175eb58166e8babe45fd8?time=7d&types=crash&sessionEventKey=aed6b2d4ed3a40079870da45b384b68f_2226860224141214111

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 Uri.parse (dart:core)
1  ???                            0x0 TranscriptSocketServiceFactory._buildUrlWithParams + 450 (transcription_service.dart:450)
2  ???                            0x0 TranscriptSocketServiceFactory._createStreamingSocket + 369 (transcription_service.dart:369)
3  ???                            0x0 TranscriptSocketServiceFactory.createFromCustomConfig + 329 (transcription_service.dart:329)
4  ???                            0x0 SocketServicePool.socket + 84 (sockets.dart:84)
5  ???                            0x0 SocketServicePool.conversation + 124 (sockets.dart:124)
6  ???                            0x0 CaptureProvider._initiateWebsocket + 543 (capture_provider.dart:543)
7  ???                            0x0 CaptureProvider._startKeepAliveServices.<fn> + 1281 (capture_provider.dart:1281)
```

Fix:

`_buildUrlWithParams` called `Uri.parse` on user-configured STT URLs. When a user saves a Tailscale URL with a literal `<capture-port>` placeholder (e.g. `wss://<address>.tailb6a000.ts.net:<capture-port>/stt`), `Uri.parse` throws a `FormatException` because the port field is not a valid integer. Switched to `Uri.tryParse`, which returns null instead of throwing on malformed input. If parsing fails, the method now logs a debug message and returns the original URL unchanged, letting the downstream WebSocket connection fail gracefully rather than crashing with an unhandled exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)