### PR TITLE
Update whisper dependency for Windows setup fix

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2564,8 +2564,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "684fb43710dd4de5538ac2da7d0b1fa405363212"
-      resolved-ref: "684fb43710dd4de5538ac2da7d0b1fa405363212"
+      ref: "af6b457cca4cdd6c97cc2dfa8557333ee09c81f1"
+      resolved-ref: "af6b457cca4cdd6c97cc2dfa8557333ee09c81f1"
       url: "https://github.com/BasedHardware/whisper_flutter_new.git"
     source: git
     version: "1.0.1"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -133,7 +133,7 @@ dependencies:
   whisper_flutter_new:
     git:
       url: https://github.com/BasedHardware/whisper_flutter_new.git
-      ref: 684fb43710dd4de5538ac2da7d0b1fa405363212
+      ref: af6b457cca4cdd6c97cc2dfa8557333ee09c81f1
   disk_space_2: ^1.0.11
   pasteboard: ^0.4.0
   vector_math: ^2.2.0


### PR DESCRIPTION
## Summary
- Pin `whisper_flutter_new` to `af6b457cca4cdd6c97cc2dfa8557333ee09c81f1`, the upstream dependency commit that fixes the Windows setup failure described in #4806.
- Update `app/pubspec.lock` so `ref` and `resolved-ref` stay aligned with `app/pubspec.yaml`.
- Leave all other Flutter dependencies unchanged.

Fixes #4806

## Windows context
- The current dependency pin points at `684fb43710dd4de5538ac2da7d0b1fa405363212` on `whisper_flutter_new/main`.
- The new pin is the `whisper_flutter_new` fix commit titled `Fixed the Comma error which was causing the setup to fail in OMI for Windows user`.
- A normal filtered clone of `BasedHardware/whisper_flutter_new` can resolve the pinned SHA with `git cat-file -e af6b457cca4cdd6c97cc2dfa8557333ee09c81f1^{commit}`.

## Testing
- `git diff --check`
- Verified `app/pubspec.yaml` and `app/pubspec.lock` both reference `af6b457cca4cdd6c97cc2dfa8557333ee09c81f1`.
- `git ls-remote https://github.com/BasedHardware/whisper_flutter_new.git` shows the current main SHA and the target fix SHA.

Not run: `flutter pub get` or a Flutter app build, because Flutter/Dart is not installed in this Windows Codex environment.