### PR TITLE
Stabilize rate limiting tests on Windows

### DIFF
--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -15,8 +15,10 @@ for mod_name in [
     'firebase_admin.auth',
     'google.cloud',
     'google.cloud.firestore',
+    'google.cloud.firestore_v1',
     'database.redis_db',
     'database.auth',
+    'database.users',
 ]:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = types.ModuleType(mod_name)
@@ -43,6 +45,7 @@ firebase_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {}
 redis_db_stub = sys.modules['database.redis_db']
 redis_db_stub._RATE_LIMIT_LUA = MagicMock(return_value=[1, 3600])
 redis_db_stub.try_acquire_listen_lock = MagicMock(return_value=True)
+sys.modules['database.users'].record_user_platform = MagicMock()
 
 
 def _check_rate_limit(key, policy, max_requests, window):
@@ -365,7 +368,7 @@ class TestRouterWiring(unittest.TestCase):
         import re
 
         matches = []
-        with open(filepath) as f:
+        with open(filepath, encoding='utf-8') as f:
             for line in f:
                 if re.search(pattern, line):
                     matches.append(line.strip())
@@ -478,19 +481,30 @@ class TestRealCheckRateLimit(unittest.TestCase):
             sys.modules['redis'] = original_redis
 
         cls.mock_lua = mock_lua_callable
+        cls.lua_sources = [
+            call.args[0] if call.args else call.kwargs.get('script', '')
+            for call in mock_redis_client.register_script.call_args_list
+        ]
+
+    @classmethod
+    def _rate_limit_lua_source(cls):
+        # Matches by content rather than call order. These anchors are present in
+        # database/redis_db.py _RATE_LIMIT_LUA; update them if those Lua variables change.
+        for lua_source in cls.lua_sources:
+            if 'local key = KEYS[1]' in lua_source and 'return {current, ttl}' in lua_source:
+                return lua_source
+        raise AssertionError('rate limit Lua script was not registered')
 
     def test_lua_script_has_ttl_self_heal(self):
         """Verify the registered Lua script contains TTL self-heal logic."""
-        # register_script was called with the Lua source
-        call_args = self.real_module.r.register_script.call_args
-        lua_source = call_args[0][0]
+        lua_source = self._rate_limit_lua_source()
         self.assertIn('TTL', lua_source)
         self.assertIn('ttl < 0', lua_source)
         self.assertIn('EXPIRE', lua_source)
 
     def test_lua_script_uses_incr(self):
         """Verify Lua uses INCR for atomic counter."""
-        lua_source = self.real_module.r.register_script.call_args[0][0]
+        lua_source = self._rate_limit_lua_source()
         self.assertIn('INCR', lua_source)
 
     def test_real_check_rate_limit_key_format(self):


### PR DESCRIPTION
## Summary
- stub the additional Firebase/Firestore and user database modules needed by rate-limiting tests in lightweight environments
- read router source files with explicit UTF-8 encoding for Windows compatibility
- select the registered rate-limit Lua script by content instead of relying on `register_script` call order
- make Lua source capture resilient to positional or keyword `register_script` calls, with documented anchors for the selected script

## Verification
- `python -m pytest tests\unit\test_rate_limiting.py -q`
  - 53 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_rate_limiting.py --check`
  - 1 file would be left unchanged
- `python -m py_compile tests\unit\test_rate_limiting.py`
- `git diff --check origin/main..HEAD`