### PR TITLE
fix(backend): convert action item due dates from local time to UTC

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -16,6 +16,7 @@ import sys
 import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -464,8 +465,8 @@ class TestExtractActionItemsPostValidation:
             )
 
         invoke_args = mock_chain.invoke.call_args[0][0]
-        assert 'current_time' in invoke_args, "Must pass current_time to prompt"
-        assert 'started_at' in invoke_args, "Must still pass started_at"
+        assert 'current_time_local' in invoke_args, "Must pass current_time (local) to prompt"
+        assert 'started_at_local' in invoke_args, "Must still pass started_at (local)"
 
     def test_preserves_none_due_dates(self):
         """Action items with no due date should remain unchanged."""
@@ -552,3 +553,79 @@ class TestExtractActionItemsPostValidation:
         assert len(result) == 1
         # At exact boundary, strict < means it should NOT be cleared
         assert result[0].due_at is not None
+
+
+class TestActionItemTimezoneConversion:
+    """#7059: the LLM emits naive LOCAL due dates; the server must convert them to UTC in Python."""
+
+    def _run(self, due_at, tz):
+        from models.structured import ActionItem, ActionItemsExtraction
+
+        mock_response = ActionItemsExtraction(action_items=[ActionItem(description="Task", due_at=due_at)])
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = mock_response
+        mock_chain.__or__ = MagicMock(return_value=mock_chain)
+
+        conv_proc = sys.modules.get("utils.llm.conversation_processing")
+        if conv_proc is None:
+            conv_proc = _load_module_from_file(
+                "utils.llm.conversation_processing",
+                BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
+            )
+
+        mock_llm = MagicMock()
+        mock_llm.bind.return_value = mock_llm
+        mock_llm.__or__ = MagicMock(return_value=mock_chain)
+        with patch.object(conv_proc, 'get_llm', return_value=mock_llm), patch.object(
+            conv_proc, 'PydanticOutputParser'
+        ) as mock_parser_cls, patch.object(conv_proc, 'ChatPromptTemplate') as mock_prompt_cls:
+            mock_parser = MagicMock()
+            mock_parser.get_format_instructions.return_value = "format"
+            mock_parser_cls.return_value = mock_parser
+            mock_prompt = MagicMock()
+            mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+            mock_prompt_cls.from_messages.return_value = mock_prompt
+            result = conv_proc.extract_action_items(
+                transcript="t",
+                started_at=datetime.now(timezone.utc),
+                language_code="en",
+                tz=tz,
+            )
+        return result, mock_chain
+
+    def test_naive_local_due_converted_to_utc_for_ist(self):
+        # LLM emits naive local 10:00 IST tomorrow -> server stores 04:30 UTC (the #7059 bug).
+        naive_local = (datetime.now(timezone.utc).astimezone(ZoneInfo("Asia/Kolkata")) + timedelta(days=1)).replace(
+            hour=10, minute=0, second=0, microsecond=0, tzinfo=None
+        )
+        result, _ = self._run(naive_local, tz="Asia/Kolkata")
+        assert len(result) == 1 and result[0].due_at is not None
+        due = result[0].due_at
+        assert due.utcoffset() == timedelta(0)  # stored as UTC
+        assert (due.hour, due.minute) == (4, 30)  # 10:00 IST == 04:30 UTC
+
+    def test_utc_tz_no_shift(self):
+        naive_local = (datetime.now(timezone.utc) + timedelta(days=1)).replace(
+            hour=15, minute=0, second=0, microsecond=0, tzinfo=None
+        )
+        result, _ = self._run(naive_local, tz="UTC")
+        due = result[0].due_at
+        assert due.utcoffset() == timedelta(0)
+        assert (due.hour, due.minute) == (15, 0)  # no shift for UTC
+
+    def test_invalid_tz_falls_back_to_utc_without_crashing(self):
+        naive_local = (datetime.now(timezone.utc) + timedelta(days=1)).replace(
+            hour=9, minute=0, second=0, microsecond=0, tzinfo=None
+        )
+        result, _ = self._run(naive_local, tz="Not/AZone")
+        due = result[0].due_at
+        assert due is not None and due.utcoffset() == timedelta(0)
+        assert (due.hour, due.minute) == (9, 0)  # treated as UTC on fallback
+
+    def test_passes_local_reference_times_to_prompt(self):
+        naive_local = (datetime.now(timezone.utc) + timedelta(days=1)).replace(microsecond=0, tzinfo=None)
+        _, mock_chain = self._run(naive_local, tz="Asia/Kolkata")
+        invoke_args = mock_chain.invoke.call_args[0][0]
+        assert 'started_at_local' in invoke_args and 'current_time_local' in invoke_args
+        ct = invoke_args['current_time_local']
+        assert 'Z' not in ct and '+' not in ct  # naive local string, no offset/suffix

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -629,3 +629,20 @@ class TestActionItemTimezoneConversion:
         assert 'started_at_local' in invoke_args and 'current_time_local' in invoke_args
         ct = invoke_args['current_time_local']
         assert 'Z' not in ct and '+' not in ct  # naive local string, no offset/suffix
+
+    def test_aware_datetime_is_normalized_to_utc(self):
+        # Regression guard for the else-branch: if the LLM ignores the prompt and emits a tz-aware
+        # value, it must be normalized to UTC (not shifted again, not trusted at a non-UTC offset).
+        base = datetime.now(timezone.utc) + timedelta(days=1)
+        # (a) already-UTC aware value stays UTC unchanged
+        aware_utc = base.replace(hour=4, minute=30, second=0, microsecond=0)
+        r1, _ = self._run(aware_utc, tz="Asia/Kolkata")
+        d1 = r1[0].due_at
+        assert d1 is not None and d1.utcoffset() == timedelta(0)
+        assert (d1.hour, d1.minute) == (4, 30)
+        # (b) aware +05:30 value is converted to UTC, not trusted as-is
+        aware_ist = base.replace(hour=10, minute=0, second=0, microsecond=0, tzinfo=ZoneInfo("Asia/Kolkata"))
+        r2, _ = self._run(aware_ist, tz="UTC")
+        d2 = r2[0].due_at
+        assert d2 is not None and d2.utcoffset() == timedelta(0)
+        assert (d2.hour, d2.minute) == (4, 30)  # 10:00 IST -> 04:30 UTC

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from typing import List, Optional, Tuple
 
 from langchain_core.output_parsers import PydanticOutputParser
@@ -510,19 +511,19 @@ def extract_action_items(
     • Order by: due date → urgency → alphabetical
 
     DUE DATE EXTRACTION:
-    All due_at values MUST be future UTC timestamps with 'Z' suffix. NEVER produce a past date.
+    Resolve each due date in the user's LOCAL time. NEVER produce a past date.
 
-    REFERENCE_TIME: If {started_at} is >7 days before {current_time}, use {current_time} (historical reprocessing). Otherwise use {started_at}.
+    REFERENCE_TIME (user's local time): If {started_at_local} is >7 days before {current_time_local}, use {current_time_local} (historical reprocessing). Otherwise use {started_at_local}.
 
     Date resolution: "today" → REFERENCE_TIME date, "tomorrow" → next day, weekday names → next occurrence, "next week" → +7 days.
     Time resolution: "morning" → 9AM, "afternoon" → 2PM, "evening" → 6PM, "noon" → 12PM, "end of day"/"midnight" → 11:59PM, no time → 11:59PM. "urgent"/"ASAP" → 2h from REFERENCE_TIME.
-    Process: resolve date + time in user's timezone ({tz}), convert to UTC with 'Z' suffix, verify it's future relative to {current_time}. If past, omit due_at.
+    Output the resolved value as the user's LOCAL wall-clock time in ISO 8601 with NO timezone suffix or offset (no 'Z', no '+05:30') — the server converts it to UTC. Verify it is in the future relative to REFERENCE_TIME; if past, omit due_at.
 
-    Example: REFERENCE_TIME "2025-10-03T13:25:00Z", tz "Asia/Kolkata": "tomorrow before 10am" → Oct 4 10:00 IST → "2025-10-04T04:30:00Z"
-    Format: UTC with 'Z' suffix only (e.g., "2025-10-04T04:30:00Z"). No timezone offsets like "+05:30".
+    Example: REFERENCE_TIME "2025-10-03T13:25:00", "tomorrow before 10am" → "2025-10-04T10:00:00"
+    Format: naive local ISO 8601, no suffix (e.g., "2025-10-04T10:00:00").
 
-    Conversation started at: {started_at}
-    Current time: {current_time}
+    Conversation started at (local): {started_at_local}
+    Current time (local): {current_time_local}
     User timezone: {tz}
 
     {format_instructions}'''.replace(
@@ -538,6 +539,20 @@ def extract_action_items(
 
     current_time = datetime.now(timezone.utc)
 
+    # Resolve the user's timezone once; fall back to UTC on an invalid/missing tz (and log it).
+    # The LLM emits naive LOCAL wall-clock due dates (see prompt); we convert them to UTC here
+    # deterministically instead of trusting the model to do the timezone math (the cause of #7059).
+    try:
+        user_tz = ZoneInfo(tz) if tz else timezone.utc
+    except Exception:
+        logger.warning(f'Invalid timezone {tz!r} for action item extraction; falling back to UTC')
+        user_tz = timezone.utc
+
+    started_at_local = (started_at if started_at.tzinfo else started_at.replace(tzinfo=timezone.utc)).astimezone(
+        user_tz
+    )
+    current_time_local = current_time.astimezone(user_tz)
+
     try:
         response = chain.invoke(
             {
@@ -545,8 +560,8 @@ def extract_action_items(
                 'format_instructions': action_items_parser.get_format_instructions(),
                 'language_code': language_code,
                 'response_language': response_language,
-                'started_at': started_at.isoformat(),
-                'current_time': current_time.isoformat(),
+                'started_at_local': started_at_local.replace(tzinfo=None).isoformat(),
+                'current_time_local': current_time_local.replace(tzinfo=None).isoformat(),
                 'tz': tz,
                 'existing_items_context': existing_items_context,
             }
@@ -557,12 +572,14 @@ def extract_action_items(
         for action_item in response.action_items or []:
             if action_item.created_at is None:
                 action_item.created_at = now
-            # Post-extraction validation: clear due dates more than 1 day in the past
+            # The LLM returns naive LOCAL time; convert to UTC deterministically (and normalize any
+            # tz-aware value), then clear due dates more than 1 day in the past.
             if action_item.due_at is not None:
-                due_utc = (
-                    action_item.due_at if action_item.due_at.tzinfo else action_item.due_at.replace(tzinfo=timezone.utc)
-                )
-                if due_utc < now - timedelta(days=1):
+                if action_item.due_at.tzinfo is None:
+                    action_item.due_at = action_item.due_at.replace(tzinfo=user_tz).astimezone(timezone.utc)
+                else:
+                    action_item.due_at = action_item.due_at.astimezone(timezone.utc)
+                if action_item.due_at < now - timedelta(days=1):
                     logger.warning(
                         f'Clearing past due_at {action_item.due_at.isoformat()} for action item: {action_item.description}'
                     )

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -562,7 +562,7 @@ def extract_action_items(
                 'response_language': response_language,
                 'started_at_local': started_at_local.replace(tzinfo=None).isoformat(),
                 'current_time_local': current_time_local.replace(tzinfo=None).isoformat(),
-                'tz': tz,
+                'tz': tz or 'UTC',
                 'existing_items_context': existing_items_context,
             }
         )


### PR DESCRIPTION
Fixes #7059
Supersedes the abandoned #7066.

## Summary

Action item due dates are skewed by the user's UTC offset, so reminders fire at the wrong time, +5:30 late for India (IST) and off by each user's offset elsewhere. This moves the timezone conversion off the LLM and does it deterministically in Python.

## Root cause

In `backend/utils/llm/conversation_processing.py`, the DUE DATE EXTRACTION prompt asked the LLM to "resolve date + time in the user's timezone, convert to UTC with 'Z' suffix." LLMs do timezone arithmetic unreliably, they emit the local wall-clock time stamped with `Z` (e.g. `10:00:00Z` for 10am IST instead of the true `04:30:00Z`). The post-extraction loop only cleared past-due dates and assumed UTC; it performed no conversion. Downstream, `due_at` is serialized verbatim to the device for local notification scheduling, so the skew reaches the user.

## Fix

- The prompt now resolves dates against a Python-computed **local** reference time and outputs **naive local** wall-clock time in ISO 8601 with no `Z`/offset.
- The server converts local → UTC deterministically: `due_at.replace(tzinfo=ZoneInfo(tz)).astimezone(timezone.utc)`, with the timezone resolved once and a logged fallback to UTC on an invalid/missing tz. Already-aware values are normalized with `.astimezone(timezone.utc)`. The existing >1-day-past clearing now runs on the corrected UTC value.
- This also passes the LLM a local reference time so it no longer has to infer the user's calendar day for "today/tomorrow" near midnight (the gap flagged on #7066's review).

`zoneinfo` ships with Python 3.11 and `tzdata` is already in `requirements.txt`, so IANA data is available in all environments.

## Behavior change

- Due dates are now stored/scheduled at the correct UTC instant for every timezone (IST 10:00 → 04:30 UTC, etc.).
- UTC users: unchanged. Invalid tz: falls back to treating the value as UTC (logged), same as before.

## Testing

Extended `backend/tests/unit/test_action_item_date_validation.py` (already in `test.sh`):
- naive local 10:00 IST → stored as 04:30 UTC
- UTC tz → no shift
- invalid tz → UTC fallback, no crash
- local reference times (`started_at_local`/`current_time_local`) are passed to the prompt
- updated the existing invoke-payload assertion to the new local keys

I verified the real `extract_action_items` end to end locally with a stub harness: a naive-local 10:00 IST input returns `04:30:00+00:00` with this change, and the unmodified code returns the naive `10:00:00` (the bug).

## Scope / notes

- Minimal, narrow change to the due-date extraction block only — action-item selection/dedup rules are untouched.
- Ambiguous/nonexistent DST-transition local times use Python's default `zoneinfo` fold behavior; acceptable for this path.
- Prior abandoned attempt #7066 took the same approach and was self-closed by its author (not maintainer-rejected); this PR adds the local-reference-time handling and tests.

## Duplication + history check

Checked: `git log -S "ZoneInfo"` and `git log -S "astimezone"` on `conversation_processing.py` return nothing (no prior fix merged then reverted). The only PR matching the issue is the closed/unmerged #7066. The only open PR touching this file is #7104 (CJK word count), which does not touch `extract_action_items`/`due_at`.
