### PR TITLE
fix(backend): appcast parses 2-component desktop version tags (#5285)

### DIFF
--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -25,16 +25,19 @@ def _parse_desktop_version(tag_name: str) -> Optional[Dict[str, str]]:
     """
     Parse desktop version from tag name.
     Expected format: v1.0.77+464-desktop-cm or v1.0.77+464-macos-cm or v1.0.77+464-desktop-auto or v0.6.4+6004-macos
+    The patch component is optional (newer tags use 2-component versions, e.g. v11.0+11000-macos);
+    it defaults to "0" when absent.
     Returns dict with version info or None if invalid.
     """
-    # Match pattern: v{major}.{minor}.{patch}+{build}-{platform}[-{cm|auto}]
-    pattern = r'^v?(\d+)\.(\d+)\.(\d+)\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
+    # Match pattern: v{major}.{minor}[.{patch}]+{build}-{platform}[-{cm|auto}]
+    pattern = r'^v?(\d+)\.(\d+)(?:\.(\d+))?\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
     match = re.match(pattern, tag_name, re.IGNORECASE)
 
     if not match:
         return None
 
     major, minor, patch, build = match.groups()
+    patch = patch if patch is not None else '0'
 
     return {
         'major': major,

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -72,6 +72,22 @@ class TestParseDesktopVersion:
         result = _parse_desktop_version("1.0.0+100-macos")
         assert result is not None
 
+    def test_two_component_version_macos(self):
+        # Newer release tags omit the patch component (e.g. v11.0+11000-macos).
+        result = _parse_desktop_version("v11.0+11000-macos")
+        assert result is not None
+        assert result["major"] == "11"
+        assert result["minor"] == "0"
+        assert result["patch"] == "0"
+        assert result["build"] == "11000"
+        assert result["version"] == "11.0.0+11000"
+
+    def test_two_component_version_desktop_cm(self):
+        result = _parse_desktop_version("v11.3+11003-desktop-cm")
+        assert result is not None
+        assert result["version"] == "11.3.0+11003"
+        assert result["build"] == "11003"
+
 
 # --- _parse_changelog_to_changes ---
 


### PR DESCRIPTION
## Bug
The `/v2/desktop/appcast.xml` endpoint (`backend/routers/updates.py`) silently dropped desktop releases whose Git tags use a **2-component** version, e.g. `v11.0+11000-macos`, `v11.3+11003-macos`. These releases never appeared in the Sparkle appcast feed, so affected desktop users **could not auto-update** (#5285).

## Root cause
`_parse_desktop_version()` required a 3-component `{major}.{minor}.{patch}` version:
```python
pattern = r'^v?(\d+)\.(\d+)\.(\d+)\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
```
Newer release tags use `{major}.{minor}+{build}-{platform}` (no patch). The regex returns `None` for them, and `_get_live_desktop_releases` filters out any tag that fails to parse — so those releases were excluded from the feed.

## Fix
Make the patch component optional and default it to `"0"` when absent:
```python
pattern = r'^v?(\d+)\.(\d+)(?:\.(\d+))?\+(\d+)-(?:desktop|macos|windows|linux)(?:-(?:cm|auto))?$'
...
patch = patch if patch is not None else '0'
```
So `v11.0+11000-macos` parses to version `11.0.0+11000`. Existing 3-component tags and invalid tags are unaffected.

## Tests
Added `test_two_component_version_macos` and `test_two_component_version_desktop_cm` to `backend/tests/unit/test_desktop_updates.py`. Verified the regex against all existing + new cases with stdlib `re` (pytest not installed in the watchdog env, so the suite itself was not run locally — CI will run it).

🤖 automated by hourly watchdog; opened for review, not merged.