### PR TITLE
Fix floating bar visibility issues with queued notifications

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed the floating bar staying visible after notifications when \"Show floating bar\" is turned off"
+  ],
   "releases": [
     {
       "version": "0.11.459",

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -398,8 +398,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
 
             // If the user has the bar disabled, hide it completely after closing the
-            // AI conversation instead of leaving the compact pill visible.
-            if !FloatingControlBarManager.shared.isEnabled {
+            // AI conversation instead of leaving the compact pill visible — unless a
+            // queued notification was just flushed; hiding now would swallow it, and
+            // its dismissal re-hides the bar anyway.
+            if !FloatingControlBarManager.shared.isEnabled && self?.state.currentNotification == nil {
                 self?.orderOut(nil)
             }
         }
@@ -1451,10 +1453,15 @@ class FloatingControlBarManager {
         // notification is presented the window is already visible from the
         // temp-show, so resetting it here would skip the re-hide in
         // dismissNotificationAndAdvanceQueue and leave the bar on screen
-        // forever with "Show floating bar" off (#6972).
-        if !window.isVisible {
+        // forever with "Show floating bar" off (#6972). The bar can also be
+        // visible while disabled (e.g. a notification flushed right as an AI
+        // conversation closes), so any presentation with the bar disabled
+        // must arm the re-hide.
+        if !window.isVisible || !isEnabled {
             notificationWasTemporarilyShown = true
-            window.orderFrontRegardless()
+            if !window.isVisible {
+                window.orderFrontRegardless()
+            }
         }
 
         window.showNotification(notification)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1456,7 +1456,7 @@ class FloatingControlBarManager {
         // forever with "Show floating bar" off (#6972). The bar can also be
         // visible while disabled (e.g. a notification flushed right as an AI
         // conversation closes), so any presentation with the bar disabled
-        // must arm the re-hide.
+        // must arm the re-hide; dismissNotificationAndAdvanceQueue owns the reset.
         if !window.isVisible || !isEnabled {
             notificationWasTemporarilyShown = true
             if !window.isVisible {

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1447,11 +1447,14 @@ class FloatingControlBarManager {
     private func presentNotification(_ notification: FloatingBarNotification, in window: FloatingControlBarWindow) {
         persistNotificationMessageIfNeeded(notification)
 
+        // The flag must survive the whole notification chain: when a queued
+        // notification is presented the window is already visible from the
+        // temp-show, so resetting it here would skip the re-hide in
+        // dismissNotificationAndAdvanceQueue and leave the bar on screen
+        // forever with "Show floating bar" off (#6972).
         if !window.isVisible {
             notificationWasTemporarilyShown = true
             window.orderFrontRegardless()
-        } else {
-            notificationWasTemporarilyShown = false
         }
 
         window.showNotification(notification)


### PR DESCRIPTION
## Summary

Fixes #6972 — with "Show floating bar" turned **off**, the floating bar reappears during normal use and then stays on screen permanently.

## Root cause

When the bar is disabled, floating-bar notifications (proactive assistants, trial banner) still surface it temporarily by design: `presentNotification` sets `notificationWasTemporarilyShown = true`, and `dismissNotificationAndAdvanceQueue` re-hides the bar when the notification goes away.

That flag was clobbered mid-chain: when a **queued** notification is presented (any notification arriving during another's 6-second display window queues), the window is already visible from the temp-show, so the `else` branch reset `notificationWasTemporarilyShown = false`. When the last notification in the chain dismissed, the re-hide condition was false — and the bar stayed visible forever despite the toggle being off.

This matches the report exactly ("continue using the application for a period of time… the bar just appears forever after a moment"): proactive assistants regularly emit notification bursts (e.g. focus-lost/regained), so two notifications chaining is a routine occurrence. The sibling path `showTemporarily()` was already patched for this same symptom; the notification-queue path was missed.

## Fix

Preserve the flag for the duration of the notification chain — it now means "the bar was hidden when this chain started". It is still consumed by the re-hide or reset when the chain ends, so all other lifecycle paths are unchanged:

- Bar enabled, notification arrives → flag stays `false`, no behavior change.
- Bar disabled, single notification → temp-show, re-hide after dismiss (unchanged).
- Bar disabled, queued notifications → temp-show survives the chain, **bar now re-hides after the last dismiss** (the bug).
- User clicks a notification into a chat → conversation-close path already re-hides when `!isEnabled`.
- User re-enables the bar mid-chain → `isEnabled` is rechecked at chain end, bar correctly stays up.

**Follow-up (review feedback):** a notification queued during an active AI conversation is flushed by `closeAIConversation`'s completion while the window is still visible, so the temp-show flag was never armed and the unconditional `orderOut(nil)` hid the just-presented notification instantly. Two complementary changes: presenting a notification while the bar is disabled now always arms `notificationWasTemporarilyShown` (even if the window is visible), and the close path skips `orderOut` when a flushed notification is on screen — its dismissal re-hides the bar instead.

Also appends the user-facing entry to `unreleased` in `desktop/CHANGELOG.json`.

## Testing

- Traced every producer/consumer of `notificationWasTemporarilyShown` and the show/hide lifecycle paths (`show`, `hide`, `showTemporarily`, `openAIInput*`, snooze, conversation close) — details above.
- Authored from a Linux environment, so no local macOS build; the changes are control-flow-only edits in two methods of one class (no signature/type changes). Codemagic's clean release build covers compilation.
- Suggested manual verification on macOS: disable "Show floating bar", trigger two floating-bar notifications within ~6s of each other (or use the proactive assistant focus sounds), and confirm the bar hides again after the second notification dismisses.