### PR TITLE
Make Developer API memories list tolerate malformed records

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 import database.folders as folders_db
 import database.memories as memories_db
@@ -107,17 +107,89 @@ def delete_key(key_id: str, uid: str = Depends(get_current_user_id)):
 class CleanerMemory(BaseModel):
     # Core fields (aligned with MemoryResponse)
     id: str
-    content: str
-    category: MemoryCategory
+    content: str = ''
+    category: MemoryCategory = MemoryCategory.interesting
     visibility: Optional[str] = 'private'
-    tags: List[str] = []
-    created_at: datetime
-    updated_at: datetime
-    manually_added: bool
+    tags: List[str] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    manually_added: bool = False
     scoring: Optional[str] = None
-    reviewed: bool
+    reviewed: bool = False
     user_review: Optional[bool] = None
-    edited: bool
+    edited: bool = False
+
+    @field_validator('id', mode='before')
+    def coerce_id(cls, value):
+        if value is None:
+            return ''
+        return str(value)
+
+    @field_validator('content', mode='before')
+    def coerce_content(cls, value):
+        if value is None:
+            return ''
+        return str(value)
+
+    @field_validator('category', mode='before')
+    def coerce_category(cls, value):
+        if isinstance(value, MemoryCategory):
+            return value
+        try:
+            return MemoryCategory(value)
+        except (TypeError, ValueError):
+            return MemoryCategory.interesting
+
+    @field_validator('visibility', mode='before')
+    def coerce_visibility(cls, value):
+        return value if value in ['public', 'private'] else 'private'
+
+    @field_validator('tags', mode='before')
+    def coerce_tags(cls, value):
+        if not isinstance(value, list):
+            return []
+        return [str(tag) for tag in value if tag is not None]
+
+    @field_validator('scoring', mode='before')
+    def coerce_scoring(cls, value):
+        if value is None:
+            return None
+        return str(value)
+
+    @field_validator('created_at', 'updated_at', mode='before')
+    def coerce_datetime(cls, value):
+        if value in [None, '']:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace('Z', '+00:00'))
+            except ValueError:
+                return None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value
+        return None
+
+    @field_validator('user_review', mode='before')
+    def coerce_user_review(cls, value):
+        if isinstance(value, bool):
+            return value
+        if value in [None, '']:
+            return None
+        if isinstance(value, str):
+            return value.lower() in ['true', '1', 'yes']
+        return bool(value)
+
+    @field_validator('manually_added', 'reviewed', 'edited', mode='before')
+    def coerce_bool(cls, value):
+        if isinstance(value, bool):
+            return value
+        if value in [None, '']:
+            return False
+        if isinstance(value, str):
+            return value.lower() in ['true', '1', 'yes']
+        return bool(value)
 
 
 class CreateMemoryRequest(BaseModel):
@@ -171,11 +243,16 @@ def get_memories(
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
     memories = memories_db.get_memories(uid, limit, offset, [c.value for c in category_list])
+    safe_memories = []
     for memory in memories:
+        if not isinstance(memory, dict) or not memory.get('id'):
+            logger.warning('Skipping malformed memory in Developer API memory list')
+            continue
         if memory.get('is_locked', False):
-            content = memory.get('content', '')
+            content = str(memory.get('content') or '')
             memory['content'] = (content[:70] + '...') if len(content) > 70 else content
-    return memories
+        safe_memories.append(memory)
+    return safe_memories
 
 
 @router.post("/v1/dev/user/memories", response_model=MemoryResponse, tags=["developer"])

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -361,6 +361,19 @@ def _build_test_app():
     return app, TestClient(app)
 
 
+def _build_memories_test_app():
+    """Build a minimal FastAPI app for Developer API memories routes."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from routers.developer import router as developer_router
+    from dependencies import get_uid_with_memories_read
+
+    app = FastAPI()
+    app.include_router(developer_router)
+    app.dependency_overrides[get_uid_with_memories_read] = lambda: 'uid1'
+    return app, TestClient(app, raise_server_exceptions=False)
+
+
 class TestDevApiHttpLayer:
     """HTTP layer tests using FastAPI TestClient."""
 
@@ -461,3 +474,106 @@ class TestDevApiHttpLayer:
         assert len(body) == 1
         assert body[0]['id'] == 'f1'
         assert body[0]['name'] == 'Work'
+
+
+class TestDevApiMemoriesHttpLayer:
+    """HTTP layer tests for Developer API memory list resilience."""
+
+    def setup_method(self):
+        import database.memories as memories_db
+
+        memories_db.get_memories = MagicMock()
+
+    def test_memories_page_tolerates_legacy_malformed_record(self):
+        """A single legacy record must not turn an offset page into HTTP 500."""
+        import database.memories as memories_db
+
+        now = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        memories_db.get_memories.return_value = [
+            {
+                'id': 'mem-ok',
+                'content': 'normal memory',
+                'category': 'manual',
+                'visibility': 'private',
+                'tags': ['source'],
+                'created_at': now,
+                'updated_at': now,
+                'manually_added': True,
+                'scoring': '01_998_1736935200',
+                'reviewed': True,
+                'user_review': True,
+                'edited': False,
+            },
+            {
+                'id': 'mem-legacy',
+                'content': 'legacy memory',
+                'category': 'unexpected-legacy-category',
+                'visibility': None,
+                'tags': None,
+                'created_at': 'not-a-date',
+                'updated_at': {'bad': 'date'},
+                'user_review': 'yes',
+            },
+            {
+                'id': 'mem-locked-legacy',
+                'content': None,
+                'category': None,
+                'is_locked': True,
+                'scoring': 123,
+            },
+            {
+                'content': 'no id should be skipped',
+                'category': 'manual',
+            },
+        ]
+
+        _, client = _build_memories_test_app()
+        resp = client.get('/v1/dev/user/memories?limit=3&offset=7')
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 3
+        legacy = body[1]
+        assert legacy['id'] == 'mem-legacy'
+        assert legacy['content'] == 'legacy memory'
+        assert legacy['category'] == 'interesting'
+        assert legacy['visibility'] == 'private'
+        assert legacy['tags'] == []
+        assert legacy['created_at'] is None
+        assert legacy['updated_at'] is None
+        assert legacy['manually_added'] is False
+        assert legacy['reviewed'] is False
+        assert legacy['user_review'] is True
+        assert legacy['edited'] is False
+
+        locked_legacy = body[2]
+        assert locked_legacy['id'] == 'mem-locked-legacy'
+        assert locked_legacy['content'] == ''
+        assert locked_legacy['category'] == 'interesting'
+        assert locked_legacy['scoring'] == '123'
+
+    def test_cleaner_memory_coerces_edge_values(self):
+        """CleanerMemory validators should be resilient outside the endpoint pre-filter too."""
+        from routers.developer import CleanerMemory
+
+        memory = CleanerMemory(
+            id=None,
+            content=None,
+            category=None,
+            created_at={'bad': 'date'},
+            updated_at=[],
+            manually_added='1',
+            reviewed='true',
+            user_review='no',
+            edited='',
+        )
+
+        assert memory.id == ''
+        assert memory.content == ''
+        assert memory.category == 'interesting'
+        assert memory.created_at is None
+        assert memory.updated_at is None
+        assert memory.manually_added is True
+        assert memory.reviewed is True
+        assert memory.user_review is False
+        assert memory.edited is False


### PR DESCRIPTION
## Summary
- make the Developer API memories response model tolerate legacy or malformed memory fields instead of turning a page into a 500
- skip non-dict or id-less records before response validation
- keep locked-memory truncation resilient when content is missing or non-string
- coerce edge cases for `id`, `user_review`, and invalid datetime values so corrupted records still serialize safely
- add HTTP-layer and model-level coverage for mixed valid, legacy, locked, id-less, and corrupted memory records

## Verification
- `python -m pytest tests\unit\test_dev_api_folder_filters.py -q`
  - 18 passed, 2 warnings
- `python -m black routers\developer.py tests\unit\test_dev_api_folder_filters.py --check`
  - 2 files would be left unchanged
- `python -m py_compile routers\developer.py tests\unit\test_dev_api_folder_filters.py`
- `git diff --check origin/main..HEAD`