### PR TITLE
[codex] Isolate VAD test imports

### DIFF
--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -7,9 +7,52 @@ import tempfile
 import threading
 import time
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package_path(name: str, path: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+
+    module.__path__ = [str(path)]
+
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, child_name, module)
+
+    return module
+
+
+def _drop_stale_module(name: str, expected_file: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is not None and Path(module_file).resolve() == expected_file.resolve():
+        return
+
+    sys.modules.pop(name, None)
+    parent_name, _, child_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.stt", BACKEND_DIR / "utils" / "stt")
+_drop_stale_module("utils.http_client", BACKEND_DIR / "utils" / "http_client.py")
+_drop_stale_module("utils.stt.vad", BACKEND_DIR / "utils" / "stt" / "vad.py")
+_drop_stale_module("utils.stt.vad_gate", BACKEND_DIR / "utils" / "stt" / "vad_gate.py")
 
 sys.modules.setdefault('database.redis_db', MagicMock())
 sys.modules.setdefault('onnxruntime', MagicMock())

--- a/backend/tests/unit/test_vad_onnx.py
+++ b/backend/tests/unit/test_vad_onnx.py
@@ -11,6 +11,7 @@ import os
 import struct
 import tempfile
 import wave
+from pathlib import Path
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import numpy as np
@@ -24,6 +25,47 @@ _mock_redis = MagicMock()
 
 import sys
 import types
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package_path(name: str, path: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+
+    module.__path__ = [str(path)]
+
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, child_name, module)
+
+    return module
+
+
+def _drop_stale_module(name: str, expected_file: Path):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is not None and Path(module_file).resolve() == expected_file.resolve():
+        return
+
+    sys.modules.pop(name, None)
+    parent_name, _, child_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.stt", BACKEND_DIR / "utils" / "stt")
+_drop_stale_module("utils.http_client", BACKEND_DIR / "utils" / "http_client.py")
+_drop_stale_module("utils.stt.vad", BACKEND_DIR / "utils" / "stt" / "vad.py")
 
 
 class _MockAudioSegment:


### PR DESCRIPTION
## Summary

- restore real `utils` and `utils.stt` package paths before VAD tests import the modules under test
- discard stale `utils.http_client`, `utils.stt.vad`, and `utils.stt.vad_gate` stubs left by earlier unit tests
- keep `test_vad_onnx.py` and `test_vad_gate.py` pointed at the real VAD implementation during Windows/full-suite collection

## Root cause

`test_sync_transcription_prefs.py` and other backend unit tests can leave lightweight `utils.stt.vad` or `utils.http_client` stubs in `sys.modules` during collection. When pytest later collects `test_vad_onnx.py` or `test_vad_gate.py` in the same Windows process, Python can reuse those partial stubs instead of the real backend modules, causing imports such as `_run_file_vad`, `_get_ort_session`, or `get_stt_client` to fail before the VAD assertions run.

## Refresh note

Refreshed onto current `main` (`f05687ae9`) so the PR is mergeable again.

## Validation

- `python -m black --check --line-length 120 --skip-string-normalization backend\tests\unit\test_vad_gate.py backend\tests\unit\test_vad_onnx.py` -> passed
- `python -m py_compile backend\tests\unit\test_vad_gate.py backend\tests\unit\test_vad_onnx.py` -> passed
- `git diff --check origin/main..HEAD` -> passed
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit` -> passed
- `python -m pytest backend\tests\unit\test_vad_onnx.py backend\tests\unit\test_vad_gate.py -q --tb=short` -> 138 passed
- `python -m pytest backend\tests\unit\test_sync_transcription_prefs.py backend\tests\unit\test_vad_onnx.py --collect-only -q --tb=short --continue-on-collection-errors` -> 85 collected
- `python -m pytest backend\tests\unit\test_sync_transcription_prefs.py backend\tests\unit\test_vad_gate.py --collect-only -q --tb=short --continue-on-collection-errors` -> 177 collected

## Note

Running `test_sync_transcription_prefs.py` as an actual test file together with the VAD files can expose existing runtime stub gaps in that file, so this PR uses it only as the collection-order reproducer for the VAD import isolation issue.