### PR TITLE
test(backend): isolate apps review reply stubs

### DIFF
--- a/backend/tests/unit/test_apps_review_reply_validation.py
+++ b/backend/tests/unit/test_apps_review_reply_validation.py
@@ -40,6 +40,12 @@ _STUB = (
 )
 
 
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            sys.modules.pop(name, None)
+
+
 class _AutoMock(types.ModuleType):
     __path__ = []
 
@@ -65,14 +71,13 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
 
 
 _finder = _Finder()
+_clear_stubbed_modules()
 sys.meta_path.insert(0, _finder)
 try:
     from routers import apps as apps_mod
 finally:
     sys.meta_path.remove(_finder)
-    for _n in list(sys.modules):
-        if any(_n == p or _n.startswith(p + '.') for p in _STUB):
-            sys.modules.pop(_n, None)
+    _clear_stubbed_modules()
 
 from fastapi import HTTPException  # noqa: E402
 


### PR DESCRIPTION
## Summary
- clear the test's stubbed heavy namespaces before installing its auto-mock finder
- keep `test_apps_review_reply_validation.py` independent of stale `utils.notifications` stubs left by earlier test collection
- reuse the same cleanup helper after importing `routers.apps`, leaving production code unchanged

## Why
In broad Windows/backend unit collection, earlier tests can leave partial modules such as `utils.notifications` in `sys.modules`. That bypasses this test's stub finder and makes importing `routers.apps` fail with `ImportError: cannot import name 'send_notification' from 'utils.notifications'`. Focused runs already passed; this makes the test collection-order independent.

## Tests
- `python -m pytest tests\unit\test_apps_review_reply_validation.py -q --tb=short`
- import probe with pre-populated partial `utils` / `utils.notifications` stubs
- `python -m py_compile tests\unit\test_apps_review_reply_validation.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_apps_review_reply_validation.py --check`
- `git diff --check`
- `python -m pytest tests\unit --collect-only -q` still reports unrelated existing collection errors, but `test_apps_review_reply_validation.py` now collects its 4 tests instead of failing during import.