### PR TITLE
Stabilize async webhook source tests on Windows

### DIFF
--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -203,13 +203,13 @@ class TestConversationAndSummaryWebhooksStructural:
     @staticmethod
     def _read_webhooks_source() -> str:
         webhooks_path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'webhooks.py')
-        with open(webhooks_path) as f:
+        with open(webhooks_path, encoding='utf-8') as f:
             return f.read()
 
     @staticmethod
     def _parse_webhooks_ast():
         webhooks_path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'webhooks.py')
-        with open(webhooks_path) as f:
+        with open(webhooks_path, encoding='utf-8') as f:
             return ast.parse(f.read())
 
     def test_conversation_created_webhook_is_async(self):
@@ -357,7 +357,7 @@ class TestSendSummaryNotificationWiresSummaryJson:
 
     def test_notifications_passes_summary_data_as_summary_json(self):
         path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'other', 'notifications.py')
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             src = f.read()
 
         assert 'day_summary_webhook(uid, str(summary_data), summary_data)' in src, (


### PR DESCRIPTION
## Summary
- read inspected webhook and notification source files as UTF-8 in `test_async_webhooks.py`
- fix Windows non-UTF-8 locale failures in structural webhook tests
- keep the existing AST and string assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_async_webhooks.py -q` -> 7 failed, 15 passed
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading UTF-8 source files

## Testing
- `python -m pytest tests\unit\test_async_webhooks.py -q` -> 22 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_async_webhooks.py --check`
- `python -m py_compile tests\unit\test_async_webhooks.py`
- `git diff --check`