### PR TITLE
fix dead null-aware expression in photo hero tag

### DIFF
--- a/app/lib/widgets/photo_viewer_page.dart
+++ b/app/lib/widgets/photo_viewer_page.dart
@@ -63,7 +63,7 @@ class _PhotoViewerPageState extends State<PhotoViewerPage> {
                     imageProvider: MemoryImage(imageBytes),
                     minScale: PhotoViewComputedScale.contained,
                     maxScale: PhotoViewComputedScale.covered * 4,
-                    heroAttributes: PhotoViewHeroAttributes(tag: photo.id ?? index.toString()),
+                    heroAttributes: PhotoViewHeroAttributes(tag: photo.id),
                   );
                 },
                 scrollPhysics: const BouncingScrollPhysics(),


### PR DESCRIPTION
## Summary
- `ConversationPhoto.id` is a non-nullable `String`, so the `?? index.toString()` fallback in `PhotoViewHeroAttributes` could never execute
- Removed the dead null-aware expression to fix the `dead_null_aware_expression` lint warning

## Test plan
- [ ] Open a conversation with photos and confirm the photo viewer opens and hero animations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)