### PR TITLE
Stabilize conversation render factory source tests on Windows

### DIFF
--- a/backend/tests/unit/test_conversation_render_factory.py
+++ b/backend/tests/unit/test_conversation_render_factory.py
@@ -226,7 +226,7 @@ class TestConversationModelNoRenderMethod:
 
     def test_render_module_not_imported_in_conversation_model(self):
         model_path = os.path.join(os.path.dirname(__file__), '../../models/conversation.py')
-        with open(model_path) as f:
+        with open(model_path, encoding='utf-8') as f:
             tree = ast.parse(f.read())
         imports = [
             node
@@ -253,7 +253,7 @@ class TestProductionCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in self.RENDER_CONSUMERS:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert (
                 'Conversation.conversations_to_string' not in content
@@ -263,6 +263,6 @@ class TestProductionCallSitesMigrated:
         backend = os.path.join(os.path.dirname(__file__), '../..')
         for rel_path in self.RENDER_CONSUMERS:
             path = os.path.join(backend, rel_path)
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 content = f.read()
             assert 'from utils.conversations.render import' in content, f"{rel_path} does not import from render module"


### PR DESCRIPTION
## Summary
- read inspected conversation model and render consumer source files as UTF-8 in `test_conversation_render_factory.py`
- fix Windows non-UTF-8 locale failures in static render migration tests
- keep the existing AST and string assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_conversation_render_factory.py -q` -> 2 failed, 17 passed
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading UTF-8 source files

## Testing
- `python -m pytest tests\unit\test_conversation_render_factory.py -q` -> 19 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_conversation_render_factory.py --check`
- `python -m py_compile tests\unit\test_conversation_render_factory.py`
- `git diff --check`