### PR TITLE
[codex] Complete desktop Deepgram test stubs

### DIFF
--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -8,7 +8,7 @@ Verifies:
 import os
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -98,12 +98,14 @@ sys.modules.setdefault('firebase_admin.auth', _fb.auth)
 _deepgram = ModuleType('deepgram')
 _deepgram.DeepgramClient = MagicMock
 _deepgram.DeepgramClientOptions = MagicMock
+_deepgram.LiveTranscriptionEvents = MagicMock()
 sys.modules.setdefault('deepgram', _deepgram)
 
 _speaker_embedding = ModuleType('utils.stt.speaker_embedding')
 _speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45
 _speaker_embedding.compare_embeddings = MagicMock(return_value=0.0)
 _speaker_embedding.extract_embedding_from_bytes = MagicMock()
+_speaker_embedding.async_extract_embedding_from_bytes = AsyncMock(return_value=None)
 sys.modules['utils.stt.speaker_embedding'] = _speaker_embedding
 
 import google.cloud.storage as _gcs


### PR DESCRIPTION
## Summary

- Add the `LiveTranscriptionEvents` attribute to the lightweight `deepgram` stub in `test_desktop_transcribe.py`.
- Add the async speaker-embedding helper to the test's `utils.stt.speaker_embedding` stub with `AsyncMock`.

## Root cause

`test_desktop_transcribe.py` is collected before `test_dg_start_guard.py` in a Windows unit-test collection. It leaves lightweight `deepgram` and `utils.stt.speaker_embedding` modules in `sys.modules`, but those stubs did not include the full import surface that `utils.stt.streaming` requires. When `test_dg_start_guard.py` later imports `connect_to_deepgram`, collection fails on missing `LiveTranscriptionEvents` or `async_extract_embedding_from_bytes` before the start-guard assertions can run.

## Validation

- before fix: `python -m pytest backend\tests\unit\test_desktop_transcribe.py backend\tests\unit\test_dg_start_guard.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'LiveTranscriptionEvents' from 'deepgram'`
- `python -m pytest backend\tests\unit\test_desktop_transcribe.py backend\tests\unit\test_dg_start_guard.py --collect-only -q --tb=short --continue-on-collection-errors` -> 58 collected
- `python -m pytest backend\tests\unit\test_desktop_transcribe.py::TestDeepgramPrerecordedFromBytesPCM backend\tests\unit\test_dg_start_guard.py -q --tb=short` -> 8 passed
- `python -m pytest backend\tests\unit\test_streaming_deepgram_backoff.py backend\tests\unit\test_dg_start_guard.py -q --tb=short` -> 84 passed
- `python -m pytest backend\tests\unit\test_dg_start_guard.py -q --tb=short` -> 2 passed
- `python -m py_compile backend\tests\unit\test_desktop_transcribe.py`
- `python -m black backend\tests\unit\test_desktop_transcribe.py`
- `bash scripts/pre-commit`

Note: `test_desktop_transcribe.py` still has existing runtime failures on `origin/main` around `models.conversation_enums` when running the full file; this PR is scoped to the collection-order import failure above.