### PR TITLE
test(backend): read timeout middleware source as utf-8

### DIFF
--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -234,7 +234,7 @@ def test_main_methods_timeout_includes_post():
     from pathlib import Path
 
     main_py = Path(__file__).resolve().parents[2] / "main.py"
-    tree = ast.parse(main_py.read_text())
+    tree = ast.parse(main_py.read_text(encoding="utf-8"), filename=str(main_py))
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:


### PR DESCRIPTION
## Summary
- read `backend/main.py` with explicit UTF-8 in the timeout middleware AST test
- include the source filename in `ast.parse` diagnostics
- keep production timeout middleware behavior unchanged

## Why
`test_timeout_middleware.py` includes a source-scanning assertion for `methods_timeout`. On Windows, Python may default to a non-UTF-8 locale such as cp936 when UTF-8 mode is disabled. Source-scanning tests should not depend on the host locale when reading Python source files.

## Tests
- `python -X utf8=0 -m pytest tests\unit\test_timeout_middleware.py -q --tb=short`
- `python -m py_compile tests\unit\test_timeout_middleware.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_timeout_middleware.py --check`
- `git diff --check`