### PR TITLE
backend: track mobile custom-STT users on the user doc (#7690 step 1)

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1199,9 +1199,17 @@ def get_user_transcription_preferences(uid: str) -> dict:
             'single_language_mode': prefs.get('single_language_mode', False),
             'vocabulary': prefs.get('vocabulary', []),
             'language': user_data.get('language', ''),
+            'uses_custom_stt': prefs.get('uses_custom_stt', False),
+            'custom_stt_since': prefs.get('custom_stt_since'),
         }
 
-    return {'single_language_mode': False, 'vocabulary': [], 'language': ''}
+    return {
+        'single_language_mode': False,
+        'vocabulary': [],
+        'language': '',
+        'uses_custom_stt': False,
+        'custom_stt_since': None,
+    }
 
 
 def get_agent_vm(uid: str) -> Optional[dict]:
@@ -1241,6 +1249,26 @@ def set_user_transcription_preferences(uid: str, single_language_mode: bool = No
 
     if update_data:
         user_ref.update(update_data)
+
+
+def set_user_custom_stt_usage(uid: str, uses_custom_stt: bool) -> None:
+    """Persist whether the user is using a custom (third-party) mobile STT provider.
+
+    There is no other record that a user is on custom STT — the app only sends a
+    per-session `custom_stt=enabled` WS param. This stamps it onto the user doc so
+    custom-STT users are queryable/meterable (see #7690).
+
+    - `transcription_preferences.uses_custom_stt`: current state (bool).
+    - `transcription_preferences.custom_stt_since`: when the current custom-STT
+      streak began (set on the off->on transition; cleared when turned off).
+
+    Callers should only invoke this when the value actually changes, so the
+    `_since` timestamp is not overwritten on every session and writes stay rare.
+    """
+    user_ref = db.collection('users').document(uid)
+    update_data = {'transcription_preferences.uses_custom_stt': uses_custom_stt}
+    update_data['transcription_preferences.custom_stt_since'] = datetime.now(timezone.utc) if uses_custom_stt else None
+    user_ref.update(update_data)
 
 
 # ============================================================================

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -331,6 +331,12 @@ async def _stream_handler(
     single_language_mode = transcription_prefs.get('single_language_mode', False)
     vocabulary = transcription_prefs.get('vocabulary', [])
 
+    # Stamp mobile custom-STT usage onto the user doc so these users are queryable
+    # and meterable (#7690) — the app otherwise only signals it per-session via the
+    # custom_stt WS param. Write only on change to keep this off the hot path.
+    if use_custom_stt != transcription_prefs.get('uses_custom_stt', False):
+        await run_blocking(db_executor, user_db.set_user_custom_stt_usage, uid, use_custom_stt)
+
     # Onboarding mode: force single language for better accuracy
     if onboarding_mode:
         single_language_mode = True

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -334,8 +334,13 @@ async def _stream_handler(
     # Stamp mobile custom-STT usage onto the user doc so these users are queryable
     # and meterable (#7690) — the app otherwise only signals it per-session via the
     # custom_stt WS param. Write only on change to keep this off the hot path.
+    # Best-effort telemetry only: never let a tracking write failure (e.g. a
+    # transient Firestore error) tear down the session — catch, log, and proceed.
     if use_custom_stt != transcription_prefs.get('uses_custom_stt', False):
-        await run_blocking(db_executor, user_db.set_user_custom_stt_usage, uid, use_custom_stt)
+        try:
+            await run_blocking(db_executor, user_db.set_user_custom_stt_usage, uid, use_custom_stt)
+        except Exception as e:
+            logger.warning(f"Failed to persist custom_stt usage {uid} {session_id}: {e}")
 
     # Onboarding mode: force single language for better accuracy
     if onboarding_mode:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -597,6 +597,8 @@ class TranscriptionPreferencesResponse(BaseModel):
     single_language_mode: bool = False
     vocabulary: List[str] = []
     language: str = ''
+    uses_custom_stt: bool = False
+    custom_stt_since: Optional[datetime] = None
 
 
 class TranscriptionPreferencesUpdate(BaseModel):


### PR DESCRIPTION
## Why

Mobile custom‑STT usage is currently **not recorded anywhere** — the app only sends a per‑session `custom_stt=enabled` WS param, so there's no way to query "who uses custom STT" or meter it. This blocks acting on #7690 (custom‑STT users get uncapped Omi LLM post‑processing on the free tier). Step 1 is to make these users identifiable.

## What

Persist custom‑STT usage onto the user doc, written from the listen handler **only when it changes** (kept off the hot path):

- `transcription_preferences.uses_custom_stt` — bool, current state (defaults to false / absent).
- `transcription_preferences.custom_stt_since` — timestamp the current custom‑STT streak began (set on off→on, cleared on on→off).

Changes:
- `database/users.py`: new `set_user_custom_stt_usage(uid, uses_custom_stt)`; `get_user_transcription_preferences` now returns the two fields.
- `routers/transcribe.py`: after reading prefs, if `use_custom_stt` differs from the stored value, write via `run_blocking(db_executor, …)`. Steady‑state users (no change) trigger **no** extra write.
- `routers/users.py`: `TranscriptionPreferencesResponse` exposes the two fields via the existing GET endpoint.

## Notes

- No backfill — absence = false; the field populates naturally as users connect. (We can backfill from listen logs later if needed.)
- This is desktop‑BYOK‑independent — `byok.active` (desktop, keys) is a separate system.
- Sets up the follow‑ups in #7690: cap free custom‑STT users' processing, and a "BYO‑AI" plan.

Refs #7690.
