### PR TITLE
fix(backend): remove duplicate GOOGLE_CLIENT_ID/SECRET from .env.template

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -50,7 +50,7 @@ FIREBASE_PROJECT_ID=
 # Encrypt the conversations, memories, chat messages
 ENCRYPTION_SECRET='omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv'
 
-# Apple and Google OAuth
+# Apple and Google OAuth (also used for Google Calendar and other Google integrations)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 APPLE_CLIENT_ID=
@@ -77,10 +77,6 @@ WHOOP_CLIENT_SECRET=
 # Notion OAuth Credentials
 NOTION_CLIENT_ID=
 NOTION_CLIENT_SECRET=
-
-# Google OAuth Credentials (used for Calendar and other Google integrations)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
 
 # Twitter OAuth Credentials
 TWITTER_CLIENT_ID=


### PR DESCRIPTION
## Bug

`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are declared twice in `backend/.env.template`. Most `.env` parsers use the **last** value when a key appears more than once, silently discarding the first — meaning any developer who sets the first occurrence but not the second will get empty credentials at runtime with no error message.

### Root cause

Two separate commits added the same variables under different section headings:

| Commit | Section added | Date |
|--------|--------------|------|
| `5a3e755` ("adding env vars") | `# Google OAuth Credentials (used for Calendar and other Google integrations)` | Nov 2025 |
| `7334f58` ("OAuth for Google and Apple on desktop", #2673) | `# Apple and Google OAuth` | Sep 2025 |

Commit `7334f58` inserted its block _above_ the existing one without noticing the variables were already declared. Both `routers/auth.py` (user sign-in) and `routers/integrations.py` (Google Calendar) read the same `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` env vars — there is only one credential, not two.

### Impact

Any developer or self-hoster who populates the first occurrence (under `# Apple and Google OAuth`) and leaves the second blank will end up with empty `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` at runtime. Google sign-in and Calendar integration both silently fail.

## Fix

- Remove the duplicate `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` block (the later-positioned one under `# Google OAuth Credentials`)
- Update the comment on the surviving entry to clarify it covers both authentication **and** Google integrations (Calendar etc.)

## Test plan

- [ ] Confirm `grep -c 'GOOGLE_CLIENT_ID' backend/.env.template` returns `1`
- [ ] Confirm Google OAuth sign-in and Google Calendar integration still work with a single credential set

🤖 Generated with [Claude Code](https://claude.com/claude-code)