### PR TITLE
chore(app): dedup $set events by caching last-sent person property

### DIFF
--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -81,6 +81,9 @@ class AnalyticsManager {
       PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
         final adapter = _adapter;
         if (adapter == null) return;
+        // If the SDK silently drops the identify call we must not cache it as
+        // sent — that would suppress every retry once the SDK is ready.
+        if (!adapter.isInitialized) return;
         final uid = _preferences.uid;
         if (uid.isEmpty) return;
         final coerced = <String, Object>{};
@@ -90,16 +93,20 @@ class AnalyticsManager {
         });
         if (coerced.isEmpty) return;
         final fresh = <String, Object>{};
+        final pending = <String, String>{};
         coerced.forEach((k, v) {
           final cacheKey = '$uid:$k';
           final serialized = _serializePersonPropertyValue(v);
           if (_lastSentPersonProperty[cacheKey] == serialized) return;
           fresh[k] = v;
-          _lastSentPersonProperty[cacheKey] = serialized;
-          _persistPersonPropertyCacheEntry(cacheKey, serialized);
+          pending[cacheKey] = serialized;
         });
         if (fresh.isEmpty) return;
         adapter.identify(userId: uid, userProperties: fresh);
+        pending.forEach((cacheKey, serialized) {
+          _lastSentPersonProperty[cacheKey] = serialized;
+          _persistPersonPropertyCacheEntry(cacheKey, serialized);
+        });
       });
 
   static const String _personPropertyCachePrefix = '_ph_lastset_';

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -33,8 +33,6 @@ class AnalyticsManager {
     final adapter = _adapter;
     if (adapter == null) return;
     await PlatformService.executeIfSupportedAsync(PlatformService.isAnalyticsSupported, adapter.init);
-    // Hydrate the person-property dedup cache so the first $set call after
-    // launch can skip when the value hasn't changed across sessions.
     await _loadPersonPropertyCache();
   }
 
@@ -91,13 +89,6 @@ class AnalyticsManager {
           if (c != null) coerced[k] = c;
         });
         if (coerced.isEmpty) return;
-        // Dedup against the last value we sent for this user — every entry in
-        // `properties` would otherwise become a billable `$set` event on the
-        // PostHog side. The high-volume callsites (subscription tier refresh
-        // on every recording, language change, app enable/disable count) fire
-        // these on every state touch even when the value hasn't actually
-        // changed; for those the SDK was sending the same `$set` over and
-        // over for no analytic benefit.
         final fresh = <String, Object>{};
         coerced.forEach((k, v) {
           final cacheKey = '$uid:$k';
@@ -105,23 +96,11 @@ class AnalyticsManager {
           if (_lastSentPersonProperty[cacheKey] == serialized) return;
           fresh[k] = v;
           _lastSentPersonProperty[cacheKey] = serialized;
-          // Fire-and-forget persistence so dedup survives cold launch. A
-          // failure here just means we re-send the property once on next
-          // launch, which is harmless.
           _persistPersonPropertyCacheEntry(cacheKey, serialized);
         });
         if (fresh.isEmpty) return;
         adapter.identify(userId: uid, userProperties: fresh);
       });
-
-  // ---- $set dedup cache ----
-  //
-  // PostHog charges per ingested event, and the `$set` event the SDK fires for
-  // every `identify(userId, userProperties)` call is a billable event. We
-  // store the last value we sent for every `<uid>:<property>` pair so a
-  // subsequent call with the same value is a no-op (no SDK call, no event).
-  // The cache is hydrated from SharedPreferences at init() so dedup survives
-  // app restart; writes back are fire-and-forget.
 
   static const String _personPropertyCachePrefix = '_ph_lastset_';
   static final Map<String, String> _lastSentPersonProperty = {};
@@ -137,9 +116,7 @@ class AnalyticsManager {
         if (v == null) continue;
         _lastSentPersonProperty[key.substring(_personPropertyCachePrefix.length)] = v;
       }
-    } catch (_) {
-      // Best-effort hydration.
-    }
+    } catch (_) {}
     _personPropertyCacheLoaded = true;
   }
 
@@ -147,14 +124,10 @@ class AnalyticsManager {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('$_personPropertyCachePrefix$cacheKey', value);
-    } catch (_) {
-      // Persistence is best-effort.
-    }
+    } catch (_) {}
   }
 
-  // Type-tagged serialization so dedup distinguishes `true` from `"true"`,
-  // `1` from `"1"`, etc. — protects against the SDK round-tripping booleans
-  // through string properties on some paths.
+  // Tagged so the bool `true` doesn't collide with the string `"true"`.
   static String _serializePersonPropertyValue(Object value) {
     if (value is bool) return 'b:$value';
     if (value is num) return 'n:$value';
@@ -162,9 +135,6 @@ class AnalyticsManager {
     return 'x:${value.runtimeType}:$value';
   }
 
-  /// Forget the dedup cache so the next call to [_setUserPropertiesBatch]
-  /// re-sends everything. Called on sign-out and user migration where the
-  /// downstream identity changes.
   static Future<void> _clearPersonPropertyCache() async {
     _lastSentPersonProperty.clear();
     _personPropertyCacheLoaded = false;
@@ -192,9 +162,6 @@ class AnalyticsManager {
       if (adapter == null) return;
       adapter.disable();
       adapter.reset();
-      // After reset the SDK forgets its distinct_id, so any cached
-      // last-sent values are stale — wipe them so the next user gets a
-      // fresh full identify on sign-in.
       _clearPersonPropertyCache();
     });
   }
@@ -215,8 +182,6 @@ class AnalyticsManager {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
       final adapter = _adapter;
       if (adapter == null) return;
-      // Distinct_id is changing — drop the dedup cache so the new uid starts
-      // with a clean slate and gets the full property set on next identify.
       _clearPersonPropertyCache();
       adapter.alias(newUserId: newUid);
       adapter.identify(userId: newUid);

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -6,6 +6,7 @@ import 'package:omi/utils/analytics/adapters/posthog_adapter.dart';
 import 'package:omi/utils/analytics/analytics_adapter.dart';
 import 'package:omi/utils/analytics/intercom.dart';
 import 'package:omi/utils/platform/platform_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AnalyticsManager {
   static final AnalyticsManager _instance = AnalyticsManager._internal();
@@ -32,6 +33,9 @@ class AnalyticsManager {
     final adapter = _adapter;
     if (adapter == null) return;
     await PlatformService.executeIfSupportedAsync(PlatformService.isAnalyticsSupported, adapter.init);
+    // Hydrate the person-property dedup cache so the first $set call after
+    // launch can skip when the value hasn't changed across sessions.
+    await _loadPersonPropertyCache();
   }
 
   factory AnalyticsManager() {
@@ -87,8 +91,91 @@ class AnalyticsManager {
           if (c != null) coerced[k] = c;
         });
         if (coerced.isEmpty) return;
-        adapter.identify(userId: uid, userProperties: coerced);
+        // Dedup against the last value we sent for this user — every entry in
+        // `properties` would otherwise become a billable `$set` event on the
+        // PostHog side. The high-volume callsites (subscription tier refresh
+        // on every recording, language change, app enable/disable count) fire
+        // these on every state touch even when the value hasn't actually
+        // changed; for those the SDK was sending the same `$set` over and
+        // over for no analytic benefit.
+        final fresh = <String, Object>{};
+        coerced.forEach((k, v) {
+          final cacheKey = '$uid:$k';
+          final serialized = _serializePersonPropertyValue(v);
+          if (_lastSentPersonProperty[cacheKey] == serialized) return;
+          fresh[k] = v;
+          _lastSentPersonProperty[cacheKey] = serialized;
+          // Fire-and-forget persistence so dedup survives cold launch. A
+          // failure here just means we re-send the property once on next
+          // launch, which is harmless.
+          _persistPersonPropertyCacheEntry(cacheKey, serialized);
+        });
+        if (fresh.isEmpty) return;
+        adapter.identify(userId: uid, userProperties: fresh);
       });
+
+  // ---- $set dedup cache ----
+  //
+  // PostHog charges per ingested event, and the `$set` event the SDK fires for
+  // every `identify(userId, userProperties)` call is a billable event. We
+  // store the last value we sent for every `<uid>:<property>` pair so a
+  // subsequent call with the same value is a no-op (no SDK call, no event).
+  // The cache is hydrated from SharedPreferences at init() so dedup survives
+  // app restart; writes back are fire-and-forget.
+
+  static const String _personPropertyCachePrefix = '_ph_lastset_';
+  static final Map<String, String> _lastSentPersonProperty = {};
+  static bool _personPropertyCacheLoaded = false;
+
+  static Future<void> _loadPersonPropertyCache() async {
+    if (_personPropertyCacheLoaded) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      for (final key in prefs.getKeys()) {
+        if (!key.startsWith(_personPropertyCachePrefix)) continue;
+        final v = prefs.getString(key);
+        if (v == null) continue;
+        _lastSentPersonProperty[key.substring(_personPropertyCachePrefix.length)] = v;
+      }
+    } catch (_) {
+      // Best-effort hydration.
+    }
+    _personPropertyCacheLoaded = true;
+  }
+
+  static Future<void> _persistPersonPropertyCacheEntry(String cacheKey, String value) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('$_personPropertyCachePrefix$cacheKey', value);
+    } catch (_) {
+      // Persistence is best-effort.
+    }
+  }
+
+  // Type-tagged serialization so dedup distinguishes `true` from `"true"`,
+  // `1` from `"1"`, etc. — protects against the SDK round-tripping booleans
+  // through string properties on some paths.
+  static String _serializePersonPropertyValue(Object value) {
+    if (value is bool) return 'b:$value';
+    if (value is num) return 'n:$value';
+    if (value is String) return 's:$value';
+    return 'x:${value.runtimeType}:$value';
+  }
+
+  /// Forget the dedup cache so the next call to [_setUserPropertiesBatch]
+  /// re-sends everything. Called on sign-out and user migration where the
+  /// downstream identity changes.
+  static Future<void> _clearPersonPropertyCache() async {
+    _lastSentPersonProperty.clear();
+    _personPropertyCacheLoaded = false;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final keys = prefs.getKeys().where((k) => k.startsWith(_personPropertyCachePrefix)).toList();
+      for (final k in keys) {
+        await prefs.remove(k);
+      }
+    } catch (_) {}
+  }
 
   void optInTracking() {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
@@ -105,6 +192,10 @@ class AnalyticsManager {
       if (adapter == null) return;
       adapter.disable();
       adapter.reset();
+      // After reset the SDK forgets its distinct_id, so any cached
+      // last-sent values are stale — wipe them so the next user gets a
+      // fresh full identify on sign-in.
+      _clearPersonPropertyCache();
     });
   }
 
@@ -124,6 +215,9 @@ class AnalyticsManager {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
       final adapter = _adapter;
       if (adapter == null) return;
+      // Distinct_id is changing — drop the dedup cache so the new uid starts
+      // with a clean slate and gets the full property set on next identify.
+      _clearPersonPropertyCache();
       adapter.alias(newUserId: newUid);
       adapter.identify(userId: newUid);
       setNameAndEmail();


### PR DESCRIPTION
## Summary

`$set` is the single biggest event family on our PostHog bill (~2M/mo, 100% mobile-side per a quick MCP query: `posthog-flutter` + `posthog-ios`). Root cause is structural: every call to `_setUserPropertiesBatch` in `analytics_manager.dart` routed through `adapter.identify(userId, userProperties)`, which fires one billable `$set` per call — even when the value hadn't actually changed.

The high-volume offenders aren't user-driven:

- `setSubscriptionTier` runs on every `fetchSubscription()` — and `CaptureProvider` calls that after every recording.
- `Primary Language` fires on every locale check from `HomeProvider`.
- `Apps Enabled Count` fires on every `appEnabled` / `appDisabled`.
- `setPeopleValues` ships 8 properties in one batch but reruns on every `identify()` (app launch, sign-in, etc.), re-sending the same values.

So a typical session was generating dozens of redundant `$set` events with no analytic benefit.

## Fix

Add a per-property dedup cache keyed by `<uid>:<property_name>`:

- **In-memory** Map of last-sent values for fast hot-path checks.
- **SharedPreferences-backed**, hydrated once at `AnalyticsManager.init()`, so dedup survives cold launch (otherwise every app launch would re-send the same 10 properties).
- Inside `_setUserPropertiesBatch`, filter `properties` against the cache; drop entries whose value matches. If the filtered set is empty, skip the SDK call entirely (no `$set` event fires).
- On sign-out (`optOutTracking`) and user migration (`migrateUser`), wipe the cache so the next identity gets a clean full identify.

Value serialization is type-tagged (`b:`/`n:`/`s:`/`x:`) so dedup distinguishes the bool `true` from the string `"true"` — important because the SDK round-trips some bools through string fields.

## Projected savings

`$set` last 7 days from PostHog:

| Library | Events |
|---|---|
| `posthog-flutter` | ~205k |
| `posthog-ios` | ~7k |

Projected monthly: ~1.9M `$set` events. After dedup we expect to drop to roughly **50–100k/mo** (only genuine property changes survive). That's ~**1.8M events/mo killed**, ~**$150/mo** off the PostHog bill at our current tier.

## Risk

Low. The data still propagates — the first call after a value change still fires the SDK identify; we only silence no-op repeats. Edge cases handled:

- **First launch with no cache** → behaves as before (full identify on every call) until cache hydrates within milliseconds.
- **Sign-out + sign-in** → cache cleared, full identify on next call.
- **User migration (alias)** → cache cleared.
- **SharedPreferences read/write failure** → falls through to "no dedup", same behavior as today.

## Test plan

- [ ] Smoke test mobile dev build: sign in, confirm `setPeopleValues` fires once at startup, then dedups on subsequent identify calls
- [ ] Confirm `setSubscriptionTier` only fires `$set` once per session unless the plan actually changes
- [ ] Sign out → sign back in: confirm cache is reset and full identify fires
- [ ] On PostHog dashboard, verify `$set` volume drops to near-zero within 24h of release