### PR TITLE
[codex] Isolate usage tracking test imports

### DIFF
--- a/backend/tests/unit/test_high_priority_usage_tracking.py
+++ b/backend/tests/unit/test_high_priority_usage_tracking.py
@@ -26,6 +26,8 @@ os.environ.setdefault(
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
 
 def _stub_module(name: str) -> types.ModuleType:
     if name not in sys.modules:
@@ -49,6 +51,51 @@ def _optional_stub_module(name: str) -> tuple[types.ModuleType, bool]:
     mod = types.ModuleType(name)
     sys.modules[name] = mod
     return mod, True
+
+
+def _module_path_points_to(module: types.ModuleType, expected_path: Path) -> bool:
+    raw_paths = getattr(module, "__path__", None)
+    if raw_paths is None:
+        return False
+
+    try:
+        paths = list(raw_paths)
+    except TypeError:
+        return False
+
+    return any(Path(path).resolve() == expected_path for path in paths)
+
+
+def _restore_usage_tracker_import_path() -> None:
+    utils_dir = BACKEND_DIR / "utils"
+    llm_dir = utils_dir / "llm"
+
+    utils_mod = sys.modules.get("utils")
+    if utils_mod is not None and not _module_path_points_to(utils_mod, utils_dir):
+        utils_mod.__path__ = [str(utils_dir)]
+
+    llm_mod = sys.modules.get("utils.llm")
+    if llm_mod is not None and not _module_path_points_to(llm_mod, llm_dir):
+        llm_mod.__path__ = [str(llm_dir)]
+
+    tracker_mod = sys.modules.get("utils.llm.usage_tracker")
+    if tracker_mod is None:
+        return
+
+    expected_file = (llm_dir / "usage_tracker.py").resolve()
+    tracker_file = getattr(tracker_mod, "__file__", None)
+    try:
+        tracker_path = Path(tracker_file).resolve() if tracker_file else None
+    except TypeError:
+        tracker_path = None
+
+    if tracker_path == expected_file:
+        return
+
+    sys.modules.pop("utils.llm.usage_tracker", None)
+    llm_mod = sys.modules.get("utils.llm")
+    if llm_mod is not None and getattr(llm_mod, "usage_tracker", None) is tracker_mod:
+        delattr(llm_mod, "usage_tracker")
 
 
 # --- Stub minimal LangChain modules needed by usage_tracker ---
@@ -168,6 +215,7 @@ _stub_module("utils.llms.memory")
 sys.modules["utils.llms.memory"].get_prompt_memories = MagicMock(return_value=("TestUser", "some memories"))
 
 # --- Import real usage_tracker ---
+_restore_usage_tracker_import_path()
 from utils.llm.usage_tracker import _usage_context, Features
 
 # --- Stub LLM clients (AFTER importing usage_tracker so it's already loaded) ---

--- a/backend/tests/unit/test_new_usage_tracking_gaps.py
+++ b/backend/tests/unit/test_new_usage_tracking_gaps.py
@@ -31,11 +31,58 @@ os.environ.setdefault(
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
 
 def _stub_module(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     sys.modules[name] = mod
     return mod
+
+
+def _module_path_points_to(module: types.ModuleType, expected_path: Path) -> bool:
+    raw_paths = getattr(module, "__path__", None)
+    if raw_paths is None:
+        return False
+
+    try:
+        paths = list(raw_paths)
+    except TypeError:
+        return False
+
+    return any(Path(path).resolve() == expected_path for path in paths)
+
+
+def _restore_usage_tracker_import_path() -> None:
+    utils_dir = BACKEND_DIR / "utils"
+    llm_dir = utils_dir / "llm"
+
+    utils_mod = sys.modules.get("utils")
+    if utils_mod is not None and not _module_path_points_to(utils_mod, utils_dir):
+        utils_mod.__path__ = [str(utils_dir)]
+
+    llm_mod = sys.modules.get("utils.llm")
+    if llm_mod is not None and not _module_path_points_to(llm_mod, llm_dir):
+        llm_mod.__path__ = [str(llm_dir)]
+
+    tracker_mod = sys.modules.get("utils.llm.usage_tracker")
+    if tracker_mod is None:
+        return
+
+    expected_file = (llm_dir / "usage_tracker.py").resolve()
+    tracker_file = getattr(tracker_mod, "__file__", None)
+    try:
+        tracker_path = Path(tracker_file).resolve() if tracker_file else None
+    except TypeError:
+        tracker_path = None
+
+    if tracker_path == expected_file:
+        return
+
+    sys.modules.pop("utils.llm.usage_tracker", None)
+    llm_mod = sys.modules.get("utils.llm")
+    if llm_mod is not None and getattr(llm_mod, "usage_tracker", None) is tracker_mod:
+        delattr(llm_mod, "usage_tracker")
 
 
 # Stub database package so usage_tracker can import database.llm_usage
@@ -95,6 +142,7 @@ except ImportError:
     sys.modules["langchain_core.outputs"] = outputs_mod
     setattr(_langchain_core_package(), "outputs", outputs_mod)
 
+_restore_usage_tracker_import_path()
 from utils.llm.usage_tracker import (
     Features,
     LLMUsageCallback,


### PR DESCRIPTION
## Summary

- restore the local `utils` / `utils.llm` import paths before usage tracking tests import the real `utils.llm.usage_tracker`
- discard stale in-memory `utils.llm.usage_tracker` stubs left by earlier unit tests
- let both usage tracking test modules collect under broader Windows/full-suite collection order

## Root cause

Some unit tests install lightweight `utils.llm.usage_tracker` stubs during collection. When the usage tracking tests were collected afterward, Python reused those stub modules instead of the real backend implementation, causing import errors for `_usage_context`, `Features`, and `LLMUsageCallback`.

## Refresh note

Refreshed onto current `main` (`f05687ae9`) so the PR is mergeable again.

## Validation

- `python -m pytest backend\tests\unit\test_high_priority_usage_tracking.py backend\tests\unit\test_new_usage_tracking_gaps.py -q --tb=short` -> 66 passed
- `python -m pytest backend\tests\unit\test_fair_use_classifier.py backend\tests\unit\test_high_priority_usage_tracking.py --collect-only -q --tb=short --continue-on-collection-errors` -> 37 collected
- `python -m pytest backend\tests\unit\test_prompt_cache_integration.py backend\tests\unit\test_new_usage_tracking_gaps.py --collect-only -q --tb=short --continue-on-collection-errors` -> 63 collected
- `python -m black --check --line-length 120 --skip-string-normalization backend\tests\unit\test_high_priority_usage_tracking.py backend\tests\unit\test_new_usage_tracking_gaps.py` -> passed
- `python -m py_compile backend\tests\unit\test_high_priority_usage_tracking.py backend\tests\unit\test_new_usage_tracking_gaps.py` -> passed
- `git diff --check origin/main..HEAD` -> passed
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit` -> passed