### PR TITLE
test(backend): isolate desktop updates redis cache stubs

### DIFF
--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -18,6 +18,11 @@ sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
 sys.modules.setdefault('google.auth', MagicMock())
 sys.modules.setdefault('google.auth.transport.requests', MagicMock())
 
+redis_db_stub = sys.modules.setdefault('database.redis_db', MagicMock())
+redis_db_stub.get_generic_cache = MagicMock(return_value=None)
+redis_db_stub.set_generic_cache = MagicMock()
+redis_db_stub.delete_generic_cache = MagicMock()
+
 from fastapi import FastAPI
 
 from routers.updates import (


### PR DESCRIPTION
## Summary
- add explicit Redis cache helper stubs for desktop update tests
- keep `routers.updates` import stable when earlier tests pre-populate a partial `database.redis_db` module

## Tests
- `python -m pytest tests\unit\test_desktop_updates.py -q --tb=short`
- `python -m pytest tests\unit\test_rate_limiting.py tests\unit\test_desktop_updates.py -q --tb=short`
- `python -m py_compile tests\unit\test_desktop_updates.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_desktop_updates.py --check`
- `git diff --check`
- `python -m pytest tests\unit --collect-only -q` still reports existing unrelated collection errors, but `test_desktop_updates.py` now collects its 57 tests instead of failing on `database.redis_db.get_generic_cache`.