### PR TITLE
fix(desktop-backend): chat no longer shares the Gemini burst limiter (fixes chat 429s)

### DIFF
--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -56,6 +56,9 @@ pub struct AppState {
     pub config: Arc<Config>,
     pub crisp_session_cache: routes::crisp::SessionCache,
     pub gemini_rate_limiter: routes::rate_limit::SharedRateLimiter,
+    /// Separate limiter for chat so a burst of Gemini proxy calls can never
+    /// rate-limit a user's chat (high burst cap, no daily cap, isolated keys).
+    pub chat_rate_limiter: routes::rate_limit::SharedRateLimiter,
     /// Vertex AI auth provider (present when USE_VERTEX_AI=true)
     pub vertex_auth: Option<vertex::VertexAuth>,
 }
@@ -222,14 +225,19 @@ async fn main() {
 
     // Create app state
     let gemini_rate_limiter = routes::rate_limit::GeminiRateLimiter::new();
+    // Chat gets its own limiter (isolated Redis namespace, high burst cap, no daily
+    // cap) so Gemini proxy bursts can't 429 a user's chat.
+    let chat_rate_limiter = routes::rate_limit::GeminiRateLimiter::for_chat();
 
     // Spawn background task to evict stale rate limit entries every hour
     {
-        let limiter = gemini_rate_limiter.clone();
+        let gemini_limiter = gemini_rate_limiter.clone();
+        let chat_limiter = chat_rate_limiter.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
-                limiter.evict_stale().await;
+                gemini_limiter.evict_stale().await;
+                chat_limiter.evict_stale().await;
             }
         });
     }
@@ -251,6 +259,7 @@ async fn main() {
         config: Arc::new(config.clone()),
         crisp_session_cache: routes::crisp::new_session_cache(),
         gemini_rate_limiter,
+        chat_rate_limiter,
         vertex_auth,
     };
 

--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -470,10 +470,13 @@ async fn chat_completions(
     let byok_anthropic_key = byok::get_byok_key_if_active(&headers, byok::HEADER_ANTHROPIC, byok_stripped);
     let is_byok = byok_anthropic_key.is_some();
 
-    // Rate limiting — skip when using BYOK key
+    // Rate limiting — uses the dedicated CHAT limiter (NOT the Gemini one), so a
+    // burst of proactive/vision Gemini calls can never 429 a user's chat. The chat
+    // limiter only trips on a pathological per-minute burst (runaway client), which
+    // a human typing never reaches. Skipped entirely when using a BYOK key.
     if !is_byok {
         let decision = state
-            .gemini_rate_limiter
+            .chat_rate_limiter
             .check_and_record(&user.uid, state.redis.as_ref())
             .await;
         if decision == RateDecision::Reject {

--- a/desktop/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/Backend-Rust/src/routes/rate_limit.rs
@@ -26,8 +26,15 @@ use crate::services::RedisService;
 // Daily soft/hard limits are tier-aware — see crate::llm::model_qos.
 use crate::llm::model_qos;
 
-/// Burst cap — max requests per rolling 60-second window.
+/// Default Gemini burst cap — max requests per rolling 60-second window.
 const BURST_PER_MINUTE: usize = 30;
+
+/// Chat burst cap. Chat is human-typed, so this only exists as a runaway-client
+/// guard — a person never approaches it. It is deliberately high (and chat has NO
+/// daily cap) so a normal user's chat is never rate-limited. The chat path used to
+/// share the Gemini limiter's 30/min budget, so a burst of proactive/vision Gemini
+/// calls would 429 the user's chat as collateral (issue: "chat down" on beta).
+const CHAT_BURST_PER_MINUTE: usize = 120;
 
 /// Rolling window duration for burst detection (60 seconds).
 const BURST_WINDOW_SECS: u64 = 60;
@@ -54,12 +61,16 @@ struct RateSnapshot {
 }
 
 impl RateSnapshot {
-    fn to_decision(&self) -> RateDecision {
-        if self.burst_count > BURST_PER_MINUTE {
+    /// Decide Allow/Degrade/Reject for this snapshot.
+    /// `burst_cap` is the per-limiter burst ceiling. `enforce_daily` enables the
+    /// Gemini daily soft (degrade-to-flash) / hard (reject) tiers; chat sets it to
+    /// false so it only ever rejects on a pathological per-minute burst.
+    fn to_decision(&self, burst_cap: usize, enforce_daily: bool) -> RateDecision {
+        if self.burst_count > burst_cap {
             RateDecision::Reject
-        } else if self.daily_count >= model_qos::daily_hard_limit() {
+        } else if enforce_daily && self.daily_count >= model_qos::daily_hard_limit() {
             RateDecision::Reject
-        } else if self.daily_count >= model_qos::daily_soft_limit() {
+        } else if enforce_daily && self.daily_count >= model_qos::daily_soft_limit() {
             RateDecision::DegradeToFlash
         } else {
             RateDecision::Allow
@@ -77,18 +88,40 @@ struct CachedEntry {
     local_burst: VecDeque<Instant>,
 }
 
-/// Gemini rate limiter: Redis source of truth, local cache to reduce Redis calls.
+/// Per-user burst/daily rate limiter: Redis source of truth, local cache to reduce
+/// Redis calls. Reused for both the Gemini proxy and chat, each with its own Redis
+/// namespace and burst cap so the two budgets are fully independent.
 pub struct GeminiRateLimiter {
     /// Per-user cache of recent Redis decisions + local burst tracking.
     cache: Mutex<HashMap<String, CachedEntry>>,
+    /// Burst ceiling (requests per rolling 60s window) for this limiter.
+    burst_per_minute: usize,
+    /// Redis key namespace (e.g. "gemini_rl" or "chat_rl") — isolates counters.
+    redis_ns: &'static str,
+    /// Whether to apply the Gemini daily soft/hard tiers (false for chat).
+    enforce_daily: bool,
 }
 
 pub type SharedRateLimiter = Arc<GeminiRateLimiter>;
 
 impl GeminiRateLimiter {
+    /// Gemini proxy limiter: 30/min burst + daily soft/hard tiers, "gemini_rl" keys.
     pub fn new() -> SharedRateLimiter {
+        Self::with_config(BURST_PER_MINUTE, "gemini_rl", true)
+    }
+
+    /// Chat limiter: high burst cap, no daily cap, isolated "chat_rl" keys, so a
+    /// human's chat is never rejected and Gemini bursts can't starve it.
+    pub fn for_chat() -> SharedRateLimiter {
+        Self::with_config(CHAT_BURST_PER_MINUTE, "chat_rl", false)
+    }
+
+    pub fn with_config(burst_per_minute: usize, redis_ns: &'static str, enforce_daily: bool) -> SharedRateLimiter {
         Arc::new(Self {
             cache: Mutex::new(HashMap::new()),
+            burst_per_minute,
+            redis_ns,
+            enforce_daily,
         })
     }
 
@@ -105,7 +138,7 @@ impl GeminiRateLimiter {
     ) -> RateDecision {
         // Phase 1: No Redis → unmetered (skip cache entirely)
         let Some(redis) = redis else {
-            tracing::warn!("gemini rate limit: Redis not configured, request unmetered");
+            tracing::warn!("{} rate limit: Redis not configured, request unmetered", self.redis_ns);
             return RateDecision::Allow;
         };
 
@@ -122,7 +155,7 @@ impl GeminiRateLimiter {
                 }
 
                 // Fast reject on local burst (this instance alone has seen >= cap)
-                if entry.local_burst.len() >= BURST_PER_MINUTE {
+                if entry.local_burst.len() >= self.burst_per_minute {
                     return RateDecision::Reject;
                 }
 
@@ -135,19 +168,22 @@ impl GeminiRateLimiter {
         }
 
         // Phase 3: Call Redis (source of truth — records the request)
-        match redis.check_gemini_rate_limit(uid, BURST_PER_MINUTE, BURST_WINDOW_SECS).await {
+        match redis
+            .check_rate_limit(self.redis_ns, uid, self.burst_per_minute, BURST_WINDOW_SECS)
+            .await
+        {
             Ok((daily_count, burst_count)) => {
                 let snapshot = RateSnapshot {
                     daily_count: daily_count as u32,
                     burst_count: burst_count as usize,
                 };
-                let decision = snapshot.to_decision();
+                let decision = snapshot.to_decision(self.burst_per_minute, self.enforce_daily);
 
                 let mut cache = self.cache.lock().await;
                 let entry = cache.entry(uid.to_string()).or_insert_with(|| CachedEntry {
                     decision: RateDecision::Allow,
                     expires_at: now,
-                    local_burst: VecDeque::with_capacity(BURST_PER_MINUTE + 1),
+                    local_burst: VecDeque::with_capacity(self.burst_per_minute + 1),
                 });
 
                 // Only cache Reject decisions (Allow/Degrade always go to Redis)
@@ -168,7 +204,7 @@ impl GeminiRateLimiter {
                 decision
             }
             Err(e) => {
-                tracing::error!("gemini rate limit: Redis error, request unmetered: {}", e);
+                tracing::error!("{} rate limit: Redis error, request unmetered: {}", self.redis_ns, e);
                 RateDecision::Allow
             }
         }
@@ -227,34 +263,34 @@ mod tests {
     #[test]
     fn snapshot_allow() {
         let s = RateSnapshot { daily_count: 10, burst_count: 5 };
-        assert_eq!(s.to_decision(), RateDecision::Allow);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Allow);
     }
 
     #[test]
     fn snapshot_degrade_at_soft_limit() {
         let soft = model_qos::daily_soft_limit();
         let s = RateSnapshot { daily_count: soft, burst_count: 5 };
-        assert_eq!(s.to_decision(), RateDecision::DegradeToFlash);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::DegradeToFlash);
     }
 
     #[test]
     fn snapshot_reject_at_hard_limit() {
         let hard = model_qos::daily_hard_limit();
         let s = RateSnapshot { daily_count: hard, burst_count: 5 };
-        assert_eq!(s.to_decision(), RateDecision::Reject);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Reject);
     }
 
     #[test]
     fn snapshot_reject_burst() {
         let s = RateSnapshot { daily_count: 10, burst_count: 31 };
-        assert_eq!(s.to_decision(), RateDecision::Reject);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Reject);
     }
 
     #[test]
     fn snapshot_burst_at_exact_limit() {
         // burst_count == BURST_PER_MINUTE is not over (it's the count AFTER add)
         let s = RateSnapshot { daily_count: 10, burst_count: 30 };
-        assert_eq!(s.to_decision(), RateDecision::Allow);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Allow);
     }
 
     // --- Boundary: just below thresholds ---
@@ -263,14 +299,42 @@ mod tests {
     fn snapshot_allow_just_below_soft_limit() {
         let soft = model_qos::daily_soft_limit();
         let s = RateSnapshot { daily_count: soft - 1, burst_count: 5 };
-        assert_eq!(s.to_decision(), RateDecision::Allow);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Allow);
     }
 
     #[test]
     fn snapshot_degrade_just_below_hard_limit() {
         let hard = model_qos::daily_hard_limit();
         let s = RateSnapshot { daily_count: hard - 1, burst_count: 5 };
-        assert_eq!(s.to_decision(), RateDecision::DegradeToFlash);
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::DegradeToFlash);
+    }
+
+    // --- Chat limiter: high burst cap, NO daily tiers (enforce_daily=false) ---
+
+    #[test]
+    fn chat_never_rejects_or_degrades_on_daily() {
+        // Far past Gemini's daily hard limit, chat still allows — chat has no daily cap.
+        let s = RateSnapshot { daily_count: model_qos::daily_hard_limit() + 1000, burst_count: 10 };
+        assert_eq!(s.to_decision(CHAT_BURST_PER_MINUTE, false), RateDecision::Allow);
+    }
+
+    #[test]
+    fn chat_allows_burst_that_would_reject_gemini() {
+        // A burst of 100/min rejects Gemini (>30) but is fine for chat (<=120).
+        let s = RateSnapshot { daily_count: 5, burst_count: 100 };
+        assert_eq!(s.to_decision(BURST_PER_MINUTE, true), RateDecision::Reject);
+        assert_eq!(s.to_decision(CHAT_BURST_PER_MINUTE, false), RateDecision::Allow);
+    }
+
+    #[test]
+    fn chat_rejects_only_on_pathological_burst() {
+        let s = RateSnapshot { daily_count: 5, burst_count: CHAT_BURST_PER_MINUTE + 1 };
+        assert_eq!(s.to_decision(CHAT_BURST_PER_MINUTE, false), RateDecision::Reject);
+    }
+
+    #[test]
+    fn for_chat_constructs() {
+        let _ = GeminiRateLimiter::for_chat();
     }
 
     // --- No Redis → unmetered (cache bypassed entirely) ---

--- a/desktop/Backend-Rust/src/services/redis.rs
+++ b/desktop/Backend-Rust/src/services/redis.rs
@@ -218,11 +218,13 @@ impl RedisService {
     // Issue #6098 L2
     // ============================================================================
 
-    /// Check and record a Gemini API request for rate limiting.
+    /// Check and record an API request for rate limiting under the given key
+    /// namespace (e.g. "gemini_rl" or "chat_rl"), keeping each budget isolated.
     /// Uses a Lua script for atomic burst (sorted set) + daily (counter) in one round-trip.
     /// Returns (daily_count, burst_count) so the caller can decide Allow/Degrade/Reject.
-    pub async fn check_gemini_rate_limit(
+    pub async fn check_rate_limit(
         &self,
+        key_prefix: &str,
         uid: &str,
         _burst_limit: usize,
         burst_window_secs: u64,
@@ -233,8 +235,8 @@ impl RedisService {
         let day_ordinal = (now_ms / 86_400_000).to_string();
         let cutoff_ms = now_ms - (burst_window_secs as i64 * 1000);
 
-        let burst_key = format!("gemini_rl:{}:burst", uid);
-        let daily_key = format!("gemini_rl:{}:daily:{}", uid, day_ordinal);
+        let burst_key = format!("{}:{}:burst", key_prefix, uid);
+        let daily_key = format!("{}:{}:daily:{}", key_prefix, uid, day_ordinal);
 
         // Lua script: increment daily first (for unique member), prune burst, add, count.
         // KEYS[1] = burst_key, KEYS[2] = daily_key

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active"
+  ],
   "releases": [
     {
       "version": "0.11.453",


### PR DESCRIPTION
## Incident
Desktop **chat ("Ask Omi")** intermittently returned `429 Rate limit exceeded` — confirmed live on the **dev/Beta** backend (the last several `/v2/chat/completions` requests were all 429, rejected in <40ms). Prod chat is currently healthy (453× 200 / 6h) but has the **same latent bug**.

## Root cause
`chat_completions.rs` called `state.gemini_rate_limiter.check_and_record(...)` — the **same** per-user limiter as the Gemini proxy (`/v1/proxy/gemini/*`), capped at **30 requests / 60s, shared**. When a user's proactive/vision/Live-Notes assistants fire a burst of Gemini `generateContent` calls, they exhaust that user's 30/min budget, so the user's **chat** requests get 429'd as collateral. Dev breaks first because it runs few Cloud Run instances (local per-instance burst trips faster) and its small, heavy-usage user set bursts Gemini constantly. Logs showed 2 dev uids over budget (35 / 19 rejections in 30 min).

## Fix
Give chat its **own** limiter, fully isolated from Gemini:
- Dedicated Redis namespace `chat_rl:` (separate counters).
- High burst cap (**120/min**) — unreachable by a human typing; only guards a runaway client.
- **No daily cap** (`enforce_daily=false`) — chat never degrades or hard-rejects on daily volume.
- Gemini's limiter is **unchanged** (30/min + daily tiers, `gemini_rl:` keys).
- BYOK chat was already exempt; still is.

The limiter struct is now parameterized (`with_config(burst, ns, enforce_daily)`, plus `new()` for Gemini and `for_chat()`), and the Redis helper takes a key-namespace param.

## Verification
- `cargo build` clean; **`cargo test` 251 passed / 0 failed**, including 4 new chat-limiter tests (chat allows a 100/min burst that rejects Gemini; chat never rejects on daily; rejects only past 120/min) and all existing Gemini tests unchanged.

Merging deploys desktop-backend to **dev then prod** automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)