### PR TITLE
feat(desktop): mute music during push-to-talk instead of leaving it playing (WisprFlow-style)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request"
+    "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request",
+    "Push-to-talk now mutes music and other audio while you talk and restores it on release, instead of leaving it playing"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -225,6 +225,9 @@ class PushToTalkManager: ObservableObject {
 
   private func startListening() {
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    if ShortcutSettings.shared.pttMuteSystemAudio {
+      SystemAudioMuteController.shared.muteForListening()
+    }
     state = .listening
     isCurrentSessionFollowUp = barState?.showingAIResponse == true
     transcriptSegments = []
@@ -251,6 +254,9 @@ class PushToTalkManager: ObservableObject {
 
   private func enterLockedListening() {
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    if ShortcutSettings.shared.pttMuteSystemAudio {
+      SystemAudioMuteController.shared.muteForListening()
+    }
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
     state = .lockedListening
@@ -298,6 +304,8 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func stopListening() {
+    // Always restore audio on teardown (cancel, error, cleanup) so we never leave it muted.
+    SystemAudioMuteController.shared.restore()
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
     liveFinalizationTimeout?.cancel()
@@ -329,6 +337,8 @@ class PushToTalkManager: ObservableObject {
     guard state == .listening || state == .lockedListening || state == .pendingLockDecision else { return }
 
     lastOptionUpTime = 0
+    // Dictation is over — restore any audio we muted so the track resumes immediately.
+    SystemAudioMuteController.shared.restore()
     finalizedMode = state == .lockedListening ? "locked" : "hold"
     state = .finalizing
     finalizeWorkItem?.cancel()

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -320,6 +320,13 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(pttSoundsEnabled, forKey: "shortcut_pttSoundsEnabled") }
     }
 
+    /// When true, holding push-to-talk mutes any audio playing on the default output
+    /// device (e.g. music) for the duration of dictation, then restores it on release —
+    /// like Wispr Flow. The track keeps playing silently rather than being paused.
+    @Published var pttMuteSystemAudio: Bool {
+        didSet { UserDefaults.standard.set(pttMuteSystemAudio, forKey: "shortcut_pttMuteSystemAudio") }
+    }
+
     /// Selected AI model for Ask Omi.
     @Published var selectedModel: String {
         didSet { UserDefaults.standard.set(selectedModel, forKey: "shortcut_selectedModel") }
@@ -530,6 +537,7 @@ class ShortcutSettings: ObservableObject {
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
+        self.pttMuteSystemAudio = UserDefaults.standard.object(forKey: "shortcut_pttMuteSystemAudio") as? Bool ?? true
         self.selectedModel = ModelQoS.Claude.sanitizedSelection(
             UserDefaults.standard.string(forKey: "shortcut_selectedModel")
         )

--- a/desktop/Desktop/Sources/FloatingControlBar/SystemAudioMuteController.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/SystemAudioMuteController.swift
@@ -1,0 +1,167 @@
+import CoreAudio
+import Foundation
+
+/// Mutes the system's default audio-output device while push-to-talk is active,
+/// mirroring Wispr Flow's "mute audio while dictating" behavior.
+///
+/// Unlike pausing media (which stops the track), this leaves playback running but
+/// silent, so it resumes seamlessly the instant the user releases the key. To match
+/// Wispr Flow exactly we only mute when audio is *already playing* on the device, we
+/// never touch a device the user has muted themselves, and we always restore the
+/// prior state when listening ends.
+@MainActor
+final class SystemAudioMuteController {
+  static let shared = SystemAudioMuteController()
+
+  /// The device we muted, or nil if we currently hold no mute.
+  private var mutedDevice: AudioDeviceID?
+  /// Per-channel volumes to restore when the fallback path was used.
+  private var restoreVolumes: [(channel: UInt32, value: Float32)] = []
+  private var usedVolumeFallback = false
+
+  private init() {}
+
+  // MARK: - Public API
+
+  /// Mute the default output device if audio is currently playing through it.
+  /// Idempotent — safe to call repeatedly while already muted.
+  func muteForListening() {
+    guard mutedDevice == nil else { return }  // we already hold a mute
+    guard let device = Self.defaultOutputDevice() else { return }
+    guard Self.isDeviceRunningSomewhere(device) else { return }  // nothing is playing
+    if Self.deviceIsMuted(device) == true { return }  // user already muted it — leave it
+
+    // Preferred path: toggle the device's master mute.
+    if Self.setMute(device, muted: true) {
+      mutedDevice = device
+      usedVolumeFallback = false
+      log("SystemAudioMuteController: muted output device \(device)")
+      return
+    }
+
+    // Fallback: device has no settable mute → drop volume to zero, remembering prior.
+    let saved = Self.zeroVolume(device)
+    if !saved.isEmpty {
+      restoreVolumes = saved
+      mutedDevice = device
+      usedVolumeFallback = true
+      log("SystemAudioMuteController: muted via volume fallback on device \(device)")
+    }
+  }
+
+  /// Restore whatever `muteForListening()` changed. No-op if we hold no mute.
+  func restore() {
+    guard let device = mutedDevice else { return }
+    if usedVolumeFallback {
+      for v in restoreVolumes { _ = Self.setVolume(device, channel: v.channel, value: v.value) }
+    } else {
+      _ = Self.setMute(device, muted: false)
+    }
+    log("SystemAudioMuteController: restored output device \(device)")
+    mutedDevice = nil
+    restoreVolumes = []
+    usedVolumeFallback = false
+  }
+
+  // MARK: - CoreAudio helpers
+
+  private static func defaultOutputDevice() -> AudioDeviceID? {
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain)
+    var device = AudioDeviceID(0)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &device)
+    guard status == noErr, device != 0 else { return nil }
+    return device
+  }
+
+  /// True if any process is actively running I/O on the device (i.e. audio is playing).
+  private static func isDeviceRunningSomewhere(_ device: AudioDeviceID) -> Bool {
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain)
+    var running = UInt32(0)
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    let status = AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &running)
+    return status == noErr && running != 0
+  }
+
+  private static func muteAddress() -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyMute,
+      mScope: kAudioObjectPropertyScopeOutput,
+      mElement: kAudioObjectPropertyElementMain)
+  }
+
+  /// Current mute state, or nil if the device exposes no mute property.
+  private static func deviceIsMuted(_ device: AudioDeviceID) -> Bool? {
+    var addr = muteAddress()
+    guard AudioObjectHasProperty(device, &addr) else { return nil }
+    var muted = UInt32(0)
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &muted) == noErr else { return nil }
+    return muted != 0
+  }
+
+  @discardableResult
+  private static func setMute(_ device: AudioDeviceID, muted: Bool) -> Bool {
+    var addr = muteAddress()
+    var settable = DarwinBoolean(false)
+    guard AudioObjectHasProperty(device, &addr),
+      AudioObjectIsPropertySettable(device, &addr, &settable) == noErr,
+      settable.boolValue
+    else { return false }
+    var value: UInt32 = muted ? 1 : 0
+    let size = UInt32(MemoryLayout<UInt32>.size)
+    return AudioObjectSetPropertyData(device, &addr, 0, nil, size, &value) == noErr
+  }
+
+  private static func volumeAddress(_ channel: UInt32) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyVolumeScalar,
+      mScope: kAudioObjectPropertyScopeOutput,
+      mElement: channel)
+  }
+
+  private static func getVolume(_ device: AudioDeviceID, channel: UInt32) -> Float32? {
+    var addr = volumeAddress(channel)
+    guard AudioObjectHasProperty(device, &addr) else { return nil }
+    var value = Float32(0)
+    var size = UInt32(MemoryLayout<Float32>.size)
+    guard AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &value) == noErr else { return nil }
+    return value
+  }
+
+  @discardableResult
+  private static func setVolume(_ device: AudioDeviceID, channel: UInt32, value: Float32) -> Bool {
+    var addr = volumeAddress(channel)
+    var settable = DarwinBoolean(false)
+    guard AudioObjectHasProperty(device, &addr),
+      AudioObjectIsPropertySettable(device, &addr, &settable) == noErr,
+      settable.boolValue
+    else { return false }
+    var v = value
+    let size = UInt32(MemoryLayout<Float32>.size)
+    return AudioObjectSetPropertyData(device, &addr, 0, nil, size, &v) == noErr
+  }
+
+  /// Zero out the device volume, returning the prior values so they can be restored.
+  /// Tries the master element first, then falls back to per-channel (stereo).
+  private static func zeroVolume(_ device: AudioDeviceID) -> [(channel: UInt32, value: Float32)] {
+    let main = kAudioObjectPropertyElementMain
+    if let prior = getVolume(device, channel: main), setVolume(device, channel: main, value: 0) {
+      return [(channel: main, value: prior)]
+    }
+    var saved: [(channel: UInt32, value: Float32)] = []
+    for ch: UInt32 in [1, 2] {
+      if let prior = getVolume(device, channel: ch), setVolume(device, channel: ch, value: 0) {
+        saved.append((channel: ch, value: prior))
+      }
+    }
+    return saved
+  }
+}

--- a/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -22,6 +22,7 @@ struct ShortcutsSettingsSection: View {
       pttKeyCard
       doubleTapCard
       pttSoundsCard
+      muteAudioCard
     }
     .onDisappear {
       stopShortcutCapture()
@@ -203,6 +204,33 @@ struct ShortcutsSettingsSection: View {
     .modifier(
       SettingHighlightModifier(
         settingId: "floatingbar.pttsounds", highlightedSettingId: $highlightedSettingId))
+  }
+
+  private var muteAudioCard: some View {
+    HStack(spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Mute Audio While Talking")
+          .scaledFont(size: 16, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+        Text("Silence music and other playback while holding push-to-talk, then restore it on release.")
+          .scaledFont(size: 13)
+          .foregroundColor(OmiColors.textSecondary)
+      }
+      Spacer()
+      Toggle("", isOn: $settings.pttMuteSystemAudio)
+        .toggleStyle(.switch)
+        .tint(OmiColors.purplePrimary)
+    }
+    .padding(20)
+    .background(
+      RoundedRectangle(cornerRadius: 12)
+        .fill(OmiColors.backgroundTertiary.opacity(0.5))
+    )
+    .opacity(settings.pttEnabled ? 1 : 0.55)
+    .disabled(!settings.pttEnabled)
+    .modifier(
+      SettingHighlightModifier(
+        settingId: "floatingbar.muteaudio", highlightedSettingId: $highlightedSettingId))
   }
 
   private var referenceCard: some View {


### PR DESCRIPTION
## What

While holding push-to-talk on the desktop app, any audio playing on the default output device (music, video, etc.) is now **muted** for the duration of dictation and **restored on release** — matching Wispr Flow's "mute audio while dictating" behavior. The track keeps playing silently and resumes seamlessly, rather than being paused.

## Why

Requested: when music is playing and you use PTT, it should mute the music (not pause it), exactly like Wispr Flow does. Omi previously had no media handling here.

## How

- **`SystemAudioMuteController`** (new) — mutes the default output device via CoreAudio `kAudioDevicePropertyMute` (falls back to zeroing volume for devices without a settable mute), only when audio is actively playing (`DeviceIsRunningSomewhere`), never touching a device the user already muted. Remembers prior state and restores exactly.
- **`PushToTalkManager`** — mutes on `startListening`/`enterLockedListening`; restores on `finalize` (release) and `stopListening` (cancel/error/cleanup), so audio always comes back.
- **`ShortcutSettings.pttMuteSystemAudio`** — setting, default **on**.
- **Settings UI** — "Mute Audio While Talking" toggle.

## Verification

- Compiled the real `SystemAudioMuteController` source into a standalone harness and ran it against the machine's actual default output device — independently confirmed via `osascript`: `false → true → false`, system left clean.
- Drove the genuine `startListening()` → `finalize()` path in a running signed-in named bundle via the in-process automation bridge while a tone played: `setting=on, before=false, during=true, after=false`.
- Clean release build (`rm -rf .build && xcrun swift build -c release --triple arm64-apple-macosx --package-path Desktop`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)