### PR TITLE
[codex] Reject empty Windows automation send_keys steps

### DIFF
--- a/desktop/windows/src/main/automation/bridge.test.ts
+++ b/desktop/windows/src/main/automation/bridge.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AutomationPlan, AutomationStep, StepResult } from '../../shared/types'
+
+const spawnMock = vi.hoisted(() => vi.fn())
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+import { automationBridge } from './bridge'
+
+afterEach(() => {
+  automationBridge.dispose()
+  spawnMock.mockClear()
+})
+
+describe('AutomationBridge.run', () => {
+  it('rejects malformed send_keys plans before starting the helper', async () => {
+    const plan: AutomationPlan = {
+      id: 'p',
+      summary: 's',
+      targetWindow: 'Notepad',
+      steps: [{ type: 'send_keys' } as unknown as AutomationStep]
+    }
+    const steps: StepResult[] = []
+
+    const result = await automationBridge.run(plan, (step) => steps.push(step))
+
+    expect(result).toEqual({ planId: 'p', ok: false, message: 'rejected: step 0: keys is empty' })
+    expect(steps).toEqual([])
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/main/automation/capabilities.test.ts
+++ b/desktop/windows/src/main/automation/capabilities.test.ts
@@ -39,6 +39,9 @@ describe('validateStep', () => {
   it('rejects empty/whitespace value-bearing fields', () => {
     bad({ type: 'invoke_element', elementRef: '' })
     bad({ type: 'focus_window', windowRef: '   ' })
+    bad({ type: 'send_keys', keys: '' })
+    bad({ type: 'send_keys', keys: '   ' })
+    bad({ type: 'send_keys' } as unknown as AutomationStep)
   })
 
   it('rejects set_value with an empty value', () => {
@@ -101,5 +104,16 @@ describe('validatePlan', () => {
     const r = validatePlan(plan)
     expect(r.ok).toBe(false)
     expect(r.ok ? '' : r.reason).toMatch(/step 1/)
+  })
+
+  it('rejects malformed send_keys plans before any bridge execution', () => {
+    const plan: AutomationPlan = {
+      id: 'p',
+      summary: 's',
+      targetWindow: 'Notepad',
+      steps: [{ type: 'send_keys' } as unknown as AutomationStep]
+    }
+    const r = validatePlan(plan)
+    expect(r).toEqual({ ok: false, reason: 'step 0: keys is empty' })
   })
 })

--- a/desktop/windows/src/main/automation/capabilities.ts
+++ b/desktop/windows/src/main/automation/capabilities.ts
@@ -43,6 +43,9 @@ const FORBIDDEN_MODIFIER_CHARS = ['^', '%', '+', '#']
 
 function validateSendKeys(keys: string): ValidationResult {
   keys = keys.normalize('NFKC')
+  if (keys.trim().length === 0) {
+    return { ok: false, reason: 'keys is empty' }
+  }
   for (const c of FORBIDDEN_MODIFIER_CHARS) {
     if (keys.includes(c)) return { ok: false, reason: `modifier chord "${c}" not allowed` }
   }
@@ -85,8 +88,11 @@ export function validateStep(step: AutomationStep): ValidationResult {
       return step.timeoutMs > 0 && step.timeoutMs <= MAX_WAIT_FOR_MS
         ? { ok: true }
         : { ok: false, reason: 'timeoutMs out of range' }
-    case 'send_keys':
+    case 'send_keys': {
+      const r = nonEmpty(step.keys, 'keys')
+      if (!r.ok) return r
       return validateSendKeys(step.keys)
+    }
     case 'click':
       if (step.elementRef && step.elementRef.trim()) return { ok: true }
       if (step.point && ALLOW_RAW_COORDINATE_CLICK) return { ok: true }
@@ -101,7 +107,8 @@ export function validatePlan(plan: AutomationPlan): ValidationResult {
   if (!t.ok) return t
   const target = plan.targetWindow.toLowerCase()
   for (const sub of BLOCKLISTED_WINDOW_SUBSTRINGS) {
-    if (target.includes(sub)) return { ok: false, reason: `target window "${plan.targetWindow}" is blocklisted` }
+    if (target.includes(sub))
+      return { ok: false, reason: `target window "${plan.targetWindow}" is blocklisted` }
   }
   for (let i = 0; i < plan.steps.length; i++) {
     const r = validateStep(plan.steps[i])


### PR DESCRIPTION
## Summary
- Reject empty or whitespace-only Windows automation `send_keys` steps.
- Treat runtime `send_keys` payloads missing `keys` as validation failures instead of throwing during `.normalize()`.
- Add step-level, plan-level, and bridge-level coverage for empty, whitespace-only, and missing `keys` payloads.
- Keep the touched Windows automation files formatted with the local Windows app Prettier config.

## Windows automation proof
`AutomationBridge.run()` validates the plan before entering its step loop. The new `bridge.test.ts` regression sends a malformed runtime plan with `{ type: 'send_keys' }`, mocks `child_process.spawn`, and asserts all three safety properties:

- the bridge returns `rejected: step 0: keys is empty`
- no `onStep` callback fires
- the Windows automation helper process is never spawned

That directly covers the requested proof that malformed `send_keys` steps are rejected without executing the plan.

## Refresh
- Rebased on `main` at `b781d91767ac96a20f2305614eb50c7744a8a6c3`.
- Current head: `105e95be3af60685a2b9053734fc787f31d68d9e`.
- GitHub currently reports this PR as mergeable.

## Validation
- From `desktop/windows/`: `npm run test -- src/main/automation/bridge.test.ts src/main/automation/capabilities.test.ts` -> 2 files, 15 tests passed
- From `desktop/windows/`: `npm run typecheck` -> passed
- targeted `npx eslint --quiet` on changed Windows files -> no errors
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `scripts/pre-commit` with `PYTHONUTF8=1` -> passed
- `scripts/pre-push` with `PYTHONUTF8=1` -> passed

Note: npm prints `node-linker` config warnings in this Windows checkout; the commands still exited 0.