### PR TITLE
feat(desktop): add fallbacks to the remaining 4 AI paths (synthesis, voice, reverse STT, proactive)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -3,7 +3,8 @@
     "Fixed the floating bar reappearing after you turned off \u201cShow floating bar\u201d \u2014 it now stays hidden even while a background browser action runs",
     "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active",
     "Restored the Device settings page so you can pair and manage a Bluetooth device from Settings",
-    "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription"
+    "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription",
+    "More reliable AI: memory imports retry on failure, voice replies fall back to the system voice, and transcription/assistants fail over instead of dropping"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -392,6 +392,11 @@ class AppState: ObservableObject {
   /// Sticky for the app run: once on-device Parakeet fails to load, force cloud STT for subsequent
   /// recordings too (a broken/undownloaded model won't fix itself mid-run; cloud beats blank).
   private var forceCloudSTTForSession = false
+  /// Reverse fallback: once the cloud WS is unreachable (reconnects exhausted), keep recording by
+  /// forcing on-device Parakeet. Tried at most once per session, and never if we're on cloud
+  /// *because* Parakeet already failed (forceCloudSTTForSession).
+  private var forceLocalSTTForSession = false
+  private var sttCloudFallbackTried = false
 
   /// True on Apple Silicon (M-series), where on-device Parakeet runs on the Neural Engine.
   /// Desktop transcribes with Parakeet here by default; Intel Macs fall back to cloud STT.
@@ -1510,9 +1515,10 @@ class AppState: ObservableObject {
       // Desktop transcribes on-device with Parakeet by default on Apple Silicon — no Deepgram.
       // Intel Macs (no Neural Engine) fall back to the cloud path. Force cloud for debugging with
       // OMI_FORCE_CLOUD_STT=1 or `defaults write <bundle> forceCloudSTT -bool true`.
-      let forceCloudSTT = ProcessInfo.processInfo.environment["OMI_FORCE_CLOUD_STT"] == "1"
-        || UserDefaults.standard.bool(forKey: "forceCloudSTT")
-        || forceCloudSTTForSession  // set after an on-device Parakeet model-load failure
+      let forceCloudSTT = !forceLocalSTTForSession  // reverse fallback overrides toward on-device
+        && (ProcessInfo.processInfo.environment["OMI_FORCE_CLOUD_STT"] == "1"
+          || UserDefaults.standard.bool(forKey: "forceCloudSTT")
+          || forceCloudSTTForSession)  // set after an on-device Parakeet model-load failure
       useLocalSTT = !forceCloudSTT && Self.isAppleSilicon
       if useLocalSTT {
         log("Transcription: ON-DEVICE Parakeet mode (OMI_LOCAL_STT) — no cloud STT")
@@ -1596,7 +1602,9 @@ class AppState: ObservableObject {
           Task { @MainActor in
             logError("Transcription error", error: error)
             AnalyticsManager.shared.recordingError(error: error.localizedDescription)
-            self?.stopTranscription()
+            // Cloud WS gave up (reconnects exhausted) → try to keep recording on-device
+            // instead of dropping it. Falls through to stopTranscription if not possible.
+            self?.handleCloudSTTReconnectFailure()
           }
         },
         onConnected: { [weak self] in
@@ -1975,6 +1983,36 @@ class AppState: ObservableObject {
     stopTranscription()
     // Restart in cloud mode once stop has settled (isTranscribing flips false inside the stop's
     // async teardown). Bounded wait avoids racing the `!isTranscribing` guard in startTranscription.
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      for _ in 0..<20 {
+        if !self.isTranscribing { break }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+      }
+      self.startTranscription(source: source)
+      self.sttFallbackInProgress = false
+    }
+  }
+
+  /// Cloud STT websocket gave up (reconnects exhausted). On Apple Silicon, keep the recording
+  /// alive by switching to on-device Parakeet (which works offline) instead of stopping. Skipped
+  /// — and falls back to a normal stop — if we're only on cloud because Parakeet already failed,
+  /// or we've already tried this once this session.
+  @MainActor
+  private func handleCloudSTTReconnectFailure() {
+    guard isTranscribing, !useLocalSTT, Self.isAppleSilicon,
+      !forceCloudSTTForSession, !sttCloudFallbackTried, !sttFallbackInProgress
+    else {
+      stopTranscription()
+      return
+    }
+    sttCloudFallbackTried = true
+    sttFallbackInProgress = true
+    forceLocalSTTForSession = true
+    log("Transcription: cloud STT unreachable (reconnects exhausted) — falling back to on-device Parakeet")
+    AnalyticsManager.shared.recordingError(error: "cloud_stt_reconnect_failed_fallback_local")
+    let source = audioSource
+    stopTranscription()
     Task { @MainActor [weak self] in
       guard let self else { return }
       for _ in 0..<20 {

--- a/desktop/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/Desktop/Sources/AppleNotesReaderService.swift
@@ -133,7 +133,15 @@ actor AppleNotesReaderService {
       - Do not invent details not supported by the notes
       """
 
+    // Retry the synthesis (bridge/LLM call) on transient failure instead of silently
+    // dropping the whole import. Each attempt uses a fresh bridge.
+    let maxAttempts = 2
+    for attempt in 1...maxAttempts {
     do {
+      if ProcessInfo.processInfo.environment["OMI_FORCE_SYNTHESIS_FAIL"] == "1"
+        || UserDefaults.standard.bool(forKey: "forceSynthesisFail") {
+        throw NSError(domain: "Synthesis", code: -1, userInfo: [NSLocalizedDescriptionKey: "forced synthesis failure"])
+      }
       let bridge = AgentBridge(harnessMode: "piMono")
       try await bridge.start()
       defer { Task { await bridge.stop() } }
@@ -181,9 +189,16 @@ actor AppleNotesReaderService {
 
       return (memoriesSaved, profileSummary)
     } catch {
-      log("AppleNotesReaderService: Synthesis failed: \(error)")
+      if attempt < maxAttempts {
+        log("AppleNotesReaderService: Synthesis attempt \(attempt) failed, retrying: \(error)")
+        try? await Task.sleep(nanoseconds: 800_000_000)
+        continue
+      }
+      log("AppleNotesReaderService: Synthesis failed after \(attempt) attempts: \(error)")
       return (0, "")
     }
+    }
+    return (0, "")
   }
 
   func saveAsMemories(notes: [AppleNoteRecord], limit: Int? = nil) async -> (saved: Int, failed: Int) {

--- a/desktop/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/Desktop/Sources/CalendarReaderService.swift
@@ -182,7 +182,14 @@ actor CalendarReaderService {
       - Do NOT include sensitive medical or financial details
       """
 
+    // Retry the synthesis on transient failure instead of silently dropping the import.
+    let maxAttempts = 2
+    for attempt in 1...maxAttempts {
     do {
+      if ProcessInfo.processInfo.environment["OMI_FORCE_SYNTHESIS_FAIL"] == "1"
+        || UserDefaults.standard.bool(forKey: "forceSynthesisFail") {
+        throw NSError(domain: "Synthesis", code: -1, userInfo: [NSLocalizedDescriptionKey: "forced synthesis failure"])
+      }
       let bridge = AgentBridge(harnessMode: "piMono")
       try await bridge.start()
       defer { Task { await bridge.stop() } }
@@ -275,9 +282,16 @@ actor CalendarReaderService {
       return (memoriesSaved, tasksSaved, profileSummary)
 
     } catch {
-      log("CalendarReaderService: Synthesis failed: \(error)")
+      if attempt < maxAttempts {
+        log("CalendarReaderService: Synthesis attempt \(attempt) failed, retrying: \(error)")
+        try? await Task.sleep(nanoseconds: 800_000_000)
+        continue
+      }
+      log("CalendarReaderService: Synthesis failed after \(attempt) attempts: \(error)")
       return (0, 0, "")
     }
+    }
+    return (0, 0, "")
   }
 
   func saveAsMemories(events: [CalendarEvent], limit: Int? = nil) async -> (saved: Int, failed: Int)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -40,7 +40,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   private var streamedText = ""
   private var bufferedText = ""
   private var synthesisQueue: [String] = []
-  private var audioQueue: [Data] = []
+  // Carries each chunk's source text alongside its synthesized audio so playback can fall
+  // back to the system voice (speaking the text) if AVAudioPlayer can't play the audio.
+  private var audioQueue: [(audio: Data, text: String)] = []
   private var isSynthesizing = false
   private var hasStartedRealPlayback = false
   private var hasEmittedFirstChunk = false
@@ -203,7 +205,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
-          self.audioQueue.append(audioData)
+          self.audioQueue.append((audio: audioData, text: text))
           self.startPlaybackIfNeeded()
           self.startSynthesisIfNeeded(mode: mode)
         }
@@ -298,7 +300,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
           let audio = try await Self.synthesizeOpenAISpeech(
             text: trimmed, voiceID: voiceID, instructions: instructions)
           await MainActor.run {
-            self?.startPlayback(audio)
+            self?.startPlayback(audio, fallbackText: trimmed)
           }
         } catch {
           await MainActor.run {
@@ -324,11 +326,15 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   private func startPlaybackIfNeeded() {
     guard audioPlayer == nil else { return }
     guard !audioQueue.isEmpty else { return }
-    startPlayback(audioQueue.removeFirst())
+    let next = audioQueue.removeFirst()
+    startPlayback(next.audio, fallbackText: next.text)
   }
 
-  private func startPlayback(_ data: Data) {
+  private func startPlayback(_ data: Data, fallbackText: String = "") {
     do {
+      if UserDefaults.standard.bool(forKey: "forceTTSPlaybackFail") {
+        throw NSError(domain: "TTSPlayback", code: -1, userInfo: [NSLocalizedDescriptionKey: "forced playback failure"])
+      }
       let player = try AVAudioPlayer(data: data)
       player.delegate = self
       player.enableRate = true
@@ -337,9 +343,11 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       player.play()
       audioPlayer = player
     } catch {
+      // Don't drop the reply silently — speak this chunk with the system voice instead.
       log(
-        "FloatingBarVoicePlaybackService: could not start audio playback: \(error.localizedDescription)"
+        "FloatingBarVoicePlaybackService: audio playback failed, falling back to system voice: \(error.localizedDescription)"
       )
+      enqueueSystemSpeech(fallbackText)
     }
   }
 

--- a/desktop/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/Desktop/Sources/GmailReaderService.swift
@@ -258,7 +258,14 @@ actor GmailReaderService {
       - Output ONLY the JSON object, nothing else
       """
 
+    // Retry the synthesis on transient failure instead of silently dropping the import.
+    let maxAttempts = 2
+    for attempt in 1...maxAttempts {
     do {
+      if ProcessInfo.processInfo.environment["OMI_FORCE_SYNTHESIS_FAIL"] == "1"
+        || UserDefaults.standard.bool(forKey: "forceSynthesisFail") {
+        throw NSError(domain: "Synthesis", code: -1, userInfo: [NSLocalizedDescriptionKey: "forced synthesis failure"])
+      }
       let bridge = AgentBridge(harnessMode: "piMono")
       try await bridge.start()
       defer { Task { await bridge.stop() } }
@@ -341,9 +348,16 @@ actor GmailReaderService {
       return (memoriesSaved, tasksSaved, profileSummary)
 
     } catch {
-      log("GmailReaderService: Synthesis failed: \(error)")
+      if attempt < maxAttempts {
+        log("GmailReaderService: Synthesis attempt \(attempt) failed, retrying: \(error)")
+        try? await Task.sleep(nanoseconds: 800_000_000)
+        continue
+      }
+      log("GmailReaderService: Synthesis failed after \(attempt) attempts: \(error)")
       return (0, 0, "")
     }
+    }
+    return (0, 0, "")
   }
 
   /// Save fetched emails as memories via the OMI backend API.

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -76,7 +76,7 @@ actor FocusAssistant: ProactiveAssistant {
         onRefocus: (() -> Void)? = nil,
         onDistraction: (() -> Void)? = nil
     ) throws {
-        self.geminiClient = try GeminiClient(apiKey: apiKey)
+        self.geminiClient = try GeminiClient(apiKey: apiKey, fallbackModel: "gemini-2.5-flash")
         self.onAlert = onAlert
         self.onStatusChange = onStatusChange
         self.onRefocus = onRefocus

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -63,7 +63,7 @@ actor InsightAssistant: ProactiveAssistant {
     // MARK: - Initialization
 
     init(apiKey: String? = nil) throws {
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.insight)
+        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.insight, fallbackModel: "gemini-2.5-flash")
 
         let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
         self.frameSignal = stream

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -162,7 +162,7 @@ actor TaskAssistant: ProactiveAssistant {
     // MARK: - Initialization
 
     init(apiKey: String? = nil) throws {
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.taskExtraction)
+        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.taskExtraction, fallbackModel: "gemini-2.5-flash")
 
         let (stream, continuation) = AsyncStream.makeStream(of: TriggerEvent.self, bufferingPolicy: .bufferingNewest(1))
         self.triggerStream = stream

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -247,7 +247,11 @@ actor GeminiClient {
     }
   }
 
-  init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive) throws {
+  /// Optional model to retry with if the primary model keeps failing transiently
+  /// (e.g. Pro overloaded → fall back to Flash). Nil or equal-to-primary = no fallback.
+  private let fallbackModel: String?
+
+  init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive, fallbackModel: String? = nil) throws {
     // BREAKING CHANGE (issue #5861): apiKey parameter is ignored.
     // All Gemini requests now route through the backend proxy which supplies
     // the key server-side. Defaults to production when OMI_DESKTOP_API_URL is absent
@@ -256,6 +260,7 @@ actor GeminiClient {
       throw GeminiClientError.missingAPIKey
     }
     self.model = model
+    self.fallbackModel = fallbackModel
   }
 
   /// Get Firebase auth header for proxy requests
@@ -264,9 +269,10 @@ actor GeminiClient {
     return try await authService.getAuthHeader()
   }
 
-  /// Build proxy URL for a Gemini model action
-  private func proxyURL(action: String) -> URL {
-    URL(string: "\(Self.proxyBaseURL)v1/proxy/gemini/models/\(model):\(action)")!
+  /// Build proxy URL for a Gemini model action. Pass `modelOverride` to use a model
+  /// other than the instance default (e.g. the fallback model).
+  private func proxyURL(action: String, modelOverride: String? = nil) -> URL {
+    URL(string: "\(Self.proxyBaseURL)v1/proxy/gemini/models/\(modelOverride ?? model):\(action)")!
   }
 
 
@@ -795,9 +801,16 @@ extension GeminiClient {
     forceToolCall: Bool = false,
     thinkingBudget: Int = 0
   ) async throws -> ToolChatResult {
+    // Try the primary model first; if it keeps failing transiently, fall back to the
+    // secondary model (e.g. Pro overloaded → Flash) before giving up.
+    let models: [String] = {
+      if let fb = fallbackModel, fb != model { return [model, fb] }
+      return [model]
+    }()
     let maxRetries = 2
     var lastError: Error?
 
+    for (modelIndex, activeModel) in models.enumerated() {
     for attempt in 0...maxRetries {
       do {
         // Wrap JSON serialization in autoreleasepool (contents may include
@@ -815,7 +828,7 @@ extension GeminiClient {
               parts: [.init(text: systemPrompt)]
             ),
             generationConfig: GeminiImageToolRequest.GenerationConfig(
-              thinkingConfig: ThinkingConfig(thinkingBudget: max(thinkingBudget, ThinkingConfig.minimumBudget(for: model)))
+              thinkingConfig: ThinkingConfig(thinkingBudget: max(thinkingBudget, ThinkingConfig.minimumBudget(for: activeModel)))
             ),
             tools: tools,
             toolConfig: toolConfig
@@ -824,7 +837,7 @@ extension GeminiClient {
           return try JSONEncoder().encode(request)
         }
 
-        let url = proxyURL(action: "generateContent")
+        let url = proxyURL(action: "generateContent", modelOverride: activeModel)
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -873,10 +886,17 @@ extension GeminiClient {
       } catch {
         lastError = error
         guard attempt < maxRetries && isTransientError(error) else {
+          // Primary model's retries exhausted — fall back to the next model (e.g. Pro→Flash)
+          // if the failure is transient and a fallback model remains.
+          if modelIndex < models.count - 1 && isTransientError(error) {
+            log("GeminiClient: model \(activeModel) failing transiently, falling back to \(models[modelIndex + 1])")
+            break
+          }
           throw error
         }
         await retryBackoff(attempt: attempt, error: error)
       }
+    }
     }
 
     throw lastError!

--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -301,6 +301,13 @@ class TranscriptionService {
     // MARK: - Private Methods (Connection)
 
     private func connect() {
+        // Test hook: simulate the cloud WS being unreachable (reconnects exhausted) to exercise
+        // the on-device fallback. Toggle with `defaults write <bundle> forceCloudReconnectFail -bool true`.
+        if UserDefaults.standard.bool(forKey: "forceCloudReconnectFail") {
+            log("TranscriptionService: forceCloudReconnectFail set — simulating max reconnects reached")
+            onError?(TranscriptionError.webSocketError("Max reconnect attempts reached"))
+            return
+        }
         // Always use Firebase auth for Python backend
         Task { [weak self] in
             guard let self = self else { return }


### PR DESCRIPTION
Completes the "≥1 fallback for every AI path" hardening. Each change is additive in an error/catch branch — it can't affect the happy path, only what happens on failure.

## 1. Memory synthesis retry (Notes / Calendar / Gmail)
Was: a single bridge/LLM failure silently dropped the whole import (`return (0, …)`, no retry). Now: 2 attempts with backoff; only gives up (empty) after both fail. Test hook: `forceSynthesisFail`.

## 2. Voice reply → system voice on playback failure
Was: `AVAudioPlayer` init failure was logged and **silently swallowed** (no audio). Now: the audio queue carries each chunk's source text, so a playback failure falls back to speaking that text with the macOS system voice. Test hook: `forceTTSPlaybackFail`.

## 3. Reverse STT fallback (cloud → on-device)  ✅ live-verified
Mirror of the shipped on-device→cloud fallback. When the cloud websocket exhausts its reconnects, instead of **stopping the recording** it now keeps it alive by switching to on-device Parakeet (works offline). Guarded: once per session, and never if we're only on cloud because Parakeet already failed (no ping-pong). Test hook: `forceCloudReconnectFail`.

## 4. Proactive assistant fallback model
`GeminiClient` gains an optional `fallbackModel`. In the image-tool path the assistants use, if the primary model keeps failing transiently (e.g. Pro overloaded), it retries once with Flash before giving up. Wired into Insight/Task/Focus with `fallbackModel: "gemini-2.5-flash"`.

## Verification
- **Full `xcrun swift build` clean.**
- **#3 (reverse STT) live-verified** on a named bundle (signed in, real recording): forced cloud-reconnect exhaustion → logs show `cloud STT unreachable — falling back to on-device Parakeet` → `ON-DEVICE Parakeet mode` → `Microphone capture started`. Recording switched engines instead of dying.
- #1/#2/#4 are compile-verified, low-risk catch-branch additions, each with a `defaults`/env test hook (matching the codebase's debug-default pattern) for live fault injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)