### PR TITLE
fix conversation detail provider crash when rating timer fires after navigation

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -313,7 +313,9 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
         if (!hasConversationSummaryRatingSet) {
           _ratingTimer = Timer(const Duration(seconds: 15), () {
             if (_isDisposed) return;
-            setConversationSummaryRating(conversation.id, -1); // set -1 to indicate is was shown
+            final conv = conversationOrNull;
+            if (conv == null) return;
+            setConversationSummaryRating(conv.id, -1); // set -1 to indicate is was shown
             showRatingUI = true;
             notifyListeners();
           });


### PR DESCRIPTION
ConversationDetailProvider.conversation
FlutterError - Bad state: No conversation available
package:omi/pages/conversation_detail/conversation_detail_provider.dart:47

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/8da74a612952e8ce7b9e07447166a3ca?time=7d&types=crash&sessionEventKey=b07d01afcb2d417996bf4753f12a448e_2228780794352976020

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 ConversationDetailProvider.conversation + 93 (conversation_detail_provider.dart:93)
1  ???                            0x0 ConversationDetailProvider.initConversation.<fn>.<fn> + 316 (conversation_detail_provider.dart:316)
2  ???                            0x0 _CustomZone.bindCallback.<fn> (dart:async)
3  ???                            0x0 TickerFuture.whenCompleteOrCancel.thunk + 450 (ticker.dart:450)
```

The 15-second rating timer callback called the throwing `conversation` getter. If the user navigated away before the timer fired and the provider was not yet disposed, `conversationOrNull` returns null and the getter throws `StateError`. The existing `_isDisposed` guard does not cover this case.

Fix: use `conversationOrNull` in the timer callback and early-return on null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)