### PR TITLE
[codex] Isolate translation test imports

### DIFF
--- a/backend/tests/unit/test_translation_cost_optimization.py
+++ b/backend/tests/unit/test_translation_cost_optimization.py
@@ -11,6 +11,7 @@ Covers:
 
 import asyncio
 import hashlib
+import os
 import sys
 import time
 from collections import OrderedDict
@@ -37,6 +38,46 @@ if 'google.cloud' not in sys.modules:
     sys.modules['google.cloud'] = MagicMock()
 if 'google.cloud.translate_v3' not in sys.modules:
     sys.modules['google.cloud.translate_v3'] = MagicMock()
+sys.modules['google.cloud'].translate_v3 = sys.modules['google.cloud.translate_v3']
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_REAL_PACKAGE_DIRS = {
+    "utils": os.path.join(_BACKEND_DIR, "utils"),
+    "models": os.path.join(_BACKEND_DIR, "models"),
+}
+
+
+def _restore_real_backend_package(package_name: str) -> None:
+    """Discard empty package stubs left by earlier collected unit tests."""
+    if _BACKEND_DIR not in sys.path:
+        sys.path.insert(0, _BACKEND_DIR)
+
+    package = sys.modules.get(package_name)
+    if package is None:
+        return
+
+    expected_dir = os.path.abspath(_REAL_PACKAGE_DIRS[package_name])
+    package_paths = getattr(package, "__path__", None)
+    if not package_paths:
+        sys.modules.pop(package_name, None)
+        return
+
+    try:
+        has_real_path = any(os.path.abspath(str(path)) == expected_dir for path in package_paths)
+    except TypeError:
+        has_real_path = False
+    if not has_real_path:
+        sys.modules.pop(package_name, None)
+
+
+_restore_real_backend_package("utils")
+_restore_real_backend_package("models")
+for mod_name in list(sys.modules.keys()):
+    if not mod_name.startswith("utils.translation"):
+        continue
+    module_file = getattr(sys.modules[mod_name], "__file__", None)
+    if not module_file or not os.path.abspath(module_file).startswith(_BACKEND_DIR):
+        del sys.modules[mod_name]
 
 # Now import project modules (they'll use the mocks above)
 from utils.translation import (

--- a/backend/tests/unit/test_translation_optimization.py
+++ b/backend/tests/unit/test_translation_optimization.py
@@ -21,6 +21,35 @@ os.environ.setdefault(
 )
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
 
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_REAL_PACKAGE_DIRS = {
+    "utils": os.path.join(_BACKEND_DIR, "utils"),
+    "models": os.path.join(_BACKEND_DIR, "models"),
+}
+
+
+def _restore_real_backend_package(package_name: str) -> None:
+    """Discard empty package stubs left by earlier collected unit tests."""
+    if _BACKEND_DIR not in sys.path:
+        sys.path.insert(0, _BACKEND_DIR)
+
+    package = sys.modules.get(package_name)
+    if package is None:
+        return
+
+    expected_dir = os.path.abspath(_REAL_PACKAGE_DIRS[package_name])
+    package_paths = getattr(package, "__path__", None)
+    if not package_paths:
+        sys.modules.pop(package_name, None)
+        return
+
+    try:
+        has_real_path = any(os.path.abspath(str(path)) == expected_dir for path in package_paths)
+    except TypeError:
+        has_real_path = False
+    if not has_real_path:
+        sys.modules.pop(package_name, None)
+
 
 def _ensure_mock_module(name: str):
     if name not in sys.modules:
@@ -50,11 +79,14 @@ sys.modules["google"].__path__ = []
 _ensure_mock_module("google.cloud")
 sys.modules["google.cloud"].__path__ = []
 _ensure_mock_module("google.cloud.translate_v3")
+sys.modules["google.cloud"].translate_v3 = sys.modules["google.cloud.translate_v3"]
 
 mock_translate_client = MagicMock()
 sys.modules["google.cloud.translate_v3"].TranslationServiceClient = MagicMock(return_value=mock_translate_client)
 
 # Force reimport translation modules
+_restore_real_backend_package("utils")
+_restore_real_backend_package("models")
 for mod_name in list(sys.modules.keys()):
     if 'translation' in mod_name and 'test' not in mod_name:
         del sys.modules[mod_name]


### PR DESCRIPTION
## Summary
- Restore real `utils` and `models` backend package parents before importing translation modules when earlier unit tests left empty package stubs in `sys.modules`.
- Keep the Google Translate stub attached to `google.cloud.translate_v3` so the translation tests do not fall through to a parent-module mock.
- Avoid reloading an already-real `utils.translation` module from `test_translation_cost_optimization.py`, preserving pytest collection-order safety for the sibling translation test file.

## Root cause
On Windows backend unit collection, tests such as `test_tools_router.py` install lightweight package stubs with empty `__path__` values. When the translation tests are collected later in the same pytest process, Python can resolve `utils` or `models` to those stale stubs and fail before collecting `utils.translation` tests.

## Validation
- `python -m pytest backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py -q --tb=short` -> 175 passed
- `python -m pytest backend\tests\unit\test_translation_cost_optimization.py backend\tests\unit\test_translation_optimization.py -q --tb=short` -> 175 passed
- `python -m pytest backend\tests\unit\test_tools_router.py backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py -q --tb=short` -> 256 passed, 1 skipped, 1 warning
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` -> still exits 1 for existing unrelated collection errors, but both translation test files now collect; total collection errors dropped from 22 to 20
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py --check`
- `python -m py_compile backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py`
- `git diff --check`
- `scripts/pre-commit` with backend venv on PATH -> passed