### PR TITLE
fix(ble): restore audio after Limitless pendant reconnect on iOS

### DIFF
--- a/app/lib/services/devices/limitless_connection.dart
+++ b/app/lib/services/devices/limitless_connection.dart
@@ -6,6 +6,7 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/services/devices.dart';
 import 'package:omi/services/devices/device_connection.dart';
 import 'package:omi/services/devices/models.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -26,7 +27,10 @@ class LimitlessDeviceConnection extends DeviceConnection {
   final List<Map<String, dynamic>> _completedFlashPages = [];
 
   StreamSubscription? _rxSubscription;
+  StreamSubscription? _transportReconnectSubscription;
   bool _isInitialized = false;
+  bool _isReinitializing = false;
+  bool _pendingReinit = false;
   bool _isBatchMode = false;
 
   int _highestReceivedIndex = -1;
@@ -45,23 +49,61 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
     await Future.delayed(const Duration(seconds: 1));
 
-    _rxSubscription = transport
-        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
-        .listen(_handleNotification);
+    _attachRxSubscription();
 
     await Future.delayed(const Duration(seconds: 1));
 
     await _initialize();
+
+    _transportReconnectSubscription = transport.connectionStateStream
+        .where((s) => s == DeviceTransportState.connected)
+        .listen((_) => _handleTransportReconnected());
   }
 
   @override
   Future<void> disconnect() async {
+    await _transportReconnectSubscription?.cancel();
+    _transportReconnectSubscription = null;
     await _rxSubscription?.cancel();
     await _audioController.close();
     await _flashPageController.close();
     await _buttonController.close();
     _isBatchMode = false;
     await super.disconnect();
+  }
+
+  void _attachRxSubscription() {
+    _rxSubscription?.cancel();
+    _rxSubscription = transport
+        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
+        .listen(_handleNotification);
+  }
+
+  Future<void> _handleTransportReconnected() async {
+    if (_isReinitializing) {
+      _pendingReinit = true;
+      return;
+    }
+    _isReinitializing = true;
+    try {
+      do {
+        _pendingReinit = false;
+        _attachRxSubscription();
+        await _reinitializeAfterReconnect();
+      } while (_pendingReinit);
+    } finally {
+      _isReinitializing = false;
+    }
+  }
+
+  Future<void> _reinitializeAfterReconnect() async {
+    try {
+      final dataStreamCmd = _encodeEnableDataStream();
+      await transport.writeCharacteristic(limitlessServiceUuid, limitlessTxCharUuid, dataStreamCmd);
+      DebugLogManager.logInfo('Limitless device re-initialized after reconnect');
+    } catch (e) {
+      Logger.debug('Limitless: Re-initialization after reconnect failed: $e');
+    }
   }
 
   @override

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -233,9 +233,13 @@ class NativeBleTransport extends DeviceTransport {
 
   void _handleConnectionState(bool connected, String? error) {
     if (!connected) {
-      // Remember active subscriptions before closing streams
-      _activeSubscriptionKeys.clear();
-      _activeSubscriptionKeys.addAll(_streamControllers.keys);
+      // Guard against double-fire (didDisconnect + didFailToConnect both invoke this).
+      // On the 2nd call _streamControllers is already empty; overwriting _activeSubscriptionKeys
+      // with {} would prevent re-subscription on the next reconnect.
+      if (_streamControllers.isNotEmpty) {
+        _activeSubscriptionKeys.clear();
+        _activeSubscriptionKeys.addAll(_streamControllers.keys);
+      }
 
       _closeAllStreams();
       _services = [];


### PR DESCRIPTION
## Summary

Fixes a silent-audio bug where the Limitless pendant appeared connected after a BLE drop/reconnect but produced no transcription. Two independent root causes, both in the native BLE reconnect path.

### Bug 1 — `_activeSubscriptionKeys` wiped by iOS double-fire (`NativeBleTransport`)

iOS CoreBluetooth fires **both** `didDisconnectPeripheral` and `didFailToConnect` for the same drop event (e.g. encryption timeout on retry). Both callbacks invoke `_handleConnectionState(false)`, so it fires twice on the same transport instance.

- **First call**: saves `{audio_char, battery_char}` into `_activeSubscriptionKeys`, then calls `_closeAllStreams()` → `_streamControllers` is now empty.
- **Second call**: finds `_streamControllers` empty → clears `_activeSubscriptionKeys` and adds `{}` → subscription set wiped.

Result: `_resubscribeAfterReconnect()` had no keys to iterate. The battery characteristic (`00002a19`) re-subscribed anyway because iOS automatically re-enables CCCD for standard bonded characteristics — but the vendor audio characteristic (`632de003`) did not. `isNotifying` was never set to `true` for it.

**Fix**: guard the update with `if (_streamControllers.isNotEmpty)` so the second fire is a no-op.

### Bug 2 — `_rxSubscription` left dead after reconnect (`LimitlessDeviceConnection`)

`connect()` wired `_rxSubscription` to the BLE characteristic's `StreamController.broadcast()`. On disconnect, `_closeAllStreams()` closes that controller, which automatically cancels all listeners including `_rxSubscription`. After the native auto-reconnect, `_resubscribeAfterReconnect()` created a **new** stream controller — but `_rxSubscription` still referenced the old closed one. Audio data was emitted into a void; `_audioController` received nothing.

**Fix**: listen to `transport.connectionStateStream` after initial connect and re-attach `_rxSubscription` (via `_attachRxSubscription()`) synchronously on every subsequent `connected` event, then re-send the enable-data-stream command to the pendant.

### Secondary effect

By recovering real-time streaming on reconnect rather than accumulating offline recordings, this reduces the offline backlog size that gets synced on the next hard reconnect — which should ease the batch-request pressure that contributes to 429s downstream.

## Test plan

- [x] Walk-away test (clean reconnect): `didDisconnect` → `didConnect` → `isNotifying=true` for `632de003` ✓
- [x] Edge-of-range test triggering double-fire: `didDisconnect` → `didFailToConnect` (`Failed to encrypt the connection`) → `didConnect` → `isNotifying=true` for `632de003` ✓
- [x] Audio transcription resumes after reconnect in both cases
- [ ] Same walk-away test on Omi/Friend pendant (also uses `NativeBleTransport`)

## Related issues

Closes #7324
Related: #6610, #6721

🤖 Generated with [Claude Code](https://claude.ai/claude-code)