### PR TITLE
Stabilize speaker ID pipeline tests without AV or SciPy

### DIFF
--- a/backend/tests/unit/test_short_audio_embedding.py
+++ b/backend/tests/unit/test_short_audio_embedding.py
@@ -19,6 +19,40 @@ from unittest.mock import MagicMock
 
 _MISSING = object()
 _SCIPY_MODULES = ("scipy", "scipy.spatial", "scipy.spatial.distance")
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_SPEAKER_EMBEDDING_MODULE = "utils.stt.speaker_embedding"
+_SPEAKER_EMBEDDING_REQUIRED_ATTRS = (
+    "MIN_EMBEDDING_AUDIO_DURATION",
+    "_get_wav_duration",
+    "extract_embedding_from_bytes",
+)
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, types.ModuleType) or not hasattr(module, "__path__"):
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+
+    if "." in name:
+        parent_name, attr = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, module)
+
+    return module
+
+
+def _drop_stale_speaker_embedding_stub():
+    module = sys.modules.get(_SPEAKER_EMBEDDING_MODULE)
+    if module is None or all(hasattr(module, attr) for attr in _SPEAKER_EMBEDDING_REQUIRED_ATTRS):
+        return
+
+    sys.modules.pop(_SPEAKER_EMBEDDING_MODULE, None)
+    parent = sys.modules.get("utils.stt")
+    if parent is not None and getattr(parent, "speaker_embedding", _MISSING) is module:
+        delattr(parent, "speaker_embedding")
 
 
 def _install_scipy_stub_if_missing():
@@ -75,10 +109,14 @@ def _restore_modules(original_modules):
 
 
 def _import_speaker_embedding_module():
+    _ensure_package("utils", os.path.join(_BACKEND_DIR, "utils"))
+    _ensure_package("utils.stt", os.path.join(_BACKEND_DIR, "utils", "stt"))
+    _drop_stale_speaker_embedding_stub()
+
     original_modules = _install_scipy_stub_if_missing()
     try:
         # The imported module keeps its cdist binding; sys.modules stubs are restored below.
-        return importlib.import_module("utils.stt.speaker_embedding")
+        return importlib.import_module(_SPEAKER_EMBEDDING_MODULE)
     finally:
         _restore_modules(original_modules)
 

--- a/backend/tests/unit/test_short_audio_embedding.py
+++ b/backend/tests/unit/test_short_audio_embedding.py
@@ -26,6 +26,11 @@ _SPEAKER_EMBEDDING_REQUIRED_ATTRS = (
     "_get_wav_duration",
     "extract_embedding_from_bytes",
 )
+_IMPORT_STUB_GUARDS = {
+    "utils.http_client": ("get_stt_client",),
+    "utils.executors": ("storage_executor", "run_blocking"),
+    _SPEAKER_EMBEDDING_MODULE: _SPEAKER_EMBEDDING_REQUIRED_ATTRS,
+}
 
 
 def _ensure_package(name, path):
@@ -44,15 +49,19 @@ def _ensure_package(name, path):
     return module
 
 
-def _drop_stale_speaker_embedding_stub():
-    module = sys.modules.get(_SPEAKER_EMBEDDING_MODULE)
-    if module is None or all(hasattr(module, attr) for attr in _SPEAKER_EMBEDDING_REQUIRED_ATTRS):
+def _drop_stale_stub(module_name, required_attrs):
+    module = sys.modules.get(module_name)
+    if module is None or all(hasattr(module, attr) for attr in required_attrs):
         return
 
-    sys.modules.pop(_SPEAKER_EMBEDDING_MODULE, None)
-    parent = sys.modules.get("utils.stt")
-    if parent is not None and getattr(parent, "speaker_embedding", _MISSING) is module:
-        delattr(parent, "speaker_embedding")
+    sys.modules.pop(module_name, None)
+    if "." not in module_name:
+        return
+
+    parent_name, attr = module_name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, attr, _MISSING) is module:
+        delattr(parent, attr)
 
 
 def _install_scipy_stub_if_missing():
@@ -111,7 +120,8 @@ def _restore_modules(original_modules):
 def _import_speaker_embedding_module():
     _ensure_package("utils", os.path.join(_BACKEND_DIR, "utils"))
     _ensure_package("utils.stt", os.path.join(_BACKEND_DIR, "utils", "stt"))
-    _drop_stale_speaker_embedding_stub()
+    for module_name, required_attrs in _IMPORT_STUB_GUARDS.items():
+        _drop_stale_stub(module_name, required_attrs)
 
     original_modules = _install_scipy_stub_if_missing()
     try:

--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -29,7 +29,7 @@ def _cosine_cdist(a, b, metric="cosine"):
     denominator = np.linalg.norm(a, axis=1)[:, None] * np.linalg.norm(b, axis=1)[None, :]
 
     with np.errstate(divide="ignore", invalid="ignore"):
-        similarity = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)
+        similarity = numerator / denominator
     return 1.0 - similarity
 
 
@@ -153,7 +153,15 @@ _http_client_mod = ModuleType("utils.http_client")
 _http_client_mod.get_stt_client = MagicMock()
 _install_module("utils.http_client", _http_client_mod)
 
-_install_module("av", MagicMock())
+_av_mod = ModuleType("av")
+
+
+def _av_open(*args, **kwargs):
+    raise RuntimeError("av is not installed; this test module only covers helpers that do not decode audio")
+
+
+_av_mod.open = _av_open
+_install_module("av", _av_mod)
 
 _storage_mod = ModuleType("utils.other.storage")
 for _name in [
@@ -520,6 +528,12 @@ class TestSpeakerEmbeddingMath:
         b[0, 1] = 1.0
         distance = compare_embeddings(a, b)
         assert distance == pytest.approx(1.0, abs=1e-6)
+
+    def test_compare_zero_vector_distance_nan(self):
+        """Zero-norm inputs match scipy cosine behavior."""
+        zero = np.zeros((1, 512), dtype=np.float32)
+        emb = self._random_embedding(seed=42)
+        assert np.isnan(compare_embeddings(zero, emb))
 
     def test_compare_opposite_vectors_distance_two(self):
         """Opposite vectors → cosine distance 2."""


### PR DESCRIPTION
## Summary
- install test-only stubs for optional `av` and `scipy.spatial.distance` imports when those packages are absent
- keep the stubs scoped to import-time so `utils.speaker_identification` and `utils.stt.speaker_embedding` can be imported for pure helper tests in lightweight Windows environments
- make the `av.open()` stub fail explicitly if a future test accidentally exercises the real audio trimming path without PyAV installed
- mirror SciPy's zero-norm cosine behavior in the stub and cover it with a regression test
- restore the real `utils.stt.speaker_embedding` import in `test_short_audio_embedding.py` when earlier collected tests leave lightweight speaker embedding, HTTP client, or executor stubs in `sys.modules`

## Review Follow-Up
- Prior review comments remain addressed: `_av_open` no longer shadows the built-in `open`, and zero-norm cosine inputs return `np.nan` like SciPy.
- Follow-up from a local stacked Windows collect scan: after merging the open Windows collect-isolation PRs locally, `test_short_audio_embedding.py` still saw stale speaker embedding and dependency stubs from earlier files. This PR now drops stale speaker embedding / `utils.http_client` / `utils.executors` stubs before importing the real module.

## Current status
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`
- Head refreshed to `60a0e0d0a654956a3c6b61233768cf6dd1e830f7`
- GitHub currently reports the PR as mergeable
- GitHub Actions `Lint Check` run `27684590397` completed successfully on this head

## Testing
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_dg_start_guard.py backend\tests\unit\test_short_audio_embedding.py --collect-only -q --tb=short --continue-on-collection-errors`
  - 14 tests collected
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_short_audio_embedding.py -q --tb=short`
  - 12 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_speaker_id_pipeline.py backend\tests\unit\test_short_audio_embedding.py -q --tb=short`
  - 120 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\tests\unit\test_short_audio_embedding.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_speaker_id_pipeline.py backend\tests\unit\test_short_audio_embedding.py`
  - 2 files would be left unchanged
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`

## Stacked Windows collect check
On a local-only integration branch containing the open Windows collect-isolation PR heads, `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` now exits 0 with 4206 tests collected.