### PR TITLE
test(backend): harden proactive language client stub

### DIFF
--- a/backend/tests/unit/test_proactive_notification_language.py
+++ b/backend/tests/unit/test_proactive_notification_language.py
@@ -19,10 +19,12 @@ sys.path.insert(0, str(BACKEND_DIR))
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
 
 # Stub the only heavy import so the real module loads (utils/ and utils/llm/ __init__ are empty).
-if "utils.llm.clients" not in sys.modules:
+_clients = sys.modules.get("utils.llm.clients")
+if _clients is None:
     _clients = types.ModuleType("utils.llm.clients")
-    _clients.get_llm = MagicMock()
     sys.modules["utils.llm.clients"] = _clients
+if not hasattr(_clients, "get_llm"):
+    _clients.get_llm = MagicMock()
 
 from utils.llm import proactive_notification as pn  # noqa: E402
 


### PR DESCRIPTION
## Summary
- make `test_proactive_notification_language.py` tolerate a pre-existing partial `utils.llm.clients` stub
- ensure the test always provides `get_llm` before importing the real proactive notification module
- keep the production proactive notification code unchanged

## Verification
- `python -m pytest tests\unit\test_proactive_notification_language.py -q` -> 9 passed
- simulated an existing partial `utils.llm.clients` module without `get_llm` and imported the test module successfully
- `python -m py_compile tests\unit\test_proactive_notification_language.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_proactive_notification_language.py --check`
- filtered Windows collect smoke no longer reports `test_proactive_notification_language.py`, reducing the remaining error list from 27 to 26 after excluding the pusher group covered by #7823.