### PR TITLE
Add Windows backend test preflight script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -131,7 +131,7 @@ macOS/Linux:
 bash test-preflight.sh
 ```
 
-Windows PowerShell:
+Windows PowerShell (works with the default Restricted execution policy):
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\test-preflight.ps1
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,7 +124,7 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
 
 ## Running Backend Test Preflight
 
-Before running the full backend test suite, use the preflight script for your shell. It checks the Python test runner, key packages, optional service environment variables, Redis reachability, and `test.sh` file references.
+Before running the full backend test suite, use the preflight script for your shell. It checks the Python test runner and version, key packages, optional service environment variables, Redis reachability, backend unit-test discovery, and OpenAPI export startup.
 
 macOS/Linux:
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -133,7 +133,7 @@ bash test-preflight.sh
 
 Windows PowerShell:
 ```powershell
-.\test-preflight.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\test-preflight.ps1
 ```
 
 The preflight script does not replace `test.sh`; it only catches setup issues before running the tests.

--- a/backend/README.md
+++ b/backend/README.md
@@ -122,6 +122,22 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
     deactivate
     ```
 
+## Running Backend Test Preflight
+
+Before running the full backend test suite, use the preflight script for your shell. It checks the Python test runner, key packages, optional service environment variables, Redis reachability, and `test.sh` file references.
+
+macOS/Linux:
+```bash
+bash test-preflight.sh
+```
+
+Windows PowerShell:
+```powershell
+.\test-preflight.ps1
+```
+
+The preflight script does not replace `test.sh`; it only catches setup issues before running the tests.
+
 ## Additional Resources
 
 - [Full Backend Setup Documentation](https://docs.omi.me/developer/backend/Backend_Setup)

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -409,6 +409,11 @@ def _host_from_address(address: object) -> object:
     return None
 
 
+def _is_unix_socket(sock: socket.socket) -> bool:
+    af_unix = getattr(socket, 'AF_UNIX', None)
+    return af_unix is not None and sock.family == af_unix
+
+
 @contextmanager
 def record_and_block_outbound_network() -> Iterator[list[str]]:
     attempts: list[str] = []
@@ -423,13 +428,13 @@ def record_and_block_outbound_network() -> Iterator[list[str]]:
         attempts.append(f'{kind}: {target!r}')
 
     def guarded_connect(sock: socket.socket, address: object):
-        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+        if not _is_unix_socket(sock) and not is_local_address(_host_from_address(address)):
             record('connect', address)
             raise OpenAPIContractError(f'blocked outbound network connection to {address!r}')
         return original_connect(sock, address)
 
     def guarded_connect_ex(sock: socket.socket, address: object):
-        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+        if not _is_unix_socket(sock) and not is_local_address(_host_from_address(address)):
             record('connect_ex', address)
             raise OpenAPIContractError(f'blocked outbound network connection to {address!r}')
         return original_connect_ex(sock, address)

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -1,0 +1,196 @@
+param()
+
+$ErrorActionPreference = "Continue"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $RootDir
+
+$PassCount = 0
+$WarnCount = 0
+$FailCount = 0
+$Script:PythonLauncher = $null
+
+function Add-Pass {
+    param([string]$Message)
+    Write-Host "  OK    $Message" -ForegroundColor Green
+    $script:PassCount += 1
+}
+
+function Add-Warn {
+    param([string]$Message)
+    Write-Host "  WARN  $Message" -ForegroundColor Yellow
+    $script:WarnCount += 1
+}
+
+function Add-Fail {
+    param([string]$Message)
+    Write-Host "  FAIL  $Message" -ForegroundColor Red
+    $script:FailCount += 1
+}
+
+function Invoke-SelectedPython {
+    param([string[]]$Arguments)
+    if ($Script:PythonLauncher -eq "py") {
+        & py -3 @Arguments
+    } else {
+        & $Script:PythonLauncher @Arguments
+    }
+}
+
+Write-Host "Tools:"
+
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+if ($pythonCommand) {
+    $Script:PythonLauncher = $pythonCommand.Source
+    $pythonVersion = (& $Script:PythonLauncher --version 2>&1)
+    Add-Pass "python $pythonVersion"
+} elseif (Get-Command py -ErrorAction SilentlyContinue) {
+    $Script:PythonLauncher = "py"
+    $pythonVersion = (& py -3 --version 2>&1)
+    Add-Pass "python $pythonVersion"
+} else {
+    Add-Fail "python not found"
+}
+
+if ($Script:PythonLauncher) {
+    $pytestOutput = Invoke-SelectedPython @("-m", "pytest", "--version") 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Add-Pass $pytestOutput
+    } else {
+        Add-Fail "pytest not installed (pip install pytest)"
+    }
+} else {
+    Add-Fail "pytest not checked because python is missing"
+}
+
+if (Get-Command black -ErrorAction SilentlyContinue) {
+    Add-Pass "black (formatter)"
+} else {
+    Add-Warn "black not installed - pre-commit hook will fail (pip install black)"
+}
+
+Write-Host ""
+Write-Host "Python packages:"
+
+$missingPackages = @()
+foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firestore", "redis", "deepgram_sdk", "openpipe")) {
+    if (-not $Script:PythonLauncher) {
+        $missingPackages += $pkg
+        Add-Warn "$pkg not checked because python is missing"
+        continue
+    }
+
+    Invoke-SelectedPython @("-c", "import $pkg") *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Add-Pass $pkg
+    } else {
+        $missingPackages += $pkg
+        Add-Warn "$pkg not importable"
+    }
+}
+
+if ($missingPackages.Count -gt 0) {
+    Write-Host "  -> Run: pip install -r requirements.txt" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Env vars (unit tests):"
+
+if ($env:ENCRYPTION_SECRET) {
+    Add-Pass "ENCRYPTION_SECRET (set in env)"
+} else {
+    Add-Pass "ENCRYPTION_SECRET (set by test.sh - no action needed)"
+}
+
+Write-Host ""
+Write-Host "Env vars (integration - optional):"
+
+function Test-OptionalEnv {
+    param(
+        [string]$Name,
+        [string]$Description
+    )
+    if ([Environment]::GetEnvironmentVariable($Name)) {
+        Add-Pass "$Name ($Description)"
+    } else {
+        Add-Warn "$Name not set ($Description)"
+    }
+}
+
+Test-OptionalEnv "OPENAI_API_KEY" "LLM calls - some integration tests skip without it"
+Test-OptionalEnv "DEEPGRAM_API_KEY" "STT streaming and pre-recorded transcription"
+Test-OptionalEnv "ADMIN_KEY" "admin endpoint tests"
+Test-OptionalEnv "REDIS_DB_HOST" "Redis connection (default: localhost)"
+Test-OptionalEnv "REDIS_DB_PASSWORD" "Redis auth"
+Test-OptionalEnv "GOOGLE_APPLICATION_CREDENTIALS" "Firebase/Firestore integration tests"
+
+Write-Host ""
+Write-Host "Services:"
+
+$redisCli = Get-Command redis-cli -ErrorAction SilentlyContinue
+if ($redisCli) {
+    $redisHost = if ($env:REDIS_DB_HOST) { $env:REDIS_DB_HOST } else { "localhost" }
+    $redisPort = if ($env:REDIS_DB_PORT) { $env:REDIS_DB_PORT } else { "6379" }
+    $redisArgs = @("-h", $redisHost, "-p", $redisPort)
+    if ($env:REDIS_DB_PASSWORD) {
+        $redisArgs += @("-a", $env:REDIS_DB_PASSWORD)
+    }
+    $redisArgs += "ping"
+
+    & $redisCli.Source @redisArgs *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Add-Pass "Redis ($redisHost`:$redisPort) - connected"
+    } else {
+        Add-Warn "Redis ($redisHost`:$redisPort) - not reachable (integration tests may fail)"
+    }
+} else {
+    Add-Warn "redis-cli not installed - cannot check Redis connectivity"
+}
+
+Write-Host ""
+Write-Host "Test files:"
+
+$unitTests = @(Get-ChildItem -Path "tests/unit" -Filter "test_*.py" -Recurse -ErrorAction SilentlyContinue)
+if ($unitTests.Count -gt 0) {
+    Add-Pass "$($unitTests.Count) unit test files found"
+} else {
+    Add-Fail "No unit test files found in tests/unit/"
+}
+
+$missingTests = @()
+if (Test-Path "test.sh") {
+    foreach ($line in Get-Content "test.sh") {
+        if ($line -match '^pytest\s+(tests/\S+)') {
+            $testFile = $Matches[1]
+            if (-not (Test-Path $testFile)) {
+                $missingTests += $testFile
+            }
+        }
+    }
+
+    if ($missingTests.Count -gt 0) {
+        Add-Fail "test.sh references missing files: $($missingTests -join ', ')"
+    } else {
+        Add-Pass "All test.sh references resolve to existing files"
+    }
+} else {
+    Add-Fail "test.sh not found"
+}
+
+Write-Host ""
+Write-Host "Summary:"
+$total = $PassCount + $WarnCount + $FailCount
+Write-Host "  $PassCount passed  $WarnCount warnings  $FailCount failed  ($total checks)"
+
+if ($FailCount -gt 0) {
+    Write-Host "  Fix failures above before running test.sh" -ForegroundColor Red
+    exit 1
+}
+
+if ($WarnCount -gt 0) {
+    Write-Host "  Warnings are optional - unit tests should still pass" -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Host "  All clear - ready to run test.sh" -ForegroundColor Green
+exit 0

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -3,7 +3,7 @@ param()
 $ErrorActionPreference = "Continue"
 
 $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location $RootDir
+Push-Location $RootDir
 
 $PassCount = 0
 $WarnCount = 0
@@ -36,6 +36,8 @@ function Invoke-SelectedPython {
         & $Script:PythonLauncher @Arguments
     }
 }
+
+try {
 
 Write-Host "Tools:"
 
@@ -194,3 +196,7 @@ if ($WarnCount -gt 0) {
 
 Write-Host "  All clear - ready to run test.sh" -ForegroundColor Green
 exit 0
+
+} finally {
+    Pop-Location
+}

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -147,7 +147,7 @@ Write-Host ""
 Write-Host "Python packages:"
 
 $missingPackages = @()
-foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firestore", "redis", "deepgram_sdk", "openpipe", "pytest_asyncio", "fake_firestore", "fakeredis")) {
+foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firestore", "redis", "deepgram", "openpipe", "pytest_asyncio", "fake_firestore", "fakeredis")) {
     if (-not $Script:PythonLauncher) {
         $missingPackages += $pkg
         Add-Warn "$pkg not checked because python is missing"

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -119,7 +119,7 @@ if ($Script:PythonLauncher) {
             Add-Pass "Python version matches .python-version ($ExpectedPythonVersion)"
         } else {
             Add-Fail "Python version mismatch: expected $ExpectedPythonVersion from .python-version, got $pythonVersion from $Script:PythonLauncherName"
-            Write-Host "  -> Run: .\scripts\sync-python-deps.ps1, then `$env:PYTHON = '.\.venv\Scripts\python.exe'; powershell -NoProfile -ExecutionPolicy Bypass -File .\test-preflight.ps1" -ForegroundColor Yellow
+            Write-Host "  -> Run: bash ./scripts/sync-python-deps.sh, then `$env:PYTHON = '.\.venv\Scripts\python.exe'; powershell -NoProfile -ExecutionPolicy Bypass -File .\test-preflight.ps1" -ForegroundColor Yellow
         }
     }
 } else {

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -9,6 +9,7 @@ $PassCount = 0
 $WarnCount = 0
 $FailCount = 0
 $Script:PythonLauncher = $null
+$Script:PythonLauncherArgs = @()
 
 function Add-Pass {
     param([string]$Message)
@@ -30,10 +31,33 @@ function Add-Fail {
 
 function Invoke-SelectedPython {
     param([string[]]$Arguments)
-    if ($Script:PythonLauncher -eq "py") {
-        & py -3 @Arguments
-    } else {
-        & $Script:PythonLauncher @Arguments
+    $allArgs = @()
+    $allArgs += $Script:PythonLauncherArgs
+    $allArgs += $Arguments
+    & $Script:PythonLauncher @allArgs
+}
+
+function Invoke-PythonCandidate {
+    param(
+        [pscustomobject]$Candidate,
+        [string[]]$Arguments
+    )
+    $allArgs = @()
+    $allArgs += $Candidate.Args
+    $allArgs += $Arguments
+    & $Candidate.Command @allArgs
+}
+
+function Test-PythonCandidate {
+    param(
+        [pscustomobject]$Candidate,
+        [string[]]$Arguments
+    )
+    try {
+        Invoke-PythonCandidate $Candidate $Arguments *> $null
+        return $LASTEXITCODE -eq 0
+    } catch {
+        return $false
     }
 }
 
@@ -41,14 +65,46 @@ try {
 
 Write-Host "Tools:"
 
-$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-if ($pythonCommand) {
-    $Script:PythonLauncher = $pythonCommand.Source
-    $pythonVersion = (& $Script:PythonLauncher --version 2>&1)
-    Add-Pass "python $pythonVersion"
-} elseif (Get-Command py -ErrorAction SilentlyContinue) {
-    $Script:PythonLauncher = "py"
-    $pythonVersion = (& py -3 --version 2>&1)
+$pythonCandidates = @()
+if ($env:PYTHON) {
+    $pythonEnvCommand = Get-Command $env:PYTHON -ErrorAction SilentlyContinue
+    if ($pythonEnvCommand) {
+        $pythonCandidates += [pscustomobject]@{ Name = $env:PYTHON; Command = $pythonEnvCommand.Source; Args = @() }
+    }
+}
+foreach ($commandName in @("python3", "python")) {
+    $command = Get-Command $commandName -ErrorAction SilentlyContinue
+    if ($command) {
+        $pythonCandidates += [pscustomobject]@{ Name = $commandName; Command = $command.Source; Args = @() }
+    }
+}
+$pyCommand = Get-Command py -ErrorAction SilentlyContinue
+if ($pyCommand) {
+    $pythonCandidates += [pscustomobject]@{ Name = "py -3"; Command = $pyCommand.Source; Args = @("-3") }
+}
+
+$firstRunnablePython = $null
+foreach ($candidate in $pythonCandidates) {
+    if (-not (Test-PythonCandidate $candidate @("-c", "import sys"))) {
+        continue
+    }
+    if (-not $firstRunnablePython) {
+        $firstRunnablePython = $candidate
+    }
+    if (Test-PythonCandidate $candidate @("-m", "pytest", "--version")) {
+        $Script:PythonLauncher = $candidate.Command
+        $Script:PythonLauncherArgs = $candidate.Args
+        break
+    }
+}
+
+if (-not $Script:PythonLauncher -and $firstRunnablePython) {
+    $Script:PythonLauncher = $firstRunnablePython.Command
+    $Script:PythonLauncherArgs = $firstRunnablePython.Args
+}
+
+if ($Script:PythonLauncher) {
+    $pythonVersion = Invoke-SelectedPython @("--version") 2>&1
     Add-Pass "python $pythonVersion"
 } else {
     Add-Fail "python not found"
@@ -59,7 +115,7 @@ if ($Script:PythonLauncher) {
     if ($LASTEXITCODE -eq 0) {
         Add-Pass $pytestOutput
     } else {
-        Add-Fail "pytest not installed (pip install pytest)"
+        Add-Fail "pytest not installed (python -m pip install pytest)"
     }
 } else {
     Add-Fail "pytest not checked because python is missing"

--- a/backend/test-preflight.ps1
+++ b/backend/test-preflight.ps1
@@ -8,7 +8,9 @@ Push-Location $RootDir
 $PassCount = 0
 $WarnCount = 0
 $FailCount = 0
+$ExpectedPythonVersion = if (Test-Path ".python-version") { (Get-Content ".python-version" -Raw).Trim() } else { "" }
 $Script:PythonLauncher = $null
+$Script:PythonLauncherName = $null
 $Script:PythonLauncherArgs = @()
 
 function Add-Pass {
@@ -93,6 +95,7 @@ foreach ($candidate in $pythonCandidates) {
     }
     if (Test-PythonCandidate $candidate @("-m", "pytest", "--version")) {
         $Script:PythonLauncher = $candidate.Command
+        $Script:PythonLauncherName = $candidate.Name
         $Script:PythonLauncherArgs = $candidate.Args
         break
     }
@@ -100,12 +103,25 @@ foreach ($candidate in $pythonCandidates) {
 
 if (-not $Script:PythonLauncher -and $firstRunnablePython) {
     $Script:PythonLauncher = $firstRunnablePython.Command
+    $Script:PythonLauncherName = $firstRunnablePython.Name
     $Script:PythonLauncherArgs = $firstRunnablePython.Args
 }
 
 if ($Script:PythonLauncher) {
-    $pythonVersion = Invoke-SelectedPython @("--version") 2>&1
-    Add-Pass "python $pythonVersion"
+    if (-not $Script:PythonLauncherName) {
+        $Script:PythonLauncherName = $Script:PythonLauncher
+    }
+    $pythonVersionOutput = Invoke-SelectedPython @("--version") 2>&1
+    $pythonVersion = (($pythonVersionOutput -join " ").Trim() -replace "^Python\s+", "")
+    Add-Pass "$Script:PythonLauncherName $pythonVersion"
+    if ($ExpectedPythonVersion) {
+        if ($pythonVersion -eq $ExpectedPythonVersion) {
+            Add-Pass "Python version matches .python-version ($ExpectedPythonVersion)"
+        } else {
+            Add-Fail "Python version mismatch: expected $ExpectedPythonVersion from .python-version, got $pythonVersion from $Script:PythonLauncherName"
+            Write-Host "  -> Run: .\scripts\sync-python-deps.ps1, then `$env:PYTHON = '.\.venv\Scripts\python.exe'; powershell -NoProfile -ExecutionPolicy Bypass -File .\test-preflight.ps1" -ForegroundColor Yellow
+        }
+    }
 } else {
     Add-Fail "python not found"
 }
@@ -131,7 +147,7 @@ Write-Host ""
 Write-Host "Python packages:"
 
 $missingPackages = @()
-foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firestore", "redis", "deepgram_sdk", "openpipe")) {
+foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firestore", "redis", "deepgram_sdk", "openpipe", "pytest_asyncio", "fake_firestore", "fakeredis")) {
     if (-not $Script:PythonLauncher) {
         $missingPackages += $pkg
         Add-Warn "$pkg not checked because python is missing"
@@ -148,7 +164,8 @@ foreach ($pkg in @("pydantic", "fastapi", "firebase_admin", "google.cloud.firest
 }
 
 if ($missingPackages.Count -gt 0) {
-    Write-Host "  -> Run: pip install -r requirements.txt" -ForegroundColor Yellow
+    $pythonPip = if ($Script:PythonLauncherName) { $Script:PythonLauncherName } else { "python" }
+    Write-Host "  -> Run: $pythonPip -m pip install -r requirements.txt" -ForegroundColor Yellow
 }
 
 Write-Host ""
@@ -215,24 +232,28 @@ if ($unitTests.Count -gt 0) {
     Add-Fail "No unit test files found in tests/unit/"
 }
 
-$missingTests = @()
-if (Test-Path "test.sh") {
-    foreach ($line in Get-Content "test.sh") {
-        if ($line -match '^pytest\s+(tests/\S+)') {
-            $testFile = $Matches[1]
-            if (-not (Test-Path $testFile)) {
-                $missingTests += $testFile
-            }
-        }
-    }
-
-    if ($missingTests.Count -gt 0) {
-        Add-Fail "test.sh references missing files: $($missingTests -join ', ')"
+$selectedTestsPath = Join-Path ([System.IO.Path]::GetTempPath()) "backend-unit-tests-preflight.txt"
+if ($Script:PythonLauncher) {
+    Invoke-SelectedPython @("scripts/select_backend_unit_tests.py", "--all") > $selectedTestsPath
+    if ($LASTEXITCODE -eq 0) {
+        $selectedTestCount = @(Get-Content $selectedTestsPath -ErrorAction SilentlyContinue).Count
+        Add-Pass "$selectedTestCount backend unit test files selected"
     } else {
-        Add-Pass "All test.sh references resolve to existing files"
+        Add-Fail "backend unit test selection failed"
     }
 } else {
-    Add-Fail "test.sh not found"
+    Add-Fail "backend unit test selection skipped because python is missing"
+}
+
+if ($Script:PythonLauncher) {
+    Invoke-SelectedPython @("scripts/export_openapi.py", "--help") *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Add-Pass "OpenAPI export script is runnable"
+    } else {
+        Add-Fail "OpenAPI export script failed to start"
+    }
+} else {
+    Add-Fail "OpenAPI export script check skipped because python is missing"
 }
 
 Write-Host ""

--- a/backend/tests/unit/test_openapi_contract.py
+++ b/backend/tests/unit/test_openapi_contract.py
@@ -172,6 +172,20 @@ def test_network_recorder_fails_even_when_blocked_attempt_is_swallowed():
     assert attempts == ["getaddrinfo: 'example.com'"]
 
 
+def test_network_recorder_handles_windows_without_af_unix(monkeypatch):
+    monkeypatch.delattr(socket, 'AF_UNIX', raising=False)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    with export_openapi.record_and_block_outbound_network() as attempts:
+        try:
+            with pytest.raises(export_openapi.OpenAPIContractError, match='blocked outbound network connection'):
+                sock.connect(('example.com', 443))
+        finally:
+            sock.close()
+
+    assert attempts == ["connect: ('example.com', 443)"]
+
+
 def test_hermetic_environment_restore_pattern():
     before = dict(os.environ)
     export_openapi.configure_hermetic_environment()

--- a/backend/tests/unit/test_windows_preflight.py
+++ b/backend/tests/unit/test_windows_preflight.py
@@ -9,3 +9,10 @@ def test_windows_preflight_points_to_existing_dependency_sync_script():
     assert 'sync-python-deps.ps1' not in script
     assert 'bash ./scripts/sync-python-deps.sh' in script
     assert (BACKEND_DIR / 'scripts' / 'sync-python-deps.sh').is_file()
+
+
+def test_windows_preflight_uses_deepgram_import_name():
+    script = (BACKEND_DIR / 'test-preflight.ps1').read_text(encoding='utf-8')
+
+    assert '"deepgram"' in script
+    assert 'deepgram_sdk' not in script

--- a/backend/tests/unit/test_windows_preflight.py
+++ b/backend/tests/unit/test_windows_preflight.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def test_windows_preflight_points_to_existing_dependency_sync_script():
+    script = (BACKEND_DIR / 'test-preflight.ps1').read_text(encoding='utf-8')
+
+    assert 'sync-python-deps.ps1' not in script
+    assert 'bash ./scripts/sync-python-deps.sh' in script
+    assert (BACKEND_DIR / 'scripts' / 'sync-python-deps.sh').is_file()


### PR DESCRIPTION
## Summary
- rebases the Windows backend preflight work onto current `main` (`81b885eff2bd`)
- adds `backend/test-preflight.ps1` as the native PowerShell counterpart to the maintained backend preflight
- documents the reliable Windows invocation under the default Restricted execution policy
- keeps the OpenAPI network guard compatible with Windows Python builds without `socket.AF_UNIX`
- fixes the dependency recovery hint to reference the existing sync script
- probes the Deepgram SDK through its actual Python import name, `deepgram`, with regression coverage

## Product invariants affected
- None. This PR only changes local backend developer tooling, setup documentation, and OpenAPI contract test compatibility.

## Review follow-up
The remaining review blocker is addressed: `deepgram-sdk==4.8.1` exposes `deepgram`, not `deepgram_sdk`. The PowerShell preflight now checks `import deepgram`, and `test_windows_preflight_uses_deepgram_import_name` prevents regression.

## Validation
- PowerShell parser for `backend/test-preflight.ps1` -> `parse-ok`
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -c "import deepgram; print(deepgram.__name__)"` -> `deepgram`
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -m pytest tests\unit\test_windows_preflight.py tests\unit\test_openapi_contract.py -q --tb=short` -> 17 passed
- `D:\codex-omi-work\.venvs\omi-backend-311\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check tests\unit\test_windows_preflight.py scripts\export_openapi.py tests\unit\test_openapi_contract.py`
- `git diff --check origin/main...HEAD`
