### PR TITLE
[codex] Isolate phone call test imports

### DIFF
--- a/backend/tests/unit/test_phone_calls.py
+++ b/backend/tests/unit/test_phone_calls.py
@@ -1,9 +1,75 @@
 import os
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+
+    return module
+
+
+def _install_module(name):
+    module = ModuleType(name)
+    sys.modules[name] = module
+    parent_name, _, attr_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        setattr(parent, attr_name, module)
+    return module
+
+
+_ensure_package("database", BACKEND_DIR / "database")
+_ensure_package("utils", BACKEND_DIR / "utils")
+_ensure_package("utils.other", BACKEND_DIR / "utils" / "other")
+
+_install_module("database.phone_calls")
+_install_module("database.phone_call_usage")
+
+_phone_utils = _install_module("utils.phone_calls")
+_phone_utils.check_call_access = MagicMock()
+_phone_utils.check_destination_allowed = MagicMock()
+_phone_utils.get_quota_snapshot = MagicMock()
+
+_endpoints = _install_module("utils.other.endpoints")
+_endpoints.get_current_user_uid = lambda: "test-uid-123"
+
+
+def _rate_limit_dependency(**_kwargs):
+    def _dependency():
+        return None
+
+    return _dependency
+
+
+_endpoints.rate_limit_dependency = _rate_limit_dependency
+
+_twilio_service = _install_module("utils.twilio_service")
+for _attr in [
+    "generate_access_token",
+    "start_caller_id_verification",
+    "check_caller_id_verified",
+    "delete_caller_id",
+    "get_caller_id",
+    "validate_twilio_signature",
+]:
+    setattr(_twilio_service, _attr, MagicMock())
 
 # Mock modules that initialize GCP/Firebase clients at import time
 _mock_firebase = MagicMock()


### PR DESCRIPTION
## Summary

- Install lightweight import-time stubs for the phone call router dependencies used by `test_phone_calls.py`.
- Keep the test focused on router behavior without importing the real Firestore, Redis, auth dependency, or Twilio service layers during collection.

## Root cause

When `test_notification_token_cleanup.py` is collected first, it leaves a minimal `database.redis_db` module in `sys.modules`. `test_phone_calls.py` previously imported `routers.phone_calls` through real `database.phone_calls` / `utils.phone_calls` dependencies, which then reached `database.users` and expected Redis helpers that the prior stub does not provide. That made collection order matter on Windows.

## Validation

- before fix: `python -m pytest backend\tests\unit\test_notification_token_cleanup.py backend\tests\unit\test_phone_calls.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'try_acquire_user_platform_write_lock' from 'database.redis_db'`
- `python -m pytest backend\tests\unit\test_notification_token_cleanup.py backend\tests\unit\test_phone_calls.py --collect-only -q --tb=short --continue-on-collection-errors` -> 20 collected
- `python -m pytest backend\tests\unit\test_phone_calls.py -q --tb=short` -> 18 passed
- `python -m pytest backend\tests\unit\test_notification_token_cleanup.py backend\tests\unit\test_phone_calls.py -q --tb=short` -> 20 passed
- `python -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` filtered for `test_phone_calls.py` -> 18 phone-call tests collected, no matching collection error
- `python -m black backend\tests\unit\test_phone_calls.py`
- `python -m py_compile backend\tests\unit\test_phone_calls.py`
- `bash scripts/pre-commit`