### PR TITLE
test(backend): allow auth redirect tests without jinja

### DIFF
--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,6 +42,13 @@ os.environ.setdefault("BASE_API_URL", "http://localhost:8080")
 _mock = MagicMock()
 for mod in ['firebase_admin.auth', 'database.redis_db', 'utils.http_client', 'utils.log_sanitizer']:
     sys.modules.setdefault(mod, _mock)
+
+try:
+    import jinja2  # noqa: F401
+except ImportError:
+    _templating_mod = types.ModuleType("fastapi.templating")
+    _templating_mod.Jinja2Templates = MagicMock(return_value=MagicMock())
+    sys.modules["fastapi.templating"] = _templating_mod
 
 # Allow importing ``backend.routers.auth`` without running the full backend
 # entrypoint — same trick the rest of tests/unit uses.
@@ -288,6 +296,7 @@ class TestCallbackTemplateRendering:
 
     def test_template_uses_dynamic_redirect_uri(self):
         """Verify auth_callback.html renders with the session's redirect_uri, not hardcoded."""
+        pytest.importorskip("jinja2")
         from jinja2 import Environment, FileSystemLoader
         import pathlib
 
@@ -306,6 +315,7 @@ class TestCallbackTemplateRendering:
 
     def test_template_json_escapes_redirect_uri(self):
         """Verify redirect_uri is JSON-escaped in the template (XSS prevention)."""
+        pytest.importorskip("jinja2")
         from jinja2 import Environment, FileSystemLoader
         import pathlib
 
@@ -323,6 +333,7 @@ class TestCallbackTemplateRendering:
 
     def test_template_defaults_when_redirect_uri_missing(self):
         """Verify template falls back to omi://auth/callback when redirect_uri not provided."""
+        pytest.importorskip("jinja2")
         from jinja2 import Environment, FileSystemLoader
         import pathlib
 


### PR DESCRIPTION
## Summary
- stub `fastapi.templating.Jinja2Templates` during router import when `jinja2` is not installed
- keep the actual callback template rendering tests active in full dependency environments via `pytest.importorskip("jinja2")`
- let redirect URI and auth code binding tests run in lean local test environments

## Why
`test_auth_redirect_uri.py` primarily validates redirect URI allowlisting and auth-code binding behavior, but importing `routers.auth` requires `Jinja2Templates`. In a lean Windows test environment without the full backend requirements installed, collection failed before those unit tests could run. The template-specific tests still execute when `jinja2` is present.

## Verification
- `python -m pytest tests\unit\test_auth_redirect_uri.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_auth_redirect_uri.py -q --tb=short` (`43 passed, 3 skipped` without local Jinja2)
- `python -m pytest tests\unit\test_auth_redirect_uri.py tests\unit\test_async_auth.py -q --tb=short` (`51 passed, 3 skipped` without local Jinja2)
- `python -m py_compile tests\unit\test_auth_redirect_uri.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_auth_redirect_uri.py --check`
- `git diff --check`