### PR TITLE
Read payment source tests as UTF-8

### DIFF
--- a/backend/tests/unit/test_payment_available_plans_source.py
+++ b/backend/tests/unit/test_payment_available_plans_source.py
@@ -4,7 +4,7 @@ PAYMENT_SOURCE_FILE = Path(__file__).resolve().parents[2] / "routers" / "payment
 
 
 def test_available_plans_support_partial_billing_options():
-    source = PAYMENT_SOURCE_FILE.read_text()
+    source = PAYMENT_SOURCE_FILE.read_text(encoding="utf-8")
 
     assert 'if monthly_price_id:' in source
     assert 'if annual_price_id:' in source

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -10,26 +10,31 @@ import pytest
 PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
 STRIPE_UTILS_SOURCE = Path(__file__).resolve().parents[2] / "utils" / "stripe.py"
 
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Source-level structural tests (fast, no import needed)
 # ---------------------------------------------------------------------------
 
 
 def test_checkout_request_model_accepts_promotion_code():
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     assert 'class CreateCheckoutRequest(BaseModel):' in source
     assert 'promotion_code: Optional[str] = None' in source
 
 
 def test_upgrade_request_model_accepts_promotion_code():
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     assert 'class UpgradeSubscriptionRequest(BaseModel):' in source
     assert 'promotion_code: Optional[str] = None' in source
 
 
 def test_checkout_validates_promo_before_reactivation():
     """Promo validation must happen before _try_reactivate_subscription."""
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     endpoint_start = source.index("def create_checkout_session_endpoint")
     promo_in_checkout = source.index("PromotionCode.list", endpoint_start)
     reactivation_in_checkout = source.index("_try_reactivate_subscription", endpoint_start)
@@ -38,7 +43,7 @@ def test_checkout_validates_promo_before_reactivation():
 
 def test_upgrade_uses_promotion_code_id_not_coupon():
     """Upgrade must use promotion_code ID (preserves restrictions) not coupon ID."""
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     upgrade_start = source.index("def upgrade_subscription_endpoint")
     upgrade_section = source[upgrade_start:]
     assert "{'promotion_code': resolved_promo_id}" in upgrade_section
@@ -47,7 +52,7 @@ def test_upgrade_uses_promotion_code_id_not_coupon():
 
 def test_upgrade_applies_promo_to_schedule_phases():
     """Same-plan interval changes must apply promo discount to the target phase."""
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     upgrade_start = source.index("def upgrade_subscription_endpoint")
     upgrade_section = source[upgrade_start:]
     assert "SubscriptionSchedule.modify" in upgrade_section
@@ -57,18 +62,18 @@ def test_upgrade_applies_promo_to_schedule_phases():
 
 
 def test_checkout_helper_uses_discounts_when_promo_provided():
-    source = STRIPE_UTILS_SOURCE.read_text()
+    source = _read_source(STRIPE_UTILS_SOURCE)
     assert "if promotion_code_id:" in source
     assert "session_params['discounts'] = [{'promotion_code': promotion_code_id}]" in source
 
 
 def test_checkout_helper_allows_promo_codes_when_no_promo():
-    source = STRIPE_UTILS_SOURCE.read_text()
+    source = _read_source(STRIPE_UTILS_SOURCE)
     assert "session_params['allow_promotion_codes'] = True" in source
 
 
 def test_upgrade_catches_stripe_invalid_request_error():
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     upgrade_start = source.index("def upgrade_subscription_endpoint")
     upgrade_section = source[upgrade_start:]
     assert "stripe.error.InvalidRequestError" in upgrade_section
@@ -79,7 +84,7 @@ def test_upgrade_releases_attached_schedule_before_change():
     Subscription.modify() / SubscriptionSchedule.create(), otherwise Stripe
     rejects the change ("cannot migrate a subscription already attached to a
     schedule") and the user can never switch plans."""
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     assert "def _release_attached_schedules" in source
     upgrade_section = source[source.index("def upgrade_subscription_endpoint") :]
     assert "_release_attached_schedules(stripe_sub)" in upgrade_section
@@ -89,7 +94,7 @@ def test_upgrade_releases_attached_schedule_before_change():
 
 
 def test_checkout_catches_stripe_invalid_request_error():
-    source = PAYMENT_SOURCE.read_text()
+    source = _read_source(PAYMENT_SOURCE)
     checkout_start = source.index("def create_checkout_session_endpoint")
     checkout_section = source[checkout_start : source.index("def upgrade_subscription_endpoint")]
     assert "stripe.error.InvalidRequestError" in checkout_section

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -23,7 +23,7 @@ from models.users import PlanType, SubscriptionStatus, Subscription
 def _get_build_subscription_fn():
     """Extract _build_subscription_from_stripe_object from payment.py source and
     compile it into an executable function with controlled dependencies."""
-    source = (Path(__file__).resolve().parents[2] / "routers" / "payment.py").read_text()
+    source = (Path(__file__).resolve().parents[2] / "routers" / "payment.py").read_text(encoding="utf-8")
     func_start = source.index('def _build_subscription_from_stripe_object')
     next_func = source.index('\ndef ', func_start + 1)
     func_source = source[func_start:next_func]

--- a/backend/tests/unit/test_stripe_webhook_none_guard.py
+++ b/backend/tests/unit/test_stripe_webhook_none_guard.py
@@ -18,7 +18,7 @@ PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
 
 
 def _read_source():
-    return PAYMENT_SOURCE.read_text()
+    return PAYMENT_SOURCE.read_text(encoding="utf-8")
 
 
 # ── Fix 1: FirestoreNotFound guard for deleted users ─────────────────────────


### PR DESCRIPTION
## Summary
- read payment and Stripe helper source snapshots with explicit UTF-8 encoding in source-level tests
- avoid Windows locale-dependent `Path.read_text()` failures when the default code page is GBK and `routers/payment.py` contains UTF-8 punctuation

## Testing
- `python -m pytest tests\unit\test_payment_available_plans_source.py tests\unit\test_payment_promotion_codes.py tests\unit\test_stripe_webhook_none_guard.py tests\unit\test_stripe_webhook_behavioral.py -q` -> 41 passed, 2 warnings
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_payment_available_plans_source.py tests\unit\test_payment_promotion_codes.py tests\unit\test_stripe_webhook_none_guard.py tests\unit\test_stripe_webhook_behavioral.py --check`
- `python -m py_compile tests\unit\test_payment_available_plans_source.py tests\unit\test_payment_promotion_codes.py tests\unit\test_stripe_webhook_none_guard.py tests\unit\test_stripe_webhook_behavioral.py`
- `git diff --check origin/main...HEAD`