### PR TITLE
fix(backend): use configured user name in summary transcript (#5319)

### DIFF
--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -508,3 +508,26 @@ def test_mixed_english_cjk_sentence_splitting():
     assert len(segments) == 2
     assert segments[0].text.endswith("。")
     assert segments[1].text == "Next part."
+
+
+def test_segments_as_string_uses_configured_user_name():
+    """User segments must render the configured name, not the generic 'User' label (#5319)."""
+    segs = [
+        _segment("Hi, this is me.", speaker="SPEAKER_00", is_user=True, start=0.0, end=2.0),
+        _segment("Nice to meet you.", speaker="SPEAKER_01", is_user=False, start=2.0, end=4.0),
+    ]
+
+    rendered = TranscriptSegment.segments_as_string(segs, user_name="Stephen")
+
+    assert "Stephen: Hi, this is me." in rendered
+    assert "User:" not in rendered
+    assert "Speaker 1: Nice to meet you." in rendered
+
+
+def test_segments_as_string_defaults_to_user_when_name_missing():
+    """No configured name (None) falls back to the generic 'User' label — unchanged behavior."""
+    segs = [_segment("Hello.", speaker="SPEAKER_00", is_user=True, start=0.0, end=1.0)]
+
+    rendered = TranscriptSegment.segments_as_string(segs, user_name=None)
+
+    assert rendered.startswith("User: Hello.")

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -11,6 +11,7 @@ from typing import Union, Tuple, List, Optional
 from fastapi import HTTPException
 
 from database import redis_db
+from database.auth import get_user_name
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.notifications as notification_db
@@ -192,7 +193,8 @@ def _get_structured(
             # not supported conversation source
             raise HTTPException(status_code=400, detail=f'Invalid conversation source: {conversation.text_source}')
 
-        transcript_text = conversation.get_transcript(False, people=people)
+        user_name = get_user_name(uid, use_default=False)
+        transcript_text = conversation.get_transcript(False, people=people, user_name=user_name)
 
         # For re-processing, we don't discard, just re-structure.
         if force_process:
@@ -550,7 +552,6 @@ def _extract_memories_inner(uid: str, conversation: Conversation):
 
         try:
             from utils.llm.knowledge_graph import extract_knowledge_from_memory
-            from database.auth import get_user_name
 
             user_name = get_user_name(uid)
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -7,7 +7,6 @@ from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
-from database.auth import get_user_name
 from models.app import App
 from models.calendar_context import CalendarMeetingContext
 from models.conversation import Conversation
@@ -631,11 +630,6 @@ def get_transcript_structure(
         return Structured()  # Should be caught by discard logic, but as a safeguard.
 
     response_language = output_language_code or language_code
-    try:
-        user_name = get_user_name(uid)
-    except Exception as e:
-        logger.warning(f'Failed to load user name for transcript structuring (uid={uid}): {e}')
-        user_name = 'The User'
 
     # First system message: task-specific instructions (static prefix enables cross-conversation caching)
     # NOTE: language instructions are in context_message (second message) to keep this prefix fully static.


### PR DESCRIPTION
## Bug (#5319)
Conversation summaries (and action-item extraction) refer to the user as **"User"** / their initials instead of the name configured in app settings (e.g. "Stephen").

## Root cause
`_get_structured` in `backend/utils/conversations/process_conversation.py` built the transcript fed to the LLM via:

```python
transcript_text = conversation.get_transcript(False, people=people)
```

`get_transcript` → `TranscriptSegment.segments_as_string` defaults `user_name` to `'User'` when none is passed. The `people` map only names *other* speakers, never the user. So the user's own segments always rendered as "User".

Separately, `get_transcript_structure` (conversation_processing.py) computed `user_name = get_user_name(uid)` but **never used it** — an incomplete/dead attempt at the same fix that also cost a redundant Firestore/cache lookup per conversation.

## Fix
- Pass the user's configured name into the transcript that drives structuring/discard/action-items:
  ```python
  user_name = get_user_name(uid, use_default=False)
  transcript_text = conversation.get_transcript(False, people=people, user_name=user_name)
  ```
  `use_default=False` returns `None` when no name is set, preserving the existing `'User'` fallback. This mirrors how `chat.py` and `memories.py` already pass `user_name` to `segments_as_string`.
- Removed the dead `user_name` computation (and now-unused import) from `get_transcript_structure`.
- Added two regression tests asserting the rendered transcript uses the configured name and falls back to `'User'` when unset.

## Verification
`py_compile`, `black`, and `scripts/lint_async_blockers.py` all clean. Rendering logic traced against `segments_as_string` (`SPEAKER_01` → `speaker_id 1`). pytest/pydantic not installed locally — CI runs the suite. UNVERIFIED against a live summary generation.

Scope: +3/-8 across 2 source files + 2 tests, surgical, mirrors an existing pattern.

🤖 automated by hourly watchdog; opened for review, not merged. Not auto-merged: this is summary-quality degradation, not a crash/data-loss/security/broken-core-flow, so it does not meet the prod-bug auto-deploy bar.