### PR TITLE
fix(backend): cache async task metrics without registry internals

### DIFF
--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,7 @@ def test_metrics_are_reused_after_module_cache_eviction():
 
 def test_metrics_are_tracked_in_module_cache():
     cache = async_tasks_mod._metric_cache()
+    assert async_tasks_mod._METRIC_CACHE_MODULE in sys.modules
     supervisor_key = async_tasks_mod._metric_cache_key(
         async_tasks_mod.Counter,
         'async_supervisor_exit_total',
@@ -57,6 +59,41 @@ def test_metrics_are_tracked_in_module_cache():
 
     assert cache[supervisor_key] is async_tasks_mod.SUPERVISOR_EXIT_TOTAL
     assert cache[drain_duration_key] is async_tasks_mod.DRAIN_DURATION
+
+
+def test_metric_cache_key_handles_nested_lists():
+    cache_key = async_tasks_mod._metric_cache_key(
+        async_tasks_mod.Histogram,
+        'nested_bucket_metric',
+        ['label'],
+        buckets=[[0.1, 0.2], [0.3, 0.4]],
+    )
+
+    hash(cache_key)
+
+
+def test_metric_creation_is_lock_guarded():
+    class FakeMetric:
+        created = 0
+
+        def __init__(self, name, documentation, labelnames=(), **kwargs):
+            type(self).created += 1
+            self.name = name
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        metrics = list(
+            executor.map(
+                lambda _: async_tasks_mod._get_or_create_metric(
+                    FakeMetric,
+                    'threaded_cache_metric',
+                    'Threaded cache metric',
+                ),
+                range(8),
+            )
+        )
+
+    assert len({id(metric) for metric in metrics}) == 1
+    assert FakeMetric.created == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -41,6 +41,24 @@ def test_metrics_are_reused_after_module_cache_eviction():
                 utils_pkg.async_tasks = previous_attr
 
 
+def test_metrics_are_tracked_in_module_cache():
+    cache = async_tasks_mod._metric_cache()
+    supervisor_key = async_tasks_mod._metric_cache_key(
+        async_tasks_mod.Counter,
+        'async_supervisor_exit_total',
+        ['label', 'reason'],
+    )
+    drain_duration_key = async_tasks_mod._metric_cache_key(
+        async_tasks_mod.Histogram,
+        'async_drain_duration_seconds',
+        ['label'],
+        buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
+    )
+
+    assert cache[supervisor_key] is async_tasks_mod.SUPERVISOR_EXIT_TOTAL
+    assert cache[drain_duration_key] is async_tasks_mod.DRAIN_DURATION
+
+
 # ---------------------------------------------------------------------------
 # Tests for create_named_task
 # ---------------------------------------------------------------------------

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -19,10 +19,13 @@ named utilities with bounded resources, clean shutdown, and observability.
 
 import asyncio
 import logging
+import sys
+import threading
 from dataclasses import dataclass, field
+from types import ModuleType
 from typing import Any, Awaitable, Generic, Iterable, TypeVar
 
-from prometheus_client import Counter, Histogram, REGISTRY
+from prometheus_client import Counter, Histogram
 
 logger = logging.getLogger(__name__)
 
@@ -32,20 +35,30 @@ T = TypeVar('T')
 # Metrics
 # ---------------------------------------------------------------------------
 
-_METRIC_CACHE_ATTR = 'omi_async_tasks_metric_cache'
+_METRIC_CACHE_MODULE = 'utils._async_tasks_metric_cache'
+
+
+def _new_metric_cache_module():
+    module = ModuleType(_METRIC_CACHE_MODULE)
+    module.cache = {}
+    module.lock = threading.Lock()
+    return module
+
+
+def _metric_cache_state():
+    state = sys.modules.get(_METRIC_CACHE_MODULE)
+    if state is None:
+        state = sys.modules.setdefault(_METRIC_CACHE_MODULE, _new_metric_cache_module())
+    return state
 
 
 def _metric_cache():
-    cache = getattr(REGISTRY, _METRIC_CACHE_ATTR, None)
-    if cache is None:
-        cache = {}
-        setattr(REGISTRY, _METRIC_CACHE_ATTR, cache)
-    return cache
+    return _metric_cache_state().cache
 
 
 def _cacheable_value(value):
     if isinstance(value, list):
-        return tuple(value)
+        return tuple(_cacheable_value(item) for item in value)
     if isinstance(value, dict):
         return tuple(sorted((key, _cacheable_value(item)) for key, item in value.items()))
     return value
@@ -61,14 +74,16 @@ def _metric_cache_key(metric_class, name, labelnames=(), **kwargs):
 
 
 def _get_or_create_metric(metric_class, name, documentation, labelnames=(), **kwargs):
-    cache = _metric_cache()
+    state = _metric_cache_state()
     cache_key = _metric_cache_key(metric_class, name, labelnames, **kwargs)
-    existing = cache.get(cache_key)
-    if existing is not None:
-        return existing
-    metric = metric_class(name, documentation, labelnames, **kwargs)
-    cache[cache_key] = metric
-    return metric
+    with state.lock:
+        cache = state.cache
+        existing = cache.get(cache_key)
+        if existing is not None:
+            return existing
+        metric = metric_class(name, documentation, labelnames, **kwargs)
+        cache[cache_key] = metric
+        return metric
 
 
 SUPERVISOR_EXIT_TOTAL = _get_or_create_metric(

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -32,32 +32,43 @@ T = TypeVar('T')
 # Metrics
 # ---------------------------------------------------------------------------
 
+_METRIC_CACHE_ATTR = 'omi_async_tasks_metric_cache'
 
-def _get_registered_collector(name):
-    names_to_collectors = getattr(REGISTRY, '_names_to_collectors', {})
-    candidates = [name]
-    if name.endswith('_total'):
-        candidates.append(name[: -len('_total')])
-    else:
-        candidates.append(f'{name}_total')
-    for candidate in candidates:
-        collector = names_to_collectors.get(candidate)
-        if collector is not None:
-            return collector
-    return None
+
+def _metric_cache():
+    cache = getattr(REGISTRY, _METRIC_CACHE_ATTR, None)
+    if cache is None:
+        cache = {}
+        setattr(REGISTRY, _METRIC_CACHE_ATTR, cache)
+    return cache
+
+
+def _cacheable_value(value):
+    if isinstance(value, list):
+        return tuple(value)
+    if isinstance(value, dict):
+        return tuple(sorted((key, _cacheable_value(item)) for key, item in value.items()))
+    return value
+
+
+def _metric_cache_key(metric_class, name, labelnames=(), **kwargs):
+    return (
+        metric_class,
+        name,
+        tuple(labelnames),
+        tuple(sorted((key, _cacheable_value(value)) for key, value in kwargs.items())),
+    )
 
 
 def _get_or_create_metric(metric_class, name, documentation, labelnames=(), **kwargs):
-    existing = _get_registered_collector(name)
+    cache = _metric_cache()
+    cache_key = _metric_cache_key(metric_class, name, labelnames, **kwargs)
+    existing = cache.get(cache_key)
     if existing is not None:
         return existing
-    try:
-        return metric_class(name, documentation, labelnames, **kwargs)
-    except ValueError as exc:
-        existing = _get_registered_collector(name)
-        if existing is None or 'Duplicated timeseries' not in str(exc):
-            raise
-        return existing
+    metric = metric_class(name, documentation, labelnames, **kwargs)
+    cache[cache_key] = metric
+    return metric
 
 
 SUPERVISOR_EXIT_TOTAL = _get_or_create_metric(


### PR DESCRIPTION
## Summary
- replace the `utils.async_tasks` Prometheus collector lookup that read `REGISTRY._names_to_collectors`
- keep the re-import-safe metric cache in a locked sidecar module instead of attaching state to Prometheus `REGISTRY`
- cover cache reuse, nested metric kwargs, and concurrent cache creation in `test_async_tasks.py`

## Why
PR #7866 fixed duplicate Prometheus collector registration when `utils.async_tasks` is evicted from `sys.modules` and imported again, but the first implementation recovered existing collectors through the private `prometheus_client` `_names_to_collectors` map. This follow-up keeps the re-import fix without depending on Prometheus internals or third-party object attributes.

## Current status
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`
- Head refreshed to `7a1a3e7495d6ad69409ce70166ed6718d86cde8c`
- GitHub currently reports the PR as mergeable
- Existing review feedback remains addressed by the locked sidecar cache and recursive cache-key conversion

## Tests
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest tests\unit\test_async_tasks.py -q --tb=short`
  - 49 passed
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest tests\unit\test_async_tasks.py tests\unit\test_streaming_deepgram_backoff.py --collect-only -q --tb=short`
  - 131 tests collected
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile utils\async_tasks.py tests\unit\test_async_tasks.py`
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check utils\async_tasks.py tests\unit\test_async_tasks.py`
  - 2 files would be left unchanged
- `PYTHONUTF8=1 D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe backend\scripts\scan_async_blockers.py`
  - exit 0; existing async-blocker backlog reported, no new async_tasks blocker
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`