### PR TITLE
fix(backend): reuse async task prometheus metrics

### DIFF
--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -1,11 +1,14 @@
 """Unit tests for utils/async_tasks.py — structured concurrency utilities."""
 
 import asyncio
+import importlib
+import sys
 from pathlib import Path
 
 import pytest
 from unittest.mock import patch
 
+import utils.async_tasks as async_tasks_mod
 from utils.async_tasks import (
     GatherResult,
     SupervisorResult,
@@ -16,6 +19,27 @@ from utils.async_tasks import (
     create_named_task,
     wait_for_event,
 )
+
+
+def test_metrics_are_reused_after_module_cache_eviction():
+    utils_pkg = sys.modules.get('utils')
+    previous_attr = getattr(utils_pkg, 'async_tasks', None) if utils_pkg is not None else None
+    sys.modules.pop('utils.async_tasks', None)
+    try:
+        reimported = importlib.import_module('utils.async_tasks')
+        assert reimported.SUPERVISOR_EXIT_TOTAL is async_tasks_mod.SUPERVISOR_EXIT_TOTAL
+        assert reimported.DRAIN_TIMEOUT_TOTAL is async_tasks_mod.DRAIN_TIMEOUT_TOTAL
+        assert reimported.DRAIN_DURATION is async_tasks_mod.DRAIN_DURATION
+        assert reimported.GATHER_FAILURES_TOTAL is async_tasks_mod.GATHER_FAILURES_TOTAL
+        assert reimported.GATHER_DURATION is async_tasks_mod.GATHER_DURATION
+    finally:
+        sys.modules['utils.async_tasks'] = async_tasks_mod
+        if utils_pkg is not None:
+            if previous_attr is None:
+                utils_pkg.__dict__.pop('async_tasks', None)
+            else:
+                utils_pkg.async_tasks = previous_attr
+
 
 # ---------------------------------------------------------------------------
 # Tests for create_named_task

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -22,7 +22,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Generic, Iterable, TypeVar
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, REGISTRY
 
 logger = logging.getLogger(__name__)
 
@@ -32,32 +32,65 @@ T = TypeVar('T')
 # Metrics
 # ---------------------------------------------------------------------------
 
-SUPERVISOR_EXIT_TOTAL = Counter(
+
+def _get_registered_collector(name):
+    names_to_collectors = getattr(REGISTRY, '_names_to_collectors', {})
+    candidates = [name]
+    if name.endswith('_total'):
+        candidates.append(name[: -len('_total')])
+    else:
+        candidates.append(f'{name}_total')
+    for candidate in candidates:
+        collector = names_to_collectors.get(candidate)
+        if collector is not None:
+            return collector
+    return None
+
+
+def _get_or_create_metric(metric_class, name, documentation, labelnames=(), **kwargs):
+    existing = _get_registered_collector(name)
+    if existing is not None:
+        return existing
+    try:
+        return metric_class(name, documentation, labelnames, **kwargs)
+    except ValueError as exc:
+        existing = _get_registered_collector(name)
+        if existing is None or 'Duplicated timeseries' not in str(exc):
+            raise
+        return existing
+
+
+SUPERVISOR_EXIT_TOTAL = _get_or_create_metric(
+    Counter,
     'async_supervisor_exit_total',
     'Supervisor loop exits by reason',
     ['label', 'reason'],
 )
 
-DRAIN_TIMEOUT_TOTAL = Counter(
+DRAIN_TIMEOUT_TOTAL = _get_or_create_metric(
+    Counter,
     'async_drain_timeout_total',
     'Task drain operations that hit timeout',
     ['label'],
 )
 
-DRAIN_DURATION = Histogram(
+DRAIN_DURATION = _get_or_create_metric(
+    Histogram,
     'async_drain_duration_seconds',
     'Time spent draining tasks',
     ['label'],
     buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
 )
 
-GATHER_FAILURES_TOTAL = Counter(
+GATHER_FAILURES_TOTAL = _get_or_create_metric(
+    Counter,
     'async_gather_failures_total',
     'Individual coroutine failures in gather_safe',
     ['label'],
 )
 
-GATHER_DURATION = Histogram(
+GATHER_DURATION = _get_or_create_metric(
+    Histogram,
     'async_gather_duration_seconds',
     'Total duration of gather_safe calls',
     ['label'],


### PR DESCRIPTION
## Summary
- reuse already-registered `utils.async_tasks` Prometheus collectors when the module is imported again in the same process
- keep the existing Counter/Histogram names and label sets unchanged
- add a regression test that evicts `utils.async_tasks` from `sys.modules` and re-imports it without duplicate collector registration

## Why
Broad Windows/backend unit collection can import modules that depend on `utils.async_tasks` after earlier tests have already registered its Prometheus collectors. If `utils.async_tasks` is removed from `sys.modules` and imported again in the same Python process, prometheus_client raises `ValueError: Duplicated timeseries`, which blocks collection for downstream STT/realtime tests.

## Tests
- `python -m pytest tests\unit\test_async_tasks.py -q --tb=short` -> `46 passed`
- `python -m pytest tests\unit\test_async_tasks.py tests\unit\test_streaming_deepgram_backoff.py --collect-only -q --tb=short` -> `125 tests collected`
- targeted collect with async tasks + STT/realtime files no longer reports duplicated Prometheus timeseries; remaining errors are unrelated missing optional stubs (`websockets`, `langchain_core`)
- full `python -m pytest tests\unit --collect-only -q` summary reports `NO_DUPLICATED_TIMESERIES`; remaining collection errors are unrelated and already tracked by other PRs
- `python -m py_compile utils\async_tasks.py tests\unit\test_async_tasks.py`
- `python -m black --line-length 120 --skip-string-normalization utils\async_tasks.py tests\unit\test_async_tasks.py --check`
- `git diff --check`