### PR TITLE
fix(ble): resume Limitless recording after network-only reconnect

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -244,29 +244,29 @@ class CaptureProvider extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().mic.start(
-          onByteReceived: (bytes) {
-            final frames = _activeSource?.processBytes(bytes) ?? [];
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_callActive) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-        );
+      onByteReceived: (bytes) {
+        final frames = _activeSource?.processBytes(bytes) ?? [];
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_callActive) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+    );
   }
 
   void _onMicStalled() {
@@ -352,6 +352,11 @@ class CaptureProvider extends ChangeNotifier
   /// Future tracking the in-progress _finalizeAndStampSession(), so _autoSyncSessionWals()
   /// can await it before querying disk WALs. Prevents race when backend responds fast.
   Future<void>? _pendingFinalizeAndStamp;
+
+  /// Set in onClosed() when the socket drops during active device recording.
+  /// Consumed in _initiateWebsocket() to trigger onNetworkSocketReconnected()
+  /// on the device connection (e.g. Limitless re-sends enable-data-stream).
+  bool _socketReconnectPending = false;
 
   /// Returns unsynced WALs belonging to the current capture session.
   /// Empty when all frames have been streamed successfully (clean UI).
@@ -526,8 +531,9 @@ class CaptureProvider extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -541,13 +547,13 @@ class CaptureProvider extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-          codec: codec,
-          sampleRate: sampleRate,
-          language: language,
-          force: force,
-          source: source,
-          customSttConfig: effectiveConfig,
-        );
+      codec: codec,
+      sampleRate: sampleRate,
+      language: language,
+      force: force,
+      source: source,
+      customSttConfig: effectiveConfig,
+    );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -557,6 +563,16 @@ class CaptureProvider extends ChangeNotifier
     _transcriptServiceReady = true;
     if (_sessionStartSeconds == 0) {
       _sessionStartSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    }
+
+    // Notify the device connection that the socket reconnected after a network
+    // outage so it can re-enable streaming if needed (e.g. Limitless pendant).
+    // Guard on deviceRecord: skip if the user has paused — no point waking the
+    // device when _bleBytesStream is cancelled and audio would just be dropped.
+    if (_socketReconnectPending && _recordingDevice != null && recordingState == RecordingState.deviceRecord) {
+      _socketReconnectPending = false;
+      final conn = await ServiceManager.instance().device.ensureConnection(_recordingDevice!.id);
+      await conn?.onNetworkSocketReconnected();
     }
 
     await _loadInProgressConversation();
@@ -645,20 +661,24 @@ class CaptureProvider extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error resuming device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              resumeDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error resuming device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error pausing device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              pauseDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error pausing device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -751,8 +771,8 @@ class CaptureProvider extends ChangeNotifier
         }
 
         // Local storage syncs
-        var checkWalSupported = (_recordingDevice?.type == DeviceType.omi ||
-                _recordingDevice?.type == DeviceType.openglass) &&
+        var checkWalSupported =
+            (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
         if (checkWalSupported != _isWalSupported) {
@@ -809,6 +829,7 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future _cleanupCurrentState({bool disableNativeBackground = false}) async {
+    _socketReconnectPending = false;
     _stopInProgressConversationRefresh();
     await _closeBleStream(disableNativeBackground: disableNativeBackground);
     _activeSource = null;
@@ -858,8 +879,9 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1154,32 +1176,32 @@ class CaptureProvider extends ChangeNotifier
 
     // record
     await ServiceManager.instance().mic.start(
-          onByteReceived: (bytes) {
-            // Process through AudioSource for frame splitting and sync key generation
-            final frames = _activeSource?.processBytes(bytes) ?? [];
+      onByteReceived: (bytes) {
+        // Process through AudioSource for frame splitting and sync key generation
+        final frames = _activeSource?.processBytes(bytes) ?? [];
 
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
 
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_callActive) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-        );
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_callActive) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+    );
   }
 
   stopStreamRecording() async {
@@ -1247,6 +1269,14 @@ class CaptureProvider extends ChangeNotifier
       if (ctx != null) {
         AppSnackbar.showSnackbar(ctx.l10n.transcriptionPausedReconnecting, duration: const Duration(seconds: 3));
       }
+    }
+
+    // Mark that a device-recording session was interrupted by a network drop.
+    // _initiateWebsocket() will call onNetworkSocketReconnected() on the device
+    // connection so it can re-enable streaming (e.g. Limitless re-sends the
+    // enable-data-stream command after its BLE audio times out).
+    if (recordingState == RecordingState.deviceRecord) {
+      _socketReconnectPending = true;
     }
 
     notifyListeners();

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -244,29 +244,29 @@ class CaptureProvider extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        final frames = _activeSource?.processBytes(bytes) ?? [];
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_callActive) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-    );
+          onByteReceived: (bytes) {
+            final frames = _activeSource?.processBytes(bytes) ?? [];
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_callActive) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+        );
   }
 
   void _onMicStalled() {
@@ -531,9 +531,8 @@ class CaptureProvider extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    String language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -547,13 +546,13 @@ class CaptureProvider extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-      codec: codec,
-      sampleRate: sampleRate,
-      language: language,
-      force: force,
-      source: source,
-      customSttConfig: effectiveConfig,
-    );
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+          source: source,
+          customSttConfig: effectiveConfig,
+        );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -661,24 +660,20 @@ class CaptureProvider extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error resuming device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              resumeDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error resuming device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error pausing device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              pauseDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error pausing device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -771,8 +766,8 @@ class CaptureProvider extends ChangeNotifier
         }
 
         // Local storage syncs
-        var checkWalSupported =
-            (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
+        var checkWalSupported = (_recordingDevice?.type == DeviceType.omi ||
+                _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
         if (checkWalSupported != _isWalSupported) {
@@ -879,9 +874,8 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    var language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1176,32 +1170,32 @@ class CaptureProvider extends ChangeNotifier
 
     // record
     await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        // Process through AudioSource for frame splitting and sync key generation
-        final frames = _activeSource?.processBytes(bytes) ?? [];
+          onByteReceived: (bytes) {
+            // Process through AudioSource for frame splitting and sync key generation
+            final frames = _activeSource?.processBytes(bytes) ?? [];
 
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
 
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_callActive) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-    );
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_callActive) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+        );
   }
 
   stopStreamRecording() async {

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -59,12 +59,7 @@ class RingStatus {
   final int freeBytes;
   final int rtcValid; // 0 = device RTC not yet synced (timestamps unreliable), 1 = synced
 
-  RingStatus({
-    required this.usedBytes,
-    required this.unreadPackets,
-    required this.freeBytes,
-    required this.rtcValid,
-  });
+  RingStatus({required this.usedBytes, required this.unreadPackets, required this.freeBytes, required this.rtcValid});
 
   bool get isRtcValid => rtcValid != 0;
 
@@ -105,7 +100,8 @@ class DeviceConnectionFactory {
 
     // Use name-based detection as fallback for OmiGlass devices (some advertise as DeviceType.omi).
     final deviceName = device.name.toLowerCase();
-    final isOmiGlass = device.type == DeviceType.openglass ||
+    final isOmiGlass =
+        device.type == DeviceType.openglass ||
         deviceName.contains('openglass') ||
         deviceName.contains('omiglass') ||
         deviceName.contains('glass');
@@ -626,4 +622,10 @@ abstract class DeviceConnection {
   }
 
   Future<int?> performGetMicGain();
+
+  /// Called when the server transcription WebSocket reconnects after a
+  /// network-only outage (BLE stayed connected throughout). Override to
+  /// re-initialize device streaming if the device may have stopped sending
+  /// audio while the socket was dead.
+  Future<void> onNetworkSocketReconnected() async {}
 }

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -100,8 +100,7 @@ class DeviceConnectionFactory {
 
     // Use name-based detection as fallback for OmiGlass devices (some advertise as DeviceType.omi).
     final deviceName = device.name.toLowerCase();
-    final isOmiGlass =
-        device.type == DeviceType.openglass ||
+    final isOmiGlass = device.type == DeviceType.openglass ||
         deviceName.contains('openglass') ||
         deviceName.contains('omiglass') ||
         deviceName.contains('glass');

--- a/app/lib/services/devices/limitless_connection.dart
+++ b/app/lib/services/devices/limitless_connection.dart
@@ -107,6 +107,14 @@ class LimitlessDeviceConnection extends DeviceConnection {
   }
 
   @override
+  Future<void> onNetworkSocketReconnected() async {
+    // The Limitless pendant stops streaming BLE audio after an extended period
+    // without a live server connection. Re-send the enable-data-stream command
+    // so it resumes, just as _reinitializeAfterReconnect() does after BT reconnect.
+    await _reinitializeAfterReconnect();
+  }
+
+  @override
   Future<void> unpair() async {
     await unpairWithoutReset();
   }

--- a/app/lib/services/devices/limitless_connection.dart
+++ b/app/lib/services/devices/limitless_connection.dart
@@ -74,9 +74,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   void _attachRxSubscription() {
     _rxSubscription?.cancel();
-    _rxSubscription = transport
-        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
-        .listen(_handleNotification);
+    _rxSubscription =
+        transport.getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid).listen(_handleNotification);
   }
 
   Future<void> _handleTransportReconnected() async {
@@ -375,10 +374,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
           } else {
             // Audio page that yielded zero frames — genuine parse failure
             final firstBytesLen = flashPageData.length < 64 ? flashPageData.length : 64;
-            final firstBytes = flashPageData
-                .sublist(0, firstBytesLen)
-                .map((b) => b.toRadixString(16).padLeft(2, '0'))
-                .join(' ');
+            final firstBytes =
+                flashPageData.sublist(0, firstBytesLen).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ');
             DebugLogManager.logWarning('Limitless flash page yielded zero Opus frames', {
               'index': index,
               'session': session,
@@ -1779,7 +1776,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -1793,7 +1791,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;


### PR DESCRIPTION
## Problem

When the Limitless pendant is recording and the network drops entirely (Bluetooth stays connected), the pendant silently stops streaming BLE audio after its internal timeout elapses. When the network comes back, the app's keep-alive timer successfully reconnects the transcription WebSocket, but no audio flows — the pendant is no longer emitting frames. The UI continues to show `deviceRecord`, giving no indication that transcription has stopped. The only recovery is force-closing the app or disconnecting/reconnecting Bluetooth.

This is the network-side analog of #7725 (BT reconnect fix). That fix added `_handleTransportReconnected()` to re-send the `enable-data-stream` command after a BLE drop. This PR does the same for network-only drops.

Fixes #7841

## Root Cause

`_initiateWebsocket()` in `CaptureProvider` has no way to notify the active device connection that the socket has recovered. After reconnecting the socket, the `_bleBytesStream` pipeline is live and waiting, but the Limitless pendant stopped producing BLE audio frames while the socket was dead. Nobody re-sent the enable-data-stream command.

`CaptureProvider.onConnected()` is the natural hook, but it is unreachable from the keep-alive reconnect path: `subscribe()` is called after `start()` completes (socket already connected), so the `onConnected` event fires on an empty listeners map and never reaches `CaptureProvider`. Even if it did, it only handles the `interrupted` state (phone mic).

## Solution

**Add `onNetworkSocketReconnected()` as a virtual hook on `DeviceConnection`** (no-op default). `LimitlessDeviceConnection` overrides it to call `_reinitializeAfterReconnect()` — the same enable-data-stream command used by the BT reconnect fix.

A `_socketReconnectPending` boolean in `CaptureProvider` gates the call:
- **Set** in `onClosed()` when `recordingState == deviceRecord` (socket dropped during active device recording)
- **Consumed and cleared** in `_initiateWebsocket()` after successful reconnect, guarded by `recordingState == deviceRecord` (skipped if the user paused between the drop and the reconnect)
- **Cleared** in `_cleanupCurrentState()` on explicit stop so it does not carry over into the next session

Explicit socket stops call `TranscriptSegmentSocketService.stop()` which clears listeners before the async close fires, so `CaptureProvider.onClosed()` is never reached from those paths — the flag is never set spuriously.

## Changes

- **`device_connection.dart`** — `onNetworkSocketReconnected()` no-op hook on the base class; all existing device types unaffected
- **`limitless_connection.dart`** — override calls `_reinitializeAfterReconnect()` (re-sends enable-data-stream)
- **`capture_provider.dart`** — `_socketReconnectPending` flag wiring in `onClosed()`, `_cleanupCurrentState()`, and `_initiateWebsocket()`

Note: the diff also includes formatter-only normalizations in `capture_provider.dart` and `device_connection.dart` produced by the pre-commit hook (`dart format --line-length 120`). No logic is changed in those lines.

## Testing

Verified on hardware (Limitless pendant on iOS):
1. Start recording — confirm transcription is live.
2. Toggle airplane mode on (Bluetooth stays connected on iOS).
3. Wait 60+ seconds for the pendant's internal streaming timeout.
4. Toggle airplane mode off.
5. Transcription resumes within ~15 seconds (keep-alive interval) without touching the pendant or restarting the app. ✅

Regression verified:
- BT disconnect/reconnect still works (`_handleTransportReconnected()` path unchanged) ✅
- Explicit stop/start cycle works correctly (flag cleared by `_cleanupCurrentState()`) ✅
- Pause/resume cycle unaffected (`deviceRecord` guard prevents reinit while paused) ✅