### PR TITLE
test(backend): isolate async geocoding imports

### DIFF
--- a/backend/tests/unit/test_async_geocoding.py
+++ b/backend/tests/unit/test_async_geocoding.py
@@ -6,11 +6,28 @@ instead of blocking requests.get.
 
 import asyncio
 import json
+import os
 import sys
 import types
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
+
+BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _ensure_package_path(name, path):
+    mod = sys.modules.get(name)
+    if mod is None or not isinstance(mod, types.ModuleType):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod.__path__ = [path]
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = _ensure_package_path(parent_name, os.path.dirname(path))
+        setattr(parent, attr_name, mod)
+    return mod
+
 
 # Mock database._client before importing anything that touches GCP
 sys.modules.setdefault("database._client", MagicMock())
@@ -24,12 +41,20 @@ if not hasattr(_redis_mod, 'r'):
     _redis_mod.r = MagicMock()
 
 # Stub utils.http_client
-if "utils.http_client" not in sys.modules:
+_http_mod = sys.modules.get("utils.http_client")
+if _http_mod is None:
     _http_mod = types.ModuleType("utils.http_client")
-    _http_mod.get_maps_client = MagicMock()
-    _http_mod.get_webhook_client = MagicMock()
-    _http_mod.get_maps_semaphore = MagicMock(return_value=asyncio.Semaphore(8))
     sys.modules["utils.http_client"] = _http_mod
+if not hasattr(_http_mod, "get_maps_client"):
+    _http_mod.get_maps_client = MagicMock()
+if not hasattr(_http_mod, "get_webhook_client"):
+    _http_mod.get_webhook_client = MagicMock()
+if not hasattr(_http_mod, "get_maps_semaphore"):
+    _http_mod.get_maps_semaphore = MagicMock(return_value=asyncio.Semaphore(8))
+
+_ensure_package_path("utils", os.path.join(BACKEND_DIR, "utils"))
+_ensure_package_path("utils.conversations", os.path.join(BACKEND_DIR, "utils", "conversations"))
+sys.modules.pop("utils.conversations.location", None)
 
 from models.conversation import Geolocation
 from utils.conversations.location import async_get_google_maps_location

--- a/backend/tests/unit/test_async_geocoding.py
+++ b/backend/tests/unit/test_async_geocoding.py
@@ -21,7 +21,10 @@ def _ensure_package_path(name, path):
     if mod is None or not isinstance(mod, types.ModuleType):
         mod = types.ModuleType(name)
         sys.modules[name] = mod
-    mod.__path__ = [path]
+    paths = list(getattr(mod, "__path__", []) or [])
+    if path not in paths:
+        paths.append(path)
+    mod.__path__ = paths
     if '.' in name:
         parent_name, attr_name = name.rsplit('.', 1)
         parent = _ensure_package_path(parent_name, os.path.dirname(path))
@@ -52,7 +55,6 @@ if not hasattr(_http_mod, "get_webhook_client"):
 if not hasattr(_http_mod, "get_maps_semaphore"):
     _http_mod.get_maps_semaphore = MagicMock(return_value=asyncio.Semaphore(8))
 
-_ensure_package_path("utils", os.path.join(BACKEND_DIR, "utils"))
 _ensure_package_path("utils.conversations", os.path.join(BACKEND_DIR, "utils", "conversations"))
 sys.modules.pop("utils.conversations.location", None)
 


### PR DESCRIPTION
## Summary
- restore the real `utils` / `utils.conversations` package paths before importing `utils.conversations.location`
- fill missing `utils.http_client` geocoding helpers on an existing partial stub instead of only stubbing when absent
- keep the async geocoding tests focused on cache and httpx behavior without depending on broad collection order

## Why
On Windows broad backend unit collection, earlier tests can leave `utils.conversations` as a stub package and `utils.http_client` as a partial module. Focused async geocoding tests pass, but broad collection failed while importing `utils.conversations.location` or `get_maps_semaphore`. This makes the test collection-order independent while leaving production code unchanged.

## Tests
- `python -m pytest backend\tests\unit\test_async_geocoding.py -q --tb=short` -> 7 passed
- `python -m py_compile backend\tests\unit\test_async_geocoding.py`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_async_geocoding.py --check`
- `git diff --check origin/main...HEAD`

Note: this branch was refreshed onto latest `main`; no unresolved review threads remain.