### PR TITLE
test(backend): stub conversation search in tools router tests

### DIFF
--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -140,6 +140,17 @@ factory_mod = _stub_module("utils.conversations.factory")
 factory_mod.deserialize_conversation = MagicMock(
     side_effect=lambda d: d if not isinstance(d, dict) else type('FakeConv', (), d)()
 )
+search_mod = _stub_module("utils.conversations.search")
+search_mod.keyword_search_conversation_ids = MagicMock(return_value=[])
+
+
+def _merge_conversation_search_ids(keyword_ids, vector_ids):
+    return list(keyword_ids) + [cid for cid in vector_ids if cid not in keyword_ids]
+
+
+search_mod.merge_conversation_search_ids = MagicMock(side_effect=_merge_conversation_search_ids)
+transcript_chunks_mod = _stub_module("utils.conversations.transcript_chunks")
+transcript_chunks_mod.hydrate_chunk_texts = MagicMock(side_effect=lambda _uid, conversations: conversations)
 endpoints_mod = _stub_module("utils.other.endpoints")
 endpoints_mod.get_current_user_uid = MagicMock()
 endpoints_mod.with_rate_limit = MagicMock(return_value=MagicMock())
@@ -223,6 +234,16 @@ action_items_svc = _load_module_from_file(
     "utils.retrieval.tool_services.action_items",
     BACKEND_DIR / "utils" / "retrieval" / "tool_services" / "action_items.py",
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_conversation_search_stubs():
+    search_mod.keyword_search_conversation_ids.reset_mock()
+    search_mod.keyword_search_conversation_ids.return_value = []
+    search_mod.merge_conversation_search_ids.reset_mock()
+    search_mod.merge_conversation_search_ids.side_effect = _merge_conversation_search_ids
+    transcript_chunks_mod.hydrate_chunk_texts.reset_mock()
+    transcript_chunks_mod.hydrate_chunk_texts.side_effect = lambda _uid, conversations: conversations
 
 
 # ===========================================================================

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -150,7 +150,25 @@ def _merge_conversation_search_ids(keyword_ids, vector_ids):
 
 search_mod.merge_conversation_search_ids = MagicMock(side_effect=_merge_conversation_search_ids)
 transcript_chunks_mod = _stub_module("utils.conversations.transcript_chunks")
-transcript_chunks_mod.hydrate_chunk_texts = MagicMock(side_effect=lambda _uid, conversations: conversations)
+
+
+def _hydrate_chunk_texts(_uid, conversations):
+    return conversations
+
+
+transcript_chunks_mod.hydrate_chunk_texts = MagicMock(side_effect=_hydrate_chunk_texts)
+
+
+@pytest.fixture(autouse=True)
+def reset_conversation_search_stubs():
+    search_mod.keyword_search_conversation_ids.reset_mock()
+    search_mod.keyword_search_conversation_ids.return_value = []
+    search_mod.merge_conversation_search_ids.reset_mock()
+    search_mod.merge_conversation_search_ids.side_effect = _merge_conversation_search_ids
+    transcript_chunks_mod.hydrate_chunk_texts.reset_mock()
+    transcript_chunks_mod.hydrate_chunk_texts.side_effect = _hydrate_chunk_texts
+
+
 endpoints_mod = _stub_module("utils.other.endpoints")
 endpoints_mod.get_current_user_uid = MagicMock()
 endpoints_mod.with_rate_limit = MagicMock(return_value=MagicMock())
@@ -234,16 +252,6 @@ action_items_svc = _load_module_from_file(
     "utils.retrieval.tool_services.action_items",
     BACKEND_DIR / "utils" / "retrieval" / "tool_services" / "action_items.py",
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_conversation_search_stubs():
-    search_mod.keyword_search_conversation_ids.reset_mock()
-    search_mod.keyword_search_conversation_ids.return_value = []
-    search_mod.merge_conversation_search_ids.reset_mock()
-    search_mod.merge_conversation_search_ids.side_effect = _merge_conversation_search_ids
-    transcript_chunks_mod.hydrate_chunk_texts.reset_mock()
-    transcript_chunks_mod.hydrate_chunk_texts.side_effect = lambda _uid, conversations: conversations
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- stub `utils.conversations.search` in `test_tools_router.py` so the retrieval conversation service can import without the Typesense-backed search module
- stub `utils.conversations.transcript_chunks.hydrate_chunk_texts` so `routers.tools` can load in the isolated test harness
- preserve existing vector-search expectations by making the search merge stub return keyword hits followed by vector hits with stable de-duplication

## Verification
- `python -m pytest tests\unit\test_tools_router.py --collect-only -q`
- `python -m pytest tests\unit\test_tools_router.py -q`
- `python -m py_compile tests\unit\test_tools_router.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_tools_router.py --check`
- `git diff --check`