### PR TITLE
test(backend): update kg user type vector stub

### DIFF
--- a/backend/tests/unit/test_kg_user_type_mismatch.py
+++ b/backend/tests/unit/test_kg_user_type_mismatch.py
@@ -68,6 +68,7 @@ for attr in [
     "find_similar_action_items",
     "upsert_vector2",
     "update_vector_metadata",
+    "upsert_transcript_chunk_vectors",
 ]:
     setattr(vector_db_mod, attr, MagicMock())
 


### PR DESCRIPTION
## Summary
- add the missing `upsert_transcript_chunk_vectors` mock to `test_kg_user_type_mismatch.py`
- keep the test aligned with `utils.conversations.process_conversation`'s current `database.vector_db` imports

## Verification
- `python -m pytest tests\unit\test_kg_user_type_mismatch.py --collect-only -q`
- `python -m pytest tests\unit\test_kg_user_type_mismatch.py -q`
- `python -m py_compile tests\unit\test_kg_user_type_mismatch.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_kg_user_type_mismatch.py --check`
- `git diff --check`