### PR TITLE
test(backend): isolate integration malformed stubs

### DIFF
--- a/backend/tests/unit/test_integration_malformed_records.py
+++ b/backend/tests/unit/test_integration_malformed_records.py
@@ -66,6 +66,9 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
 
 
 _finder = _Finder()
+for _n in list(sys.modules):
+    if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+        sys.modules.pop(_n, None)
 sys.meta_path.insert(0, _finder)
 try:
     from routers import integration as integ


### PR DESCRIPTION
## Summary
- clear pre-existing stubbed modules before `test_integration_malformed_records.py` installs its auto-mock finder
- keep the test's import isolation deterministic when earlier tests leave partial `utils`/`database` stubs in `sys.modules`
- leave production integration code unchanged

## Verification
- `python -m pytest tests\unit\test_integration_malformed_records.py -q` -> 4 passed
- simulated a pre-existing partial `utils.apps` stub and imported the test module successfully
- `python -m py_compile tests\unit\test_integration_malformed_records.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_integration_malformed_records.py --check`
- filtered Windows collect smoke no longer reports `test_integration_malformed_records.py`, reducing the remaining error list from 24 to 23 after excluding previously covered groups.