### PR TITLE
Stabilize more backend unit tests in lightweight Windows env

### DIFF
--- a/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
+++ b/backend/tests/unit/test_action_item_reminder_cancel_on_complete.py
@@ -53,11 +53,25 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
+def _install_stub_module(name):
+    module = _AutoMock(name)
+    sys.modules[name] = module
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        setattr(parent, attr, module)
+    return module
+
+
 def _load_real_notifications():
     sys.path.insert(0, str(BACKEND_DIR))
     finder = _Finder()
     sys.meta_path.insert(0, finder)
     try:
+        firebase_admin = _install_stub_module("firebase_admin")
+        firebase_admin.messaging = _install_stub_module("firebase_admin.messaging")
+        firebase_admin.auth = _install_stub_module("firebase_admin.auth")
+
         import utils.notifications as notif
 
         return notif

--- a/backend/tests/unit/test_batch_upload_storage.py
+++ b/backend/tests/unit/test_batch_upload_storage.py
@@ -17,6 +17,9 @@ os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 
 # Mock heavy dependencies at sys.modules level before importing storage
 sys.modules.setdefault("database._client", MagicMock())
+sys.modules.setdefault("database.redis_db", MagicMock())
+sys.modules.setdefault("database.users", MagicMock())
+sys.modules.setdefault("opuslib", MagicMock())
 
 _mock_gcs_storage = MagicMock()
 _mock_gcs_client_instance = MagicMock()
@@ -586,6 +589,8 @@ class TestCopyAudioChunksForMergeBatchAware:
             'database.tasks',
             'database.plugins',
             'database.notifications',
+            'database.vector_db',
+            'pinecone',
         ]:
             sys.modules.setdefault(mod_name, MagicMock())
 


### PR DESCRIPTION
## Summary
- Make `test_action_item_reminder_cancel_on_complete.py` install explicit `firebase_admin.messaging/auth` stubs before importing the real `utils.notifications` helper.
- Stub storage-test-only heavy imports (`opuslib`, DB modules, `pinecone`/`database.vector_db`) so `test_batch_upload_storage.py` can run without native Opus or Pinecone SDK setup.

## Why
In a minimal Windows backend venv, these tests failed during collection/import before reaching their own assertions:
- `utils.notifications` import failed because `from firebase_admin import messaging, auth` could not resolve submodules from the test meta-path stub.
- `utils.other.storage` import failed when `opuslib` could not find the native Opus library, even though the batch upload tests do not exercise Opus encode/decode paths.
- The merge-copy tests in the same storage file imported `database.vector_db`, which required `pinecone` although those tests only patch and exercise copy path naming.

## Testing
- `python -m pytest tests\unit\test_action_item_reminder_cancel_on_complete.py -q` -> 7 passed
- `python -m pytest tests\unit\test_batch_upload_storage.py -q` -> 27 passed, 1 warning
- `python -m pytest tests\unit\test_action_item_reminder_cancel_on_complete.py tests\unit\test_batch_upload_storage.py -q` -> 34 passed, 1 warning
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_action_item_reminder_cancel_on_complete.py tests\unit\test_batch_upload_storage.py --check`
- `python -m py_compile tests\unit\test_action_item_reminder_cancel_on_complete.py tests\unit\test_batch_upload_storage.py`
- `git diff --check -- backend/tests/unit/test_action_item_reminder_cancel_on_complete.py backend/tests/unit/test_batch_upload_storage.py`

Note: after excluding files already covered by open Windows test-stability PRs, collection now progresses through these files and reaches a later independent `test_daily_summary_race_condition.py` sys.modules issue; this PR intentionally stays scoped to the two fixed files.