### PR TITLE
fix(app): auto-resume Limitless offline sync until the backlog fully drains

### DIFF
--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -164,6 +164,19 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
   }
 
   @override
+  Future<void> refreshWalsFromDevice() async {
+    // Re-enumerate from the device's current flash-page pointers. ACKs sent
+    // during a previous sync advance oldest_flash_page, so this re-reads the
+    // remaining range. Without it, a second in-session Sync tap would reuse the
+    // stale cached WAL (possibly already marked synced) and report "no data" —
+    // forcing the user to relaunch the app to resume. Skip while a download is
+    // in flight so we never swap the list out from under an active sync.
+    if (_isSyncing) return;
+    _wals = await _getMissingWals();
+    listener.onWalUpdated();
+  }
+
+  @override
   Future stop() async {
     _wals = [];
     await _pageStream?.cancel();
@@ -392,8 +405,17 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
           }
         }
 
-        if (emptyExtractions >= maxEmptyExtractions) {
-          Logger.debug("FlashPageSync: No more data from device");
+        // Authoritative completion is reaching the newest page that existed at
+        // enumeration — driven off the device's page pointer, not a transfer
+        // lull. A gap in the BLE frame stream (backpressure or a device-side
+        // pause between sessions) no longer counts as "fully drained".
+        if (lastProcessedIndex != null && lastProcessedIndex >= endPage) {
+          Logger.debug("FlashPageSync: Reached newest page $endPage, download complete");
+          syncComplete = true;
+        } else if (emptyExtractions >= maxEmptyExtractions) {
+          Logger.debug(
+            "FlashPageSync: Stream stalled at page ${lastProcessedIndex ?? startPage} before end $endPage; pausing for resume",
+          );
           syncComplete = true;
         }
 
@@ -493,10 +515,33 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
       await limitlessConnection.enableRealTimeMode();
 
-      Logger.debug("FlashPageSync: Download complete. $filesSaved files saved and registered with LocalWalSync");
-      DebugLogManager.logEvent('flash_page_download_completed', {'filesSaved': filesSaved});
-      progress?.onWalSyncedProgress(1.0);
-      return true; // Completed successfully
+      final bool reachedEnd = lastProcessedIndex != null && lastProcessedIndex >= endPage;
+      if (reachedEnd) {
+        Logger.debug("FlashPageSync: Download complete. $filesSaved files saved and registered with LocalWalSync");
+        DebugLogManager.logEvent('flash_page_download_completed', {'filesSaved': filesSaved});
+        progress?.onWalSyncedProgress(1.0);
+        return true; // Fully drained — safe for the caller to mark this WAL synced
+      }
+
+      // Stalled before the newest page. Advance the WAL to the first page we
+      // have NOT pulled and leave it 'miss' (mirrors the cancel path above), so
+      // the next sync resumes from here instead of marking the whole range
+      // synced after only a partial download. refreshWalsFromDevice() re-reads
+      // the device's advanced pointer on the next Sync.
+      if (lastProcessedIndex != null) {
+        wal.storageOffset = lastProcessedIndex + 1;
+        final remainingPages = endPage - lastProcessedIndex;
+        wal.seconds = (remainingPages * secondsPerFlashPage).round();
+        Logger.debug(
+          "FlashPageSync: Partial download — resume start page ${wal.storageOffset}, $remainingPages pages remaining",
+        );
+      }
+      DebugLogManager.logEvent('flash_page_download_partial', {
+        'filesSaved': filesSaved,
+        'lastProcessedIndex': lastProcessedIndex ?? 0,
+        'endPage': endPage,
+      });
+      return false; // Not fully drained — WAL stays 'miss' for the next sync
     } catch (e) {
       Logger.debug("FlashPageSync: Error: $e");
       DebugLogManager.logError(e, null, 'Flash page download error');

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -46,10 +46,8 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   @override
   void cancelSync() {
-    if (_isSyncing) {
-      Logger.debug("FlashPageSync: Cancel requested");
-      _cancelRequested = true;
-    }
+    Logger.debug("FlashPageSync: Cancel requested");
+    _cancelRequested = true;
   }
 
   Future<Map<String, int>?> _getStorageStatus(String deviceId) async {
@@ -184,38 +182,72 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   @override
   Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
-    var wals = _wals.where((w) => w.status == WalStatus.miss && w.storage == WalStorage.flashPage).toList();
-    if (wals.isEmpty) {
-      Logger.debug("FlashPageSync: All downloaded!");
-      return null;
-    }
+    _cancelRequested = false;
 
-    for (var i = wals.length - 1; i >= 0; i--) {
-      var wal = wals[i];
+    int? globalStartPage;
+    int globalEndPage = 0;
+    bool drained = false;
 
-      wal.isSyncing = true;
-      wal.syncStartedAt = DateTime.now();
-      wal.syncMethod = SyncMethod.ble;
-      listener.onWalUpdated();
-
-      final completed = await _syncWal(wal, progress);
-
-      if (completed) {
-        wal.status = WalStatus.synced;
-      }
-      // If cancelled, status remains 'miss' so user can resume later
-
-      wal.isSyncing = false;
-      wal.syncStartedAt = null;
-      wal.syncEtaSeconds = null;
-      wal.syncSpeedKBps = null;
-      listener.onWalUpdated();
-
-      // If cancelled, stop processing remaining WALs
-      if (!completed && _cancelRequested) {
-        Logger.debug("FlashPageSync: Stopping syncAll due to cancellation");
+    while (!_cancelRequested) {
+      final wals = _wals.where((w) => w.status == WalStatus.miss && w.storage == WalStorage.flashPage).toList();
+      if (wals.isEmpty) {
+        Logger.debug("FlashPageSync: All downloaded!");
+        drained = globalStartPage != null;
         break;
       }
+
+      final int passStartPage = wals.map((w) => w.storageOffset).reduce((a, b) => a < b ? a : b);
+      globalStartPage ??= passStartPage;
+      for (final w in wals) {
+        if (w.storageTotalBytes > globalEndPage) globalEndPage = w.storageTotalBytes;
+      }
+
+      for (var i = wals.length - 1; i >= 0; i--) {
+        var wal = wals[i];
+
+        wal.isSyncing = true;
+        wal.syncStartedAt = DateTime.now();
+        wal.syncMethod = SyncMethod.ble;
+        listener.onWalUpdated();
+
+        final completed = await _syncWal(wal, progress, globalStartPage: globalStartPage, globalEndPage: globalEndPage);
+
+        if (completed) {
+          wal.status = WalStatus.synced;
+        }
+
+        wal.isSyncing = false;
+        wal.syncStartedAt = null;
+        wal.syncEtaSeconds = null;
+        wal.syncSpeedKBps = null;
+        listener.onWalUpdated();
+
+        if (!completed && _cancelRequested) {
+          Logger.debug("FlashPageSync: Stopping syncAll due to cancellation");
+          break;
+        }
+      }
+
+      if (_cancelRequested) break;
+
+      await refreshWalsFromDevice();
+      final resumeWals = _wals.where((w) => w.status == WalStatus.miss && w.storage == WalStorage.flashPage).toList();
+      if (resumeWals.isEmpty) {
+        drained = true;
+        break;
+      }
+
+      final int resumeStartPage = resumeWals.map((w) => w.storageOffset).reduce((a, b) => a < b ? a : b);
+      if (resumeStartPage <= passStartPage) {
+        Logger.debug("FlashPageSync: No forward progress past page $passStartPage; stopping auto-resume");
+        DebugLogManager.logWarning('Flash page auto-resume halted: no forward progress', {'startPage': passStartPage});
+        break;
+      }
+      Logger.debug("FlashPageSync: Auto-resuming flash-page sync from page $resumeStartPage");
+    }
+
+    if (drained && !_cancelRequested) {
+      progress?.onWalSyncedProgress(1.0);
     }
 
     return null;
@@ -223,6 +255,7 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   @override
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
+    _cancelRequested = false;
     var walToSync = _wals.where((w) => w == wal).toList().first;
 
     walToSync.isSyncing = true;
@@ -247,12 +280,11 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   /// Downloads flash page data from device and registers chunks with LocalWalSync.
   /// Returns true if sync completed successfully, false if cancelled or failed.
-  Future<bool> _syncWal(Wal wal, IWalSyncProgressListener? progress) async {
+  Future<bool> _syncWal(Wal wal, IWalSyncProgressListener? progress, {int? globalStartPage, int? globalEndPage}) async {
     if (_device == null) return false;
 
     String deviceId = _device!.id;
     _currentDeviceId = deviceId;
-    _cancelRequested = false;
 
     try {
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
@@ -309,7 +341,11 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
             lastProcessedIndex = maxIndex;
 
             final pagesProcessed = lastProcessedIndex - startPage;
-            final progressPercent = totalPages > 0 ? pagesProcessed / totalPages : 0.0;
+
+            final int progStart = globalStartPage ?? startPage;
+            final int progEnd = globalEndPage ?? endPage;
+            final int progTotal = progEnd - progStart;
+            final progressPercent = progTotal > 0 ? (lastProcessedIndex - progStart) / progTotal : 0.0;
 
             // Calculate speed (pages per second) and ETA
             final elapsedSeconds = DateTime.now().difference(syncStartTime).inMilliseconds / 1000.0;
@@ -321,13 +357,14 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
             // Update WAL with sync progress info
             wal.syncedFrameOffset = pagesProcessed;
             if (pagesPerSecond > 0) {
-              final pagesRemaining = endPage - lastProcessedIndex;
+              final pagesRemaining = progEnd - lastProcessedIndex;
               wal.syncEtaSeconds = (pagesRemaining / pagesPerSecond).round();
               // Convert pages/sec to approx KB/s (each page ~160 bytes of opus data)
               wal.syncSpeedKBps = pagesPerSecond * 0.16;
             }
 
-            progress?.onWalSyncedProgress(progressPercent.clamp(0.0, 0.95), speedKBps: wal.syncSpeedKBps);
+            final double reportCap = globalStartPage != null ? 0.99 : 0.95;
+            progress?.onWalSyncedProgress(progressPercent.clamp(0.0, reportCap), speedKBps: wal.syncSpeedKBps);
             listener.onWalUpdated();
           }
 
@@ -457,7 +494,6 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
           // Switch back to real-time mode
           _isSyncing = false;
-          _cancelRequested = false;
           wal.syncEtaSeconds = null;
           wal.syncSpeedKBps = null;
           listener.onWalUpdated();
@@ -519,7 +555,9 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
       if (reachedEnd) {
         Logger.debug("FlashPageSync: Download complete. $filesSaved files saved and registered with LocalWalSync");
         DebugLogManager.logEvent('flash_page_download_completed', {'filesSaved': filesSaved});
-        progress?.onWalSyncedProgress(1.0);
+        if (globalStartPage == null) {
+          progress?.onWalSyncedProgress(1.0);
+        }
         return true; // Fully drained — safe for the caller to mark this WAL synced
       }
 

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -120,4 +120,5 @@ abstract class FlashPageWalSync implements IWalSync {
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();
   bool get isSyncing;
+  Future<void> refreshWalsFromDevice();
 }

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -264,7 +264,15 @@ class WalSyncs implements IWalSync {
     // Phase 1b: Download flash page data to phone
     Logger.debug("WalSyncs: Phase 1b - Downloading flash page data to phone");
     DebugLogManager.logInfo('Sync Phase 1b: Downloading flash page data to phone');
-    await _flashPageSync.syncAll(progress: progress);
+    // Re-enumerate from the device first (mirrors the ring/storage phases
+    // above) so a repeat Sync tap resumes from the device's current flash-page
+    // pointer instead of a stale cached WAL — no app relaunch needed.
+    await _flashPageSync.refreshWalsFromDevice();
+    final flashMissing = (await _flashPageSync.getMissingWals()).where((w) => w.status == WalStatus.miss).toList();
+    if (flashMissing.isNotEmpty) {
+      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      await _flashPageSync.syncAll(progress: progress);
+    }
 
     if (_isCancelled) {
       Logger.debug("WalSyncs: Cancelled after flash page phase");


### PR DESCRIPTION
## Problem

Limitless users with a large offline backlog tap **Sync**, but only a random small window downloads (sometimes 5 min, 10 min, 30 min, occasionally 1–2 h), the UI then reports **"no data to sync"**, and the only way to fetch the next chunk is to **kill and relaunch the app**. A full day's backlog becomes a kill/relaunch grind. The partial data is also marked synced when it wasn't fully downloaded, and large bursts on re-upload trip the fair-use limit.

## Root cause

Two defects in the flash-page sync path (`flash_page_wal_sync.dart`, `wal_syncs.dart`):

1. **False completion.** The whole backlog is one WAL spanning oldest→newest flash page. `_syncWal`'s download loop exited and `return true`'d after 60 consecutive empty buffer polls (`maxEmptyExtractions` = 30 s of no BLE frames). A transfer lull / device-side pause was misread as "drained", so `syncAll` marked the entire WAL `synced` after only a partial pull. Where the first ≥30 s lull landed = the random window size.
2. **No in-session re-enumeration.** The flash-page WAL list is built only at `start()` / `setDevice()`. Phase 1b called `_flashPageSync.syncAll()` **without** a `refreshWalsFromDevice()` — unlike the ring/storage phases. After defect 1 marked the cached WAL synced, a second tap filtered `status == miss` → empty → "no data to sync". Only an app relaunch re-enumerated.

## Fix

**Pointer-based completion + re-enumeration (no false completion, no relaunch):**
- **`wal_interfaces.dart`** — add `refreshWalsFromDevice()` to `FlashPageWalSync` (parity with `RingStorageSync`/`StorageSync`).
- **`flash_page_wal_sync.dart`** — completion is now **pointer-based**: a pass marks the WAL synced **only** when `lastProcessedIndex >= endPage`. A buffer lull no longer counts as drained. On a stall before the end it advances `wal.storageOffset` to the first un-pulled page, keeps status `miss`, and returns `false`. Implements `refreshWalsFromDevice()` (re-run `_getMissingWals()`), guarded to skip while a download is in flight.

**Auto-resume — one Sync tap drains the whole backlog (no second tap, no relaunch):**
- **`flash_page_wal_sync.dart`** — `syncAll()` now wraps the download pass in a resume loop. When a pass stalls, it has already ACKed the pages it pulled, advancing the device's `oldest_flash_page` pointer; the loop then calls `refreshWalsFromDevice()` and continues from that pointer in-process until the backlog drains.
  - **Forward-progress guard:** after re-enumerating, if the device's start page didn't advance past the pass just run, the loop stops instead of spinning (handles "device not releasing pages" / only the open current session remaining). The loop is strictly monotonic and bounded, so it always terminates.
  - **Cancellation across passes:** `cancelSync()` is no longer gated on `_isSyncing` (a cancel landing in the brief between-pass window is now honored), and `_syncWal` no longer resets `_cancelRequested` (it was wiping the flag before the caller could see it). The reset moves to the public `syncAll`/`syncWal` entry points so it survives across resume passes but doesn't leak into the next sync.
  - **Smooth progress:** progress is reported against the whole-backlog span (`globalStartPage`/`globalEndPage`) instead of per-pass, so the bar climbs once 0→100% instead of resetting to 0 on every resume. Intermediate passes cap at 0.99; the final `1.0` fires only when the backlog actually drains.
- **`wal_syncs.dart`** — Phase 1b calls `refreshWalsFromDevice()` + a `miss` guard before `syncAll()`, mirroring the ring/storage phases.

## Effect

- One **Sync** tap drains the entire backlog automatically — no second tap, no kill/relaunch.
- Data is never marked synced unless it was actually downloaded (stops the silent loss and the fair-use re-upload bursts).
- Progress reflects the whole backlog and a Cancel is honored at any point during the resume loop.

## Verification

- Analyzer clean on the changed files (the 2 remaining warnings predate this PR).
- All wal/sync unit tests pass (`local_wal_sync`, `phone_mic_wal`, `session_wal_sync`, `wal_recovery`, `wal_upload_resilience`, `wal_sync_display_state`, `sync_response_handling` — 123 tests).
- BLE flash-page transfer itself is not exercisable in CI — needs a device check with a real Limitless backlog.

## Deliberately out of scope (follow-ups)

- Pre-existing `pageCount > 30` guard in `_getMissingWals` leaves the last ≤30 pages (~42 s) unreachable via Sync, and a still-open current-session page can keep `lastProcessedIndex` from reaching `endPage`. Predates this change; negligible for the reported large-window bug, and the auto-resume loop's forward-progress guard terminates cleanly on that tail.
- A unit test for the resume loop ("stall before endPage → returns false, WAL stays miss, next pass resumes") — fakeable `LimitlessDeviceConnection`, no real BLE — worth adding given there's no flash-page coverage today.
