### PR TITLE
[codex] Harden Windows memory dump parsing

### DIFF
--- a/desktop/windows/src/main/memoryImport/parse.test.ts
+++ b/desktop/windows/src/main/memoryImport/parse.test.ts
@@ -13,9 +13,21 @@ describe('parseMemoryDump', () => {
     ])
   })
 
+  it('handles common pasted markdown list markers', () => {
+    const dump = `— Enjoys tea
+‣ Uses Windows
+⁃ Keeps notes in Obsidian`
+    expect(parseMemoryDump(dump)).toEqual(['Enjoys tea', 'Uses Windows', 'Keeps notes in Obsidian'])
+  })
+
   it('handles numbered lists', () => {
     const dump = `1. Lives in Seattle\n2) Is learning Spanish`
     expect(parseMemoryDump(dump)).toEqual(['Lives in Seattle', 'Is learning Spanish'])
+  })
+
+  it('drops markdown code fences around copied dumps', () => {
+    const dump = "```markdown\n- Likes coffee\n- Prefers short replies\n```"
+    expect(parseMemoryDump(dump)).toEqual(['Likes coffee', 'Prefers short replies'])
   })
 
   it('drops conversational scaffolding but keeps real memories', () => {

--- a/desktop/windows/src/main/memoryImport/parse.test.ts
+++ b/desktop/windows/src/main/memoryImport/parse.test.ts
@@ -26,7 +26,7 @@ describe('parseMemoryDump', () => {
   })
 
   it('drops markdown code fences around copied dumps', () => {
-    const dump = "```markdown\n- Likes coffee\n- Prefers short replies\n```"
+    const dump = '```markdown\n- Likes coffee\n- Prefers short replies\n```'
     expect(parseMemoryDump(dump)).toEqual(['Likes coffee', 'Prefers short replies'])
   })
 

--- a/desktop/windows/src/main/memoryImport/parse.ts
+++ b/desktop/windows/src/main/memoryImport/parse.ts
@@ -20,9 +20,10 @@ const SCAFFOLDING = [
   /^i (?:currently )?(?:remember|have stored|don'?t have)\b.*(?:memor|the following|about you)/i
 ]
 
-// Remove a single leading list marker: -, *, •, –, or "1." / "1)".
+// Remove a single leading list marker: -, *, common bullet/dash markers,
+// or "1." / "1)".
 function stripMarker(line: string): string {
-  return line.replace(/^\s*(?:[-*•–]\s+|\d+[.)]\s+)/, '')
+  return line.replace(/^\s*(?:[-*\u2022\u2013\u2014\u2023\u2043]\s+|\d+[.)]\s+)/, '')
 }
 
 // Strip surrounding markdown emphasis / heading syntax.
@@ -34,10 +35,15 @@ function stripFormatting(s: string): string {
   return t.trim()
 }
 
+function isMarkdownFence(line: string): boolean {
+  return /^\s*(?:```|~~~)/.test(line)
+}
+
 export function parseMemoryDump(dump: string): string[] {
   const out: string[] = []
   const seen = new Set<string>()
   for (const raw of dump.split(/\r?\n/)) {
+    if (isMarkdownFence(raw)) continue
     const stripped = stripFormatting(stripMarker(raw))
     if (stripped.length < 3) continue // blank lines, stray numbering/punctuation
     if (SCAFFOLDING.some((re) => re.test(stripped))) continue


### PR DESCRIPTION
## Summary
- Skip Markdown code fence lines when parsing pasted ChatGPT/Claude memory dumps.
- Strip additional common pasted list markers, including em dash, triangular bullet, and hyphen bullet variants.
- Add focused coverage for fenced dumps and richer pasted list markers.
- Format the touched fence test with the current Windows app dev dependencies.

## Why
Windows users often copy memory lists from chat surfaces that wrap content in Markdown fences or use typographic bullets/dashes. The existing parser could keep ``` fences as bogus memories and leave some common marker characters in the imported text.

## Refresh
- Rebased on `main` at `b781d91767ac96a20f2305614eb50c7744a8a6c3`.
- Current head: `22e3d0ca67e4c7afe4141ad3fb919f1d7dec5f89`.
- GitHub currently reports this PR as mergeable.

## Validation
- From `desktop/windows/`: `npm run test -- src/main/memoryImport/parse.test.ts` -> 1 file, 8 tests passed
- From `desktop/windows/`: `npm run typecheck` -> passed
- targeted `npx eslint --quiet` on changed Windows files -> no errors
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `scripts/pre-commit` with `PYTHONUTF8=1` -> passed
- `scripts/pre-push` with `PYTHONUTF8=1` -> passed