### PR TITLE
Stabilize backend unit smoke tests on Windows

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -157,7 +157,7 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     - `stripe_executor` (4w) — Stripe API calls
     - `sync_executor` (16w) — sync endpoint pipeline work, parent calls that fan out to storage_executor
     - `postprocess_executor` (24w) — post-conversation processing, coordinator functions
-    - `storage_executor` (96w) — GCS uploads/downloads, audio chunk I/O (fan-out gated by semaphores: 32 global chunks, 8 per-call window, 4 concurrent precache files)
+    - `storage_executor` (128w) — GCS uploads/downloads, audio chunk I/O (fan-out gated by semaphores: 32 global chunks, 8 per-call window, 4 concurrent precache files)
   - **Deadlock prevention — 4 rules:**
     1. **Worker threads are leaf operations only.** Never `.result()` on another pool from inside a worker thread. If pool A thread submits to pool B and calls `.result()`, and vice versa, both pools deadlock.
     2. **Orchestration stays in async code.** The async handler coordinates via `await run_blocking(pool, fn)` — sequentially or with `asyncio.gather`. The event loop never blocks, pools stay independent.

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -26,6 +26,10 @@ import pytest
 # ---------------------------------------------------------------------------
 BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 IST_TZ = timezone(timedelta(hours=5, minutes=30), "IST")
+ZONEINFO_FALLBACKS = {
+    "UTC": timezone.utc,
+    "Asia/Kolkata": IST_TZ,
+}
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
@@ -67,11 +71,10 @@ def _zoneinfo_for_test(key):
     try:
         return ZoneInfo(key)
     except (ZoneInfoNotFoundError, KeyError):
-        if key == "UTC":
-            return timezone.utc
-        if key == "Asia/Kolkata":
-            return timezone(timedelta(hours=5, minutes=30), key)
-        raise
+        fallback = ZONEINFO_FALLBACKS.get(key)
+        if fallback is None:
+            raise
+        return fallback
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -63,6 +63,17 @@ def _load_module_from_file(module_name, file_path):
     return mod
 
 
+def _zoneinfo_for_test(key):
+    try:
+        return ZoneInfo(key)
+    except Exception:
+        if key == "UTC":
+            return timezone.utc
+        if key == "Asia/Kolkata":
+            return timezone(timedelta(hours=5, minutes=30), key)
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies
 # ---------------------------------------------------------------------------
@@ -101,13 +112,18 @@ action_items_db.get_action_item = MagicMock(
     }
 )
 action_items_db.update_action_item = MagicMock(return_value=True)
-_stub_package("database")
+database_pkg = _stub_package("database")
+database_pkg.__path__ = [str(BACKEND_DIR / "database")]
+database_pkg.action_items = action_items_db
 
 # Stub notifications
 notif_mod = _stub_module("utils.notifications")
 notif_mod.send_action_item_completed_notification = MagicMock()
 notif_mod.send_action_item_created_notification = MagicMock()
 notif_mod.send_action_item_data_message = MagicMock()
+notif_mod.send_app_review_reply_notification = MagicMock()
+notif_mod.send_new_app_review_notification = MagicMock()
+notif_mod.send_notification = MagicMock()
 notif_mod.sync_action_item_reminder = MagicMock()
 
 # Stub langchain
@@ -138,12 +154,17 @@ langchain_prompts.ChatPromptTemplate = MagicMock()
 # Stub pydantic (already installed, just need BaseModel/Field accessible)
 # pydantic is real, no stub needed
 
-# Stub utils packages
-_stub_package("utils")
-_stub_package("utils.retrieval")
-_stub_package("utils.retrieval.tools")
-_stub_package("utils.llm")
-_stub_package("utils.conversations")
+# Stub utils packages while preserving imports for unstubbed submodules in later tests.
+utils_pkg = _stub_package("utils")
+utils_pkg.__path__ = [str(BACKEND_DIR / "utils")]
+retrieval_pkg = _stub_package("utils.retrieval")
+retrieval_pkg.__path__ = [str(BACKEND_DIR / "utils" / "retrieval")]
+tools_pkg = _stub_package("utils.retrieval.tools")
+tools_pkg.__path__ = [str(BACKEND_DIR / "utils" / "retrieval" / "tools")]
+llm_pkg = _stub_package("utils.llm")
+llm_pkg.__path__ = [str(BACKEND_DIR / "utils" / "llm")]
+conversations_pkg = _stub_package("utils.conversations")
+conversations_pkg.__path__ = [str(BACKEND_DIR / "utils" / "conversations")]
 
 # Stub utils.retrieval.agentic
 import contextvars
@@ -162,6 +183,7 @@ llm_clients_stub.parser = MagicMock()
 llm_clients_stub.llm_high = MagicMock()
 llm_clients_stub.llm_medium_experiment = MagicMock()
 llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
+llm_clients_stub.embeddings = MagicMock()
 
 # Load models first
 _stub_package("models")
@@ -591,7 +613,7 @@ class TestActionItemTimezoneConversion:
         with patch.object(conv_proc, 'get_llm', return_value=mock_llm), patch.object(
             conv_proc, 'PydanticOutputParser'
         ) as mock_parser_cls, patch.object(conv_proc, 'ChatPromptTemplate') as mock_prompt_cls, patch.object(
-            conv_proc, 'ZoneInfo', side_effect=self._zone_info
+            conv_proc, 'ZoneInfo', side_effect=_zoneinfo_for_test
         ):
             mock_parser = MagicMock()
             mock_parser.get_format_instructions.return_value = "format"
@@ -609,9 +631,9 @@ class TestActionItemTimezoneConversion:
 
     def test_naive_local_due_converted_to_utc_for_ist(self):
         # LLM emits naive local 10:00 IST tomorrow -> server stores 04:30 UTC (the #7059 bug).
-        naive_local = (datetime.now(timezone.utc).astimezone(IST_TZ) + timedelta(days=1)).replace(
-            hour=10, minute=0, second=0, microsecond=0, tzinfo=None
-        )
+        naive_local = (
+            datetime.now(timezone.utc).astimezone(_zoneinfo_for_test("Asia/Kolkata")) + timedelta(days=1)
+        ).replace(hour=10, minute=0, second=0, microsecond=0, tzinfo=None)
         result, _ = self._run(naive_local, tz="Asia/Kolkata")
         assert len(result) == 1 and result[0].due_at is not None
         due = result[0].due_at
@@ -655,7 +677,7 @@ class TestActionItemTimezoneConversion:
         assert d1 is not None and d1.utcoffset() == timedelta(0)
         assert (d1.hour, d1.minute) == (4, 30)
         # (b) aware +05:30 value is converted to UTC, not trusted as-is
-        aware_ist = base.replace(hour=10, minute=0, second=0, microsecond=0, tzinfo=IST_TZ)
+        aware_ist = base.replace(hour=10, minute=0, second=0, microsecond=0, tzinfo=_zoneinfo_for_test("Asia/Kolkata"))
         r2, _ = self._run(aware_ist, tz="UTC")
         d2 = r2[0].due_at
         assert d2 is not None and d2.utcoffset() == timedelta(0)

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -16,7 +16,7 @@ import sys
 import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -66,7 +66,7 @@ def _load_module_from_file(module_name, file_path):
 def _zoneinfo_for_test(key):
     try:
         return ZoneInfo(key)
-    except Exception:
+    except (ZoneInfoNotFoundError, KeyError):
         if key == "UTC":
             return timezone.utc
         if key == "Asia/Kolkata":

--- a/backend/tests/unit/test_apps_review_reply_validation.py
+++ b/backend/tests/unit/test_apps_review_reply_validation.py
@@ -70,6 +70,11 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
+_preserved_stub_modules = {
+    _n: sys.modules[_n] for _n in list(sys.modules) if any(_n == p or _n.startswith(p + '.') for p in _STUB)
+}
+for _n in _preserved_stub_modules:
+    sys.modules.pop(_n, None)
 _finder = _Finder()
 _clear_stubbed_modules()
 sys.meta_path.insert(0, _finder)
@@ -78,6 +83,7 @@ try:
 finally:
     sys.meta_path.remove(_finder)
     _clear_stubbed_modules()
+    sys.modules.update(_preserved_stub_modules)
 
 from fastapi import HTTPException  # noqa: E402
 

--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -7,6 +7,7 @@ use asyncio.gather + httpx instead of Thread+join + requests.
 import os
 import sys
 import types
+import functools
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
@@ -152,6 +153,7 @@ if _http_mod is not None and not hasattr(_http_mod, '__file__'):
     _mock_cb.record_failure = MagicMock()
     _http_mod.get_webhook_circuit_breaker = MagicMock(return_value=_mock_cb)
     _http_mod.get_webhook_semaphore = MagicMock(return_value=_asyncio.Semaphore(64))
+    _http_mod.get_maps_semaphore = MagicMock(return_value=_asyncio.Semaphore(64))
     _http_mod.latest_wins_start = MagicMock(return_value=1)
     _http_mod.latest_wins_check = MagicMock(return_value=True)
 
@@ -159,21 +161,34 @@ if _http_mod is not None and not hasattr(_http_mod, '__file__'):
 # run_in_executor calls executor.submit() and wraps the returned Future.
 from concurrent.futures import ThreadPoolExecutor as _TPE
 
-_executors_mod = sys.modules.setdefault("utils.executors", types.ModuleType("utils.executors"))
-_executors_mod.critical_executor = _TPE(max_workers=2, thread_name_prefix="test-critical")
-_executors_mod.db_executor = _TPE(max_workers=2, thread_name_prefix="test-db")
-_executors_mod.storage_executor = _TPE(max_workers=2, thread_name_prefix="test-storage")
+
+def _make_test_executor(name):
+    return _TPE(max_workers=2, thread_name_prefix=f"test-{name}")
 
 
-async def _run_blocking(_executor, func, *args, **kwargs):
-    return func(*args, **kwargs)
+def _executor_call(fn, *args, **kwargs):
+    return functools.partial(fn, *args, **kwargs)
 
 
-_executors_mod.run_blocking = _run_blocking
+async def _run_blocking(_executor, fn, *args, **kwargs):
+    loop = _asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, _executor_call(fn, *args, **kwargs))
+
+
+def _install_executor_stubs():
+    executors_mod = sys.modules.setdefault("utils.executors", types.ModuleType("utils.executors"))
+    executors_mod.db_executor = _make_test_executor("db")
+    executors_mod.critical_executor = _make_test_executor("critical")
+    executors_mod.storage_executor = _make_test_executor("storage")
+    executors_mod.run_blocking = _run_blocking
+
+
+_install_executor_stubs()
 
 import importlib
 
 app_integrations = importlib.import_module("utils.app_integrations")
+sys.modules["utils"].mentor_notifications = sys.modules["utils.mentor_notifications"]
 
 
 def _make_app(app_id: str, webhook_url: str, triggers_realtime=False, triggers_audio=False, uid=None):

--- a/backend/tests/unit/test_async_geocoding.py
+++ b/backend/tests/unit/test_async_geocoding.py
@@ -34,6 +34,11 @@ if "utils.http_client" not in sys.modules:
 from models.conversation import Geolocation
 from utils.conversations.location import async_get_google_maps_location
 
+if "utils" in sys.modules and "utils.conversations" in sys.modules:
+    sys.modules["utils"].conversations = sys.modules["utils.conversations"]
+if "utils.conversations" in sys.modules and "utils.conversations.location" in sys.modules:
+    sys.modules["utils.conversations"].location = sys.modules["utils.conversations.location"]
+
 
 class TestAsyncCacheHit:
     """When Redis has cached data, return without calling Google API."""

--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -9,10 +9,19 @@ Covers:
 """
 
 import asyncio
+import sys
 import time
 from unittest.mock import patch
 
 import pytest
+
+for _module_name in ("utils.http_client", "utils.executors"):
+    sys.modules.pop(_module_name, None)
+_utils_pkg = sys.modules.get("utils")
+if _utils_pkg is not None:
+    for _attr in ("http_client", "executors"):
+        if hasattr(_utils_pkg, _attr):
+            delattr(_utils_pkg, _attr)
 
 from utils.http_client import (
     WebhookCircuitBreaker,
@@ -521,7 +530,9 @@ class TestCircuitBreakerAccessTracking:
         _webhook_circuit_breakers.clear()
         cb = get_webhook_circuit_breaker('https://test.test/hook')
         old_access = cb._last_access_time
-        time.sleep(0.01)
+        deadline = time.monotonic() + 0.1
+        while time.monotonic() <= old_access and time.monotonic() < deadline:
+            time.sleep(0.001)
         cb.allow_request()
         assert cb._last_access_time > old_access
         _webhook_circuit_breakers.clear()

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -33,7 +33,14 @@ _db_redis.r = MagicMock()
 
 _backend_dir = os.path.join(os.path.dirname(__file__), '..', '..')
 
-for mod_name in ["database", "database.notifications", "database.users", "database.folders", "database.conversations"]:
+for mod_name in [
+    "database",
+    "database.notifications",
+    "database.users",
+    "database.folders",
+    "database.conversations",
+    "database.webhook_health",
+]:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = types.ModuleType(mod_name)
         if mod_name == "database":
@@ -44,6 +51,9 @@ sys.modules["database.users"].get_user_profile = MagicMock(return_value={"name":
 sys.modules["database.users"].get_people_by_ids = MagicMock(return_value=[])
 sys.modules["database.folders"].get_folders = MagicMock(return_value=[])
 sys.modules["database.conversations"].get_conversations = MagicMock(return_value=[])
+sys.modules["database.webhook_health"].record_dev_webhook_failure = MagicMock(return_value=False)
+sys.modules["database.webhook_health"].record_dev_webhook_success = MagicMock()
+sys.modules["database.webhook_health"]._DEV_FAILURE_THRESHOLD = 100
 
 if "utils.notifications" not in sys.modules:
     sys.modules["utils.notifications"] = types.ModuleType("utils.notifications")

--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -40,8 +40,23 @@ os.environ.setdefault("BASE_API_URL", "http://localhost:8080")
 # Pre-mock heavy deps before importing the module under test (Python 3.9 compat —
 # database.redis_db uses dict | None syntax that requires 3.10+).
 _mock = MagicMock()
-for mod in ['firebase_admin.auth', 'database.redis_db', 'utils.http_client', 'utils.log_sanitizer']:
-    sys.modules.setdefault(mod, _mock)
+_stub_modules = [
+    'firebase_admin.auth',
+    'database.redis_db',
+    'fastapi.templating',
+    'utils.http_client',
+    'utils.log_sanitizer',
+]
+_missing = object()
+_previous_modules = {mod: sys.modules.get(mod, _missing) for mod in _stub_modules}
+_previous_parent_attrs = {}
+for mod in _stub_modules:
+    parent_name, _, attr = mod.rpartition('.')
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        _previous_parent_attrs[mod] = (parent, attr, getattr(parent, attr, _missing))
+        setattr(parent, attr, _mock)
+    sys.modules[mod] = _mock
 
 try:
     import jinja2  # noqa: F401
@@ -57,6 +72,20 @@ if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
 from routers.auth import _validate_redirect_uri  # noqa: E402
+
+for mod, previous in _previous_modules.items():
+    if previous is _missing:
+        sys.modules.pop(mod, None)
+    else:
+        sys.modules[mod] = previous
+for parent, attr, previous in _previous_parent_attrs.values():
+    if previous is _missing:
+        try:
+            delattr(parent, attr)
+        except AttributeError:
+            pass
+    else:
+        setattr(parent, attr, previous)
 
 # ---------------------------------------------------------------------------
 # Acceptance — every shape an existing Omi client uses
@@ -294,15 +323,18 @@ class TestAuthCodeBinding:
 class TestCallbackTemplateRendering:
     """Test that the callback template receives and uses dynamic redirect_uri."""
 
-    def test_template_uses_dynamic_redirect_uri(self):
-        """Verify auth_callback.html renders with the session's redirect_uri, not hardcoded."""
-        pytest.importorskip("jinja2")
-        from jinja2 import Environment, FileSystemLoader
+    @staticmethod
+    def _load_template():
+        jinja2 = pytest.importorskip("jinja2")
         import pathlib
 
         templates_dir = pathlib.Path(__file__).parent.parent.parent / "templates"
-        env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
-        template = env.get_template("auth_callback.html")
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)), autoescape=True)
+        return env.get_template("auth_callback.html")
+
+    def test_template_uses_dynamic_redirect_uri(self):
+        """Verify auth_callback.html renders with the session's redirect_uri, not hardcoded."""
+        template = self._load_template()
 
         html = template.render(
             code="test-auth-code",
@@ -315,13 +347,7 @@ class TestCallbackTemplateRendering:
 
     def test_template_json_escapes_redirect_uri(self):
         """Verify redirect_uri is JSON-escaped in the template (XSS prevention)."""
-        pytest.importorskip("jinja2")
-        from jinja2 import Environment, FileSystemLoader
-        import pathlib
-
-        templates_dir = pathlib.Path(__file__).parent.parent.parent / "templates"
-        env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
-        template = env.get_template("auth_callback.html")
+        template = self._load_template()
 
         html = template.render(
             code='test</script><script>alert(1)',
@@ -333,13 +359,7 @@ class TestCallbackTemplateRendering:
 
     def test_template_defaults_when_redirect_uri_missing(self):
         """Verify template falls back to omi://auth/callback when redirect_uri not provided."""
-        pytest.importorskip("jinja2")
-        from jinja2 import Environment, FileSystemLoader
-        import pathlib
-
-        templates_dir = pathlib.Path(__file__).parent.parent.parent / "templates"
-        env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
-        template = env.get_template("auth_callback.html")
+        template = self._load_template()
 
         html = template.render(
             code="test-code",

--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -20,6 +20,7 @@ Mapping to real-world clients:
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import types
@@ -72,6 +73,11 @@ if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
 from routers.auth import _validate_redirect_uri  # noqa: E402
+
+
+def _run_async(coro):
+    return asyncio.run(coro)
+
 
 for mod, previous in _previous_modules.items():
     if previous is _missing:
@@ -214,12 +220,10 @@ class TestAuthCodeBinding:
         )
 
         with patch('routers.auth.get_auth_code', return_value=code_data), patch('routers.auth.delete_auth_code'):
-            import asyncio
-
             request = MagicMock()
 
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
+                _run_async(
                     auth_token(
                         request=request,
                         grant_type='authorization_code',
@@ -248,11 +252,9 @@ class TestAuthCodeBinding:
         )
 
         with patch('routers.auth.get_auth_code', return_value=code_data), patch('routers.auth.delete_auth_code'):
-            import asyncio
-
             request = MagicMock()
 
-            result = asyncio.get_event_loop().run_until_complete(
+            result = _run_async(
                 auth_token(
                     request=request,
                     grant_type='authorization_code',
@@ -276,11 +278,9 @@ class TestAuthCodeBinding:
         )
 
         with patch('routers.auth.get_auth_code', return_value=legacy_data), patch('routers.auth.delete_auth_code'):
-            import asyncio
-
             request = MagicMock()
 
-            result = asyncio.get_event_loop().run_until_complete(
+            result = _run_async(
                 auth_token(
                     request=request,
                     grant_type='authorization_code',
@@ -304,10 +304,8 @@ class TestAuthCodeBinding:
         )
         request = MagicMock()
         with patch('routers.auth.get_auth_code', return_value=code_data), patch('routers.auth.delete_auth_code'):
-            import asyncio
-
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
+                _run_async(
                     auth_token(
                         request=request,
                         grant_type='authorization_code',
@@ -375,7 +373,6 @@ class TestCallbackEndpoints:
     def test_google_callback_binds_redirect_uri_to_auth_code(self):
         """Google callback wraps credentials with redirect_uri and stores with TTL 300."""
         from routers.auth import auth_callback_google
-        import asyncio
 
         session_data = {
             'provider': 'google',
@@ -394,9 +391,7 @@ class TestCallbackEndpoints:
             return_value=fake_creds,
         ), patch('routers.auth.set_auth_code') as mock_set_code, patch('routers.auth.templates') as mock_templates:
             mock_templates.TemplateResponse.return_value = MagicMock()
-            asyncio.get_event_loop().run_until_complete(
-                auth_callback_google(request=request, code='oauth-code', state='session-id')
-            )
+            _run_async(auth_callback_google(request=request, code='oauth-code', state='session-id'))
             mock_set_code.assert_called_once()
             stored_json = mock_set_code.call_args[0][1]
             ttl = mock_set_code.call_args[0][2]
@@ -408,7 +403,6 @@ class TestCallbackEndpoints:
     def test_callback_defaults_redirect_uri_when_missing_from_session(self):
         """When session has no redirect_uri, callback falls back to default."""
         from routers.auth import auth_callback_google
-        import asyncio
 
         session_data = {
             'provider': 'google',
@@ -426,7 +420,7 @@ class TestCallbackEndpoints:
             return_value=fake_creds,
         ), patch('routers.auth.set_auth_code') as mock_set_code, patch('routers.auth.templates') as mock_templates:
             mock_templates.TemplateResponse.return_value = MagicMock()
-            asyncio.get_event_loop().run_until_complete(auth_callback_google(request=request, code='c', state='s'))
+            _run_async(auth_callback_google(request=request, code='c', state='s'))
             stored = json.loads(mock_set_code.call_args[0][1])
             assert stored['redirect_uri'] == _DEFAULT_MOBILE_REDIRECT
 
@@ -436,8 +430,6 @@ class TestTokenEdgeCases:
 
     def test_token_deletes_code_on_use(self):
         """Auth code is single-use — delete_auth_code must be called."""
-        import asyncio
-
         code_data = json.dumps(
             {'provider': 'google', 'id_token': 't', 'access_token': 'a', 'provider_id': 'google.com'}
         )
@@ -446,7 +438,7 @@ class TestTokenEdgeCases:
         with patch('routers.auth.get_auth_code', return_value=code_data), patch(
             'routers.auth.delete_auth_code'
         ) as mock_delete:
-            asyncio.get_event_loop().run_until_complete(
+            _run_async(
                 auth_token(
                     request=request,
                     grant_type='authorization_code',
@@ -459,12 +451,10 @@ class TestTokenEdgeCases:
 
     def test_token_rejects_expired_code(self):
         """Expired/missing code returns 400."""
-        import asyncio
-
         request = MagicMock()
         with patch('routers.auth.get_auth_code', return_value=None):
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
+                _run_async(
                     auth_token(
                         request=request,
                         grant_type='authorization_code',
@@ -478,8 +468,6 @@ class TestTokenEdgeCases:
 
     def test_token_handles_credentials_as_dict(self):
         """When credentials is already a dict (not JSON string), parsing succeeds."""
-        import asyncio
-
         code_data = json.dumps(
             {
                 'credentials': {
@@ -494,7 +482,7 @@ class TestTokenEdgeCases:
         request = MagicMock()
 
         with patch('routers.auth.get_auth_code', return_value=code_data), patch('routers.auth.delete_auth_code'):
-            result = asyncio.get_event_loop().run_until_complete(
+            result = _run_async(
                 auth_token(
                     request=request,
                     grant_type='authorization_code',
@@ -508,11 +496,9 @@ class TestTokenEdgeCases:
 
     def test_token_rejects_unsupported_grant_type(self):
         """Non-authorization_code grant type returns 400."""
-        import asyncio
-
         request = MagicMock()
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.get_event_loop().run_until_complete(
+            _run_async(
                 auth_token(
                     request=request,
                     grant_type='client_credentials',

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -135,6 +135,13 @@ _endpoints_mod.get_current_user_uid_no_byok_validation = lambda: "test-user"
 
 # Ensure utils.other has endpoints attr for `from utils.other import endpoints`
 sys.modules["utils.other"].endpoints = _endpoints_mod
+sys.modules.pop("utils.subscription", None)
+_utils_pkg = sys.modules.get("utils")
+if _utils_pkg is not None and hasattr(_utils_pkg, "subscription"):
+    delattr(_utils_pkg, "subscription")
+for _name in list(sys.modules):
+    if _name == "google" or _name.startswith("google."):
+        sys.modules.pop(_name, None)
 
 # Stripe — use real module but we'll mock Price.retrieve per-test
 import stripe

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -2115,7 +2115,7 @@ class TestBulkheadExecutors:
         assert 'max_workers=24' in source
         from utils.executors import storage_executor
 
-        assert storage_executor._max_workers == 96, "storage_executor must have 96 workers (#7376)"
+        assert storage_executor._max_workers == 128, "storage_executor must have 128 workers"
 
     def test_all_executors_in_shutdown(self):
         source = self._read_executors_source()


### PR DESCRIPTION
## Summary
- Make backend unit tests more robust in lightweight Windows environments by tightening test stubs and avoiding cross-test `sys.modules` pollution.
- Add UTF-8 source reads for tests that inspect Python files, avoiding Windows default-codepage decode failures.
- Let auth callback template rendering tests skip when optional `jinja2` is not installed, while still running when the dependency is present.
- Run auth async helper calls with fresh event loops so they do not depend on prior pytest async collection order.
- Align `storage_executor` test/docs expectations with the current production configuration of 128 workers.

## Why
While running backend unit tests from a minimal Windows venv, several tests failed during collection or import before reaching their actual assertions. Most failures came from test-local stubs leaking into later tests, Windows lacking system IANA timezone data, Windows defaulting `open()` to a non-UTF-8 code page, optional template dependencies not being installed, or tests assuming a current event loop after earlier async tests had run.

## Testing
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_action_item_dedup.py backend\tests\unit\test_apps_review_reply_validation.py backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_geocoding.py backend\tests\unit\test_async_http_infrastructure.py backend\tests\unit\test_async_webhooks.py backend\tests\unit\test_auth_redirect_uri.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_sync_v2.py::TestBulkheadExecutors::test_executor_worker_counts -q --tb=short` -> 171 passed, 3 skipped, 2 warnings
- `python -m py_compile backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_apps_review_reply_validation.py backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_geocoding.py backend\tests\unit\test_async_http_infrastructure.py backend\tests\unit\test_async_webhooks.py backend\tests\unit\test_auth_redirect_uri.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_sync_v2.py`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_apps_review_reply_validation.py backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_geocoding.py backend\tests\unit\test_async_http_infrastructure.py backend\tests\unit\test_async_webhooks.py backend\tests\unit\test_auth_redirect_uri.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_sync_v2.py --check`
- `git diff --check origin/main...HEAD`

Note: this branch was refreshed onto latest `main`; the repository commit hook also ran backend black formatting during commit creation and passed.