### PR TITLE
fix(backend): honor MCP isError flag — stop reporting failed MCP tool calls (Notion writes) as success (#5124)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -23,6 +23,7 @@ pytest tests/unit/test_parakeet_nim.py -v
 pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
+pytest tests/unit/test_mcp_client_tool_result.py -v
 pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/tests/unit/test_mcp_client_tool_result.py
+++ b/backend/tests/unit/test_mcp_client_tool_result.py
@@ -1,0 +1,98 @@
+"""Unit tests for utils.mcp_client._extract_tool_result.
+
+Covers the MCP isError contract (#5124/#5130): tool execution failures are
+reported in-band as result.isError=true, and must come back with an "Error"
+prefix so app_tools.py failure detection (startswith 'Error'/'MCP error')
+and the LLM both see the failure instead of treating it as success.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+for _mod in ['models.app', 'utils.log_sanitizer']:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = _AutoMockModule(_mod)
+
+from utils.mcp_client import _extract_tool_result
+
+
+def test_success_text_content():
+    resp = {"result": {"content": [{"type": "text", "text": "Page created"}]}}
+    assert _extract_tool_result(resp) == "Page created"
+
+
+def test_success_multiple_text_items():
+    resp = {
+        "result": {
+            "content": [
+                {"type": "text", "text": "line 1"},
+                {"type": "text", "text": "line 2"},
+            ]
+        }
+    }
+    assert _extract_tool_result(resp) == "line 1\nline 2"
+
+
+def test_is_error_with_text_gets_error_prefix():
+    resp = {
+        "result": {
+            "isError": True,
+            "content": [{"type": "text", "text": "insufficient permissions to create page"}],
+        }
+    }
+    result = _extract_tool_result(resp)
+    assert result.startswith("Error")
+    assert "insufficient permissions to create page" in result
+
+
+def test_is_error_without_content_gets_error_prefix():
+    resp = {"result": {"isError": True, "content": []}}
+    result = _extract_tool_result(resp)
+    assert result.startswith("Error")
+
+
+def test_is_error_false_is_treated_as_success():
+    resp = {"result": {"isError": False, "content": [{"type": "text", "text": "ok"}]}}
+    assert _extract_tool_result(resp) == "ok"
+
+
+def test_jsonrpc_error_still_reported():
+    resp = {"error": {"code": -32602, "message": "Invalid params"}}
+    assert _extract_tool_result(resp) == "MCP error: Invalid params"
+
+
+def test_empty_response():
+    assert _extract_tool_result({}) == "No result returned from MCP tool."
+
+
+def test_result_without_content_falls_back_to_str():
+    resp = {"result": {"structuredContent": {"ok": True}}}
+    assert _extract_tool_result(resp) == str({"structuredContent": {"ok": True}})
+
+
+@pytest.mark.parametrize(
+    "failure_resp",
+    [
+        {"result": {"isError": True, "content": [{"type": "text", "text": "API rate limited"}]}},
+        {"result": {"isError": True, "content": []}},
+        {"error": {"message": "boom"}},
+    ],
+)
+def test_failures_match_app_tools_prefix_contract(failure_resp):
+    # utils/retrieval/tools/app_tools.py records failures via
+    # result.startswith('Error') or result.startswith('MCP error').
+    result = _extract_tool_result(failure_resp)
+    assert result.startswith("Error") or result.startswith("MCP error")

--- a/backend/utils/mcp_client.py
+++ b/backend/utils/mcp_client.py
@@ -689,17 +689,28 @@ async def _call_mcp_tool_sse(
 
 
 def _extract_tool_result(resp: dict) -> str:
-    """Extract text result from a JSON-RPC tool call response."""
-    result = resp.get("result", {})
+    """Extract text result from a JSON-RPC tool call response.
 
-    content = result.get("content", [])
+    Tool execution failures are reported in-band as result.isError=true (MCP
+    spec), not as JSON-RPC errors. Those must be returned with an "Error"
+    prefix: callers (utils/retrieval/tools/app_tools.py) detect failures by
+    prefix to drive circuit-breaker/webhook-health tracking, and the LLM needs
+    an explicit failure marker to avoid claiming the action succeeded.
+    """
+    result = resp.get("result", {})
+    is_error = isinstance(result, dict) and result.get("isError") is True
+
+    content = result.get("content", []) if isinstance(result, dict) else []
     texts = []
     for item in content:
         if isinstance(item, dict) and item.get("type") == "text":
             texts.append(item.get("text", ""))
     if texts:
-        return "\n".join(texts)
+        text = "\n".join(texts)
+        return f"Error: MCP tool failed: {text}" if is_error else text
 
+    if is_error:
+        return "Error: MCP tool failed with no error details."
     if result:
         return str(result)
     if resp.get("error"):


### PR DESCRIPTION
## Bug
#5124 / #5130: Notion integration writes silently fail — AI Chat claims the page/database entry was created, but nothing appears in Notion. Two independent user reports.

## Root cause
Per the MCP spec (protocol `2025-03-26`, which this client pins), **tool execution failures are returned in-band as `result.isError: true`**, not as JSON-RPC errors. `_extract_tool_result()` in `backend/utils/mcp_client.py` ignored `isError` entirely and returned just the content text (or `str(result)`).

Consequences for a failed Notion `create_page`/`update_page`:
1. The LLM receives the error body as if it were a normal tool result, with no failure marker → it answers "Done!" (hallucinated success).
2. `utils/retrieval/tools/app_tools.py:191` detects MCP failures via `result.startswith('Error') or result.startswith('MCP error')` — an `isError` result matches neither, so the circuit breaker records a **success** and webhook-health failure tracking / auto-disable never fires.

## Fix
`_extract_tool_result()` now checks `result.isError`:
- error + text content → `Error: MCP tool failed: <text>`
- error + no content → `Error: MCP tool failed with no error details.`
- non-error paths unchanged.

This both tells the model honestly that the action failed (the issue's explicitly requested behavior) and makes the existing prefix-based failure tracking in `app_tools.py` work for MCP servers that follow the spec.

## Tests
New `backend/tests/unit/test_mcp_client_tool_result.py` (registered in `test.sh`): success paths unchanged, isError paths get the Error prefix, JSON-RPC error path unchanged, plus an explicit test that all failure shapes satisfy the `app_tools.py` prefix contract. Logic additionally verified locally against the real function with stubbed imports (all 6 cases pass).

Closes #5124. Closes #5130.

🤖 automated by hourly watchdog; opened for review, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)