### PR TITLE
fix(backend): embeddings fall back to Omi key when a user's BYOK OpenAI key fails (fixes empty memory search)

### DIFF
--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -73,6 +73,47 @@ class _OpenAIEmbeddingsProxy:
             return inst
         return self._default
 
+    @staticmethod
+    def _is_key_failure(e: Exception) -> bool:
+        # A user's BYOK OpenAI key being out of quota / invalid / rate-limited must not
+        # silently break memory search (it would return empty). Detect those and fall
+        # back to Omi's key instead. Heuristic on the error text — embeddings have no
+        # typed error here, and a false positive only means one extra default-key call.
+        s = str(e).lower()
+        return any(
+            k in s
+            for k in (
+                'insufficient_quota',
+                'exceeded your current quota',
+                'invalid_api_key',
+                'incorrect api key',
+                'invalid api key',
+                'rate_limit',
+                ' 429',
+                ' 401',
+            )
+        )
+
+    def embed_query(self, text: str) -> List[float]:
+        inst = self._resolve()
+        try:
+            return inst.embed_query(text)
+        except Exception as e:
+            if inst is not self._default and self._is_key_failure(e):
+                logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
+                return self._default.embed_query(text)
+            raise
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        inst = self._resolve()
+        try:
+            return inst.embed_documents(texts)
+        except Exception as e:
+            if inst is not self._default and self._is_key_failure(e):
+                logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
+                return self._default.embed_documents(texts)
+            raise
+
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
 


### PR DESCRIPTION
## Problem
Prod logs show **~200 `OpenAI 429 insufficient_quota` errors / 6h** on `search_memories_text` → memory search returns **empty** for those users. Root cause: the embeddings proxy (`_OpenAIEmbeddingsProxy`) substitutes a user's **BYOK OpenAI key** when set; if that key is out of quota / invalid, every embedding call fails and memory search silently returns nothing.

(Found while investigating why an agent got "no hiring memories" — the data was fine and searchable; this is a separate, real reliability bug for BYOK users.)

## Fix
`embed_query` / `embed_documents` now catch a **key-specific** failure (insufficient_quota / invalid key / rate limit) on the BYOK key and **retry once with Omi's default key**, instead of letting the empty/error propagate. Non-key errors (network/timeout) still raise. Only triggers when a BYOK key is active and fails — no behavior change for default-key users.

## Verification
- Compiles; `black` clean; heuristic unit-checked (insufficient_quota / invalid key / rate_limit → fallback; network/timeout → raise).
- Full live BYOK-failure path not exercised (needs a user with a dead BYOK key) — low-risk additive catch branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)