### PR TITLE
[codex] Isolate available plans test imports

### DIFF
--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -8,7 +8,20 @@ would be caught.
 import os
 import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, types.ModuleType):
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    return module
+
 
 # --- env vars needed at import time ---
 os.environ.setdefault(
@@ -100,6 +113,10 @@ _redis_mod.set_credits_invalidation_signal = MagicMock()
 _redis_mod.r = MagicMock()
 
 # Utils stubs for heavy external deps
+_ensure_package("utils", BACKEND_DIR / "utils")
+sys.modules.pop("utils.executors", None)
+sys.modules.pop("utils.subscription", None)
+
 for _name in [
     "utils.fair_use",
     "utils.notifications",


### PR DESCRIPTION
## Summary

- Restore the real `utils` package path before `test_available_plans_resilience.py` imports `routers.payment`.
- Drop stale `utils.subscription` and `utils.executors` stubs left by earlier-collected tests so the payment router can import the real helpers it needs.

## Root cause

When `test_async_app_integrations.py` is collected first, it leaves lightweight `utils.subscription` and `utils.executors` modules in `sys.modules`. Those stubs only contain the attributes needed by that test, so `test_available_plans_resilience.py` fails during collection when `routers.payment` imports `get_basic_plan_limits` and `stripe_executor`.

## Validation

- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_available_plans_resilience.py --collect-only -q --tb=short --continue-on-collection-errors`
- `python -m pytest backend\tests\unit\test_available_plans_resilience.py -q --tb=short`
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_available_plans_resilience.py -q --tb=short`
- `python -m black backend\tests\unit\test_available_plans_resilience.py`
- `python -m py_compile backend\tests\unit\test_available_plans_resilience.py`
- `bash scripts/pre-commit`