### PR TITLE
[codex] Isolate WS auth test stubs after TTS/tools collection

### DIFF
--- a/backend/tests/unit/test_tts.py
+++ b/backend/tests/unit/test_tts.py
@@ -30,6 +30,11 @@ os.environ.setdefault(
 def _stub_module(name):
     mod = types.ModuleType(name)
     sys.modules[name] = mod
+    if "." in name:
+        parent_name, attr = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, mod)
     return mod
 
 
@@ -47,6 +52,60 @@ def _restore_real_package(name, path):
         sys.modules[name] = mod
     mod.__path__ = [str(path)]
     return mod
+
+
+_RESTORED_MODULES = (
+    "firebase_admin",
+    "firebase_admin.firestore",
+    "firebase_admin.auth",
+    "firebase_admin.credentials",
+    "redis",
+    "database",
+    "database.redis_db",
+    "utils.other.endpoints",
+    "utils.http_client",
+    "utils.log_sanitizer",
+    "models",
+    "models.tts",
+    "routers.tts",
+)
+_PARENT_ATTRS = (
+    ("firebase_admin", "firestore"),
+    ("firebase_admin", "auth"),
+    ("firebase_admin", "credentials"),
+    ("database", "redis_db"),
+    ("utils.other", "endpoints"),
+    ("utils", "http_client"),
+    ("utils", "log_sanitizer"),
+    ("models", "tts"),
+    ("routers", "tts"),
+)
+_MISSING = object()
+_saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+_saved_parent_attrs = {
+    (parent_name, attr): getattr(sys.modules.get(parent_name), attr, _MISSING)
+    for parent_name, attr in _PARENT_ATTRS
+    if sys.modules.get(parent_name) is not None
+}
+
+
+def _restore_stub_modules():
+    for name in sorted(_RESTORED_MODULES, key=lambda module_name: module_name.count("."), reverse=True):
+        original = _saved_modules[name]
+        if original is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+    for (parent_name, attr), original in _saved_parent_attrs.items():
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            continue
+        if original is _MISSING:
+            if hasattr(parent, attr):
+                delattr(parent, attr)
+        else:
+            setattr(parent, attr, original)
 
 
 # ---------------------------------------------------------------------------
@@ -83,8 +142,10 @@ def _load_tts_router_module():
     redis_db_stub = types.ModuleType("database.redis_db")
     redis_db_stub.check_tts_rate_limit = MagicMock(return_value=(0, 0))
     sys.modules["database.redis_db"] = redis_db_stub
-    sys.modules.setdefault("database", _stub_package("database"))
-    sys.modules["database"].redis_db = redis_db_stub
+    database_pkg = sys.modules.get("database")
+    if database_pkg is None:
+        database_pkg = _stub_package("database")
+    database_pkg.redis_db = redis_db_stub
 
     # Stub http_client
     http_client_stub = types.ModuleType("utils.http_client")
@@ -114,7 +175,10 @@ def _load_tts_router_module():
     return mod
 
 
-tts_router = _load_tts_router_module()
+try:
+    tts_router = _load_tts_router_module()
+finally:
+    _restore_stub_modules()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -11,12 +11,90 @@ import importlib
 import sys
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from fastapi import FastAPI, WebSocket, WebSocketException, Depends
 from fastapi.testclient import TestClient
-from firebase_admin.auth import InvalidIdTokenError
 from starlette.websockets import WebSocketDisconnect
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+def _remove_module(name):
+    mod = sys.modules.pop(name, None)
+    if "." not in name:
+        return
+
+    parent_name, attr = name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, attr, None) is mod:
+        delattr(parent, attr)
+
+
+def _restore_package_path(name, path):
+    mod = sys.modules.get(name)
+    if not isinstance(mod, types.ModuleType) or not getattr(mod, "__path__", None):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod.__path__ = [str(path)]
+    if "." in name:
+        parent_name, attr = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, mod)
+    return mod
+
+
+def _remove_incomplete_module(name, required_attrs):
+    mod = sys.modules.get(name)
+    if mod is not None and not all(hasattr(mod, attr) for attr in required_attrs):
+        _remove_module(name)
+
+
+def _install_firebase_auth_stub():
+    firebase_admin = types.ModuleType("firebase_admin")
+    firebase_admin.__path__ = []
+    auth_module = types.ModuleType("firebase_admin.auth")
+
+    class _InvalidIdTokenError(Exception):
+        pass
+
+    def _raise_invalid_token(_token):
+        raise _InvalidIdTokenError("invalid token")
+
+    auth_module.InvalidIdTokenError = _InvalidIdTokenError
+    auth_module.verify_id_token = _raise_invalid_token
+    auth_module.get_user = MagicMock()
+    firebase_admin.auth = auth_module
+    sys.modules["firebase_admin"] = firebase_admin
+    sys.modules["firebase_admin.auth"] = auth_module
+
+
+firebase_auth_module = sys.modules.get("firebase_admin.auth")
+if firebase_auth_module is None or not isinstance(getattr(firebase_auth_module, "InvalidIdTokenError", None), type):
+    _install_firebase_auth_stub()
+
+_restore_package_path("database", BACKEND_DIR / "database")
+_restore_package_path("utils", BACKEND_DIR / "utils")
+_restore_package_path("utils.other", BACKEND_DIR / "utils" / "other")
+
+_remove_incomplete_module("database.redis_db", ("check_rate_limit", "try_acquire_listen_lock"))
+_remove_incomplete_module(
+    "utils.byok",
+    ("extract_byok_from_websocket", "set_byok_keys", "validate_byok_request", "validate_byok_websocket"),
+)
+_remove_incomplete_module("utils.executors", ("critical_executor", "run_blocking"))
+_remove_incomplete_module(
+    "utils.rate_limit_config",
+    ("RATE_POLICIES", "RATE_LIMIT_SHADOW", "get_effective_limit"),
+)
+_remove_incomplete_module(
+    "utils.other.endpoints",
+    ("get_current_user_uid_ws_listen", "get_current_user_uid_ws", "get_current_user_uid"),
+)
+
+from firebase_admin.auth import InvalidIdTokenError
 
 database_users_stub = types.ModuleType('database.users')
 database_users_stub.record_user_platform = MagicMock()

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -20,10 +20,13 @@ from starlette.websockets import WebSocketDisconnect
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 
+# Keep these helpers local: they repair import-time state for this test module
+# without adding a global collection hook that could affect unrelated tests.
+
 
 def _remove_module(name):
     mod = sys.modules.pop(name, None)
-    if "." not in name:
+    if mod is None or "." not in name:
         return
 
     parent_name, attr = name.rsplit(".", 1)
@@ -112,6 +115,30 @@ finally:
         sys.modules.pop('database.users', None)
     else:
         sys.modules['database.users'] = original_database_users
+
+
+def test_remove_module_ignores_absent_child_attribute():
+    sentinel = object()
+    parent_name = "test_ws_auth_absent_parent"
+    child_name = f"{parent_name}.child"
+    original_parent = sys.modules.get(parent_name, sentinel)
+    original_child = sys.modules.get(child_name, sentinel)
+    parent = types.ModuleType(parent_name)
+    sys.modules[parent_name] = parent
+    sys.modules.pop(child_name, None)
+
+    try:
+        _remove_module(child_name)
+        assert not hasattr(parent, "child")
+    finally:
+        if original_child is sentinel:
+            sys.modules.pop(child_name, None)
+        else:
+            sys.modules[child_name] = original_child
+        if original_parent is sentinel:
+            sys.modules.pop(parent_name, None)
+        else:
+            sys.modules[parent_name] = original_parent
 
 
 class WebSocketAuthTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Restore the import-time stubs that `test_tts.py` installs while loading `routers.tts`, including parent-package attributes.
- Make `test_ws_auth_handshake.py` discard incomplete prior stubs and use a local Firebase auth stub before importing `utils.other.endpoints`.
- Keep the WebSocket auth tests independent from earlier Windows collection order pollution left by tests such as `test_tools_router.py` and `test_tts.py`.
- Address review feedback by making `_remove_module(...)` no-op safely when the target child module is absent, with regression coverage for that helper edge case.

## Root cause

On Windows backend unit collection, earlier tests can leave partial `firebase_admin.auth`, `utils.other.endpoints`, `utils`, or `database` stubs in `sys.modules`. When `test_ws_auth_handshake.py` is collected afterward, it can import those partial stubs instead of the real endpoint helpers, failing with missing `InvalidIdTokenError` or missing WebSocket auth functions.

## Validation

- `python -m pytest backend\tests\unit\test_ws_auth_handshake.py -q --tb=short` -> 19 passed
- `python -m pytest backend\tests\unit\test_tts.py -q --tb=short` -> 14 passed
- `python -m pytest backend\tests\unit\test_tools_router.py backend\tests\unit\test_ws_auth_handshake.py --collect-only -q --tb=short --continue-on-collection-errors` -> 101 tests collected
- `python -m pytest backend\tests\unit\test_tts.py backend\tests\unit\test_vertex_ai_system_role.py backend\tests\unit\test_ws_auth_handshake.py --collect-only -q --tb=short --continue-on-collection-errors` -> 36 tests collected
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` -> still exits 1 for unrelated existing collection errors, but `test_ws_auth_handshake.py` is collected instead of listed as an error
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_tts.py backend\tests\unit\test_ws_auth_handshake.py --check`
- `python -m py_compile backend\tests\unit\test_tts.py backend\tests\unit\test_ws_auth_handshake.py`
- `git diff --check`