### PR TITLE
Stabilize action item date validation tests

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -53,7 +53,11 @@ def _load_module_from_file(module_name, file_path):
     spec = importlib.util.spec_from_file_location(module_name, str(file_path))
     mod = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = mod
-    spec.loader.exec_module(mod)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
     return mod
 
 
@@ -81,6 +85,7 @@ for mod_name in [
 ]:
     if mod_name not in sys.modules:
         _stub_module(mod_name)
+sys.modules["database.auth"].get_user_name = MagicMock(return_value="Test User")
 
 # Stub database.action_items
 action_items_db = _stub_module("database.action_items")


### PR DESCRIPTION
## Summary
- remove partially imported modules from `sys.modules` when dynamic test imports fail, so later imports do not reuse half-initialized modules
- stub `database.auth.get_user_name` for action item date validation tests in lightweight environments
- keep the existing action item date behavior assertions unchanged

## Verification
- `python -m pytest tests\unit\test_action_item_date_validation.py -q`
  - 21 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_action_item_date_validation.py --check`
  - 1 file would be left unchanged
- `python -m py_compile tests\unit\test_action_item_date_validation.py`
- `git diff --check origin/main..HEAD`