### PR TITLE
fix(backend): AI Chat can't find conversations by speaker/participant names — hybrid keyword+vector search (#5072)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -141,6 +141,7 @@ pytest tests/unit/test_webhook_auto_disable.py -v
 pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
 pytest tests/unit/test_conversation_search_date_validation.py -v
+pytest tests/unit/test_conversation_hybrid_search.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v
 pytest tests/unit/test_delete_account_purge_storage.py -v
 pytest tests/unit/test_apps_review_reply_validation.py -v

--- a/backend/tests/unit/test_conversation_hybrid_search.py
+++ b/backend/tests/unit/test_conversation_hybrid_search.py
@@ -1,0 +1,94 @@
+"""Regression tests for hybrid (keyword + vector) conversation search (#5072).
+
+AI Chat could not find conversations by participant/speaker names: search_conversations_tool
+and search_conversations_text used Pinecone vector search only, and embeddings rank proper
+names poorly — so "when did I talk to Steph?" returned the k nearest (wrong) conversations
+even when "Steph" was literally in a conversation summary. The fix merges the existing
+Typesense keyword search (titles/overviews) with the vector results, keyword hits first.
+
+These tests cover the merge ordering/dedup, the fail-open behavior of the keyword helper,
+and structurally guard that both chat retrieval call sites use the hybrid path.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault('TYPESENSE_HOST', 'localhost')
+os.environ.setdefault('TYPESENSE_HOST_PORT', '8108')
+os.environ.setdefault('TYPESENSE_API_KEY', 'test-key-not-real')
+
+import utils.conversations.search as search_module
+from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class TestMergeConversationSearchIds:
+    def test_keyword_hits_first_then_vector_deduplicated(self):
+        assert merge_conversation_search_ids(['k1', 'k2'], ['v1', 'k2', 'v2']) == ['k1', 'k2', 'v1', 'v2']
+
+    def test_empty_keyword_returns_vector_only(self):
+        assert merge_conversation_search_ids([], ['v1', 'v2']) == ['v1', 'v2']
+
+    def test_empty_vector_returns_keyword_only(self):
+        assert merge_conversation_search_ids(['k1'], []) == ['k1']
+
+    def test_both_empty(self):
+        assert merge_conversation_search_ids([], []) == []
+
+    def test_does_not_mutate_inputs(self):
+        keyword_ids = ['k1']
+        vector_ids = ['v1']
+        merged = merge_conversation_search_ids(keyword_ids, vector_ids)
+        merged.append('x')
+        assert keyword_ids == ['k1']
+        assert vector_ids == ['v1']
+
+
+class TestKeywordSearchConversationIds:
+    def test_returns_ids_from_search_items(self):
+        with patch.object(search_module, 'search_conversations') as mock_search:
+            mock_search.return_value = {'items': [{'id': 'c1'}, {'id': 'c2'}]}
+            assert keyword_search_conversation_ids('uid1', 'Steph', limit=5) == ['c1', 'c2']
+
+    def test_skips_items_without_id(self):
+        with patch.object(search_module, 'search_conversations') as mock_search:
+            mock_search.return_value = {'items': [{'id': 'c1'}, {'foo': 'bar'}, {'id': None}]}
+            assert keyword_search_conversation_ids('uid1', 'Steph') == ['c1']
+
+    def test_fails_open_to_empty_list_on_search_error(self):
+        with patch.object(search_module, 'search_conversations') as mock_search:
+            mock_search.side_effect = Exception('typesense unreachable')
+            assert keyword_search_conversation_ids('uid1', 'Steph') == []
+
+    def test_passes_filters_and_excludes_discarded(self):
+        with patch.object(search_module, 'search_conversations') as mock_search:
+            mock_search.return_value = {'items': []}
+            keyword_search_conversation_ids('uid1', 'Steph', limit=7, start_date=100, end_date=200)
+            mock_search.assert_called_once_with(
+                uid='uid1',
+                query='Steph',
+                per_page=7,
+                include_discarded=False,
+                start_date=100,
+                end_date=200,
+            )
+
+
+class TestCallSitesUseHybridSearch:
+    """Structural guards: both chat retrieval paths must merge keyword + vector results."""
+
+    @pytest.mark.parametrize(
+        'rel_path',
+        [
+            'utils/retrieval/tools/conversation_tools.py',
+            'utils/retrieval/tool_services/conversations.py',
+        ],
+    )
+    def test_call_site_merges_keyword_and_vector(self, rel_path):
+        source = (BACKEND_DIR / rel_path).read_text()
+        assert 'keyword_search_conversation_ids(' in source, f'{rel_path} lost the keyword search half of #5072'
+        assert 'merge_conversation_search_ids(' in source, f'{rel_path} lost the hybrid merge of #5072'

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List
 
 import typesense
 
@@ -81,3 +81,34 @@ def search_conversations(
         }
     except Exception as e:
         raise Exception(f"Failed to search conversations: {str(e)}")
+
+
+def keyword_search_conversation_ids(
+    uid: str,
+    query: str,
+    limit: int = 5,
+    start_date: int = None,
+    end_date: int = None,
+) -> List[str]:
+    """Typesense keyword search returning only conversation ids, for hybrid (keyword + vector) retrieval.
+
+    Fail-open: any search error returns [] so callers can fall back to vector-only results.
+    """
+    try:
+        results = search_conversations(
+            uid=uid,
+            query=query,
+            per_page=limit,
+            include_discarded=False,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        return [item['id'] for item in results.get('items', []) if item.get('id')]
+    except Exception as e:
+        logger.warning("keyword_search_conversation_ids failed for uid=%s, falling back to vector-only: %s", uid, e)
+        return []
+
+
+def merge_conversation_search_ids(keyword_ids: List[str], vector_ids: List[str]) -> List[str]:
+    """Merge keyword and vector search results, keyword hits first (exact text matches), deduplicated."""
+    return list(keyword_ids) + [cid for cid in vector_ids if cid not in keyword_ids]

--- a/backend/utils/retrieval/tool_services/conversations.py
+++ b/backend/utils/retrieval/tool_services/conversations.py
@@ -15,6 +15,7 @@ from models.conversation import Conversation
 from models.other import Person
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.render import conversations_to_string
+from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
 import logging
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ def search_conversations_text(
     include_transcript: bool = True,
     include_timestamps: bool = False,
 ) -> str:
-    """Semantic vector search for conversations, formatted as LLM-ready text."""
+    """Hybrid keyword + semantic vector search for conversations, formatted as LLM-ready text."""
     logger.info(f"search_conversations_text - uid: {uid}, query: {query}, limit: {limit}")
 
     # Cap limits
@@ -179,7 +180,13 @@ def search_conversations_text(
         starts_at = 0  # epoch
 
     try:
-        conversation_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
+        # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
+        keyword_ids = keyword_search_conversation_ids(
+            uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
+        )
+        vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
 
         if not conversation_ids:
             date_info = ""
@@ -227,7 +234,7 @@ def search_conversations_text(
                 logger.error(f"Error parsing conversation {conv_data.get('id')}: {e}")
                 continue
 
-        result = f"Found {len(conversations)} conversations semantically matching '{query}':\n\n"
+        result = f"Found {len(conversations)} conversations matching '{query}':\n\n"
         result += conversations_to_string(
             conversations,
             use_transcript=include_transcript,

--- a/backend/utils/retrieval/tools/conversation_tools.py
+++ b/backend/utils/retrieval/tools/conversation_tools.py
@@ -18,6 +18,7 @@ from models.conversation import Conversation
 from models.other import Person
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.render import conversations_to_string
+from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
 from utils.llm.clients import embeddings
 import logging
 
@@ -286,10 +287,12 @@ def search_conversations_tool(
     config: RunnableConfig = None,
 ) -> str:
     """
-    Search conversations using semantic vector search - USE THIS FOR EVENTS/INCIDENTS.
+    Search conversations using hybrid keyword + semantic vector search - USE THIS FOR EVENTS/INCIDENTS.
 
-    This tool uses AI embeddings to find conversations that are semantically similar to your query,
-    even if they don't contain the exact keywords. Perfect for finding when specific events happened.
+    This tool combines exact keyword matching on conversation titles/summaries (best for proper names
+    like people or places) with AI embeddings that find semantically similar conversations even if
+    they don't contain the exact keywords. Perfect for finding when specific events happened or
+    conversations with a specific person (e.g. "When did I talk to Steph?").
 
     **CRITICAL: Use this tool for EVENT/INCIDENT questions:**
     - "When did a dog bite me?" → USE THIS TOOL
@@ -394,10 +397,18 @@ def search_conversations_tool(
     limit = min(limit, 20)
 
     try:
-        # Perform vector search
-        conversation_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
+        # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
+        keyword_ids = keyword_search_conversation_ids(
+            uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
+        )
+        vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
 
-        logger.info(f"📊 search_conversations_tool - found {len(conversation_ids)} results for query: '{query}'")
+        logger.info(
+            f"📊 search_conversations_tool - found {len(conversation_ids)} results "
+            f"({len(keyword_ids)} keyword, {len(vector_ids)} vector) for query: '{query}'"
+        )
 
         if not conversation_ids:
             date_info = ""


### PR DESCRIPTION
## Bug
#5072 — asking AI Chat "when did I talk to Steph?" returns nothing, even when the conversation exists with the name clearly in its summary. The user can see the conversation in the feed and the app's search bar would find it, but chat cannot.

## Root cause
Both chat retrieval paths are **vector-search-only**:
- `search_conversations_tool` (agentic chat) → `vector_db.query_vectors` (Pinecone)
- `search_conversations_text` (tool_services, desktop/web REST + mobile LangChain) → same

Pinecone always returns the k nearest neighbors regardless of relevance, and embeddings rank proper names poorly — so a name query returns k semantically-near (wrong) conversations and the right one never surfaces. The existing Typesense keyword search (`utils/conversations/search.py`, `query_by: structured.overview, structured.title`) that powers the app's search bar would match the name literally, but chat never calls it.

(The issue's suggested fix — indexing speakers/transcripts in Typesense — requires Firestore→Typesense extension schema changes, infra-side; verified against the live collection schema that only `structured.*` fields are indexed. This PR is the in-code fix that resolves the reported failure: names that appear in titles/overviews — which conversation summaries normally include — become findable by chat.)

## Fix
Hybrid retrieval at both call sites:
- New `keyword_search_conversation_ids()` — wraps the existing Typesense search, returns ids only, **fail-open** (any Typesense error → `[]` → exact previous vector-only behavior).
- New `merge_conversation_search_ids()` — keyword hits first (exact text matches, sorted newest-first), then vector hits, deduplicated.
- No change to the Typesense query itself (same `query_by` fields already used in prod by `/v1/conversations/search`), so no schema risk. Locked conversations are already excluded by both halves; keyword search excludes discarded.
- Tool/docstring updated so the agent knows the tool now handles exact name matching.

## Tests
`tests/unit/test_conversation_hybrid_search.py` (registered in `test.sh`): merge ordering/dedup/non-mutation, id extraction, fail-open on search error, filter passthrough (incl. `include_discarded=False`), plus structural guards that both call sites keep the hybrid path. Helper logic verified locally via stdlib harness (pytest not installed locally; CI runs the suite). black + lint_async_blockers clean. UNVERIFIED at runtime against a live chat session.

Fixes #5072

🤖 automated by hourly watchdog; opened for review, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)