### PR TITLE
fix remove unused imports and dead code from task integration files

### DIFF
--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -115,14 +115,6 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     SharedPreferencesUtil().taskGoalLinks = Map<String, String>.from(_taskGoalLinks);
   }
 
-  void _attachTaskToGoal(String taskId, String goalId) {
-    setState(() {
-      _taskGoalLinks[taskId] = goalId;
-    });
-    SharedPreferencesUtil().taskGoalLinks = Map<String, String>.from(_taskGoalLinks);
-    HapticFeedback.lightImpact();
-  }
-
   String? _getGoalTitleForTask(ActionItemWithMetadata item) {
     final goalId = _taskGoalLinks[item.id];
     if (goalId == null) return null;
@@ -827,46 +819,6 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
               ...goals.map((goal) => _buildGoalItem(goal, actionProvider)),
               const SizedBox(height: 8),
             ],
-          ),
-        );
-      },
-    );
-  }
-
-  Widget _buildGoalDropTile(Goal? goal) {
-    return DragTarget<ActionItemWithMetadata>(
-      onWillAcceptWithDetails: (details) => goal != null,
-      onAcceptWithDetails: (details) {
-        if (goal == null) return;
-        PlatformManager.instance.analytics.taskDraggedToGoal(taskId: details.data.id, goalId: goal.id);
-        _attachTaskToGoal(details.data.id, goal.id);
-      },
-      builder: (context, candidateData, rejectedData) {
-        final isHovering = candidateData.isNotEmpty && goal != null;
-        return AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          height: 64,
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-          decoration: BoxDecoration(
-            color: Colors.white.withOpacity(goal == null ? 0.04 : 0.08),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isHovering ? Colors.white.withOpacity(0.5) : Colors.white.withOpacity(0.08),
-              width: 1,
-            ),
-          ),
-          child: Center(
-            child: Text(
-              goal?.title ?? '',
-              textAlign: TextAlign.center,
-              maxLines: 3,
-              style: TextStyle(
-                color: goal == null ? Colors.white.withOpacity(0.2) : Colors.white.withOpacity(0.9),
-                fontSize: 12,
-                fontWeight: FontWeight.w500,
-                height: 1.2,
-              ),
-            ),
           ),
         );
       },

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -8,7 +8,6 @@ import 'package:pull_down_button/pull_down_button.dart';
 import 'package:omi/backend/http/api/goals.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/schema.dart';
-import 'package:omi/pages/settings/task_integrations_page.dart';
 import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/goals_provider.dart';
 import 'package:omi/providers/task_integration_provider.dart';

--- a/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
+++ b/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
@@ -8,7 +8,6 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/http/api/action_items.dart';
-import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/pages/settings/task_integrations_page.dart';
 import 'package:omi/pages/settings/usage_page.dart';

--- a/app/lib/services/asana_service.dart
+++ b/app/lib/services/asana_service.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/http/api/task_integrations.dart';

--- a/app/lib/services/clickup_service.dart
+++ b/app/lib/services/clickup_service.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/http/api/task_integrations.dart';

--- a/app/lib/services/google_tasks_service.dart
+++ b/app/lib/services/google_tasks_service.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/http/api/task_integrations.dart';

--- a/app/lib/services/todoist_service.dart
+++ b/app/lib/services/todoist_service.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/http/api/task_integrations.dart';


### PR DESCRIPTION
## Summary
- Remove unused `flutter/foundation.dart` import from all four task integration service files (`asana_service`, `clickup_service`, `google_tasks_service`, `todoist_service`)
- Remove unused `task_integrations_page.dart` import from `action_items_page.dart`
- Remove unused `preferences.dart` import from `action_item_tile_widget.dart`
- Remove dead `_buildGoalDropTile` and `_attachTaskToGoal` methods from `action_items_page.dart` — neither method was referenced anywhere in the file

## Test plan
- [x] Build and verify no compilation errors
- [x] Action items page loads correctly with goals row intact
- [x] Task export to all integrations (Todoist, Asana, Google Tasks, ClickUp, Apple Reminders) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)