### PR TITLE
test(backend): isolate twilio service imports

### DIFF
--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -1,9 +1,7 @@
 import os
-import sys
-import types
 from unittest.mock import patch
 
-from tests.unit.twilio_stub import ensure_real_twilio_service_package, install_twilio_stub, restore_backend_package
+from tests.unit.twilio_stub import install_phone_calls_stub, install_twilio_stub, prepare_twilio_service_import
 
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
@@ -11,27 +9,14 @@ os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
 install_twilio_stub()
-ensure_real_twilio_service_package()
+prepare_twilio_service_import()
 
 
 # Stub `database.phone_calls` before twilio_service tries to import it so we can
 # unit-test delete_user_caller_ids without dragging in firebase_admin and the
 # rest of the database init chain. The real implementation only uses
 # `get_phone_numbers`, which the tests override per-case via patch.object.
-def _install_phone_calls_stub():
-    database_module = restore_backend_package('database')
-    if 'database.phone_calls' not in sys.modules:
-        stub = types.ModuleType('database.phone_calls')
-
-        def get_phone_numbers(uid):
-            return []
-
-        stub.get_phone_numbers = get_phone_numbers
-        sys.modules['database.phone_calls'] = stub
-        setattr(database_module, 'phone_calls', stub)
-
-
-_install_phone_calls_stub()
+install_phone_calls_stub()
 
 from utils import twilio_service
 from database import phone_calls as phone_calls_db  # noqa: E402  (stub above)

--- a/backend/tests/unit/test_twilio_account_deletion.py
+++ b/backend/tests/unit/test_twilio_account_deletion.py
@@ -3,7 +3,7 @@ import sys
 import types
 from unittest.mock import patch
 
-from tests.unit.twilio_stub import install_twilio_stub
+from tests.unit.twilio_stub import ensure_real_twilio_service_package, install_twilio_stub, restore_backend_package
 
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
@@ -11,6 +11,7 @@ os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
 install_twilio_stub()
+ensure_real_twilio_service_package()
 
 
 # Stub `database.phone_calls` before twilio_service tries to import it so we can
@@ -18,8 +19,7 @@ install_twilio_stub()
 # rest of the database init chain. The real implementation only uses
 # `get_phone_numbers`, which the tests override per-case via patch.object.
 def _install_phone_calls_stub():
-    if 'database' not in sys.modules:
-        sys.modules['database'] = types.ModuleType('database')
+    database_module = restore_backend_package('database')
     if 'database.phone_calls' not in sys.modules:
         stub = types.ModuleType('database.phone_calls')
 
@@ -28,7 +28,7 @@ def _install_phone_calls_stub():
 
         stub.get_phone_numbers = get_phone_numbers
         sys.modules['database.phone_calls'] = stub
-        setattr(sys.modules['database'], 'phone_calls', stub)
+        setattr(database_module, 'phone_calls', stub)
 
 
 _install_phone_calls_stub()

--- a/backend/tests/unit/test_twilio_service.py
+++ b/backend/tests/unit/test_twilio_service.py
@@ -1,9 +1,7 @@
 import os
-import sys
-import types
 from unittest.mock import patch, MagicMock
 
-from tests.unit.twilio_stub import ensure_real_twilio_service_package, install_twilio_stub, restore_backend_package
+from tests.unit.twilio_stub import install_phone_calls_stub, install_twilio_stub, prepare_twilio_service_import
 
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
@@ -11,19 +9,8 @@ os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
 install_twilio_stub()
-ensure_real_twilio_service_package()
-
-
-def _install_phone_calls_stub():
-    database_module = restore_backend_package('database')
-    if 'database.phone_calls' not in sys.modules:
-        stub = types.ModuleType('database.phone_calls')
-        stub.get_phone_numbers = lambda uid: []
-        sys.modules['database.phone_calls'] = stub
-        setattr(database_module, 'phone_calls', stub)
-
-
-_install_phone_calls_stub()
+prepare_twilio_service_import()
+install_phone_calls_stub()
 
 from utils.twilio_service import generate_access_token, validate_twilio_signature
 

--- a/backend/tests/unit/test_twilio_service.py
+++ b/backend/tests/unit/test_twilio_service.py
@@ -3,7 +3,7 @@ import sys
 import types
 from unittest.mock import patch, MagicMock
 
-from tests.unit.twilio_stub import install_twilio_stub
+from tests.unit.twilio_stub import ensure_real_twilio_service_package, install_twilio_stub, restore_backend_package
 
 os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
 os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
@@ -11,15 +11,11 @@ os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
 os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
 os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
 install_twilio_stub()
+ensure_real_twilio_service_package()
 
 
 def _install_phone_calls_stub():
-    database_module = sys.modules.get('database')
-    if database_module is None:
-        database_module = types.ModuleType('database')
-        sys.modules['database'] = database_module
-    if not hasattr(database_module, '__path__'):
-        database_module.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'database'))]
+    database_module = restore_backend_package('database')
     if 'database.phone_calls' not in sys.modules:
         stub = types.ModuleType('database.phone_calls')
         stub.get_phone_numbers = lambda uid: []

--- a/backend/tests/unit/twilio_stub.py
+++ b/backend/tests/unit/twilio_stub.py
@@ -16,7 +16,7 @@ def restore_backend_package(package_name):
     return package_module
 
 
-def ensure_real_twilio_service_package():
+def prepare_twilio_service_import():
     utils_module = restore_backend_package('utils')
     twilio_service_module = sys.modules.get('utils.twilio_service')
     if twilio_service_module is None:
@@ -30,6 +30,16 @@ def ensure_real_twilio_service_package():
     sys.modules.pop('utils.twilio_service', None)
     if getattr(utils_module, 'twilio_service', None) is twilio_service_module:
         delattr(utils_module, 'twilio_service')
+
+
+def install_phone_calls_stub():
+    database_module = restore_backend_package('database')
+    if 'database.phone_calls' not in sys.modules:
+        stub = types.ModuleType('database.phone_calls')
+        stub.get_phone_numbers = lambda uid: []
+        sys.modules['database.phone_calls'] = stub
+        setattr(database_module, 'phone_calls', stub)
+    return sys.modules['database.phone_calls']
 
 
 def install_twilio_stub():

--- a/backend/tests/unit/twilio_stub.py
+++ b/backend/tests/unit/twilio_stub.py
@@ -1,7 +1,35 @@
+import os
 import importlib.util
 import sys
 import types
 from html import escape
+
+BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def restore_backend_package(package_name):
+    package_module = sys.modules.get(package_name)
+    if package_module is None:
+        package_module = types.ModuleType(package_name)
+        sys.modules[package_name] = package_module
+    package_module.__path__ = [os.path.join(BACKEND_DIR, package_name)]
+    return package_module
+
+
+def ensure_real_twilio_service_package():
+    utils_module = restore_backend_package('utils')
+    twilio_service_module = sys.modules.get('utils.twilio_service')
+    if twilio_service_module is None:
+        return
+
+    real_service_path = os.path.join(BACKEND_DIR, 'utils', 'twilio_service.py')
+    module_file = getattr(twilio_service_module, '__file__', None)
+    if module_file is not None and os.path.abspath(module_file) == real_service_path:
+        return
+
+    sys.modules.pop('utils.twilio_service', None)
+    if getattr(utils_module, 'twilio_service', None) is twilio_service_module:
+        delattr(utils_module, 'twilio_service')
 
 
 def install_twilio_stub():


### PR DESCRIPTION
## Summary
- restore the real backend `utils` package before Twilio service test imports when earlier unit tests leave a stubbed `utils` package in `sys.modules`
- share the backend package restoration helper through `tests/unit/twilio_stub.py`
- keep the `database.phone_calls` stub isolated while still preserving the real backend package path

## Why
On Windows/local pytest runs, collecting some tests before the Twilio service tests can leave `utils.__path__ = []`. The Twilio tests then fail during collection with `ModuleNotFoundError: No module named 'utils.twilio_service'` / `ImportError: cannot import name 'twilio_service' from 'utils'` even though the focused Twilio tests pass alone.

## Verification
- `python -m pytest tests\unit\test_action_item_date_validation.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_conversation_structure_timezone.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q --tb=short`
- `python -m pytest tests\unit\test_action_item_date_validation.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q --tb=short`
- `python -m pytest tests\unit\test_desktop_migration.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_desktop_migration.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q --tb=short`
- `python -m py_compile tests\unit\twilio_stub.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py`
- `python -m black --check tests\unit\twilio_stub.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py`
- `git diff --check`