### PR TITLE
Stabilize KG user type tests

### DIFF
--- a/backend/tests/unit/test_kg_user_type_mismatch.py
+++ b/backend/tests/unit/test_kg_user_type_mismatch.py
@@ -11,6 +11,7 @@ from Firebase Auth — the canonical way to get user names in this codebase.
 import os
 import sys
 import types
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -62,6 +63,9 @@ for attr in [
     "find_similar_memories",
     "upsert_memory_vector",
     "delete_memory_vector",
+    "upsert_action_item_vectors_batch",
+    "delete_action_item_vectors_batch",
+    "find_similar_action_items",
     "upsert_vector2",
     "update_vector_metadata",
 ]:
@@ -106,18 +110,21 @@ for name in [
     "utils.llm.chat",
     "utils.llm.clients",
     "utils.llm.knowledge_graph",
+    "utils.llm.usage_tracker",
     "utils.notifications",
+    "utils.subscription",
     "utils.other.hume",
     "utils.retrieval.rag",
     "utils.webhooks",
     "utils.task_sync",
     "utils.other.storage",
+    "utils.conversations.calendar_linking",
 ]:
     if name not in sys.modules:
         sys.modules[name] = types.ModuleType(name)
 
 utils_apps = sys.modules["utils.apps"]
-for attr in ["get_available_apps", "update_personas_async", "sync_update_persona_prompt"]:
+for attr in ["get_available_apps", "update_personas_async", "update_persona_prompt", "sync_update_persona_prompt"]:
     setattr(utils_apps, attr, MagicMock())
 
 utils_analytics = sys.modules["utils.analytics"]
@@ -165,9 +172,32 @@ llm_clients.generate_embedding = MagicMock()
 llm_kg = sys.modules["utils.llm.knowledge_graph"]
 llm_kg.extract_knowledge_from_memory = MagicMock()
 
+llm_usage_tracker = sys.modules["utils.llm.usage_tracker"]
+
+
+@contextmanager
+def _track_usage_stub(*_args, **_kwargs):
+    yield
+
+
+llm_usage_tracker.track_usage = _track_usage_stub
+llm_usage_tracker.Features = types.SimpleNamespace(
+    CONVERSATION_STRUCTURE="conversation_structure",
+    CONVERSATION_ACTION_ITEMS="conversation_action_items",
+    CONVERSATION_DISCARD="conversation_discard",
+    CONVERSATION_APPS="conversation_apps",
+    CONVERSATION_FOLDER="conversation_folder",
+    GOALS="goals",
+    MEMORIES="memories",
+    TRENDS="trends",
+)
+
 utils_notifications = sys.modules["utils.notifications"]
 for attr in ["send_notification", "send_important_conversation_message", "send_action_item_data_message"]:
     setattr(utils_notifications, attr, MagicMock())
+
+utils_subscription = sys.modules["utils.subscription"]
+utils_subscription.is_trial_paywalled = MagicMock(return_value=False)
 
 utils_hume = sys.modules["utils.other.hume"]
 for attr in ["get_hume", "HumeJobCallbackModel", "HumeJobModelPredictionResponseModel"]:
@@ -184,6 +214,10 @@ utils_task_sync.auto_sync_action_items_batch = MagicMock()
 
 utils_storage = sys.modules["utils.other.storage"]
 utils_storage.precache_conversation_audio = MagicMock()
+
+utils_calendar_linking = sys.modules["utils.conversations.calendar_linking"]
+utils_calendar_linking.get_overlapping_calendar_event = MagicMock(return_value=None)
+utils_calendar_linking.write_conversation_link_to_calendar_event = MagicMock()
 
 import importlib
 
@@ -213,9 +247,16 @@ def _make_memory_mock(memory_id="mem-1", content="Test memory", kg_extracted=Fal
     return m
 
 
+def _make_raw_memory(content="Test memory"):
+    """Create a raw extracted memory mock with content for duplicate filtering."""
+    memory = MagicMock()
+    memory.content = content
+    return memory
+
+
 def _setup_extract_memories(memory_mock):
     """Configure stubs so _extract_memories_inner reaches the KG block with one memory."""
-    llm_memories.new_memories_extractor.return_value = [MagicMock()]  # raw Memory
+    llm_memories.new_memories_extractor.return_value = [_make_raw_memory(memory_mock.content)]
     vector_db_mod.find_similar_memories.return_value = []
     memories_mod.get_memory_ids_for_conversation.return_value = []
     memories_mod.save_memories.reset_mock()
@@ -246,7 +287,7 @@ class TestKnowledgeGraphUserLookup:
         from pathlib import Path
 
         router_path = Path(__file__).resolve().parent.parent.parent / "routers" / "knowledge_graph.py"
-        source = router_path.read_text()
+        source = router_path.read_text(encoding="utf-8")
         assert "get_user_name" in source, "Router should use get_user_name from database.auth"
         assert (
             "get_user_profile" not in source
@@ -318,7 +359,11 @@ class TestKnowledgeGraphUserLookup:
         mem3 = _make_memory_mock("mem-c", "Third memory", kg_extracted=True)  # already extracted
 
         mock_from_memory.side_effect = [mem1, mem2, mem3]
-        llm_memories.new_memories_extractor.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        llm_memories.new_memories_extractor.return_value = [
+            _make_raw_memory(mem1.content),
+            _make_raw_memory(mem2.content),
+            _make_raw_memory(mem3.content),
+        ]
         vector_db_mod.find_similar_memories.return_value = []
         memories_mod.get_memory_ids_for_conversation.return_value = []
         memories_mod.save_memories.reset_mock()
@@ -373,7 +418,11 @@ class TestKnowledgeGraphFailureHandling:
         mem3 = _make_memory_mock("mem-ok2", "Another good", kg_extracted=False)
 
         mock_from_memory.side_effect = [mem1, mem2, mem3]
-        llm_memories.new_memories_extractor.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        llm_memories.new_memories_extractor.return_value = [
+            _make_raw_memory(mem1.content),
+            _make_raw_memory(mem2.content),
+            _make_raw_memory(mem3.content),
+        ]
         vector_db_mod.find_similar_memories.return_value = []
         memories_mod.get_memory_ids_for_conversation.return_value = []
         memories_mod.save_memories.reset_mock()
@@ -439,7 +488,10 @@ class TestKnowledgeGraphLockedMemorySkip:
         mem2 = _make_memory_mock("mem-2", "More secret", kg_extracted=False)
 
         mock_from_memory.side_effect = [mem1, mem2]
-        llm_memories.new_memories_extractor.return_value = [MagicMock(), MagicMock()]
+        llm_memories.new_memories_extractor.return_value = [
+            _make_raw_memory(mem1.content),
+            _make_raw_memory(mem2.content),
+        ]
         vector_db_mod.find_similar_memories.return_value = []
         memories_mod.get_memory_ids_for_conversation.return_value = []
         memories_mod.save_memories.reset_mock()


### PR DESCRIPTION
## Summary
- stub the newer `process_conversation` dependencies needed by `test_kg_user_type_mismatch.py`
- give raw extracted memory mocks stable `content` values so duplicate filtering reaches the KG extraction path under test
- read `routers/knowledge_graph.py` with explicit UTF-8 encoding for Windows test runs

## Testing
- `python -m pytest tests\unit\test_kg_user_type_mismatch.py -q` -> 11 passed, 1 Pydantic V2 deprecation warning
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_kg_user_type_mismatch.py --check`
- `python -m py_compile tests\unit\test_kg_user_type_mismatch.py`
- `git diff --check origin/main...HEAD`