### PR TITLE
Stabilize task sharing tests

### DIFF
--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -80,6 +80,8 @@ notif_mod.send_notification = MagicMock()
 notif_mod.send_action_item_data_message = MagicMock()
 notif_mod.send_action_item_update_message = MagicMock()
 notif_mod.send_action_item_deletion_message = MagicMock()
+notif_mod.send_action_items_batch_deletion_message = MagicMock()
+notif_mod.sync_action_item_reminder = MagicMock()
 
 _stub_module("utils.task_sync")
 sys.modules["utils.task_sync"].auto_sync_action_item = MagicMock()


### PR DESCRIPTION
## Summary
- add the current `routers.action_items` notification imports to the task sharing test stubs
- keep task sharing tests isolated from real notification/reminder modules while importing the real router

## Testing
- `python -m pytest tests\unit\test_task_sharing.py -q` -> 29 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_task_sharing.py --check`
- `python -m py_compile tests\unit\test_task_sharing.py`
- `git diff --check`