### PR TITLE
fix(desktop): run.sh fails when Node is installed via Homebrew — fall back to official Node (#7802)

### DIFF
--- a/desktop/scripts/prepare-agent-runtime.sh
+++ b/desktop/scripts/prepare-agent-runtime.sh
@@ -125,7 +125,18 @@ stage_local_node() {
   cp -f "$node_bin" "$NODE_RESOURCE"
   chmod +x "$NODE_RESOURCE"
   xattr -cr "$NODE_RESOURCE" 2>/dev/null || true
-  log "Staged local Node $("$NODE_RESOURCE" --version) from $node_bin"
+
+  # Homebrew's node is a stub dynamically linked to libnode.dylib via @rpath,
+  # so the copied binary aborts at startup outside its install prefix. Fall back
+  # to the self-contained official build when the staged copy can't run alone.
+  local staged_version
+  if ! staged_version="$("$NODE_RESOURCE" --version 2>/dev/null)"; then
+    log "Local Node at $node_bin is not self-contained (dynamically linked, e.g. Homebrew); falling back to official Node $NODE_VERSION download"
+    rm -f "$NODE_RESOURCE"
+    stage_universal_node
+    return
+  fi
+  log "Staged local Node $staged_version from $node_bin"
 }
 
 download_node_archive() {


### PR DESCRIPTION
## Bug
#7802 — `./run.sh` aborts during `[Preparing agent runtime...]` for any developer whose `node` comes from Homebrew (v22+):

```
dyld[4902]: Library not loaded: @rpath/libnode.147.dylib
  Referenced from: .../Desktop/Sources/Resources/node
Abort trap: 6
```

## Root cause
`scripts/prepare-agent-runtime.sh --local-node` (always invoked by `run.sh`) stages the developer's `node` binary by copying it into `Desktop/Sources/Resources/node`. Homebrew's node is a thin stub dynamically linked to `libnode.X.dylib` via `@rpath`/`@loader_path`, so the copy aborts the moment it runs outside its install prefix. Official nodejs.org tarballs are statically linked and unaffected.

## Fix
After staging the local binary, run `$NODE_RESOURCE --version` to verify the copy is actually self-contained. If it can't run, delete it and fall back to the script's existing checksum-verified official-Node download path (`stage_universal_node`). Static builds stage locally exactly as before — no behavior change for them.

An exec-check (rather than `otool -L` sniffing) also catches any other future linkage/arch problem with a staged local binary.

## Verification
Reproduced and verified on a machine with Homebrew node v26 (`@rpath/libnode.147.dylib`):
- Before: copied stub aborts with the exact dyld error from the issue (exit 134).
- After: script logs the fallback, downloads checksummed Node v22.14.0, stages a universal binary; `Desktop/Sources/Resources/node --version` → `v22.14.0`.
- Happy path: with a self-contained node first in `PATH`, the script stages it locally with no download, as before.

(Ran with `--skip-npm` in a fresh worktree, so the later unrelated `agent/dist` validation failed as expected; the staging logic under change was exercised end-to-end.)

Fixes #7802

🤖 automated by hourly watchdog; opened for review, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)