### PR TITLE
[codex] Include all unit tests in backend runner

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -18,6 +18,7 @@ pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v
 pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_parakeet_diarization.py -v
+pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
 pytest tests/unit/test_parakeet_prerecorded.py -v
 pytest tests/unit/test_parakeet_nim.py -v
 pytest tests/unit/test_parakeet_stream_session.py -v
@@ -25,13 +26,20 @@ pytest tests/unit/test_parakeet_gpu_worker.py -v
 pytest tests/unit/test_parakeet_batch_engine.py -v
 pytest tests/unit/test_parakeet_batch_routing.py -v
 pytest tests/unit/test_parakeet_endpoints.py -v
+pytest tests/unit/test_audiobuffer_guard.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
+pytest tests/unit/test_mcp_memory_filters.py -v
 pytest tests/unit/test_mcp_client_tool_result.py -v
 pytest tests/unit/test_mcp_data_endpoints.py -v
 pytest tests/unit/test_memory_temporal_brain.py -v
+pytest tests/unit/test_memory_category_auto.py -v
+pytest tests/unit/test_memories_validation.py -v
+pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v
+pytest tests/unit/test_high_priority_usage_tracking.py -v
+pytest tests/unit/test_new_usage_tracking_gaps.py -v
 pytest tests/unit/test_llm_usage_db.py -v
 pytest tests/unit/test_llm_usage_endpoints.py -v
 pytest tests/unit/test_app_uid_keyerror.py -v
@@ -41,6 +49,7 @@ pytest tests/unit/test_chat_tools_messages.py -v
 pytest tests/unit/test_prompt_caching.py -v
 pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v
+pytest tests/unit/test_notification_token_cleanup.py -v
 pytest tests/unit/test_conversations_to_string.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
@@ -53,6 +62,8 @@ pytest tests/unit/test_firmware_pagination.py -v
 pytest tests/unit/test_vad_gate.py -v
 pytest tests/unit/test_vad_onnx.py -v
 pytest tests/unit/test_log_sanitizer.py -v
+pytest tests/unit/test_file_upload_security.py -v
+pytest tests/unit/test_file_upload_endpoint_security.py -v
 pytest tests/unit/test_auth_redirect_uri.py -v
 pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_pusher_conversation_retry.py -v
@@ -83,6 +94,7 @@ pytest tests/unit/test_conversation_structure_timezone.py -v
 pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
 pytest tests/unit/test_action_item_idempotency.py -v
+pytest tests/unit/test_goals_id_fallback.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v
 pytest tests/unit/test_kg_edge_id_sanitization.py -v
@@ -140,7 +152,6 @@ pytest tests/unit/test_async_geocoding.py -v
 pytest tests/unit/test_geocoding_cache.py -v
 pytest tests/unit/test_realtime_integrations_usage_tracking.py -v
 pytest tests/unit/test_async_auth.py -v
-pytest tests/unit/test_auth_redirect_uri.py -v
 pytest tests/unit/test_thread_join_elimination.py -v
 pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
@@ -153,6 +164,8 @@ pytest tests/unit/test_vertex_ai_system_role.py -v
 pytest tests/unit/test_tts.py -v
 pytest tests/unit/test_webhook_auto_disable.py -v
 pytest tests/unit/test_merge_validation.py -v
+pytest tests/unit/test_phone_calls.py -v
+pytest tests/unit/test_twilio_service.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
 pytest tests/unit/test_conversation_search_date_validation.py -v
 pytest tests/unit/test_conversation_hybrid_search.py -v


### PR DESCRIPTION
## Summary

- Add all existing unit test files that were missing from `backend/test.sh` so the backend CI runner exercises them.
- Remove the duplicate `test_auth_redirect_uri.py` invocation.
- Bring the runner to full current coverage for `backend/tests/unit/test_*.py`: 0 missing, 0 duplicate entries.

## Why

`backend/AGENTS.md` says new unit test files should be added to `test.sh` or they will not run in CI. A current local comparison now finds every `backend/tests/unit/test_*.py` file listed exactly once in `backend/test.sh`.

## Refresh

- Rebased on `main` at `1a5824403b`.
- Current head: `9cddfccf35`.
- This supersedes #7995, which was an accidental duplicate after the latest runner audit.

## Validation

- Local comparison script: `MISSING_COUNT=0`, `DUP_COUNT=0`
- Each newly-added file run in a separate pytest process, matching `backend/test.sh`'s execution model: 175 passed
  - `test_audiobuffer_guard.py` -> 15 passed
  - `test_diarizer_embedding_decoder_bypass.py` -> 2 passed
  - `test_file_upload_endpoint_security.py` -> 13 passed
  - `test_file_upload_security.py` -> 13 passed
  - `test_goals_id_fallback.py` -> 9 passed
  - `test_high_priority_usage_tracking.py` -> 21 passed
  - `test_mcp_memory_filters.py` -> 8 passed
  - `test_memories_user_review.py` -> 6 passed
  - `test_memories_validation.py` -> 11 passed
  - `test_memory_category_auto.py` -> 7 passed, 1 warning
  - `test_new_usage_tracking_gaps.py` -> 45 passed
  - `test_notification_token_cleanup.py` -> 2 passed
  - `test_phone_calls.py` -> 18 passed, 1 warning
  - `test_twilio_service.py` -> 5 passed
- `C:\Program Files\Git\bin\bash.exe -n backend/test.sh`
- `git diff --check`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`