### PR TITLE
test(backend): stub fair use classifier llm deps

### DIFF
--- a/backend/tests/unit/test_fair_use_classifier.py
+++ b/backend/tests/unit/test_fair_use_classifier.py
@@ -32,6 +32,14 @@ _llm_clients = types.ModuleType('utils.llm.clients')
 _llm_clients.llm_mini = MagicMock()
 sys.modules.setdefault('utils.llm.clients', _llm_clients)
 
+_langchain_openai = types.ModuleType('langchain_openai')
+_langchain_openai.ChatOpenAI = MagicMock(return_value=_llm_clients.llm_mini)
+sys.modules['langchain_openai'] = _langchain_openai
+
+_usage_tracker = types.ModuleType('utils.llm.usage_tracker')
+_usage_tracker.get_usage_callback = MagicMock(return_value=MagicMock())
+sys.modules['utils.llm.usage_tracker'] = _usage_tracker
+
 import utils.llm.fair_use_classifier as classifier_mod
 
 


### PR DESCRIPTION
## Summary
- add a minimal `langchain_openai.ChatOpenAI` stub for `test_fair_use_classifier.py`
- route the import-time classifier LLM instance to the test's existing `_llm_clients.llm_mini` mock
- stub `utils.llm.usage_tracker.get_usage_callback` so collection does not require the full LLM usage stack in lean environments

## Why
`utils.llm.fair_use_classifier` now imports `ChatOpenAI` and constructs `_classifier_llm` at module import. In a lean Windows test environment without the full backend requirements installed, `test_fair_use_classifier.py` failed during collection before its async LLM response mocks could run.

## Verification
- `python -m pytest tests\unit\test_fair_use_classifier.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_fair_use_classifier.py -q --tb=short`
- `python -m pytest tests\unit\test_fair_use_classifier.py tests\unit\test_fair_use_models.py -q --tb=short`
- `python -m pytest tests\unit\test_fair_use_engine.py -q --tb=short`
- `python -m py_compile tests\unit\test_fair_use_classifier.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_fair_use_classifier.py --check`
- `git diff --check`