### PR TITLE
test(backend): stub optional websockets in pusher tests

### DIFF
--- a/backend/tests/unit/pusher_websockets_stub.py
+++ b/backend/tests/unit/pusher_websockets_stub.py
@@ -1,0 +1,21 @@
+import sys
+import types
+from unittest.mock import AsyncMock
+
+
+def install_websockets_stub():
+    if 'websockets' not in sys.modules:
+        websockets_stub = types.ModuleType('websockets')
+        websockets_stub.__path__ = []
+        sys.modules['websockets'] = websockets_stub
+
+    websockets_stub = sys.modules['websockets']
+    if not hasattr(websockets_stub, 'connect'):
+        websockets_stub.connect = AsyncMock()
+
+    if 'websockets.exceptions' not in sys.modules:
+        websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
+        websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
+        sys.modules['websockets.exceptions'] = websockets_exceptions_stub
+
+    websockets_stub.exceptions = sys.modules['websockets.exceptions']

--- a/backend/tests/unit/test_pusher_circuit_breaker.py
+++ b/backend/tests/unit/test_pusher_circuit_breaker.py
@@ -11,10 +11,23 @@ Verifies:
 """
 
 import asyncio
+import sys
 import time
+import types
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
+
+if 'websockets' not in sys.modules:
+    websockets_stub = types.ModuleType('websockets')
+    websockets_stub.__path__ = []
+    websockets_stub.connect = AsyncMock()
+    sys.modules['websockets'] = websockets_stub
+if 'websockets.exceptions' not in sys.modules:
+    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
+    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
+    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
+    sys.modules['websockets'].exceptions = websockets_exceptions_stub
 
 from utils.pusher import (
     PusherCircuitBreaker,

--- a/backend/tests/unit/test_pusher_circuit_breaker.py
+++ b/backend/tests/unit/test_pusher_circuit_breaker.py
@@ -11,23 +11,14 @@ Verifies:
 """
 
 import asyncio
-import sys
 import time
-import types
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-if 'websockets' not in sys.modules:
-    websockets_stub = types.ModuleType('websockets')
-    websockets_stub.__path__ = []
-    websockets_stub.connect = AsyncMock()
-    sys.modules['websockets'] = websockets_stub
-if 'websockets.exceptions' not in sys.modules:
-    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
-    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
-    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
-    sys.modules['websockets'].exceptions = websockets_exceptions_stub
+from pusher_websockets_stub import install_websockets_stub
+
+install_websockets_stub()
 
 from utils.pusher import (
     PusherCircuitBreaker,

--- a/backend/tests/unit/test_pusher_conversation_retry.py
+++ b/backend/tests/unit/test_pusher_conversation_retry.py
@@ -8,23 +8,14 @@ messages are silently lost (#5391).
 import asyncio
 import json
 import struct
-import sys
 import time
-import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-if 'websockets' not in sys.modules:
-    websockets_stub = types.ModuleType('websockets')
-    websockets_stub.__path__ = []
-    websockets_stub.connect = AsyncMock()
-    sys.modules['websockets'] = websockets_stub
-if 'websockets.exceptions' not in sys.modules:
-    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
-    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
-    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
-    sys.modules['websockets'].exceptions = websockets_exceptions_stub
+from pusher_websockets_stub import install_websockets_stub
+
+install_websockets_stub()
 
 from websockets.exceptions import ConnectionClosed
 

--- a/backend/tests/unit/test_pusher_conversation_retry.py
+++ b/backend/tests/unit/test_pusher_conversation_retry.py
@@ -8,10 +8,24 @@ messages are silently lost (#5391).
 import asyncio
 import json
 import struct
+import sys
 import time
+import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+if 'websockets' not in sys.modules:
+    websockets_stub = types.ModuleType('websockets')
+    websockets_stub.__path__ = []
+    websockets_stub.connect = AsyncMock()
+    sys.modules['websockets'] = websockets_stub
+if 'websockets.exceptions' not in sys.modules:
+    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
+    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
+    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
+    sys.modules['websockets'].exceptions = websockets_exceptions_stub
+
 from websockets.exceptions import ConnectionClosed
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_pusher_heartbeat.py
+++ b/backend/tests/unit/test_pusher_heartbeat.py
@@ -7,22 +7,13 @@ timeout kills on the backend→pusher WebSocket connection.
 import asyncio
 import json
 import struct
-import sys
-import types
 from unittest.mock import AsyncMock
 
 import pytest
 
-if 'websockets' not in sys.modules:
-    websockets_stub = types.ModuleType('websockets')
-    websockets_stub.__path__ = []
-    websockets_stub.connect = AsyncMock()
-    sys.modules['websockets'] = websockets_stub
-if 'websockets.exceptions' not in sys.modules:
-    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
-    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
-    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
-    sys.modules['websockets'].exceptions = websockets_exceptions_stub
+from pusher_websockets_stub import install_websockets_stub
+
+install_websockets_stub()
 
 from websockets.exceptions import ConnectionClosed
 

--- a/backend/tests/unit/test_pusher_heartbeat.py
+++ b/backend/tests/unit/test_pusher_heartbeat.py
@@ -7,9 +7,23 @@ timeout kills on the backend→pusher WebSocket connection.
 import asyncio
 import json
 import struct
+import sys
+import types
 from unittest.mock import AsyncMock
 
 import pytest
+
+if 'websockets' not in sys.modules:
+    websockets_stub = types.ModuleType('websockets')
+    websockets_stub.__path__ = []
+    websockets_stub.connect = AsyncMock()
+    sys.modules['websockets'] = websockets_stub
+if 'websockets.exceptions' not in sys.modules:
+    websockets_exceptions_stub = types.ModuleType('websockets.exceptions')
+    websockets_exceptions_stub.ConnectionClosed = type('ConnectionClosed', (Exception,), {})
+    sys.modules['websockets.exceptions'] = websockets_exceptions_stub
+    sys.modules['websockets'].exceptions = websockets_exceptions_stub
+
 from websockets.exceptions import ConnectionClosed
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a lightweight `websockets` fallback stub for pusher unit tests when the package is absent in minimal local environments
- cover `websockets.exceptions.ConnectionClosed` for heartbeat and retry tests
- include `websockets.connect = AsyncMock()` in every local stub so collection order does not affect later `utils.pusher` imports
- keep the production pusher code unchanged

## Verification
- `python -m pytest tests\unit\test_pusher_circuit_breaker.py tests\unit\test_pusher_heartbeat.py tests\unit\test_pusher_conversation_retry.py --collect-only -q`
- `python -m pytest tests\unit\test_pusher_circuit_breaker.py tests\unit\test_pusher_heartbeat.py tests\unit\test_pusher_conversation_retry.py -q` -> 59 passed
- `python -m pytest tests\unit\test_pusher_heartbeat.py tests\unit\test_pusher_circuit_breaker.py --collect-only -q` -> reversed-order collection passes
- `python -m py_compile tests\unit\test_pusher_circuit_breaker.py tests\unit\test_pusher_heartbeat.py tests\unit\test_pusher_conversation_retry.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_pusher_circuit_breaker.py tests\unit\test_pusher_heartbeat.py tests\unit\test_pusher_conversation_retry.py --check`
- `git diff --check`