### PR TITLE
Stabilize memories create source tests on Windows

### DIFF
--- a/backend/tests/unit/test_memories_create.py
+++ b/backend/tests/unit/test_memories_create.py
@@ -24,14 +24,14 @@ ROUTER_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'me
 
 
 def _read_router():
-    with open(ROUTER_PATH) as f:
+    with open(ROUTER_PATH, encoding='utf-8') as f:
         return f.read()
 
 
 def _grep_router(pattern: str) -> list[str]:
     """Return lines matching pattern in the memories router."""
     matches = []
-    with open(ROUTER_PATH) as f:
+    with open(ROUTER_PATH, encoding='utf-8') as f:
         for line in f:
             if re.search(pattern, line):
                 matches.append(line.strip())


### PR DESCRIPTION
## Summary
- read `routers/memories.py` as UTF-8 in `test_memories_create.py`
- fix Windows non-UTF-8 locale failures in source-level memories create/router tests
- keep the existing rate-limit and error-handling assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_memories_create.py -q` -> 13 failed, 9 passed
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading `routers/memories.py`

## Testing
- `python -m pytest tests\unit\test_memories_create.py -q` -> 22 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_memories_create.py --check`
- `python -m py_compile tests\unit\test_memories_create.py`
- `git diff --check`