### PR TITLE
fix(web): correct app-store product price to $89 (#5855)

### DIFF
--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -115,7 +115,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
         },
         offers: {
           '@type': 'Offer',
-          price: '69.99',
+          price: '89',
           priceCurrency: 'USD',
           availability: 'https://schema.org/InStock',
           url: productUrl,
@@ -156,8 +156,8 @@ function getPlatformLink(userAgent: string) {
   return isAndroid
     ? 'https://play.google.com/store/apps/details?id=com.friend.ios'
     : isIOS
-    ? 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163'
-    : 'https://omi.me';
+      ? 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163'
+      : 'https://omi.me';
 }
 
 // Helper function to format date

--- a/web/frontend/src/app/apps/utils/metadata.ts
+++ b/web/frontend/src/app/apps/utils/metadata.ts
@@ -101,7 +101,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
 const productInfo = {
   name: 'OMI Necklace',
   description: 'AI-powered wearable necklace. Real-time AI voice assistant.',
-  price: '69.99',
+  price: '89',
   currency: 'USD',
   url: 'https://www.omi.me/products/friend-dev-kit-2',
 };

--- a/web/frontend/src/app/components/product-banner/types.ts
+++ b/web/frontend/src/app/components/product-banner/types.ts
@@ -20,7 +20,7 @@ export interface CategoryBannerProps extends ProductBannerBase {
 
 export const PRODUCT_INFO = {
   name: 'OMI Necklace',
-  price: '$69.99',
+  price: '$89',
   url: 'https://www.omi.me/products/omi-dev-kit-2?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
   shipping: 'Ships Worldwide',
   images: {


### PR DESCRIPTION
## Bug
[#5855](https://github.com/BasedHardware/omi/issues/5855) — the web app store (`h.omi.me/apps`) shows the wrong device price ($69.99) on the product banner and in the page's structured data. Current price is **$89** (verified on the live product page https://www.omi.me/products/omi-dev-kit-2).

## Root cause
The price was hardcoded as `69.99` in three places and never updated when the device price changed:
- `web/frontend/src/app/components/product-banner/types.ts` — the `PRODUCT_INFO.price` constant rendered in all three banner variants (detail / floating / category).
- `web/frontend/src/app/apps/utils/metadata.ts` — `productInfo.price` used for SEO structured data.
- `web/frontend/src/app/apps/[id]/page.tsx` — JSON-LD `Offer.price` on each app detail page.

## Fix
Updated all three to `89`. Scoped strictly to the verified-wrong value.

## Out of scope (intentionally not changed)
The issue also mentions "Duo Dev Kit" naming and "broken CTAs". Both are stale: the code already uses "OMI Necklace", and the `omi-dev-kit-2` CTA URL is the current, live product page. Only the price was actually wrong, so only the price is changed.

🤖 automated by hourly watchdog; opened for review, not merged.