### PR TITLE
test(backend): isolate action item dedup imports

### DIFF
--- a/backend/tests/unit/test_action_item_dedup.py
+++ b/backend/tests/unit/test_action_item_dedup.py
@@ -9,6 +9,8 @@ context" rather than failing the whole conversation pipeline), and
 (d) preserve match order from Pinecone (most-similar first).
 """
 
+import importlib.util
+import os
 import sys
 import types
 from unittest.mock import MagicMock
@@ -46,13 +48,16 @@ sys.modules['google.cloud.firestore'].FieldFilter = MagicMock
 sys.modules['google.cloud.firestore'].Query = MagicMock
 sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
 
-if 'utils.llm.clients' not in sys.modules:
-    clients_stub = types.ModuleType('utils.llm.clients')
-    clients_stub.embeddings = MagicMock()
-    sys.modules['utils.llm.clients'] = clients_stub
+clients_stub = sys.modules.setdefault('utils.llm.clients', types.ModuleType('utils.llm.clients'))
+clients_stub.embeddings = MagicMock()
 
-
-from database import vector_db  # noqa: E402
+_backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_vector_db_path = os.path.join(_backend_dir, 'database', 'vector_db.py')
+_vector_db_spec = importlib.util.spec_from_file_location('action_item_dedup_vector_db', _vector_db_path)
+if _vector_db_spec is None or _vector_db_spec.loader is None:
+    raise ImportError(f'Unable to load vector_db from {_vector_db_path}')
+vector_db = importlib.util.module_from_spec(_vector_db_spec)
+_vector_db_spec.loader.exec_module(vector_db)
 
 
 def _setup_mocks(monkeypatch, *, index_none=False, query_response=None, embed_raises=None, query_raises=None):


### PR DESCRIPTION
## Summary
- load `backend/database/vector_db.py` into a private test module before `test_action_item_dedup.py` assertions run
- make the `utils.llm.clients` stub cache-compatible with earlier partial stubs by always providing `embeddings`
- avoid mutating the process-wide `database` package while leaving production vector DB code unchanged

## Why
In broad Windows/backend unit collection, earlier tests can leave partial `database` and `utils.llm.clients` modules in `sys.modules`. The focused action item dedup tests pass alone, but broad collection failed while importing `database.vector_db` with either `cannot import name 'vector_db' from 'database'` or a missing `embeddings` symbol.

## Tests
- `python -m pytest tests\unit\test_action_item_dedup.py -q --tb=short`
- import probe with pre-populated partial `database` and `utils.llm.clients` stubs; verifies the existing `database` stub is not given `__path__`
- `python -m py_compile tests\unit\test_action_item_dedup.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_action_item_dedup.py --check`
- `git diff --check`
- `python -m pytest tests\unit --collect-only -q` still reports unrelated existing collection errors, but `test_action_item_dedup.py` now collects its 9 tests instead of failing during import.