### PR TITLE
[codex] Isolate speaker ID pipeline test imports

### DIFF
--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -63,6 +63,7 @@ _PARENT_ATTRS = (
     ("scipy.spatial", "distance"),
 )
 _MISSING = object()
+_NOT_IMPORTED = object()
 _saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
 _saved_parent_attrs = {
     (parent_name, attr): getattr(sys.modules.get(parent_name), attr, _MISSING) for parent_name, attr in _PARENT_ATTRS
@@ -78,8 +79,16 @@ def _install_module(name, module):
             setattr(parent, attr, module)
 
 
+def _restore_parent_attr(parent, attr, original, current):
+    if original is _MISSING:
+        if current is not _NOT_IMPORTED and getattr(parent, attr, _MISSING) is current:
+            delattr(parent, attr)
+    else:
+        setattr(parent, attr, original)
+
+
 def _restore_stub_modules():
-    current_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+    current_modules = {name: sys.modules.get(name, _NOT_IMPORTED) for name in _RESTORED_MODULES}
     for name in sorted(_RESTORED_MODULES, key=lambda module_name: module_name.count("."), reverse=True):
         original = _saved_modules[name]
         if original is _MISSING:
@@ -91,12 +100,8 @@ def _restore_stub_modules():
         parent = sys.modules.get(parent_name)
         if parent is None:
             continue
-        if original is _MISSING:
-            child_name = f"{parent_name}.{attr}"
-            if getattr(parent, attr, _MISSING) is current_modules.get(child_name):
-                delattr(parent, attr)
-        else:
-            setattr(parent, attr, original)
+        child_name = f"{parent_name}.{attr}"
+        _restore_parent_attr(parent, attr, original, current_modules.get(child_name, _NOT_IMPORTED))
 
 
 _install_module("database._client", MagicMock())
@@ -149,6 +154,13 @@ finally:
     _restore_stub_modules()
 
 # ─── AudioRingBuffer ─────────────────────────────────────────────────────────
+
+
+class TestImportStubCleanup:
+    def test_restore_parent_attr_ignores_missing_child_and_absent_attr(self):
+        parent = ModuleType("parent")
+        _restore_parent_attr(parent, "child", _MISSING, _NOT_IMPORTED)
+        assert not hasattr(parent, "child")
 
 
 class TestAudioRingBuffer:

--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -105,6 +105,17 @@ def _restore_stub_modules():
 
 
 _install_module("database._client", MagicMock())
+_conversations_mod = ModuleType("database.conversations")
+_conversations_mod.get_conversation = MagicMock(return_value=None)
+_install_module("database.conversations", _conversations_mod)
+
+_users_mod = ModuleType("database.users")
+_users_mod.get_person = MagicMock(return_value=None)
+_users_mod.get_person_speech_samples_count = MagicMock(return_value=0)
+_users_mod.add_person_speech_sample = MagicMock(return_value=True)
+_users_mod.set_person_speaker_embedding = MagicMock(return_value=None)
+_install_module("database.users", _users_mod)
+
 _install_module("av", MagicMock())
 
 _storage_mod = ModuleType("utils.other.storage")

--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -39,10 +39,14 @@ _RESTORED_MODULES = (
     "database.conversations",
     "database.users",
     "av",
+    "utils.audio",
+    "utils.http_client",
+    "utils.other",
     "utils.other.storage",
     "utils.speaker_identification",
     "utils.speaker_sample",
     "utils.speaker_sample_migration",
+    "utils.stt",
     "utils.stt.speaker_embedding",
     "utils.stt.pre_recorded",
     "scipy",
@@ -53,10 +57,14 @@ _PARENT_ATTRS = (
     ("database", "_client"),
     ("database", "conversations"),
     ("database", "users"),
+    ("utils", "audio"),
+    ("utils", "http_client"),
+    ("utils", "other"),
     ("utils.other", "storage"),
     ("utils", "speaker_identification"),
     ("utils", "speaker_sample"),
     ("utils", "speaker_sample_migration"),
+    ("utils", "stt"),
     ("utils.stt", "speaker_embedding"),
     ("utils.stt", "pre_recorded"),
     ("scipy", "spatial"),
@@ -77,6 +85,23 @@ def _install_module(name, module):
         parent = sys.modules.get(parent_name)
         if parent is not None:
             setattr(parent, attr, module)
+
+
+def _drop_module_and_parent_attr(name):
+    current = sys.modules.pop(name, _MISSING)
+    if "." not in name:
+        return
+
+    parent_name, attr = name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if parent is None:
+        return
+
+    if current is _MISSING:
+        if hasattr(parent, attr):
+            delattr(parent, attr)
+    elif getattr(parent, attr, _MISSING) is current:
+        delattr(parent, attr)
 
 
 def _restore_parent_attr(parent, attr, original, current):
@@ -104,6 +129,14 @@ def _restore_stub_modules():
         _restore_parent_attr(parent, attr, original, current_modules.get(child_name, _NOT_IMPORTED))
 
 
+for _real_import in (
+    "utils.audio",
+    "utils.speaker_identification",
+    "utils.speaker_sample",
+    "utils.stt.speaker_embedding",
+):
+    _drop_module_and_parent_attr(_real_import)
+
 _install_module("database._client", MagicMock())
 _conversations_mod = ModuleType("database.conversations")
 _conversations_mod.get_conversation = MagicMock(return_value=None)
@@ -115,6 +148,10 @@ _users_mod.get_person_speech_samples_count = MagicMock(return_value=0)
 _users_mod.add_person_speech_sample = MagicMock(return_value=True)
 _users_mod.set_person_speaker_embedding = MagicMock(return_value=None)
 _install_module("database.users", _users_mod)
+
+_http_client_mod = ModuleType("utils.http_client")
+_http_client_mod.get_stt_client = MagicMock()
+_install_module("utils.http_client", _http_client_mod)
 
 _install_module("av", MagicMock())
 

--- a/backend/tests/unit/test_speaker_id_pipeline.py
+++ b/backend/tests/unit/test_speaker_id_pipeline.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 # Mock modules that initialize GCP clients at import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 
 def _cosine_cdist(a, b, metric="cosine"):
@@ -34,30 +34,119 @@ def _cosine_cdist(a, b, metric="cosine"):
 
 
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
-sys.modules.setdefault("database._client", MagicMock())
-sys.modules.setdefault("av", MagicMock())
-sys.modules.setdefault("utils.other.storage", MagicMock())
-sys.modules.setdefault("utils.stt.pre_recorded", MagicMock())
+_RESTORED_MODULES = (
+    "database._client",
+    "database.conversations",
+    "database.users",
+    "av",
+    "utils.other.storage",
+    "utils.speaker_identification",
+    "utils.speaker_sample",
+    "utils.speaker_sample_migration",
+    "utils.stt.speaker_embedding",
+    "utils.stt.pre_recorded",
+    "scipy",
+    "scipy.spatial",
+    "scipy.spatial.distance",
+)
+_PARENT_ATTRS = (
+    ("database", "_client"),
+    ("database", "conversations"),
+    ("database", "users"),
+    ("utils.other", "storage"),
+    ("utils", "speaker_identification"),
+    ("utils", "speaker_sample"),
+    ("utils", "speaker_sample_migration"),
+    ("utils.stt", "speaker_embedding"),
+    ("utils.stt", "pre_recorded"),
+    ("scipy", "spatial"),
+    ("scipy.spatial", "distance"),
+)
+_MISSING = object()
+_saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+_saved_parent_attrs = {
+    (parent_name, attr): getattr(sys.modules.get(parent_name), attr, _MISSING) for parent_name, attr in _PARENT_ATTRS
+}
+
+
+def _install_module(name, module):
+    sys.modules[name] = module
+    if "." in name:
+        parent_name, attr = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, module)
+
+
+def _restore_stub_modules():
+    current_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+    for name in sorted(_RESTORED_MODULES, key=lambda module_name: module_name.count("."), reverse=True):
+        original = _saved_modules[name]
+        if original is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+    for (parent_name, attr), original in _saved_parent_attrs.items():
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            continue
+        if original is _MISSING:
+            child_name = f"{parent_name}.{attr}"
+            if getattr(parent, attr, _MISSING) is current_modules.get(child_name):
+                delattr(parent, attr)
+        else:
+            setattr(parent, attr, original)
+
+
+_install_module("database._client", MagicMock())
+_install_module("av", MagicMock())
+
+_storage_mod = ModuleType("utils.other.storage")
+for _name in [
+    "delete_speech_profile_blob",
+    "download_audio_chunks_and_merge",
+    "download_speech_profile_bytes",
+    "list_audio_chunks",
+    "upload_person_speech_sample_from_bytes",
+]:
+    setattr(_storage_mod, _name, MagicMock())
+_install_module("utils.other.storage", _storage_mod)
+
+_migration_mod = ModuleType("utils.speaker_sample_migration")
+_migration_mod.maybe_migrate_person_samples = AsyncMock(side_effect=lambda _uid, person: person)
+_install_module("utils.speaker_sample_migration", _migration_mod)
+
+_install_module("utils.stt.pre_recorded", MagicMock())
 try:
     from scipy.spatial.distance import cdist as _scipy_cdist  # noqa: F401
 except ImportError:
-    scipy_mod = sys.modules.setdefault("scipy", ModuleType("scipy"))
-    spatial_mod = sys.modules.setdefault("scipy.spatial", ModuleType("scipy.spatial"))
+    scipy_mod = ModuleType("scipy")
+    spatial_mod = ModuleType("scipy.spatial")
     distance_mod = ModuleType("scipy.spatial.distance")
     distance_mod.cdist = _cosine_cdist
     scipy_mod.spatial = spatial_mod
     spatial_mod.distance = distance_mod
-    sys.modules["scipy.spatial.distance"] = distance_mod
+    _install_module("scipy", scipy_mod)
+    _install_module("scipy.spatial", spatial_mod)
+    _install_module("scipy.spatial.distance", distance_mod)
 
-from utils.audio import AudioRingBuffer
-from utils.speaker_identification import detect_speaker_from_text, SPEAKER_IDENTIFICATION_PATTERNS, _pcm_to_wav_bytes
-from utils.stt.speaker_embedding import (
-    compare_embeddings,
-    is_same_speaker,
-    find_best_match,
-    SPEAKER_MATCH_THRESHOLD,
-    _get_wav_duration,
-)
+try:
+    from utils.audio import AudioRingBuffer
+    from utils.speaker_identification import (
+        detect_speaker_from_text,
+        SPEAKER_IDENTIFICATION_PATTERNS,
+        _pcm_to_wav_bytes,
+    )
+    from utils.stt.speaker_embedding import (
+        compare_embeddings,
+        is_same_speaker,
+        find_best_match,
+        SPEAKER_MATCH_THRESHOLD,
+        _get_wav_duration,
+    )
+finally:
+    _restore_stub_modules()
 
 # ─── AudioRingBuffer ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Install explicit import-time stubs for the speaker ID pipeline test dependencies that otherwise initialize external services or optional native packages.
- Restore the original `sys.modules` entries and parent package attrs immediately after importing the target functions.
- Split the cleanup sentinels so partial-import cleanup does not mask the original import error.
- Drop stale target module attrs before the isolated import and stub DB / HTTP-client imports that can be polluted by earlier Windows unit-test collection.
- Make the migration stub async to match the production `maybe_migrate_person_samples` contract.

## Why

On Windows, backend unit-test collection can depend on file order because other tests leave partial module stubs behind, such as `utils.other.storage`, `utils.stt.speaker_embedding`, or `utils.http_client` without the symbols imported by the speaker ID pipeline. This makes `test_speaker_id_pipeline.py` fail during collection even though it passes in isolation.

This keeps the speaker pipeline test self-contained during import while avoiding pollution for tests collected later.

## Validation

- `python -m pytest backend\\tests\\unit\\test_speaker_id_pipeline.py -q --tb=short` -> 107 passed
- `python -m pytest backend\\tests\\unit\\test_merge_validation.py backend\\tests\\unit\\test_speaker_id_pipeline.py --collect-only -q --tb=short --continue-on-collection-errors` -> 143 tests collected
- `python -m pytest backend\\tests\\unit\\test_mcp_data_endpoints.py backend\\tests\\unit\\test_speaker_id_pipeline.py --collect-only -q --tb=short --continue-on-collection-errors` -> 126 tests collected
- `python -m pytest backend\\tests\\unit --collect-only -q --tb=short --continue-on-collection-errors` -> exits with existing unrelated collection errors, but `test_speaker_id_pipeline.py` is collected and is no longer listed as an error source; 3043 tests collected, 32 errors
- `python -m black --check --line-length 120 --skip-string-normalization backend\\tests\\unit\\test_speaker_id_pipeline.py`
- `python -m py_compile backend\\tests\\unit\\test_speaker_id_pipeline.py`
- `git diff --check origin/main..HEAD`
- `git diff --check`
- `scripts/pre-commit`