### PR TITLE
Stabilize conversation render source tests on Windows

### DIFF
--- a/backend/tests/unit/test_conversation_redact_enrich.py
+++ b/backend/tests/unit/test_conversation_redact_enrich.py
@@ -295,7 +295,7 @@ class TestCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in self.REDACT_CONSUMERS:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             # Should not have the old inline pattern of stripping action_items inside an is_locked check
             assert (
@@ -309,7 +309,7 @@ class TestCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in ['routers/mcp.py', 'routers/developer.py']:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert (
                 'def _add_speaker_names_to_segments' not in content
@@ -322,7 +322,7 @@ class TestCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in ['routers/developer.py']:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert (
                 'def _add_folder_names_to_conversations' not in content
@@ -335,7 +335,7 @@ class TestCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in ['utils/webhooks.py', 'utils/app_integrations.py']:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert (
                 'def _json_serialize_datetime' not in content
@@ -348,7 +348,7 @@ class TestCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in ['utils/webhooks.py', 'utils/app_integrations.py', 'routers/conversations.py']:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert '.as_dict_cleaned_dates()' not in content, f"{rel_path} still uses .as_dict_cleaned_dates()"
 
@@ -364,7 +364,7 @@ class TestCallSitesMigrated:
             'utils/conversations/merge_conversations.py',
         ]:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert (
                 'upsert_conversation(uid, conversation.as_dict_cleaned_dates())' not in content


### PR DESCRIPTION
## Summary
- read inspected router and utility source files as UTF-8 in `test_conversation_redact_enrich.py`
- fix Windows non-UTF-8 locale failures in static migration guards
- keep the existing assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_conversation_redact_enrich.py -q` -> 6 failed, 16 passed, 2 warnings
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading UTF-8 source files

## Testing
- `python -m pytest tests\unit\test_conversation_redact_enrich.py -q` -> 22 passed, 2 warnings
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_conversation_redact_enrich.py --check`
- `python -m py_compile tests\unit\test_conversation_redact_enrich.py`
- `git diff --check`