### PR TITLE
test(backend): isolate folder enrichment render import

### DIFF
--- a/backend/tests/unit/test_folder_name_enrichment.py
+++ b/backend/tests/unit/test_folder_name_enrichment.py
@@ -3,6 +3,8 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
@@ -14,6 +16,16 @@ def _stub_module(name):
         mod = types.ModuleType(name)
         sys.modules[name] = mod
     return sys.modules[name]
+
+
+def _ensure_package_path(name, path):
+    mod = _stub_module(name)
+    mod.__path__ = [path]
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = _stub_module(parent_name)
+        setattr(parent, attr_name, mod)
+    return mod
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +112,10 @@ sys.modules["utils.scopes"].validate_scopes = MagicMock()
 
 # utils.conversations.render imports database.folders and database.users
 # which are already stubbed above — no additional stubs needed.
+
+_ensure_package_path("utils", os.path.join(BACKEND_DIR, "utils"))
+_ensure_package_path("utils.conversations", os.path.join(BACKEND_DIR, "utils", "conversations"))
+sys.modules.pop("utils.conversations.render", None)
 
 _stub_module("utils.llm")
 _stub_module("utils.llm.memories")


### PR DESCRIPTION
## Summary
- restore the real backend `utils` and `utils.conversations` package paths before importing `utils.conversations.render` in `test_folder_name_enrichment.py`
- clear any stale `utils.conversations.render` module left by earlier collection stubs
- keep the existing database/user/folder stubs in place and leave production code unchanged

## Why
On Windows in a lean backend test environment, broad unit collection can leave `utils` / `utils.conversations` as stub packages with empty `__path__`. `test_folder_name_enrichment.py` passes alone, but after that pollution it fails during collection with `ModuleNotFoundError: No module named 'utils.conversations.render'`.

## Verification
- `python -m pytest tests\unit\test_folder_name_enrichment.py -q --tb=short` -> `19 passed`
- simulated empty `utils` and `utils.conversations` packages before importing the test file -> `folder_import_probe=ok`
- `python -m py_compile tests\unit\test_folder_name_enrichment.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_folder_name_enrichment.py --check`
- `git diff --check`
- broad `python -m pytest tests\unit --collect-only -q --tb=short --continue-on-collection-errors` still has unrelated collection errors from other files, but no longer reports `test_folder_name_enrichment.py`