### PR TITLE
[codex] Normalize Windows Google sync state

### DIFF
--- a/desktop/windows/src/main/integrations/syncState.ts
+++ b/desktop/windows/src/main/integrations/syncState.ts
@@ -3,7 +3,7 @@
 import { app } from 'electron'
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
-import { emptySourceState, recordProcessed, type SourceState } from './syncStateLogic'
+import { emptySourceState, normalizeSourceState, recordProcessed, type SourceState } from './syncStateLogic'
 import type { GoogleSource } from '../../shared/types'
 
 type SyncFile = { gmail: SourceState; calendar: SourceState }
@@ -17,8 +17,8 @@ function read(): SyncFile {
     if (existsSync(file())) {
       const raw = JSON.parse(readFileSync(file(), 'utf8')) as Partial<SyncFile>
       return {
-        gmail: raw.gmail ?? emptySourceState(),
-        calendar: raw.calendar ?? emptySourceState()
+        gmail: normalizeSourceState(raw.gmail),
+        calendar: normalizeSourceState(raw.calendar)
       }
     }
   } catch {

--- a/desktop/windows/src/main/integrations/syncState.ts
+++ b/desktop/windows/src/main/integrations/syncState.ts
@@ -3,7 +3,12 @@
 import { app } from 'electron'
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
-import { emptySourceState, normalizeSourceState, recordProcessed, type SourceState } from './syncStateLogic'
+import {
+  emptySourceState,
+  normalizeSourceState,
+  recordProcessed,
+  type SourceState
+} from './syncStateLogic'
 import type { GoogleSource } from '../../shared/types'
 
 type SyncFile = { gmail: SourceState; calendar: SourceState }

--- a/desktop/windows/src/main/integrations/syncStateLogic.test.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   emptySourceState,
   filterNew,
+  normalizeSourceState,
   recordProcessed,
   MAX_PROCESSED
 } from './syncStateLogic'
@@ -14,6 +15,31 @@ describe('filterNew', () => {
 
   it('returns all when nothing processed', () => {
     expect(filterNew([{ id: 'a' }], []).map((i) => i.id)).toEqual(['a'])
+  })
+})
+
+describe('normalizeSourceState', () => {
+  it('returns an empty state for missing or malformed persisted data', () => {
+    expect(normalizeSourceState(null)).toEqual(emptySourceState())
+    expect(normalizeSourceState('bad')).toEqual(emptySourceState())
+    expect(normalizeSourceState({ lastSyncAt: 'soon', processedIds: 'a,b' })).toEqual(emptySourceState())
+  })
+
+  it('keeps valid fields and drops invalid processed ids', () => {
+    expect(
+      normalizeSourceState({
+        lastSyncAt: 1234,
+        processedIds: ['a', '', 42, 'b', 'a', 'c']
+      })
+    ).toEqual({ lastSyncAt: 1234, processedIds: ['b', 'a', 'c'] })
+  })
+
+  it('bounds normalized ids to the newest MAX_PROCESSED entries', () => {
+    const ids = Array.from({ length: MAX_PROCESSED + 2 }, (_, i) => `id${i}`)
+    const next = normalizeSourceState({ lastSyncAt: 1, processedIds: ids })
+    expect(next.processedIds.length).toBe(MAX_PROCESSED)
+    expect(next.processedIds[0]).toBe('id2')
+    expect(next.processedIds.at(-1)).toBe(`id${MAX_PROCESSED + 1}`)
   })
 })
 

--- a/desktop/windows/src/main/integrations/syncStateLogic.test.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.test.ts
@@ -22,7 +22,9 @@ describe('normalizeSourceState', () => {
   it('returns an empty state for missing or malformed persisted data', () => {
     expect(normalizeSourceState(null)).toEqual(emptySourceState())
     expect(normalizeSourceState('bad')).toEqual(emptySourceState())
-    expect(normalizeSourceState({ lastSyncAt: 'soon', processedIds: 'a,b' })).toEqual(emptySourceState())
+    expect(normalizeSourceState({ lastSyncAt: 'soon', processedIds: 'a,b' })).toEqual(
+      emptySourceState()
+    )
   })
 
   it('keeps valid fields and drops invalid processed ids', () => {

--- a/desktop/windows/src/main/integrations/syncStateLogic.test.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.test.ts
@@ -41,6 +41,14 @@ describe('normalizeSourceState', () => {
     expect(next.processedIds[0]).toBe('id2')
     expect(next.processedIds.at(-1)).toBe(`id${MAX_PROCESSED + 1}`)
   })
+
+  it('bounds normalized ids after deduping newest entries', () => {
+    const ids = [...Array.from({ length: MAX_PROCESSED }, (_, i) => `id${i}`), 'tail', 'tail']
+    const next = normalizeSourceState({ lastSyncAt: 1, processedIds: ids })
+    expect(next.processedIds.length).toBe(MAX_PROCESSED)
+    expect(next.processedIds[0]).toBe('id1')
+    expect(next.processedIds.at(-1)).toBe('tail')
+  })
 })
 
 describe('recordProcessed', () => {

--- a/desktop/windows/src/main/integrations/syncStateLogic.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.ts
@@ -12,6 +12,32 @@ export function emptySourceState(): SourceState {
   return { lastSyncAt: 0, processedIds: [] }
 }
 
+export function normalizeSourceState(value: unknown): SourceState {
+  if (!value || typeof value !== 'object') return emptySourceState()
+  const raw = value as { lastSyncAt?: unknown; processedIds?: unknown }
+  const lastSyncAt =
+    typeof raw.lastSyncAt === 'number' && Number.isFinite(raw.lastSyncAt) && raw.lastSyncAt > 0
+      ? raw.lastSyncAt
+      : 0
+
+  if (!Array.isArray(raw.processedIds)) {
+    return { lastSyncAt, processedIds: [] }
+  }
+
+  const seen = new Set<string>()
+  const processedIds: string[] = []
+  for (let i = raw.processedIds.length - 1; i >= 0; i--) {
+    const id = raw.processedIds[i]
+    if (typeof id !== 'string' || !id || seen.has(id)) continue
+    processedIds.unshift(id)
+    seen.add(id)
+  }
+
+  const bounded =
+    processedIds.length > MAX_PROCESSED ? processedIds.slice(processedIds.length - MAX_PROCESSED) : processedIds
+  return { lastSyncAt, processedIds: bounded }
+}
+
 /** Items whose id is NOT already in the processed set. */
 export function filterNew<T extends { id: string }>(items: T[], processedIds: string[]): T[] {
   const seen = new Set(processedIds)

--- a/desktop/windows/src/main/integrations/syncStateLogic.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.ts
@@ -35,7 +35,9 @@ export function normalizeSourceState(value: unknown): SourceState {
   }
 
   const bounded =
-    processedIds.length > MAX_PROCESSED ? processedIds.slice(processedIds.length - MAX_PROCESSED) : processedIds
+    processedIds.length > MAX_PROCESSED
+      ? processedIds.slice(processedIds.length - MAX_PROCESSED)
+      : processedIds
   return { lastSyncAt, processedIds: bounded }
 }
 

--- a/desktop/windows/src/main/integrations/syncStateLogic.ts
+++ b/desktop/windows/src/main/integrations/syncStateLogic.ts
@@ -31,6 +31,7 @@ export function normalizeSourceState(value: unknown): SourceState {
     if (typeof id !== 'string' || !id || seen.has(id)) continue
     processedIds.unshift(id)
     seen.add(id)
+    if (seen.size >= MAX_PROCESSED) break
   }
 
   const bounded =


### PR DESCRIPTION
## Summary
- Add a pure `normalizeSourceState` helper for persisted Google sync source state.
- Use it when reading `google-sync.json` from Electron `userData` so partial, legacy, or malformed per-source entries fall back safely.
- Drop invalid processed IDs, dedupe while preserving the latest occurrence, stop scanning once `MAX_PROCESSED` newest unique IDs are found, and keep the existing bound during normalization.
- Format the touched sync-state files with the current Windows app dev dependencies.

## Why
The Windows app stores Google sync progress in a local JSON file. A partially written, manually edited, or older-shaped file could currently pass non-array `processedIds` or invalid timestamps into sync logic. That can break filtering or produce bad `lastSyncAt` values even though the file read itself succeeded.

## Refresh
- Rebased on `main` at `cc06c20fae75e88b15e220d57402f6f47591dd72`.
- Current head: `5f71c9a4750fd7f9ac07b0d2b369a6259337d380`.
- GitHub compare reports this branch as ahead 5 / behind 0; PR is mergeable.
- Preserved the Greptile-requested early break in the backwards dedupe loop; the review thread is already resolved.

## Validation
- From `desktop/windows/`: `npx vitest run src/main/integrations/syncStateLogic.test.ts`
  - 1 file passed, 8 tests passed
- From `desktop/windows/`: `npm run typecheck` -> passed
- Fresh LF checkout: `prettier --check src/main/integrations/syncState.ts src/main/integrations/syncStateLogic.ts src/main/integrations/syncStateLogic.test.ts` -> passed
- `git diff --check origin/main...HEAD` and `git diff --check`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`