### PR TITLE
Stabilize VAD gate tests without ONNX deps

### DIFF
--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -2,12 +2,21 @@
 
 import os
 import struct
+import sys
 import tempfile
 import threading
 import time
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+sys.modules.setdefault('database.redis_db', MagicMock())
+sys.modules.setdefault('onnxruntime', MagicMock())
+if 'pydub' not in sys.modules:
+    _pydub_mod = types.ModuleType('pydub')
+    _pydub_mod.AudioSegment = MagicMock()
+    sys.modules['pydub'] = _pydub_mod
 
 from utils.stt.safe_socket import KeepaliveConfig, SafeDeepgramSocket
 from utils.stt.vad_gate import (


### PR DESCRIPTION
## Summary
- stub optional VAD import dependencies for `test_vad_gate.py` so the existing gate regression tests run in lightweight Windows/backend environments
- avoid importing real Redis, ONNX Runtime, or pydub during test collection
- leave VAD gate production behavior unchanged

## Testing
- `python -m pytest tests\unit\test_vad_gate.py -q` -> 115 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_vad_gate.py --check`
- `python -m py_compile tests\unit\test_vad_gate.py`
- `git diff --check origin/main..HEAD`