### PR TITLE
[codex] Isolate integration malformed import stubs

### DIFF
--- a/backend/tests/unit/test_integration_malformed_records.py
+++ b/backend/tests/unit/test_integration_malformed_records.py
@@ -66,8 +66,21 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
 
 
 _finder = _Finder()
+
+
+def _is_stubbed_name(name):
+    return any(name == prefix or name.startswith(prefix + '.') for prefix in _STUB)
+
+
+def _is_model_name(name):
+    return name == 'models' or name.startswith('models.')
+
+
+_saved_model_modules = {name: module for name, module in sys.modules.items() if _is_model_name(name)}
 for _n in list(sys.modules):
-    if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+    if _is_stubbed_name(_n):
+        sys.modules.pop(_n, None)
+    if _is_model_name(_n):
         sys.modules.pop(_n, None)
 sys.meta_path.insert(0, _finder)
 try:
@@ -75,8 +88,12 @@ try:
 finally:
     sys.meta_path.remove(_finder)
     for _n in list(sys.modules):
-        if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+        if _is_stubbed_name(_n):
             sys.modules.pop(_n, None)
+        if _is_model_name(_n) and _n not in _saved_model_modules:
+            sys.modules.pop(_n, None)
+    for _n, _module in _saved_model_modules.items():
+        sys.modules[_n] = _module
 
 
 def _setup_gates():

--- a/backend/tests/unit/test_integration_malformed_records.py
+++ b/backend/tests/unit/test_integration_malformed_records.py
@@ -80,7 +80,7 @@ _saved_model_modules = {name: module for name, module in sys.modules.items() if 
 for _n in list(sys.modules):
     if _is_stubbed_name(_n):
         sys.modules.pop(_n, None)
-    if _is_model_name(_n):
+    elif _is_model_name(_n):
         sys.modules.pop(_n, None)
 sys.meta_path.insert(0, _finder)
 try:
@@ -90,8 +90,9 @@ finally:
     for _n in list(sys.modules):
         if _is_stubbed_name(_n):
             sys.modules.pop(_n, None)
-        if _is_model_name(_n) and _n not in _saved_model_modules:
+        elif _is_model_name(_n) and _n not in _saved_model_modules:
             sys.modules.pop(_n, None)
+    # Restore the pre-collection module state; integ already holds the real model classes it needs.
     for _n, _module in _saved_model_modules.items():
         sys.modules[_n] = _module
 


### PR DESCRIPTION
## Summary
- keep `test_integration_malformed_records.py` using real `models.*` modules even when earlier test collection leaves model stubs in `sys.modules`
- preserve the test's existing cleanup behavior for heavy `_STUB` imports while restoring any pre-existing model modules after the router import

## Root cause
When this test was collected after `test_desktop_transcribe.py`, `models.integrations` could already be a `MagicMock`. The integration router then registered FastAPI routes with mocked Pydantic response models, causing collection to fail before the malformed-record tests could run.

## Validation
- `python -m pytest backend\tests\unit\test_integration_malformed_records.py -q --tb=short` -> 4 passed
- `python -m pytest backend\tests\unit\test_desktop_transcribe.py backend\tests\unit\test_integration_malformed_records.py --collect-only -q --tb=short` -> 60 collected
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` -> `test_integration_malformed_records.py` no longer errors; remaining collection errors are unrelated existing stub-isolation issues
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_integration_malformed_records.py --check`
- `python -m py_compile backend\tests\unit\test_integration_malformed_records.py`
- `git diff --check`