### PR TITLE
[codex] Stabilize sync transcription preference tests

### DIFF
--- a/backend/tests/unit/test_sync_transcription_prefs.py
+++ b/backend/tests/unit/test_sync_transcription_prefs.py
@@ -54,6 +54,7 @@ for _sub in [
     'redis_db',
     'redis_pubsub',
     'screen_activity',
+    'sync_jobs',
     'tasks',
     'trends',
     'user_usage',
@@ -129,10 +130,20 @@ _speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
 sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
 
 # Stub google.cloud.storage.Client to avoid GCS credentials
+import google.cloud as _google_cloud
 import google.cloud.storage as _gcs
 
 _orig_storage_client = _gcs.Client
 _gcs.Client = MagicMock
+
+_tasks_v2 = ModuleType('google.cloud.tasks_v2')
+_tasks_v2.CloudTasksClient = MagicMock
+_tasks_v2.Task = MagicMock
+_tasks_v2.HttpRequest = MagicMock
+_tasks_v2.OidcToken = MagicMock
+_tasks_v2.HttpMethod = MagicMock(POST='POST')
+sys.modules.setdefault('google.cloud.tasks_v2', _tasks_v2)
+setattr(_google_cloud, 'tasks_v2', sys.modules['google.cloud.tasks_v2'])
 
 # Ensure env vars for modules that read them at import time
 os.environ.setdefault('OPENAI_API_KEY', 'sk-fake-for-test')


### PR DESCRIPTION
## Summary

- add the missing `database.sync_jobs` import-time stub used by `routers.sync`
- provide a minimal `google.cloud.tasks_v2` module stub so `utils.cloud_tasks` can import in lightweight Windows backend test environments
- keep the sync transcription preference tests focused on transcription/speaker-id behavior without requiring Cloud Tasks SDK credentials or package installs

## Root cause

On this Windows backend venv, `test_sync_transcription_prefs.py` could collect but failed 38 runtime tests when decorators or test bodies tried to patch/import `routers.sync`. The router now imports `database.sync_jobs` and transitively imports `google.cloud.tasks_v2` through the storage/cloud-tasks path, but this test's import-time stubs did not cover those dependencies.

## Validation

- before fix: `python -m pytest backend\tests\unit\test_sync_transcription_prefs.py -q --tb=short` -> 38 failed, 24 passed
- `python -m pytest backend\tests\unit\test_sync_transcription_prefs.py -q --tb=short` -> 62 passed
- `black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_sync_transcription_prefs.py`
- `python -m py_compile backend\tests\unit\test_sync_transcription_prefs.py`
- `python -m pytest backend\tests\unit\test_sync_transcription_prefs.py --collect-only -q --tb=short` -> 62 collected
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit`