### PR TITLE
test(backend): make conversation timezone tests portable

### DIFF
--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -14,7 +14,7 @@ import importlib.util
 import os
 import sys
 import types
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -100,6 +100,32 @@ conv_proc = _load_module_from_file(
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",
 )
 
+# Keep timezone assertions independent of host OS tzdata, which is often absent on Windows test environments.
+
+
+class _NewYorkTestZone(tzinfo):
+    def utcoffset(self, dt):
+        return timedelta(hours=-4 if dt is not None and dt.month == 7 else -5)
+
+    def dst(self, dt):
+        return timedelta(hours=1 if dt is not None and dt.month == 7 else 0)
+
+    def tzname(self, dt):
+        return "EDT" if dt is not None and dt.month == 7 else "EST"
+
+
+def _test_zone_info(name):
+    if name == "Pacific/Honolulu":
+        return timezone(timedelta(hours=-10), name)
+    if name == "America/New_York":
+        return _NewYorkTestZone()
+    if name == "UTC":
+        return timezone.utc
+    raise KeyError(name)
+
+
+conv_proc.ZoneInfo = _test_zone_info
+
 
 # ===========================================================================
 # _local_started_at_iso unit tests (pure conversion logic)
@@ -163,9 +189,7 @@ def _capture_structure(fn, **kwargs):
 
     with patch.object(conv_proc, "get_llm", return_value=mock_llm), patch.object(
         conv_proc, "ChatPromptTemplate"
-    ) as mock_prompt_cls, patch.object(conv_proc, "get_user_name", return_value="Test User"), patch.object(
-        conv_proc, "_build_conversation_context", return_value="ctx"
-    ):
+    ) as mock_prompt_cls, patch.object(conv_proc, "_build_conversation_context", return_value="ctx"):
         mock_prompt = MagicMock()
         mock_prompt.__or__ = MagicMock(return_value=mock_chain)
         mock_prompt_cls.from_messages.return_value = mock_prompt

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -103,7 +103,9 @@ conv_proc = _load_module_from_file(
 # Keep timezone assertions independent of host OS tzdata, which is often absent on Windows test environments.
 
 
-class _NewYorkTestZone(tzinfo):
+class _JulyOnlyNewYorkTestZone(tzinfo):
+    """Minimal test zone: only the current July DST case needs EDT behavior."""
+
     def utcoffset(self, dt):
         return timedelta(hours=-4 if dt is not None and dt.month == 7 else -5)
 
@@ -118,7 +120,7 @@ def _test_zone_info(name):
     if name == "Pacific/Honolulu":
         return timezone(timedelta(hours=-10), name)
     if name == "America/New_York":
-        return _NewYorkTestZone()
+        return _JulyOnlyNewYorkTestZone()
     if name == "UTC":
         return timezone.utc
     raise KeyError(name)


### PR DESCRIPTION
## Summary
- make `test_conversation_structure_timezone.py` independent of host OS timezone database availability
- inject deterministic test timezone objects for Honolulu, New York, and UTC
- remove an obsolete patch for `conv_proc.get_user_name`, which is no longer defined in `conversation_processing.py`

## Why
On Windows dev/test environments without system IANA tzdata available, `ZoneInfo('Pacific/Honolulu')`, `ZoneInfo('America/New_York')`, and even `ZoneInfo('UTC')` can fail. This made the timezone unit test fall back to UTC and fail even though the test only needs deterministic timezone behavior.

## Verification
- `python -m pytest tests\unit\test_conversation_structure_timezone.py -q --tb=short`
- `python -m pytest tests\unit\test_action_item_date_validation.py tests\unit\test_conversation_structure_timezone.py --collect-only -q --tb=short`
- `python -m pytest tests\unit\test_action_item_date_validation.py tests\unit\test_conversation_structure_timezone.py -q --tb=short`
- `python -m py_compile tests\unit\test_conversation_structure_timezone.py`
- `python -m black --check tests\unit\test_conversation_structure_timezone.py`
- `git diff --check`