### PR TITLE
fix(desktop): stage and sign libnode dylib for Homebrew-installed Node

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -58,6 +58,7 @@ scripts/
 **/python_reference/
 Desktop/Sources/Resources/ffmpeg
 Desktop/Sources/Resources/node
+Desktop/Sources/Resources/libnode.*.dylib
 
 # Local Rust helper build output
 codex-proxy/target/

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -587,8 +587,15 @@ if [ -n "$SIGN_IDENTITY" ]; then
     fi
     # Sign the bundled node binary with developer identity + Node.entitlements
     # (macOS requires executables inside app bundles to be properly signed)
-    NODE_BIN="$APP_BUNDLE/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
+    NODE_BUNDLE_DIR="$APP_BUNDLE/Contents/Resources/Omi Computer_Omi Computer.bundle"
+    NODE_BIN="$NODE_BUNDLE_DIR/node"
     if [ -f "$NODE_BIN" ]; then
+        # Sign any libnode dylib staged alongside the binary (Homebrew dynamic builds)
+        for libnode_dylib in "$NODE_BUNDLE_DIR"/libnode.*.dylib; do
+            [ -f "$libnode_dylib" ] || continue
+            substep "Signing $(basename "$libnode_dylib")"
+            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$libnode_dylib"
+        done
         substep "Signing bundled node binary"
         codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$NODE_BIN"
     fi

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -590,11 +590,12 @@ if [ -n "$SIGN_IDENTITY" ]; then
     NODE_BUNDLE_DIR="$APP_BUNDLE/Contents/Resources/Omi Computer_Omi Computer.bundle"
     NODE_BIN="$NODE_BUNDLE_DIR/node"
     if [ -f "$NODE_BIN" ]; then
-        # Sign any libnode dylib staged alongside the binary (Homebrew dynamic builds)
+        # Sign any libnode dylib staged alongside the binary (Homebrew dynamic builds).
+        # libnode contains V8 JIT code, so it needs the same entitlements as the node binary.
         for libnode_dylib in "$NODE_BUNDLE_DIR"/libnode.*.dylib; do
             [ -f "$libnode_dylib" ] || continue
             substep "Signing $(basename "$libnode_dylib")"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$libnode_dylib"
+            codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$libnode_dylib"
         done
         substep "Signing bundled node binary"
         codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$NODE_BIN"

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -591,11 +591,12 @@ if [ -n "$SIGN_IDENTITY" ]; then
     NODE_BIN="$NODE_BUNDLE_DIR/node"
     if [ -f "$NODE_BIN" ]; then
         # Sign any libnode dylib staged alongside the binary (Homebrew dynamic builds).
-        # libnode contains V8 JIT code, so it needs the same entitlements as the node binary.
+        # Dylibs don't carry entitlements at runtime (macOS reads them from the main executable only);
+        # sign with --options runtime alone, no --entitlements.
         for libnode_dylib in "$NODE_BUNDLE_DIR"/libnode.*.dylib; do
             [ -f "$libnode_dylib" ] || continue
             substep "Signing $(basename "$libnode_dylib")"
-            codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$libnode_dylib"
+            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$libnode_dylib"
         done
         substep "Signing bundled node binary"
         codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$NODE_BIN"

--- a/desktop/scripts/prepare-agent-runtime.sh
+++ b/desktop/scripts/prepare-agent-runtime.sh
@@ -125,6 +125,34 @@ stage_local_node() {
   cp -f "$node_bin" "$NODE_RESOURCE"
   chmod +x "$NODE_RESOURCE"
   xattr -cr "$NODE_RESOURCE" 2>/dev/null || true
+
+  # Homebrew node is a small stub that dlopen()s libnode.X.dylib via @loader_path.
+  # Copy the dylib alongside the binary so it resolves at both validation and runtime.
+  local libnode_name
+  libnode_name=$(otool -L "$node_bin" 2>/dev/null \
+    | awk '/@rpath\/libnode\.[0-9]+\.dylib/ {gsub(/@rpath\//, ""); gsub(/ \(.*/, ""); print; exit}')
+  if [ -n "$libnode_name" ]; then
+    local libnode_src=""
+    local node_bin_dir
+    node_bin_dir="$(dirname "$(realpath "$node_bin")")"
+    for candidate in \
+        "$node_bin_dir/../lib/$libnode_name" \
+        "$node_bin_dir/$libnode_name" \
+        "$(brew --prefix 2>/dev/null)/lib/$libnode_name"; do
+      if [ -f "$candidate" ]; then
+        libnode_src="$(realpath "$candidate")"
+        break
+      fi
+    done
+    if [ -z "$libnode_src" ]; then
+      echo "ERROR: node requires $libnode_name but it was not found near $node_bin or in Homebrew lib." >&2
+      exit 1
+    fi
+    cp -f "$libnode_src" "$(dirname "$NODE_RESOURCE")/$libnode_name"
+    xattr -cr "$(dirname "$NODE_RESOURCE")/$libnode_name" 2>/dev/null || true
+    log "Staged $libnode_name alongside node (Homebrew dynamic build)"
+  fi
+
   log "Staged local Node $("$NODE_RESOURCE" --version) from $node_bin"
 }
 

--- a/desktop/scripts/prepare-agent-runtime.sh
+++ b/desktop/scripts/prepare-agent-runtime.sh
@@ -149,6 +149,7 @@ stage_local_node() {
       exit 1
     fi
     cp -f "$libnode_src" "$(dirname "$NODE_RESOURCE")/$libnode_name"
+    chmod u+w "$(dirname "$NODE_RESOURCE")/$libnode_name"
     xattr -cr "$(dirname "$NODE_RESOURCE")/$libnode_name" 2>/dev/null || true
     log "Staged $libnode_name alongside node (Homebrew dynamic build)"
   fi

--- a/desktop/scripts/prepare-agent-runtime.sh
+++ b/desktop/scripts/prepare-agent-runtime.sh
@@ -130,7 +130,7 @@ stage_local_node() {
   # Copy the dylib alongside the binary so it resolves at both validation and runtime.
   local libnode_name
   libnode_name=$(otool -L "$node_bin" 2>/dev/null \
-    | awk '/@rpath\/libnode\.[0-9]+\.dylib/ {gsub(/@rpath\//, ""); gsub(/ \(.*/, ""); print; exit}')
+    | awk 'match($0, /libnode\.[0-9]+\.dylib/) {print substr($0, RSTART, RLENGTH); exit}')
   if [ -n "$libnode_name" ]; then
     local libnode_src=""
     local node_bin_dir


### PR DESCRIPTION
## Summary

Fixes #7802 — `run.sh` crashes during agent runtime preparation when Node is installed via Homebrew.

Homebrew's `node` binary (v22+) is a small stub (~68KB) that dynamically loads `libnode.X.dylib` at startup via `@loader_path`. The official nodejs.org prebuilt binaries are statically linked, so this was never an issue until a developer had only Homebrew-installed Node.

Three files changed across four commits:

**`desktop/scripts/prepare-agent-runtime.sh`**
- After copying the node stub in `stage_local_node`, use `otool -L` to detect a `libnode.X.dylib` dependency, locate the dylib in the Homebrew prefix, copy it alongside the binary, and `chmod u+w` it (Homebrew installs it 0444, which would cause the downstream `codesign --force` to fail with EACCES)

**`desktop/run.sh`**
- Sign any `libnode.*.dylib` found in the resource bundle before the final app bundle signature step — an unsigned dylib inside the bundle causes `codesign` to abort with "internal error in Code Signing subsystem"
- Sign the dylib with `--options runtime` only (no `--entitlements`) — macOS reads process entitlements exclusively from the main executable, not from loaded dylibs; the JIT permission comes from the `node` binary's own signature

**`desktop/.gitignore`**
- Add `Desktop/Sources/Resources/libnode.*.dylib` — the existing rule only covered the literal `node` binary; the 70MB dylib was an accidental-commit hazard

## Test plan

- [x] `cd desktop && ./run.sh --yolo` completes successfully with Homebrew Node (v22+) installed
- [x] Agent runtime validation passes: `[agent-runtime] Runtime validated: node=v26.0.0, agent dist and piMono files present`
- [x] App bundle signs without error: no "internal error in Code Signing subsystem"
- [x] `Desktop/Sources/Resources/libnode.*.dylib` does not appear in `git status` after a run
- [x] Unaffected: `--universal-node` path (statically linked, no dylib staged) continues to work as before — new block only runs when `otool -L` detects a `libnode` dependency; static nodejs.org builds have none

🤖 Generated with [Claude Code](https://claude.com/claude-code)