### PR TITLE
test(backend): stub cloud tasks in sync decode tests

### DIFF
--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -68,6 +68,10 @@ for _mod in _stub_modules:
 
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
+if 'google.cloud.tasks_v2' not in sys.modules:
+    sys.modules['google.cloud.tasks_v2'] = MagicMock()
+if not hasattr(sys.modules.setdefault('google.cloud', MagicMock()), 'tasks_v2'):
+    sys.modules['google.cloud'].tasks_v2 = sys.modules['google.cloud.tasks_v2']
 sys.modules['utils.log_sanitizer'].sanitize = lambda x: x
 sys.modules['utils.log_sanitizer'].sanitize_pii = lambda x: x
 

--- a/backend/tests/unit/test_sync_pcm_decode.py
+++ b/backend/tests/unit/test_sync_pcm_decode.py
@@ -55,6 +55,10 @@ for mod_name in _stub_modules:
 # Ensure specific attributes exist on key stubs
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
+if 'google.cloud.tasks_v2' not in sys.modules:
+    sys.modules['google.cloud.tasks_v2'] = MagicMock()
+if not hasattr(sys.modules.setdefault('google.cloud', MagicMock()), 'tasks_v2'):
+    sys.modules['google.cloud'].tasks_v2 = sys.modules['google.cloud.tasks_v2']
 
 from routers.sync import _is_pcm_codec, decode_pcm_file_to_wav, decode_files_to_wav
 


### PR DESCRIPTION
## Summary
- stub `google.cloud.tasks_v2` in the PCM and Opus sync decode tests before importing `routers.sync`
- keep these decode tests focused on local WAL decoding without requiring the Cloud Tasks client package in lean test environments

## Verification
- `python -m pytest tests\unit\test_sync_pcm_decode.py tests\unit\test_sync_opus_decode.py --collect-only -q`
- `python -m pytest tests\unit\test_sync_pcm_decode.py tests\unit\test_sync_opus_decode.py -q`
- `python -m py_compile tests\unit\test_sync_pcm_decode.py tests\unit\test_sync_opus_decode.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_sync_pcm_decode.py tests\unit\test_sync_opus_decode.py --check`
- `git diff --check`