### PR TITLE
fix(backend): buffer speaker sample requests across pusher reconnect

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1101,6 +1101,9 @@ async def _stream_handler(
         MAX_RETRIES_PER_REQUEST = 3
         pending_conversation_requests: Dict[str, dict] = {}
         pending_request_event = asyncio.Event()
+        # Speaker sample (type-105) requests buffered while pusher is disconnected and replayed on
+        # reconnect — mirrors pending_conversation_requests so samples aren't silently dropped (#6060).
+        pending_speaker_sample_requests: Dict[str, dict] = {}
 
         def transcript_send(segments):
             nonlocal segment_buffers
@@ -1498,6 +1501,18 @@ async def _stream_handler(
                     for cid in list(pending_conversation_requests.keys()):
                         pending_conversation_requests[cid]['sent_at'] = time.time()
                         await request_conversation_processing(cid)
+                # Re-send any pending speaker sample requests after reconnect (#6060). Remove each
+                # entry only after a confirmed send; on failure send_speaker_sample_request re-buffers.
+                if pending_speaker_sample_requests:
+                    logger.info(
+                        f"Reconnected to pusher, re-sending {len(pending_speaker_sample_requests)} pending speaker sample requests {uid} {session_id}"
+                    )
+                    for key in list(pending_speaker_sample_requests.keys()):
+                        req = pending_speaker_sample_requests.get(key)
+                        if not req:
+                            continue
+                        if await send_speaker_sample_request(req['person_id'], req['conv_id'], req['segment_ids']):
+                            pending_speaker_sample_requests.pop(key, None)
             except PusherCircuitBreakerOpen:
                 raise  # Let caller handle circuit breaker
             except Exception as e:
@@ -1520,15 +1535,52 @@ async def _stream_handler(
         def is_degraded():
             return reconnect_state in (PusherReconnectState.DEGRADED, PusherReconnectState.HALF_OPEN_PROBE)
 
+        def _buffer_speaker_sample_request(person_id: str, conv_id: str, segment_ids: List[str]):
+            """Buffer a type-105 request so it survives a pusher reconnect (#6060).
+
+            Keyed by person:conversation. On a duplicate key the segment_ids are merged (order
+            preserved, de-duplicated) so an outage window with multiple assignments does not discard
+            segments. Capped at MAX_PENDING_REQUESTS, dropping the oldest by sent_at.
+            """
+            key = f"{person_id}:{conv_id}"
+            existing = pending_speaker_sample_requests.get(key)
+            if existing:
+                existing['segment_ids'] = list(dict.fromkeys([*existing['segment_ids'], *segment_ids]))
+                existing['sent_at'] = time.time()
+                return
+            if len(pending_speaker_sample_requests) >= MAX_PENDING_REQUESTS:
+                oldest = min(
+                    pending_speaker_sample_requests,
+                    key=lambda k: pending_speaker_sample_requests[k]['sent_at'],
+                )
+                logger.info(
+                    f"Too many pending speaker sample requests, dropping {oldest} to add {key} {uid} {session_id}"
+                )
+                del pending_speaker_sample_requests[oldest]
+            pending_speaker_sample_requests[key] = {
+                'person_id': person_id,
+                'conv_id': conv_id,
+                'segment_ids': list(segment_ids),
+                'sent_at': time.time(),
+            }
+
         async def send_speaker_sample_request(
             person_id: str,
             conv_id: str,
             segment_ids: List[str],
-        ):
-            """Send speaker sample extraction request to pusher with segment IDs."""
+        ) -> bool:
+            """Send a speaker sample extraction request (type 105) to pusher with segment IDs.
+
+            Returns True only if the frame was sent. When pusher is disconnected, or the send fails,
+            the request is buffered and replayed on reconnect instead of being silently dropped (#6060).
+            """
             nonlocal pusher_ws, pusher_connected
             if not pusher_connected or not pusher_ws:
-                return
+                logger.warning(
+                    f"Pusher not connected, buffering speaker sample request person={person_id} {uid} {session_id}"
+                )
+                _buffer_speaker_sample_request(person_id, conv_id, segment_ids)
+                return False
             try:
                 data = bytearray()
                 data.extend(struct.pack("I", 105))
@@ -1548,8 +1600,18 @@ async def _stream_handler(
                 logger.info(
                     f"Sent speaker sample request to pusher: person={person_id}, {len(segment_ids)} segments {uid} {session_id}"
                 )
+                return True
+            except ConnectionClosed:
+                logger.warning(
+                    f"Pusher connection closed sending speaker sample, buffering person={person_id} {uid} {session_id}"
+                )
+                _buffer_speaker_sample_request(person_id, conv_id, segment_ids)
+                _mark_disconnected()
+                return False
             except Exception as e:
                 logger.error(f"Failed to send speaker sample request: {e} {uid} {session_id}")
+                _buffer_speaker_sample_request(person_id, conv_id, segment_ids)
+                return False
 
         def is_connected():
             return pusher_connected

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -46,6 +46,7 @@ pytest tests/unit/test_log_sanitizer.py -v
 pytest tests/unit/test_auth_redirect_uri.py -v
 pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_pusher_conversation_retry.py -v
+pytest tests/unit/test_speaker_sample_reconnect.py -v
 pytest tests/unit/test_listen_fallback_removal.py -v
 pytest tests/unit/test_desktop_updates.py -v
 pytest tests/unit/test_translation_optimization.py -v

--- a/backend/tests/unit/test_speaker_sample_reconnect.py
+++ b/backend/tests/unit/test_speaker_sample_reconnect.py
@@ -13,10 +13,11 @@ a regression that removes the behavior.
 
 import asyncio
 import json
+import re
 import struct
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 # ---------------------------------------------------------------------------
 # Mirror of the real helpers in create_pusher_task_handler (transcribe.py)
@@ -43,8 +44,19 @@ def _buffer_speaker_sample_request(pending: dict, person_id: str, conv_id: str, 
     }
 
 
-async def _send_speaker_sample_request(pending, person_id, conv_id, segment_ids, pusher_ws, pusher_connected):
-    """Mirrors send_speaker_sample_request(): buffer when disconnected/failed, True only on send."""
+class _ConnectionClosed(Exception):
+    """Stand-in for websockets.exceptions.ConnectionClosed, to exercise that distinct branch."""
+
+
+async def _send_speaker_sample_request(
+    pending, person_id, conv_id, segment_ids, pusher_ws, pusher_connected, mark_disconnected=None
+):
+    """Mirrors send_speaker_sample_request(): buffer when disconnected/failed, True only on send.
+
+    Models the two distinct failure branches: ConnectionClosed re-buffers AND signals disconnect
+    (mark_disconnected, which in the real code starts the reconnect loop), while a generic
+    exception only re-buffers.
+    """
     if not pusher_connected or not pusher_ws:
         _buffer_speaker_sample_request(pending, person_id, conv_id, segment_ids)
         return False
@@ -56,19 +68,30 @@ async def _send_speaker_sample_request(pending, person_id, conv_id, segment_ids,
         )
         await pusher_ws.send(data)
         return True
+    except _ConnectionClosed:
+        _buffer_speaker_sample_request(pending, person_id, conv_id, segment_ids)
+        if mark_disconnected is not None:
+            mark_disconnected()
+        return False
     except Exception:
         _buffer_speaker_sample_request(pending, person_id, conv_id, segment_ids)
         return False
 
 
-async def _replay_speaker_samples(pending, pusher_ws, pusher_connected):
+async def _replay_speaker_samples(pending, pusher_ws, pusher_connected, mark_disconnected=None):
     """Mirrors the _connect() replay: remove an entry only after a confirmed send."""
     for key in list(pending.keys()):
         req = pending.get(key)
         if not req:
             continue
         if await _send_speaker_sample_request(
-            pending, req['person_id'], req['conv_id'], req['segment_ids'], pusher_ws, pusher_connected
+            pending,
+            req['person_id'],
+            req['conv_id'],
+            req['segment_ids'],
+            pusher_ws,
+            pusher_connected,
+            mark_disconnected,
         ):
             pending.pop(key, None)
 
@@ -105,13 +128,26 @@ def test_replay_drains_buffer_on_reconnect():
     assert ws.send.await_count == 2
 
 
-def test_replay_retains_entry_when_send_fails():
+def test_replay_retains_entry_on_generic_failure_without_marking_disconnected():
     pending = {}
     asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1"], None, False))
     ws = AsyncMock()
-    ws.send.side_effect = RuntimeError("connection closed")
-    asyncio.run(_replay_speaker_samples(pending, ws, True))
+    ws.send.side_effect = RuntimeError("boom")
+    mark = MagicMock()
+    asyncio.run(_replay_speaker_samples(pending, ws, True, mark))
     assert "p1:c1" in pending  # not dropped — preserved for the next reconnect
+    mark.assert_not_called()  # a generic send error does not flag the connection as down
+
+
+def test_connection_closed_rebuffers_and_marks_disconnected():
+    pending = {}
+    asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1"], None, False))
+    ws = AsyncMock()
+    ws.send.side_effect = _ConnectionClosed()
+    mark = MagicMock()
+    asyncio.run(_replay_speaker_samples(pending, ws, True, mark))
+    assert "p1:c1" in pending  # retained for the next reconnect
+    mark.assert_called_once()  # ConnectionClosed flags disconnect so the reconnect loop drains it
 
 
 def test_cap_drops_oldest():
@@ -141,6 +177,15 @@ def _transcribe_source():
     return (Path(__file__).resolve().parent.parent.parent / "routers" / "transcribe.py").read_text(encoding="utf-8")
 
 
+def _send_function_source():
+    """Slice just send_speaker_sample_request() out of transcribe.py (up to the next sibling def)."""
+    src = _transcribe_source()
+    start = src.index("async def send_speaker_sample_request")
+    rest = src[start + 1 :]
+    m = re.search(r"\n        (?:async def|def) ", rest)
+    return rest[: m.start()] if m else rest
+
+
 def test_real_code_buffers_and_replays_speaker_samples():
     src = _transcribe_source()
     assert "pending_speaker_sample_requests" in src
@@ -150,3 +195,13 @@ def test_real_code_buffers_and_replays_speaker_samples():
     # replayed on reconnect, removed only after a confirmed send
     assert "pending speaker sample requests" in src
     assert "pending_speaker_sample_requests.pop(" in src
+
+
+def test_real_code_has_distinct_connection_closed_branch():
+    # Greptile #6060: the ConnectionClosed branch must stay distinct from the generic handler so it
+    # keeps calling _mark_disconnected(); merging them would silently drop the reconnect trigger.
+    body = _send_function_source()
+    assert "except ConnectionClosed:" in body
+    assert "_mark_disconnected()" in body  # only present in the ConnectionClosed branch
+    assert "except Exception" in body  # the generic branch still exists and is separate
+    assert body.count("_buffer_speaker_sample_request(") >= 2  # both failure branches re-buffer

--- a/backend/tests/unit/test_speaker_sample_reconnect.py
+++ b/backend/tests/unit/test_speaker_sample_reconnect.py
@@ -1,0 +1,152 @@
+"""Unit tests for the speaker-sample (type-105) reconnect buffer (#6060).
+
+Speaker sample extraction requests were silently dropped when the backend->pusher WebSocket was
+mid-reconnect: send_speaker_sample_request() returned on a disconnected socket with no log, queue,
+or retry, so the speaker profile was never built. The fix buffers the request and replays it on
+reconnect, mirroring the existing pending_conversation_requests (type-104) pattern.
+
+The real logic lives inside the create_pusher_task_handler closure in routers/transcribe.py and
+cannot be imported in isolation, so (as with test_pusher_conversation_retry.py) these tests mirror
+the buffer/send/replay helpers faithfully, and a source-inspection test guards the real file against
+a regression that removes the behavior.
+"""
+
+import asyncio
+import json
+import struct
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+# ---------------------------------------------------------------------------
+# Mirror of the real helpers in create_pusher_task_handler (transcribe.py)
+# ---------------------------------------------------------------------------
+MAX_PENDING_REQUESTS = 100
+
+
+def _buffer_speaker_sample_request(pending: dict, person_id: str, conv_id: str, segment_ids):
+    """Mirrors _buffer_speaker_sample_request(): key by person:conv, merge on dup, cap+drop oldest."""
+    key = f"{person_id}:{conv_id}"
+    existing = pending.get(key)
+    if existing:
+        existing['segment_ids'] = list(dict.fromkeys([*existing['segment_ids'], *segment_ids]))
+        existing['sent_at'] = time.time()
+        return
+    if len(pending) >= MAX_PENDING_REQUESTS:
+        oldest = min(pending, key=lambda k: pending[k]['sent_at'])
+        del pending[oldest]
+    pending[key] = {
+        'person_id': person_id,
+        'conv_id': conv_id,
+        'segment_ids': list(segment_ids),
+        'sent_at': time.time(),
+    }
+
+
+async def _send_speaker_sample_request(pending, person_id, conv_id, segment_ids, pusher_ws, pusher_connected):
+    """Mirrors send_speaker_sample_request(): buffer when disconnected/failed, True only on send."""
+    if not pusher_connected or not pusher_ws:
+        _buffer_speaker_sample_request(pending, person_id, conv_id, segment_ids)
+        return False
+    try:
+        data = bytearray()
+        data.extend(struct.pack("I", 105))
+        data.extend(
+            bytes(json.dumps({"person_id": person_id, "conversation_id": conv_id, "segment_ids": segment_ids}), "utf-8")
+        )
+        await pusher_ws.send(data)
+        return True
+    except Exception:
+        _buffer_speaker_sample_request(pending, person_id, conv_id, segment_ids)
+        return False
+
+
+async def _replay_speaker_samples(pending, pusher_ws, pusher_connected):
+    """Mirrors the _connect() replay: remove an entry only after a confirmed send."""
+    for key in list(pending.keys()):
+        req = pending.get(key)
+        if not req:
+            continue
+        if await _send_speaker_sample_request(
+            pending, req['person_id'], req['conv_id'], req['segment_ids'], pusher_ws, pusher_connected
+        ):
+            pending.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests
+# ---------------------------------------------------------------------------
+def test_buffers_when_disconnected():
+    pending = {}
+    sent = asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1", "s2"], None, False))
+    assert sent is False
+    assert list(pending.keys()) == ["p1:c1"]
+    assert pending["p1:c1"]["segment_ids"] == ["s1", "s2"]
+
+
+def test_sends_immediately_when_connected():
+    pending = {}
+    ws = AsyncMock()
+    sent = asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1"], ws, True))
+    assert sent is True
+    ws.send.assert_awaited_once()
+    assert pending == {}  # nothing buffered on a successful send
+
+
+def test_replay_drains_buffer_on_reconnect():
+    pending = {}
+    # two requests arrive while disconnected
+    asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1"], None, False))
+    asyncio.run(_send_speaker_sample_request(pending, "p2", "c2", ["s2"], None, False))
+    assert len(pending) == 2
+    ws = AsyncMock()
+    asyncio.run(_replay_speaker_samples(pending, ws, True))
+    assert pending == {}  # all replayed and removed
+    assert ws.send.await_count == 2
+
+
+def test_replay_retains_entry_when_send_fails():
+    pending = {}
+    asyncio.run(_send_speaker_sample_request(pending, "p1", "c1", ["s1"], None, False))
+    ws = AsyncMock()
+    ws.send.side_effect = RuntimeError("connection closed")
+    asyncio.run(_replay_speaker_samples(pending, ws, True))
+    assert "p1:c1" in pending  # not dropped — preserved for the next reconnect
+
+
+def test_cap_drops_oldest():
+    pending = {
+        f"p{i}:c{i}": {'person_id': f"p{i}", 'conv_id': f"c{i}", 'segment_ids': ["s"], 'sent_at': float(i)}
+        for i in range(MAX_PENDING_REQUESTS)
+    }
+    assert len(pending) == MAX_PENDING_REQUESTS
+    _buffer_speaker_sample_request(pending, "pnew", "cnew", ["s"])
+    assert len(pending) == MAX_PENDING_REQUESTS  # capped
+    assert "p0:c0" not in pending  # oldest (sent_at=0.0) evicted
+    assert "pnew:cnew" in pending
+
+
+def test_merges_segment_ids_on_duplicate_key():
+    pending = {}
+    _buffer_speaker_sample_request(pending, "p1", "c1", ["s1", "s2"])
+    _buffer_speaker_sample_request(pending, "p1", "c1", ["s2", "s3"])
+    assert list(pending.keys()) == ["p1:c1"]
+    assert pending["p1:c1"]["segment_ids"] == ["s1", "s2", "s3"]  # merged, de-duplicated, ordered
+
+
+# ---------------------------------------------------------------------------
+# Source-inspection regression guard on the real file
+# ---------------------------------------------------------------------------
+def _transcribe_source():
+    return (Path(__file__).resolve().parent.parent.parent / "routers" / "transcribe.py").read_text(encoding="utf-8")
+
+
+def test_real_code_buffers_and_replays_speaker_samples():
+    src = _transcribe_source()
+    assert "pending_speaker_sample_requests" in src
+    assert "_buffer_speaker_sample_request" in src
+    # buffered on the disconnected path (no longer a bare return)
+    assert "buffering speaker sample request" in src
+    # replayed on reconnect, removed only after a confirmed send
+    assert "pending speaker sample requests" in src
+    assert "pending_speaker_sample_requests.pop(" in src


### PR DESCRIPTION
Fixes #6060

## Summary

Speaker sample extraction is silently dropped when the backend-to-pusher WebSocket is mid-reconnect, so the speaker profile is never built and the failure is invisible. This buffers the request and replays it on reconnect, mirroring the existing type-104 pattern.

## Not a duplicate of #5989

#5989 (closed unmerged) fixed a *different* mechanism, it rehydrated `current_session_segments` on client WebSocket resume so `can_assign` survives reconnect, targeting #5949. It never added a pending queue for the type-105 request and never touched `send_speaker_sample_request()`. This PR fixes the distinct backend->pusher reconnect drop. The two are complementary, not the same change.

## Root cause

In `backend/routers/transcribe.py`, `send_speaker_sample_request()` returned on a disconnected socket with no log, queue, or retry:

```python
if not pusher_connected or not pusher_ws:
    return
```

It is fired fire-and-forget via `spawn(...)` from the `speaker_assigned` path, and `spawn` only logs exceptions so a bare return is completely invisible. Meanwhile the speaker-assignment maps update and log success, so the only "recovery" was the user happening to record another conversation outside a reconnect window. The sibling type-104 path (`request_conversation_processing` / `pending_conversation_requests`) already buffers and replays on reconnect; the type-105 path had no equivalent.

## Fix

Mirror the proven `pending_conversation_requests` pattern, one function away:

- Add `pending_speaker_sample_requests`, keyed `person_id:conversation_id`. On a duplicate key the `segment_ids` are merged (order preserved, de-duplicated) so an outage window with multiple assignments doesn't discard segments. Capped at `MAX_PENDING_REQUESTS`, dropping the oldest by `sent_at` (logged).
- On the disconnected path, buffer the request and log a warning (satisfies the backend's "log when dropping work" rule) instead of returning silently.
- `send_speaker_sample_request()` now returns a bool. On a failed send it re-buffers; on `ConnectionClosed` it also calls the existing `_mark_disconnected()` so the reconnect loop starts and later drains the buffer.
- `_connect()` replays the buffer right after the type-104 replay, removing each entry only after a confirmed send (a re-failed send re-buffers and is retried on the next reconnect).

## Safety / scope

- All of this runs on the single per-session event loop; no new threads, no `.result()`, no executor cross-pool calls (no deadlock surface per backend/AGENTS.md).
- The buffer lives in the per-session pusher closure (like `pending_conversation_requests`), so it is garbage-collected at session end and never persisted beyond the WebSocket session. `person_id == 'user'` stays gated before send, so user samples aren't buffered. Segment IDs remain valid for replay within the same `/v4/listen` session.
- This fixes only the backend->pusher reconnect drop; it does not change client WS reconnect state or audio-chunk handling.

## Testing

New `backend/tests/unit/test_speaker_sample_reconnect.py` (registered in `test.sh`): buffers when disconnected, sends immediately when connected, replay drains the buffer on reconnect, a failed replay retains the entry, cap eviction drops the oldest, and `segment_ids` merge on a duplicate key. The real logic lives in an un-importable closure (same as `test_pusher_conversation_retry.py`), so the behavioral cases mirror the helpers and a source-inspection test guards the real file against a regression that removes the buffering (verified: it fails on current `main`, passes with this change).

## Duplication + history check

`git log --all -S "pending_speaker"` has no hits and `git log --all -S "send_speaker_sample_request"` only finds the original speaker-identification feature commit, so there is no merged-then-reverted prior fix. No open PR references #6060, and #5989 (the only related PR) fixed a different mechanism as noted above.
