### PR TITLE
test(backend): update geocoding cache stubs

### DIFF
--- a/backend/tests/unit/test_geocoding_cache.py
+++ b/backend/tests/unit/test_geocoding_cache.py
@@ -8,6 +8,7 @@ Verifies that:
 5. geo.dict() is used for serialization (Pydantic-safe)
 """
 
+import asyncio
 import json
 import sys
 import types
@@ -30,6 +31,7 @@ if _http_mod is None:
     _http_mod = types.ModuleType("utils.http_client")
     sys.modules["utils.http_client"] = _http_mod
 _http_mod.get_maps_client = MagicMock()
+_http_mod.get_maps_semaphore = MagicMock(return_value=asyncio.Semaphore(1))
 _http_mod.get_webhook_client = MagicMock()
 
 from models.geolocation import Geolocation
@@ -44,10 +46,10 @@ class TestCacheKeyPrecision:
         # 37.78512 -> 37.785, -122.40932 -> -122.409
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {"status": "OK", "results": []}
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 get_google_maps_location(37.78512, -122.40932)
 
@@ -80,11 +82,11 @@ class TestCacheHit:
         }
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = json.dumps(cached)
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 result = get_google_maps_location(37.78512, -122.40932)
 
                 # Should NOT call Google API
-                mock_req.get.assert_not_called()
+                mock_httpx.get.assert_not_called()
 
         assert isinstance(result, Geolocation)
         assert result.google_place_id == "ChIJIQBpAG2ahYAR_6128GcTUEo"
@@ -96,9 +98,9 @@ class TestCacheHit:
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = json.dumps(cached)
             with patch.dict("os.environ", {}, clear=True):
-                with patch("utils.conversations.location.requests") as mock_req:
+                with patch("utils.conversations.location.httpx") as mock_httpx:
                     result = get_google_maps_location(37.785, -122.409)
-                    mock_req.get.assert_not_called()
+                    mock_httpx.get.assert_not_called()
         assert result is not None
 
 
@@ -118,10 +120,10 @@ class TestCacheMiss:
         }
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = api_response
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -139,10 +141,10 @@ class TestCacheMiss:
     def test_api_no_results_returns_none(self):
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {"status": "OK", "results": []}
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -165,10 +167,10 @@ class TestRedisFailure:
         }
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.side_effect = ConnectionError("Redis down")
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = api_response
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 with patch("utils.conversations.location.logging") as mock_log:
                     result = get_google_maps_location(37.785, -122.409)
@@ -191,10 +193,10 @@ class TestRedisFailure:
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
             mock_r.set.side_effect = ConnectionError("Redis down")
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = api_response
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 with patch("utils.conversations.location.logging") as mock_log:
                     result = get_google_maps_location(37.785, -122.409)
@@ -211,10 +213,10 @@ class TestApiEdgeCases:
         """Non-OK status (e.g. ZERO_RESULTS, OVER_QUERY_LIMIT) returns None."""
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {"status": "ZERO_RESULTS", "results": []}
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -225,13 +227,13 @@ class TestApiEdgeCases:
         """Result with no place_id returns None."""
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {
                     "status": "OK",
                     "results": [{"place_id": None, "formatted_address": "Nowhere", "types": []}],
                 }
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -241,13 +243,13 @@ class TestApiEdgeCases:
         """Result with no place_id key at all returns None."""
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {
                     "status": "OK",
                     "results": [{"formatted_address": "No ID St", "types": ["route"]}],
                 }
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -257,13 +259,13 @@ class TestApiEdgeCases:
         """Result with no types gives location_type=None."""
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {
                     "status": "OK",
                     "results": [{"place_id": "ChIJ_notype", "formatted_address": "No Type St", "types": []}],
                 }
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -274,13 +276,13 @@ class TestApiEdgeCases:
         """Result with no 'types' key at all gives location_type=None."""
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = None
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = {
                     "status": "OK",
                     "results": [{"place_id": "ChIJ_nokey", "formatted_address": "No Key St"}],
                 }
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 result = get_google_maps_location(37.785, -122.409)
 
@@ -305,10 +307,10 @@ class TestCorruptCache:
         }
         with patch("utils.conversations.location.r") as mock_r:
             mock_r.get.return_value = "not-valid-json{{"
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = api_response
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 with patch("utils.conversations.location.logging") as mock_log:
                     result = get_google_maps_location(37.785, -122.409)
@@ -332,10 +334,10 @@ class TestCorruptCache:
         with patch("utils.conversations.location.r") as mock_r:
             # Missing required 'latitude' and 'longitude' fields
             mock_r.get.return_value = json.dumps({"bad_field": "bad_value"})
-            with patch("utils.conversations.location.requests") as mock_req:
+            with patch("utils.conversations.location.httpx") as mock_httpx:
                 mock_resp = MagicMock()
                 mock_resp.json.return_value = api_response
-                mock_req.get.return_value = mock_resp
+                mock_httpx.get.return_value = mock_resp
 
                 with patch("utils.conversations.location.logging") as mock_log:
                     result = get_google_maps_location(37.785, -122.409)


### PR DESCRIPTION
## Summary
- add the current `get_maps_semaphore` symbol to the `utils.http_client` stub used by geocoding cache tests
- update sync geocoding tests to patch `utils.conversations.location.httpx`, matching the current implementation
- keep cache-hit assertions verifying that no Google Maps API call is made

## Why
`test_geocoding_cache.py` had stale test scaffolding. `utils.conversations.location` now imports `get_maps_semaphore` and uses `httpx.get` in the sync geocoding path, so a lean Windows test environment failed collection first and then failed runtime patching against the removed `requests` attribute.

## Verification
- `python -m pytest tests\unit\test_geocoding_cache.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_geocoding_cache.py -q --tb=short`
- `python -m pytest tests\unit\test_geocoding_cache.py tests\unit\test_async_geocoding.py -q --tb=short`
- `python -m py_compile tests\unit\test_geocoding_cache.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_geocoding_cache.py --check`
- `git diff --check`