### PR TITLE
test(backend): isolate knowledge graph firestore stubs

### DIFF
--- a/backend/tests/unit/test_kg_edge_id_sanitization.py
+++ b/backend/tests/unit/test_kg_edge_id_sanitization.py
@@ -18,25 +18,37 @@ os.environ.setdefault(
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
-_google = sys.modules.setdefault("google", types.ModuleType("google"))
-_google_cloud = sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
-_google_firestore = sys.modules.setdefault("google.cloud.firestore", types.ModuleType("google.cloud.firestore"))
-_google_firestore_v1 = sys.modules.setdefault(
-    "google.cloud.firestore_v1", types.ModuleType("google.cloud.firestore_v1")
-)
-_google.cloud = _google_cloud
-_google_cloud.firestore = _google_firestore
-_google_cloud.firestore_v1 = _google_firestore_v1
-_google_firestore.Client = getattr(_google_firestore, "Client", MagicMock)
-_google_firestore_v1.FieldFilter = getattr(_google_firestore_v1, "FieldFilter", MagicMock)
-
 _BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 _database_pkg = sys.modules.setdefault("database", types.ModuleType("database"))
 _database_pkg.__path__ = [os.path.join(_BACKEND_DIR, "database")]
-sys.modules.pop("database.knowledge_graph", None)
-sys.modules.pop("database._client", None)
+
+
+def _install_google_firestore_stubs():
+    google_mod = sys.modules.setdefault("google", types.ModuleType("google"))
+    cloud_mod = sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+    firestore_mod = sys.modules.setdefault("google.cloud.firestore", types.ModuleType("google.cloud.firestore"))
+    firestore_v1_mod = sys.modules.setdefault(
+        "google.cloud.firestore_v1", types.ModuleType("google.cloud.firestore_v1")
+    )
+    google_mod.cloud = cloud_mod
+    cloud_mod.firestore = firestore_mod
+    cloud_mod.firestore_v1 = firestore_v1_mod
+    firestore_mod.Client = getattr(firestore_mod, "Client", MagicMock)
+    firestore_v1_mod.FieldFilter = getattr(firestore_v1_mod, "FieldFilter", MagicMock)
+
+
+def _clear_database_module_imports():
+    for module_name in ("database.knowledge_graph", "database._client"):
+        sys.modules.pop(module_name, None)
+    for attr_name in ("knowledge_graph", "_client"):
+        if hasattr(_database_pkg, attr_name):
+            delattr(_database_pkg, attr_name)
+
+
+_install_google_firestore_stubs()
+_clear_database_module_imports()
 
 # Patch the Firestore Client before importing any database module
 with patch("google.cloud.firestore.Client") as mock_client_cls:
@@ -44,11 +56,7 @@ with patch("google.cloud.firestore.Client") as mock_client_cls:
     mock_client_cls.return_value = mock_db
     from database.knowledge_graph import upsert_knowledge_edge
 
-sys.modules.pop("database.knowledge_graph", None)
-sys.modules.pop("database._client", None)
-for _database_attr in ("knowledge_graph", "_client"):
-    if hasattr(_database_pkg, _database_attr):
-        delattr(_database_pkg, _database_attr)
+_clear_database_module_imports()
 
 
 class TestEdgeIdSanitization:

--- a/backend/tests/unit/test_kg_edge_id_sanitization.py
+++ b/backend/tests/unit/test_kg_edge_id_sanitization.py
@@ -18,11 +18,37 @@ os.environ.setdefault(
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
+_google = sys.modules.setdefault("google", types.ModuleType("google"))
+_google_cloud = sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+_google_firestore = sys.modules.setdefault("google.cloud.firestore", types.ModuleType("google.cloud.firestore"))
+_google_firestore_v1 = sys.modules.setdefault(
+    "google.cloud.firestore_v1", types.ModuleType("google.cloud.firestore_v1")
+)
+_google.cloud = _google_cloud
+_google_cloud.firestore = _google_firestore
+_google_cloud.firestore_v1 = _google_firestore_v1
+_google_firestore.Client = getattr(_google_firestore, "Client", MagicMock)
+_google_firestore_v1.FieldFilter = getattr(_google_firestore_v1, "FieldFilter", MagicMock)
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+_database_pkg = sys.modules.setdefault("database", types.ModuleType("database"))
+_database_pkg.__path__ = [os.path.join(_BACKEND_DIR, "database")]
+sys.modules.pop("database.knowledge_graph", None)
+sys.modules.pop("database._client", None)
+
 # Patch the Firestore Client before importing any database module
 with patch("google.cloud.firestore.Client") as mock_client_cls:
     mock_db = MagicMock()
     mock_client_cls.return_value = mock_db
     from database.knowledge_graph import upsert_knowledge_edge
+
+sys.modules.pop("database.knowledge_graph", None)
+sys.modules.pop("database._client", None)
+for _database_attr in ("knowledge_graph", "_client"):
+    if hasattr(_database_pkg, _database_attr):
+        delattr(_database_pkg, _database_attr)
 
 
 class TestEdgeIdSanitization:


### PR DESCRIPTION
## Summary
- make `test_kg_edge_id_sanitization.py` resilient to earlier unit tests that leave a partial `google` module in `sys.modules`
- install a minimal `google.cloud.firestore` / `google.cloud.firestore_v1` module chain before patching `firestore.Client`, including parent attributes for both children
- force `database.knowledge_graph` and `database._client` to import from the real backend package under the patch, then remove the mocked module entries so later tests do not reuse them

## Verification
- `python -m pytest tests\unit\test_kg_edge_id_sanitization.py -q` -> 8 passed
- filtered `python -m pytest tests\unit --collect-only -q ... -x` now collects `test_kg_edge_id_sanitization.py` and advances to the next pre-existing blocker (`test_llm_usage_endpoints.py`)
- `python -m py_compile tests\unit\test_kg_edge_id_sanitization.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_kg_edge_id_sanitization.py --check`
- `git diff --check`