### PR TITLE
Stabilize fair-use upgrade source tests

### DIFF
--- a/backend/tests/unit/test_fair_use_upgrade.py
+++ b/backend/tests/unit/test_fair_use_upgrade.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import os
+import re
 import sys
 import types
 from datetime import datetime, timedelta
@@ -228,8 +229,16 @@ class TestWebhookClearFairUseSourceLevel:
     PAYMENT_SOURCE_FILE = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'payment.py')
 
     def _read_source(self):
-        with open(self.PAYMENT_SOURCE_FILE) as f:
+        with open(self.PAYMENT_SOURCE_FILE, encoding='utf-8') as f:
             return f.read()
+
+    @staticmethod
+    def _assert_clear_fair_use_called(block):
+        direct_call = r'\bclear_fair_use_on_upgrade\s*\(\s*uid\b'
+        run_blocking_call = r'\brun_blocking\s*\([^)]*\bclear_fair_use_on_upgrade\b[^)]*\buid\b'
+        assert re.search(direct_call, block) or re.search(
+            run_blocking_call, block, re.DOTALL
+        ), "clear_fair_use_on_upgrade is not called with uid"
 
     def test_payment_imports_clear_fair_use_on_upgrade(self):
         """payment.py must import clear_fair_use_on_upgrade."""
@@ -245,7 +254,7 @@ class TestWebhookClearFairUseSourceLevel:
         # The clear call should appear between checkout handler and the next event type
         next_event_idx = source.find("customer.subscription.updated", checkout_idx)
         block = source[checkout_idx:next_event_idx]
-        assert 'clear_fair_use_on_upgrade(uid)' in block
+        self._assert_clear_fair_use_called(block)
 
     def test_subscription_event_calls_clear(self):
         """customer.subscription.* path must call clear_fair_use_on_upgrade."""
@@ -254,13 +263,14 @@ class TestWebhookClearFairUseSourceLevel:
         assert sub_idx != -1, "customer.subscription handler not found"
         next_event_idx = source.find("subscription_schedule.completed", sub_idx)
         block = source[sub_idx:next_event_idx]
-        assert 'clear_fair_use_on_upgrade(uid)' in block
+        self._assert_clear_fair_use_called(block)
 
     def test_schedule_completed_calls_clear(self):
         """subscription_schedule.completed path must call clear_fair_use_on_upgrade."""
         source = self._read_source()
         schedule_idx = source.find("'subscription_schedule.completed'")
         assert schedule_idx != -1, "subscription_schedule handler not found"
-        # Get a reasonable block after the schedule handler
-        block = source[schedule_idx : schedule_idx + 1500]
-        assert 'clear_fair_use_on_upgrade(uid)' in block
+        canceled_idx = source.find("elif schedule_obj.get('status') == 'canceled'", schedule_idx)
+        assert canceled_idx != -1, "subscription_schedule canceled branch not found"
+        block = source[schedule_idx:canceled_idx]
+        self._assert_clear_fair_use_called(block)


### PR DESCRIPTION
## Summary
- read `routers/payment.py` as UTF-8 in `test_fair_use_upgrade.py` so source-level checks pass on Windows non-UTF-8 locales
- update the webhook source assertions to accept either a direct `clear_fair_use_on_upgrade(uid)` call or a `run_blocking(...)` call containing both `clear_fair_use_on_upgrade` and `uid`
- replace the fixed-length subscription schedule slice with a block bounded by the canceled branch marker

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_fair_use_upgrade.py -q` -> 4 failed, 9 passed
- the failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading `routers/payment.py`

After fixing the read encoding, the file exposed stale source-level assertions: `payment.py` currently calls `clear_fair_use_on_upgrade` through `run_blocking(...)` inside the async webhook handler rather than as `clear_fair_use_on_upgrade(uid)`.

## Testing
- `python -m pytest tests\unit\test_fair_use_upgrade.py -q` -> 13 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_fair_use_upgrade.py --check`
- `python -m py_compile tests\unit\test_fair_use_upgrade.py`
- `git diff --check`