### PR TITLE
fix(backend): chat assistant uses user's timezone for conversation times (#6214)

### DIFF
--- a/backend/tests/unit/test_conversations_to_string.py
+++ b/backend/tests/unit/test_conversations_to_string.py
@@ -118,3 +118,35 @@ class TestConversationsToStringDedup:
         )
         result = conversations_to_string([conv])
         assert "Summarization:" not in result
+
+
+class TestConversationsToStringTimezone:
+    """Timestamps must render in the user's timezone when tz is provided (issue #6214)."""
+
+    def test_default_is_utc(self):
+        # created_at is 10:00 UTC
+        conv = _make_conversation()
+        result = conversations_to_string([conv])
+        assert "15 Jan 2026 at 10:00 UTC" in result
+        assert "Started: 15 Jan 2026 at 10:00 UTC" in result
+        assert "Finished: 15 Jan 2026 at 10:30 UTC" in result
+
+    def test_converts_to_user_timezone(self):
+        # 10:00 UTC -> 07:00 in America/Sao_Paulo (UTC-3), matching the issue's "off by 3 hours" report
+        conv = _make_conversation()
+        result = conversations_to_string([conv], tz="America/Sao_Paulo")
+        assert "15 Jan 2026 at 07:00 America/Sao_Paulo" in result
+        assert "Started: 15 Jan 2026 at 07:00 America/Sao_Paulo" in result
+        assert "Finished: 15 Jan 2026 at 07:30 America/Sao_Paulo" in result
+        assert "UTC" not in result
+
+    def test_kolkata_half_hour_offset(self):
+        # 10:00 UTC -> 15:30 IST (UTC+5:30)
+        conv = _make_conversation()
+        result = conversations_to_string([conv], tz="Asia/Kolkata")
+        assert "15 Jan 2026 at 15:30 Asia/Kolkata" in result
+
+    def test_invalid_timezone_falls_back_to_utc(self):
+        conv = _make_conversation()
+        result = conversations_to_string([conv], tz="Not/AZone")
+        assert "15 Jan 2026 at 10:00 UTC" in result

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Sequence
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import database.folders as folders_db
 import database.users as users_db
@@ -9,6 +11,18 @@ from models.other import Person
 
 if TYPE_CHECKING:
     from models.conversation import Conversation
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_display_tz(tz: str | None):
+    """Return (tzinfo, label) for formatting timestamps. Falls back to UTC on a missing/invalid zone."""
+    if tz:
+        try:
+            return ZoneInfo(tz), tz
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning(f"conversations_to_string: invalid timezone '{tz}', falling back to UTC")
+    return timezone.utc, "UTC"
 
 
 # ---------------------------------------------------------------------------
@@ -131,16 +145,22 @@ def conversations_to_string(
     include_timestamps: bool = False,
     people: List[Person] = None,
     user_name: str = None,
+    tz: str = None,
 ) -> str:
     """Format a sequence of Conversation objects into a human-readable string.
 
     Callers must pass deserialized Conversation objects (use factory.deserialize_conversation
     for raw dicts). This function does NOT accept dicts.
+
+    When ``tz`` (an IANA timezone name like "America/Sao_Paulo") is provided, timestamps are
+    rendered in that timezone and labelled accordingly; otherwise they default to UTC. Pass the
+    user's timezone when this text is fed to the chat LLM so it reasons about times correctly.
     """
     result = []
     people_map = {p.id: p for p in people} if people else {}
+    display_tz, tz_label = _resolve_display_tz(tz)
     for i, conversation in enumerate(conversations):
-        formatted_date = conversation.created_at.astimezone(timezone.utc).strftime("%d %b %Y at %H:%M") + " UTC"
+        formatted_date = conversation.created_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
         conversation_str = (
             f"Conversation #{i + 1}\n"
             f"{formatted_date} ({str(conversation.structured.category.value).capitalize()})\n"
@@ -148,11 +168,13 @@ def conversations_to_string(
 
         # Add started_at and finished_at if available
         if conversation.started_at:
-            formatted_started = conversation.started_at.astimezone(timezone.utc).strftime("%d %b %Y at %H:%M") + " UTC"
+            formatted_started = (
+                conversation.started_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
+            )
             conversation_str += f"Started: {formatted_started}\n"
         if conversation.finished_at:
             formatted_finished = (
-                conversation.finished_at.astimezone(timezone.utc).strftime("%d %b %Y at %H:%M") + " UTC"
+                conversation.finished_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
             )
             conversation_str += f"Finished: {formatted_finished}\n"
 

--- a/backend/utils/retrieval/tool_services/conversations.py
+++ b/backend/utils/retrieval/tool_services/conversations.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 import database.conversations as conversations_db
+import database.notifications as notification_db
 import database.users as users_db
 import database.vector_db as vector_db
 from models.conversation import Conversation
@@ -128,7 +129,11 @@ def get_conversations_text(
             continue
 
     return conversations_to_string(
-        conversations, use_transcript=include_transcript, include_timestamps=include_timestamps, people=people
+        conversations,
+        use_transcript=include_transcript,
+        include_timestamps=include_timestamps,
+        people=people,
+        tz=notification_db.get_user_time_zone(uid),
     )
 
 
@@ -224,7 +229,11 @@ def search_conversations_text(
 
         result = f"Found {len(conversations)} conversations semantically matching '{query}':\n\n"
         result += conversations_to_string(
-            conversations, use_transcript=include_transcript, include_timestamps=include_timestamps, people=people
+            conversations,
+            use_transcript=include_transcript,
+            include_timestamps=include_timestamps,
+            people=people,
+            tz=notification_db.get_user_time_zone(uid),
         )
         return result
 

--- a/backend/utils/retrieval/tools/conversation_tools.py
+++ b/backend/utils/retrieval/tools/conversation_tools.py
@@ -11,6 +11,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 import database.conversations as conversations_db
+import database.notifications as notification_db
 import database.users as users_db
 import database.vector_db as vector_db
 from models.conversation import Conversation
@@ -253,9 +254,13 @@ def get_conversations_tool(
             f"📚 get_conversations_tool - Added {len(conversations)} conversations to collection (total: {len(conversations_collected)})"
         )
 
-        # Return formatted string
+        # Return formatted string (timestamps rendered in the user's timezone for correct chat answers)
         result = conversations_to_string(
-            conversations, use_transcript=include_transcript, include_timestamps=include_timestamps, people=people
+            conversations,
+            use_transcript=include_transcript,
+            include_timestamps=include_timestamps,
+            people=people,
+            tz=notification_db.get_user_time_zone(uid),
         )
         logger.info(f"🔍 get_conversations_tool - Generated result string, length: {len(result)}")
         return result
@@ -477,7 +482,11 @@ def search_conversations_tool(
         # Return formatted string
         result = f"Found {len(conversations)} conversations semantically matching '{query}':\n\n"
         result += conversations_to_string(
-            conversations, use_transcript=include_transcript, include_timestamps=include_timestamps, people=people
+            conversations,
+            use_transcript=include_transcript,
+            include_timestamps=include_timestamps,
+            people=people,
+            tz=notification_db.get_user_time_zone(uid),
         )
 
         logger.info(f"🔍 search_conversations_tool - Generated result string, length: {len(result)}")


### PR DESCRIPTION
## Bug (#6214)
The chat assistant answers time questions in **UTC** instead of the user's local timezone. A user in `America/Sao_Paulo` (UTC−3) asking "what time did X happen?" gets an answer 3 hours off. Users lose trust in timing answers.

## Root cause
`conversations_to_string()` (`backend/utils/conversations/render.py`) — which builds the conversation text fed to the chat LLM — hard-coded `.astimezone(timezone.utc)` and appended a literal `" UTC"` label for `created_at` / `started_at` / `finished_at`. So every conversation timestamp in the LLM's context was in UTC, regardless of the user's configured timezone. The model then reports those UTC times verbatim.

## Fix
- Add an optional `tz` (IANA name, e.g. `America/Sao_Paulo`) parameter to `conversations_to_string()`. When provided, timestamps render in that zone and are labelled with it; a missing/invalid zone falls back to UTC. **All existing callers are unchanged** (default `tz=None` → UTC behaviour preserved).
- Thread the user's timezone (`notification_db.get_user_time_zone(uid)` — the same helper already used in `utils/llm/chat.py`) into the four chat/tools LLM-context call sites:
  - `utils/retrieval/tools/conversation_tools.py` — `get_conversations_tool`, `search_conversations_tool` (agentic chat)
  - `utils/retrieval/tool_services/conversations.py` — `get_conversations_text`, `search_conversations_text` (desktop/web tools router)

Non-chat callers of `conversations_to_string` (app integrations, post-processing RAG context) intentionally keep UTC — they aren't user-facing time answers.

## Tests
Added `TestConversationsToStringTimezone` to `tests/unit/test_conversations_to_string.py` (already run by `test.sh`): default→UTC, `America/Sao_Paulo` (10:00 UTC→07:00), `Asia/Kolkata` half-hour offset (→15:30), and invalid-zone fallback. Verified the tz-resolution logic locally; `black` clean. pytest isn't installed in the watchdog env, so CI runs the suite — **UNVERIFIED at runtime against a live chat session.**

🤖 automated by hourly watchdog; opened for review, not merged.