### PR TITLE
fix(audio): unbuildable audio surfaces as terminal 'unavailable' instead of pending-forever

### DIFF
--- a/app/lib/backend/http/api/audio.dart
+++ b/app/lib/backend/http/api/audio.dart
@@ -7,7 +7,7 @@ import 'package:omi/utils/logger.dart';
 /// Audio file info from signed URL endpoint
 class AudioFileUrlInfo {
   final String id;
-  final String status; // 'cached' or 'pending'
+  final String status; // 'cached' | 'pending' | 'unavailable'
   final String? signedUrl;
   final String? contentType;
   final double duration;

--- a/app/lib/backend/http/api/audio.dart
+++ b/app/lib/backend/http/api/audio.dart
@@ -37,7 +37,8 @@ class AudioUrlsResponse {
 
   AudioUrlsResponse({required this.files, this.pollAfterMs});
 
-  bool get hasPending => files.any((f) => !f.isCached);
+  /// 'unavailable' is terminal (source chunks gone) — not worth polling for.
+  bool get hasPending => files.any((f) => !f.isCached && f.status != 'unavailable');
 }
 
 String getAudioStreamUrl({required String conversationId, required String audioFileId, String format = 'wav'}) {

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -71,6 +71,8 @@ from utils.other.storage import (
     get_playback_artifact_signed_url,
     download_playback_artifact,
     upload_playback_artifact,
+    mark_playback_unavailable,
+    is_playback_unavailable,
     enqueue_conversation_audio_merge,
     _PRECACHE_FILE_SEM,
 )
@@ -290,6 +292,15 @@ def _get_audio_urls_via_artifacts(uid: str, conversation_id: str, audio_files: l
                     "status": "cached",
                     "signed_url": signed_url,
                     "content_type": content_type,
+                    "duration": af.get('duration', 0),
+                }
+            )
+        elif is_playback_unavailable(uid, conversation_id, audio_file_id):
+            result.append(
+                {
+                    "id": audio_file_id,
+                    "status": "unavailable",
+                    "signed_url": None,
                     "duration": af.get('duration', 0),
                 }
             )
@@ -2172,6 +2183,11 @@ async def run_audio_merge_job(request: Request, task_retry_count: int = Depends(
             mp3_data = await run_blocking(sync_executor, _build_playback_artifact, uid, conversation_id, timestamps)
         except FileNotFoundError:
             logger.warning(f'audio_merge: chunks missing conv={conversation_id} file={audio_file_id}, dropping')
+            # Persist the verdict or /urls reports pending forever and clients
+            # poll to exhaustion (named-task tombstones block re-enqueues too)
+            await run_blocking(
+                storage_executor, mark_playback_unavailable, uid, conversation_id, audio_file_id, 'chunks_missing'
+            )
             return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': 'chunks_missing'})
         except Exception as e:
             max_attempts = get_sync_tasks_max_attempts()

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -2193,6 +2193,12 @@ async def run_audio_merge_job(request: Request, task_retry_count: int = Depends(
             max_attempts = get_sync_tasks_max_attempts()
             if task_retry_count >= max_attempts - 1:
                 logger.error(f'audio_merge_failed_final conv={conversation_id} file={audio_file_id}: {e}')
+                # Same pending-forever trap as chunks_missing: a consumed task
+                # leaves a tombstone that blocks re-enqueue. Mark unavailable so
+                # clients stop polling; the 30-day lifecycle grants a retry.
+                await run_blocking(
+                    storage_executor, mark_playback_unavailable, uid, conversation_id, audio_file_id, 'merge_failed'
+                )
                 return JSONResponse(status_code=200, content={'status': 'failed_final'})
             logger.warning(
                 f'audio_merge: attempt {task_retry_count + 1} failed conv={conversation_id} '
@@ -2202,6 +2208,9 @@ async def run_audio_merge_job(request: Request, task_retry_count: int = Depends(
 
         if not mp3_data:
             logger.warning(f'audio_merge: no audio data conv={conversation_id} file={audio_file_id}, dropping')
+            await run_blocking(
+                storage_executor, mark_playback_unavailable, uid, conversation_id, audio_file_id, 'empty_audio'
+            )
             return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': 'empty_audio'})
 
         await run_blocking(storage_executor, upload_playback_artifact, uid, conversation_id, audio_file_id, mp3_data)

--- a/backend/tests/unit/test_audio_merge_tasks.py
+++ b/backend/tests/unit/test_audio_merge_tasks.py
@@ -132,6 +132,34 @@ class TestPlaybackReadPathsStructure:
         assert 'HTTP_AUDIO_MERGE_RUN_TIMEOUT' in src
 
 
+class TestUnavailableContract:
+    """Unbuildable audio (chunks gone) must surface as terminal 'unavailable',
+    never as pending-forever (named-task tombstones block re-enqueues)."""
+
+    def test_handler_marks_unavailable_on_chunks_missing(self):
+        src = _read_source(os.path.join('routers', 'sync.py'))
+        handler = src[src.index('async def run_audio_merge_job') :]
+        missing = handler[handler.index('except FileNotFoundError') : handler.index("'chunks_missing'}")]
+        assert 'mark_playback_unavailable' in missing
+
+    def test_urls_reports_unavailable_without_enqueue(self):
+        src = _read_source(os.path.join('routers', 'sync.py'))
+        fn = src[src.index('def _get_audio_urls_via_artifacts') : src.index('def get_audio_signed_urls_endpoint')]
+        unavailable = fn[fn.index('is_playback_unavailable') : fn.index('else:')]
+        assert '"unavailable"' in unavailable
+        assert 'to_enqueue.append' not in unavailable
+
+    def test_storage_marker_helpers(self):
+        src = _read_source(os.path.join('utils', 'other', 'storage.py'))
+        assert 'def mark_playback_unavailable' in src
+        assert 'def is_playback_unavailable' in src
+        assert '.unavailable' in src
+
+    def test_app_treats_unavailable_as_terminal(self):
+        src = _read_source(os.path.join('..', 'app', 'lib', 'backend', 'http', 'api', 'audio.dart'))
+        assert "f.status != 'unavailable'" in src
+
+
 class TestStorageArtifactHelpers:
     def test_playback_prefix_and_helpers(self):
         src = _read_source(os.path.join('utils', 'other', 'storage.py'))

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -1134,6 +1134,26 @@ def upload_playback_artifact(uid: str, conversation_id: str, audio_file_id: str,
     blob.upload_from_string(mp3_data, content_type='audio/mpeg')
 
 
+def _playback_unavailable_blob(uid: str, conversation_id: str, audio_file_id: str):
+    bucket = storage_client.bucket(private_cloud_sync_bucket)
+    return bucket.blob(f'{PLAYBACK_ARTIFACT_PREFIX}/{uid}/{conversation_id}/{audio_file_id}.unavailable')
+
+
+def mark_playback_unavailable(uid: str, conversation_id: str, audio_file_id: str, reason: str) -> None:
+    """Mark an audio file as unbuildable (e.g. source chunks gone).
+
+    Without this, /urls would report the file as pending forever and clients
+    would poll to exhaustion. The marker lives under playback/ so the 30-day
+    lifecycle rule grants even these a retry eventually.
+    """
+    blob = _playback_unavailable_blob(uid, conversation_id, audio_file_id)
+    blob.upload_from_string(reason, content_type='text/plain')
+
+
+def is_playback_unavailable(uid: str, conversation_id: str, audio_file_id: str) -> bool:
+    return _playback_unavailable_blob(uid, conversation_id, audio_file_id).exists()
+
+
 def enqueue_conversation_audio_merge(uid: str, conversation_id: str, audio_files: list, caller: str) -> None:
     """Enqueue one audio-merge Cloud Task per audio file (named-task deduped).
 

--- a/web/app/src/components/conversations/AudioPlayer.tsx
+++ b/web/app/src/components/conversations/AudioPlayer.tsx
@@ -88,6 +88,11 @@ export const AudioPlayer = forwardRef<AudioPlayerRef, AudioPlayerProps>(
               setIsLoading(false);
               return;
             }
+            if (info?.status === 'unavailable') {
+              setError('Audio is no longer available for this conversation');
+              setIsLoading(false);
+              return;
+            }
             await new Promise((resolve) => setTimeout(resolve, pollAfterMs ?? 3000));
           }
           if (!cancelled) {

--- a/web/app/src/components/conversations/AudioPlayer.tsx
+++ b/web/app/src/components/conversations/AudioPlayer.tsx
@@ -73,6 +73,12 @@ export const AudioPlayer = forwardRef<AudioPlayerRef, AudioPlayerProps>(
             return;
           }
 
+          if (firstFile.status === 'unavailable') {
+            setError('Audio is no longer available for this conversation');
+            setIsLoading(false);
+            return;
+          }
+
           // The backend builds playback artifacts asynchronously; poll until
           // the file is cached instead of streaming through the merge proxy
           // that used to time out on long conversations.

--- a/web/app/src/components/conversations/ConversationDetailPanel.tsx
+++ b/web/app/src/components/conversations/ConversationDetailPanel.tsx
@@ -30,7 +30,14 @@ import { ManagePeopleModal } from './ManagePeopleModal';
 import { AudioPlayer, AudioPlayerRef } from './AudioPlayer';
 import { usePeople } from '@/hooks/usePeople';
 import { precacheConversationAudio, getConversationAudioUrls } from '@/lib/api';
-import type { Conversation, ActionItem, AppResponse, TranscriptSegment, AudioFile, Geolocation } from '@/types/conversation';
+import type {
+  Conversation,
+  ActionItem,
+  AppResponse,
+  TranscriptSegment,
+  AudioFile,
+  Geolocation,
+} from '@/types/conversation';
 
 // Dynamic import for Leaflet map (SSR not supported)
 const SingleLocationMap = dynamic(() => import('@/components/ui/SingleLocationMap'), {
@@ -95,16 +102,14 @@ function ActionItemRow({ item }: { item: ActionItem }) {
       className={cn(
         'flex items-start gap-3 p-4 rounded-xl',
         'bg-bg-tertiary border border-bg-quaternary/50',
-        item.completed && 'opacity-60'
+        item.completed && 'opacity-60',
       )}
     >
       <div
         className={cn(
           'w-5 h-5 rounded-md border-2 flex-shrink-0 mt-0.5',
           'flex items-center justify-center',
-          item.completed
-            ? 'bg-success border-success'
-            : 'border-text-quaternary'
+          item.completed ? 'bg-success border-success' : 'border-text-quaternary',
         )}
       >
         {item.completed && (
@@ -121,7 +126,7 @@ function ActionItemRow({ item }: { item: ActionItem }) {
         <span
           className={cn(
             'text-text-primary',
-            item.completed && 'line-through text-text-tertiary'
+            item.completed && 'line-through text-text-tertiary',
           )}
         >
           {item.description}
@@ -200,9 +205,13 @@ function SummaryTab({
                 ref={textRef}
                 className={cn(
                   'transition-all duration-300',
-                  !isExpanded && needsTruncation && 'overflow-hidden'
+                  !isExpanded && needsTruncation && 'overflow-hidden',
                 )}
-                style={!isExpanded && needsTruncation && mapHeight > 0 ? { maxHeight: mapHeight - 56 } : undefined}
+                style={
+                  !isExpanded && needsTruncation && mapHeight > 0
+                    ? { maxHeight: mapHeight - 56 }
+                    : undefined
+                }
               >
                 {category && (
                   <div className="mb-3">
@@ -211,9 +220,7 @@ function SummaryTab({
                     </span>
                   </div>
                 )}
-                <p className="text-text-secondary leading-relaxed text-lg">
-                  {overview}
-                </p>
+                <p className="text-text-secondary leading-relaxed text-lg">{overview}</p>
                 {geolocation.address && (
                   <div className="mt-4 flex items-start gap-2 text-sm text-text-tertiary">
                     <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -224,10 +231,13 @@ function SummaryTab({
 
               {/* Gradient fade and Show more button */}
               {needsTruncation && (
-                <div className={cn(
-                  'mt-2',
-                  !isExpanded && 'absolute bottom-0 left-0 right-0 pt-12 pb-4 px-5 bg-gradient-to-t from-bg-secondary via-bg-secondary/90 to-transparent'
-                )}>
+                <div
+                  className={cn(
+                    'mt-2',
+                    !isExpanded &&
+                      'absolute bottom-0 left-0 right-0 pt-12 pb-4 px-5 bg-gradient-to-t from-bg-secondary via-bg-secondary/90 to-transparent',
+                  )}
+                >
                   <button
                     onClick={() => setIsExpanded(!isExpanded)}
                     className="flex items-center gap-1 text-sm text-purple-primary hover:text-purple-400 transition-colors"
@@ -268,9 +278,7 @@ function SummaryTab({
               </span>
             </div>
           )}
-          <p className="text-text-secondary leading-relaxed text-lg">
-            {overview}
-          </p>
+          <p className="text-text-secondary leading-relaxed text-lg">{overview}</p>
         </div>
       )}
 
@@ -305,7 +313,8 @@ function SummaryTab({
         {/* Empty state for templates */}
         {!hasAppSummaries && (
           <p className="text-sm text-text-tertiary mt-2">
-            No summaries yet. Click Templates above to generate one or create a custom template.
+            No summaries yet. Click Templates above to generate one or create a custom
+            template.
           </p>
         )}
       </div>
@@ -317,7 +326,7 @@ function SummaryTab({
  * Action items tab content
  */
 function ActionItemsTab({ items }: { items: ActionItem[] }) {
-  const completedCount = items.filter(i => i.completed).length;
+  const completedCount = items.filter((i) => i.completed).length;
 
   return (
     <div className="space-y-4">
@@ -401,7 +410,9 @@ export function ConversationDetailPanel({
   const audioPlayerRef = useRef<AudioPlayerRef>(null);
   const [audioAvailable, setAudioAvailable] = useState(false);
   const [fetchedAudioFiles, setFetchedAudioFiles] = useState<AudioFile[]>([]);
-  const [currentPlaybackTime, setCurrentPlaybackTime] = useState<number | undefined>(undefined);
+  const [currentPlaybackTime, setCurrentPlaybackTime] = useState<number | undefined>(
+    undefined,
+  );
 
   // Check audio availability for the conversation
   const audio_files = conversation?.audio_files || [];
@@ -415,10 +426,11 @@ export function ConversationDetailPanel({
     async function checkAudioAvailability() {
       // Helper to map audio URLs to AudioFile format
       const mapAudioUrls = (urls: Awaited<ReturnType<typeof getConversationAudioUrls>>) =>
-        urls.map(af => ({
+        urls.map((af) => ({
           id: af.id,
           duration: af.duration || 0,
           signed_url: af.signed_url,
+          status: af.status,
         }));
 
       // If audio_files array has data, audio is available
@@ -453,7 +465,7 @@ export function ConversationDetailPanel({
       for (let attempt = 0; attempt < 3; attempt++) {
         if (signal.aborted) return;
         if (attempt > 0) {
-          await new Promise(resolve => setTimeout(resolve, 500));
+          await new Promise((resolve) => setTimeout(resolve, 500));
         }
 
         const audioUrls = await getConversationAudioUrls(conversationId, signal);
@@ -488,42 +500,44 @@ export function ConversationDetailPanel({
   }, []);
 
   // Handle segment updates from transcript editing
-  const handleSegmentsUpdate = useCallback((
-    segmentIds: string[],
-    personId: string | null,
-    isUser: boolean
-  ) => {
-    if (!conversation || !onConversationUpdate) return;
+  const handleSegmentsUpdate = useCallback(
+    (segmentIds: string[], personId: string | null, isUser: boolean) => {
+      if (!conversation || !onConversationUpdate) return;
 
-    const updatedSegments = conversation.transcript_segments.map((seg) => {
-      if (seg.id && segmentIds.includes(seg.id)) {
-        return {
-          ...seg,
-          is_user: isUser,
-          person_id: isUser ? null : personId,
-        };
-      }
-      return seg;
-    });
+      const updatedSegments = conversation.transcript_segments.map((seg) => {
+        if (seg.id && segmentIds.includes(seg.id)) {
+          return {
+            ...seg,
+            is_user: isUser,
+            person_id: isUser ? null : personId,
+          };
+        }
+        return seg;
+      });
 
-    onConversationUpdate({
-      ...conversation,
-      transcript_segments: updatedSegments,
-    });
-  }, [conversation, onConversationUpdate]);
-
-  // Handle title change - update conversation with new title
-  const handleTitleChange = useCallback((newTitle: string) => {
-    if (conversation && onConversationUpdate) {
       onConversationUpdate({
         ...conversation,
-        structured: {
-          ...conversation.structured,
-          title: newTitle,
-        },
+        transcript_segments: updatedSegments,
       });
-    }
-  }, [conversation, onConversationUpdate]);
+    },
+    [conversation, onConversationUpdate],
+  );
+
+  // Handle title change - update conversation with new title
+  const handleTitleChange = useCallback(
+    (newTitle: string) => {
+      if (conversation && onConversationUpdate) {
+        onConversationUpdate({
+          ...conversation,
+          structured: {
+            ...conversation.structured,
+            title: newTitle,
+          },
+        });
+      }
+    },
+    [conversation, onConversationUpdate],
+  );
 
   // Handle delete
   const handleDelete = useCallback(() => {
@@ -570,10 +584,10 @@ export function ConversationDetailPanel({
   ];
 
   // Filter to only enabled tabs
-  const enabledTabs = tabs.filter(tab => !tab.disabled);
+  const enabledTabs = tabs.filter((tab) => !tab.disabled);
 
   // Ensure active tab is valid
-  if (!enabledTabs.find(t => t.id === activeTab)) {
+  if (!enabledTabs.find((t) => t.id === activeTab)) {
     const firstEnabled = enabledTabs[0];
     if (firstEnabled && activeTab !== firstEnabled.id) {
       setActiveTab(firstEnabled.id);
@@ -662,7 +676,7 @@ export function ConversationDetailPanel({
                   'text-sm font-medium transition-all duration-150',
                   activeTab === tab.id
                     ? 'bg-purple-primary text-white'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary'
+                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary',
                 )}
               >
                 {tab.icon}
@@ -671,9 +685,7 @@ export function ConversationDetailPanel({
                   <span
                     className={cn(
                       'px-1.5 py-0.5 rounded-full text-xs',
-                      activeTab === tab.id
-                        ? 'bg-white/20'
-                        : 'bg-bg-tertiary'
+                      activeTab === tab.id ? 'bg-white/20' : 'bg-bg-tertiary',
                     )}
                   >
                     {tab.count}

--- a/web/app/src/types/conversation.ts
+++ b/web/app/src/types/conversation.ts
@@ -3,7 +3,12 @@
  * Reference: /backend/routers/conversations.py
  */
 
-export type ConversationStatus = 'in_progress' | 'processing' | 'merging' | 'completed' | 'failed';
+export type ConversationStatus =
+  | 'in_progress'
+  | 'processing'
+  | 'merging'
+  | 'completed'
+  | 'failed';
 
 export interface Structured {
   title: string;
@@ -77,11 +82,12 @@ export interface AudioFile {
   chunk_end?: number;
   duration?: number;
   signed_url?: string | null;
+  status?: 'cached' | 'pending' | 'unavailable';
 }
 
 export interface AudioFileUrlInfo {
   id: string;
-  status: 'cached' | 'pending';
+  status: 'cached' | 'pending' | 'unavailable';
   signed_url: string | null;
   duration: number;
 }
@@ -101,7 +107,7 @@ export interface Conversation {
   geolocation: Geolocation | null;
   photos: ConversationPhoto[];
   audio_files: AudioFile[];
-  apps_results: AppResponse[];  // Note: backend uses 'apps_results' (with 's')
+  apps_results: AppResponse[]; // Note: backend uses 'apps_results' (with 's')
   suggested_summarization_apps: string[];
   source: string | null;
   language: string | null;
@@ -164,7 +170,12 @@ export interface Memory {
 // Knowledge Graph Types
 // =============================================================================
 
-export type KnowledgeGraphNodeType = 'person' | 'place' | 'organization' | 'thing' | 'concept';
+export type KnowledgeGraphNodeType =
+  | 'person'
+  | 'place'
+  | 'organization'
+  | 'thing'
+  | 'concept';
 
 export interface KnowledgeGraphNode {
   id: string;
@@ -219,7 +230,7 @@ export interface ServerMessage {
   text: string;
   sender: MessageSender;
   type: MessageType;
-  plugin_id?: string | null;  // app_id for routing
+  plugin_id?: string | null; // app_id for routing
   from_integration: boolean;
   files: MessageFile[];
   memories: MessageMemory[];


### PR DESCRIPTION
## Bug (found in prod ~1h after flipping #7872)

A March conversation got stuck at "preparing audio" until timeout on share/play. Trace:

1. The merge task ran and correctly found **the source chunks no longer exist in storage** (`audio_merge: chunks missing ... dropping`) — that conversation's audio predates current chunk retention and is unrecoverable by any pipeline (it failed under the old inline merge too, with a different timeout flavor).
2. But nothing recorded that verdict: `/urls` kept reporting the file as `pending`, while Cloud Tasks **named-task tombstones** silently blocked every re-enqueue (`already enqueued, skipping duplicate` on each poll).
3. Result: clients poll to exhaustion — pending forever for audio that can never exist.

## Fix

A terminal **`unavailable`** state:

- **Handler**: on `chunks_missing`, writes a tiny marker blob (`playback/{uid}/{conv}/{file}.unavailable`, content = reason) before consuming the task.
- **`/urls`**: artifact missing + marker present → `status: "unavailable"` — no enqueue, no poll hint.
- **Flutter**: `unavailable` is excluded from `hasPending`, so the poll loop exits immediately and the existing error path (snackbar + `audioPlaybackFailed`) fires instead of 90s of spinning. Share fails fast the same way.
- **Web**: shows "Audio is no longer available" immediately.

The marker lives under `playback/`, so the existing 30-day lifecycle rule auto-clears it — even genuinely transient chunk-listing failures get a retry within a month, with zero extra machinery.

## Tests

4 new structural tests in `test_audio_merge_tasks.py` (marker written on chunks-missing, `/urls` unavailable branch without enqueue, storage helpers, app terminal handling) — 15/15 passing; tsc + dart analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)