### PR TITLE
[codex] Reload async HTTP infrastructure modules

### DIFF
--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -9,10 +9,52 @@ Covers:
 """
 
 import asyncio
+import sys
 import time
+import types
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if module is None or not hasattr(module, "__path__"):
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+
+
+def _drop_stale_module(name, required_attrs):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    if (
+        isinstance(module, types.ModuleType)
+        and getattr(module, "__file__", None)
+        and all(hasattr(module, attr) for attr in required_attrs)
+    ):
+        return
+
+    sys.modules.pop(name, None)
+    parent_name, attr_name = name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, attr_name, None) is module:
+        delattr(parent, attr_name)
+
+
+_ensure_package("utils", BACKEND_DIR / "utils")
+_drop_stale_module("utils.http_client", ["WebhookCircuitBreaker", "get_webhook_circuit_breaker"])
+_drop_stale_module("utils.executors", ["critical_executor", "storage_executor", "shutdown_executors"])
 
 from utils.http_client import (
     WebhookCircuitBreaker,


### PR DESCRIPTION
## Summary

- make `test_async_http_infrastructure.py` restore the real `utils` package path before importing infrastructure modules
- drop stale `utils.http_client` and `utils.executors` stubs when earlier tests leave incomplete modules in `sys.modules`
- keep the async HTTP infrastructure tests exercising the real circuit breaker, semaphore, and executor implementations regardless of collection order

## Root cause

When `test_async_app_integrations.py` is collected first, it installs lightweight `utils.http_client` and `utils.executors` stubs for its own isolated app-integration tests. If `test_async_http_infrastructure.py` is collected afterward, those stubs can shadow the real modules and collection fails before the infrastructure assertions run, for example with `ImportError: cannot import name 'WebhookCircuitBreaker' from 'utils.http_client'`.

This test is intended to verify the actual HTTP client and executor infrastructure, so it now removes incomplete stubs and reloads the real modules before importing the symbols under test.

## Validation

- before fix: `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_http_infrastructure.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'WebhookCircuitBreaker' from 'utils.http_client'`
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_http_infrastructure.py --collect-only -q --tb=short --continue-on-collection-errors` -> 54 collected
- `python -m pytest backend\tests\unit\test_async_http_infrastructure.py -q --tb=short` -> 45 passed
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_async_http_infrastructure.py -q --tb=short` -> 54 passed
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` filtered for `test_async_http_infrastructure.py` -> no matching collection error; 3359 collected, 21 unrelated errors remain on this branch
- `black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_async_http_infrastructure.py`
- `python -m py_compile backend\tests\unit\test_async_http_infrastructure.py`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/pre-commit`