### PR TITLE
[codex] Isolate prompt caching test imports

### DIFF
--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -11,13 +11,74 @@ import inspect
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package_path(name: str, path: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        module = ModuleType(name)
+        sys.modules[name] = module
+
+    module.__path__ = [str(path)]
+
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, child_name, module)
+
+    return module
+
+
+def _drop_stale_module(name: str, expected_file: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is not None and Path(module_file).resolve() == expected_file.resolve():
+        return
+
+    sys.modules.pop(name, None)
+    parent_name, _, child_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.llm", BACKEND_DIR / "utils" / "llm")
+_ensure_package_path("models", BACKEND_DIR / "models")
+for _module_name in [
+    "models.app",
+    "models.audio_file",
+    "models.calendar_context",
+    "models.chat",
+    "models.conversation",
+    "models.conversation_enums",
+    "models.conversation_photo",
+    "models.geolocation",
+    "models.other",
+    "models.structured",
+    "models.transcript_segment",
+]:
+    _drop_stale_module(_module_name, BACKEND_DIR / Path(*_module_name.split(".")).with_suffix(".py"))
+_drop_stale_module("utils.llm.conversation_processing", BACKEND_DIR / "utils" / "llm" / "conversation_processing.py")
+
 # Mock modules that initialize GCP clients or require API keys at import time
 sys.modules.setdefault("database._client", MagicMock())
-_mock_clients = MagicMock()
-sys.modules.setdefault("utils.llm.clients", _mock_clients)
+_mock_clients = sys.modules.get("utils.llm.clients")
+if _mock_clients is None:
+    _mock_clients = ModuleType("utils.llm.clients")
+    sys.modules["utils.llm.clients"] = _mock_clients
+sys.modules["utils.llm"].clients = _mock_clients
+_mock_clients.get_llm = MagicMock()
+_mock_clients.parser = MagicMock()
 
 
 class _FakePydanticOutputParser:


### PR DESCRIPTION
## Summary

- restore real `utils`, `utils.llm`, and `models` package paths before `test_prompt_caching.py` imports `utils.llm.conversation_processing`
- discard stale model/conversation-processing modules left by earlier unit tests in the same pytest process
- provide the `utils.llm.clients` symbols needed by `conversation_processing` without relying on a previously installed stub shape

## Root cause

`test_prompt_cache_integration.py` and other backend unit tests can leave lightweight package/module stubs in `sys.modules`, including `utils.llm` with an empty package path and partial `models.*` modules. When `test_prompt_caching.py` is collected later in the same Windows pytest process, those stubs can hide the real `utils.llm.conversation_processing` module or its model dependencies, causing collection to fail before the prompt-cache assertions run.

## Validation

- `black --line-length 120 --skip-string-normalization backend\tests\unit\test_prompt_caching.py --check`
- `python -m py_compile backend\tests\unit\test_prompt_caching.py`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit`
- `python -m pytest backend\tests\unit\test_prompt_caching.py -q --tb=short` -> 24 passed
- `python -m pytest backend\tests\unit\test_prompt_cache_integration.py backend\tests\unit\test_prompt_caching.py --collect-only -q --tb=short --continue-on-collection-errors` -> 42 collected
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` -> 3338 collected, 21 remaining unrelated collection errors; `test_prompt_caching.py` now collects

## Note

`test_prompt_cache_integration.py` still has existing local runtime failures in this Windows venv when run as a test file, so this PR uses it only as a collection-order reproducer for the stale import issue.