### PR TITLE
[codex] Restore async app integration test stubs

### DIFF
--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -16,12 +16,85 @@ os.environ.setdefault(
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
+_database_stubs = [
+    "database._client",
+    "database",
+    "database.mem_db",
+    "database.redis_db",
+    "database.memories",
+    "database.conversations",
+    "database.notifications",
+    "database.users",
+    "database.tasks",
+    "database.trends",
+    "database.action_items",
+    "database.folders",
+    "database.calendar_meetings",
+    "database.vector_db",
+    "database.apps",
+    "database.llm_usage",
+    "database.chat",
+    "database.goals",
+    "database.webhook_health",
+]
+_utils_stubs = [
+    "utils.apps",
+    "utils.notifications",
+    "utils.conversations",
+    "utils.conversations.factory",
+    "utils.conversations.render",
+    "utils.llm",
+    "utils.llm.clients",
+    "utils.llm.proactive_notification",
+    "utils.llm.usage_tracker",
+    "utils.llms",
+    "utils.llms.memory",
+    "utils.mentor_notifications",
+    "utils.log_sanitizer",
+    "utils.http_client",
+    "utils.subscription",
+    "utils.executors",
+]
+_RESTORED_MODULES = tuple(_database_stubs + _utils_stubs + ["utils.app_integrations"])
+_MISSING = object()
+_saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+
+
+def _install_module(name, module):
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, module)
+
+
+def _restore_stub_modules():
+    for name in sorted(_RESTORED_MODULES, key=lambda module_name: module_name.count('.'), reverse=True):
+        current = sys.modules.get(name)
+        original = _saved_modules[name]
+        if original is _MISSING:
+            sys.modules.pop(name, None)
+            if '.' in name:
+                parent_name, attr = name.rsplit('.', 1)
+                parent = sys.modules.get(parent_name)
+                if parent is not None and getattr(parent, attr, _MISSING) is current:
+                    delattr(parent, attr)
+        else:
+            sys.modules[name] = original
+            if '.' in name:
+                parent_name, attr = name.rsplit('.', 1)
+                parent = sys.modules.get(parent_name)
+                if parent is not None:
+                    setattr(parent, attr, original)
+
+
 # Stub database modules
-sys.modules.setdefault("database._client", MagicMock())
+_install_module("database._client", MagicMock())
 
 _db_pkg = types.ModuleType("database")
 _db_pkg.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'database'))]
-sys.modules.setdefault("database", _db_pkg)
+_install_module("database", _db_pkg)
 
 for submod in [
     "redis_db",
@@ -42,9 +115,9 @@ for submod in [
     "webhook_health",
 ]:
     mod = types.ModuleType(f"database.{submod}")
-    sys.modules.setdefault(f"database.{submod}", mod)
+    _install_module(f"database.{submod}", mod)
 
-sys.modules.setdefault("database.mem_db", types.ModuleType("database.mem_db"))
+_install_module("database.mem_db", types.ModuleType("database.mem_db"))
 sys.modules["database.mem_db"].get_proactive_noti_sent_at = MagicMock(return_value=None)
 sys.modules["database.mem_db"].set_proactive_noti_sent_at = MagicMock()
 sys.modules["database.redis_db"].get_generic_cache = MagicMock(return_value=None)
@@ -75,26 +148,8 @@ sys.modules["database.webhook_health"].record_dev_webhook_failure = MagicMock(re
 sys.modules["database.webhook_health"].record_dev_webhook_success = MagicMock()
 sys.modules["database.webhook_health"]._DEV_FAILURE_THRESHOLD = 100
 
-_utils_stubs = [
-    "utils.apps",
-    "utils.notifications",
-    "utils.conversations",
-    "utils.conversations.factory",
-    "utils.conversations.render",
-    "utils.llm",
-    "utils.llm.clients",
-    "utils.llm.proactive_notification",
-    "utils.llm.usage_tracker",
-    "utils.llms",
-    "utils.llms.memory",
-    "utils.mentor_notifications",
-    "utils.log_sanitizer",
-    "utils.http_client",
-    "utils.subscription",
-]
 for name in _utils_stubs:
-    if name not in sys.modules:
-        sys.modules[name] = types.ModuleType(name)
+    _install_module(name, types.ModuleType(name))
 
 sys.modules["utils.apps"].get_available_apps = MagicMock(return_value=[])
 sys.modules["utils.notifications"].send_notification = MagicMock()
@@ -159,7 +214,7 @@ if _http_mod is not None and not hasattr(_http_mod, '__file__'):
 # run_in_executor calls executor.submit() and wraps the returned Future.
 from concurrent.futures import ThreadPoolExecutor as _TPE
 
-_executors_mod = sys.modules.setdefault("utils.executors", types.ModuleType("utils.executors"))
+_executors_mod = sys.modules["utils.executors"]
 _executors_mod.critical_executor = _TPE(max_workers=2, thread_name_prefix="test-critical")
 _executors_mod.db_executor = _TPE(max_workers=2, thread_name_prefix="test-db")
 _executors_mod.storage_executor = _TPE(max_workers=2, thread_name_prefix="test-storage")
@@ -174,6 +229,7 @@ _executors_mod.run_blocking = _run_blocking
 import importlib
 
 app_integrations = importlib.import_module("utils.app_integrations")
+_restore_stub_modules()
 
 
 def _make_app(app_id: str, webhook_url: str, triggers_realtime=False, triggers_audio=False, uid=None):
@@ -213,8 +269,8 @@ class TestAsyncTriggerRealtimeAudioBytes:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch(
-            "utils.app_integrations.get_webhook_client", return_value=mock_client
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
         ):
             await app_integrations.trigger_realtime_audio_bytes("uid-1", 8000, bytearray(b'\x00' * 10))
 
@@ -243,8 +299,8 @@ class TestAsyncTriggerRealtimeAudioBytes:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=_side_effect)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch(
-            "utils.app_integrations.get_webhook_client", return_value=mock_client
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
         ):
             # Should not raise
             await app_integrations.trigger_realtime_audio_bytes("uid-1", 8000, bytearray(b'\x00'))
@@ -262,9 +318,9 @@ class TestAsyncTriggerRealtimeAudioBytes:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch(
-            "utils.app_integrations.get_webhook_client", return_value=mock_client
-        ), patch("utils.app_integrations.threading") as mock_threading:
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
+        ), patch.object(app_integrations, "threading") as mock_threading:
             await app_integrations.trigger_realtime_audio_bytes("uid-1", 8000, bytearray(b'\x00'))
             mock_threading.Thread.assert_not_called()
 
@@ -289,8 +345,8 @@ class TestAudioBytesChunkedFanOut:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=apps), patch(
-            "utils.app_integrations.get_webhook_client", return_value=mock_client
+        with patch.object(app_integrations, "get_available_apps", return_value=apps), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
         ):
             await app_integrations.trigger_realtime_audio_bytes("uid-1", 8000, bytearray(b'\x00' * 100))
 
@@ -304,8 +360,8 @@ class TestAsyncTriggerRealtimeIntegrations:
     @pytest.mark.asyncio
     async def test_no_apps_returns_empty(self):
         """No apps and no mentor → empty result."""
-        with patch.object(app_integrations, "get_available_apps", return_value=[]), patch(
-            "utils.app_integrations.process_mentor_notification", return_value=None
+        with patch.object(app_integrations, "get_available_apps", return_value=[]), patch.object(
+            app_integrations, "process_mentor_notification", return_value=None
         ):
             result = await app_integrations.trigger_realtime_integrations("uid-1", [{"text": "hi"}], "conv-1")
         assert result == {}
@@ -324,9 +380,9 @@ class TestAsyncTriggerRealtimeIntegrations:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch(
-            "utils.app_integrations.process_mentor_notification", return_value=None
-        ), patch("utils.app_integrations.get_webhook_client", return_value=mock_client):
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1, app2]), patch.object(
+            app_integrations, "process_mentor_notification", return_value=None
+        ), patch.object(app_integrations, "get_webhook_client", return_value=mock_client):
             await app_integrations.trigger_realtime_integrations("uid-1", [{"text": "hi"}], "conv-1")
 
         assert mock_client.post.call_count == 2
@@ -344,9 +400,9 @@ class TestAsyncTriggerRealtimeIntegrations:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch(
-            "utils.app_integrations.process_mentor_notification", return_value=None
-        ), patch("utils.app_integrations.get_webhook_client", return_value=mock_client), patch.object(
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch.object(
+            app_integrations, "process_mentor_notification", return_value=None
+        ), patch.object(app_integrations, "get_webhook_client", return_value=mock_client), patch.object(
             app_integrations, "send_app_notification"
         ) as mock_notify, patch.object(
             app_integrations, "add_app_message", return_value={"id": "msg-1"}
@@ -368,9 +424,9 @@ class TestAsyncTriggerRealtimeIntegrations:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch(
-            "utils.app_integrations.process_mentor_notification", return_value=None
-        ), patch("utils.app_integrations.get_webhook_client", return_value=mock_client):
+        with patch.object(app_integrations, "get_available_apps", return_value=[app1]), patch.object(
+            app_integrations, "process_mentor_notification", return_value=None
+        ), patch.object(app_integrations, "get_webhook_client", return_value=mock_client):
             await app_integrations.trigger_realtime_integrations("uid-1", [{"text": "hi"}], None)
 
         call_url = mock_client.post.call_args[0][0]

--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -17,8 +17,8 @@ os.environ.setdefault(
 )
 
 _database_stubs = [
-    "database._client",
     "database",
+    "database._client",
     "database.mem_db",
     "database.redis_db",
     "database.memories",
@@ -56,6 +56,9 @@ _utils_stubs = [
     "utils.executors",
 ]
 _RESTORED_MODULES = tuple(_database_stubs + _utils_stubs + ["utils.app_integrations"])
+# The real "utils" parent package is intentionally left out: restoring child
+# stubs below also removes any attributes _install_module attached to it.
+# "database" is restored because this test temporarily replaces that parent.
 _MISSING = object()
 _saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
 
@@ -90,11 +93,10 @@ def _restore_stub_modules():
 
 
 # Stub database modules
-_install_module("database._client", MagicMock())
-
 _db_pkg = types.ModuleType("database")
 _db_pkg.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'database'))]
 _install_module("database", _db_pkg)
+_install_module("database._client", MagicMock())
 
 for submod in [
     "redis_db",


### PR DESCRIPTION
## Summary

- Save and restore the `database.*`, `utils.*`, and imported `utils.app_integrations` modules that `test_async_app_integrations.py` stubs during collection.
- Install the stubs explicitly for the router import instead of mutating whatever module a previous test may have left in `sys.modules`.
- Switch string-based patches to `patch.object(app_integrations, ...)` so the test can use its local imported module after `sys.modules` is restored.

## Root cause

On Windows/backend unit collection, `test_async_app_integrations.py` left collection-time stubs such as `utils.conversations`, `utils.http_client`, `utils.subscription`, and `database.webhook_health` in `sys.modules`. Later tests then imported those stubs instead of the real modules, causing errors like `utils.conversations` not being a package or missing names from real modules.

## Validation

- `python -m pytest backend\tests\unit\test_async_app_integrations.py -q --tb=short` -> 9 passed
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_geocoding.py -q --tb=short` -> 16 passed
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_geocoding.py --collect-only -q --tb=short --continue-on-collection-errors` -> 16 tests collected
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_http_infrastructure.py backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_conversation_hybrid_search.py --collect-only -q --tb=short --continue-on-collection-errors` -> 70 tests collected
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_async_app_integrations.py --check`
- `python -m py_compile backend\tests\unit\test_async_app_integrations.py`
- `git diff --check`