### PR TITLE
test(backend): isolate mcp tests from partial stubs

### DIFF
--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -77,11 +77,20 @@ _stubs = [
     'utils.llm.chat',
     'utils.log_sanitizer',
     'utils.executors',
+    'dependencies',
 ]
 for mod_name in _stubs:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = _AutoMockModule(mod_name)
 
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+sys.modules['utils.executors'].db_executor = MagicMock()
+sys.modules['utils.executors'].postprocess_executor = MagicMock()
+sys.modules['utils.llm.memories'].identify_category_for_memory = MagicMock(return_value='other')
 sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
 sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenError', (Exception,), {})
 sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -71,11 +71,20 @@ _stubs = [
     'utils.llm.chat',
     'utils.log_sanitizer',
     'utils.executors',
+    'dependencies',
 ]
 for mod_name in _stubs:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = _AutoMockModule(mod_name)
 
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+sys.modules['utils.executors'].db_executor = MagicMock()
+sys.modules['utils.executors'].postprocess_executor = MagicMock()
+sys.modules['utils.llm.memories'].identify_category_for_memory = MagicMock(return_value='other')
 sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
 sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenError', (Exception,), {})
 sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})


### PR DESCRIPTION
## Summary
- make MCP data endpoint tests tolerate partial `utils.apps`, `utils.executors`, `utils.llm.memories`, `utils.other.endpoints`, and `dependencies` stubs left by earlier unit-test collection
- cover both `test_mcp_data_endpoints.py` and `test_mcp_search_memories.py`, which import `routers.mcp` / `routers.mcp_sse`
- leave production MCP code unchanged

## Why
On Windows in a lean backend test environment, broad unit collection can leave plain stub modules in `sys.modules` before the MCP tests are collected. Those stubs do not provide import-time symbols required by `routers.mcp`, such as `update_personas_async`, executor pools, category identification, FastAPI dependency helpers, and MCP auth dependencies. Focused MCP tests pass alone, but full-suite collection reports both MCP files as import errors.

## Verification
- `python -m pytest tests\unit\test_mcp_data_endpoints.py tests\unit\test_mcp_search_memories.py -q --tb=short` -> `39 passed, 1 warning`
- simulated incomplete `dependencies`, `utils.apps`, `utils.executors`, `utils.llm.memories`, and `utils.other.endpoints` modules before importing both MCP test files -> `mcp_import_probe=ok`
- `python -m py_compile tests\unit\test_mcp_data_endpoints.py tests\unit\test_mcp_search_memories.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_mcp_data_endpoints.py tests\unit\test_mcp_search_memories.py --check`
- `git diff --check`
- broad `python -m pytest tests\unit --collect-only -q --tb=short --continue-on-collection-errors` still has unrelated collection errors, but no longer reports `test_mcp_data_endpoints.py` or `test_mcp_search_memories.py`