### PR TITLE
Windows: fix onboarding dead-end + opaque 1008 on transcription

### DIFF
--- a/desktop/windows/src/renderer/src/components/overlay/OverlayApp.tsx
+++ b/desktop/windows/src/renderer/src/components/overlay/OverlayApp.tsx
@@ -39,9 +39,7 @@ function OverlayPanel({ replayEnter }: { replayEnter: () => void }): React.JSX.E
     // Single send choke-point (typed Enter + voice commit) — tell onboarding the
     // user asked something in the bar.
     window.omiOverlay.notifyAsked()
-    sendChainRef.current = sendChainRef.current
-      .then(() => sendRef.current(text))
-      .catch(() => {})
+    sendChainRef.current = sendChainRef.current.then(() => sendRef.current(text)).catch(() => {})
   }, [])
 
   // Hold-Space-to-talk: a quick Space tap types a space; holding past the threshold
@@ -56,9 +54,12 @@ function OverlayPanel({ replayEnter }: { replayEnter: () => void }): React.JSX.E
     onCommit: (text) => {
       setDraft('')
       enqueueSend(text)
-      // Let the onboarding voice step know a hold-Space capture completed.
-      window.omiOverlay.notifyVoiceCaptured()
     },
+    // Fires on every completed hold-Space capture, even when transcription was
+    // unavailable (quota/1008) or silent. Drives the onboarding voice step so a
+    // no-quota account can finish onboarding instead of being stuck waiting for a
+    // transcript that will never arrive.
+    onCaptureEnd: () => window.omiOverlay.notifyVoiceCaptured(),
     restoreDraft: (snapshot) => setDraft(snapshot),
     getDraft: () => draftRef.current
   })

--- a/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
+++ b/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
@@ -37,6 +37,11 @@ type Options = {
    *  the caller can render it in the input box before it's sent. Fires '' at the
    *  start of a capture to clear any leftover. */
   onTranscript: (text: string) => void
+  /** Fires when a hold-capture finalizes, whether or not it produced any
+   *  transcript. Lets a caller treat the GESTURE as complete even when cloud
+   *  transcription was unavailable (e.g. quota/1008 closed the socket) — used by
+   *  onboarding so a no-quota account isn't dead-ended on "hold Space and speak". */
+  onCaptureEnd?: () => void
   /** Restore the input to its pre-hold contents, removing the space(s) that were
    *  typed while the key was held. Receives the snapshot captured at key-down. */
   restoreDraft: (snapshot: string) => void
@@ -305,6 +310,9 @@ export function usePushToTalk(opts: Options): PushToTalk {
       linesRef.current = []
       interimRef.current = ''
       sessionRef.current++ // invalidate any still-pending async work from this session
+      // The hold-capture gesture completed (even if STT produced nothing, e.g.
+      // quota/1008 or silence) — notify before the text-gated send.
+      opts.onCaptureEnd?.()
       if (text) onCommit(text)
     }
 

--- a/desktop/windows/src/renderer/src/lib/omiListenClient.ts
+++ b/desktop/windows/src/renderer/src/lib/omiListenClient.ts
@@ -15,9 +15,11 @@ export type OmiListenCallbacks = {
    * Fires when the WS closes AFTER it had connected (any code — clean 1000,
    * quota 1008, or abnormal 1005/1006). The Omi socket is dead, so no more
    * transcripts will arrive; the caller should fall back to keep recording.
-   * Pre-connect closes come through `onError(_, fatal=true)` instead.
+   * `reason` is the backend's close text (e.g. `trial_expired`) — needed to tell
+   * a quota/entitlement close apart from a generic drop. Pre-connect closes come
+   * through `onError(_, fatal=true)` instead.
    */
-  onClosed: (code: number) => void
+  onClosed: (code: number, reason: string) => void
 }
 
 export type OmiListenHandle = {
@@ -90,8 +92,9 @@ export async function startOmiListen(
       if (stopped) return
       if (connected) {
         // Connected then dropped (clean, quota, or abnormal) → let the caller
-        // end the session and surface an error.
-        cb.onClosed(msg.code)
+        // end the session and surface an error. Pass the reason so a 1008
+        // entitlement/quota close can be reported as such, not a bare code.
+        cb.onClosed(msg.code, msg.reason)
       } else {
         // Never connected → an initial failure; surface as fatal so the caller
         // reports that transcription couldn't start.
@@ -109,10 +112,26 @@ export async function startOmiListen(
     })
   } catch (e) {
     unsub()
-    try { processor.disconnect() } catch { /* ignore */ }
-    try { node.disconnect() } catch { /* ignore */ }
-    try { stream.getTracks().forEach((t) => t.stop()) } catch { /* ignore */ }
-    try { void audioCtx.close() } catch { /* ignore */ }
+    try {
+      processor.disconnect()
+    } catch {
+      /* ignore */
+    }
+    try {
+      node.disconnect()
+    } catch {
+      /* ignore */
+    }
+    try {
+      stream.getTracks().forEach((t) => t.stop())
+    } catch {
+      /* ignore */
+    }
+    try {
+      void audioCtx.close()
+    } catch {
+      /* ignore */
+    }
     throw e
   }
 
@@ -133,10 +152,26 @@ export async function startOmiListen(
     stop: (): void => {
       stopped = true
       unsub()
-      try { processor.disconnect() } catch { /* ignore */ }
-      try { node.disconnect() } catch { /* ignore */ }
-      try { stream.getTracks().forEach((t) => t.stop()) } catch { /* ignore */ }
-      try { void audioCtx.close() } catch { /* ignore */ }
+      try {
+        processor.disconnect()
+      } catch {
+        /* ignore */
+      }
+      try {
+        node.disconnect()
+      } catch {
+        /* ignore */
+      }
+      try {
+        stream.getTracks().forEach((t) => t.stop())
+      } catch {
+        /* ignore */
+      }
+      try {
+        void audioCtx.close()
+      } catch {
+        /* ignore */
+      }
       void window.omi.listenStop(sessionId)
     }
   }

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -52,6 +52,15 @@ function isQuotaExhaustedEvent(ev: { type: string; raw: Record<string, unknown> 
 function isTrialExpiredError(err: Error): boolean {
   return /\(1008\)/.test(err.message) || /trial_expired/i.test(err.message)
 }
+// A connected-then-closed event that means the account isn't entitled to cloud
+// STT (free trial/quota used up): WS policy-violation 1008, or a backend reason
+// naming the quota. Distinguishes this from a generic network drop so the user
+// gets an actionable message instead of a bare "closed (1008)".
+function isQuotaClose(code: number, reason: string): boolean {
+  return code === 1008 || /trial_expired|freemium|quota/i.test(reason)
+}
+const QUOTA_MESSAGE =
+  'free Omi transcription quota is used up (1008) — add an Omi subscription or sign in with an entitled account to keep transcribing'
 
 /**
  * Start an Omi v4/listen session for one source. Resolves the handle once the
@@ -72,7 +81,11 @@ async function startWithOmi(
     const timeout = setTimeout(() => {
       if (outcome !== 'pending') return
       outcome = 'failed'
-      try { handle?.stop() } catch { /* ignore */ }
+      try {
+        handle?.stop()
+      } catch {
+        /* ignore */
+      }
       resolve(null)
     }, CONNECT_TIMEOUT_MS)
 
@@ -96,24 +109,37 @@ async function startWithOmi(
           // Never connected as the winner yet: treat as an initial failure.
           outcome = 'failed'
           clearTimeout(timeout)
-          try { handle?.stop() } catch { /* ignore */ }
+          try {
+            handle?.stop()
+          } catch {
+            /* ignore */
+          }
           resolve(null)
         } else if (outcome === 'omi') {
           // Already connected and committed: tell the caller the session is over.
           onLost('Omi free quota exhausted')
         }
       },
-      onClosed: (code) => {
+      onClosed: (code, reason) => {
         // The Omi socket dropped AFTER connecting (abnormal 1005/1006, clean
         // 1000, etc.). Omi will emit no more transcripts, so end the session.
         // (Pre-connect closes arrive via onError and drive the initial failure.)
-        if (outcome === 'omi') onLost(`Omi /v4/listen closed (${code})`)
+        if (outcome !== 'omi') return
+        onLost(
+          isQuotaClose(code, reason)
+            ? QUOTA_MESSAGE
+            : `Omi /v4/listen closed (${code})${reason ? ` ${reason}` : ''}`
+        )
       },
       onError: (err, fatal) => {
         if (outcome === 'pending' && fatal) {
           outcome = 'failed'
           clearTimeout(timeout)
-          try { handle?.stop() } catch { /* ignore */ }
+          try {
+            handle?.stop()
+          } catch {
+            /* ignore */
+          }
           console.warn(`[v4/listen ${source}] initial failure:`, err.message)
           resolve(null)
           return
@@ -123,7 +149,7 @@ async function startWithOmi(
           // Quota backstop: a 1008 'trial_expired' close (in case the typed
           // event didn't arrive first). End the session rather than erroring twice.
           if (isTrialExpiredError(err)) {
-            onLost('Omi trial_expired (1008)')
+            onLost(QUOTA_MESSAGE)
             return
           }
           cb.onError(err)
@@ -137,7 +163,11 @@ async function startWithOmi(
         // Only tear down if we've ALREADY failed; closing here on a still-pending
         // outcome aborts the handshake mid-connect (ws code 1006).
         if (outcome === 'failed') {
-          try { h.stop() } catch { /* ignore */ }
+          try {
+            h.stop()
+          } catch {
+            /* ignore */
+          }
         } else {
           handle = h
         }
@@ -182,7 +212,11 @@ export async function startTranscription(
 
   return {
     stop: (): void => {
-      try { active?.stop() } catch { /* ignore */ }
+      try {
+        active?.stop()
+      } catch {
+        /* ignore */
+      }
     }
   }
 }


### PR DESCRIPTION
## Fix onboarding dead-end + opaque 1008 on Omi transcription

When the signed-in account has no cloud-STT entitlement (free trial/quota used up), `api.omi.me/v4/listen` accepts the socket then closes it with **1008 `trial_expired`**. Three issues made this worse than it should be:

1. **The close reason was dropped.** `omiListenClient.ts` passed only the numeric code to `onClosed`, so a 1008 entitlement close looked identical to a generic disconnect. Now the backend reason is plumbed through.
2. **Cryptic error.** A 1008 surfaced as `Omi /v4/listen closed (1008)`. Now: *"free Omi transcription quota is used up (1008) — add an Omi subscription or sign in with an entitled account to keep transcribing."*
3. **Onboarding dead-end (the real bug).** The "hold Space and speak" step revealed **Continue** only after a *successful transcript* (`notifyVoiceCaptured` fired solely on non-empty text). With transcription quota-blocked, no transcript ever arrives → Continue never appears, leaving only Skip. New `usePushToTalk` `onCaptureEnd` fires on the completed hold-Space **gesture** (even with no transcript), and the overlay drives the onboarding step from that — so a no-quota account can finish onboarding.

This does not (cannot) grant server-side STT entitlement; it makes the failure clear and non-blocking.

### Test plan
- `cd desktop/windows && npm run typecheck` — clean
- `npm run test` — 508 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
