### PR TITLE
Windows app: packaged sign-in + security hardening

### DIFF
--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -1,12 +1,4 @@
-import {
-  app,
-  shell,
-  BrowserWindow,
-  ipcMain,
-  session,
-  nativeImage,
-  desktopCapturer
-} from 'electron'
+import { app, shell, BrowserWindow, ipcMain, session, nativeImage, desktopCapturer } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import iconPath from '../../resources/icon.png?asset'
@@ -40,6 +32,7 @@ import {
   stopAutomationTargetTracker
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
+import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
 import { startRewindRetention } from './rewind/retentionRunner'
@@ -159,14 +152,32 @@ function createWindow(): BrowserWindow {
         }
       }
     }
-    shell.openExternal(url)
+    // Hand only web/mail links to the OS. A prompt-injected chat reply could emit
+    // a file://, UNC, or custom-protocol URL; passing those to shell.openExternal
+    // enables NTLM-hash leak / protocol-handler abuse. Defense-in-depth alongside
+    // the renderer's Markdown scheme allow-list.
+    try {
+      const scheme = new URL(url).protocol
+      if (scheme === 'http:' || scheme === 'https:' || scheme === 'mailto:') {
+        shell.openExternal(url)
+      } else {
+        console.warn('[main] blocked external open of non-web URL scheme:', scheme)
+      }
+    } catch {
+      console.warn('[main] blocked external open of unparseable URL')
+    }
     return { action: 'deny' }
   })
 
   // HMR for renderer base on electron-vite cli.
-  // Load the remote URL for development or the local html file for production.
+  // Load the remote URL for development, or the loopback renderer server in
+  // production — a file:// origin would break Firebase sign-in (see
+  // rendererServer.ts). loadFile stays as a last resort so a server failure
+  // still produces a window (signed-out features only).
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+  } else if (rendererBaseUrl()) {
+    mainWindow.loadURL(`${rendererBaseUrl()}/index.html`)
   } else {
     mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
   }
@@ -176,8 +187,22 @@ function createWindow(): BrowserWindow {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   perfMark('main:ready')
+
+  // Production only (dev uses the vite dev server): serve the packaged renderer
+  // over localhost so Firebase auth sees an authorized origin. Must be up before
+  // any window loads.
+  if (!(is.dev && process.env['ELECTRON_RENDERER_URL'])) {
+    try {
+      await startRendererServer(join(__dirname, '../renderer'))
+    } catch (e) {
+      console.error(
+        '[main] renderer server failed to start — falling back to file:// (sign-in will not work):',
+        e
+      )
+    }
+  }
   // Set app user model id for windows
   electronApp.setAppUserModelId('com.omiwindows.app')
 
@@ -192,10 +217,7 @@ app.whenReady().then(() => {
   // In Electron we control the network stack, so strip the Origin header on
   // outgoing requests and inject permissive CORS response headers. Scoped to
   // the specific upstreams — everything else flows normally.
-  const apiUrls = [
-    'https://api.omi.me/*',
-    'https://desktop-backend-hhibjajaja-uc.a.run.app/*'
-  ]
+  const apiUrls = ['https://api.omi.me/*', 'https://desktop-backend-hhibjajaja-uc.a.run.app/*']
   session.defaultSession.webRequest.onBeforeSendHeaders({ urls: apiUrls }, (details, cb) => {
     const headers = { ...details.requestHeaders }
     delete headers.Origin

--- a/desktop/windows/src/main/insight/toastWindow.ts
+++ b/desktop/windows/src/main/insight/toastWindow.ts
@@ -7,6 +7,7 @@ import { BrowserWindow, screen } from 'electron'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
 import type { InsightPayload } from '../../shared/types'
+import { rendererBaseUrl } from '../rendererServer'
 
 const WIDTH = 360
 const HEIGHT = 168
@@ -58,8 +59,12 @@ function ensureWindow(): BrowserWindow {
   win.on('closed', () => {
     toastWindow = null
   })
+  // Same-origin as the main window (see overlay/window.ts) so the toast sees
+  // the signed-in auth state.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     win.loadURL(`${process.env['ELECTRON_RENDERER_URL']}#/insight-toast`)
+  } else if (rendererBaseUrl()) {
+    win.loadURL(`${rendererBaseUrl()}/index.html#/insight-toast`)
   } else {
     win.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'insight-toast' })
   }

--- a/desktop/windows/src/main/ipc/automation.ts
+++ b/desktop/windows/src/main/ipc/automation.ts
@@ -1,7 +1,7 @@
-import { ipcMain, dialog, BrowserWindow, type WebContents } from 'electron'
+import { ipcMain, dialog, BrowserWindow } from 'electron'
 import { automationBridge } from '../automation/bridge'
 import { getAutomationTargetHandle } from '../automation/foregroundTarget'
-import type { AutomationPlan, AutomationStep, PlanRunResult, UiSnapshot } from '../../shared/types'
+import type { AutomationPlan, AutomationStep, UiSnapshot } from '../../shared/types'
 
 // Result of the native-dialog confirm flow. `canceled` distinguishes a user
 // "Cancel" from an execution failure.
@@ -45,12 +45,11 @@ export function registerAutomationHandlers(): void {
     return getAutomationTargetHandle()
   })
 
-  ipcMain.handle('automation:run', async (e, plan: AutomationPlan): Promise<PlanRunResult> => {
-    const wc: WebContents = e.sender
-    return automationBridge.run(plan, (r) => {
-      if (!wc.isDestroyed()) wc.send('automation:step', r)
-    })
-  })
+  // The only run path is the consent-gated automation:confirmRun below. The
+  // former dialog-less 'automation:run' IPC was removed: it was exposed to the
+  // renderer but had no legitimate caller, and let web content drive Windows UI
+  // input with no approval. Per-step progress events aren't needed by the
+  // confirm flow (it resolves once on completion).
 
   // Consent gate as a NATIVE Windows dialog (works identically from the main
   // window and the floating overlay, since it lives here in main). Shows the plan

--- a/desktop/windows/src/main/overlay/window.ts
+++ b/desktop/windows/src/main/overlay/window.ts
@@ -10,6 +10,7 @@ import { app, BrowserWindow, screen } from 'electron'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
 import { computeOverlayBounds, OVERLAY_WIDTH } from './bounds'
+import { rendererBaseUrl } from '../rendererServer'
 
 let overlayWindow: BrowserWindow | null = null
 
@@ -103,8 +104,13 @@ export function createOverlayWindow(): BrowserWindow {
     console.error('[overlay] did-fail-load', code, desc, url)
   )
 
+  // Must load from the same origin as the main window (dev server or the
+  // production loopback server) — auth/localStorage state is per-origin, so a
+  // file:// overlay would always look signed out.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     win.loadURL(`${process.env['ELECTRON_RENDERER_URL']}#/overlay`)
+  } else if (rendererBaseUrl()) {
+    win.loadURL(`${rendererBaseUrl()}/index.html#/overlay`)
   } else {
     win.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'overlay' })
   }

--- a/desktop/windows/src/main/rendererServer.ts
+++ b/desktop/windows/src/main/rendererServer.ts
@@ -1,0 +1,108 @@
+// Serves the packaged renderer over http://localhost:<port> instead of file://.
+//
+// Firebase's signInWithPopup validates window.location.origin against the
+// project's authorized domains; `localhost` is authorized (and is what dev mode
+// uses via the vite server on 5179), but a file:// origin fails hard with
+// auth/unauthorized-domain — so a packaged build that loadFile()s the renderer
+// can never sign in. Serving the same files over a loopback HTTP server gives
+// every window the authorized `localhost` origin in production too.
+//
+// Port 5179 is preferred to match the dev server (web auth/localStorage state is
+// per-origin INCLUDING port, so keeping it stable preserves the saved session
+// across launches). If it's taken — e.g. a dev instance is running — the next
+// free port is used; sign-in still works on any localhost port, the session
+// just starts fresh for that run.
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { extname, join, normalize, sep } from 'node:path'
+
+const PREFERRED_PORT = 5179
+const PORT_ATTEMPTS = 10
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.txt': 'text/plain; charset=utf-8'
+}
+
+let baseUrl: string | null = null
+
+/** http://localhost:<port> once startRendererServer has resolved, else null (dev mode). */
+export function rendererBaseUrl(): string | null {
+  return baseUrl
+}
+
+function listen(server: Server, port: number): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: NodeJS.ErrnoException): void => {
+      server.removeListener('listening', onListening)
+      if (err.code === 'EADDRINUSE') resolve(false)
+      else reject(err)
+    }
+    const onListening = (): void => {
+      server.removeListener('error', onError)
+      resolve(true)
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port, '127.0.0.1')
+  })
+}
+
+/**
+ * Start serving the built renderer directory (works transparently from inside
+ * app.asar — Electron's patched fs handles it) and remember the resulting base
+ * URL. Call once at startup in production, before any window loads.
+ */
+export async function startRendererServer(rendererRoot: string): Promise<string> {
+  const root = normalize(rendererRoot)
+
+  const server = createServer((req, res) => {
+    void (async () => {
+      const pathname = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname)
+      const rel = pathname === '/' ? 'index.html' : pathname.slice(1)
+      const file = normalize(join(root, rel))
+      // Containment check — never serve anything outside the renderer dir.
+      if (file !== root && !file.startsWith(root + sep)) {
+        res.writeHead(403).end()
+        return
+      }
+      try {
+        const body = await readFile(file)
+        res.writeHead(200, {
+          'content-type': MIME[extname(file).toLowerCase()] ?? 'application/octet-stream',
+          'cache-control': 'no-cache'
+        })
+        res.end(body)
+      } catch {
+        res.writeHead(404).end()
+      }
+    })()
+  })
+
+  for (let i = 0; i < PORT_ATTEMPTS; i++) {
+    const port = PREFERRED_PORT + i
+    if (await listen(server, port)) {
+      baseUrl = `http://localhost:${port}`
+      if (port !== PREFERRED_PORT) {
+        console.warn(
+          `[renderer-server] port ${PREFERRED_PORT} busy — using ${port} (saved session may not carry over)`
+        )
+      }
+      console.log(`[renderer-server] serving ${root} at ${baseUrl}`)
+      return baseUrl
+    }
+  }
+  throw new Error(
+    `[renderer-server] no free port in ${PREFERRED_PORT}–${PREFERRED_PORT + PORT_ATTEMPTS - 1}`
+  )
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -124,8 +124,7 @@ const omi: OmiBridgeApi = {
   },
   perfFirstPaint: () => ipcRenderer.send('perf:firstPaint'),
   perfMark: (name: string) => ipcRenderer.send('perf:mark', name),
-  perfAnimResult: (stats: Record<string, number>) =>
-    ipcRenderer.send('perf:animResult', stats),
+  perfAnimResult: (stats: Record<string, number>) => ipcRenderer.send('perf:animResult', stats),
   isAnimBench: process.env.OMI_ANIM_BENCH === '1',
   benchEcho: (x: number) => ipcRenderer.invoke('bench:echo', x),
   isBench: process.env.OMI_BENCH === '1',
@@ -135,7 +134,11 @@ const omi: OmiBridgeApi = {
   automationSnapshot: (windowHandle?: string) =>
     ipcRenderer.invoke('automation:snapshot', windowHandle),
   automationTargetWindow: () => ipcRenderer.invoke('automation:targetWindow'),
-  automationRun: (plan: AutomationPlan) => ipcRenderer.invoke('automation:run', plan),
+  // NOTE: the dialog-less `automationRun` is intentionally NOT exposed to the
+  // renderer. Every renderer-initiated plan must go through automationConfirmRun,
+  // which gates on a native approval dialog built in main from the real plan.
+  // Exposing a consent-free run primitive to web content would let any future
+  // renderer-side code (XSS, hostile navigation) silently drive Windows UI input.
   automationConfirmRun: (plan: AutomationPlan) => ipcRenderer.invoke('automation:confirmRun', plan),
   onAutomationStep: (cb: (r: StepResult) => void) => {
     const listener = (_e: unknown, r: StepResult): void => cb(r)
@@ -175,12 +178,15 @@ const omiOverlay: OmiOverlayApi = {
     ipcRenderer.on('overlay:summoned', listener)
     return () => ipcRenderer.removeListener('overlay:summoned', listener)
   },
-  setAccelerator: (accelerator: string) => ipcRenderer.invoke('overlay:setAccelerator', accelerator),
+  setAccelerator: (accelerator: string) =>
+    ipcRenderer.invoke('overlay:setAccelerator', accelerator),
   suspendShortcut: () => ipcRenderer.send('overlay:suspendShortcut'),
   resumeShortcut: () => ipcRenderer.invoke('overlay:resumeShortcut'),
   onVisibilityChange: (cb: (state: { open: boolean; active: boolean }) => void) => {
-    const listener = (_e: Electron.IpcRendererEvent, state: { open: boolean; active: boolean }): void =>
-      cb(state)
+    const listener = (
+      _e: Electron.IpcRendererEvent,
+      state: { open: boolean; active: boolean }
+    ): void => cb(state)
     ipcRenderer.on('overlay:visibility', listener)
     return () => ipcRenderer.removeListener('overlay:visibility', listener)
   },

--- a/desktop/windows/src/renderer/src/components/Markdown.tsx
+++ b/desktop/windows/src/renderer/src/components/Markdown.tsx
@@ -27,12 +27,22 @@ function renderInline(text: string): React.ReactNode[] {
     )
       return <em key={i}>{part.slice(1, -1)}</em>
     const link = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(part)
-    if (link)
-      return (
-        <a key={i} href={link[2]} target="_blank" rel="noreferrer" className="underline">
-          {link[1]}
-        </a>
-      )
+    if (link) {
+      // Only http(s)/mailto links are clickable. Chat replies can be steered by
+      // indirect prompt injection (the prompt includes OCR of whatever is on the
+      // user's screen), so a model could emit a file://, UNC (\\host\share), or
+      // custom-protocol href; rendering those as live links enables one-click
+      // NTLM-hash leakage and OS protocol-handler abuse. Anything else falls back
+      // to plain text — the label still shows, it just isn't a link.
+      const href = link[2].trim()
+      if (/^(https?:|mailto:)/i.test(href))
+        return (
+          <a key={i} href={href} target="_blank" rel="noreferrer" className="underline">
+            {link[1]}
+          </a>
+        )
+      return <span key={i}>{link[1]}</span>
+    }
     return <span key={i}>{part}</span>
   })
 }

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -168,7 +168,10 @@ export type OmiBridgeApi = {
   /** Load the local onboarding knowledge graph. */
   localGraphLoad: () => Promise<KnowledgeGraph>
   /** Upsert nodes/edges (idempotent by id); returns the full graph after write. */
-  localGraphUpsert: (nodes: OnboardingGraphNode[], edges: OnboardingGraphEdge[]) => Promise<KnowledgeGraph>
+  localGraphUpsert: (
+    nodes: OnboardingGraphNode[],
+    edges: OnboardingGraphEdge[]
+  ) => Promise<KnowledgeGraph>
   /** Clear the local onboarding graph (called once at first onboarding start). */
   localGraphClear: () => Promise<void>
   /** Aggregated local app-usage rows (foreground seconds per app). */
@@ -271,9 +274,10 @@ export type OmiBridgeApi = {
   automationEnabled: boolean
   automationSnapshot: (windowHandle?: string) => Promise<UiSnapshot>
   automationTargetWindow: () => Promise<string | null>
-  automationRun: (plan: AutomationPlan) => Promise<PlanRunResult>
   // Native-dialog consent gate: shows the plan in a Windows dialog and runs it
-  // only on approval. `canceled` = user declined; otherwise ok/message.
+  // only on approval. `canceled` = user declined; otherwise ok/message. This is
+  // the ONLY automation-run path exposed to the renderer (the consent-free
+  // `automation:run` handler was removed — it had no legitimate caller).
   automationConfirmRun: (
     plan: AutomationPlan
   ) => Promise<{ ok: boolean; canceled?: boolean; message?: string }>
@@ -561,7 +565,14 @@ export type FetchNewResult<T> = {
 
 // --- Windows OCR helper (win-ocr-helper) ---
 
-export type OcrLine = { text: string; x: number; y: number; w: number; h: number; confidence: number }
+export type OcrLine = {
+  text: string
+  x: number
+  y: number
+  w: number
+  h: number
+  confidence: number
+}
 export type OcrResult =
   | { ok: true; fullText: string; lines: OcrLine[] }
   | { ok: false; code: 'NO_LANGUAGE' | 'DECODE_FAILED' | 'HELPER_ERROR'; message?: string }
@@ -605,12 +616,7 @@ export type RewindSettings = {
 }
 
 // --- Proactive Insights (Rewind OCR → Gemini → acrylic toast) ---
-export type InsightCategory =
-  | 'productivity'
-  | 'communication'
-  | 'learning'
-  | 'health'
-  | 'other'
+export type InsightCategory = 'productivity' | 'communication' | 'learning' | 'health' | 'other'
 
 // One insight as shown in the toast (mirrors macOS ExtractedInsight).
 export type InsightPayload = {


### PR DESCRIPTION
## Windows app: packaged sign-in + security hardening

Follow-up to the Omi Windows app (now at [`desktop/windows/`](https://github.com/BasedHardware/omi/tree/main/desktop/windows)). Brings `main` in line with the published **v1.0.0** installer by adding two fixes that aren't yet on `main`.

📂 **App folder: [`desktop/windows/`](https://github.com/BasedHardware/omi/tree/main/desktop/windows)** · [README](https://github.com/BasedHardware/omi/blob/main/desktop/windows/README.md)

### 1. Packaged sign-in (blocker)
`signInWithPopup` validates the window origin against Firebase's authorized domains. The packaged app loaded the renderer via `file://`, which fails with `auth/unauthorized-domain` — **installed builds could never sign in** (dev worked only because Vite serves `localhost`). New `rendererServer.ts` serves the bundled renderer over a `127.0.0.1` loopback (port 5179, so the session carries over); all three windows load that origin.

### 2. Security hardening (from an adversarial review of this code)
- **Removed a consent-free desktop-automation IPC** (`automation:run` / `window.omi.automationRun`) that was exposed to renderer content with **no approval dialog** and had **no legitimate caller** — the UI only ever uses the dialog-gated `automationConfirmRun`. Left in, any renderer-side code could silently inject keystrokes/clicks into the foreground app.
- **URL-scheme allow-list** (http(s)/mailto) on chat-message links and the external-open handler, blocking prompt-injection-driven `file://`/UNC/protocol-handler abuse (the chat prompt includes OCR of on-screen text, so link targets are attacker-influenceable).

### Test plan
- `cd desktop/windows && npm run build` — typecheck + electron-vite bundle, green
- `npm run test` — 508 passing
- Packaged installer verified: launches, reaches Google consent on a clean profile, boots already-signed-in on an existing profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
