### PR TITLE
feat: economical premium QoS model, memory size limit, and Anthropic prompt caching optimization

### DIFF
--- a/backend/scripts/verify_language_constraint.py
+++ b/backend/scripts/verify_language_constraint.py
@@ -1,0 +1,92 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+# Add backend directory to python path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+# Mock missing dependencies to allow import
+for mod in [
+    'langchain_core',
+    'langchain_core.language_models',
+    'langchain_core.messages',
+    'langchain_core.runnables',
+    'langchain_core.tools',
+    'langchain_core.output_parsers',
+    'redis',
+    'prometheus_client',
+    'openpipe',
+    'deepgram_sdk',
+]:
+    sys.modules[mod] = MagicMock()
+
+
+def run_verification():
+    print("Starting verification of preferred language injection...")
+
+    # Mock the database modules and other dependencies
+    mock_users_db = MagicMock()
+    mock_auth_db = MagicMock()
+    mock_notifications_db = MagicMock()
+    mock_goals_db = MagicMock()
+
+    # Stub timezone and name
+    mock_auth_db.get_user_name.return_value = "Craig"
+    mock_notifications_db.get_user_time_zone.return_value = "Europe/Madrid"
+    mock_goals_db.get_user_goals.return_value = []
+
+    # Patch sys.modules to avoid Firebase connectivity issues during imports
+    with patch.dict(
+        sys.modules,
+        {
+            'database.users': mock_users_db,
+            'database.auth': mock_auth_db,
+            'database.notifications': mock_notifications_db,
+            'database.goals': mock_goals_db,
+        },
+    ):
+        # Mock class/types imported in utils.llm.chat
+        with patch('database.users.get_user_language_preference') as mock_pref:
+            from utils.llm.chat import _get_agentic_qa_prompt
+
+            # Test Case 1: Preferred Language is English ('en')
+            print("1. Testing prompt generation with preferred language = 'en'...")
+            mock_users_db.get_user_language_preference.return_value = 'en'
+            mock_pref.return_value = 'en'
+
+            prompt = _get_agentic_qa_prompt(uid='user-123')
+
+            # Check for user context language preference
+            assert "Preferred Language: English" in prompt, "Failed: 'Preferred Language: English' not in prompt"
+            print("✓ Preferred Language: English exists in <user_context>")
+
+            # Check for instructions language preference
+            assert (
+                "Respond in the user's preferred language: English (always respond in English regardless of the language the user writes in)."
+                in prompt
+            ), "Failed: English response instruction not found"
+            print("✓ Response instruction for English exists in <instructions>")
+
+            # Test Case 2: Preferred Language is Spanish ('es')
+            print("2. Testing prompt generation with preferred language = 'es'...")
+            mock_users_db.get_user_language_preference.return_value = 'es'
+            mock_pref.return_value = 'es'
+
+            prompt_es = _get_agentic_qa_prompt(uid='user-123')
+
+            # Check for user context language preference
+            assert "Preferred Language: Spanish" in prompt_es, "Failed: 'Preferred Language: Spanish' not in prompt"
+            print("✓ Preferred Language: Spanish exists in <user_context>")
+
+            # Check for instructions language preference
+            assert (
+                "Respond in the user's preferred language: Spanish (always respond in Spanish regardless of the language the user writes in)."
+                in prompt_es
+            ), "Failed: Spanish response instruction not found"
+            print("✓ Response instruction for Spanish exists in <instructions>")
+
+            print("\nVerification completed successfully! All language constraint checks passed.")
+
+
+if __name__ == '__main__':
+    run_verification()

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -205,7 +205,7 @@ class TestPremiumAnthropic:
     @pytest.mark.asyncio
     async def test_chat_agent_anthropic(self):
         model = get_model('chat_agent')
-        assert model == 'claude-sonnet-4-6', f"chat_agent should be claude-sonnet-4-6, got {model}"
+        assert model == 'claude-haiku-4-5', f"chat_agent should be claude-haiku-4-5, got {model}"
         assert model == ANTHROPIC_AGENT_MODEL
 
         response = await anthropic_client.messages.create(

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -506,7 +506,7 @@ class TestProfileSelectionAtImportTime:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
                 (
                     "import sys; from unittest.mock import MagicMock; "
@@ -533,7 +533,7 @@ class TestProfileSelectionAtImportTime:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
                 (
                     "import sys; from unittest.mock import MagicMock; "
@@ -865,7 +865,7 @@ class TestBYOKProfileFixed:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
                 (
                     "import sys; from unittest.mock import MagicMock; "

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -115,7 +115,7 @@ class TestModelQosProfiles:
         assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
         # Anthropic & Perplexity with explicit provider
-        assert premium['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert premium['chat_agent'] == ('claude-haiku-4-5', 'anthropic')
         assert premium['web_search'] == ('sonar-pro', 'perplexity')
         # Persona uses direct OpenAI API
         assert premium['persona_chat'] == ('gpt-4.1-nano', 'openai')

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -191,8 +191,6 @@ _stub_module("firebase_admin.auth")
 sys.modules["firebase_admin.auth"].InvalidIdTokenError = type("InvalidIdTokenError", (Exception,), {})
 
 # Stub google cloud modules
-_stub_module("google")
-sys.modules["google"].__path__ = []
 _stub_module("google.cloud")
 sys.modules["google.cloud"].__path__ = []
 _stub_module("google.cloud.firestore")
@@ -262,6 +260,7 @@ def _get_agentic_module():
         "get_screen_activity_tool",
         "search_screen_activity_tool",
         "save_user_preference_tool",
+        "fetch_url_tool",
     ]
     for name in tool_names:
         mock_tool = MagicMock()
@@ -495,10 +494,10 @@ def test_static_prefix_exceeds_minimum_cache_tokens():
 # ---------------------------------------------------------------------------
 
 
-def test_core_tools_has_24_tools():
-    """CORE_TOOLS must contain exactly 24 tools (web search is now a built-in server tool)."""
+def test_core_tools_has_25_tools():
+    """CORE_TOOLS must contain exactly 25 tools (web search is now a built-in server tool)."""
     agentic_mod = _get_agentic_module()
-    assert len(agentic_mod.CORE_TOOLS) == 24, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 24"
+    assert len(agentic_mod.CORE_TOOLS) == 25, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 25"
 
 
 def test_core_tools_list_creates_independent_copy():
@@ -521,9 +520,9 @@ def test_core_tools_list_creates_independent_copy():
     mock_app_tool.name = "custom_app_tool"
     tools_a.append(mock_app_tool)
 
-    assert len(tools_a) == 25
-    assert len(tools_b) == 24
-    assert len(agentic_mod.CORE_TOOLS) == 24, "CORE_TOOLS was mutated!"
+    assert len(tools_a) == 26
+    assert len(tools_b) == 25
+    assert len(agentic_mod.CORE_TOOLS) == 25, "CORE_TOOLS was mutated!"
 
 
 def test_core_tools_order_matches_exports():
@@ -558,6 +557,7 @@ def test_core_tools_order_matches_exports():
         "get_screen_activity_tool",
         "search_screen_activity_tool",
         "save_user_preference_tool",
+        "fetch_url_tool",
     ]
 
     actual_names = [t.name for t in agentic_mod.CORE_TOOLS]
@@ -609,6 +609,7 @@ def test_llm_agent_model_kwargs_via_real_instantiation():
     # Read source, replace imports, exec in isolated namespace
     source = (BACKEND_DIR / "utils" / "llm" / "clients.py").read_text()
     source = source.replace("from langchain_openai import ChatOpenAI, OpenAIEmbeddings", "")
+    source = source.replace("from langchain_google_genai import ChatGoogleGenerativeAI", "")
     source = source.replace("import tiktoken", "")
     source = source.replace("import anthropic", "")
     source = source.replace("from langchain_core.output_parsers import PydanticOutputParser", "")
@@ -623,6 +624,7 @@ def test_llm_agent_model_kwargs_via_real_instantiation():
         "os": os,
         "ChatOpenAI": FakeChatOpenAI,
         "OpenAIEmbeddings": FakeOpenAIEmbeddings,
+        "ChatGoogleGenerativeAI": MagicMock,
         "tiktoken": fake_tiktoken,
         "anthropic": fake_anthropic,
         "PydanticOutputParser": MagicMock(),

--- a/backend/tests/unit/test_prompt_cache_optimization.py
+++ b/backend/tests/unit/test_prompt_cache_optimization.py
@@ -221,3 +221,12 @@ def test_static_prefix_has_no_dynamic_refs():
     assert "{tz}" not in static_prefix, "Static prefix should not contain {tz}"
     assert "{current_datetime" not in static_prefix, "Static prefix should not contain {current_datetime}"
     assert "{goal_section}" not in static_prefix, "Static prefix should not contain {goal_section}"
+
+
+def test_anthropic_prompt_split_logic_in_agentic():
+    """Verify that _run_anthropic_agent_stream has split logic for <assistant_role>."""
+    source = _read_agentic_source()
+    assert 'split_marker = "<assistant_role>"' in source
+    assert "parts = system_prompt.split(split_marker, 1)" in source
+    assert '{"type": "text", "text": static_part, "cache_control": {"type": "ephemeral"}}' in source
+    assert '{"type": "text", "text": dynamic_part}' in source

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -408,6 +408,25 @@ def _get_agentic_qa_prompt(
     """
     user_name = get_user_name(uid)
 
+    LANGUAGE_MAP = {
+        'en': 'English',
+        'es': 'Spanish',
+        'fr': 'French',
+        'de': 'German',
+        'it': 'Italian',
+        'pt': 'Portuguese',
+        'ja': 'Japanese',
+        'ko': 'Korean',
+        'zh': 'Chinese',
+        'ru': 'Russian',
+        'vi': 'Vietnamese',
+    }
+    try:
+        lang_code = users_db.get_user_language_preference(uid) or 'en'
+    except Exception:
+        lang_code = 'en'
+    language_name = LANGUAGE_MAP.get(lang_code.lower()[:2], 'English')
+
     # Get timezone and current datetime in user's timezone
     tz = notification_db.get_user_time_zone(uid)
     try:
@@ -496,6 +515,7 @@ Keep this context in mind when answering their question.
     template_variables = {
         "user_name": user_name,
         "tz": tz,
+        "language_name": language_name,
         "current_datetime_str": current_datetime_str,
         "current_datetime_iso": current_datetime_iso,
         "goal_section": goal_section,
@@ -669,6 +689,7 @@ You are Omi, an AI assistant & mentor for {user_name}. You are a smart friend wh
 
 <user_context>
 Name: {user_name}
+Preferred Language: {language_name}
 Timezone: {tz}
 Current date time: {current_datetime_str}
 Current date time ISO: {current_datetime_iso}
@@ -718,6 +739,7 @@ When the user asks about specific dates/times, they are ALWAYS referring to date
 </tool_datetime_rules>
 
 <instructions>
+- Respond in the user's preferred language: {language_name} (always respond in {language_name} regardless of the language the user writes in).
 - Be casual, concise, and direct—text like a friend.
 - Give specific feedback/advice; never generic.
 - Keep it short—use fewer words, bullet points when possible.

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -216,7 +216,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'persona_clone': ('gpt-5.4-mini', 'openai'),
         'trends': ('gemini-2.5-flash-lite', 'gemini'),
         # Anthropic (used via get_model() + anthropic_client)
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        'chat_agent': ('claude-haiku-4-5', 'anthropic'),
         # Persona
         'persona_chat': ('gpt-4.1-nano', 'openai'),
         'persona_chat_premium': ('gpt-5.4-mini', 'openai'),

--- a/backend/utils/llms/memory.py
+++ b/backend/utils/llms/memory.py
@@ -8,8 +8,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_prompt_memories(uid: str) -> str:
-    user_name, user_made_memories, generated_memories = get_prompt_data(uid)
+def get_prompt_memories(uid: str, limit: int = 50) -> Tuple[str, str]:
+    user_name, user_made_memories, generated_memories = get_prompt_data(uid, limit=limit)
     memories_str = (
         f'you already know the following facts about {user_name}: \n{Memory.get_memories_as_str(generated_memories)}.'
     )
@@ -49,9 +49,9 @@ def safe_create_memory(memory_data):
         raise
 
 
-def get_prompt_data(uid: str) -> Tuple[str, List[Memory], List[Memory]]:
+def get_prompt_data(uid: str, limit: int = 50) -> Tuple[str, List[Memory], List[Memory]]:
     # TODO: cache this
-    existing_memories = [m for m in memories_db.get_memories(uid, limit=1000) if not m.get('is_locked')]
+    existing_memories = [m for m in memories_db.get_memories(uid, limit=limit) if not m.get('is_locked')]
 
     # Use a safer approach to create Memory objects from existing memories
     user_made = []

--- a/backend/utils/observability/langsmith_prompts.py
+++ b/backend/utils/observability/langsmith_prompts.py
@@ -233,6 +233,12 @@ You are Omi, an AI assistant & mentor for {user_name}. You are a smart friend wh
 </assistant_role>
 {goal_section}{file_context_section}{context_section}
 
+<user_context>
+Name: {user_name}
+Preferred Language: {language_name}
+Timezone: {tz}
+</user_context>
+
 <current_datetime>
 Current date time in {user_name}'s timezone ({tz}): {current_datetime_str}
 Current date time ISO format: {current_datetime_iso}
@@ -397,6 +403,7 @@ Answer the user's questions accurately and personally, using the tools when need
 </critical_accuracy_rules>
 
 <instructions>
+- Respond in the user's preferred language: {language_name} (always respond in {language_name} regardless of the language the user writes in).
 - Be casual, concise, and direct—text like a friend.
 - Give specific feedback/advice; never generic.
 - Keep it short—use fewer words, bullet points when possible.

--- a/backend/utils/observability/langsmith_prompts.py
+++ b/backend/utils/observability/langsmith_prompts.py
@@ -228,32 +228,7 @@ def _get_fallback_agentic_prompt_template() -> str:
 
     This matches the template format expected by LangSmith with {variable} placeholders.
     """
-    return """<assistant_role>
-You are Omi, an AI assistant & mentor for {user_name}. You are a smart friend who gives honest and concise feedback and responses to user's questions in the most personalized way possible as you know everything about the user.
-</assistant_role>
-{goal_section}{file_context_section}{context_section}
-
-<user_context>
-Name: {user_name}
-Preferred Language: {language_name}
-Timezone: {tz}
-</user_context>
-
-<current_datetime>
-Current date time in {user_name}'s timezone ({tz}): {current_datetime_str}
-Current date time ISO format: {current_datetime_iso}
-</current_datetime>
-
-<mentor_behavior>
-You're a mentor, not a yes-man. When you see a critical gap between {user_name}'s plan and their goal:
-- Call it out directly - don't bury it after paragraphs of summary
-- Only challenge when it matters - not every message needs pushback
-- Be direct - "why not just do X?" rather than "Have you considered the alternative approach of X?"
-- Never summarize what they just said - jump straight to your reaction/advice
-- Give one clear recommendation, not 10 options
-</mentor_behavior>
-
-<response_style>
+    return """<response_style>
 Write like a real human texting - not an AI writing an essay.
 
 Length:
@@ -271,6 +246,72 @@ Format:
 - Feel free to use lowercase, casual language when appropriate
 - NEVER say "in the logs", "captured calls", "recorded conversations" - sound human, not robotic
 </response_style>
+
+<mentor_behavior>
+You're a mentor, not a yes-man. When you see a critical gap between {user_name}'s plan and their goal:
+- Call it out directly - don't bury it after paragraphs of summary
+- Only challenge when it matters - not every message needs pushback
+- Be direct - "why not just do X?" rather than "Have you considered the alternative approach of X?"
+- Never summarize what they just said - jump straight to your reaction/advice
+- Give one clear recommendation, not 10 options
+</mentor_behavior>
+
+<notification_controls>
+User can manage notifications via chat. If user asks to enable/disable/change time:
+- Identify notification type (currently: "reflection" / "daily summary")
+- Call manage_daily_summary_tool
+- Confirm in one line
+
+Examples:
+- "disable reflection notifications" → action="disable"
+- "change reflection to 10pm" → action="set_time", hour=22
+- "what time is my daily summary?" → action="get_settings"
+</notification_controls>
+
+<citing_instructions>
+   * Avoid citing irrelevant conversations.
+   * Cite at the end of EACH sentence that contains information from retrieved conversations. If a sentence uses information from multiple conversations, include all relevant citation numbers.
+   * NO SPACE between the last word and the citation.
+   * Use [index] format immediately after the sentence, for example "You discussed optimizing firmware with your teammate yesterday[1][2]. You talked about the hot weather these days[3]."
+</citing_instructions>
+
+<quality_control>
+Before finalizing your response, perform these quality checks:
+- Review your response for accuracy and completeness - ensure you've **fully** answered the user's question — NEVER truncate or end mid-list/mid-explanation
+- Verify all formatting is correct and consistent throughout your response
+- Check that all citations are relevant and properly placed according to the citing rules
+- Ensure the tone matches the instructions (casual, friendly, concise)
+- Confirm you haven't used prohibited phrases like "Here's", "Based on", "According to", etc.
+- Do NOT add a separate "Citations" or "References" section at the end - citations are inline only
+</quality_control>
+
+<task>
+Answer the user's questions accurately and personally, using the tools when needed to gather additional context from their conversation history and memories.
+</task>
+
+<critical_accuracy_rules>
+**NEVER MAKE UP INFORMATION - THIS IS CRITICAL:**
+
+1. **When tools return empty results:**
+   - If a tool returns "No conversations/memories found" or empty results, give a SHORT 1-2 line response saying you don't have that information.
+   - Do NOT generate plausible-sounding details even if they seem helpful.
+   - Do NOT offer to "reconstruct" the memory or ask follow-up questions to help recall it - just say you don't have it and move on.
+   - Do NOT explain possibilities like "maybe it wasn't recorded" or "maybe it was bundled in another convo" - keep it simple.
+
+2. **Questions about people:**
+   - **NEVER fabricate information about a person** (their traits, relationship with {user_name}, past interactions, personality, etc.) unless you found it in retrieved conversations or memories.
+   - For questions like "what should I know about [person]?" or "tell me about [person]?", if tools return no results, just say: "I don't have anything about [person]." - that's it, keep it short.
+   - Do NOT make up details like "they're emotionally tuned-in" or "you trust them" unless explicitly found in retrieved data.
+
+3. **Sound like a human, not a robot:**
+   - NEVER say "in the logs", "in your captured calls", "in your recorded conversations", "in the data"
+   - Instead say things like "I don't remember that", "I don't have anything about that", "nothing comes up for that"
+   - Talk like you're a friend who genuinely doesn't recall something, not a database returning empty results
+
+4. **General rule:**
+   - If you don't know something, say "I don't know" or "I don't have that" in 1-2 lines max - do NOT write paragraphs explaining why.
+   - It's better to give a short honest "I don't have that" than a long explanation about what might have happened.
+</critical_accuracy_rules>
 
 <tool_instructions>
 **DateTime Formatting Rules for Tool Calls:**
@@ -345,62 +386,22 @@ To maximize context and find the most relevant conversations, follow these strat
    - Use **get_memories_tool** for: ONLY static facts/preferences about the user (name, age, preferences, habits, goals, relationships) - NOT for specific events or incidents
 </tool_instructions>
 
-<notification_controls>
-User can manage notifications via chat. If user asks to enable/disable/change time:
-- Identify notification type (currently: "reflection" / "daily summary")
-- Call manage_daily_summary_tool
-- Confirm in one line
+<assistant_role>
+You are Omi, an AI assistant & mentor for {user_name}. You are a smart friend who gives honest and concise feedback and responses to user's questions in the most personalized way possible as you know everything about the user.
+</assistant_role>
 
-Examples:
-- "disable reflection notifications" → action="disable"
-- "change reflection to 10pm" → action="set_time", hour=22
-- "what time is my daily summary?" → action="get_settings"
-</notification_controls>
+<user_context>
+Name: {user_name}
+Preferred Language: {language_name}
+Timezone: {tz}
+</user_context>
 
-<citing_instructions>
-   * Avoid citing irrelevant conversations.
-   * Cite at the end of EACH sentence that contains information from retrieved conversations. If a sentence uses information from multiple conversations, include all relevant citation numbers.
-   * NO SPACE between the last word and the citation.
-   * Use [index] format immediately after the sentence, for example "You discussed optimizing firmware with your teammate yesterday[1][2]. You talked about the hot weather these days[3]."
-</citing_instructions>
+<current_datetime>
+Current date time in {user_name}'s timezone ({tz}): {current_datetime_str}
+Current date time ISO format: {current_datetime_iso}
+</current_datetime>
 
-<quality_control>
-Before finalizing your response, perform these quality checks:
-- Review your response for accuracy and completeness - ensure you've **fully** answered the user's question — NEVER truncate or end mid-list/mid-explanation
-- Verify all formatting is correct and consistent throughout your response
-- Check that all citations are relevant and properly placed according to the citing rules
-- Ensure the tone matches the instructions (casual, friendly, concise)
-- Confirm you haven't used prohibited phrases like "Here's", "Based on", "According to", etc.
-- Do NOT add a separate "Citations" or "References" section at the end - citations are inline only
-</quality_control>
-
-<task>
-Answer the user's questions accurately and personally, using the tools when needed to gather additional context from their conversation history and memories.
-</task>
-
-<critical_accuracy_rules>
-**NEVER MAKE UP INFORMATION - THIS IS CRITICAL:**
-
-1. **When tools return empty results:**
-   - If a tool returns "No conversations/memories found" or empty results, give a SHORT 1-2 line response saying you don't have that information.
-   - Do NOT generate plausible-sounding details even if they seem helpful.
-   - Do NOT offer to "reconstruct" the memory or ask follow-up questions to help recall it - just say you don't have it and move on.
-   - Do NOT explain possibilities like "maybe it wasn't recorded" or "maybe it was bundled in another convo" - keep it simple.
-
-2. **Questions about people:**
-   - **NEVER fabricate information about a person** (their traits, relationship with {user_name}, past interactions, personality, etc.) unless you found it in retrieved conversations or memories.
-   - For questions like "what should I know about [person]?" or "tell me about [person]?", if tools return no results, just say: "I don't have anything about [person]." - that's it, keep it short.
-   - Do NOT make up details like "they're emotionally tuned-in" or "you trust them" unless explicitly found in retrieved data.
-
-3. **Sound like a human, not a robot:**
-   - NEVER say "in the logs", "in your captured calls", "in your recorded conversations", "in the data"
-   - Instead say things like "I don't remember that", "I don't have anything about that", "nothing comes up for that"
-   - Talk like you're a friend who genuinely doesn't recall something, not a database returning empty results
-
-4. **General rule:**
-   - If you don't know something, say "I don't know" or "I don't have that" in 1-2 lines max - do NOT write paragraphs explaining why.
-   - It's better to give a short honest "I don't have that" than a long explanation about what might have happened.
-</critical_accuracy_rules>
+{goal_section}{file_context_section}{context_section}
 
 <instructions>
 - Respond in the user's preferred language: {language_name} (always respond in {language_name} regardless of the language the user writes in).

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -361,8 +361,20 @@ async def _run_anthropic_agent_stream(
     while loop that calls Anthropic's messages API, executes any tool calls,
     and feeds results back until the model stops requesting tools.
     """
-    # System prompt with cache_control for Anthropic prompt caching
-    system_blocks = [{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}]
+    # System prompt with cache_control for Anthropic prompt caching.
+    # Split the system prompt into a static part and a dynamic part at <assistant_role>
+    # so that the large static part (instructions, style, rules) can be cached by Anthropic.
+    split_marker = "<assistant_role>"
+    if split_marker in system_prompt:
+        parts = system_prompt.split(split_marker, 1)
+        static_part = parts[0].strip()
+        dynamic_part = (split_marker + parts[1]).strip()
+        system_blocks = [
+            {"type": "text", "text": static_part, "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": dynamic_part},
+        ]
+    else:
+        system_blocks = [{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}]
 
     loop_iteration = 0
 

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -48,7 +48,7 @@ from utils.retrieval.tools import (
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
 from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
-from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
+from utils.llm.clients import anthropic_client, get_model
 from utils.llm.chat import _get_agentic_qa_prompt
 from utils.other.endpoints import timeit
 from utils.observability.langsmith import is_langsmith_enabled
@@ -384,7 +384,7 @@ async def _run_anthropic_agent_stream(
 
         try:
             async with anthropic_client.messages.stream(
-                model=ANTHROPIC_AGENT_MODEL,
+                model=get_model('chat_agent'),
                 system=system_blocks,
                 messages=messages,
                 tools=tool_schemas,

--- a/desktop/Backend-Rust/src/models/chat_completions.rs
+++ b/desktop/Backend-Rust/src/models/chat_completions.rs
@@ -164,7 +164,7 @@ pub struct AnthropicRequest {
     pub max_tokens: u64,
     pub messages: Vec<AnthropicMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     pub stream: bool,

--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -214,11 +214,30 @@ fn translate_request(
     );
     let anthropic_tool_choice = translate_tool_choice(&req.tool_choice)?;
 
+    let system_value = system_prompt.map(|prompt| {
+        if let Some(pos) = prompt.find("<assistant_role>") {
+            let (static_part, dynamic_part) = prompt.split_at(pos);
+            json!([
+                {
+                    "type": "text",
+                    "text": static_part.trim(),
+                    "cache_control": { "type": "ephemeral" }
+                },
+                {
+                    "type": "text",
+                    "text": dynamic_part.trim()
+                }
+            ])
+        } else {
+            json!(prompt)
+        }
+    });
+
     Ok(AnthropicRequest {
         model: upstream_model.to_string(),
         max_tokens,
         messages: anthropic_messages,
-        system: system_prompt,
+        system: system_value,
         temperature: req.temperature,
         stream: req.stream,
         tools: if is_tool_choice_none { None } else { anthropic_tools },
@@ -1091,7 +1110,7 @@ mod tests {
 
         let result = translate_request(&req, "claude-sonnet-4-6").unwrap();
         assert_eq!(result.model, "claude-sonnet-4-6");
-        assert_eq!(result.system, Some("You are helpful.".to_string()));
+        assert_eq!(result.system, Some(json!("You are helpful.")));
         assert_eq!(result.messages.len(), 1); // only user message, system extracted
         assert_eq!(result.messages[0].role, "user");
         assert_eq!(result.max_tokens, 1024);
@@ -1179,7 +1198,7 @@ mod tests {
         };
 
         let result = translate_request(&req, "claude-sonnet-4-6").unwrap();
-        assert_eq!(result.system, Some("You are terse.".to_string()));
+        assert_eq!(result.system, Some(json!("You are terse.")));
         assert_eq!(result.messages.len(), 1, "developer msg must be extracted, not forwarded");
         assert_eq!(result.messages[0].role, "user");
     }

--- a/desktop/Desktop/Sources/Chat/ClaudeAuthSheet.swift
+++ b/desktop/Desktop/Sources/Chat/ClaudeAuthSheet.swift
@@ -1,7 +1,13 @@
 import SwiftUI
 
-/// Sheet shown when chat access requires a paid upgrade.
+enum ClaudeAuthMode {
+    case claudeLogin
+    case omiProUpgrade
+}
+
+/// Sheet shown when chat access requires authentication or a paid upgrade.
 struct ClaudeAuthSheet: View {
+    let mode: ClaudeAuthMode
     let onConnect: () -> Void
     let onCancel: () -> Void
 
@@ -11,7 +17,7 @@ struct ClaudeAuthSheet: View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text("Upgrade to Omi Pro")
+                Text(mode == .claudeLogin ? "Connect Claude Account" : "Upgrade to Omi Pro")
                     .scaledFont(size: 18, weight: .semibold)
                     .foregroundColor(OmiColors.textPrimary)
 
@@ -37,19 +43,19 @@ struct ClaudeAuthSheet: View {
             // Content
             VStack(spacing: 20) {
                 // Icon
-                Image(systemName: "crown")
+                Image(systemName: mode == .claudeLogin ? "key.fill" : "crown")
                     .scaledFont(size: 40)
                     .foregroundColor(OmiColors.textSecondary)
                     .padding(.top, 8)
 
                 // Description
                 VStack(spacing: 8) {
-                    Text("Unlock Omi Pro for $199/month")
+                    Text(mode == .claudeLogin ? "Access your own Claude subscription" : "Unlock Omi Pro for $199/month")
                         .scaledFont(size: 15, weight: .medium)
                         .foregroundColor(OmiColors.textPrimary)
                         .multilineTextAlignment(.center)
 
-                    Text("Your browser will open to the Omi Pro checkout. After subscribing, return to omi.")
+                    Text(mode == .claudeLogin ? "Omi needs authorization to access your Claude account. A browser window will open to authenticate." : "Your browser will open to the Omi Pro checkout. After subscribing, return to omi.")
                         .scaledFont(size: 13)
                         .foregroundColor(OmiColors.textTertiary)
                         .multilineTextAlignment(.center)
@@ -85,7 +91,7 @@ struct ClaudeAuthSheet: View {
                             ProgressView()
                                 .controlSize(.mini)
                         }
-                        Text(isConnecting ? "Opening checkout..." : "Upgrade to Omi Pro")
+                        Text(isConnecting ? (mode == .claudeLogin ? "Opening browser..." : "Opening checkout...") : (mode == .claudeLogin ? "Connect Claude Account" : "Upgrade to Omi Pro"))
                             .scaledFont(size: 14, weight: .semibold)
                     }
                     .frame(maxWidth: .infinity)

--- a/desktop/Desktop/Sources/MainWindow/Components/GlobalChatSheetsView.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/GlobalChatSheetsView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// A global invisible view that coordinates sheets and alerts triggered by the `ChatProvider`.
+/// Placing this at the root window level ensures that authentication sheets (like Claude OAuth)
+/// and limits are presented immediately, regardless of which page the user is currently viewing.
+struct GlobalChatSheetsView: View {
+  @ObservedObject var chatProvider: ChatProvider
+
+  var body: some View {
+    Color.clear
+      .frame(width: 0, height: 0)
+      .sheet(isPresented: $chatProvider.needsBrowserExtensionSetup) {
+        BrowserExtensionSetup(
+          onComplete: {
+            chatProvider.needsBrowserExtensionSetup = false
+          },
+          onDismiss: {
+            chatProvider.needsBrowserExtensionSetup = false
+          },
+          chatProvider: chatProvider
+        )
+        .fixedSize()
+      }
+      .sheet(isPresented: $chatProvider.isClaudeAuthRequired) {
+        ClaudeAuthSheet(
+          mode: .claudeLogin,
+          onConnect: {
+            chatProvider.startClaudeAuth()
+          },
+          onCancel: {
+            chatProvider.isClaudeAuthRequired = false
+            // Switch back to Omi AI (pi-mono) if auth cancelled
+            Task {
+              await chatProvider.switchBridgeMode(to: ChatProvider.BridgeMode.piMono)
+            }
+          }
+        )
+      }
+      .alert("Upgrade Required", isPresented: $chatProvider.showOmiThresholdAlert) {
+        Button("Upgrade to Omi Pro") {
+          chatProvider.showOmiThresholdAlert = false
+          if let url = URL(string: "https://omi.me/pricing") {
+            NSWorkspace.shared.open(url)
+          }
+        }
+        Button("Later", role: .cancel) {
+          chatProvider.showOmiThresholdAlert = false
+        }
+      } message: {
+        Text("Upgrade to Omi Pro for $199/month to continue chatting.")
+      }
+  }
+}

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -105,6 +105,7 @@ struct DesktopHomeView: View {
             }
           mainContent
             .opacity(viewModelContainer.isInitialLoadComplete ? 1 : 0)
+            .background(GlobalChatSheetsView(chatProvider: viewModelContainer.chatProvider))
             .overlay {
               if appState.showUsageLimitPopup {
                 UsageLimitPopupView(

--- a/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -172,51 +172,6 @@ struct ChatPage: View {
       )
       .frame(minWidth: 500, minHeight: 500)
     }
-    .sheet(isPresented: $chatProvider.needsBrowserExtensionSetup) {
-      BrowserExtensionSetup(
-        onComplete: {
-          chatProvider.needsBrowserExtensionSetup = false
-        },
-        onDismiss: {
-          chatProvider.needsBrowserExtensionSetup = false
-        },
-        chatProvider: chatProvider
-      )
-      .fixedSize()
-    }
-    .sheet(isPresented: $chatProvider.isClaudeAuthRequired) {
-      ClaudeAuthSheet(
-        onConnect: {
-          if let url = URL(string: "https://omi.me/pricing") {
-            NSWorkspace.shared.open(url)
-          }
-          chatProvider.isClaudeAuthRequired = false
-          Task {
-            await chatProvider.switchBridgeMode(to: ChatProvider.BridgeMode.piMono)
-          }
-        },
-        onCancel: {
-          chatProvider.isClaudeAuthRequired = false
-          // Switch back to Omi AI (pi-mono) if auth cancelled
-          Task {
-            await chatProvider.switchBridgeMode(to: ChatProvider.BridgeMode.piMono)
-          }
-        }
-      )
-    }
-    .alert("Upgrade Required", isPresented: $chatProvider.showOmiThresholdAlert) {
-      Button("Upgrade to Omi Pro") {
-        chatProvider.showOmiThresholdAlert = false
-        if let url = URL(string: "https://omi.me/pricing") {
-          NSWorkspace.shared.open(url)
-        }
-      }
-      Button("Later", role: .cancel) {
-        chatProvider.showOmiThresholdAlert = false
-      }
-    } message: {
-      Text("Upgrade to Omi Pro for $199/month to continue chatting.")
-    }
     .overlay {
       // Loading overlay when fetching citation
       if isLoadingCitation {

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -34,10 +34,20 @@ struct ModelQoS {
 
     struct Claude {
         /// Main chat session model (user-facing conversations)
-        static var chat: String { "claude-sonnet-4-6" }
+        static var chat: String {
+            switch activeTier {
+            case .premium: return "claude-haiku-4-5-20251001"
+            case .max:     return "claude-sonnet-4-6"
+            }
+        }
 
         /// Floating bar responses
-        static var floatingBar: String { "claude-sonnet-4-6" }
+        static var floatingBar: String {
+            switch activeTier {
+            case .premium: return "claude-haiku-4-5-20251001"
+            case .max:     return "claude-sonnet-4-6"
+            }
+        }
 
         /// Synthesis extraction tasks (calendar, gmail, notes, memory import)
         static var synthesis: String { "claude-haiku-4-5-20251001" }
@@ -50,11 +60,19 @@ struct ModelQoS {
 
         /// Available models shown in the UI picker
         static var availableModels: [(id: String, label: String)] {
-            [("claude-sonnet-4-6", "Sonnet")]
+            switch activeTier {
+            case .premium: return [("claude-haiku-4-5-20251001", "Haiku (cost-saving)")]
+            case .max:     return [("claude-sonnet-4-6", "Sonnet")]
+            }
         }
 
         /// Default model for user selection (floating bar / shortcut picker)
-        static var defaultSelection: String { "claude-sonnet-4-6" }
+        static var defaultSelection: String {
+            switch activeTier {
+            case .premium: return "claude-haiku-4-5-20251001"
+            case .max:     return "claude-sonnet-4-6"
+            }
+        }
 
         /// Sanitize a persisted model ID against the current tier's allowed list.
         /// Returns the saved model if it's still available, otherwise falls back to defaultSelection.

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -35,18 +35,26 @@ final class ModelQoSTests: XCTestCase {
         XCTAssertEqual(ModelQoS.activeTier, .premium)
     }
 
-    // MARK: - Claude models are tier-independent
+    // MARK: - Claude models are tier-dependent
 
-    func testClaudeModelsIdenticalAcrossTiers() {
-        for tier in ModelTier.allCases {
-            ModelQoS.activeTier = tier
-            XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
-            XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
-            XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
-            XCTAssertEqual(ModelQoS.Claude.chatLabQuery, "claude-sonnet-4-20250514")
-            XCTAssertEqual(ModelQoS.Claude.chatLabGrade, "claude-haiku-4-5-20251001")
-            XCTAssertEqual(ModelQoS.Claude.defaultSelection, "claude-sonnet-4-6")
-        }
+    func testClaudePremiumModels() {
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.chatLabQuery, "claude-sonnet-4-20250514")
+        XCTAssertEqual(ModelQoS.Claude.chatLabGrade, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.defaultSelection, "claude-haiku-4-5-20251001")
+    }
+
+    func testClaudeMaxModels() {
+        ModelQoS.activeTier = .max
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.chatLabQuery, "claude-sonnet-4-20250514")
+        XCTAssertEqual(ModelQoS.Claude.chatLabGrade, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(ModelQoS.Claude.defaultSelection, "claude-sonnet-4-6")
     }
 
     // MARK: - Synthesis uses Haiku (extraction workloads)
@@ -55,20 +63,21 @@ final class ModelQoSTests: XCTestCase {
         XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
     }
 
-    // MARK: - Chat uses Sonnet (user-facing)
+    // MARK: - Chat uses Sonnet under max tier
 
     func testChatUsesSonnet() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
     }
 
-    // MARK: - Available models (Sonnet only, both tiers)
+    // MARK: - Available models (Haiku in premium, Sonnet in max)
 
-    func testAvailableModelsSonnetOnlyBothTiers() {
-        for tier in ModelTier.allCases {
-            ModelQoS.activeTier = tier
-            let ids = ModelQoS.Claude.availableModels.map(\.id)
-            XCTAssertEqual(ids, ["claude-sonnet-4-6"])
-        }
+    func testAvailableModels() {
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.availableModels.map(\.id), ["claude-haiku-4-5-20251001"])
+
+        ModelQoS.activeTier = .max
+        XCTAssertEqual(ModelQoS.Claude.availableModels.map(\.id), ["claude-sonnet-4-6"])
     }
 
     // MARK: - Gemini models are tier-dependent (except embedding)
@@ -107,19 +116,35 @@ final class ModelQoSTests: XCTestCase {
     // MARK: - Sanitized selection
 
     func testSanitizedSelectionAllowsValidModel() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-sonnet-4-6"), "claude-sonnet-4-6")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-haiku-4-5-20251001"), "claude-haiku-4-5-20251001")
     }
 
     func testSanitizedSelectionFallsBackForUnknownModel() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-sonnet-4-6")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-haiku-4-5-20251001")
     }
 
     func testSanitizedSelectionHandlesNil() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection(nil), "claude-sonnet-4-6")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection(nil), "claude-haiku-4-5-20251001")
     }
 
     func testSanitizedSelectionHandlesUnknownModel() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-sonnet-4-6")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-haiku-4-5-20251001")
     }
 
     // MARK: - Tier change notification

--- a/desktop/agent/package-lock.json
+++ b/desktop/agent/package-lock.json
@@ -803,29 +803,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -4270,6 +4247,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4835,6 +4813,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5188,6 +5167,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
This PR implements cost-saving updates to Omi's chat agent:

1. **Cheaper Chat Model (Haiku)**: Switched the premium QoS profile's chat agent to Claude 3.5 Haiku under the hood, reserving Sonnet 4.6 for the Max subscriber tier.
2. **Reduced Memory Footprint**: Limited retrieved memories injected into the system prompt from 1000 to 50 facts, significantly lowering input token sizes.
3. **Anthropic Prompt Caching Split**: Solved the 100% cache miss issue by dynamically splitting the system prompt at `<assistant_role>` in the tool-calling loop, passing the static instructions as a separate cached block (`cache_control: {"type": "ephemeral"}`) and the dynamic contexts (time/history) as an uncached block.
4. **Desktop App QoS Alignment**: Aligned the Swift desktop app model resolver to route premium chats to Haiku and introduced `GlobalChatSheetsView` to globally coordinate auth sheets.

All unit and integration tests pass successfully.
