### PR TITLE
fix(backend): offload sync Firestore calls off event loop in /v4/listen (#6947)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -375,7 +375,7 @@ async def _stream_handler(
         translation_language = None
     elif stt_language == 'multi':
         if language == "multi":
-            user_language_preference = user_db.get_user_language_preference(uid)
+            user_language_preference = await run_blocking(db_executor, user_db.get_user_language_preference, uid)
             if user_language_preference:
                 translation_language = user_language_preference
         else:
@@ -550,7 +550,9 @@ async def _stream_handler(
                 words_transcribed_since_last_record = 0  # reset
 
                 if transcription_seconds > 0 or words_to_record > 0 or speech_seconds_delta > 0:
-                    record_usage(
+                    await run_blocking(
+                        db_executor,
+                        record_usage,
                         uid,
                         transcription_seconds=transcription_seconds,
                         words_transcribed=words_to_record,
@@ -618,7 +620,9 @@ async def _stream_handler(
                 )
             )
             if needs_refresh:
-                remaining_seconds_cache = get_remaining_transcription_seconds(uid, source=source)
+                remaining_seconds_cache = await run_blocking(
+                    db_executor, get_remaining_transcription_seconds, uid, source=source
+                )
                 remaining_seconds_cache_ts = now
                 remaining_seconds_cache_initialized = True
             elif remaining_seconds_cache is not None and transcription_seconds > 0:
@@ -660,7 +664,7 @@ async def _stream_handler(
                     freemium_threshold_sent = False
 
             # Silence notification logic for basic plan users
-            user_subscription = user_db.get_user_valid_subscription(uid)
+            user_subscription = await run_blocking(db_executor, user_db.get_user_valid_subscription, uid)
             if not user_subscription or user_subscription.plan == PlanType.basic:
                 time_of_last_words = last_transcript_time or first_audio_byte_timestamp
                 if (
@@ -746,13 +750,13 @@ async def _stream_handler(
     )
 
     # Validate user
-    if not user_db.is_exists_user(uid):
+    if not await run_blocking(db_executor, user_db.is_exists_user, uid):
         websocket_active = False
         await websocket.close(code=1008, reason="Bad user")
         return
 
     # Create or get conversation ID early for audio chunk storage
-    private_cloud_sync_enabled = user_db.get_user_private_cloud_sync_enabled(uid)
+    private_cloud_sync_enabled = await run_blocking(db_executor, user_db.get_user_private_cloud_sync_enabled, uid)
 
     # Enable speaker identification when user has speech profile or private cloud sync
     has_speech_profile = False
@@ -2822,7 +2826,9 @@ async def _stream_handler(
                 dg_usage_ms_pending = 0
 
             if transcription_seconds > 0 or words_to_record > 0 or speech_seconds_delta > 0:
-                record_usage(
+                await run_blocking(
+                    db_executor,
+                    record_usage,
                     uid,
                     transcription_seconds=transcription_seconds,
                     words_transcribed=words_to_record,


### PR DESCRIPTION
## Bug (#6947)
All ~34 `backend-listen` pods fail liveness health checks simultaneously, causing mass pod kills (161 on Apr 16, 48 on Apr 17, 35 on Apr 22) and LB 5xx spikes. The health endpoint is trivial (`return {"status": "ok"}`), so the **asyncio event loop itself is blocked**.

## Root cause
The `/v4/listen` WebSocket handler (`_stream_handler` in `backend/routers/transcribe.py`) makes **synchronous Firestore calls directly on the event loop**:

- **Periodic usage loop** (`_record_usage_periodically`, runs every 60s per active connection): `record_usage` → `update_hourly_usage` (write), `get_remaining_transcription_seconds`, `get_user_valid_subscription` (reads).
- **On WS session open**: `is_exists_user`, `get_user_private_cloud_sync_enabled`, `get_user_language_preference` (reads).
- **Session-end flush** (in `finally`): `record_usage`.

With ~30 connections/pod and Firestore latency spikes (200–500ms), fleet-wide restarts synchronize the 60s timers so all connections' calls fire at once — blocking the loop long enough to fail liveness checks across the fleet.

## Fix
Wrap each sync Firestore call in `await run_blocking(db_executor, fn, ...)` — the repo's documented pattern for Firestore CRUD inside `async def` (already used throughout this same file, e.g. lines 341, 1819+). All targets are confirmed **sync leaf operations** (no nested executor `.result()`), so `db_executor` is the correct pool and there's no deadlock risk. Behavior is unchanged — identical calls, results awaited in place; they just no longer block the event loop.

Scope: 1 file, +13/−7. Redis fail-open calls and the secondary timer-thundering-herd concern (#3 in the issue) are intentionally left untouched.

## Verification
- `python3 -m py_compile routers/transcribe.py` ✓
- `python3 scripts/lint_async_blockers.py` → "No async-blocking violations found." ✓
- `black --line-length 120 --skip-string-normalization` clean ✓
- pytest not run locally (not installed); CI runs the suite. Not exercised against a live WS session.

🤖 automated by hourly watchdog.