### PR TITLE
[codex] Harden sync decode import stubs

### DIFF
--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -67,7 +67,41 @@ for _mod in _stub_modules:
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
 
-sys.modules['opuslib'].Decoder = MagicMock()
+
+def _ensure_attr(module_name: str, attr: str):
+    module = sys.modules[module_name]
+    if not hasattr(module, attr):
+        setattr(module, attr, MagicMock())
+
+
+for _module_name, _attrs in {
+    'opuslib': ['Decoder'],
+    'database.conversations': ['get_closest_conversation_to_timestamps', 'update_conversation_segments'],
+    'models.conversation': ['Conversation', 'CreateConversation'],
+    'models.conversation_enums': ['ConversationSource'],
+    'models.transcript_segment': ['TranscriptSegment'],
+    'utils.conversations.factory': ['deserialize_conversation'],
+    'utils.conversations.process_conversation': ['process_conversation'],
+    'utils.analytics': ['record_usage'],
+    'utils.byok': ['get_byok_keys', 'set_byok_keys', 'has_byok_keys'],
+    'utils.cloud_tasks': [
+        'enqueue_sync_job',
+        'get_sync_tasks_max_attempts',
+        'is_audio_merge_dispatch_enabled',
+        'is_cloud_tasks_dispatch_enabled',
+        'verify_cloud_tasks_oidc',
+    ],
+    'utils.http_client': ['_get_semaphore'],
+    'utils.log_sanitizer': ['sanitize'],
+    'utils.stt.pre_recorded': ['postprocess_words', 'prerecorded'],
+    'utils.stt.vad': ['vad_is_empty'],
+    'utils.speaker_assignment': ['process_speaker_assigned_segments'],
+    'utils.speaker_identification': ['detect_speaker_from_text'],
+    'utils.stt.speaker_embedding': ['extract_embedding_from_bytes', 'compare_embeddings', 'SPEAKER_MATCH_THRESHOLD'],
+    'utils.subscription': ['has_transcription_credits'],
+}.items():
+    for _attr in _attrs:
+        _ensure_attr(_module_name, _attr)
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
 if 'google.cloud.tasks_v2' not in sys.modules:

--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -48,6 +48,7 @@ _stub_modules = [
     'utils.encryption',
     'utils.analytics',
     'utils.byok',
+    'utils.cloud_tasks',
     'utils.http_client',
     'utils.stt.pre_recorded',
     'utils.stt.vad',
@@ -66,6 +67,7 @@ for _mod in _stub_modules:
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
 
+sys.modules['opuslib'].Decoder = MagicMock()
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
 if 'google.cloud.tasks_v2' not in sys.modules:

--- a/backend/tests/unit/test_sync_pcm_decode.py
+++ b/backend/tests/unit/test_sync_pcm_decode.py
@@ -37,6 +37,7 @@ _stub_modules = [
     'utils.executors',
     'utils.analytics',
     'utils.byok',
+    'utils.cloud_tasks',
     'utils.http_client',
     'utils.stt.pre_recorded',
     'utils.stt.vad',
@@ -53,6 +54,7 @@ for mod_name in _stub_modules:
         sys.modules[mod_name] = MagicMock()
 
 # Ensure specific attributes exist on key stubs
+sys.modules['opuslib'].Decoder = MagicMock()
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
 if 'google.cloud.tasks_v2' not in sys.modules:

--- a/backend/tests/unit/test_sync_pcm_decode.py
+++ b/backend/tests/unit/test_sync_pcm_decode.py
@@ -53,8 +53,42 @@ for mod_name in _stub_modules:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = MagicMock()
 
+
+def _ensure_attr(module_name: str, attr: str):
+    module = sys.modules[module_name]
+    if not hasattr(module, attr):
+        setattr(module, attr, MagicMock())
+
+
 # Ensure specific attributes exist on key stubs
-sys.modules['opuslib'].Decoder = MagicMock()
+for _module_name, _attrs in {
+    'opuslib': ['Decoder'],
+    'database.conversations': ['get_closest_conversation_to_timestamps', 'update_conversation_segments'],
+    'models.conversation': ['Conversation', 'CreateConversation'],
+    'models.conversation_enums': ['ConversationSource'],
+    'models.transcript_segment': ['TranscriptSegment'],
+    'utils.conversations.factory': ['deserialize_conversation'],
+    'utils.conversations.process_conversation': ['process_conversation'],
+    'utils.analytics': ['record_usage'],
+    'utils.byok': ['get_byok_keys', 'set_byok_keys', 'has_byok_keys'],
+    'utils.cloud_tasks': [
+        'enqueue_sync_job',
+        'get_sync_tasks_max_attempts',
+        'is_audio_merge_dispatch_enabled',
+        'is_cloud_tasks_dispatch_enabled',
+        'verify_cloud_tasks_oidc',
+    ],
+    'utils.http_client': ['_get_semaphore'],
+    'utils.log_sanitizer': ['sanitize'],
+    'utils.stt.pre_recorded': ['postprocess_words', 'prerecorded'],
+    'utils.stt.vad': ['vad_is_empty'],
+    'utils.speaker_assignment': ['process_speaker_assigned_segments'],
+    'utils.speaker_identification': ['detect_speaker_from_text'],
+    'utils.stt.speaker_embedding': ['extract_embedding_from_bytes', 'compare_embeddings', 'SPEAKER_MATCH_THRESHOLD'],
+    'utils.subscription': ['has_transcription_credits'],
+}.items():
+    for _attr in _attrs:
+        _ensure_attr(_module_name, _attr)
 sys.modules['database.redis_db'].r = MagicMock()
 sys.modules['database._client'].db = MagicMock()
 if 'google.cloud.tasks_v2' not in sys.modules:


### PR DESCRIPTION
## Summary

- make the PCM and Opus sync decode tests repair stale import stubs before importing `routers.sync`
- add `utils.cloud_tasks` to the existing import-time stub lists so an earlier empty `utils` package stub does not hide that dependency
- ensure the other `routers.sync` import surfaces used during collection are present when prior tests leave partial module stubs in `sys.modules`
- keep the decode tests focused on local WAL decode behavior without relying on test collection order

## Root cause

`test_sync_pcm_decode.py` and `test_sync_opus_decode.py` pass in isolation, but after `test_action_item_date_validation.py` they can collect against stale package stubs left in `sys.modules`. In that order, `opuslib` may already exist without `Decoder`, and `utils` may have an empty package path that hides `utils.cloud_tasks`, causing `routers.sync` import to fail before decode assertions run.

A broader unit-test collection pass also showed the same pattern for additional `routers.sync` import-time dependencies such as `database.conversations`, `models.conversation`, STT helpers, speaker helpers, BYOK helpers, and subscription helpers. This PR makes the decode tests restore those expected stub attributes without overriding real module attributes.

## Validation

- before fix: `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_sync_pcm_decode.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'Decoder' from 'opuslib'`
- before fix: `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_sync_opus_decode.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'Decoder' from 'opuslib'`
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_sync_pcm_decode.py --collect-only -q --tb=short --continue-on-collection-errors` -> 49 collected
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_sync_opus_decode.py --collect-only -q --tb=short --continue-on-collection-errors` -> 47 collected
- `python -m pytest backend\tests\unit\test_sync_pcm_decode.py backend\tests\unit\test_sync_opus_decode.py -q --tb=short` -> 44 passed
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_sync_pcm_decode.py backend\tests\unit\test_sync_opus_decode.py -q --tb=short` -> 70 passed
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` -> no `backend\tests\unit\test_sync_*` collection errors; 3358 tests collected, 20 unrelated collection errors remain
- `black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_sync_pcm_decode.py backend\tests\unit\test_sync_opus_decode.py`
- `python -m py_compile backend\tests\unit\test_sync_pcm_decode.py backend\tests\unit\test_sync_opus_decode.py`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit`