### PR TITLE
Align Twilio test stub TwiML rendering

### DIFF
--- a/backend/tests/unit/test_twilio_service.py
+++ b/backend/tests/unit/test_twilio_service.py
@@ -40,6 +40,25 @@ def test_generate_access_token(mock_jwt):
     assert result['ttl'] == 600
 
 
+def test_twilio_stub_dial_appends_multiple_numbers():
+    from twilio.twiml.voice_response import Dial, VoiceResponse
+
+    dial = Dial(caller_id='+15550000000')
+    first_number = dial.number('+15551111111')
+    second_number = dial.number('+15552222222')
+
+    assert str(first_number) == '<Number>+15551111111</Number>'
+    assert str(second_number) == '<Number>+15552222222</Number>'
+
+    response = VoiceResponse()
+    response.append(dial)
+
+    assert (
+        str(response) == '<?xml version="1.0" encoding="utf-8"?><Response><Dial callerId="+15550000000">'
+        '<Number>+15551111111</Number><Number>+15552222222</Number></Dial></Response>'
+    )
+
+
 def test_validate_twilio_signature_valid():
     mock_validator = MagicMock()
     mock_validator.validate.return_value = True

--- a/backend/tests/unit/twilio_stub.py
+++ b/backend/tests/unit/twilio_stub.py
@@ -78,22 +78,31 @@ def install_twilio_stub():
             self.verbs.append(str(verb))
 
         def __str__(self):
-            return f'<Response>{"".join(self.verbs)}</Response>'
+            return f'<?xml version="1.0" encoding="utf-8"?><Response>{"".join(self.verbs)}</Response>'
+
+    class Number:
+        def __init__(self, phone_number):
+            self.phone_number = phone_number
+
+        def __str__(self):
+            return f'<Number>{escape(str(self.phone_number))}</Number>'
 
     class Dial:
         def __init__(self, caller_id=None, time_limit=None, **kwargs):
             self.caller_id = caller_id
             self.time_limit = time_limit
             self.kwargs = kwargs
-            self.number_value = None
+            self.number_verbs = []
 
         def number(self, phone_number):
-            self.number_value = phone_number
+            number_verb = Number(phone_number)
+            self.number_verbs.append(number_verb)
+            return number_verb
 
         def __str__(self):
             attrs = _xml_attrs({'callerId': self.caller_id, 'timeLimit': self.time_limit})
-            number = '' if self.number_value is None else escape(str(self.number_value))
-            return f'<Dial{attrs}>{number}</Dial>'
+            numbers = ''.join(str(number_verb) for number_verb in self.number_verbs)
+            return f'<Dial{attrs}>{numbers}</Dial>'
 
     rest_mod.Client = Client
     access_token_mod.AccessToken = AccessToken
@@ -102,6 +111,7 @@ def install_twilio_stub():
     exceptions_mod.TwilioRestException = TwilioRestException
     voice_response_mod.VoiceResponse = VoiceResponse
     voice_response_mod.Dial = Dial
+    voice_response_mod.Number = Number
 
     twilio_mod.rest = rest_mod
     twilio_mod.jwt = jwt_mod


### PR DESCRIPTION
## Summary
- align the Twilio test stub with the real SDK's TwiML shape by adding the XML declaration to `VoiceResponse.__str__()`
- render dialed phone numbers as `<Number>...</Number>` and expose a minimal `Number` object from `Dial.number()`
- preserve multiple `Dial.number()` calls so the stub appends each `<Number>` child like the real SDK
- follow up on the Greptile feedback from #7724 after that PR was merged before the final stub-compatibility patch landed

## Testing
- `python -m pytest tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q` -> 10 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\twilio_stub.py tests\unit\test_twilio_service.py --check`
- `python -m py_compile tests\unit\twilio_stub.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py`
- `git diff --check origin/main...HEAD`