### PR TITLE
fix(mcp): SSE search_memories was leaking rejected/superseded memories

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -549,10 +549,14 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         memory_ids = [m['memory_id'] for m in matches]
         memories = memories_db.get_memories_by_ids(user_id, memory_ids)
 
-        # Build score lookup and filter locked
+        # Build score lookup and filter out memories the user rejected or that were
+        # superseded/invalidated, then truncate locked content. Mirrors the REST MCP
+        # path (routers/mcp.py) so the SSE tool never surfaces stale/rejected facts.
         score_map = {m['memory_id']: m.get('score', 0) for m in matches}
         results = []
         for mem in memories:
+            if mem.get('user_review') is False or mem.get('invalid_at') is not None:
+                continue
             if mem.get('is_locked', False):
                 content = mem.get('content', '')
                 mem['content'] = (content[:70] + '...') if len(content) > 70 else content


### PR DESCRIPTION
## Problem
The SSE MCP `search_memories` tool (`/v1/mcp/sse`, used by external clients like personal agents) only filtered `is_locked` when building results. The REST MCP path (`routers/mcp.py`) additionally skips:
- `user_review is False` — memories the user explicitly **rejected**
- `invalid_at is not None` — memories that were **superseded** by a newer fact

So semantic search over SSE could return stale or user-rejected facts that the REST path correctly hides.

## Fix
Mirror the REST filter in the SSE results loop — skip rejected/invalidated memories before returning. Locked-content truncation behavior is unchanged.

## Verification
Reproduced on dev: created an active memory ("favorite language = Python") and a rejected one (`user_review=False`, "= COBOL"), both vectorized. Vector search returns both; the **old** loop returned both (leaking COBOL), the **fixed** loop returns only Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)