### PR TITLE
[codex] Complete desktop Deepgram test stubs

### DIFF
--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -98,12 +98,33 @@ sys.modules.setdefault('firebase_admin.auth', _fb.auth)
 _deepgram = ModuleType('deepgram')
 _deepgram.DeepgramClient = MagicMock
 _deepgram.DeepgramClientOptions = MagicMock
+_deepgram.LiveTranscriptionEvents = type(
+    'LiveTranscriptionEvents',
+    (),
+    {
+        'Open': 'Open',
+        'Transcript': 'Transcript',
+        'Metadata': 'Metadata',
+        'SpeechStarted': 'SpeechStarted',
+        'UtteranceEnd': 'UtteranceEnd',
+        'Close': 'Close',
+        'Error': 'Error',
+        'Unhandled': 'Unhandled',
+    },
+)
 sys.modules.setdefault('deepgram', _deepgram)
 
 _speaker_embedding = ModuleType('utils.stt.speaker_embedding')
 _speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
 _speaker_embedding.compare_embeddings = MagicMock(return_value=0.0)
 _speaker_embedding.extract_embedding_from_bytes = MagicMock()
+
+
+async def _async_extract_embedding_from_bytes(*_args, **_kwargs):
+    return None
+
+
+_speaker_embedding.async_extract_embedding_from_bytes = _async_extract_embedding_from_bytes
 sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
 
 import google.cloud.storage as _gcs


### PR DESCRIPTION
## Summary

- Add the `LiveTranscriptionEvents` names used by `utils.stt.streaming` to the desktop transcription test's Deepgram stub.
- Add an awaitable `async_extract_embedding_from_bytes` export to the `utils.stt.speaker_embedding` stub.

## Root cause

On Windows/backend unit collection, `test_desktop_transcribe.py` leaves lightweight Deepgram and speaker-embedding stubs in `sys.modules`. When `test_dg_start_guard.py` is collected afterward, `utils.stt.streaming` imports those stubs and expects the same named exports as the real modules. The missing names caused collection to fail before the start-guard tests could run.

## Validation

- `python -m pytest backend\tests\unit\test_desktop_transcribe.py backend\tests\unit\test_dg_start_guard.py --collect-only -q --tb=short --continue-on-collection-errors` -> 58 tests collected
- `python -m pytest backend\tests\unit\test_dg_start_guard.py -q --tb=short` -> 2 passed
- `python -m pytest backend\tests\unit\test_desktop_transcribe.py --collect-only -q --tb=short --continue-on-collection-errors` -> 56 tests collected
- `python -m pytest backend\tests\unit\test_desktop_transcribe.py::TestDeepgramPrerecordedFromBytesPCM backend\tests\unit\test_desktop_transcribe.py::TestDeepgramPrerecordedFromBytesEdgeCases -q --tb=short` -> 9 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_desktop_transcribe.py --check`
- `python -m py_compile backend\tests\unit\test_desktop_transcribe.py`
- `git diff --check`

Note: running the full `test_desktop_transcribe.py` file locally still hits existing router/chat import failures around `models.conversation_enums`; this PR is scoped to the collection-order failure between `test_desktop_transcribe.py` and `test_dg_start_guard.py`.