### PR TITLE
test(backend): keep async webhook redis stub cache-compatible

### DIFF
--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -27,6 +27,8 @@ _db_redis.user_webhook_status_db = MagicMock(return_value=True)
 _db_redis.disable_user_webhook_db = MagicMock()
 _db_redis.enable_user_webhook_db = MagicMock()
 _db_redis.set_user_webhook_db = MagicMock()
+_db_redis.get_generic_cache = MagicMock(return_value=None)
+_db_redis.set_generic_cache = MagicMock()
 _db_redis.r = MagicMock()
 
 _backend_dir = os.path.join(os.path.dirname(__file__), '..', '..')


### PR DESCRIPTION
## Summary
- add the generic cache helpers expected by `routers.firmware` to the `database.redis_db` stub installed by `test_async_webhooks.py`
- keep `test_firmware_pagination.py` collection-order independent when async webhook tests are collected first
- leave production code unchanged

## Why
On Windows in a lean backend test environment, `test_async_webhooks.py` replaces `sys.modules["database.redis_db"]` during collection with a webhook-focused stub. When `test_firmware_pagination.py` is collected later in the same pytest process, importing `routers.firmware` fails because that stub lacks `get_generic_cache` / `set_generic_cache`.

## Verification
- `python -m pytest tests\unit\test_async_webhooks.py tests\unit\test_firmware_pagination.py --collect-only -q --tb=short` -> `59 tests collected`
- `python -m pytest tests\unit\test_async_webhooks.py tests\unit\test_firmware_pagination.py -q --tb=short` -> `59 passed`
- `python -m py_compile tests\unit\test_async_webhooks.py tests\unit\test_firmware_pagination.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_async_webhooks.py tests\unit\test_firmware_pagination.py --check`
- `git diff --check`