### PR TITLE
[codex] Stabilize usage tracker test collection

### DIFF
--- a/backend/tests/unit/test_fair_use_classifier.py
+++ b/backend/tests/unit/test_fair_use_classifier.py
@@ -36,11 +36,21 @@ _langchain_openai = types.ModuleType('langchain_openai')
 _langchain_openai.ChatOpenAI = MagicMock(return_value=_llm_clients.llm_mini)
 sys.modules['langchain_openai'] = _langchain_openai
 
+_USAGE_TRACKER_MODULE = 'utils.llm.usage_tracker'
+_original_usage_tracker = sys.modules.get(_USAGE_TRACKER_MODULE)
 _usage_tracker = types.ModuleType('utils.llm.usage_tracker')
 _usage_tracker.get_usage_callback = MagicMock(return_value=MagicMock())
-sys.modules['utils.llm.usage_tracker'] = _usage_tracker
+sys.modules[_USAGE_TRACKER_MODULE] = _usage_tracker
 
-import utils.llm.fair_use_classifier as classifier_mod
+try:
+    import utils.llm.fair_use_classifier as classifier_mod
+finally:
+    if _original_usage_tracker is None:
+        sys.modules.pop(_USAGE_TRACKER_MODULE, None)
+    else:
+        sys.modules[_USAGE_TRACKER_MODULE] = _original_usage_tracker
+
+_classifier_llm = classifier_mod._classifier_llm
 
 
 class TestSelectRecipes:
@@ -175,7 +185,7 @@ class TestClassifyUserPurpose:
                 'reasoning': 'Clear audiobook pattern',
             }
         )
-        _llm_clients.llm_mini.ainvoke = AsyncMock(return_value=llm_response)
+        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
 
         result = await classifier_mod.classify_user_purpose('user1')
 
@@ -200,7 +210,7 @@ class TestClassifyUserPurpose:
 
         llm_response = MagicMock()
         llm_response.content = '```json\n{"misuse_score": 0.1, "usage_type": "none", "confidence": 0.9, "evidence": [], "reasoning": "Normal"}\n```'
-        _llm_clients.llm_mini.ainvoke = AsyncMock(return_value=llm_response)
+        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
 
         result = await classifier_mod.classify_user_purpose('user1')
         assert result['misuse_score'] == pytest.approx(0.1)
@@ -223,7 +233,7 @@ class TestClassifyUserPurpose:
         llm_response.content = json.dumps(
             {'misuse_score': 1.5, 'usage_type': 'none', 'confidence': -0.2, 'evidence': [], 'reasoning': ''}
         )
-        _llm_clients.llm_mini.ainvoke = AsyncMock(return_value=llm_response)
+        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
 
         result = await classifier_mod.classify_user_purpose('user1')
         assert result['misuse_score'] == 1.0
@@ -245,7 +255,7 @@ class TestClassifyUserPurpose:
 
         llm_response = MagicMock()
         llm_response.content = 'This is not JSON at all'
-        _llm_clients.llm_mini.ainvoke = AsyncMock(return_value=llm_response)
+        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
 
         result = await classifier_mod.classify_user_purpose('user1')
         assert result['misuse_score'] == 0.0
@@ -264,7 +274,7 @@ class TestClassifyUserPurpose:
                 'created_at': now,
             }
         ]
-        _llm_clients.llm_mini.ainvoke = AsyncMock(side_effect=Exception('LLM timeout'))
+        _classifier_llm.ainvoke = AsyncMock(side_effect=Exception('LLM timeout'))
 
         result = await classifier_mod.classify_user_purpose('user1')
         assert result['misuse_score'] == 0.0

--- a/backend/tests/unit/test_integration_malformed_records.py
+++ b/backend/tests/unit/test_integration_malformed_records.py
@@ -65,9 +65,16 @@ class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
+def _matches_stub_prefix(module_name):
+    return any(module_name == prefix or module_name.startswith(prefix + '.') for prefix in _STUB)
+
+
 _finder = _Finder()
+_original_stub_modules = {
+    module_name: module for module_name, module in sys.modules.items() if _matches_stub_prefix(module_name)
+}
 for _n in list(sys.modules):
-    if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+    if _matches_stub_prefix(_n):
         sys.modules.pop(_n, None)
 sys.meta_path.insert(0, _finder)
 try:
@@ -75,8 +82,9 @@ try:
 finally:
     sys.meta_path.remove(_finder)
     for _n in list(sys.modules):
-        if any(_n == p or _n.startswith(p + '.') for p in _STUB):
+        if _matches_stub_prefix(_n):
             sys.modules.pop(_n, None)
+    sys.modules.update(_original_stub_modules)
 
 
 def _setup_gates():


### PR DESCRIPTION
## Summary
- Restore the previous `utils.llm.usage_tracker` module after `test_fair_use_classifier.py` imports its module under a lightweight callback stub.
- Patch fair-use classifier async response tests against the classifier module's actual `_classifier_llm` instance, so later collection cannot redirect the `utils.llm.clients` stub.
- Snapshot and restore pre-existing broad `database`/`utils` stubs around `test_integration_malformed_records.py`'s temporary import finder.

## Why
Windows/full-directory collection can expose module-order coupling: temporary test stubs leaked into `sys.modules`, or a broad import finder cleanup removed stubs installed by earlier collected tests. That made usage-tracking tests import incomplete `utils.llm.usage_tracker` modules or lose their database/langchain stubs before execution.

## Validation
- `python -m pytest backend\tests\unit\test_fair_use_classifier.py backend\tests\unit\test_high_priority_usage_tracking.py backend\tests\unit\test_new_usage_tracking_gaps.py backend\tests\unit\test_integration_malformed_records.py -q --tb=short` -> 86 passed
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_fair_use_classifier.py backend\tests\unit\test_integration_malformed_records.py`
- `python -m py_compile backend\tests\unit\test_fair_use_classifier.py backend\tests\unit\test_integration_malformed_records.py`
- `git diff --check`
- `bash scripts/pre-commit`