### PR TITLE
[codex] Add Retry-After to sync fair-use restrictions

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -94,11 +94,10 @@ from utils.fair_use import (
     record_speech_ms,
     get_rolling_speech_ms,
     check_soft_caps,
-    is_hard_restricted,
+    get_hard_restriction_status,
     trigger_classifier_if_needed,
     is_dg_budget_exhausted,
     get_enforcement_stage,
-    get_hard_restriction_retry_after_seconds,
     record_dg_usage_ms,
     FAIR_USE_ENABLED,
     FAIR_USE_RESTRICT_DAILY_DG_MS,
@@ -131,9 +130,8 @@ def _get_opus_decoder_class():
     return Decoder
 
 
-def _hard_restriction_headers(uid: str, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+def _hard_restriction_headers(retry_after: int | None, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     headers = dict(base_headers or {})
-    retry_after = get_hard_restriction_retry_after_seconds(uid)
     if retry_after is not None:
         headers['Retry-After'] = str(retry_after)
     return headers
@@ -1044,11 +1042,12 @@ async def sync_local_files(
     response.headers.update(_V1_DEPRECATION_HEADERS)
 
     # Pre-check gates (#5854)
-    if is_hard_restricted(uid):
+    hard_restricted, retry_after = get_hard_restriction_status(uid)
+    if hard_restricted:
         raise HTTPException(
             status_code=429,
             detail="Account temporarily restricted due to fair-use policy",
-            headers=_hard_restriction_headers(uid, _V1_DEPRECATION_HEADERS),
+            headers=_hard_restriction_headers(retry_after, _V1_DEPRECATION_HEADERS),
         )
 
     # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
@@ -1675,8 +1674,9 @@ async def sync_local_files_v2(
     an async background task. The app polls GET /v2/sync-local-files/{job_id}.
     """
     # Pre-check gates (same as v1)
-    if await run_blocking(critical_executor, is_hard_restricted, uid):
-        headers = await run_blocking(critical_executor, _hard_restriction_headers, uid)
+    hard_restricted, retry_after = await run_blocking(critical_executor, get_hard_restriction_status, uid)
+    if hard_restricted:
+        headers = _hard_restriction_headers(retry_after)
         raise HTTPException(
             status_code=429,
             detail="Account temporarily restricted due to fair-use policy",

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -98,6 +98,7 @@ from utils.fair_use import (
     trigger_classifier_if_needed,
     is_dg_budget_exhausted,
     get_enforcement_stage,
+    get_hard_restriction_retry_after_seconds,
     record_dg_usage_ms,
     FAIR_USE_ENABLED,
     FAIR_USE_RESTRICT_DAILY_DG_MS,
@@ -128,6 +129,14 @@ def _get_opus_decoder_class():
             'Install the OS-level Opus package before processing .opus sync files.'
         ) from _OPUS_IMPORT_ERROR
     return Decoder
+
+
+def _hard_restriction_headers(uid: str, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    headers = dict(base_headers or {})
+    retry_after = get_hard_restriction_retry_after_seconds(uid)
+    if retry_after is not None:
+        headers['Retry-After'] = str(retry_after)
+    return headers
 
 
 @router.post("/v1/sync/audio/{conversation_id}/precache", tags=['v1'])
@@ -1039,7 +1048,7 @@ async def sync_local_files(
         raise HTTPException(
             status_code=429,
             detail="Account temporarily restricted due to fair-use policy",
-            headers=_V1_DEPRECATION_HEADERS,
+            headers=_hard_restriction_headers(uid, _V1_DEPRECATION_HEADERS),
         )
 
     # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
@@ -1667,7 +1676,12 @@ async def sync_local_files_v2(
     """
     # Pre-check gates (same as v1)
     if await run_blocking(critical_executor, is_hard_restricted, uid):
-        raise HTTPException(status_code=429, detail="Account temporarily restricted due to fair-use policy")
+        headers = await run_blocking(critical_executor, _hard_restriction_headers, uid)
+        raise HTTPException(
+            status_code=429,
+            detail="Account temporarily restricted due to fair-use policy",
+            headers=headers,
+        )
 
     should_lock = not await run_blocking(critical_executor, has_transcription_credits, uid)
 

--- a/backend/tests/unit/test_fair_use_upgrade.py
+++ b/backend/tests/unit/test_fair_use_upgrade.py
@@ -32,6 +32,19 @@ sys.modules.setdefault('database.redis_db', _redis_mod)
 sys.modules.setdefault('google.cloud.firestore', MagicMock())
 sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
 
+_firebase_admin = types.ModuleType('firebase_admin')
+_firebase_auth = types.ModuleType('firebase_admin.auth')
+_firebase_auth.get_user = MagicMock()
+_firebase_admin.auth = _firebase_auth
+sys.modules.setdefault('firebase_admin', _firebase_admin)
+sys.modules.setdefault('firebase_admin.auth', _firebase_auth)
+
+sys.modules.setdefault('stripe', types.ModuleType('stripe'))
+
+_announcements = types.ModuleType('database.announcements')
+_announcements.compare_versions = MagicMock(return_value=0)
+sys.modules.setdefault('database.announcements', _announcements)
+
 # Stub database.fair_use
 _fair_use_db = types.ModuleType('database.fair_use')
 _fair_use_db.get_fair_use_state = MagicMock(return_value={})

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -200,8 +200,13 @@ class TestHardRestrictionRetryAfter:
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
     @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(
+        fair_use_mod,
+        'get_rolling_speech_ms',
+        return_value={'daily_ms': 999999999, 'three_day_ms': 0, 'weekly_ms': 0},
+    )
     @patch.object(fair_use_mod, 'fair_use_db')
-    def test_returns_seconds_until_restrict_until(self, mock_fair_use_db):
+    def test_returns_seconds_until_restrict_until(self, mock_fair_use_db, mock_speech):
         mock_fair_use_db.get_fair_use_state.return_value = {
             'stage': 'restrict',
             'restrict_until': datetime.utcnow() + timedelta(seconds=120),
@@ -215,8 +220,13 @@ class TestHardRestrictionRetryAfter:
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
     @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(
+        fair_use_mod,
+        'get_rolling_speech_ms',
+        return_value={'daily_ms': 999999999, 'three_day_ms': 0, 'weekly_ms': 0},
+    )
     @patch.object(fair_use_mod, 'fair_use_db')
-    def test_supports_aware_utc_datetimes(self, mock_fair_use_db):
+    def test_supports_aware_utc_datetimes(self, mock_fair_use_db, mock_speech):
         mock_fair_use_db.get_fair_use_state.return_value = {
             'stage': 'restrict',
             'restrict_until': datetime.now(timezone.utc) + timedelta(seconds=60),
@@ -226,6 +236,50 @@ class TestHardRestrictionRetryAfter:
 
         assert retry_after is not None
         assert 1 <= retry_after <= 60
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(
+        fair_use_mod,
+        'get_rolling_speech_ms',
+        return_value={'daily_ms': 999999999, 'three_day_ms': 0, 'weekly_ms': 0},
+    )
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_supports_aware_non_utc_datetimes(self, mock_fair_use_db, mock_speech):
+        offset = timezone(timedelta(hours=5, minutes=30))
+        restrict_until = (datetime.now(timezone.utc) + timedelta(seconds=90)).astimezone(offset)
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': restrict_until,
+        }
+
+        retry_after = fair_use_mod.get_hard_restriction_retry_after_seconds('user1')
+
+        assert retry_after is not None
+        assert 1 <= retry_after <= 90
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(
+        fair_use_mod,
+        'get_rolling_speech_ms',
+        return_value={'daily_ms': 999999999, 'three_day_ms': 0, 'weekly_ms': 0},
+    )
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_status_returns_retry_after_with_single_state_read(self, mock_fair_use_db, mock_speech):
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() + timedelta(seconds=120),
+        }
+
+        restricted, retry_after = fair_use_mod.get_hard_restriction_status('user1')
+
+        assert restricted is True
+        assert retry_after is not None
+        assert 1 <= retry_after <= 120
+        mock_fair_use_db.get_fair_use_state.assert_called_once_with('user1')
 
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
@@ -242,8 +296,13 @@ class TestHardRestrictionRetryAfter:
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
     @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(
+        fair_use_mod,
+        'get_rolling_speech_ms',
+        return_value={'daily_ms': 999999999, 'three_day_ms': 0, 'weekly_ms': 0},
+    )
     @patch.object(fair_use_mod, 'fair_use_db')
-    def test_returns_none_when_restrict_until_is_missing_or_expired(self, mock_fair_use_db):
+    def test_returns_none_when_restrict_until_is_missing_or_expired(self, mock_fair_use_db, mock_speech):
         mock_fair_use_db.get_fair_use_state.return_value = {'stage': 'restrict'}
         assert fair_use_mod.get_hard_restriction_retry_after_seconds('user1') is None
 
@@ -272,6 +331,7 @@ class TestSyncEndpointImports:
         assert callable(fair_use_mod.get_rolling_speech_ms)
         assert callable(fair_use_mod.check_soft_caps)
         assert callable(fair_use_mod.is_hard_restricted)
+        assert callable(fair_use_mod.get_hard_restriction_status)
         assert callable(fair_use_mod.get_hard_restriction_retry_after_seconds)
         assert hasattr(fair_use_mod, 'FAIR_USE_ENABLED')
         assert hasattr(fair_use_mod, 'trigger_classifier_if_needed')
@@ -387,16 +447,17 @@ class TestSyncEndpointCodeStructure:
         assert 'is_locked=is_locked' in source
 
     def test_hard_restricted_gate_exists(self):
-        """sync.py must check is_hard_restricted."""
+        """sync.py must check hard restriction status once."""
         source = self._read_sync_source()
-        assert 'is_hard_restricted(uid)' in source
+        assert 'get_hard_restriction_status(uid)' in source
 
     def test_hard_restricted_429_uses_retry_after_headers(self):
         """Hard-restricted sync responses must expose Retry-After for client cooldowns."""
         source = self._read_sync_source()
-        assert 'get_hard_restriction_retry_after_seconds' in source
-        assert 'headers=_hard_restriction_headers(uid, _V1_DEPRECATION_HEADERS)' in source
+        assert 'get_hard_restriction_retry_after_seconds' not in source
+        assert 'headers=_hard_restriction_headers(retry_after, _V1_DEPRECATION_HEADERS)' in source
         assert 'headers=headers' in self._function_body(source, 'async def sync_local_files_v2(')
+        assert 'run_blocking(critical_executor, _hard_restriction_headers' not in source
 
     def test_zero_speech_skips_recording(self):
         """Verify zero-speech guard in code: only records when total_speech_ms > 0."""

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -1,5 +1,6 @@
 """Tests for sync endpoint fair-use gates (#5854)."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -9,7 +10,8 @@ import sys
 from types import ModuleType
 
 # Stub database modules
-for mod_name in [
+_MISSING = object()
+_STUB_MODULE_NAMES = [
     'database._client',
     'database.redis_db',
     'database.fair_use',
@@ -19,7 +21,15 @@ for mod_name in [
     'firebase_admin',
     'firebase_admin.auth',
     'firebase_admin.messaging',
-]:
+    'utils.fair_use',
+]
+_SAVED_MODULES = {mod_name: sys.modules.get(mod_name, _MISSING) for mod_name in _STUB_MODULE_NAMES}
+_utils_parent = sys.modules.get('utils')
+_SAVED_UTILS_FAIR_USE_ATTR = getattr(_utils_parent, 'fair_use', _MISSING) if _utils_parent else _MISSING
+
+for mod_name in _STUB_MODULE_NAMES:
+    if mod_name == 'utils.fair_use':
+        continue
     if mod_name not in sys.modules:
         sys.modules[mod_name] = ModuleType(mod_name)
 
@@ -33,7 +43,21 @@ sys.modules['database.redis_db'].r = _mock_redis
 # Stub database._client.db
 sys.modules['database._client'].db = MagicMock()
 
+sys.modules.pop('utils.fair_use', None)
 import utils.fair_use as fair_use_mod
+
+for mod_name, original in _SAVED_MODULES.items():
+    if original is _MISSING:
+        sys.modules.pop(mod_name, None)
+    else:
+        sys.modules[mod_name] = original
+_utils_parent = sys.modules.get('utils')
+if _utils_parent is not None:
+    if _SAVED_UTILS_FAIR_USE_ATTR is _MISSING:
+        if getattr(_utils_parent, 'fair_use', _MISSING) is fair_use_mod:
+            delattr(_utils_parent, 'fair_use')
+    else:
+        setattr(_utils_parent, 'fair_use', _SAVED_UTILS_FAIR_USE_ATTR)
 
 
 class TestRecordSpeechMsSource:
@@ -170,6 +194,75 @@ class TestIsHardRestrictedGate:
         assert fair_use_mod.is_hard_restricted('exempt-user') is False
 
 
+class TestHardRestrictionRetryAfter:
+    """Test Retry-After calculation for hard-restricted sync users."""
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_returns_seconds_until_restrict_until(self, mock_fair_use_db):
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() + timedelta(seconds=120),
+        }
+
+        retry_after = fair_use_mod.get_hard_restriction_retry_after_seconds('user1')
+
+        assert retry_after is not None
+        assert 1 <= retry_after <= 120
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_supports_aware_utc_datetimes(self, mock_fair_use_db):
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.now(timezone.utc) + timedelta(seconds=60),
+        }
+
+        retry_after = fair_use_mod.get_hard_restriction_retry_after_seconds('user1')
+
+        assert retry_after is not None
+        assert 1 <= retry_after <= 60
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_returns_none_when_stage_is_not_restrict(self, mock_fair_use_db):
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'throttle',
+            'restrict_until': datetime.utcnow() + timedelta(seconds=120),
+        }
+
+        assert fair_use_mod.get_hard_restriction_retry_after_seconds('user1') is None
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_returns_none_when_restrict_until_is_missing_or_expired(self, mock_fair_use_db):
+        mock_fair_use_db.get_fair_use_state.return_value = {'stage': 'restrict'}
+        assert fair_use_mod.get_hard_restriction_retry_after_seconds('user1') is None
+
+        mock_fair_use_db.get_fair_use_state.return_value = {
+            'stage': 'restrict',
+            'restrict_until': datetime.utcnow() - timedelta(seconds=1),
+        }
+        assert fair_use_mod.get_hard_restriction_retry_after_seconds('user1') is None
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'fair_use_db')
+    def test_returns_none_when_state_read_fails(self, mock_fair_use_db):
+        mock_fair_use_db.get_fair_use_state.side_effect = RuntimeError('firestore timeout')
+
+        assert fair_use_mod.get_hard_restriction_retry_after_seconds('user1') is None
+
+
 class TestSyncEndpointImports:
     """Verify that all fair-use imports are available from utils.fair_use."""
 
@@ -179,6 +272,7 @@ class TestSyncEndpointImports:
         assert callable(fair_use_mod.get_rolling_speech_ms)
         assert callable(fair_use_mod.check_soft_caps)
         assert callable(fair_use_mod.is_hard_restricted)
+        assert callable(fair_use_mod.get_hard_restriction_retry_after_seconds)
         assert hasattr(fair_use_mod, 'FAIR_USE_ENABLED')
         assert hasattr(fair_use_mod, 'trigger_classifier_if_needed')
 
@@ -296,6 +390,13 @@ class TestSyncEndpointCodeStructure:
         """sync.py must check is_hard_restricted."""
         source = self._read_sync_source()
         assert 'is_hard_restricted(uid)' in source
+
+    def test_hard_restricted_429_uses_retry_after_headers(self):
+        """Hard-restricted sync responses must expose Retry-After for client cooldowns."""
+        source = self._read_sync_source()
+        assert 'get_hard_restriction_retry_after_seconds' in source
+        assert 'headers=_hard_restriction_headers(uid, _V1_DEPRECATION_HEADERS)' in source
+        assert 'headers=headers' in self._function_body(source, 'async def sync_local_files_v2(')
 
     def test_zero_speech_skips_recording(self):
         """Verify zero-speech guard in code: only records when total_speech_ms > 0."""

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -17,10 +17,12 @@ _STUB_MODULE_NAMES = [
     'database.fair_use',
     'database.users',
     'database.user_usage',
+    'database.announcements',
     'database.conversations',
     'firebase_admin',
     'firebase_admin.auth',
     'firebase_admin.messaging',
+    'stripe',
     'utils.fair_use',
 ]
 _SAVED_MODULES = {mod_name: sys.modules.get(mod_name, _MISSING) for mod_name in _STUB_MODULE_NAMES}
@@ -42,6 +44,7 @@ sys.modules['database.redis_db'].r = _mock_redis
 
 # Stub database._client.db
 sys.modules['database._client'].db = MagicMock()
+sys.modules['database.announcements'].compare_versions = MagicMock(return_value=0)
 
 sys.modules.pop('utils.fair_use', None)
 import utils.fair_use as fair_use_mod

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import database.fair_use as fair_use_db
 import database.users as users_db
@@ -434,66 +434,69 @@ def clear_fair_use_on_upgrade(uid: str) -> bool:
     return True
 
 
-def is_hard_restricted(uid: str) -> bool:
-    """Check if a user is hard-restricted (speech cap enforced as hard block)."""
+def _as_naive_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to naive UTC for comparisons with datetime.utcnow()."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _retry_after_seconds_from_restrict_until(restrict_until) -> int | None:
+    if not isinstance(restrict_until, datetime):
+        return None
+    restrict_until = _as_naive_utc(restrict_until)
+    seconds = int((restrict_until - datetime.utcnow()).total_seconds())
+    return max(seconds, 1) if seconds > 0 else None
+
+
+def get_hard_restriction_status(uid: str) -> tuple[bool, int | None]:
+    """Return whether the user is hard-restricted and, when known, the retry window in seconds."""
     if not FAIR_USE_ENABLED or FAIR_USE_KILL_SWITCH:
-        return False
+        return False, None
     if uid in FAIR_USE_EXEMPT_UIDS:
-        return False
+        return False, None
 
     # Single Firestore read — get_enforcement_stage uses cache, but we need
     # restrict_until too, so read the full state once and check stage from it.
     state = fair_use_db.get_fair_use_state(uid)
     stage = state.get('stage', 'none')
     if stage != 'restrict':
-        return False
+        return False, None
 
     # Check if restriction has expired
     restrict_until = state.get('restrict_until')
     if restrict_until and isinstance(restrict_until, datetime):
         # Normalize to naive UTC for comparison (Firestore may return aware datetimes)
-        if restrict_until.tzinfo is not None:
-            restrict_until = restrict_until.replace(tzinfo=None)
+        restrict_until = _as_naive_utc(restrict_until)
         if datetime.utcnow() > restrict_until:
             # Restriction expired, reset to throttle
             fair_use_db.update_fair_use_state(uid, {'stage': 'throttle', 'restrict_until': None})
             invalidate_enforcement_cache(uid)
-            return False
+            return False, None
 
     # Check if speech is over hard cap
     speech = get_rolling_speech_ms(uid)
     # In restrict mode, enforce the soft caps as hard caps
-    return (
+    restricted = (
         speech['daily_ms'] > FAIR_USE_DAILY_SPEECH_MS
         or speech['three_day_ms'] > FAIR_USE_3DAY_SPEECH_MS
         or speech['weekly_ms'] > FAIR_USE_WEEKLY_SPEECH_MS
     )
+    return restricted, _retry_after_seconds_from_restrict_until(restrict_until) if restricted else None
+
+
+def is_hard_restricted(uid: str) -> bool:
+    """Check if a user is hard-restricted (speech cap enforced as hard block)."""
+    return get_hard_restriction_status(uid)[0]
 
 
 def get_hard_restriction_retry_after_seconds(uid: str) -> int | None:
     """Return seconds until the active hard restriction expires, if known."""
-    if not FAIR_USE_ENABLED or FAIR_USE_KILL_SWITCH:
-        return None
-    if uid in FAIR_USE_EXEMPT_UIDS:
-        return None
-
     try:
-        state = fair_use_db.get_fair_use_state(uid)
+        return get_hard_restriction_status(uid)[1]
     except Exception as e:
         logger.error(f'fair_use: error checking hard restriction retry-after for {uid}: {e}')
         return None
-
-    if state.get('stage', 'none') != 'restrict':
-        return None
-
-    restrict_until = state.get('restrict_until')
-    if not isinstance(restrict_until, datetime):
-        return None
-    if restrict_until.tzinfo is not None:
-        restrict_until = restrict_until.replace(tzinfo=None)
-
-    seconds = int((restrict_until - datetime.utcnow()).total_seconds())
-    return max(seconds, 1) if seconds > 0 else None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -470,6 +470,32 @@ def is_hard_restricted(uid: str) -> bool:
     )
 
 
+def get_hard_restriction_retry_after_seconds(uid: str) -> int | None:
+    """Return seconds until the active hard restriction expires, if known."""
+    if not FAIR_USE_ENABLED or FAIR_USE_KILL_SWITCH:
+        return None
+    if uid in FAIR_USE_EXEMPT_UIDS:
+        return None
+
+    try:
+        state = fair_use_db.get_fair_use_state(uid)
+    except Exception as e:
+        logger.error(f'fair_use: error checking hard restriction retry-after for {uid}: {e}')
+        return None
+
+    if state.get('stage', 'none') != 'restrict':
+        return None
+
+    restrict_until = state.get('restrict_until')
+    if not isinstance(restrict_until, datetime):
+        return None
+    if restrict_until.tzinfo is not None:
+        restrict_until = restrict_until.replace(tzinfo=None)
+
+    seconds = int((restrict_until - datetime.utcnow()).total_seconds())
+    return max(seconds, 1) if seconds > 0 else None
+
+
 # ---------------------------------------------------------------------------
 # Restrict-stage daily Deepgram budget
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a fair-use helper that derives a `Retry-After` value from an active `restrict_until` timestamp.
- Include `Retry-After` on both deprecated `/v1/sync-local-files` and current `/v2/sync-local-files` hard-restriction 429 responses.
- Keep the header fail-open: if the fair-use state cannot provide a usable expiry, the 429 still returns without `Retry-After` instead of becoming a 500.
- Reuse the hard-restriction status read to avoid an extra Firestore read on every hard-rejection.
- Normalize aware `restrict_until` values through UTC before comparing with `datetime.utcnow()`.
- Isolate fair-use test import stubs so Windows/lightweight pytest runs do not require Stripe, Firebase, or Firestore SDK modules just to collect the tests.

This addresses the sync follow-up noted in #7531 where clients fell back to a generic cooldown because hard fair-use 429s did not expose a server-driven retry window.

## Refresh
- Rebased on `main` at `a13477934a2b2a7e0e6491af20deb47d5fd11150`.
- Current head: `497fdc251db13e9d1877a9b6364e3a9ada63872a`.
- GitHub currently reports this PR as mergeable.

## Review follow-up
- Addressed Greptile's double-read concern by using `get_hard_restriction_status(uid)` for both the restricted boolean and retry window.
- Addressed the timezone concern by normalizing aware timestamps through UTC before dropping `tzinfo`.

## Validation
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest tests\unit\test_sync_fair_use_gate.py tests\unit\test_fair_use_upgrade.py -q --tb=short`
  - 52 passed, 2 warnings
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile utils\fair_use.py routers\sync.py tests\unit\test_sync_fair_use_gate.py tests\unit\test_fair_use_upgrade.py`
- From `backend/`: `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check utils\fair_use.py routers\sync.py tests\unit\test_sync_fair_use_gate.py tests\unit\test_fair_use_upgrade.py`
  - 4 files would be left unchanged
- From repo root: `PYTHONUTF8=1 D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe backend\scripts\scan_async_blockers.py`
  - exit 0; existing async-blocker backlog reported, no new `sync.py` blocker
- `git diff --check origin/main...HEAD` and `git diff --check`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`