### PR TITLE
Desktop: fix chat scrollback stalling at 200 messages

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [
-    "Fixed chat history no longer loading older messages when scrolling back in long chats"
+    "Fixed older chat messages failing to load in long chats"
   ],
   "releases": [
     {

--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed chat history no longer loading older messages when scrolling back in long chats"
+  ],
   "releases": [
     {
       "version": "0.11.463",

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -600,7 +600,6 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @Published var showOmiThresholdAlert = false
 
     private let messagesPageSize = 50
-    private let maxMessagesInMemory = 200
     private var multiChatObserver: AnyCancellable?
     private var playwrightExtensionObserver: AnyCancellable?
     private var sessionGroupingObserver: AnyCancellable?
@@ -1269,6 +1268,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         isLoadingMoreMessages = true
 
         do {
+            // messages.count doubles as the server-side pagination offset (the backend
+            // pages newest-first), so loaded history must never be trimmed while a
+            // session is open — trimming makes every scroll re-fetch the same page.
             let offset = messages.count
             let olderMessages: [ChatMessageDB]
             if let sessionId = currentSessionId {
@@ -1285,18 +1287,17 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 )
             }
 
+            // New live messages shift the newest-first offset window, so a page can
+            // overlap messages we already hold — drop those before appending.
+            let existingIds = Set(messages.map(\.id))
             let newMessages = olderMessages.map(ChatMessage.init(from:))
+                .filter { !existingIds.contains($0.id) }
 
             // Append older messages and re-sort to ensure correct chronological order
             messages.append(contentsOf: newMessages)
             messages.sort(by: { $0.createdAt < $1.createdAt })
 
-            // Cap memory usage: keep only the most recent messages
-            if messages.count > maxMessagesInMemory {
-                messages.removeFirst(messages.count - maxMessagesInMemory)
-            }
-
-            // Check if there are more
+            // Check if there are more (based on the raw page size, pre-dedupe)
             hasMoreMessages = olderMessages.count == messagesPageSize
             log("Loaded \(newMessages.count) more messages, total: \(messages.count), hasMore: \(hasMoreMessages)")
         } catch {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -604,6 +604,15 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Kept separate from messages.count: deduped pages and live messages merged by
     /// polling would otherwise stall or skew the offset.
     private var messagesPaginationOffset = 0
+
+    /// Reset history-pagination state. Must accompany every clear/replace of
+    /// `messages` outside the two loaders (`selectSession`,
+    /// `loadDefaultChatMessages`), which set both fields from a fresh fetch.
+    private func resetMessagesPagination() {
+        messagesPaginationOffset = 0
+        hasMoreMessages = false
+    }
+
     private var multiChatObserver: AnyCancellable?
     private var playwrightExtensionObserver: AnyCancellable?
     private var sessionGroupingObserver: AnyCancellable?
@@ -791,6 +800,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     await self.agentBridge.stop()
                     self.agentBridgeStarted = false
                     self.messages.removeAll()
+                    self.resetMessagesPagination()
                     self.pendingAttachments.removeAll()
                     self.sessions.removeAll()
                     self.currentSession = nil
@@ -1184,7 +1194,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             currentSession = session
             isInDefaultChat = false
             messages = []
-            hasMoreMessages = false
+            resetMessagesPagination()
             log("Created new chat session: \(session.id)")
             AnalyticsManager.shared.chatSessionCreated()
 
@@ -1260,7 +1270,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         } catch {
             logError("Failed to load messages for session", error: error)
             messages = []
-            messagesPaginationOffset = 0
+            resetMessagesPagination()
         }
 
         isLoading = false
@@ -1344,6 +1354,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 } else {
                     currentSession = nil
                     messages = []
+                    resetMessagesPagination()
                 }
             }
 
@@ -1929,6 +1940,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     func reinitialize() async {
         sessions = []
         messages = []
+        resetMessagesPagination()
         currentSession = nil
         isInDefaultChat = true
         await initialize()
@@ -2158,7 +2170,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         }
 
         messages = []
-        messagesPaginationOffset = 0
+        resetMessagesPagination()
         sessionsLoadError = lastError?.localizedDescription ?? "Failed to load messages. Check your connection and try again."
         isLoading = false
     }
@@ -3438,6 +3450,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         if isInDefaultChat {
             // Default chat mode: clear UI immediately, delete in background
             messages = []
+            resetMessagesPagination()
             log("Cleared default chat messages")
             Task {
                 do {
@@ -3456,6 +3469,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
             currentSession = nil
             messages = []
+            resetMessagesPagination()
 
             // Delete old session in background (don't await — backend is slow)
             if let session = sessionToDelete {
@@ -3485,6 +3499,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         selectedAppId = appId
         currentSession = nil
         messages = []
+        resetMessagesPagination()
         sessions = []
         errorMessage = nil
         isInDefaultChat = true

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1321,8 +1321,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 existingIds.formUnion(newMessages.map(\.id))
 
                 // Append older messages and re-sort to ensure correct chronological order
-                messages.append(contentsOf: newMessages)
-                messages.sort(by: { $0.createdAt < $1.createdAt })
+                if !newMessages.isEmpty {
+                    messages.append(contentsOf: newMessages)
+                    messages.sort(by: { $0.createdAt < $1.createdAt })
+                }
                 appendedCount += newMessages.count
 
                 // Check if there are more (based on the raw page size, pre-dedupe)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -600,6 +600,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @Published var showOmiThresholdAlert = false
 
     private let messagesPageSize = 50
+    /// Raw server records consumed by history pagination (the backend pages newest-first).
+    /// Kept separate from messages.count: deduped pages and live messages merged by
+    /// polling would otherwise stall or skew the offset.
+    private var messagesPaginationOffset = 0
     private var multiChatObserver: AnyCancellable?
     private var playwrightExtensionObserver: AnyCancellable?
     private var sessionGroupingObserver: AnyCancellable?
@@ -1249,12 +1253,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             )
             messages = persistedMessages.map(ChatMessage.init(from:))
                 .sorted(by: { $0.createdAt < $1.createdAt })
+            messagesPaginationOffset = persistedMessages.count
             // If we got a full page, there might be more messages
             hasMoreMessages = persistedMessages.count == messagesPageSize
             log("ChatProvider loaded \(messages.count) messages for session \(session.id), hasMore: \(hasMoreMessages)")
         } catch {
             logError("Failed to load messages for session", error: error)
             messages = []
+            messagesPaginationOffset = 0
         }
 
         isLoading = false
@@ -1268,10 +1274,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         isLoadingMoreMessages = true
 
         do {
-            // messages.count doubles as the server-side pagination offset (the backend
-            // pages newest-first), so loaded history must never be trimmed while a
-            // session is open — trimming makes every scroll re-fetch the same page.
-            let offset = messages.count
+            let offset = messagesPaginationOffset
             let olderMessages: [ChatMessageDB]
             if let sessionId = currentSessionId {
                 olderMessages = try await APIClient.shared.getMessages(
@@ -1286,6 +1289,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     offset: offset
                 )
             }
+
+            // Advance by raw records consumed — even when dedupe below drops some —
+            // so the next request can never re-issue the same window.
+            messagesPaginationOffset += olderMessages.count
 
             // New live messages shift the newest-first offset window, so a page can
             // overlap messages we already hold — drop those before appending.
@@ -2123,6 +2130,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 )
                 messages = persistedMessages.map(ChatMessage.init(from:))
                     .sorted(by: { $0.createdAt < $1.createdAt })
+                messagesPaginationOffset = persistedMessages.count
                 hasMoreMessages = persistedMessages.count == messagesPageSize
                 sessionsLoadError = nil
                 log("ChatProvider loaded \(messages.count) default chat messages, hasMore: \(hasMoreMessages)")
@@ -2138,6 +2146,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         }
 
         messages = []
+        messagesPaginationOffset = 0
         sessionsLoadError = lastError?.localizedDescription ?? "Failed to load messages. Check your connection and try again."
         isLoading = false
     }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1274,39 +1274,51 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         isLoadingMoreMessages = true
 
         do {
-            let offset = messagesPaginationOffset
-            let olderMessages: [ChatMessageDB]
-            if let sessionId = currentSessionId {
-                olderMessages = try await APIClient.shared.getMessages(
-                    sessionId: sessionId,
-                    limit: messagesPageSize,
-                    offset: offset
-                )
-            } else {
-                olderMessages = try await APIClient.shared.getMessages(
-                    appId: selectedAppId,
-                    limit: messagesPageSize,
-                    offset: offset
-                )
+            // A burst of live messages (e.g. from another device) shifts the
+            // newest-first window, so a fetched page can dedupe entirely to
+            // messages we already hold. Consume up to a few windows per call so
+            // one user action always yields visible progress; the cursor
+            // advances every iteration, so this terminates. Deliberately NOT
+            // derived from the local message count — overcounting (deletions,
+            // polling gaps) would overshoot and silently skip history, while a
+            // duplicate window only costs a redundant fetch.
+            var appendedCount = 0
+            for _ in 0..<3 {
+                let offset = messagesPaginationOffset
+                let olderMessages: [ChatMessageDB]
+                if let sessionId = currentSessionId {
+                    olderMessages = try await APIClient.shared.getMessages(
+                        sessionId: sessionId,
+                        limit: messagesPageSize,
+                        offset: offset
+                    )
+                } else {
+                    olderMessages = try await APIClient.shared.getMessages(
+                        appId: selectedAppId,
+                        limit: messagesPageSize,
+                        offset: offset
+                    )
+                }
+
+                // Advance by raw records consumed — even when dedupe below drops
+                // some — so the next request can never re-issue the same window.
+                messagesPaginationOffset += olderMessages.count
+
+                // Drop the window overlap before appending.
+                let existingIds = Set(messages.map(\.id))
+                let newMessages = olderMessages.map(ChatMessage.init(from:))
+                    .filter { !existingIds.contains($0.id) }
+
+                // Append older messages and re-sort to ensure correct chronological order
+                messages.append(contentsOf: newMessages)
+                messages.sort(by: { $0.createdAt < $1.createdAt })
+                appendedCount += newMessages.count
+
+                // Check if there are more (based on the raw page size, pre-dedupe)
+                hasMoreMessages = olderMessages.count == messagesPageSize
+                if appendedCount > 0 || !hasMoreMessages { break }
             }
-
-            // Advance by raw records consumed — even when dedupe below drops some —
-            // so the next request can never re-issue the same window.
-            messagesPaginationOffset += olderMessages.count
-
-            // New live messages shift the newest-first offset window, so a page can
-            // overlap messages we already hold — drop those before appending.
-            let existingIds = Set(messages.map(\.id))
-            let newMessages = olderMessages.map(ChatMessage.init(from:))
-                .filter { !existingIds.contains($0.id) }
-
-            // Append older messages and re-sort to ensure correct chronological order
-            messages.append(contentsOf: newMessages)
-            messages.sort(by: { $0.createdAt < $1.createdAt })
-
-            // Check if there are more (based on the raw page size, pre-dedupe)
-            hasMoreMessages = olderMessages.count == messagesPageSize
-            log("Loaded \(newMessages.count) more messages, total: \(messages.count), hasMore: \(hasMoreMessages)")
+            log("Loaded \(appendedCount) more messages, total: \(messages.count), hasMore: \(hasMoreMessages)")
         } catch {
             logError("Failed to load more messages", error: error)
         }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1293,6 +1293,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // polling gaps) would overshoot and silently skip history, while a
             // duplicate window only costs a redundant fetch.
             var appendedCount = 0
+            var existingIds = Set(messages.map(\.id))
             for _ in 0..<3 {
                 let offset = messagesPaginationOffset
                 let olderMessages: [ChatMessageDB]
@@ -1315,9 +1316,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 messagesPaginationOffset += olderMessages.count
 
                 // Drop the window overlap before appending.
-                let existingIds = Set(messages.map(\.id))
                 let newMessages = olderMessages.map(ChatMessage.init(from:))
                     .filter { !existingIds.contains($0.id) }
+                existingIds.formUnion(newMessages.map(\.id))
 
                 // Append older messages and re-sort to ensure correct chronological order
                 messages.append(contentsOf: newMessages)


### PR DESCRIPTION
## Summary

Fixes chat history scrollback silently breaking once a chat holds 200 messages in memory.

## Root cause

The backend (`/v2/desktop/messages`, `backend/database/chat.py`) pages messages **newest-first** with `limit`/`offset`. `ChatProvider.loadMoreMessages()` correctly used `messages.count` as the next offset — but then capped the in-memory array to `maxMessagesInMemory` (200) with `removeFirst`, which on an ascending-sorted array removes the **oldest** entries: exactly the page of older messages just fetched.

Once a chat reached 200 messages:

1. Load more → fetch `offset=200` → 50 older messages arrive → appended → immediately truncated away.
2. `messages.count` is back to 200 and `hasMoreMessages` stays `true` (full page received).
3. Next load → `offset=200` again → the **same page** is downloaded and discarded, forever.

User-visible effect: in any chat with >200 messages, loading older history stops working while the app endlessly re-fetches the same page. Both `ChatPage` and `DashboardPage` hit this path.

## Fix

- Remove the in-memory cap in `loadMoreMessages()` — the pagination cursor must not shrink while a session is open. `maxMessagesInMemory` was used only here, and ~hundreds of lightweight message structs are negligible memory. The array is still replaced on every session switch.
- Dedupe fetched pages by message `id` before appending — new live messages shift the newest-first offset window server-side, so a page can overlap messages already held.
- **Review follow-ups:** pagination now uses a dedicated `messagesPaginationOffset` cursor that advances by raw server records consumed (independent of dedupe and in-memory count), reset wherever the list is (re)loaded; and a single load action consumes up to three windows until new messages appear, so a stale cursor after a live-message burst from another device never looks like a dead button. The offset is deliberately not derived from local message counts, which could overshoot and silently skip history.

No backend changes; no behavior change for chats under 200 messages.

## Testing

- Logic traced end-to-end: Swift client → FastAPI route (`routers/chat_sessions.py`) → Firestore query (`database/chat.py`, `created_at DESC` + `limit`/`offset`).
- **Verified locally** on a named test bundle with a >200-message chat, on both the initial fix and the final cursor+loop build. Repeated loads progress past the old cap instead of freezing at 200 / re-fetching the same page:
  ```
  Loaded 50 more messages, total: 101, hasMore: true
  Loaded 50 more messages, total: 151, hasMore: true
  Loaded 50 more messages, total: 201, hasMore: true
  Loaded 50 more messages, total: 251, hasMore: true
  Loaded 50 more messages, total: 301, hasMore: true
  Loaded 50 more messages, total: 351, hasMore: true
  ```
- Lint & Format Check: green on all pushes.
- Review: Greptile P1 (offset/dedupe interaction) and both Copilot comments addressed; all review threads resolved.

## Scope note / follow-up

Loading older history is currently triggered by the explicit "Load earlier messages" control, not by scrolling to the top — this PR fixes the pagination bug behind that control and intentionally does not change the trigger UX. Possible follow-up: auto-trigger `loadMoreMessages()` via a top-of-list sentinel (or make the button more prominent).

https://claude.ai/code/session_01K6oBTTKdSzfrvKNg1yXnuB