### PR TITLE
Stabilize action item idempotency tests

### DIFF
--- a/backend/tests/unit/test_action_item_idempotency.py
+++ b/backend/tests/unit/test_action_item_idempotency.py
@@ -192,6 +192,7 @@ def _import_router_helper():
         _ensure_module(mod_name)
 
     sys.modules['utils.executors'].critical_executor = MagicMock()
+    sys.modules['utils.executors'].db_executor = MagicMock()
     sys.modules['utils.users'].get_user_display_name = lambda *a, **k: ''
     sys.modules['utils.other.endpoints'].get_current_user_uid = lambda: ''
     sys.modules['utils.other'].endpoints = sys.modules['utils.other.endpoints']
@@ -199,6 +200,8 @@ def _import_router_helper():
     sys.modules['utils.notifications'].send_action_item_data_message = lambda *a, **k: None
     sys.modules['utils.notifications'].send_action_item_update_message = lambda *a, **k: None
     sys.modules['utils.notifications'].send_action_item_deletion_message = lambda *a, **k: None
+    sys.modules['utils.notifications'].send_action_items_batch_deletion_message = lambda *a, **k: None
+    sys.modules['utils.notifications'].sync_action_item_reminder = lambda *a, **k: None
     sys.modules['utils.task_sync'].auto_sync_action_item = lambda *a, **k: None
     sys.modules['database.vector_db'].upsert_action_item_vector = lambda *a, **k: None
     sys.modules['database.vector_db'].upsert_action_item_vectors_batch = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- add the current `routers.action_items` import dependencies to the idempotency test's lightweight stubs
- keep the router-layer idempotency key tests focused on `_content_idempotency_key` without importing real executors or notification modules

## Testing
- `python -m pytest tests\unit\test_action_item_idempotency.py -q` -> 9 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_action_item_idempotency.py --check`
- `python -m py_compile tests\unit\test_action_item_idempotency.py`
- `git diff --check`