### PR TITLE
Stabilize delete-account tests stubs on Windows

### DIFF
--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -48,6 +48,7 @@ _STUB_PREFIXES = (
     'pusher',
     'modal',
     'ulid',
+    'pytz',
     'twilio',
 )
 
@@ -56,6 +57,16 @@ def _should_stub(name: str) -> bool:
     if name == 'utils.other.endpoints':  # provided as a real shim below
         return False
     return any(name == p or name.startswith(p + '.') for p in _STUB_PREFIXES)
+
+
+def _remove_module_tree(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + '.'):
+            sys.modules.pop(name, None)
+
+
+for _prefix in _STUB_PREFIXES:
+    _remove_module_tree(_prefix)
 
 
 class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -47,6 +47,7 @@ _STUB_PREFIXES = (
     'pusher',
     'modal',
     'ulid',
+    'pytz',
     'twilio',
 )
 
@@ -55,6 +56,16 @@ def _should_stub(name: str) -> bool:
     if name == 'utils.other.endpoints':  # provided as a real shim below
         return False
     return any(name == p or name.startswith(p + '.') for p in _STUB_PREFIXES)
+
+
+def _remove_module_tree(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + '.'):
+            sys.modules.pop(name, None)
+
+
+for _prefix in _STUB_PREFIXES:
+    _remove_module_tree(_prefix)
 
 
 class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):


### PR DESCRIPTION
## Summary
- Include `pytz` in the auto-stubbed import prefixes for both delete-account tests that import `routers.users`.
- Clear any existing modules under the stubbed prefixes before installing each test meta-path finder, so stale `sys.modules` entries from earlier tests cannot bypass the local `_StubFinder`.

## Why
`test_delete_account_purge_storage.py` and `test_delete_account_stripe_cancel.py` both import `routers.users`, which has a broad import graph. In a lightweight Windows test environment, collection failed first on missing `pytz`. In broader collect-only runs, earlier tests can also leave stale `database.*` or `utils.*` entries in `sys.modules`; because importlib returns existing modules before consulting these tests' finders, stale modules can break the router import before the deletion assertions run.

This keeps both delete-account import sandboxes deterministic and scoped to the namespaces they already declare as stubbed.

## Testing
- `python -m pytest tests\unit\test_delete_account_purge_storage.py -q` -> 5 passed
- `python -m pytest tests\unit\test_delete_account_stripe_cancel.py -q` -> 3 passed
- `python -m pytest tests\unit\test_delete_account_purge_storage.py tests\unit\test_delete_account_stripe_cancel.py -q` -> 8 passed
- `python -m pytest tests\unit\test_byok_security.py tests\unit\test_delete_account_purge_storage.py tests\unit\test_delete_account_stripe_cancel.py --collect-only -q -x` -> 89 tests collected
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_delete_account_purge_storage.py tests\unit\test_delete_account_stripe_cancel.py --check`
- `python -m py_compile tests\unit\test_delete_account_purge_storage.py tests\unit\test_delete_account_stripe_cancel.py`
- `git diff --check origin/main...HEAD`