### PR TITLE
Stabilize desktop migration tests on Windows

### DIFF
--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -45,9 +45,35 @@ def _stub_package(name):
     return mod
 
 
+def _remove_module_tree(prefix):
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + "."):
+            sys.modules.pop(name, None)
+
+
+def _ensure_package_path(name, path):
+    mod = sys.modules.get(name)
+    if not isinstance(mod, types.ModuleType):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod.__path__ = [str(path)]
+    return mod
+
+
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies before any production imports
 # ---------------------------------------------------------------------------
+for module_prefix in [
+    "database",
+    "models",
+    "utils",
+    "routers.chat_sessions",
+    "routers.focus_sessions",
+    "routers.advice",
+    "routers.staged_tasks",
+]:
+    _remove_module_tree(module_prefix)
+
 for mod_name in [
     "firebase_admin",
     "firebase_admin.firestore",
@@ -90,13 +116,7 @@ redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
 sys.path.insert(0, str(BACKEND_DIR))
 
 # Stub database package and _client
-if "database" not in sys.modules:
-    db_pkg = _stub_package("database")
-    db_pkg.__path__ = [str(BACKEND_DIR / "database")]
-else:
-    db_mod = sys.modules["database"]
-    if not hasattr(db_mod, '__path__'):
-        db_mod.__path__ = [str(BACKEND_DIR / "database")]
+_ensure_package_path("database", BACKEND_DIR / "database")
 
 client_stub = _stub_module("database._client")
 mock_db = MagicMock()
@@ -150,6 +170,10 @@ from routers.chat_sessions import SaveMessageRequest, RateMessageRequest  # noqa
 from routers.focus_sessions import CreateFocusSessionRequest  # noqa: E402
 from routers.advice import CreateAdviceRequest  # noqa: E402
 from routers.staged_tasks import BatchUpdateScoresRequest, BatchScoreEntry  # noqa: E402
+
+_ensure_package_path("models", BACKEND_DIR / "models")
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.other", BACKEND_DIR / "utils" / "other")
 
 # Cannot import routers.users directly — it pulls in database.conversations → utils.other.hume
 # which has heavy deps. Mirror the models here and verify parity via AST test below.

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -83,6 +83,9 @@ field_filter_stub.FieldFilter = MagicMock()
 sys.modules["google.cloud.firestore_v1"].FieldFilter = field_filter_stub.FieldFilter
 sys.modules["google.cloud.firestore_v1"].transactional = lambda f: f
 
+redis_stub = sys.modules["database.redis_db"]
+redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
+
 # Add backend dir to sys.path
 sys.path.insert(0, str(BACKEND_DIR))
 
@@ -1358,7 +1361,7 @@ class TestModelParity:
         """Inline UpdateNotificationSettingsRequest matches routers/users.py definition."""
         import ast
 
-        source = (BACKEND_DIR / 'routers' / 'users.py').read_text()
+        source = (BACKEND_DIR / 'routers' / 'users.py').read_text(encoding='utf-8')
         tree = ast.parse(source)
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef) and node.name == 'UpdateNotificationSettingsRequest':
@@ -1377,7 +1380,7 @@ class TestModelParity:
         """Inline RecordLlmUsageBucketRequest matches routers/users.py definition."""
         import ast
 
-        source = (BACKEND_DIR / 'routers' / 'users.py').read_text()
+        source = (BACKEND_DIR / 'routers' / 'users.py').read_text(encoding='utf-8')
         tree = ast.parse(source)
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef) and node.name == 'RecordLlmUsageBucketRequest':
@@ -1694,10 +1697,14 @@ class TestGenerateTitleEndpoint:
             session_id='s1',
             messages=[TitleMessageInput(text='hi', sender='human'), TitleMessageInput(text='hello', sender='ai')],
         )
-        with patch.dict('sys.modules', {'utils.llm.clients': MagicMock(llm_mini=mock_llm)}):
+        mock_get_llm = MagicMock(return_value=mock_llm)
+        llm_clients_stub = types.ModuleType('utils.llm.clients')
+        llm_clients_stub.get_llm = mock_get_llm
+        with patch.dict('sys.modules', {'utils.llm.clients': llm_clients_stub}):
             result = generate_session_title(request, uid='u1')
 
         assert result == {'title': 'Project Discussion'}
+        mock_get_llm.assert_called_once_with('session_titles')
         mock_update.assert_called_once_with('u1', 's1', title='Project Discussion')
 
     @patch('database.chat.update_chat_session')
@@ -1713,10 +1720,14 @@ class TestGenerateTitleEndpoint:
             session_id='s1',
             messages=[TitleMessageInput(text='hi', sender='human')],
         )
-        with patch.dict('sys.modules', {'utils.llm.clients': MagicMock(llm_mini=mock_llm)}):
+        mock_get_llm = MagicMock(return_value=mock_llm)
+        llm_clients_stub = types.ModuleType('utils.llm.clients')
+        llm_clients_stub.get_llm = mock_get_llm
+        with patch.dict('sys.modules', {'utils.llm.clients': llm_clients_stub}):
             result = generate_session_title(request, uid='u1')
 
         assert result == {'title': 'New Chat'}
+        mock_get_llm.assert_called_once_with('session_titles')
 
 
 class TestChatMessageCount:


### PR DESCRIPTION
## Summary
- Stub `try_acquire_user_platform_write_lock` on the test `database.redis_db` module before importing `database.users`.
- Read `routers/users.py` with UTF-8 in AST parity checks so Windows default code pages do not fail on source comments/strings.
- Patch `utils.llm.clients.get_llm` with a module-shaped stub in title generation tests, matching the current `routers.chat_sessions.generate_session_title` import path.
- Assert `get_llm` is called with the expected `session_titles` model key.
- Reset stale `database`/`models`/`utils` and imported router modules before the test's import sandbox is built, then restore parent package paths so later test modules can import real package children.

## Why
`test_desktop_migration.py` imports several production modules under a lightweight test stub environment. On a minimal Windows backend venv, collection failed when `database.users` imported a recently-added Redis lock helper that the test stub did not expose. After collection was fixed, the file still failed on Windows because `Path.read_text()` used the locale codec and because two title tests patched an old `llm_mini` shape while production imports `get_llm()`.

In broader Windows collect-only runs, earlier tests can also leave stale `database.*`/`utils.*` modules in `sys.modules`, causing this test to reuse old stubs instead of its own import sandbox. After this test imports its target modules, the parent `models`, `utils`, and `utils.other` package paths are restored so later tests are not trapped behind this file's empty stub packages.

## Testing
- `python -m pytest tests\unit\test_desktop_migration.py -q` -> 91 passed
- `python -m pytest tests\unit --collect-only -q -x --ignore=tests\unit\test_lock_bypass_fixes.py --ignore=tests\unit\test_action_item_date_validation.py --ignore=tests\unit\test_apps_review_reply_validation.py --ignore=tests\unit\test_async_app_integrations.py --ignore=tests\unit\test_async_geocoding.py --ignore=tests\unit\test_async_http_infrastructure.py --ignore=tests\unit\test_async_webhooks.py --ignore=tests\unit\test_auth_redirect_uri.py --ignore=tests\unit\test_available_plans_resilience.py --ignore=tests\unit\test_sync_v2.py --ignore=tests\unit\test_action_item_reminder_cancel_on_complete.py --ignore=tests\unit\test_batch_upload_storage.py --ignore=tests\unit\test_daily_summary_race_condition.py --ignore=tests\unit\test_delete_account_purge_storage.py --ignore=tests\unit\test_delete_account_stripe_cancel.py` -> progressed through `test_desktop_migration.py` and stopped at independent `test_desktop_transcribe.py` missing `deepgram`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_desktop_migration.py --check`
- `python -m py_compile tests\unit\test_desktop_migration.py`
- `git diff --check -- backend/tests/unit/test_desktop_migration.py`