### PR TITLE
fix(backend): return 422 instead of 500 on missing app review reply text

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -997,11 +997,15 @@ def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_current
     if not reviewer_uid:
         raise HTTPException(status_code=422, detail='Reviewer UID is required')
 
+    response = data.get('response')
+    if not isinstance(response, str) or not response.strip():
+        raise HTTPException(status_code=422, detail='Response is required')
+
     review = get_specific_user_review(app_id, reviewer_uid)
     if not review:
         raise HTTPException(status_code=404, detail='Review not found')
 
-    review['response'] = data['response']
+    review['response'] = response
     review['responded_at'] = datetime.now(timezone.utc).isoformat()
     set_app_review(app_id, reviewer_uid, review)
 
@@ -1009,7 +1013,7 @@ def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_current
     send_app_review_reply_notification(
         reviewer_uid,
         app.uid,
-        data['response'],
+        response,
         app_id,
         app.name,
     )

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -135,6 +135,7 @@ pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
 pytest tests/unit/test_conversation_search_date_validation.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v
+pytest tests/unit/test_apps_review_reply_validation.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_apps_review_reply_validation.py
+++ b/backend/tests/unit/test_apps_review_reply_validation.py
@@ -1,0 +1,113 @@
+"""reply_to_review must return 422 (not 500) when the 'response' field is missing/empty.
+
+routers/apps.py has a very heavy import graph (langchain, utils.llm, stripe, ...), so we import it
+under a stub finder that auto-mocks those namespaces (keeping models/fastapi/pydantic real), then
+call reply_to_review directly with its collaborators patched.
+"""
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    for _n in list(sys.modules):
+        if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+            sys.modules.pop(_n, None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def _call(data):
+    """Drive reply_to_review past the app/owner/reviewer gates so we reach the response check."""
+    with patch.object(apps_mod, 'get_available_app_by_id', return_value={'id': 'app-1', 'uid': 'uid1'}), patch.object(
+        apps_mod, 'App', return_value=MagicMock(uid='uid1', private=False, name='Test App')
+    ), patch.object(apps_mod, 'get_specific_user_review', return_value={'uid': 'r1', 'score': 5}), patch.object(
+        apps_mod, 'set_app_review'
+    ), patch.object(
+        apps_mod, 'send_app_review_reply_notification'
+    ):
+        return apps_mod.reply_to_review('app-1', data, uid='uid1')
+
+
+def test_missing_response_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'reviewer_uid': 'r1'})
+    assert e.value.status_code == 422
+
+
+def test_empty_or_blank_response_returns_422():
+    for bad in ('', '   '):
+        with pytest.raises(HTTPException) as e:
+            _call({'reviewer_uid': 'r1', 'response': bad})
+        assert e.value.status_code == 422
+
+
+def test_non_string_response_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'reviewer_uid': 'r1', 'response': 123})
+    assert e.value.status_code == 422
+
+
+def test_valid_response_succeeds():
+    result = _call({'reviewer_uid': 'r1', 'response': 'Thanks for the feedback'})
+    assert result['status'] == 'ok'


### PR DESCRIPTION
## Summary

`PATCH /v1/apps/{app_id}/review/reply` returns HTTP 500 when the request body omits the `response` field, instead of a clean 422. This validates the field up front, matching how the same handler already validates `reviewer_uid`. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/apps.py`, `reply_to_review` validates `reviewer_uid` (returns 422 when missing) but then uses `data['response']` directly for both the stored field and the reviewer notification:

```python
review['response'] = data['response']
...
send_app_review_reply_notification(reviewer_uid, app.uid, data['response'], app_id, app.name)
```

A request body without `response` raises `KeyError`, which surfaces as an unhandled 500. Sibling review endpoints (`submit_app_review`, `update_app_review`) read optional fields with `data.get(...)` and raise 422 for missing required input, so this endpoint was inconsistent.

## Fix

Validate `response` once, up front, and use the validated local value:

```python
response = data.get('response')
if not isinstance(response, str) or not response.strip():
    raise HTTPException(status_code=422, detail='Response is required')
```

A reply requires non-empty text, so this also rejects an empty or whitespace-only string and a non-string value, and it avoids storing a truthy non-string object. Valid non-empty replies behave exactly as before.

## Testing

New `backend/tests/unit/test_apps_review_reply_validation.py` (registered in `test.sh`). `routers/apps.py` has a heavy import graph, so the test imports it under a stub finder (auto-mocking langchain/utils/database, keeping models and fastapi real) and calls `reply_to_review` with the app, owner, and reviewer gates patched. Cases: missing, empty/blank, and non-string `response` all return 422; a valid response returns `{'status': 'ok'}`. Verified red to green: the three 422 cases fail on current `main` (KeyError/500) and pass with this change.

## PR status check

No open PR fixes this. PR #6946 edits `routers/apps.py` for auth rewiring but keeps the bare `data['response']` subscript, so it does not address it. `git log -S` on this handler shows no prior fix or revert. No filed GitHub issue matches.
