### PR TITLE
fix(backend): stop billing listening minutes while no audio is received (#4700)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -62,7 +62,7 @@ from models.message_event import (
 )
 from models.transcript_segment import Translation
 from models.users import PlanType
-from utils.analytics import record_usage
+from utils.analytics import billable_transcription_seconds, record_usage
 from utils.app_integrations import trigger_realtime_integrations
 from utils.apps import is_audio_bytes_app_enabled
 from utils.conversations.process_conversation import retrieve_in_progress_conversation
@@ -544,7 +544,11 @@ async def _stream_handler(
 
             if last_usage_record_timestamp:
                 current_time = time.time()
-                transcription_seconds = int(current_time - last_usage_record_timestamp)
+                # Clamped to the last audio actually received (#4700): keepalive
+                # pings keep the socket alive after the device stops streaming.
+                transcription_seconds = billable_transcription_seconds(
+                    last_usage_record_timestamp, last_audio_received_time, current_time
+                )
 
                 words_to_record = words_transcribed_since_last_record
                 words_transcribed_since_last_record = 0  # reset
@@ -2802,7 +2806,9 @@ async def _stream_handler(
         shutdown_event.set()
         BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
         if not use_custom_stt and last_usage_record_timestamp:
-            transcription_seconds = int(time.time() - last_usage_record_timestamp)
+            transcription_seconds = billable_transcription_seconds(
+                last_usage_record_timestamp, last_audio_received_time, time.time()
+            )
             words_to_record = words_transcribed_since_last_record
 
             # Flush any pending speech_ms delta to Redis (#5746 reviewer fix)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -83,6 +83,7 @@ pytest tests/unit/test_fair_use_engine.py -v
 pytest tests/unit/test_fair_use_classifier.py -v
 pytest tests/unit/test_fair_use_async.py -v
 pytest tests/unit/test_dg_usage_batch.py -v
+pytest tests/unit/test_billable_transcription_seconds.py -v
 pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_sync_pcm_decode.py -v
 pytest tests/unit/test_sync_opus_decode.py -v

--- a/backend/tests/unit/test_billable_transcription_seconds.py
+++ b/backend/tests/unit/test_billable_transcription_seconds.py
@@ -1,0 +1,74 @@
+"""Tests for billable_transcription_seconds (#4700).
+
+Listening minutes kept increasing while the Omi device was off: client
+keepalive pings hold the /v4/listen socket open after audio stops, and usage
+was billed as raw wall-clock time since the last record. Billing must be
+clamped to the last audio byte actually received.
+"""
+
+import os
+import re
+import sys
+import types
+
+import pytest
+
+# Stub the Firestore-backed module so importing utils.analytics does not
+# instantiate a real client (pattern from test_action_item_idempotency.py).
+_fake_user_usage = types.ModuleType('database.user_usage')
+_fake_user_usage.update_hourly_usage = lambda *args, **kwargs: None
+_fake_database = types.ModuleType('database')
+_fake_database.user_usage = _fake_user_usage
+sys.modules.setdefault('database', _fake_database)
+sys.modules['database.user_usage'] = _fake_user_usage
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from utils.analytics import billable_transcription_seconds
+
+
+class TestBillableTranscriptionSeconds:
+    def test_no_usage_record_timestamp_bills_nothing(self):
+        assert billable_transcription_seconds(None, 1000.0, 1060.0) == 0
+
+    def test_continuous_audio_bills_full_interval(self):
+        # Audio still flowing: last audio ~= now, behavior unchanged.
+        assert billable_transcription_seconds(1000.0, 1060.0, 1060.0) == 60
+
+    def test_audio_stopped_mid_interval_bills_only_until_last_audio(self):
+        # Audio stopped 20s into the 60s interval.
+        assert billable_transcription_seconds(1000.0, 1020.0, 1060.0) == 20
+
+    def test_idle_socket_bills_zero(self):
+        # The #4700 case: device off, socket kept alive by keepalive pings.
+        # Last audio predates the last usage record; hours can pass.
+        assert billable_transcription_seconds(1060.0, 1020.0, 1060.0 + 3 * 3600) == 0
+
+    def test_no_audio_timestamp_falls_back_to_wall_clock(self):
+        # Defensive: billing only starts on the first audio byte, which also
+        # sets last_audio_received_time, but None must not crash or zero out.
+        assert billable_transcription_seconds(1000.0, None, 1060.0) == 60
+
+    def test_clock_skew_never_negative(self):
+        assert billable_transcription_seconds(1060.0, 1000.0, 1050.0) == 0
+
+
+class TestTranscribeUsesClampedBilling:
+    """Structural guard: transcribe.py must not bill raw wall-clock time."""
+
+    @staticmethod
+    def _transcribe_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'transcribe.py')
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+
+    def test_no_raw_wall_clock_billing(self):
+        source = self._transcribe_source()
+        raw = re.findall(r'transcription_seconds\s*=\s*int\(.*last_usage_record_timestamp\)', source)
+        assert not raw, f'raw wall-clock billing reintroduced: {raw}'
+
+    def test_both_billing_sites_use_helper(self):
+        source = self._transcribe_source()
+        calls = re.findall(r'transcription_seconds\s*=\s*billable_transcription_seconds\(', source)
+        # Periodic 60s tick + session-end flush.
+        assert len(calls) == 2, f'expected 2 clamped billing sites, found {len(calls)}'

--- a/backend/utils/analytics.py
+++ b/backend/utils/analytics.py
@@ -1,5 +1,26 @@
 from datetime import datetime
+from typing import Optional
+
 from database import user_usage as user_usage_db
+
+
+def billable_transcription_seconds(
+    last_usage_record_timestamp: Optional[float],
+    last_audio_received_time: Optional[float],
+    current_time: float,
+) -> int:
+    """Listening seconds to bill since the last usage record, clamped to the last
+    audio byte actually received (#4700).
+
+    Client keepalive pings hold the /v4/listen socket open long after the device
+    stops sending audio; counting raw wall-clock time then accrues phantom
+    listening minutes for hours. No audio streamed also means no STT vendor cost,
+    so idle socket time must not be billed.
+    """
+    if not last_usage_record_timestamp:
+        return 0
+    billable_until = min(current_time, last_audio_received_time or current_time)
+    return max(0, int(billable_until - last_usage_record_timestamp))
 
 
 def record_usage(


### PR DESCRIPTION
## Bug — #4700: Listening minutes increase while device is OFF + app closed (p2)

Free-plan users report the "listening minutes" counter climbing for **hours** with the Omi device powered off ("46s recording, counter added 114 minutes"; "512 minutes on the counter, of which actually used no more than 50"). Reporter confirmed phone-mic and web-mic paths count correctly — only the device path runs away.

## Root cause

In `routers/transcribe.py` (`/v4/listen`):
- `last_activity_time` is updated for **every** received frame, including ≤2-byte keepalive pings (the ping check happens after the update), so the 90s inactivity timeout never fires while the client app keeps pinging.
- Once the first audio byte arrives, both billing sites — the periodic 60s tick in `_record_usage_periodically` and the session-end flush — bill **raw wall-clock** `time.time() - last_usage_record_timestamp`, with no check that audio is still arriving.

So: device on for 1 minute → billing starts; device off → app (background service) keeps the socket alive with keepalives → phantom minutes accrue until the socket finally dies.

## Fix

New pure helper `billable_transcription_seconds()` in `utils/analytics.py` (next to `record_usage`): clamp the billable window to `min(now, last_audio_received_time)`, never negative. Used at both billing sites.

- **While audio flows, billing is unchanged** — this does NOT gate on words/speech, so silent-but-streaming audio is still billed. That addresses @beastoin's Deepgram-cost concern that closed #4680: when **no audio at all** is streamed, Deepgram bills nothing either, so unbilled idle time loses no money.
- Strictly never bills more than today; granularity stays the existing 60s tick.

## Tests

`tests/unit/test_billable_transcription_seconds.py` (registered in `test.sh`): 6 logic cases (continuous audio unchanged, audio stops mid-interval, 3h idle socket → 0, None fallback, clock skew) + 2 structural guards that transcribe.py keeps using the clamped helper at both sites. Logic verified locally with stdlib Python (pytest unavailable locally; CI runs the suite). `black` + `lint_async_blockers` clean. UNVERIFIED at runtime against a live idle-keepalive session.

🤖 automated by hourly watchdog; opened for review, not merged.

Fixes #4700

🤖 Generated with [Claude Code](https://claude.com/claude-code)