### PR TITLE
feat(desktop): notifications off by default for all users

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1255,14 +1255,16 @@ def get_notification_settings(uid: str) -> dict:
     the user doc.  The Swift ``NotificationSettingsResponse`` decodes
     ``enabled`` / ``frequency``, so we map to the wire names here.
     """
+    # Proactive desktop notifications are OFF by default (frequency 0). Users opt in
+    # via the Settings frequency slider; an explicit stored value always wins.
     user_ref = db.collection('users').document(uid)
     doc = user_ref.get()
     if not doc.exists:
-        return {'enabled': True, 'frequency': 3}
+        return {'enabled': True, 'frequency': 0}
     data = doc.to_dict()
     return {
         'enabled': data.get('notifications_enabled', True),
-        'frequency': data.get('notification_frequency', 3),
+        'frequency': data.get('notification_frequency', 0),
     }
 
 

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -330,13 +330,13 @@ class TestNotificationSettingsWireCompat:
         assert result['enabled'] is False
         assert result['frequency'] == 2
 
-    def test_defaults_frequency_to_3_when_unset(self):
-        """Frequency defaults to 3 when the user doc has no notification_frequency."""
+    def test_defaults_frequency_to_off_when_unset(self):
+        """Frequency defaults to 0 (Off) when the user doc has no notification_frequency."""
         snap = self._mock_user_doc({})
         mock_db.collection.return_value.document.return_value.get.return_value = snap
         result = users_db.get_notification_settings('test-uid')
 
-        assert result['frequency'] == 3
+        assert result['frequency'] == 0
         assert result['enabled'] is True
 
     def test_defaults_when_doc_missing(self):
@@ -345,7 +345,7 @@ class TestNotificationSettingsWireCompat:
         mock_db.collection.return_value.document.return_value.get.return_value = snap
         result = users_db.get_notification_settings('test-uid')
 
-        assert result == {'enabled': True, 'frequency': 3}
+        assert result == {'enabled': True, 'frequency': 0}
 
 
 class TestAssistantSettingsWireCompat:

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Proactive notifications are now off by default \u2014 turn them on anytime in Settings"
+  ],
   "releases": [
     {
       "version": "0.11.451",

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -244,6 +244,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Refresh the "Auto" realtime-voice model pick from Artificial Analysis (daily, cached).
     AutoModelSelector.shared.refreshIfStale()
 
+    // Proactive notifications are now OFF by default for everyone. Run the one-time
+    // migration before any assistant can fire, so existing users are flipped to Off
+    // once (they can re-enable in Settings).
+    NotificationService.migrateToOffByDefaultIfNeeded()
+
     // Force macOS to use the correct app icon (bypasses icon cache).
     // Apply squircle mask with proper margins because NSApp.applicationIconImage
     // renders the raw image without macOS auto-masking.

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -71,14 +71,19 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     static let screenCaptureResetShownKey = "screenCaptureResetNotificationShown"
 
     /// UserDefaults key mirroring the user's `notification_frequency` setting from the backend.
-    /// 0=Off, 1=Minimal, 2=Low, 3=Balanced (default), 4=High, 5=Maximum.
+    /// 0=Off (default), 1=Minimal, 2=Low, 3=Balanced, 4=High, 5=Maximum.
     /// The Settings page writes this on load and on slider change; `sendNotification`
     /// reads it synchronously to throttle proactive notifications.
     static let frequencyDefaultsKey = "notification_frequency"
 
+    /// One-time migration flag: when set, the notifications-off-by-default migration
+    /// has already run for this install, so we never re-disable a user who opted back in.
+    static let offByDefaultMigrationKey = "notificationsOffByDefaultMigrationDone"
+
     /// Default level used when the key has never been written (e.g. first run before
     /// the Settings page has hydrated from the backend). Mirrors the backend default.
-    private static let defaultFrequencyLevel = 3
+    /// Proactive notifications are OFF by default — users opt in via the Settings slider.
+    private static let defaultFrequencyLevel = 0
 
     /// Stores metadata for sent notifications so we can retrieve it in delegate callbacks
     /// Key: notification identifier, Value: (title, assistantId)
@@ -364,6 +369,28 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     // MARK: - Frequency throttle
+
+    /// One-time migration to make proactive notifications OFF by default for ALL users.
+    /// Runs once per install (guarded by `offByDefaultMigrationKey`): sets the local
+    /// frequency to Off and persists it to the backend so the choice sticks across
+    /// devices and is reflected in Settings. Because it is guarded by the flag, a user
+    /// who later turns notifications back on is never re-disabled on subsequent launches.
+    /// Call early at launch, before any proactive assistant can fire.
+    static func migrateToOffByDefaultIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: Self.offByDefaultMigrationKey) else { return }
+        UserDefaults.standard.set(0, forKey: Self.frequencyDefaultsKey)
+        UserDefaults.standard.set(true, forKey: Self.offByDefaultMigrationKey)
+        log("NotificationService: applied notifications-off-by-default migration (frequency=0)")
+        guard AuthService.shared.isSignedIn else { return }
+        Task {
+            do {
+                _ = try await APIClient.shared.updateNotificationSettings(enabled: nil, frequency: 0)
+            } catch {
+                logError(
+                    "NotificationService: off-by-default migration backend push failed", error: error)
+            }
+        }
+    }
 
     /// Current frequency level from UserDefaults, clamped to [0, 5]. Falls back to
     /// `defaultFrequencyLevel` when the key is absent (first run before sync).


### PR DESCRIPTION
## What
Make proactive desktop notifications **opt-in** instead of opt-out, for **all users**. The feature is fully kept — users turn notifications back on anytime via the Settings frequency slider.

## Why
PostHog (macOS, 90d): notifications had a **~25% click-through** with high dismiss volume (9,153 sent → 2,438 clicked → 8,928 dismissed). They're the noisiest desktop surface relative to engagement.

## How
The master `notification_frequency` is the single gate (`0 = Off` suppresses all proactive notifications, overriding per-assistant toggles).

- **Client default** `NotificationService.defaultFrequencyLevel`: `3` (Balanced) → `0` (Off) — covers fresh installs.
- **One-time launch migration** (`migrateToOffByDefaultIfNeeded`, called in `applicationDidFinishLaunching`): flips existing users to Off once, persisting to the backend. Guarded by `notificationsOffByDefaultMigrationDone` so anyone who later re-enables is **never re-disabled**.
- **Backend default** `get_notification_settings` frequency `3` → `0` — covers new/unset accounts; an explicit stored value always wins.
- Updated `test_desktop_migration` for the new default.

## Reversibility
Per-user, fully reversible: Settings → notification frequency slider re-enables. Existing explicit choices are reset once (by design — "off by default for all users") and can be re-set.

## Verification
- `xcrun swift build -c debug` ✅ (clean, rebased on latest main)
- Backend default + test updated.
- ⚠️ Runtime suppression not exercised end-to-end (would require triggering a proactive assistant). Logic is the documented `frequency=0 → .infinity interval → drop` path.

## Deploy
- Merging `desktop/**` auto-triggers the desktop release (Codemagic → notarize → Sparkle).
- Python backend (`backend/database/users.py`) deploys separately via `gcp_backend.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)