### PR TITLE
fix(web): guard app-detail image src to prevent server-side crash (#7237)

### DIFF
--- a/web/app/src/app/(public)/apps/[id]/page.tsx
+++ b/web/app/src/app/(public)/apps/[id]/page.tsx
@@ -1,4 +1,9 @@
-import { findAppById, getAppsV2, transformToPlugin, type V2AppData } from '@/lib/api/public';
+import {
+  findAppById,
+  getAppsV2,
+  transformToPlugin,
+  type V2AppData,
+} from '@/lib/api/public';
 import { CompactPluginCard } from '@/components/marketplace/plugin-card/CompactPluginCard';
 import { CategoryBreadcrumb } from '@/components/marketplace/CategoryBreadcrumb';
 import { BreadcrumbJsonLd, SoftwareAppJsonLd } from '@/components/seo/JsonLd';
@@ -147,7 +152,7 @@ export default async function PluginDetailPage({ params }: Props) {
             <div className="lg:col-span-2">
               <div className="relative aspect-square overflow-hidden rounded-2xl bg-[#1A1F2E]">
                 <Image
-                  src={plugin.image}
+                  src={plugin.image || '/logo.png'}
                   alt={plugin.name}
                   className="h-full w-full object-cover transition-transform duration-300 hover:scale-105"
                   width={500}
@@ -247,7 +252,9 @@ export default async function PluginDetailPage({ params }: Props) {
           <section className="mt-16">
             <h2 className="text-2xl font-bold text-white">About</h2>
             <div className="mt-4">
-              <p className="text-lg leading-relaxed text-gray-300">{plugin.description}</p>
+              <p className="text-lg leading-relaxed text-gray-300">
+                {plugin.description}
+              </p>
             </div>
           </section>
 
@@ -328,11 +335,7 @@ export default async function PluginDetailPage({ params }: Props) {
               </h2>
               <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
                 {relatedApps.map((app, index) => (
-                  <CompactPluginCard
-                    key={app.id}
-                    plugin={app}
-                    index={index + 1}
-                  />
+                  <CompactPluginCard key={app.id} plugin={app} index={index + 1} />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Bug
Opening any app detail page (`https://h.omi.me/apps/<id>`) can show:

> Application error: a server-side exception has occurred (see the server logs for more information). Digest: 1334210280

Reported in #7237.

## Root cause
`web/app/src/app/(public)/apps/[id]/page.tsx` rendered the hero image as:

```tsx
<Image src={plugin.image} ... />
```

with **no fallback**. When an app's `image` is empty/falsy, `next/image` throws during server render (`src` is required / cannot be empty), which surfaces as the opaque "server-side exception" digest above. Many catalog apps have no logo set, so their detail pages crash deterministically.

This is inconsistent with the rest of the codebase, which always guards the image:
- `CompactPluginCard.tsx`, `FeaturedPluginCard.tsx`, `plugin-card/index.tsx` → `plugin.image || 'https://via.placeholder.com/...'`
- this same file's `generateMetadata` → `plugin.image || '/og-apps.png'`

## Fix
Add the same guard to the visible hero image, falling back to the local `/logo.png` asset (which exists in `web/app/public/`, unlike `/og-apps.png`) so the fallback itself can never 404/throw:

```tsx
<Image src={plugin.image || '/logo.png'} ... />
```

One-line behavioral change; no API or data-shape changes.

## Verification
UNVERIFIED end-to-end (no full Next.js prod build run here). Reasoned from the code: the crash path is the unguarded `next/image` `src`, and the fix mirrors the established fallback pattern used everywhere else in this app. Low risk.

🤖 automated by hourly watchdog; opened for review, not merged.