### PR TITLE
fix share PlatformException Non-empty title expected

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -687,7 +687,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
 
                               await Share.share(
                                 'https://h.omi.me/apps/${app.id}',
-                                subject: app.name,
+                                subject: app.name.isEmpty ? null : app.name,
                                 sharePositionOrigin: sharePositionOrigin,
                               );
                             },

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1211,6 +1211,7 @@ class _MessageActionBarState extends State<MessageActionBar> {
             icon: FontAwesomeIcons.share,
             onTap: () async {
               HapticFeedback.lightImpact();
+              if (widget.messageText.isEmpty) return;
               await Share.share(widget.messageText);
               PlatformManager.instance.analytics.track(
                 'Chat Message Shared',

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1210,8 +1210,8 @@ class _MessageActionBarState extends State<MessageActionBar> {
           _buildActionButton(
             icon: FontAwesomeIcons.share,
             onTap: () async {
-              HapticFeedback.lightImpact();
               if (widget.messageText.isEmpty) return;
+              HapticFeedback.lightImpact();
               await Share.share(widget.messageText);
               PlatformManager.instance.analytics.track(
                 'Chat Message Shared',

--- a/app/lib/pages/conversation_detail/share.dart
+++ b/app/lib/pages/conversation_detail/share.dart
@@ -6,5 +6,6 @@ import 'package:omi/backend/schema/conversation.dart';
 
 void shareConversationLink(ServerConversation conversation, {Rect? sharePositionOrigin}) {
   final content = 'https://h.omi.me/conversations/${conversation.id}';
-  Share.share(content, subject: conversation.structured.title, sharePositionOrigin: sharePositionOrigin);
+  final subject = conversation.structured.title;
+  Share.share(content, subject: subject.isEmpty ? null : subject, sharePositionOrigin: sharePositionOrigin);
 }


### PR DESCRIPTION
MethodChannelShare.share
FlutterError - PlatformException(error, Non-empty title expected, null, null)

package:share_plus_platform_interface/method_channel/method_channel_share.dart:25

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/40d960fea757d7ea8a9d0c02bec36346?time=7d&types=crash&sessionEventKey=9c121cc3398445498d7d53cbf3c9f259_2228414962524742499

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 StandardMethodCodec.decodeEnvelope + 653 (message_codecs.dart:653)
1  ???                            0x0 MethodChannel._invokeMethod + 367 (platform_channel.dart:367)
2  ???                            0x0 MethodChannelShare.share + 25 (method_channel_share.dart:25)
3  ???                            0x0 _MessageActionBarState.build.<fn> + 1214 (ai_message.dart:1214)
```

Fix:

The iOS share_plus plugin (FPPSharePlusPlugin.m) throws PlatformException "Non-empty title expected" when the subject/title field is present in the method channel arguments but is an empty string rather than nil. Two code paths were addressed:

1. shareConversationLink in conversation_detail/share.dart: conversation.structured.title is "" for any conversation that has not yet been processed by the backend. Passing subject: "" sends an empty NSString to the iOS plugin, triggering the crash. Fixed by passing null when the title is empty so the key is omitted from the platform map entirely.

2. MessageActionBar share button in chat/widgets/ai_message.dart: added an explicit isEmpty guard before calling Share.share so a degenerate empty messageText can never reach the platform layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)