### PR TITLE
fix(desktop): keep floating bar hidden when disabled (#6972)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs"
+  ],
   "releases": [
     {
       "version": "0.11.453",

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1162,6 +1162,14 @@ class FloatingControlBarManager {
     /// Used when browser tools activate so the bar stays visible above Chrome.
     func showTemporarily() {
         guard window != nil else { return }
+        if !isEnabled {
+            // The user has explicitly disabled the floating bar. Honor that even when
+            // a background browser tool would otherwise surface it — unlike the
+            // notification path, there is no follow-up that re-hides it, so showing
+            // here leaves the bar visible "forever" despite the toggle being off.
+            log("FloatingControlBarManager: showTemporarily() suppressed because bar is disabled")
+            return
+        }
         if isSnoozed {
             log("FloatingControlBarManager: showTemporarily() suppressed because bar is snoozed")
             return


### PR DESCRIPTION
## Bug
Issue #6972 — after turning off **Settings → Show floating bar**, the floating bar reappears "forever after a moment" of normal use, even though it should stay hidden.

## Root cause
`FloatingControlBarManager.showTemporarily()` is invoked when a background **browser tool** activates during a chat/agent query (see `ChatProvider.swift`), so the bar floats above Chrome. It only guarded against the *snooze* state — not the persisted *disable* preference (`isEnabled`). Unlike the notification path — which tracks `notificationWasTemporarilyShown` and re-hides the window on dismissal — there is no follow-up that hides the bar again after a temporary show. So once a browser tool ran, the disabled bar became visible and stayed visible.

## Fix
Add an `isEnabled` guard to `showTemporarily()`, mirroring the existing `isSnoozed` guard. When the user has explicitly disabled the bar, the temporary-show is suppressed and the toggle is honored. No behavior change when the bar is enabled.

- `desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift` — guard `showTemporarily()` on `isEnabled`
- `desktop/CHANGELOG.json` — user-facing entry

Verified the JSON is valid. Swift change is a 6-line early-return mirroring existing code; not built locally (no signing here).

🤖 automated by hourly watchdog; opened for review, not merged.