### PR TITLE
Read people conversation source tests as UTF-8

### DIFF
--- a/backend/tests/unit/test_people_conversations_500s.py
+++ b/backend/tests/unit/test_people_conversations_500s.py
@@ -169,7 +169,7 @@ class TestConversationsListNoPhotos:
         import os
 
         router_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')
-        with open(router_path) as f:
+        with open(router_path, encoding='utf-8') as f:
             source = f.read()
         # The list endpoint function should call get_conversations_without_photos
         assert 'get_conversations_without_photos' in source
@@ -179,7 +179,7 @@ class TestConversationsListNoPhotos:
         import os
 
         db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'database', 'conversations.py')
-        with open(db_path) as f:
+        with open(db_path, encoding='utf-8') as f:
             source = f.read()
         # Find the function definition and check its parameters
         assert 'def get_conversations_without_photos(' in source
@@ -199,7 +199,7 @@ class TestConversationsListNoPhotos:
         import re
 
         db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'database', 'conversations.py')
-        with open(db_path) as f:
+        with open(db_path, encoding='utf-8') as f:
             source = f.read()
 
         # Find the function definition and the lines preceding it (decorators)
@@ -223,7 +223,7 @@ class TestConversationsListNoPhotos:
         import os
 
         db_path = os.path.join(os.path.dirname(__file__), '..', '..', 'database', 'conversations.py')
-        with open(db_path) as f:
+        with open(db_path, encoding='utf-8') as f:
             source = f.read()
 
         lines = source.split('\n')


### PR DESCRIPTION
## Summary
- read `routers/conversations.py` and `database/conversations.py` as UTF-8 in `test_people_conversations_500s.py`
- fix Windows non-UTF-8 locale failures in the source-level conversations list/no-photos checks
- keep the existing people/conversation assertions unchanged

## Windows reproduction
Before this change on Windows with the default GBK locale:
- `python -m pytest tests\unit\test_people_conversations_500s.py -q` -> 3 failed, 11 passed, 1 warning
- failures were `UnicodeDecodeError: 'gbk' codec can't decode byte ...` while reading `database/conversations.py`

## Testing
- `python -m pytest tests\unit\test_people_conversations_500s.py -q` -> 14 passed, 1 warning
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_people_conversations_500s.py --check`
- `python -m py_compile tests\unit\test_people_conversations_500s.py`
- `git diff --check --cached`