### PR TITLE
Stub optional streaming test deps on Windows

### DIFF
--- a/backend/tests/unit/test_dg_start_guard.py
+++ b/backend/tests/unit/test_dg_start_guard.py
@@ -53,7 +53,7 @@ _speaker_embedding = ModuleType('utils.stt.speaker_embedding')
 _speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
 _speaker_embedding.async_extract_embedding_from_bytes = AsyncMock(return_value=None)
 _speaker_embedding.compare_embeddings = MagicMock(return_value=0.0)
-sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
+sys.modules.setdefault('utils.stt.speaker_embedding', _speaker_embedding)
 
 # Now import the real streaming module
 from utils.stt.streaming import connect_to_deepgram

--- a/backend/tests/unit/test_dg_start_guard.py
+++ b/backend/tests/unit/test_dg_start_guard.py
@@ -7,7 +7,7 @@ returns False, preventing dead connections from being passed to callers.
 import os
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -48,6 +48,12 @@ os.environ.setdefault('DEEPGRAM_API_KEY', 'fake-for-test')
 # NOTE: Do NOT set sys.modules['deepgram'].LiveTranscriptionEvents here.
 # MagicMock auto-generates attributes on access, and overwriting would pollute
 # shared pytest state for test_streaming_deepgram_backoff.py's close/error handler tests.
+
+_speaker_embedding = ModuleType('utils.stt.speaker_embedding')
+_speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
+_speaker_embedding.async_extract_embedding_from_bytes = AsyncMock(return_value=None)
+_speaker_embedding.compare_embeddings = MagicMock(return_value=0.0)
+sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
 
 # Now import the real streaming module
 from utils.stt.streaming import connect_to_deepgram

--- a/backend/tests/unit/test_parakeet_diarization.py
+++ b/backend/tests/unit/test_parakeet_diarization.py
@@ -7,13 +7,55 @@ disabled clips fall back safely), not the hosted embedding model itself.
 
 import asyncio
 import os
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 
 os.environ.setdefault('HOSTED_SPEAKER_EMBEDDING_API_URL', 'http://fake')  # enables _diarize
 os.environ.setdefault('DEEPGRAM_API_KEY', 'x')
 
+_owned_modules = set()
+for _mod_name in [
+    'deepgram',
+    'deepgram.clients',
+    'deepgram.clients.live',
+    'deepgram.clients.live.v1',
+    'websockets',
+    'websockets.exceptions',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+        _owned_modules.add(_mod_name)
+
+if 'deepgram' in _owned_modules:
+    sys.modules['deepgram'].DeepgramClient = MagicMock
+    sys.modules['deepgram'].DeepgramClientOptions = MagicMock
+    sys.modules['deepgram'].LiveTranscriptionEvents = MagicMock()
+if 'deepgram.clients.live.v1' in _owned_modules:
+    sys.modules['deepgram.clients.live.v1'].LiveOptions = MagicMock
+
+_speaker_embedding = ModuleType('utils.stt.speaker_embedding')
+_speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
+_speaker_embedding.async_extract_embedding_from_bytes = AsyncMock(return_value=None)
+
+
+def _cosine_distance(a, b):
+    a = np.asarray(a, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    if denom == 0:
+        return 1.0
+    return float(1.0 - np.sum(a * b) / denom)
+
+
+_speaker_embedding.compare_embeddings = _cosine_distance
+sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
+
 import utils.stt.streaming as st  # noqa: E402
+
+st.compare_embeddings = _cosine_distance
 
 
 def _dir_vec(idx: int, rng) -> np.ndarray:

--- a/backend/tests/unit/test_parakeet_diarization.py
+++ b/backend/tests/unit/test_parakeet_diarization.py
@@ -51,7 +51,7 @@ def _cosine_distance(a, b):
 
 
 _speaker_embedding.compare_embeddings = _cosine_distance
-sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
+sys.modules.setdefault('utils.stt.speaker_embedding', _speaker_embedding)
 
 import utils.stt.streaming as st  # noqa: E402
 

--- a/backend/tests/unit/test_parakeet_stream_session.py
+++ b/backend/tests/unit/test_parakeet_stream_session.py
@@ -29,6 +29,50 @@ mock_transcribe._model = None
 mock_transcribe.INFERENCE_MODE = "nemo"
 sys.modules['transcribe'] = mock_transcribe
 
+_scipy = types.ModuleType('scipy')
+_scipy_spatial = types.ModuleType('scipy.spatial')
+_scipy_distance = types.ModuleType('scipy.spatial.distance')
+
+
+def _cosine_cdist(a, b, metric="cosine"):
+    if metric != "cosine":
+        raise ValueError(f"unsupported metric: {metric}")
+    a = np.asarray(a, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    a_norm = np.linalg.norm(a, axis=1, keepdims=True)
+    b_norm = np.linalg.norm(b, axis=1, keepdims=True).T
+    denom = a_norm * b_norm
+    similarity = np.divide(a @ b.T, denom, out=np.zeros((a.shape[0], b.shape[0]), dtype=np.float32), where=denom != 0)
+    return 1.0 - similarity
+
+
+_scipy_distance.cdist = _cosine_cdist
+_scipy_spatial.distance = _scipy_distance
+_scipy.spatial = _scipy_spatial
+sys.modules.setdefault('scipy', _scipy)
+sys.modules.setdefault('scipy.spatial', _scipy_spatial)
+sys.modules.setdefault('scipy.spatial.distance', _scipy_distance)
+
+_torch = types.ModuleType('torch')
+_torch.int16 = np.int16
+
+
+class _TorchArray:
+    def __init__(self, value):
+        self.value = np.asarray(value)
+
+    def float(self):
+        return self
+
+    def __truediv__(self, value):
+        return _TorchArray(self.value / value)
+
+
+_torch.frombuffer = lambda buffer, dtype: _TorchArray(np.frombuffer(buffer, dtype=dtype))
+_torch.hub = MagicMock()
+_torch.hub.load.side_effect = RuntimeError("torch hub unavailable in unit tests")
+sys.modules.setdefault('torch', _torch)
+
 import stream_handler as sh
 
 

--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -8,6 +8,7 @@ Verifies:
 
 import asyncio
 import sys
+from types import ModuleType
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
@@ -38,6 +39,19 @@ if 'deepgram' in _mock_modules:
     sys.modules['deepgram'].DeepgramClientOptions = MagicMock
     sys.modules['deepgram'].LiveTranscriptionEvents = MagicMock()
     sys.modules['deepgram.clients.live.v1'].LiveOptions = MagicMock
+
+_speaker_embedding = ModuleType('utils.stt.speaker_embedding')
+_speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
+_speaker_embedding.async_extract_embedding_from_bytes = AsyncMock(return_value=None)
+_speaker_embedding.compare_embeddings = MagicMock(return_value=0.0)
+sys.modules.setdefault('utils.stt.speaker_embedding', _speaker_embedding)
+
+_vad = ModuleType('utils.stt.vad')
+_vad._get_ort_session = MagicMock()
+_vad.make_fresh_state = MagicMock(return_value=(None, None))
+_vad.run_vad_window = MagicMock(return_value=0.0)
+_vad.VAD_WINDOW_SAMPLES = 512
+sys.modules.setdefault('utils.stt.vad', _vad)
 
 from utils.stt.streaming import connect_to_deepgram_with_backoff, process_audio_dg  # noqa: E402
 from utils.stt.streaming import deepgram_options, deepgram_cloud_options  # noqa: E402


### PR DESCRIPTION
## Summary
- Stub `utils.stt.speaker_embedding` in the Deepgram start-guard and streaming backoff unit tests so they do not require SciPy in a minimal backend test environment.
- Stub the narrow `utils.stt.vad` surface needed by the streaming backoff death-reason tests so they can import `GatedDeepgramSocket` without installing `onnxruntime`.
- Stub optional Deepgram/websockets/speaker-embedding imports in `test_parakeet_diarization.py`, including a local cosine distance helper, so the diarization tests stay focused on speaker clustering and fallback behavior.
- Stub the narrow SciPy `cdist` and torch buffer/model-loading surfaces in `test_parakeet_stream_session.py` so Parakeet stream-session tests run in a lightweight Windows backend venv without native ML dependencies.
- Keep production streaming, speaker embedding, VAD, Parakeet, and audio-session code unchanged.

## Why
On this Windows backend venv, several streaming-related unit tests failed during collection before reaching their assertions because imports pulled in optional native/transitive dependencies:

- `scipy` through `utils.stt.speaker_embedding` and Parakeet stream-session code
- `onnxruntime` through `utils.stt.vad` when the backoff tests import `GatedDeepgramSocket`
- `websockets`/Deepgram client modules through `utils.stt.streaming` in Parakeet diarization tests
- `torch` model-loading helpers before the stream-session tests can use their manual VAD mock

These tests exercise Deepgram connection retry/start/death-reason behavior and Parakeet diarization/session control flow, not hosted speaker embedding, ONNX VAD inference, SciPy distance kernels, or torch model loading. Local test stubs keep the unit tests focused and runnable in lightweight Windows environments.

## Testing
- `python -m pytest tests\unit\test_dg_start_guard.py -q` -> 2 passed
- `python -m pytest tests\unit\test_streaming_deepgram_backoff.py -q` -> 79 passed
- `python -m pytest tests\unit\test_dg_start_guard.py tests\unit\test_streaming_deepgram_backoff.py -q` -> 81 passed
- `python -m pytest tests\unit\test_parakeet_diarization.py tests\unit\test_parakeet_stream_session.py -q` -> 19 passed
- `python -m pytest tests\unit\test_dg_start_guard.py tests\unit\test_streaming_deepgram_backoff.py tests\unit\test_parakeet_diarization.py tests\unit\test_parakeet_stream_session.py -q` -> 100 passed
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_dg_start_guard.py tests\unit\test_streaming_deepgram_backoff.py tests\unit\test_parakeet_diarization.py tests\unit\test_parakeet_stream_session.py --check`
- `python -m py_compile tests\unit\test_dg_start_guard.py tests\unit\test_streaming_deepgram_backoff.py tests\unit\test_parakeet_diarization.py tests\unit\test_parakeet_stream_session.py`
- `git diff --check -- backend/tests/unit/test_dg_start_guard.py backend/tests/unit/test_streaming_deepgram_backoff.py backend/tests/unit/test_parakeet_diarization.py backend/tests/unit/test_parakeet_stream_session.py`