### PR TITLE
test(backend): keep database stubs package-aware

### DIFF
--- a/backend/tests/unit/test_action_item_dedup.py
+++ b/backend/tests/unit/test_action_item_dedup.py
@@ -15,6 +15,9 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, _BACKEND_DIR)
+
 # Stub heavy deps before importing vector_db. Same pattern as test_memories_batch.
 for mod_name in [
     'pinecone',
@@ -48,16 +51,29 @@ sys.modules['google.cloud.firestore'].FieldFilter = MagicMock
 sys.modules['google.cloud.firestore'].Query = MagicMock
 sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
 
-clients_stub = sys.modules.setdefault('utils.llm.clients', types.ModuleType('utils.llm.clients'))
-clients_stub.embeddings = MagicMock()
+database_pkg = sys.modules.get('database')
+if not isinstance(database_pkg, types.ModuleType):
+    database_pkg = types.ModuleType('database')
+    sys.modules['database'] = database_pkg
+database_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
+sys.modules.pop('database.vector_db', None)
 
-_backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-_vector_db_path = os.path.join(_backend_dir, 'database', 'vector_db.py')
+previous_clients_stub = sys.modules.get('utils.llm.clients')
+clients_stub = types.ModuleType('utils.llm.clients')
+clients_stub.embeddings = MagicMock()
+sys.modules['utils.llm.clients'] = clients_stub
+
+_vector_db_path = os.path.join(_BACKEND_DIR, 'database', 'vector_db.py')
 _vector_db_spec = importlib.util.spec_from_file_location('action_item_dedup_vector_db', _vector_db_path)
 if _vector_db_spec is None or _vector_db_spec.loader is None:
     raise ImportError(f'Unable to load vector_db from {_vector_db_path}')
 vector_db = importlib.util.module_from_spec(_vector_db_spec)
 _vector_db_spec.loader.exec_module(vector_db)
+
+if previous_clients_stub is None:
+    sys.modules.pop('utils.llm.clients', None)
+else:
+    sys.modules['utils.llm.clients'] = previous_clients_stub
 
 
 def _setup_mocks(monkeypatch, *, index_none=False, query_response=None, embed_raises=None, query_raises=None):

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -28,6 +28,8 @@ os.environ["STRIPE_ARCHITECT_ANNUAL_PRICE_ID"] = ARCH_ANNUAL
 
 # --- Stub heavy infrastructure before importing any project modules ---
 
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
 # Firestore client
 _mock_client = types.ModuleType("database._client")
 _mock_client.db = MagicMock()
@@ -40,8 +42,8 @@ sys.modules["firebase_admin"] = _fb_admin
 sys.modules["firebase_admin.auth"] = _fb_admin.auth
 
 # Database submodules
-_db_mod = types.ModuleType("database")
-sys.modules.setdefault("database", _db_mod)
+_db_mod = sys.modules.setdefault("database", types.ModuleType("database"))
+_db_mod.__path__ = [os.path.join(_BACKEND_DIR, "database")]
 
 for _name in [
     "database.users",

--- a/backend/tests/unit/test_billable_transcription_seconds.py
+++ b/backend/tests/unit/test_billable_transcription_seconds.py
@@ -15,14 +15,15 @@ import pytest
 
 # Stub the Firestore-backed module so importing utils.analytics does not
 # instantiate a real client (pattern from test_action_item_idempotency.py).
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 _fake_user_usage = types.ModuleType('database.user_usage')
 _fake_user_usage.update_hourly_usage = lambda *args, **kwargs: None
-_fake_database = types.ModuleType('database')
+_fake_database = sys.modules.setdefault('database', types.ModuleType('database'))
+_fake_database.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
 _fake_database.user_usage = _fake_user_usage
-sys.modules.setdefault('database', _fake_database)
 sys.modules['database.user_usage'] = _fake_user_usage
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, _BACKEND_DIR)
 
 from utils.analytics import billable_transcription_seconds
 

--- a/backend/tests/unit/test_memory_temporal_brain.py
+++ b/backend/tests/unit/test_memory_temporal_brain.py
@@ -13,8 +13,9 @@ from datetime import datetime, timezone
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_test_secret_key_for_unit_tests_only_000000000000000000')
 
 # Stub database._client so importing models.memories doesn't spin up Firestore.
-if 'database' not in sys.modules:
-    sys.modules['database'] = ModuleType('database')
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+database_pkg = sys.modules.setdefault('database', ModuleType('database'))
+database_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
 _client_stub = ModuleType('database._client')
 _client_stub.document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
 sys.modules['database._client'] = _client_stub


### PR DESCRIPTION
## Summary
- keep database package stubs package-aware in Windows-focused backend unit tests
- preserve the latest isolated `vector_db` import in `test_action_item_dedup.py` while giving the temporary `database` stub a real package path
- avoid leaking the temporary `utils.llm.clients` embeddings stub after importing `vector_db`

## Verification
- `python -m pytest backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_billable_transcription_seconds.py backend\tests\unit\test_memory_temporal_brain.py backend\tests\unit\test_action_item_dedup.py -q --tb=short` -> 32 passed, 3 warnings
- `python -m py_compile backend\tests\unit\test_action_item_dedup.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_billable_transcription_seconds.py backend\tests\unit\test_memory_temporal_brain.py`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_action_item_dedup.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_billable_transcription_seconds.py backend\tests\unit\test_memory_temporal_brain.py --check`
- `git diff --check origin/main...HEAD`

Note: this branch was refreshed onto latest `main`; the repository commit hook also ran backend black formatting during `git cherry-pick --continue` and passed. The local checkout has no `.pre-commit-config.yaml`, so there was no repo-level `pre-commit run` target to execute.