### PR TITLE
fix(backend): reject pronouns/fillers as auto-detected speaker names (#5223)

### DIFF
--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -243,6 +243,18 @@ class TestDetectSpeakerFromText:
         "I am",  # No name follows
     ]
 
+    # Run-on / garbled transcripts where the regex captures a pronoun or filler
+    # word instead of a name — these created phantom contacts "It", "You", "Them" (#5223).
+    STOPWORD_CASES = [
+        "And I am It was great",
+        "I'm You know, the guy",
+        "Yeah, I'm Them and the others",
+        "My name is It",
+        "I am Sorry about that",
+        "I'm Just saying",
+        "i am Gonna do it",
+    ]
+
     @pytest.mark.parametrize("lang,text,expected_name", POSITIVE_CASES)
     def test_positive_detection(self, lang, text, expected_name):
         """Detects speaker name from self-introduction in each language."""
@@ -261,6 +273,17 @@ class TestDetectSpeakerFromText:
         """Non-introduction text returns None."""
         result = detect_speaker_from_text(text)
         assert result is None, f"False positive on: {text!r}"
+
+    @pytest.mark.parametrize("text", STOPWORD_CASES)
+    def test_pronoun_stopwords_rejected(self, text):
+        """Pronouns/fillers captured by the intro patterns are not returned as names."""
+        result = detect_speaker_from_text(text)
+        assert result is None, f"Stopword leaked as speaker name: {text!r} -> {result}"
+
+    def test_real_name_after_stopword_guard(self):
+        """Genuine introductions still detect after the stopword guard."""
+        assert detect_speaker_from_text("I am John") == "John"
+        assert detect_speaker_from_text("My name is Alice") == "Alice"
 
     def test_empty_string_returns_none(self):
         """Empty string input returns None."""

--- a/backend/utils/speaker_identification.py
+++ b/backend/utils/speaker_identification.py
@@ -229,13 +229,94 @@ patterns_to_check = []
 for lang_patterns in SPEAKER_IDENTIFICATION_PATTERNS.values():
     patterns_to_check.extend(lang_patterns)
 
+# Pronouns and filler words the introduction patterns can capture from run-on
+# transcripts (e.g. "I'm It was great", "I'm You know...") — never real names (#5223).
+SPEAKER_NAME_STOPWORDS = frozenset(
+    {
+        'it',
+        'you',
+        'they',
+        'them',
+        'he',
+        'she',
+        'we',
+        'us',
+        'me',
+        'him',
+        'her',
+        'his',
+        'hers',
+        'its',
+        'my',
+        'mine',
+        'your',
+        'yours',
+        'our',
+        'ours',
+        'their',
+        'theirs',
+        'this',
+        'that',
+        'these',
+        'those',
+        'here',
+        'there',
+        'what',
+        'who',
+        'when',
+        'where',
+        'why',
+        'how',
+        'which',
+        'the',
+        'and',
+        'but',
+        'not',
+        'yes',
+        'no',
+        'okay',
+        'ok',
+        'yeah',
+        'just',
+        'like',
+        'so',
+        'very',
+        'really',
+        'now',
+        'then',
+        'well',
+        'still',
+        'also',
+        'too',
+        'gonna',
+        'going',
+        'sure',
+        'sorry',
+        'good',
+        'fine',
+        'right',
+        'everyone',
+        'everybody',
+        'someone',
+        'somebody',
+        'nobody',
+        'anyone',
+        'anybody',
+        'something',
+        'nothing',
+        'one',
+        'all',
+        'some',
+    }
+)
+
 
 def detect_speaker_from_text(text: str) -> Optional[str]:
     for pattern in patterns_to_check:
         match = re.search(pattern, text)
         if match:
             name = match.groups()[-1]
-            if name and len(name) >= 2:
+            if name and len(name) >= 2 and name.lower() not in SPEAKER_NAME_STOPWORDS:
                 return name.capitalize()
     return None
 


### PR DESCRIPTION
## Bug

#5223 / #5250: phantom speaker contacts named **"It", "You", "Them"** keep being created and reappear after deletion.

The toggle half of those reports ("Auto Create Speakers off but still creating") was already fixed end-to-end on main by 041f6b227 (June 1). This PR fixes the **remaining half**: even with the toggle ON (the default), junk pronoun contacts are still created for everyone.

## Root cause

`detect_speaker_from_text` (backend/utils/speaker_identification.py) matches introduction patterns like `\b(I am|I'm|...)\s+([A-Z][a-zA-Z]*)\b` and returns whatever capitalized word follows. Run-on / smart-cased transcripts trigger it constantly:

- "And I am **It** was great" → contact "It"
- "I'm **You** know, the guy" → contact "You"
- "Yeah, I'm **Them** and the others" → contact "Them"

(Reproduced against the real patterns — these exact phrases yield exactly the reported phantom names.) The realtime /v4/listen path then calls `create_person` with that name; the next conversation recreates any contact the user deleted.

## Fix

Add `SPEAKER_NAME_STOPWORDS` (pronouns, demonstratives, question words, common fillers) and reject a captured name when it's a stopword, continuing to the next pattern. Real introductions are unaffected ("I am John", "I'm Will", "Soy Carlos", "Je m'appelle Sophie" all still detect — verified).

Covers both creation/assignment paths (realtime `transcribe.py` and offline `sync.py`) since both go through `detect_speaker_from_text`.

## Tests

- 7 parametrized regression cases for the phantom-name transcripts (all → `None`)
- Positive guard test that genuine introductions still detect
- File `tests/unit/test_speaker_id_pipeline.py` is already in `test.sh` (runs in CI)
- Verified locally by exercising the patterns + stopword logic directly (pytest not installed locally); black clean

🤖 automated by hourly watchdog; opened for review, not merged.

Fixes #5223
Fixes #5250

🤖 Generated with [Claude Code](https://claude.com/claude-code)