### PR TITLE
fix(backend): cancel action item reminder on completion (#5085)

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -25,6 +25,7 @@ from utils.notifications import (
     send_action_item_update_message,
     send_action_item_deletion_message,
     send_action_items_batch_deletion_message,
+    sync_action_item_reminder,
 )
 from utils.task_sync import auto_sync_action_item
 from pydantic import BaseModel, Field
@@ -209,8 +210,9 @@ def create_action_item(request: CreateActionItemRequest, uid: str = Depends(auth
     if not action_item:
         raise HTTPException(status_code=500, detail="Failed to create action item")
 
-    # Send FCM data message if action item has a due date
-    if request.due_at:
+    # Schedule a reminder only for an open task with a due date — an already-completed item must
+    # not arm a reminder (#5085).
+    if request.due_at and not request.completed:
         send_action_item_data_message(
             user_id=uid,
             action_item_id=action_item_id,
@@ -357,13 +359,16 @@ def update_action_item(
     # Return updated action item
     updated_item = action_items_db.get_action_item(uid, action_item_id)
 
-    # Send FCM update message if due_at changed
-    if 'due_at' in update_data and update_data['due_at']:
-        send_action_item_update_message(
+    # Reconcile the client-scheduled reminder when completion or due date changed, using the final
+    # state: cancel if completed or no due date, (re)schedule only for an open task with a due date
+    # (#5085). Previously this re-armed the reminder whenever due_at was present, even on completion.
+    if 'completed' in update_data or 'due_at' in update_data:
+        sync_action_item_reminder(
             user_id=uid,
             action_item_id=action_item_id,
             description=updated_item.get('description', ''),
-            due_at=update_data['due_at'].isoformat(),
+            completed=bool(updated_item.get('completed')),
+            due_at=updated_item.get('due_at'),
         )
 
     return ActionItemResponse(**updated_item)
@@ -388,6 +393,16 @@ def toggle_action_item_completion(
 
     # Return updated action item
     updated_item = action_items_db.get_action_item(uid, action_item_id)
+
+    # Cancel the scheduled client reminder on completion, or re-schedule it when un-completing an
+    # item that still has a future due date (#5085).
+    sync_action_item_reminder(
+        user_id=uid,
+        action_item_id=action_item_id,
+        description=updated_item.get('description', ''),
+        completed=completed,
+        due_at=updated_item.get('due_at'),
+    )
 
     # Notify sender if this was a shared task that just got completed
     if completed and existing_item.get('shared_from'):

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -43,7 +43,7 @@ from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
 from utils.apps import update_personas_async
-from utils.notifications import send_action_item_data_message
+from utils.notifications import send_action_item_data_message, sync_action_item_reminder
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations.location import get_google_maps_location
 from utils.llm.memories import identify_category_for_memory
@@ -607,14 +607,17 @@ def update_action_item(
     if not action_items_db.update_action_item(uid, action_item_id, update_data):
         raise HTTPException(status_code=500, detail="Failed to update action item")
 
-    # Send FCM notification if due_at was updated
-    if request.due_at is not None:
+    # Reconcile the client-scheduled reminder when completion or due date changed, using the final
+    # state: cancel if completed or no due date, (re)schedule only for an open task with a due date
+    # (#5085).
+    if 'completed' in update_data or 'due_at' in update_data:
         description = request.description.strip() if request.description else action_item.get('description', '')
-        send_action_item_data_message(
+        sync_action_item_reminder(
             user_id=uid,
             action_item_id=action_item_id,
             description=description,
-            due_at=request.due_at.isoformat(),
+            completed=bool(update_data.get('completed', action_item.get('completed'))),
+            due_at=update_data.get('due_at', action_item.get('due_at')),
         )
 
     return action_items_db.get_action_item(uid, action_item_id)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -67,6 +67,7 @@ pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
 pytest tests/unit/test_action_item_dedup.py -v
+pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v
 pytest tests/unit/test_kg_edge_id_sanitization.py -v

--- a/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
+++ b/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
@@ -117,6 +117,27 @@ def _src(rel):
     return (BACKEND_DIR / rel).read_text(encoding="utf-8")
 
 
+_HELPER = "sync_action_item_reminder"
+
+
+def _live_call_lines(rel):
+    """Lines that actually call the helper, excluding comments — so a commented-out or dead-text
+    occurrence can't satisfy the wire guard."""
+    return [ln for ln in _src(rel).splitlines() if f"{_HELPER}(" in ln and not ln.lstrip().startswith("#")]
+
+
+def _is_imported(rel):
+    """True if the helper is imported (single-line `from x import a, helper` or a parenthesized
+    multi-line member line `    helper,`)."""
+    for ln in _src(rel).splitlines():
+        s = ln.strip()
+        if s in (f"{_HELPER},", _HELPER):  # member of a parenthesized import block
+            return True
+        if s.startswith(("from ", "import ")) and _HELPER in s:  # single-line import
+            return True
+    return False
+
+
 def test_helper_cancels_on_completed_or_no_due():
     n = _src("utils/notifications.py")
     assert "def sync_action_item_reminder" in n
@@ -126,8 +147,9 @@ def test_helper_cancels_on_completed_or_no_due():
 
 def test_router_wires_helper_and_no_longer_blindly_rearms():
     ai = _src("routers/action_items.py")
-    # toggle-completion AND update both reconcile through the helper
-    assert ai.count("sync_action_item_reminder(") >= 2
+    assert _is_imported("routers/action_items.py")
+    # toggle-completion AND update both reconcile through the helper (real calls, not comments)
+    assert len(_live_call_lines("routers/action_items.py")) >= 2
     # the old unconditional "re-arm whenever due_at present" block is gone
     assert "if 'due_at' in update_data and update_data['due_at']:" not in ai
     # creating an already-completed item must not arm a reminder
@@ -140,4 +162,5 @@ def test_agentic_and_developer_paths_wired():
         "utils/retrieval/tool_services/action_items.py",
         "routers/developer.py",
     ]:
-        assert "sync_action_item_reminder(" in _src(rel), rel
+        assert _is_imported(rel), f"{rel} does not import {_HELPER}"
+        assert _live_call_lines(rel), f"{rel} has no live (non-comment) {_HELPER} call"

--- a/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
+++ b/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
@@ -1,0 +1,143 @@
+"""Tests for cancelling/rescheduling the client reminder on action-item completion (#5085).
+
+Completing (not deleting) an action item never cancelled its client-scheduled reminder, and the
+update endpoint actively re-armed a completed item. The fix centralizes the decision in
+utils.notifications.sync_action_item_reminder and calls it from every create/update/complete path.
+
+utils.notifications pulls in firebase/database at import, so we import the REAL module under a stub
+finder (so we exercise the real helper, not a copy), then patch the two send_* helpers. A second
+group of source-inspection tests guards that every call site stays wired to the helper.
+"""
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+# Keep these REAL (module under test + its package); stub the heavy leaves.
+_REAL = {"utils", "utils.notifications"}
+_PREF = ("firebase_admin", "database", "google", "utils.executors", "utils.llm")
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, n):
+        if n.startswith("__") and n.endswith("__"):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(self, n, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if name in _REAL:
+            return None
+        if any(name == p or name.startswith(p + ".") for p in _PREF):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, m):
+        pass
+
+
+def _load_real_notifications():
+    sys.path.insert(0, str(BACKEND_DIR))
+    finder = _Finder()
+    sys.meta_path.insert(0, finder)
+    try:
+        import utils.notifications as notif
+
+        return notif
+    finally:
+        sys.meta_path.remove(finder)
+        for name in list(sys.modules.keys()):
+            if name in _REAL:
+                continue
+            if any(name == p or name.startswith(p + ".") for p in _PREF):
+                sys.modules.pop(name, None)
+
+
+notif = _load_real_notifications()
+
+
+def _call(completed, due_at):
+    with patch.object(notif, "send_action_item_deletion_message") as cancel, patch.object(
+        notif, "send_action_item_update_message"
+    ) as reschedule:
+        notif.sync_action_item_reminder("u1", "a1", "desc", completed, due_at)
+        return cancel, reschedule
+
+
+# ---------------------------------------------------------------------------
+# Real helper behavior
+# ---------------------------------------------------------------------------
+def test_completed_cancels_reminder():
+    cancel, reschedule = _call(True, datetime.now(timezone.utc) + timedelta(days=1))
+    cancel.assert_called_once()
+    reschedule.assert_not_called()
+
+
+def test_open_with_due_reschedules():
+    due = datetime.now(timezone.utc) + timedelta(days=1)
+    cancel, reschedule = _call(False, due)
+    reschedule.assert_called_once()
+    cancel.assert_not_called()
+    assert reschedule.call_args.kwargs.get("due_at") == due.isoformat()  # datetime -> iso string
+
+
+def test_open_without_due_cancels():
+    cancel, reschedule = _call(False, None)
+    cancel.assert_called_once()  # due date cleared -> cancel any stale reminder
+    reschedule.assert_not_called()
+
+
+def test_completed_without_due_cancels():
+    cancel, reschedule = _call(True, None)
+    cancel.assert_called_once()
+    reschedule.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Source-inspection: every create/update/complete path stays wired to the helper
+# ---------------------------------------------------------------------------
+def _src(rel):
+    return (BACKEND_DIR / rel).read_text(encoding="utf-8")
+
+
+def test_helper_cancels_on_completed_or_no_due():
+    n = _src("utils/notifications.py")
+    assert "def sync_action_item_reminder" in n
+    assert "if completed or not due_at" in n  # cancel branch
+    assert "send_action_item_deletion_message" in n and "send_action_item_update_message" in n
+
+
+def test_router_wires_helper_and_no_longer_blindly_rearms():
+    ai = _src("routers/action_items.py")
+    # toggle-completion AND update both reconcile through the helper
+    assert ai.count("sync_action_item_reminder(") >= 2
+    # the old unconditional "re-arm whenever due_at present" block is gone
+    assert "if 'due_at' in update_data and update_data['due_at']:" not in ai
+    # creating an already-completed item must not arm a reminder
+    assert "not request.completed" in ai
+
+
+def test_agentic_and_developer_paths_wired():
+    for rel in [
+        "utils/retrieval/tools/action_item_tools.py",
+        "utils/retrieval/tool_services/action_items.py",
+        "routers/developer.py",
+    ]:
+        assert "sync_action_item_reminder(" in _src(rel), rel

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -3,7 +3,8 @@ import hashlib
 import json
 import math
 import uuid
-from typing import List
+from datetime import datetime
+from typing import List, Optional, Union
 from firebase_admin import messaging, auth
 import database.notifications as notification_db
 from utils.executors import db_executor, run_blocking
@@ -509,7 +510,13 @@ def send_action_item_deletion_message(user_id: str, action_item_id: str):
     _send_to_user(user_id, tag, data=data, is_background=True, priority='high')
 
 
-def sync_action_item_reminder(user_id: str, action_item_id: str, description: str, completed: bool, due_at):
+def sync_action_item_reminder(
+    user_id: str,
+    action_item_id: str,
+    description: str,
+    completed: bool,
+    due_at: Optional[Union[datetime, str]],
+):
     """Reconcile the client-scheduled reminder after an action item is created or updated (#5085).
 
     The mobile client schedules a local reminder from the action-item update/data message and

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -509,6 +509,24 @@ def send_action_item_deletion_message(user_id: str, action_item_id: str):
     _send_to_user(user_id, tag, data=data, is_background=True, priority='high')
 
 
+def sync_action_item_reminder(user_id: str, action_item_id: str, description: str, completed: bool, due_at):
+    """Reconcile the client-scheduled reminder after an action item is created or updated (#5085).
+
+    The mobile client schedules a local reminder from the action-item update/data message and
+    cancels it on the 'action_item_delete' message. The reminder must be cancelled when the task is
+    completed or no longer has a due date, and (re)scheduled only for an open task that still has a
+    due date. Reusing send_action_item_deletion_message is intentional: the client treats it as
+    "cancel the scheduled local notification by id", not as a task deletion.
+    """
+    if completed or not due_at:
+        send_action_item_deletion_message(user_id=user_id, action_item_id=action_item_id)
+        return
+    due_iso = due_at.isoformat() if hasattr(due_at, 'isoformat') else due_at
+    send_action_item_update_message(
+        user_id=user_id, action_item_id=action_item_id, description=description or '', due_at=due_iso
+    )
+
+
 def send_action_items_batch_deletion_message(user_id: str, action_item_ids: List[str]):
     """
     Bulk equivalent of send_action_item_deletion_message — one FCM data

--- a/backend/utils/retrieval/tool_services/action_items.py
+++ b/backend/utils/retrieval/tool_services/action_items.py
@@ -11,6 +11,7 @@ from utils.notifications import (
     send_action_item_completed_notification,
     send_action_item_created_notification,
     send_action_item_data_message,
+    sync_action_item_reminder,
 )
 from utils.retrieval.tool_services.conversations import parse_iso_date
 import logging
@@ -250,6 +251,20 @@ def update_action_item_text(
                 send_action_item_completed_notification(uid, existing.get('description', 'Task'))
             except Exception as notif_error:
                 logger.error(f"Failed to send completion notification: {notif_error}")
+
+        # Reconcile the scheduled reminder to match the new state — cancel on completion, (re)schedule
+        # only for an open task with a due date (#5085).
+        if 'completed' in update_data or 'due_at' in update_data:
+            try:
+                sync_action_item_reminder(
+                    uid,
+                    action_item_id,
+                    update_data.get('description', existing.get('description', '')),
+                    bool(update_data.get('completed', existing.get('completed'))),
+                    update_data.get('due_at', existing.get('due_at')),
+                )
+            except Exception as notif_error:
+                logger.error(f"Failed to sync action item reminder: {notif_error}")
 
         task_desc = update_data.get('description', existing.get('description', 'Task'))
         return f"✅ Updated '{task_desc}': {', '.join(changes)}"

--- a/backend/utils/retrieval/tool_services/action_items.py
+++ b/backend/utils/retrieval/tool_services/action_items.py
@@ -245,10 +245,14 @@ def update_action_item_text(
     try:
         action_items_db.update_action_item(uid, action_item_id, update_data)
 
+        # Re-fetch the authoritative post-write state so reminder reconciliation can't act on a stale
+        # pre-update value (matches the update_action_item_tool path).
+        updated_item = action_items_db.get_action_item(uid, action_item_id) or existing
+
         # Send notification if completed
         if completed is True:
             try:
-                send_action_item_completed_notification(uid, existing.get('description', 'Task'))
+                send_action_item_completed_notification(uid, updated_item.get('description', 'Task'))
             except Exception as notif_error:
                 logger.error(f"Failed to send completion notification: {notif_error}")
 
@@ -259,9 +263,9 @@ def update_action_item_text(
                 sync_action_item_reminder(
                     uid,
                     action_item_id,
-                    update_data.get('description', existing.get('description', '')),
-                    bool(update_data.get('completed', existing.get('completed'))),
-                    update_data.get('due_at', existing.get('due_at')),
+                    updated_item.get('description', ''),
+                    bool(updated_item.get('completed')),
+                    updated_item.get('due_at'),
                 )
             except Exception as notif_error:
                 logger.error(f"Failed to sync action item reminder: {notif_error}")

--- a/backend/utils/retrieval/tools/action_item_tools.py
+++ b/backend/utils/retrieval/tools/action_item_tools.py
@@ -14,6 +14,7 @@ from utils.notifications import (
     send_action_item_completed_notification,
     send_action_item_created_notification,
     send_action_item_data_message,
+    sync_action_item_reminder,
 )
 import logging
 
@@ -572,6 +573,20 @@ def update_action_item_tool(
             except Exception as notif_error:
                 logger.error(f"⚠️ Failed to send completion notification: {notif_error}")
                 # Don't fail the update if notification fails
+
+        # Reconcile the scheduled reminder to match the new state — cancel on completion, (re)schedule
+        # only for an open task with a due date (#5085).
+        if 'completed' in update_data or 'due_at' in update_data:
+            try:
+                sync_action_item_reminder(
+                    uid,
+                    action_item_id,
+                    updated_item.get('description', ''),
+                    bool(updated_item.get('completed')),
+                    updated_item.get('due_at'),
+                )
+            except Exception as notif_error:
+                logger.error(f"⚠️ Failed to sync action item reminder: {notif_error}")
 
         return result
 


### PR DESCRIPTION
Fixes #5085

## Summary

Completing an action item never cancelled its scheduled reminder, so users kept getting reminder notifications for tasks they'd already finished. Worse, the general update endpoint actively re-armed the reminder on a completed item. This cancels the reminder on completion and reschedules it only for open tasks with a due date.

## Root cause

Action-item reminders are scheduled **client-side** from a data FCM message; the client cancels a scheduled reminder when it receives `action_item_delete` and (re)schedules on `action_item_update`. On the backend, the cancel message was sent **only** on the delete paths. None of the completion paths sent it:

- `toggle_action_item_completion` (`routers/action_items.py`) marked the item complete and returned with no cancel.
- `update_action_item` re-sent `send_action_item_update_message` whenever `due_at` was present, even when the same request set `completed=true`, re-arming the reminder.
- The agentic tools (`utils/retrieval/tools/action_item_tools.py`, `utils/retrieval/tool_services/action_items.py`) and the Developer API update (`routers/developer.py`) had the same gap.

## Fix

Centralize the decision in one helper, `utils/notifications.sync_action_item_reminder(...)`:
- task completed, or no due date → send `send_action_item_deletion_message` (cancel the scheduled reminder).
- open task with a due date → send `send_action_item_update_message` (reschedule).

Reusing the deletion message as the cancel signal is intentional and needs no app change: the client handler treats `action_item_delete` as "cancel the scheduled local notification by id", not as a task deletion.

The helper is called with the **final** item state from every create/update/complete path:
- `toggle_action_item_completion`, cancel on complete; reschedule when un-completing an item that still has a future due date.
- `update_action_item`, reconcile when `completed` or `due_at` changed (replaces the old unconditional re-arm); a cleared due date now cancels.
- both agentic update tools and the Developer API update.
- `create_action_item` no longer arms a reminder for an item created already-completed.

## Edge cases

- Completing → cancel only (never re-arm). Un-completing with a future due date → reschedule.
- `due_at` cleared → cancel any stale reminder.
- Updates that don't touch `completed`/`due_at` (e.g. description, sort order) send no reminder traffic (no regression / no extra FCM).
- Re-completing an already-completed item → cancel is idempotent.

## Testing

New `backend/tests/unit/test_action_item_reminder_cancel_on_complete.py` (registered in `test.sh`). It imports the **real** `sync_action_item_reminder` (under a stub finder, since `utils.notifications` pulls in firebase/db) and asserts: completed → cancel; open+due → reschedule with the ISO due date; open/no-due → cancel; completed/no-due → cancel. Plus source-inspection tests that every create/update/complete path stays wired to the helper and that the old "re-arm whenever due_at present" block is gone. Verified red→green: the whole suite fails on current `main` and passes with this change. `scripts/lint_async_blockers.py` is clean.

## PR status check

`gh pr` search for 5085 is empty (open and all states); searches for `send_action_item_deletion_message` / completion-reminder PRs return nothing; `git log -S` on the notification helpers shows the scheduling/dedup/batch-delete history but no prior completion-cancel fix merged or reverted. No open PR touches these paths for this bug.
