### PR TITLE
Stabilize DG usage batch tests on Windows

### DIFF
--- a/backend/tests/unit/test_dg_usage_batch.py
+++ b/backend/tests/unit/test_dg_usage_batch.py
@@ -12,7 +12,7 @@ import pytest
 
 def _read_transcribe_source():
     path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'transcribe.py')
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         return f.read()
 
 
@@ -76,11 +76,13 @@ class TestDgUsageBatchingBehavior:
             'database.user_usage',
             'database.conversations',
             'firebase_admin',
+            'firebase_admin.auth',
             'firebase_admin.messaging',
         ]:
             if mod_name not in sys.modules:
                 sys.modules[mod_name] = ModuleType(mod_name)
 
+        sys.modules['firebase_admin'].auth = sys.modules['firebase_admin.auth']
         sys.modules['database._client'].db = MagicMock()
         sys.modules['database.redis_db'].r = MagicMock()
 


### PR DESCRIPTION
## Summary
- read `routers/transcribe.py` with explicit UTF-8 encoding in the DG usage batching source-structure test
- stub `firebase_admin.auth` and expose it on the `firebase_admin` stub so the behavior test can import transcribe dependencies in lightweight environments
- keep the existing DG usage batching assertions unchanged

## Verification
- `python -m pytest tests\unit\test_dg_usage_batch.py -q`
  - 11 passed, 1 warning
  - warning: local Windows venv is Python 3.10.6; Google API core warns support ends on 2026-10-04
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_dg_usage_batch.py --check`
  - 1 file would be left unchanged
- `python -m py_compile tests\unit\test_dg_usage_batch.py`
- `git diff --check origin/main..HEAD`