### PR TITLE
Stabilize Twilio unit tests without SDK

### DIFF
--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -3,11 +3,14 @@ import sys
 import types
 from unittest.mock import patch
 
+from tests.unit.twilio_stub import install_twilio_stub
+
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
 os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
+install_twilio_stub()
 
 
 # Stub `database.phone_calls` before twilio_service tries to import it so we can

--- a/backend/tests/unit/test_twilio_service.py
+++ b/backend/tests/unit/test_twilio_service.py
@@ -1,11 +1,33 @@
 import os
+import sys
+import types
 from unittest.mock import patch, MagicMock
+
+from tests.unit.twilio_stub import install_twilio_stub
 
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
 os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
+install_twilio_stub()
+
+
+def _install_phone_calls_stub():
+    database_module = sys.modules.get('database')
+    if database_module is None:
+        database_module = types.ModuleType('database')
+        sys.modules['database'] = database_module
+    if not hasattr(database_module, '__path__'):
+        database_module.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'database'))]
+    if 'database.phone_calls' not in sys.modules:
+        stub = types.ModuleType('database.phone_calls')
+        stub.get_phone_numbers = lambda uid: []
+        sys.modules['database.phone_calls'] = stub
+        setattr(database_module, 'phone_calls', stub)
+
+
+_install_phone_calls_stub()
 
 from utils.twilio_service import generate_access_token, validate_twilio_signature
 

--- a/backend/tests/unit/twilio_stub.py
+++ b/backend/tests/unit/twilio_stub.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+import types
+from html import escape
+
+
+def install_twilio_stub():
+    if 'twilio' in sys.modules or importlib.util.find_spec('twilio') is not None:
+        return
+
+    twilio_mod = types.ModuleType('twilio')
+    rest_mod = types.ModuleType('twilio.rest')
+    jwt_mod = types.ModuleType('twilio.jwt')
+    access_token_mod = types.ModuleType('twilio.jwt.access_token')
+    grants_mod = types.ModuleType('twilio.jwt.access_token.grants')
+    request_validator_mod = types.ModuleType('twilio.request_validator')
+    base_mod = types.ModuleType('twilio.base')
+    exceptions_mod = types.ModuleType('twilio.base.exceptions')
+    twiml_mod = types.ModuleType('twilio.twiml')
+    voice_response_mod = types.ModuleType('twilio.twiml.voice_response')
+
+    twilio_mod.__path__ = []
+    jwt_mod.__path__ = []
+    base_mod.__path__ = []
+    twiml_mod.__path__ = []
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class AccessToken:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.grants = []
+
+        def add_grant(self, grant):
+            self.grants.append(grant)
+
+        def to_jwt(self):
+            return 'test.jwt.token'
+
+    class VoiceGrant:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class RequestValidator:
+        def __init__(self, token):
+            self.token = token
+
+        def validate(self, url, params, signature):
+            return False
+
+    class TwilioRestException(Exception):
+        def __init__(self, status=None, uri=None, msg=None, code=None, method=None, details=None):
+            super().__init__(msg)
+            self.status = status
+            self.uri = uri
+            self.msg = msg
+            self.code = code
+            self.method = method
+            self.details = details
+
+    def _xml_attrs(attrs):
+        rendered = [f'{name}="{escape(str(value), quote=True)}"' for name, value in attrs.items() if value is not None]
+        return f" {' '.join(rendered)}" if rendered else ''
+
+    class VoiceResponse:
+        def __init__(self):
+            self.verbs = []
+
+        def say(self, text):
+            self.verbs.append(f'<Say>{escape(str(text))}</Say>')
+
+        def append(self, verb):
+            self.verbs.append(str(verb))
+
+        def __str__(self):
+            return f'<Response>{"".join(self.verbs)}</Response>'
+
+    class Dial:
+        def __init__(self, caller_id=None, time_limit=None, **kwargs):
+            self.caller_id = caller_id
+            self.time_limit = time_limit
+            self.kwargs = kwargs
+            self.number_value = None
+
+        def number(self, phone_number):
+            self.number_value = phone_number
+
+        def __str__(self):
+            attrs = _xml_attrs({'callerId': self.caller_id, 'timeLimit': self.time_limit})
+            number = '' if self.number_value is None else escape(str(self.number_value))
+            return f'<Dial{attrs}>{number}</Dial>'
+
+    rest_mod.Client = Client
+    access_token_mod.AccessToken = AccessToken
+    grants_mod.VoiceGrant = VoiceGrant
+    request_validator_mod.RequestValidator = RequestValidator
+    exceptions_mod.TwilioRestException = TwilioRestException
+    voice_response_mod.VoiceResponse = VoiceResponse
+    voice_response_mod.Dial = Dial
+
+    twilio_mod.rest = rest_mod
+    twilio_mod.jwt = jwt_mod
+    jwt_mod.access_token = access_token_mod
+    access_token_mod.grants = grants_mod
+    twilio_mod.request_validator = request_validator_mod
+    twilio_mod.base = base_mod
+    base_mod.exceptions = exceptions_mod
+    twilio_mod.twiml = twiml_mod
+    twiml_mod.voice_response = voice_response_mod
+
+    sys.modules.setdefault('twilio', twilio_mod)
+    sys.modules.setdefault('twilio.rest', rest_mod)
+    sys.modules.setdefault('twilio.jwt', jwt_mod)
+    sys.modules.setdefault('twilio.jwt.access_token', access_token_mod)
+    sys.modules.setdefault('twilio.jwt.access_token.grants', grants_mod)
+    sys.modules.setdefault('twilio.request_validator', request_validator_mod)
+    sys.modules.setdefault('twilio.base', base_mod)
+    sys.modules.setdefault('twilio.base.exceptions', exceptions_mod)
+    sys.modules.setdefault('twilio.twiml', twiml_mod)
+    sys.modules.setdefault('twilio.twiml.voice_response', voice_response_mod)


### PR DESCRIPTION
## Summary
- add a small explicit Twilio SDK test stub for unit tests that import `utils.twilio_service`
- update Twilio service/account-deletion tests to install the stub only for those modules, avoiding a global unit-test conftest side effect
- keep `database` as a package-capable stub in `test_twilio_service.py` so other `database.*` imports are not blocked

## Testing
- `python -m pytest tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q` -> 9 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\twilio_stub.py backend\tests\unit\test_twilio_service.py backend\tests\unit\test_twilio_account_deletion.py --check`
- `python -m py_compile tests\unit\twilio_stub.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py`
- `git diff --check origin/main...HEAD`