### PR TITLE
feat(desktop): STT fails over to cloud when on-device Parakeet can't load (no more silent blank transcripts)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,11 +1,7 @@
 {
   "unreleased": [
-<<<<<<< HEAD
-    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request",
+    "Fixed the floating bar reappearing after you turned off \u201cShow floating bar\u201d \u2014 it now stays hidden even while a background browser action runs",
     "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription"
-=======
-    "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs"
->>>>>>> origin/main
   ],
   "releases": [
     {

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request"
+    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request",
+    "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -386,6 +386,12 @@ class AppState: ObservableObject {
   private var localMicService: LocalTranscriptionService?
   private var localSystemService: LocalTranscriptionService?
   private var useLocalSTT = false
+  /// Re-entrancy guard so the mic + system Parakeet instances failing together trigger only one
+  /// cloud fallback.
+  private var sttFallbackInProgress = false
+  /// Sticky for the app run: once on-device Parakeet fails to load, force cloud STT for subsequent
+  /// recordings too (a broken/undownloaded model won't fix itself mid-run; cloud beats blank).
+  private var forceCloudSTTForSession = false
 
   /// True on Apple Silicon (M-series), where on-device Parakeet runs on the Neural Engine.
   /// Desktop transcribes with Parakeet here by default; Intel Macs fall back to cloud STT.
@@ -1506,6 +1512,7 @@ class AppState: ObservableObject {
       // OMI_FORCE_CLOUD_STT=1 or `defaults write <bundle> forceCloudSTT -bool true`.
       let forceCloudSTT = ProcessInfo.processInfo.environment["OMI_FORCE_CLOUD_STT"] == "1"
         || UserDefaults.standard.bool(forKey: "forceCloudSTT")
+        || forceCloudSTTForSession  // set after an on-device Parakeet model-load failure
       useLocalSTT = !forceCloudSTT && Self.isAppleSilicon
       if useLocalSTT {
         log("Transcription: ON-DEVICE Parakeet mode (OMI_LOCAL_STT) — no cloud STT")
@@ -1513,12 +1520,17 @@ class AppState: ObservableObject {
         let onLocalSegments: LocalTranscriptionService.SegmentsHandler = { [weak self] segments in
           self?.handleBackendSegments(segments)
         }
+        // If the on-device model can't load, fall back to cloud STT instead of recording
+        // into a void (the failure is otherwise silent — a blank transcript).
+        let onModelLoadFailed: @MainActor () -> Void = { [weak self] in
+          self?.handleLocalSTTModelLoadFailure()
+        }
         // Mic = the user; system audio = another speaker. Transcribed separately for diarization.
         let mic = LocalTranscriptionService(language: effectiveLanguage, isUser: true)
-        mic.start(onSegments: onLocalSegments)
+        mic.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
         localMicService = mic
         let system = LocalTranscriptionService(language: effectiveLanguage, isUser: false)
-        system.start(onSegments: onLocalSegments)
+        system.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
         localSystemService = system
       } else {
         // Always streaming via Python backend /v4/listen
@@ -1945,6 +1957,32 @@ class AppState: ObservableObject {
       }
 
       await loadConversations()
+    }
+  }
+
+  /// On-device Parakeet failed to load — fall back to cloud STT instead of silently recording a
+  /// blank transcript. Cleanly stops the dead on-device session and restarts the SAME recording in
+  /// cloud mode (no fragile mid-stream audio rerouting). Sticky for the app run so we don't retry a
+  /// broken model on every recording.
+  @MainActor
+  private func handleLocalSTTModelLoadFailure() {
+    guard isTranscribing, useLocalSTT, !sttFallbackInProgress else { return }
+    sttFallbackInProgress = true
+    forceCloudSTTForSession = true
+    log("Transcription: Parakeet model load failed — falling back to cloud STT")
+    AnalyticsManager.shared.recordingError(error: "parakeet_model_load_failed_fallback_cloud")
+    let source = audioSource
+    stopTranscription()
+    // Restart in cloud mode once stop has settled (isTranscribing flips false inside the stop's
+    // async teardown). Bounded wait avoids racing the `!isTranscribing` guard in startTranscription.
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      for _ in 0..<20 {
+        if !self.isTranscribing { break }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+      }
+      self.startTranscription(source: source)
+      self.sttFallbackInProgress = false
     }
   }
 

--- a/desktop/Desktop/Sources/LocalTranscriptionService.swift
+++ b/desktop/Desktop/Sources/LocalTranscriptionService.swift
@@ -53,6 +53,9 @@ final class LocalTranscriptionService: @unchecked Sendable {
 
     private var asrManager: AsrManager?
     private var onSegments: SegmentsHandler?
+    /// Fired (on the main actor) if the Parakeet model fails to download/load. Lets AppState
+    /// fall back to cloud STT instead of silently producing a blank transcript.
+    private var onModelLoadFailed: (@MainActor () -> Void)?
 
     // 16 kHz mono Float32 sample buffer, guarded by `lock`.
     private let lock = NSLock()
@@ -76,12 +79,23 @@ final class LocalTranscriptionService: @unchecked Sendable {
     }
 
     /// Begin loading the model (async) and start the periodic flush loop.
-    func start(onSegments: @escaping SegmentsHandler) {
+    /// `onModelLoadFailed` fires once if the model can't load, so the caller can fall back
+    /// to cloud transcription instead of recording into a void.
+    func start(onSegments: @escaping SegmentsHandler, onModelLoadFailed: (@MainActor () -> Void)? = nil) {
         self.onSegments = onSegments
+        self.onModelLoadFailed = onModelLoadFailed
 
         Task { [weak self] in
             guard let self else { return }
             do {
+                // Test hook: force a model-load failure to exercise the cloud fallback path.
+                // Toggle with env OMI_FORCE_PARAKEET_FAIL=1 or `defaults write <bundle> forceParakeetFail -bool true`.
+                if ProcessInfo.processInfo.environment["OMI_FORCE_PARAKEET_FAIL"] == "1"
+                    || UserDefaults.standard.bool(forKey: "forceParakeetFail") {
+                    throw NSError(
+                        domain: "LocalTranscriptionService", code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "forced model-load failure (OMI_FORCE_PARAKEET_FAIL)"])
+                }
                 // v2 = English-only (better recall); v3 = 25 European languages.
                 let version: AsrModelVersion = self.language.hasPrefix("en") ? .v2 : .v3
                 let started = Date()
@@ -95,6 +109,9 @@ final class LocalTranscriptionService: @unchecked Sendable {
                 log("LocalTranscriptionService: Parakeet \(version) ready in \(String(format: "%.1f", Date().timeIntervalSince(started)))s")
             } catch {
                 logError("LocalTranscriptionService: model load failed", error: error)
+                if let onFailed = self.onModelLoadFailed {
+                    await MainActor.run { onFailed() }
+                }
             }
         }
 


### PR DESCRIPTION
Tier-2 stability: the #1 silent-failure surface from the audit. On-device transcription (Parakeet) could fail to download/load and produce a **blank transcript with no error** — the whole recording lost. Now it automatically falls back to cloud STT.

## Change
- **`LocalTranscriptionService`**: added an `onModelLoadFailed` callback fired (once) when the model can't download/load. Also a test hook (`OMI_FORCE_PARAKEET_FAIL=1` env or `defaults write <bundle> forceParakeetFail -bool true`) to exercise the path — matches the codebase's existing debug-default pattern (`forceCloudSTT`, `disableSystemAudioCapture`).
- **`AppState`**: on that callback, `handleLocalSTTModelLoadFailure()` cleanly stops the dead on-device session and **restarts the same recording in cloud mode** (no fragile mid-stream audio rerouting). Re-entrancy guarded (mic + system instances failing together trigger one fallback), and sticky for the app run so a broken model isn't retried every recording.

## Verification — exercised on the real app (named bundle, signed in, prod backend)
Built + launched `omi-stt-fallback.app`, armed the fault injection, started a recording. Logs show the full chain:
```
ON-DEVICE Parakeet mode                          ← on-device path chosen (Apple Silicon)
LocalTranscriptionService: model load failed …   ← forced failure (mic + system)
Parakeet model load failed — falling back to cloud STT   ← fallback fired ONCE (guard works)
TranscriptionService: Connected to Python backend        ← restarted in cloud, connected ✓
```
Recording stayed alive and switched to cloud instead of going blank. (The cloud transcript itself is the existing, already-working path; only the switch is new.) Full `xcrun swift build` clean.

## Follow-ups (not in this PR)
Reverse direction (cloud reconnect-exhausted → on-device), synthesis retry (Notes/Calendar/Gmail), TTS-playback→system-voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)