### PR TITLE
fix(desktop): restore Device settings section so BLE pairing is reachable (#5917)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,8 @@
 {
   "unreleased": [
-    "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs"
+    "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs",
+    "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active",
+    "Restored the Device settings page so you can pair and manage a Bluetooth device from Settings"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -724,7 +724,10 @@ struct DesktopHomeView: View {
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToDeviceSettings)) { _ in
-      // Set the section directly and navigate to settings
+      // Set the section directly and navigate to settings. Without this the
+      // settings pane opens on whatever section was last selected (General),
+      // leaving no path to reach Device pairing from the device widget (#5917).
+      selectedSettingsSection = .device
       withAnimation(.easeInOut(duration: 0.2)) {
         selectedIndex = SidebarNavItem.settings.rawValue
       }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -302,6 +302,7 @@ struct SettingsContentView: View {
 
   enum SettingsSection: String, CaseIterable {
     case general = "General"
+    case device = "Device"
     case rewind = "Rewind"
     case transcription = "Transcription"
     case notifications = "Notifications"
@@ -454,6 +455,8 @@ struct SettingsContentView: View {
         switch selectedSection {
         case .general:
           generalSection
+        case .device:
+          DeviceSettingsPage()
         case .rewind:
           rewindSection
         case .transcription:

--- a/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -16,6 +16,12 @@ struct SettingsSearchItem: Identifiable {
   }
 
   static let allSearchableItems: [SettingsSearchItem] = [
+    // Device
+    SettingsSearchItem(
+      name: "Device", subtitle: "Pair and manage your Bluetooth device",
+      keywords: ["device", "bluetooth", "ble", "pair", "pairing", "scan", "connect", "friend"],
+      section: .device, icon: "antenna.radiowaves.left.and.right", settingId: "device.pairing"),
+
     // General
     SettingsSearchItem(
       name: "Rewind", subtitle: "Screen capture and audio recording",
@@ -318,6 +324,7 @@ struct SettingsSidebar: View {
   private let iconWidth: CGFloat = 20
   private let visibleSections: [SettingsContentView.SettingsSection] = [
     .general,
+    .device,
     .rewind,
     .transcription,
     .notifications,
@@ -502,6 +509,7 @@ struct SettingsSidebarItem: View {
   private var icon: String {
     switch section {
     case .general: return "gearshape"
+    case .device: return "antenna.radiowaves.left.and.right"
     case .rewind: return "clock.arrow.circlepath"
     case .transcription: return "waveform"
     case .notifications: return "bell"


### PR DESCRIPTION
Fixes #5917

## Bug
On the macOS desktop app there is **no UI path to pair a Bluetooth device**. Clicking the "Friend" device widget in the sidebar posts `.navigateToDeviceSettings`, which opens Settings but lands on whatever section was last selected (General) — there is no Device section to land on. Users cannot pair a new/different BLE device on desktop, and on machines without a built-in mic (e.g. Mac mini) this also blocks audio capture entirely.

## Root cause
`DeviceSettingsPage.swift` still exists, but the `.device` case of `SettingsContentView.SettingsSection` was removed as collateral in #5604 ("Fix desktop onboarding reset scoping"). That left:
- no `.device` entry in the settings sidebar,
- no `case .device` in the content switch, and
- a `navigateToDeviceSettings` handler that navigates to Settings but never selects a device section.

The navigation handler was left dangling, which indicates the section removal was an unintended regression rather than a deliberate removal of the feature.

## Fix (15 lines)
- Re-add `case device = "Device"` to `SettingsSection`.
- Render `DeviceSettingsPage()` for `.device` in the settings content switch.
- Add `.device` to the sidebar's `visibleSections` (after General) with a Bluetooth icon, plus a searchable item.
- Set `selectedSettingsSection = .device` in the `navigateToDeviceSettings` handler so the device widget and "Scan for Devices" flow are reachable again.

All three exhaustive `SettingsSection` switches (enum, content, icon) are updated so it compiles. `DeviceSettingsPage` is self-contained (`DeviceProvider.shared`), so no wiring beyond the switch is needed.

## Verification
⚠️ **UNVERIFIED** — change reviewed by inspection (exhaustive switches handled, mirrors the existing section-wiring pattern, matches the issue's own root-cause analysis), but **not built or run** in this autonomous environment. Please build the desktop app, open Settings, confirm the Device section appears and pairing works, and that clicking the sidebar device widget navigates to it.

🤖 automated by hourly watchdog; opened for review, not merged.