### PR TITLE
fix(backend): buffer speaker-sample requests across pusher reconnect (#6060)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -390,6 +390,7 @@ async def _stream_handler(
     MAX_PHOTO_BUFFER_SIZE = 100  # Max photos to buffer
     MAX_AUDIO_BUFFER_SIZE = 1024 * 1024 * 10  # 10MB max audio buffer
     MAX_PENDING_REQUESTS = 100  # Max pending conversation requests
+    MAX_PENDING_SPEAKER_SAMPLE_REQUESTS = 50  # Max speaker-sample requests buffered while pusher is down
     MAX_IMAGE_CHUNKS = 50  # Max concurrent image uploads
     IMAGE_CHUNK_TTL = 60.0  # Seconds before incomplete image chunks expire
     IMAGE_CHUNK_CLEANUP_INTERVAL = 2.0  # Seconds between cleanup scans
@@ -1113,6 +1114,11 @@ async def _stream_handler(
         pending_conversation_requests: Dict[str, dict] = {}
         pending_request_event = asyncio.Event()
 
+        # Speaker-sample extraction requests buffered while pusher is disconnected,
+        # replayed on reconnect (#6060). Bounded to avoid unbounded growth during
+        # long outages; oldest is dropped when full.
+        pending_speaker_sample_requests: deque = deque(maxlen=MAX_PENDING_SPEAKER_SAMPLE_REQUESTS)
+
         def transcript_send(segments):
             nonlocal segment_buffers
             segment_buffers.extend(segments)
@@ -1509,6 +1515,15 @@ async def _stream_handler(
                     for cid in list(pending_conversation_requests.keys()):
                         pending_conversation_requests[cid]['sent_at'] = time.time()
                         await request_conversation_processing(cid)
+                # Re-send any speaker sample requests buffered while disconnected (#6060)
+                if pending_speaker_sample_requests:
+                    buffered = list(pending_speaker_sample_requests)
+                    pending_speaker_sample_requests.clear()
+                    logger.info(
+                        f"Reconnected to pusher, re-sending {len(buffered)} pending speaker sample requests {uid} {session_id}"
+                    )
+                    for person_id, conv_id, segment_ids in buffered:
+                        await send_speaker_sample_request(person_id, conv_id, segment_ids)
             except PusherCircuitBreakerOpen:
                 raise  # Let caller handle circuit breaker
             except Exception as e:
@@ -1539,6 +1554,13 @@ async def _stream_handler(
             """Send speaker sample extraction request to pusher with segment IDs."""
             nonlocal pusher_ws, pusher_connected
             if not pusher_connected or not pusher_ws:
+                # Buffer instead of dropping so the request survives a transient
+                # pusher disconnect and is replayed on reconnect (#6060).
+                pending_speaker_sample_requests.append((person_id, conv_id, segment_ids))
+                logger.warning(
+                    f"Pusher not connected, buffered speaker sample request: person={person_id}, "
+                    f"{len(segment_ids)} segments ({len(pending_speaker_sample_requests)} pending) {uid} {session_id}"
+                )
                 return
             try:
                 data = bytearray()


### PR DESCRIPTION
## Bug (#6060)

`send_speaker_sample_request()` in `routers/transcribe.py` returned **silently** when the pusher WebSocket was disconnected (`if not pusher_connected or not pusher_ws: return`), permanently dropping the speaker-sample extraction request — no retry, no queue, no log.

If a speaker assignment happened to coincide with a transient pusher reconnect window (~1–2s), the speaker was correctly identified but **no sample was ever extracted**. The user had to record another conversation for extraction to be attempted again. This was observed in production.

## Root cause

The transcribe→pusher path already has robust reconnect machinery, and other request types survive disconnects:
- `request_conversation_processing()` buffers into `pending_conversation_requests` and is replayed in `_connect()` on reconnect.
- transcript / audio-bytes use bounded buffers flushed on reconnect.

Speaker-sample requests were the one path that just dropped on the floor.

## Fix

Mirror the existing `pending_conversation_requests` pattern (smallest correct fix, Option A in the issue):

1. Add a bounded per-session buffer `pending_speaker_sample_requests` (`deque(maxlen=50)`) — same bounded-memory discipline as the other buffers; oldest dropped on overflow during long outages.
2. When the pusher is down, buffer the `(person_id, conv_id, segment_ids)` tuple instead of dropping it, and log a `warning` so the event is observable.
3. In `_connect()`, after a successful (re)connect and right after the existing `pending_conversation_requests` replay, drain and re-send the buffered speaker-sample requests.

No new imports (`deque` already used here); change is confined to one closure. Bounded so it cannot leak memory. `python -m py_compile` OK, `black` clean, `scripts/lint_async_blockers.py` clean.

UNVERIFIED at runtime — requires a live pusher-reconnect window to reproduce; the logic mirrors the already-proven `pending_conversation_requests` replay path.

🤖 automated by hourly watchdog; opened for review, not merged.