### PR TITLE
fix(backend): skip duplicate daily summary when one already exists for the date (#4608)

### DIFF
--- a/backend/tests/unit/test_daily_summary_race_condition.py
+++ b/backend/tests/unit/test_daily_summary_race_condition.py
@@ -113,6 +113,14 @@ models_notif.NotificationMessage = mock_notification_message
 models_convo = sys.modules["models.conversation"]
 models_convo.Conversation = MagicMock()
 
+# utils.executors / utils.subscription are imported by notifications.py and pull firebase_admin
+# transitively; stub them (neither is used by _send_summary_notification).
+exec_mod = _stub_module("utils.executors")
+exec_mod.postprocess_executor = MagicMock()
+exec_mod.run_blocking = MagicMock()
+sub_mod = _stub_module("utils.subscription")
+sub_mod.is_trial_paywalled = MagicMock(return_value=False)
+
 # Now we can safely import
 from utils.other.notifications import _send_summary_notification
 
@@ -229,6 +237,7 @@ class TestSendSummaryNotificationLockIntegration:
         gen_mock.return_value = {'day_emoji': '!', 'headline': 'Test', 'overview': 'Summary'}
 
         daily_db = sys.modules["database.daily_summaries"]
+        daily_db.get_daily_summary_by_date = MagicMock(return_value=None)
         daily_db.create_daily_summary = MagicMock(return_value='summary-123')
 
         send_mock = sys.modules["utils.notifications"].send_notification
@@ -243,9 +252,40 @@ class TestSendSummaryNotificationLockIntegration:
         send_mock.assert_called_once()
 
     @patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True)
+    def test_skips_when_summary_already_exists(self, mock_lock):
+        """#4608: if a summary already exists for the date (lock lost on a later tick), skip before
+        spending LLM tokens or sending — do not create a duplicate doc."""
+        convos_db = sys.modules["database.conversations"]
+        convos_db.get_conversations = MagicMock()
+        convos_db.get_conversations.reset_mock()
+
+        gen_mock = sys.modules["utils.llm.external_integrations"].generate_comprehensive_daily_summary
+        gen_mock.reset_mock()
+
+        daily_db = sys.modules["database.daily_summaries"]
+        daily_db.get_daily_summary_by_date = MagicMock(return_value={'id': 'existing-1'})
+        daily_db.create_daily_summary = MagicMock()
+
+        send_mock = sys.modules["utils.notifications"].send_notification
+        send_mock.reset_mock()
+
+        user_data = ('uid1', ['token1'], 'America/New_York')
+        _send_summary_notification(user_data)
+
+        mock_lock.assert_called_once()
+        daily_db.get_daily_summary_by_date.assert_called_once()
+        # An existing summary short-circuits everything: no fetch, no LLM, no create, no send.
+        convos_db.get_conversations.assert_not_called()
+        gen_mock.assert_not_called()
+        daily_db.create_daily_summary.assert_not_called()
+        send_mock.assert_not_called()
+
+    @patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True)
     def test_no_conversations_skips_llm(self, mock_lock):
         convos_db = sys.modules["database.conversations"]
         convos_db.get_conversations = MagicMock(return_value=[])
+        daily_db = sys.modules["database.daily_summaries"]
+        daily_db.get_daily_summary_by_date = MagicMock(return_value=None)
 
         gen_mock = sys.modules["utils.llm.external_integrations"].generate_comprehensive_daily_summary
         gen_mock.reset_mock()

--- a/backend/tests/unit/test_daily_summary_race_condition.py
+++ b/backend/tests/unit/test_daily_summary_race_condition.py
@@ -281,6 +281,33 @@ class TestSendSummaryNotificationLockIntegration:
         send_mock.assert_not_called()
 
     @patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True)
+    def test_summary_lookup_error_propagates_no_duplicate(self, mock_lock):
+        """#4608: a transient Firestore error during the by-date lookup must propagate (skip this
+        tick, retry next) rather than being swallowed into a duplicate-creating path."""
+        daily_db = sys.modules["database.daily_summaries"]
+        daily_db.get_daily_summary_by_date = MagicMock(side_effect=Exception("Firestore unavailable"))
+        daily_db.create_daily_summary = MagicMock()
+
+        convos_db = sys.modules["database.conversations"]
+        convos_db.get_conversations = MagicMock()
+        convos_db.get_conversations.reset_mock()
+
+        gen_mock = sys.modules["utils.llm.external_integrations"].generate_comprehensive_daily_summary
+        gen_mock.reset_mock()
+
+        user_data = ('uid1', ['token1'], 'America/New_York')
+        try:
+            _send_summary_notification(user_data)
+            assert False, "Expected the Firestore error to propagate"
+        except Exception as e:
+            assert "Firestore unavailable" in str(e)
+
+        # Error surfaced (logged + retried next tick by the outer gather), no duplicate created.
+        daily_db.create_daily_summary.assert_not_called()
+        gen_mock.assert_not_called()
+        convos_db.get_conversations.assert_not_called()
+
+    @patch('utils.other.notifications.try_acquire_daily_summary_lock', return_value=True)
     def test_no_conversations_skips_llm(self, mock_lock):
         convos_db = sys.modules["database.conversations"]
         convos_db.get_conversations = MagicMock(return_value=[])

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -138,6 +138,18 @@ def _send_summary_notification(user_data: tuple):
     if not try_acquire_daily_summary_lock(uid, date_str):
         return
 
+    # Durable idempotency guard (#4608): the Redis lock above is best-effort (2h TTL, evictable, lost on
+    # failover), and create_daily_summary writes a fresh-uuid doc with no by-date check, so a later cron
+    # tick can persist a SECOND summary for the same date. If one already exists, skip before spending
+    # any LLM tokens or resending the notification. The regenerate flow stays in-place via update_daily_summary.
+    existing_summary = daily_summaries_db.get_daily_summary_by_date(uid, date_str)
+    if existing_summary:
+        logger.info(
+            f"Daily summary already exists for uid={uid} date={date_str} "
+            f"id={existing_summary.get('id')}; skipping duplicate generation"
+        )
+        return
+
     conversations_data = conversations_db.get_conversations(uid, start_date=start_date_utc, end_date=end_date_utc)
     if not conversations_data or len(conversations_data) == 0:
         return


### PR DESCRIPTION
Fixes #4608

## Summary

The daily-recap cron can persist two divergent summary documents for the same user and date. This adds a durable by-date idempotency guard so a duplicate is not created.

## Root cause

The scheduled path relies on a best-effort Redis lock as the only dedup:

- `backend/utils/other/notifications.py` `_send_summary_notification` acquires `try_acquire_daily_summary_lock(uid, date_str)` (a Redis SETNX with a ~2h TTL, `database/redis_db.py`), then generates the summary and calls `daily_summaries_db.create_daily_summary(uid, summary_data)`.
- `backend/database/daily_summaries.py` `create_daily_summary` writes a doc keyed by a fresh UUID with no by-date check.
- `start_cron_job` fires every UTC hour. The Redis lock is best-effort: it has a 2h TTL and can be evicted/flushed or lost on failover. A later cron tick that re-selects the same `(uid, date_str)` after the lock is gone creates a second durable summary doc for that date, polluting history, the `/daily-summary` feed, and the webhook.
- A `get_daily_summary_by_date(uid, date_str)` helper already exists (`daily_summaries.py`) but is unused anywhere, so the generation path has no durable by-date idempotency. The prior fix #4646 added only the Redis notification lock, not a by-date guard.

## Fix

In `_send_summary_notification`, immediately after acquiring the lock and before the LLM call, look up `get_daily_summary_by_date(uid, date_str)`. If a summary already exists for that date, log `uid`/`date`/`existing id` and return, skipping generation, creation, and the notification. This makes the durable store idempotent-by-date regardless of Redis lock state and reuses the existing helper. The regenerate flow is unaffected: it intentionally updates in place via `update_daily_summary` and does not go through this path.

Skipping (rather than updating) is intentional for the cron: updating would still spend LLM tokens and resend the notification and webhook, which is the user-visible duplicate-recap symptom.

## Note on the remaining race

The guard does not fully close a TOCTOU window (two ticks could both read "no summary" and both create), but the Redis lock still serializes the common hourly case, so this read-before-create guard removes the realistic duplicates from lock TTL/eviction/later-tick. The stronger durable fix is a deterministic document id (`uid:date`) or a transactional create-once; that is a larger schema/behavior change and is left as a follow-up if maintainers want a hard invariant.

## Testing

Extended `backend/tests/unit/test_daily_summary_race_condition.py` (already in `test.sh`): a new case mocks the lock as acquired (a later tick) and `get_daily_summary_by_date` returning an existing summary, then asserts the conversation fetch, LLM generation, `create_daily_summary`, and notification send are all skipped. The two existing lock-acquired tests were updated to mock `get_daily_summary_by_date` returning `None` so they still proceed. Verified red to green: the new test fails on current `main` (no guard) and passes with this change. `scripts/lint_async_blockers.py` is clean.

## PR status check

`gh pr` search for 4608 is empty and the issue has no linked closing PRs. The prior PR #4646 (for #4594) added only the Redis SETNX lock and its race test; its diff does not add `get_daily_summary_by_date` or any durable by-date guard. `git log -S "get_daily_summary_by_date"` shows only the initial import, and there is no merged-then-reverted by-date fix. No filed issue duplicates this durable-document fix.
