### PR TITLE
test(backend): isolate tts model package imports

### DIFF
--- a/backend/tests/unit/test_tts.py
+++ b/backend/tests/unit/test_tts.py
@@ -40,6 +40,15 @@ def _stub_package(name):
     return mod
 
 
+def _restore_real_package(name, path):
+    mod = sys.modules.get(name)
+    if mod is None or not getattr(mod, "__path__", None):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod.__path__ = [str(path)]
+    return mod
+
+
 # ---------------------------------------------------------------------------
 # Stub heavy deps pulled in transitively by routers.tts → database.redis_db
 # ---------------------------------------------------------------------------
@@ -88,8 +97,12 @@ def _load_tts_router_module():
     log_sanitizer_stub.sanitize = lambda s: str(s)
     sys.modules["utils.log_sanitizer"] = log_sanitizer_stub
 
-    # Stub models.tts (real module is safe — pure pydantic)
+    # Use the real models.tts module even if an earlier test installed a package stub.
     sys.path.insert(0, str(BACKEND_DIR))
+    _restore_real_package("models", BACKEND_DIR / "models")
+    existing_tts_model = sys.modules.get("models.tts")
+    if existing_tts_model is not None and not getattr(existing_tts_model, "__file__", None):
+        del sys.modules["models.tts"]
 
     spec = importlib.util.spec_from_file_location(
         "routers.tts",


### PR DESCRIPTION
## Summary
- make `test_tts.py` restore the real `models` package path before importing `routers.tts`
- clear stale stubbed `models.tts` modules so the pure Pydantic TTS model can load after earlier tests install package stubs
- keep the existing router collaborators stubbed while making TTS tests collection-order independent

## Why
On Windows in a lean backend test environment, collecting `test_merge_validation.py` before `test_tts.py` left `sys.modules["models"]` as a stub package with an empty `__path__`. `test_tts.py` then failed during collection with `ModuleNotFoundError: No module named 'models.tts'` even though the focused TTS test file passes by itself.

## Verification
- `python -m pytest tests\unit\test_merge_validation.py tests\unit\test_tts.py --collect-only -q --tb=short` -> `50 tests collected`
- `python -m pytest tests\unit\test_merge_validation.py tests\unit\test_tts.py -q --tb=short` -> `50 passed`
- `python -m pytest tests\unit\test_tts.py -q --tb=short` -> `14 passed`
- `python -m py_compile tests\unit\test_tts.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_tts.py --check`
- `git diff --check -- backend/tests/unit/test_tts.py`