### PR TITLE
fix(backend): stale transcript memory_id rebinds active /v4/listen conversation (#6952)

### DIFF
--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -479,12 +479,14 @@ async def _websocket_util_trigger(
                     res = json.loads(bytes(data[4:]).decode("utf-8"))
                     segments = res.get('segments')
                     memory_id = res.get('memory_id')
-                    # Update conversation_id from transcript if provided
-                    if memory_id:
-                        current_conversation_id = memory_id
+                    # A transcript's memory_id must NOT overwrite the session's authoritative
+                    # current_conversation_id (which is set only by header 103). Doing so let a stale
+                    # lifecycle event carrying an older conversation's memory_id rebind a newer recording
+                    # session, mis-associating subsequent private-cloud audio (see issue #6952).
                     if len(transcript_queue) >= TRANSCRIPT_QUEUE_WARN_SIZE:
                         logger.warning(f"Warning: transcript_queue size {len(transcript_queue)} {uid}")
-                    # Use memory_id if available, otherwise use current_conversation_id for conversations
+                    # Route this transcript by its own memory_id when present, falling back to the
+                    # session's conversation id. This does not mutate session-scoped state.
                     conversation_or_memory_id = memory_id or current_conversation_id
                     transcript_queue.append({'segments': segments, 'memory_id': conversation_or_memory_id})
                     continue

--- a/backend/tests/unit/test_listen_pipeline.py
+++ b/backend/tests/unit/test_listen_pipeline.py
@@ -633,15 +633,35 @@ class TestPusherHeaderDemux:
         assert len(private_cloud_queue[0]['data']) == 500
         assert len(private_cloud_sync_buffer) == 0
 
-    def test_flaw_header_102_memory_id_updates_conversation_id(self):
-        """FLAW TEST: memory_id in transcript should update current_conversation_id."""
-        current_conversation_id = 'old-conv'
-        payload = {'segments': [], 'memory_id': 'new-conv-from-memory'}
+    def test_header_102_memory_id_does_not_overwrite_session_conversation_id(self):
+        """A transcript's memory_id must not mutate the authoritative current_conversation_id
+        (set only by header 103). It is only used to route the queued transcript. This prevents a
+        stale lifecycle event from rebinding a newer recording session (issue #6952)."""
+        current_conversation_id = 'active-conv'  # set earlier by header 103
+        transcript_queue = []
+        payload = {'segments': [], 'memory_id': 'stale-conv-from-memory'}
         res = payload
         memory_id = res.get('memory_id')
-        if memory_id:
-            current_conversation_id = memory_id
-        assert current_conversation_id == 'new-conv-from-memory'
+        # Header 102 handling: route by memory_id, never overwrite session state.
+        conversation_or_memory_id = memory_id or current_conversation_id
+        transcript_queue.append({'segments': res.get('segments'), 'memory_id': conversation_or_memory_id})
+
+        # Authoritative session id is unchanged...
+        assert current_conversation_id == 'active-conv'
+        # ...while this transcript is still routed under its own memory_id.
+        assert transcript_queue[0]['memory_id'] == 'stale-conv-from-memory'
+
+    def test_header_102_without_memory_id_falls_back_to_session_conversation_id(self):
+        """When a transcript carries no memory_id, it routes under the session conversation id."""
+        current_conversation_id = 'active-conv'
+        transcript_queue = []
+        res = {'segments': [], 'memory_id': None}
+        memory_id = res.get('memory_id')
+        conversation_or_memory_id = memory_id or current_conversation_id
+        transcript_queue.append({'segments': res.get('segments'), 'memory_id': conversation_or_memory_id})
+
+        assert current_conversation_id == 'active-conv'
+        assert transcript_queue[0]['memory_id'] == 'active-conv'
 
 
 # ===================================================================


### PR DESCRIPTION
## Bug (#6952)

Desktop `/v4/listen` sessions can be rebound to a stale backend conversation ID from an older conversation. A new recording receives an old `memory_created` / lifecycle event, gets completed locally against that stale backend ID, then fails final reconciliation when stop/finalize returns a different backend conversation — leaving the local row in a broken state (`failed | in_progress`) and the backend conversation discarded/mismatched.

## Root cause

In `backend/routers/pusher.py`, the header-`102` (transcript) handler treated the transcript's `memory_id` as authoritative session state:

```python
memory_id = res.get('memory_id')
# Update conversation_id from transcript if provided
if memory_id:
    current_conversation_id = memory_id   # <-- overwrites authoritative session id
```

`current_conversation_id` is meant to be set **only** by header `103` (the explicit Conversation ID frame, sent before private-cloud audio in `transcribe.py`). It governs which conversation private-cloud audio chunks are associated with (lines 463/539/555/603/612). Letting a transcript's `memory_id` overwrite it means a stale lifecycle event carrying an older conversation's id rebinds the live session and mis-associates subsequent audio.

## Fix

Stop mutating session-scoped state from transcripts. The transcript is still routed under its own `memory_id` exactly as before (`conversation_or_memory_id = memory_id or current_conversation_id`), but `current_conversation_id` is no longer overwritten — header `103` remains the single source of truth for the active conversation.

This matches the issue's proposed direction ("transcript payloads should not mutate the authoritative active conversation ID for the current listen/pusher session") and is a minimal, behavior-preserving change for transcript routing.

## Tests

Replaced the `test_flaw_header_102_memory_id_updates_conversation_id` FLAW test (which encoded the buggy behavior) in `backend/tests/unit/test_listen_pipeline.py` with two tests asserting the corrected contract:
- a transcript `memory_id` does **not** overwrite the session conversation id, but still routes the transcript under its own id;
- a transcript without `memory_id` falls back to the session conversation id.

Verified the new test logic standalone (pytest not installed locally; CI runs the suite). Formatting verified with `black --line-length 120 --skip-string-normalization` (left unchanged).

## Scope / safety

Single-line behavioral change in the transcript handler plus the test update. Does not touch auth/credential/signing/workflow code. Header `103` already precedes private-cloud audio in the sender (`transcribe.py` `_audio_bytes_flush`), so removing the transcript-driven overwrite does not regress private-cloud association.

🤖 automated by hourly watchdog; opened for review, not merged.