### PR TITLE
fix(backend): structure conversation titles and summaries in the user local timezone (#4773)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -69,6 +69,7 @@ pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_conversation_structure_timezone.py -v
 pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -1,0 +1,249 @@
+"""Tests for conversation title/summary timezone correctness (issue #4773).
+
+The two structuring functions used to hand the LLM a raw UTC timestamp and ask it to convert to the
+user's timezone, which mislabeled the time of day in titles/overviews. They now convert deterministically
+in Python and tell the model the timestamp is already local.
+
+Covers:
+1. _local_started_at_iso converts UTC to the user's local wall-clock
+2. None / invalid timezone falls back to UTC; naive datetimes are treated as UTC; DST is handled
+3. get_transcript_structure and get_reprocess_transcript_structure pass the local time + a non-None tz
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _stub_module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+def _stub_package(name):
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_module_from_file(module_name, file_path):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Stub heavy dependencies so conversation_processing.py imports without external services.
+for mod_name in [
+    "firebase_admin",
+    "firebase_admin.firestore",
+    "firebase_admin.auth",
+    "firebase_admin.messaging",
+    "firebase_admin.credentials",
+    "google.cloud.firestore",
+    "google.cloud.firestore_v1",
+    "google.cloud.firestore_v1.base_query",
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.cloud.storage",
+    "opuslib",
+    "sentry_sdk",
+    "database._client",
+    "database.redis_db",
+    "database.auth",
+]:
+    if mod_name not in sys.modules:
+        _stub_module(mod_name)
+
+_stub_package("database")
+sys.modules["database.auth"].get_user_name = MagicMock(return_value="Test User")
+
+# Stub langchain core pieces used at import time.
+_stub_package("langchain_core")
+langchain_output_parsers = _stub_module("langchain_core.output_parsers")
+langchain_output_parsers.PydanticOutputParser = MagicMock()
+langchain_prompts = _stub_module("langchain_core.prompts")
+langchain_prompts.ChatPromptTemplate = MagicMock()
+
+# Stub utils packages and the LLM client module.
+_stub_package("utils")
+_stub_package("utils.llm")
+llm_clients_stub = _stub_module("utils.llm.clients")
+llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
+llm_clients_stub.parser = MagicMock()
+
+# Real models (pure pydantic) resolve from the models package directory.
+_stub_package("models")
+sys.modules["models"].__path__ = [str(BACKEND_DIR / "models")]
+
+conv_proc = _load_module_from_file(
+    "utils.llm.conversation_processing",
+    BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
+)
+
+
+# ===========================================================================
+# _local_started_at_iso unit tests (pure conversion logic)
+# ===========================================================================
+
+
+class TestLocalStartedAtIso:
+
+    def test_converts_utc_to_user_local(self):
+        # 23:48 UTC -> 13:48 in Honolulu (UTC-10), the meal/time-of-day case from the issue.
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), "Pacific/Honolulu")
+        assert out == "2025-01-01T13:48:00"
+
+    def test_none_tz_falls_back_to_utc(self):
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), None)
+        assert out == "2025-01-01T23:48:00"
+
+    def test_invalid_tz_falls_back_to_utc(self):
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), "Not/AZone")
+        assert out == "2025-01-01T23:48:00"
+
+    def test_empty_tz_falls_back_to_utc(self):
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), "")
+        assert out == "2025-01-01T23:48:00"
+
+    def test_naive_started_at_treated_as_utc(self):
+        # A naive timestamp must be read as UTC, not silently localized.
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 23, 48), "Pacific/Honolulu")
+        assert out == "2025-01-01T13:48:00"
+
+    def test_dst_summer_offset(self):
+        # July: America/New_York is EDT (UTC-4). 12:00 UTC -> 08:00 local.
+        out = conv_proc._local_started_at_iso(datetime(2025, 7, 1, 12, 0, tzinfo=timezone.utc), "America/New_York")
+        assert out == "2025-07-01T08:00:00"
+
+    def test_dst_winter_offset(self):
+        # January: America/New_York is EST (UTC-5). 12:00 UTC -> 07:00 local.
+        out = conv_proc._local_started_at_iso(datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc), "America/New_York")
+        assert out == "2025-01-01T07:00:00"
+
+
+# ===========================================================================
+# Structuring functions pass local time to the prompt
+# ===========================================================================
+
+
+def _capture_structure(fn, **kwargs):
+    """Run a structuring function with the LLM chain mocked.
+
+    Returns {'invoke': <dict passed to chain.invoke>, 'system_text': <joined system prompt text>}.
+    """
+    mock_response = MagicMock()
+    mock_response.events = []
+
+    mock_chain = MagicMock()
+    mock_chain.invoke.return_value = mock_response
+    mock_chain.__or__ = MagicMock(return_value=mock_chain)
+
+    mock_llm = MagicMock()
+    mock_llm.__or__ = MagicMock(return_value=mock_chain)
+
+    with patch.object(conv_proc, "get_llm", return_value=mock_llm), patch.object(
+        conv_proc, "ChatPromptTemplate"
+    ) as mock_prompt_cls, patch.object(conv_proc, "get_user_name", return_value="Test User"), patch.object(
+        conv_proc, "_build_conversation_context", return_value="ctx"
+    ):
+        mock_prompt = MagicMock()
+        mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+        mock_prompt_cls.from_messages.return_value = mock_prompt
+        fn(**kwargs)
+        messages = mock_prompt_cls.from_messages.call_args[0][0]
+
+    system_text = "\n".join(text for _role, text in messages)
+    return {"invoke": mock_chain.invoke.call_args[0][0], "system_text": system_text}
+
+
+class TestStructureFunctionsTimezone:
+
+    def test_get_transcript_structure_passes_local_time(self):
+        result = _capture_structure(
+            conv_proc.get_transcript_structure,
+            transcript="Lunch meeting about the project",
+            started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc),
+            language_code="en",
+            tz="Pacific/Honolulu",
+            uid="u1",
+        )
+        # 1:48 PM local, not 23:48 UTC — this is the value the model sees.
+        assert result["invoke"]["started_at"] == "2025-01-01T13:48:00"
+        assert result["invoke"]["tz"] == "Pacific/Honolulu"
+
+    def test_get_transcript_structure_none_tz_labels_utc(self):
+        result = _capture_structure(
+            conv_proc.get_transcript_structure,
+            transcript="Lunch meeting about the project",
+            started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc),
+            language_code="en",
+            tz=None,
+            uid="u1",
+        )
+        assert result["invoke"]["started_at"] == "2025-01-01T23:48:00"
+        # The prompt must never say the timezone is "None".
+        assert result["invoke"]["tz"] == "UTC"
+
+    def test_get_transcript_structure_dst_offset(self):
+        # America/New_York in July is EDT (UTC-4): 12:00 UTC -> 08:00 local end to end.
+        result = _capture_structure(
+            conv_proc.get_transcript_structure,
+            transcript="Morning standup",
+            started_at=datetime(2025, 7, 1, 12, 0, tzinfo=timezone.utc),
+            language_code="en",
+            tz="America/New_York",
+            uid="u1",
+        )
+        assert result["invoke"]["started_at"] == "2025-07-01T08:00:00"
+        assert result["invoke"]["tz"] == "America/New_York"
+
+    def test_get_reprocess_transcript_structure_passes_local_time(self):
+        result = _capture_structure(
+            conv_proc.get_reprocess_transcript_structure,
+            transcript="Lunch meeting about the project",
+            started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc),
+            language_code="en",
+            tz="Pacific/Honolulu",
+            title="Lunch",
+        )
+        assert result["invoke"]["started_at"] == "2025-01-01T13:48:00"
+        assert result["invoke"]["tz"] == "Pacific/Honolulu"
+
+    def test_both_prompts_state_local_and_drop_convert_instruction(self):
+        # The semantic core of the fix is the prompt wording; pin it so a revert can't pass silently.
+        for fn, kwargs in [
+            (
+                conv_proc.get_transcript_structure,
+                dict(transcript="x", language_code="en", tz="Pacific/Honolulu", uid="u1"),
+            ),
+            (
+                conv_proc.get_reprocess_transcript_structure,
+                dict(transcript="x", language_code="en", tz="Pacific/Honolulu", title="t"),
+            ),
+        ]:
+            result = _capture_structure(fn, started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), **kwargs)
+            text = result["system_text"]
+            assert "already the user's local time" in text
+            assert "do not re-interpret this timestamp as UTC" in text
+            # The old buggy instruction asking the model to convert must be gone.
+            assert "respond in user local timezone" not in text

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -576,7 +576,7 @@ def extract_action_items(
         return []
 
 
-def _local_started_at_iso(started_at: datetime, tz: str) -> str:
+def _local_started_at_iso(started_at: datetime, tz: Optional[str]) -> str:
     """Render the capture time as the user's local wall-clock for prompt date context (#4773).
 
     The LLM is unreliable at converting UTC to the user's timezone, which mislabels the time of day

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from typing import List, Optional, Tuple
 
 from langchain_core.output_parsers import PydanticOutputParser
@@ -575,6 +576,21 @@ def extract_action_items(
         return []
 
 
+def _local_started_at_iso(started_at: datetime, tz: str) -> str:
+    """Render the capture time as the user's local wall-clock for prompt date context (#4773).
+
+    The LLM is unreliable at converting UTC to the user's timezone, which mislabels the time of day
+    in titles and overviews. Convert deterministically here instead. Naive datetimes are treated as
+    UTC; a missing or invalid timezone falls back to UTC.
+    """
+    try:
+        user_tz = ZoneInfo(tz) if tz else timezone.utc
+    except Exception:  # noqa: BLE001 - any unknown/invalid tz falls back to UTC
+        user_tz = timezone.utc
+    aware = started_at if started_at.tzinfo is not None else started_at.replace(tzinfo=timezone.utc)
+    return aware.astimezone(user_tz).replace(tzinfo=None).isoformat()
+
+
 def get_transcript_structure(
     transcript: str,
     started_at: datetime,
@@ -636,7 +652,7 @@ def get_transcript_structure(
     • Vague suggestions ("let's grab coffee soon")
     • Hypothetical scenarios ("if we meet Tuesday...")
 
-    For date context, this content was captured on {started_at}. {tz} is the user's timezone; respond in user local timezone.
+    For date context, this content was captured at {started_at}, which is already the user's local time ({tz}). Interpret it as-is and describe times of day in the title and overview accordingly; do not re-interpret this timestamp as UTC.
 
     {format_instructions}'''.replace(
         '    ', ''
@@ -653,8 +669,8 @@ def get_transcript_structure(
             'format_instructions': parser.get_format_instructions(),
             'language_code': language_code,
             'response_language': response_language,
-            'started_at': started_at.isoformat(),
-            'tz': tz,
+            'started_at': _local_started_at_iso(started_at, tz),
+            'tz': tz or 'UTC',
         }
     )
 
@@ -719,7 +735,7 @@ def get_reprocess_transcript_structure(
     • Vague suggestions ("let's grab coffee soon")
     • Hypothetical scenarios ("if we meet Tuesday...")
     
-    For date context, this content was captured on {started_at}. {tz} is the user's timezone; respond in user local timezone.
+    For date context, this content was captured at {started_at}, which is already the user's local time ({tz}). Interpret it as-is and describe times of day in the title and overview accordingly; do not re-interpret this timestamp as UTC.
 
     Content:
     {full_context}
@@ -738,8 +754,8 @@ def get_reprocess_transcript_structure(
             'format_instructions': parser.get_format_instructions(),
             'language_code': language_code,
             'response_language': response_language,
-            'started_at': started_at.isoformat(),
-            'tz': tz,
+            'started_at': _local_started_at_iso(started_at, tz),
+            'tz': tz or 'UTC',
         }
     )
 


### PR DESCRIPTION
Fixes #4773

## Summary

Conversation titles and summaries show the wrong time of day for any user not on UTC (a 1:48 PM Honolulu chat gets labeled late-night). The two structuring functions handed the LLM a raw UTC timestamp and asked it to convert to the user's timezone, which the model does unreliably. This converts the timestamp deterministically in Python and tells the model it is already local.

## Root cause

In `backend/utils/llm/conversation_processing.py`, both structuring functions passed UTC and delegated the timezone math to the model:

- `get_transcript_structure` and `get_reprocess_transcript_structure` set `'started_at': started_at.isoformat()` (UTC) and `'tz': tz` in the prompt, with the instruction "this content was captured on {started_at}. {tz} is the user's timezone; respond in user local timezone."
- The model then has to convert UTC to local itself. It does this inconsistently, so a 23:48 UTC capture (13:48 in Honolulu) gets described as late-night in the generated title/overview.
- The deterministic conversion idiom already exists in this repo: `utils/llm/chat.py` uses `astimezone(ZoneInfo(tz))`, and `extract_action_items` in this same file resolves dates in `{tz}` rather than trusting a raw-UTC reasoning step. The two title/summary functions never got the same treatment. Prior PR #6703 only reworded the prompt and left the raw UTC value in place.

## Fix

- New helper `_local_started_at_iso(started_at, tz)`: converts the capture time to the user's local wall-clock. A naive datetime is treated as UTC; a missing, empty, or invalid timezone falls back to UTC.
- Both functions now pass `'started_at': _local_started_at_iso(started_at, tz)` and `'tz': tz or 'UTC'` (so the prompt never says the timezone is "None").
- Both prompts are reworded to say the timestamp is already the user's local time and must not be re-interpreted as UTC, scoped to the title and overview wording.

This only changes the string the model sees in the prompt. The conversation's stored `started_at` and `created_at` are written elsewhere and are not touched, so there is no change to any persisted conversation timestamp; the only effect is correct time-of-day wording in the generated title and overview.

## Scope note: extracted Event.start timezone

These functions also extract calendar events, whose `Event.start` is a bare datetime with no timezone field. Its wire timezone is under-specified on current main today (the old prompt already passed UTC `started_at` with a "respond in user local timezone" instruction), and there is no live consumer that auto-creates a device calendar entry from it. To keep this change scoped to the title/summary time-of-day bug, the reworded instruction is limited to the title and overview and does not introduce a blanket "do not convert" that would push event-time output toward local. Giving `Event.start` an explicit UTC-with-Z output contract (mirroring `extract_action_items`) is a sensible follow-up and is intentionally left out of this PR.

## Testing

New `backend/tests/unit/test_conversation_structure_timezone.py` (added to `test.sh`):

- `_local_started_at_iso` unit tests: UTC to local, None/invalid/empty tz fall back to UTC, naive treated as UTC, and DST summer/winter offsets for America/New_York.
- Invoke-capture tests for both functions: assert the dict passed to the LLM carries the local wall-clock and a non-None `tz` (including the DST case end to end).
- A prompt-wording test asserts both system prompts state the timestamp is already local and no longer ask the model to convert, so a revert of the wording cannot pass silently.

Verified red to green: all tests fail on current `main` (raw UTC, old wording) and pass with this change. `scripts/lint_async_blockers.py` is clean.

## PR status check

#4773 is open and unassigned with no linked closing PR. `gh pr list --state all --search "4773"` is empty. PR #6703 (#6214) only reworded the prompt and left `started_at.isoformat()` raw UTC; open PR #7693 (#7059) fixes only `extract_action_items` and does not touch these two functions. `git log -S "ZoneInfo"` / `-S "astimezone"` on `conversation_processing.py` shows no prior merged deterministic conversion for the structuring path.
