### PR TITLE
fix(backend): harden conversation search against malformed indexed documents

### DIFF
--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -289,6 +289,68 @@ class TestSearchRedaction:
         # total_pages uses page-level signal, not global found count
         assert result['total_pages'] == 1
 
+    def test_search_skips_malformed_timestamp_hit(self):
+        """A single hit with a missing/null timestamp must be skipped, not 500 the whole page."""
+        mock_client = MagicMock()
+        mock_client.collections.__getitem__.return_value.documents.search.return_value = {
+            'hits': [
+                {
+                    'document': {
+                        **_make_conversation(locked=False, conversation_id='good'),
+                        'created_at': 1704067200,
+                        'started_at': 1704067200,
+                        'finished_at': 1704070800,
+                    }
+                },
+                {
+                    'document': {
+                        # null started_at -> utcfromtimestamp(None) raises; finished_at missing entirely
+                        **_make_conversation(locked=False, conversation_id='bad'),
+                        'created_at': 1704067200,
+                        'started_at': None,
+                    }
+                },
+            ],
+            'found': 2,
+        }
+
+        with patch('utils.conversations.search.client', mock_client):
+            from utils.conversations.search import search_conversations
+
+            result = search_conversations(uid='test-uid', query='test')
+
+        # Does not raise; only the well-formed hit survives, with ISO-string timestamps.
+        assert len(result['items']) == 1
+        kept = result['items'][0]
+        assert isinstance(kept['created_at'], str) and 'T' in kept['created_at']
+        assert isinstance(kept['started_at'], str)
+
+    def test_search_all_malformed_returns_empty_page_not_500(self):
+        """If every hit is malformed, return an empty page instead of 500ing the whole request."""
+        mock_client = MagicMock()
+        mock_client.collections.__getitem__.return_value.documents.search.return_value = {
+            'hits': [
+                {'document': {**_make_conversation(locked=False, conversation_id='bad1'), 'created_at': None}},
+                {
+                    'document': {
+                        **_make_conversation(locked=False, conversation_id='bad2'),
+                        'created_at': 1704067200,
+                        'started_at': None,
+                    }
+                },
+            ],
+            'found': 2,
+        }
+
+        with patch('utils.conversations.search.client', mock_client):
+            from utils.conversations.search import search_conversations
+
+            result = search_conversations(uid='test-uid', query='test', page=2)
+
+        assert result['items'] == []
+        assert result['total_pages'] == 2  # falls back to the page param, not inflated
+        assert result['current_page'] == 2
+
     def test_search_total_pages_does_not_leak_locked_count(self):
         """total_pages must not inflate from locked docs on other pages."""
         mock_client = MagicMock()

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -64,7 +64,7 @@ def search_conversations(
                 # One malformed/legacy indexed doc (missing, null, or out-of-range timestamp) must not
                 # 500 the whole search page; skip just this hit (mirrors the per-record tolerance in
                 # routers/memories.py get_memories).
-                logger.warning(f"search_conversations skipping malformed hit uid={uid} id={doc.get('id')}: {e}")
+                logger.warning("search_conversations skipping malformed hit uid=%s id=%s: %s", uid, doc.get('id'), e)
                 continue
             doc['created_at'] = created_at
             doc['started_at'] = started_at

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -1,9 +1,12 @@
+import logging
 import math
 import os
 from datetime import datetime
 from typing import Dict
 
 import typesense
+
+logger = logging.getLogger(__name__)
 
 client = typesense.Client(
     {
@@ -51,9 +54,21 @@ def search_conversations(
             # Exclude locked conversations entirely to prevent inference leaks
             if doc.get('is_locked', False):
                 continue
-            doc['created_at'] = datetime.utcfromtimestamp(doc['created_at']).isoformat()
-            doc['started_at'] = datetime.utcfromtimestamp(doc['started_at']).isoformat()
-            doc['finished_at'] = datetime.utcfromtimestamp(doc['finished_at']).isoformat()
+            try:
+                # Convert all three into locals first, then assign, so a hit that fails partway is
+                # never left half-converted.
+                created_at = datetime.utcfromtimestamp(doc['created_at']).isoformat()
+                started_at = datetime.utcfromtimestamp(doc['started_at']).isoformat()
+                finished_at = datetime.utcfromtimestamp(doc['finished_at']).isoformat()
+            except (KeyError, TypeError, ValueError, OverflowError, OSError) as e:
+                # One malformed/legacy indexed doc (missing, null, or out-of-range timestamp) must not
+                # 500 the whole search page; skip just this hit (mirrors the per-record tolerance in
+                # routers/memories.py get_memories).
+                logger.warning(f"search_conversations skipping malformed hit uid={uid} id={doc.get('id')}: {e}")
+                continue
+            doc['created_at'] = created_at
+            doc['started_at'] = started_at
+            doc['finished_at'] = finished_at
             memories.append(doc)
         # Derive total_pages only from visible (unlocked) items to prevent inference leaks.
         # is_locked is not a Typesense filter field, so exact global count is unavailable.


### PR DESCRIPTION
## Summary

A single malformed or legacy document in the Typesense conversation index 500s the entire conversation-search results page. This skips just the bad hit instead, so search keeps working for the user's other conversations. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/conversations/search.py`, `search_conversations()` converts each Typesense hit's timestamps with direct subscripting:

```python
doc['created_at'] = datetime.utcfromtimestamp(doc['created_at']).isoformat()
doc['started_at'] = datetime.utcfromtimestamp(doc['started_at']).isoformat()
doc['finished_at'] = datetime.utcfromtimestamp(doc['finished_at']).isoformat()
```

If any of those keys is missing it raises `KeyError`; if a value is null, `utcfromtimestamp(None)` raises `TypeError`. The whole loop runs inside one outer `try/except` that re-raises as `Exception("Failed to search conversations: ...")`, so one bad document turns the entire page into a 500 instead of skipping that single result. There is no Typesense indexing schema in the backend that enforces non-null timestamps, so legacy or partially-indexed documents are plausible.

## Fix

Wrap the three timestamp conversions in a per-hit `try/except (KeyError, TypeError, ValueError, OSError)`. On failure, log a warning with the uid and document id and `continue`, skipping just that hit. Well-formed documents are unchanged, and `total_pages` already derives only from the visible items, so paging is unaffected.

This mirrors the per-record tolerance already merged for the memories list in `routers/memories.py` (`get_memories` validates each record and skips and logs the bad ones), so it follows an established pattern in this codebase.

## Testing

Added a case to the existing `TestSearchRedaction` in `backend/tests/unit/test_lock_bypass_fixes.py` (already in `test.sh`): two unlocked hits, one well-formed and one with a null `started_at` and a missing `finished_at`. It asserts the call does not raise, only the well-formed conversation is returned, and its timestamps are ISO strings. Verified red to green: the test 500s against current `main` and passes with this change. `scripts/lint_async_blockers.py` is clean.

## Note on overlapping PRs

Two open PRs touch this same file but leave the timestamp loop unguarded, so neither fixes this bug and the fix code is independent of both:

- #7662 ("Defer Typesense client setup for conversation search") converts the module-level `client` into a lazy getter. If it merges first, the existing and new tests that patch `utils.conversations.search.client` will need their patch target repointed to the new getter (`_get_typesense_client` / `_typesense_client`).
- #7201 (trash filtering) adds `filter_visible_conversation_ids` in this file. If it merges first, the tests may need to account for that filter as well.
