### PR TITLE
Document Windows app setup command

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -13,14 +13,21 @@ Before getting started, make sure your device is connected and unlocked. If you'
    cd app
    ```
 
-2. Run setup script:
+2. Run the setup script for your platform:
    ```bash
-   # For iOS
+   # macOS/Linux: iOS
    bash setup.sh ios
 
-   # For Android
+   # macOS/Linux: Android
    bash setup.sh android
    ```
+
+   ```powershell
+   # Windows PowerShell: Android
+   .\setup\scripts\setup.ps1 android
+   ```
+
+   iOS setup requires macOS/Xcode, so Windows developers should use the Android setup path.
  
 3. Ensure GitHub SSH access is set up correctly for pulling certificates from repositories. After running the command below, if you're prompted for a passphrase, enter your SSH passphrase — or simply press Enter/Return if you haven't set one.
     ```bash


### PR DESCRIPTION
## Summary
- Add the Windows PowerShell setup command to `app/README.md`.
- Keep the existing macOS/Linux `bash setup.sh` commands for iOS and Android.
- Clarify that iOS setup requires macOS/Xcode, so Windows developers should use the Android setup path.

## Windows context
The repository already includes `app/setup/scripts/setup.ps1`, but the app README only showed the bash setup script. This gives Windows contributors a direct setup entrypoint from the local app README.

## Testing
- Verified `app/setup/scripts/setup.ps1` exists.
- Verified `app/setup.sh` exists.
- `git diff --check`

Docs-only change; no app build was run.