### PR TITLE
Stabilize memories batch source tests on Windows

### DIFF
--- a/backend/tests/unit/test_memories_batch.py
+++ b/backend/tests/unit/test_memories_batch.py
@@ -149,7 +149,7 @@ class TestBatchMemoriesRequestValidation:
         import re
 
         path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'memories.py')
-        with open(os.path.abspath(path), 'r') as f:
+        with open(os.path.abspath(path), 'r', encoding='utf-8') as f:
             content = f.read()
         m = re.search(r'MEMORIES_BATCH_MAX\s*=\s*(\d+)', content)
         assert m, "MEMORIES_BATCH_MAX constant not found in routers/memories.py"


### PR DESCRIPTION
## Summary
- read `routers/memories.py` as UTF-8 in `test_memories_batch.py`
- fix Windows non-UTF-8 locale failures in the source-level batch-size tests
- keep the existing max-size assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_memories_batch.py -q` -> 4 failed, 4 passed
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading `routers/memories.py`

## Testing
- `python -m pytest tests\unit\test_memories_batch.py -q` -> 8 passed, 1 warning
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_memories_batch.py --check`
- `python -m py_compile tests\unit\test_memories_batch.py`
- `git diff --check`