### PR TITLE
fix(backend): don't fail queued sync jobs that were never picked up (#7469)

### DIFF
--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -70,10 +70,21 @@ def get_sync_job(job_id: str) -> Optional[dict]:
         return None
     job = json.loads(data)
 
-    # Stale-job detection: if processing for too long, mark failed
-    if job['status'] in ('queued', 'processing'):
+    # Stale-job detection: only a job that was actually picked up by a worker
+    # (status='processing') and then went quiet is a real failure. A job still
+    # 'queued' has never been picked up — usually because the worker pools are
+    # saturated — so it is NOT a failure; leave it queued and let the 24h TTL
+    # clean it up. (Flipping queued jobs to 'failed' here caused the client to
+    # surface spurious "Couldn't process — retrying" loops; see issue #7469.)
+    if job['status'] == 'processing':
         updated_at = job.get('updated_at') or job.get('created_at', 0)
         if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
+            logger.warning(
+                "sync_job %s (uid=%s) stale after %.0fs in 'processing' — marking failed",
+                job_id,
+                job.get('uid'),
+                time.time() - updated_at,
+            )
             job['status'] = 'failed'
             job['error'] = 'Job timed out (background worker likely died)'
             job['completed_at'] = time.time()

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -331,6 +331,24 @@ class TestSyncJobsRedis:
         result = mod.get_sync_job('fresh-1')
         assert result['status'] == 'processing'
 
+    def test_get_sync_job_does_not_fail_stale_queued(self):
+        """A stale 'queued' job was never picked up (pool saturation) — it is
+        NOT a worker failure and must stay 'queued' (see issue #7469)."""
+        mod, mock_redis = self._load_sync_jobs_module()
+        stale_queued = {
+            'job_id': 'queued-1',
+            'uid': 'uid',
+            'status': 'queued',
+            'updated_at': time.time() - 700,  # 700s ago > 600s threshold
+            'created_at': time.time() - 800,
+        }
+        mock_redis.get.return_value = json.dumps(stale_queued).encode()
+
+        result = mod.get_sync_job('queued-1')
+        assert result['status'] == 'queued'
+        assert result.get('error') is None
+        mock_redis.set.assert_not_called()
+
     def test_mark_job_completed_sets_status(self):
         """mark_job_completed must set correct terminal status."""
         mod, mock_redis = self._load_sync_jobs_module()


### PR DESCRIPTION
## Bug (#7469)

`backend/database/sync_jobs.py::get_sync_job` rewrote a job's status to `failed` with the error `"Job timed out (background worker likely died)"` whenever it had been in `queued` **or** `processing` for longer than `STALE_THRESHOLD_SECONDS` (600s).

That conflates two very different situations:

1. **`status == 'processing'` and stale** — a worker picked the job up and then died mid-pipeline. *Correctly failed.*
2. **`status == 'queued'` and stale** — the job was **never picked up by any worker**, because the storage/postprocess pools were saturated. *Not a failure — no worker died; the backend just hadn't had capacity yet.*

Both got the same `failed` + "worker likely died" treatment. For the queued case the message is also factually wrong, and on the client it surfaced as spurious **"Couldn't process — retrying"** loops: the reconciler read `failed`, reverted the WAL, bumped retry count, exhausted the retry budget, and landed on a red **"Failed — tap Retry"** for recordings that were merely waiting for capacity.

## Fix

- Only flip a stale **`processing`** job to `failed` (the original intent — a worker did pick it up and went quiet).
- Leave a stale **`queued`** job as `queued`; the existing 24h TTL cleans it up naturally. A never-picked-up job is not a job failure.
- Log the `processing` → `failed` rewrite, which was previously silent (observability ask in the issue).

This is the backend-side correctness fix; it complements the client mitigation in #7451 (which was pattern-matching the error string) and no longer depends on string matching for the common queued case. It does **not** touch pool sizing / Cloud Run capacity (the root-cause capacity item) — that's an infra-config change out of scope here.

## Tests

- `test_get_sync_job_does_not_fail_stale_queued` (new): a stale `queued` job stays `queued`, has no error, and triggers no Redis rewrite.
- `test_get_sync_job_detects_stale` (existing): a stale `processing` job still becomes `failed`.

Verified the guard logic locally on Python 3.11 across all four (status × fresh/stale) combinations; the full suite runs in CI.

🤖 automated by hourly watchdog; opened for review, not merged.