### PR TITLE
feat(desktop-backend): retry fallbacks for chat, TTS, and screen embeddings (Tier 1 stability)

### DIFF
--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -15,6 +15,7 @@ use axum::{
 };
 use futures::StreamExt;
 use serde_json::json;
+use std::time::Duration;
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
@@ -515,7 +516,13 @@ async fn chat_completions(
         StatusCode::BAD_REQUEST
     })?;
 
-    let client = reqwest::Client::new();
+    // Bound connection establishment so a network blip can't hang the request; the
+    // total-response timeout is applied per-call (non-streaming only) inside the retry
+    // helper so it never aborts a long streaming reply.
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
 
     if req.stream {
         handle_streaming(
@@ -542,6 +549,77 @@ async fn chat_completions(
     }
 }
 
+/// Max attempts for the INITIAL Anthropic request (1 try + 2 retries).
+const ANTHROPIC_MAX_ATTEMPTS: usize = 3;
+
+/// Upstream HTTP statuses worth retrying — transient overload/availability blips.
+/// Note: 4xx like 400/401/402 are caller/auth errors and must NOT be retried.
+fn is_transient_status(status: u16) -> bool {
+    matches!(status, 408 | 425 | 429 | 500 | 502 | 503 | 504 | 529)
+}
+
+/// Backoff before a retry (attempt is the 1-based number that just failed).
+fn retry_backoff(attempt: usize) -> Duration {
+    // 250ms, 500ms — chat is latency-sensitive, so keep retries short and few.
+    Duration::from_millis(250u64 * (1u64 << attempt.saturating_sub(1).min(3)))
+}
+
+/// Send the Anthropic request, retrying the INITIAL response on transient failures
+/// (network errors + 429/5xx/529). This is the chat fallback: a single Anthropic blip
+/// no longer fails the request. Safe to retry because no output has been produced yet
+/// (for streaming we retry before consuming the body). A transient status on the final
+/// attempt is returned as-is so the caller passes the upstream error through.
+async fn send_anthropic_with_retry(
+    client: &reqwest::Client,
+    api_key: &str,
+    anthropic_req: &AnthropicRequest,
+    streaming: bool,
+) -> Result<reqwest::Response, StatusCode> {
+    for attempt in 1..=ANTHROPIC_MAX_ATTEMPTS {
+        let mut builder = client
+            .post(ANTHROPIC_API_URL)
+            .header("x-api-key", api_key)
+            .header("anthropic-version", ANTHROPIC_API_VERSION)
+            .header("content-type", "application/json")
+            .json(anthropic_req);
+        // Bound non-streaming calls; a streaming response must NOT have a total-response
+        // timeout (it would abort long replies), only the client-level connect timeout.
+        if !streaming {
+            builder = builder.timeout(Duration::from_secs(120));
+        }
+        match builder.send().await {
+            Ok(resp) => {
+                let s = resp.status().as_u16();
+                if is_transient_status(s) && attempt < ANTHROPIC_MAX_ATTEMPTS {
+                    tracing::warn!(
+                        "chat_completions: Anthropic {} (attempt {}/{}), retrying",
+                        s,
+                        attempt,
+                        ANTHROPIC_MAX_ATTEMPTS
+                    );
+                    tokio::time::sleep(retry_backoff(attempt)).await;
+                    continue;
+                }
+                return Ok(resp);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "chat_completions: Anthropic request error (attempt {}/{}): {}",
+                    attempt,
+                    ANTHROPIC_MAX_ATTEMPTS,
+                    e
+                );
+                if attempt < ANTHROPIC_MAX_ATTEMPTS {
+                    tokio::time::sleep(retry_backoff(attempt)).await;
+                    continue;
+                }
+                return Err(StatusCode::BAD_GATEWAY);
+            }
+        }
+    }
+    Err(StatusCode::BAD_GATEWAY)
+}
+
 async fn handle_non_streaming(
     client: &reqwest::Client,
     api_key: &str,
@@ -551,18 +629,7 @@ async fn handle_non_streaming(
     state: &AppState,
     is_byok: bool,
 ) -> Result<Response, StatusCode> {
-    let upstream_resp = client
-        .post(ANTHROPIC_API_URL)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", ANTHROPIC_API_VERSION)
-        .header("content-type", "application/json")
-        .json(anthropic_req)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("chat_completions: upstream request failed: {}", e);
-            StatusCode::BAD_GATEWAY
-        })?;
+    let upstream_resp = send_anthropic_with_retry(client, api_key, anthropic_req, false).await?;
 
     let status = upstream_resp.status();
     if !status.is_success() {
@@ -606,18 +673,7 @@ async fn handle_streaming(
     state: &AppState,
     is_byok: bool,
 ) -> Result<Response, StatusCode> {
-    let upstream_resp = client
-        .post(ANTHROPIC_API_URL)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", ANTHROPIC_API_VERSION)
-        .header("content-type", "application/json")
-        .json(anthropic_req)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("chat_completions: upstream stream request failed: {}", e);
-            StatusCode::BAD_GATEWAY
-        })?;
+    let upstream_resp = send_anthropic_with_retry(client, api_key, anthropic_req, true).await?;
 
     let status = upstream_resp.status();
     if !status.is_success() {
@@ -945,6 +1001,31 @@ pub fn chat_completions_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transient_statuses_retry() {
+        for s in [408, 425, 429, 500, 502, 503, 504, 529] {
+            assert!(is_transient_status(s), "{} should be transient", s);
+        }
+    }
+
+    #[test]
+    fn non_transient_statuses_dont_retry() {
+        // 2xx success and caller/auth errors must never be retried.
+        for s in [200, 201, 400, 401, 402, 403, 404, 422] {
+            assert!(!is_transient_status(s), "{} should NOT be transient", s);
+        }
+    }
+
+    #[test]
+    fn backoff_is_short_and_increasing() {
+        let b1 = retry_backoff(1);
+        let b2 = retry_backoff(2);
+        assert_eq!(b1, Duration::from_millis(250));
+        assert_eq!(b2, Duration::from_millis(500));
+        // Stays bounded (latency-sensitive path).
+        assert!(retry_backoff(10) <= Duration::from_millis(2000));
+    }
 
     #[test]
     fn test_resolve_model_sonnet() {

--- a/desktop/Backend-Rust/src/routes/screen_activity.rs
+++ b/desktop/Backend-Rust/src/routes/screen_activity.rs
@@ -61,8 +61,38 @@ async fn sync_screen_activity(
         let config = state.config.clone();
         let uid = user.uid.clone();
         tokio::spawn(async move {
-            if let Err(e) = upsert_pinecone_vectors(&config, &uid, &rows_with_embeddings).await {
-                tracing::error!("Screen activity Pinecone upsert failed: {}", e);
+            // Retry transient Pinecone failures so embeddings don't silently go missing
+            // from the search index (the Firestore metadata is already written). Log
+            // loudly if it ultimately fails so the gap is observable rather than silent.
+            let vector_count = rows_with_embeddings.len();
+            let mut last_err = None;
+            for attempt in 1..=3u32 {
+                match upsert_pinecone_vectors(&config, &uid, &rows_with_embeddings).await {
+                    Ok(()) => {
+                        last_err = None;
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Screen activity Pinecone upsert attempt {}/3 failed for uid={}: {}",
+                            attempt,
+                            uid,
+                            e
+                        );
+                        last_err = Some(e);
+                        if attempt < 3 {
+                            tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
+                        }
+                    }
+                }
+            }
+            if let Some(e) = last_err {
+                tracing::error!(
+                    "Screen activity Pinecone upsert FAILED after 3 attempts for uid={} ({} vectors missing from search index): {}",
+                    uid,
+                    vector_count,
+                    e
+                );
             }
         });
     }

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -10,6 +10,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
@@ -18,6 +19,15 @@ use crate::AppState;
 const OPENAI_TTS_MODEL_ID: &str = "gpt-4o-mini-tts";
 const OPENAI_SPEECH_URL: &str = "https://api.openai.com/v1/audio/speech";
 const MAX_TTS_CHARS: usize = 4096;
+
+/// Max attempts for the OpenAI TTS request (1 try + 2 retries on transient errors).
+const TTS_MAX_ATTEMPTS: usize = 3;
+
+/// Transient upstream statuses worth retrying (overload/availability). Caller/auth
+/// errors (400/401/etc.) are returned immediately.
+fn is_transient_tts_status(status: u16) -> bool {
+    matches!(status, 408 | 425 | 429 | 500 | 502 | 503 | 504 | 529)
+}
 const SERVER_TTS_BURST_PER_MINUTE: i64 = 20;
 const SERVER_TTS_DAILY_CHARS: i64 = 50_000;
 const TTS_BURST_WINDOW_SECS: u64 = 60;
@@ -126,13 +136,55 @@ async fn tts_synthesize(
         response_format: "mp3",
     };
 
-    let upstream = reqwest::Client::new()
-        .post(OPENAI_SPEECH_URL)
-        .bearer_auth(api_key)
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|error| TtsProxyError::BadGateway(error.to_string()))?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_default();
+
+    // Retry the request on transient OpenAI failures (network/429/5xx) so a brief blip
+    // doesn't drop the voice reply. The client additionally falls back to the macOS
+    // system voice if this ultimately fails.
+    let mut upstream = None;
+    for attempt in 1..=TTS_MAX_ATTEMPTS {
+        match client
+            .post(OPENAI_SPEECH_URL)
+            .bearer_auth(api_key)
+            .json(&payload)
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let s = resp.status().as_u16();
+                if is_transient_tts_status(s) && attempt < TTS_MAX_ATTEMPTS {
+                    tracing::warn!(
+                        "tts_synthesize: OpenAI {} (attempt {}/{}), retrying",
+                        s,
+                        attempt,
+                        TTS_MAX_ATTEMPTS
+                    );
+                    tokio::time::sleep(Duration::from_millis(300 * attempt as u64)).await;
+                    continue;
+                }
+                upstream = Some(resp);
+                break;
+            }
+            Err(error) => {
+                if attempt < TTS_MAX_ATTEMPTS {
+                    tracing::warn!(
+                        "tts_synthesize: OpenAI request error (attempt {}/{}): {}",
+                        attempt,
+                        TTS_MAX_ATTEMPTS,
+                        error
+                    );
+                    tokio::time::sleep(Duration::from_millis(300 * attempt as u64)).await;
+                    continue;
+                }
+                return Err(TtsProxyError::BadGateway(error.to_string()));
+            }
+        }
+    }
+    let upstream = upstream.ok_or_else(|| TtsProxyError::BadGateway("tts: no upstream response".to_string()))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active"
+    "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active",
+    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request"
   ],
   "releases": [
     {


### PR DESCRIPTION
First batch of the "add ≥1 fallback everywhere" stability work — the **desktop Rust backend** (contained + unit-tested). Each AI upstream call now survives a transient blip instead of hard-failing.

## Changes
- **Chat → Anthropic** (`chat_completions.rs`): the initial request is now retried (1 try + 2 retries, 250/500ms backoff) on transient failures — network errors + `408/425/429/500/502/503/504/529`. Applies to **both** streaming and non-streaming (we retry before consuming the body, so it's safe). Added a **10s connect timeout** (reqwest had none) and a 120s total timeout on non-streaming only (never on streams). Non-transient 4xx (400/401/402…) are returned immediately. Was: 0 retries → any Anthropic blip = failed chat.
- **TTS → OpenAI** (`tts.rs`): same transient retry + connect/total timeouts. (The client already falls back to the macOS system voice; this stops most failures before that.)
- **Screen embeddings → Pinecone** (`screen_activity.rs`): the fire-and-forget upsert now retries 3× and **logs loudly on final failure** instead of silently dropping vectors from the search index.

## Verification
`cargo build` clean; **`cargo test` 254 passed / 0 failed**, including 3 new tests (transient vs non-transient status classification, backoff bounds).

## Not in this PR (Tier 2 — Swift app, needs local build/run)
STT cross-fallback (on-device⇄cloud), synthesis retry (Notes/Calendar/Gmail), TTS playback→system-voice, proactive-assistant fallback model. Tracked as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)