### PR TITLE
[codex] Stabilize QoS tier test imports

### DIFF
--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -2,6 +2,8 @@
 
 import os
 import sys
+import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +11,102 @@ import pytest
 # ---------------------------------------------------------------------------
 # Pre-mock heavy deps before any imports touch them
 # ---------------------------------------------------------------------------
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+def _install_module(name: str, **attrs) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for attr, value in attrs.items():
+        setattr(module, attr, value)
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, types.ModuleType(parent_name))
+        if not hasattr(parent, '__path__'):
+            parent.__path__ = []
+        setattr(parent, child_name, module)
+    sys.modules[name] = module
+    return module
+
+
+class _BaseCallbackHandler:
+    pass
+
+
+class _LLMResult:
+    pass
+
+
+class _BaseChatModel:
+    def invoke(self, *_args, **_kwargs):
+        return MagicMock()
+
+    async def ainvoke(self, *_args, **_kwargs):
+        return MagicMock()
+
+    def stream(self, *_args, **_kwargs):
+        return iter(())
+
+    def with_structured_output(self, *_args, **_kwargs):
+        return self
+
+    def bind(self, **kwargs):
+        bound = self.__class__(**self._constructor_kwargs)
+        bound.bound_kwargs = kwargs
+        return bound
+
+
+class _ChatOpenAI(_BaseChatModel):
+    def __init__(self, **kwargs):
+        self._constructor_kwargs = dict(kwargs)
+        self.model_name = kwargs.get('model')
+        self.model = self.model_name
+        self.temperature = kwargs.get('temperature')
+        self.openai_api_base = kwargs.get('base_url', '')
+
+
+class _ChatGoogleGenerativeAI(_BaseChatModel):
+    def __init__(self, **kwargs):
+        self._constructor_kwargs = dict(kwargs)
+        self.model_name = kwargs.get('model')
+        self.model = self.model_name
+
+
+class _OpenAIEmbeddings:
+    def __init__(self, **_kwargs):
+        pass
+
+    def embed_query(self, _text):
+        return [0.0]
+
+    def embed_documents(self, texts):
+        return [[0.0] for _text in texts]
+
+
+class _PydanticOutputParser:
+    def __init__(self, **kwargs):
+        self.pydantic_object = kwargs.get('pydantic_object')
+
+
+class _Encoding:
+    def encode(self, text):
+        return list(text)
+
+
+class _AsyncAnthropic:
+    def __init__(self, **_kwargs):
+        pass
+
+
+_install_module('anthropic', AsyncAnthropic=_AsyncAnthropic)
+_install_module('langchain_core')
+_install_module('langchain_core.callbacks', BaseCallbackHandler=_BaseCallbackHandler)
+_install_module('langchain_core.outputs', LLMResult=_LLMResult)
+_install_module('langchain_core.language_models', BaseChatModel=_BaseChatModel)
+_install_module('langchain_core.output_parsers', PydanticOutputParser=_PydanticOutputParser)
+_install_module('langchain_openai', ChatOpenAI=_ChatOpenAI, OpenAIEmbeddings=_OpenAIEmbeddings)
+_install_module('langchain_google_genai', ChatGoogleGenerativeAI=_ChatGoogleGenerativeAI)
+_install_module('tiktoken', encoding_for_model=MagicMock(return_value=_Encoding()))
+
 _HEAVY_MOCKS = {
     'firebase_admin': MagicMock(),
     'firebase_admin.firestore': MagicMock(),
@@ -23,9 +121,60 @@ _HEAVY_MOCKS = {
 for _mod, _mock in _HEAVY_MOCKS.items():
     sys.modules.setdefault(_mod, _mock)
 
+for _package, _path in {
+    'utils': BACKEND_DIR / 'utils',
+    'utils.llm': BACKEND_DIR / 'utils' / 'llm',
+}.items():
+    module = sys.modules.get(_package)
+    if module is None or not hasattr(module, '__path__'):
+        module = types.ModuleType(_package)
+        sys.modules[_package] = module
+    module.__path__ = [str(_path)]
+
+_clients_stub = sys.modules.get('utils.llm.clients')
+if _clients_stub is not None and not hasattr(_clients_stub, 'MODEL_QOS_PROFILES'):
+    sys.modules.pop('utils.llm.clients', None)
+
+_usage_tracker_stub = sys.modules.get('utils.llm.usage_tracker')
+if _usage_tracker_stub is not None and not hasattr(_usage_tracker_stub, 'get_usage_callback'):
+    sys.modules.pop('utils.llm.usage_tracker', None)
+
 # Set required env vars before importing clients
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-key-for-unit-tests')
 os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake-key')
+
+
+def _clients_subprocess_script(assertion: str) -> str:
+    lines = [
+        "import os",
+        "import sys",
+        "from unittest.mock import MagicMock",
+        "for module_name in [",
+        "    'anthropic',",
+        "    'firebase_admin',",
+        "    'firebase_admin.firestore',",
+        "    'google.cloud.firestore',",
+        "    'google.cloud.firestore_v1',",
+        "    'google.cloud.firestore_v1.base_query',",
+        "    'langchain_core',",
+        "    'langchain_core.callbacks',",
+        "    'langchain_core.language_models',",
+        "    'langchain_core.output_parsers',",
+        "    'langchain_core.outputs',",
+        "    'langchain_google_genai',",
+        "    'langchain_openai',",
+        "    'tiktoken',",
+        "    'database',",
+        "    'database._client',",
+        "    'database.llm_usage',",
+        "]:",
+        "    sys.modules.setdefault(module_name, MagicMock())",
+        "os.environ['OPENAI_API_KEY'] = 'sk-test'",
+        "os.environ['ANTHROPIC_API_KEY'] = 'sk-ant-test'",
+        *assertion.splitlines(),
+    ]
+    return "\n".join(lines) + "\n"
+
 
 # Now import the module under test
 from utils.llm.clients import (
@@ -506,24 +655,17 @@ class TestProfileSelectionAtImportTime:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
-                (
-                    "import sys; from unittest.mock import MagicMock; "
-                    "[sys.modules.setdefault(m, MagicMock()) for m in "
-                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
-                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
-                    "'database','database._client','database.llm_usage']]; "
-                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
-                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['MODEL_QOS']='premium'; "
-                    "from utils.llm.clients import _active_profile_name; "
+                _clients_subprocess_script(
+                    "os.environ['MODEL_QOS'] = 'premium'\n"
+                    "from utils.llm.clients import _active_profile_name\n"
                     "assert _active_profile_name == 'premium', f'Expected premium, got {_active_profile_name}'"
                 ),
             ],
             capture_output=True,
             text=True,
-            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode == 0, f"premium profile test failed: {result.stderr}"
 
@@ -533,24 +675,18 @@ class TestProfileSelectionAtImportTime:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
-                (
-                    "import sys; from unittest.mock import MagicMock; "
-                    "[sys.modules.setdefault(m, MagicMock()) for m in "
-                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
-                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
-                    "'database','database._client','database.llm_usage']]; "
-                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
-                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['MODEL_QOS']='bogus'; "
-                    "from utils.llm.clients import _active_profile_name; "
-                    "assert _active_profile_name == 'premium', f'Expected premium fallback, got {_active_profile_name}'"
+                _clients_subprocess_script(
+                    "os.environ['MODEL_QOS'] = 'bogus'\n"
+                    "from utils.llm.clients import _active_profile_name\n"
+                    "assert _active_profile_name == 'premium', "
+                    "f'Expected premium fallback, got {_active_profile_name}'"
                 ),
             ],
             capture_output=True,
             text=True,
-            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode == 0, f"invalid profile fallback test failed: {result.stderr}"
 
@@ -562,7 +698,7 @@ class TestExpandedCallsiteCoverage:
         from pathlib import Path
 
         backend_dir = Path(__file__).resolve().parent.parent.parent
-        return (backend_dir / rel_path).read_text()
+        return (backend_dir / rel_path).read_text(encoding='utf-8')
 
     def test_conversation_processing_all_keys(self):
         import re
@@ -865,25 +1001,18 @@ class TestBYOKProfileFixed:
 
         result = subprocess.run(
             [
-                'python3',
+                sys.executable,
                 '-c',
-                (
-                    "import sys; from unittest.mock import MagicMock; "
-                    "[sys.modules.setdefault(m, MagicMock()) for m in "
-                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
-                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
-                    "'database','database._client','database.llm_usage']]; "
-                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
-                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['MODEL_QOS']='max'; "
-                    "from utils.llm.clients import _byok_profile_name, _byok_profile; "
-                    "assert _byok_profile_name == 'byok', f'Expected byok, got {_byok_profile_name}'; "
+                _clients_subprocess_script(
+                    "os.environ['MODEL_QOS'] = 'max'\n"
+                    "from utils.llm.clients import _byok_profile_name, _byok_profile\n"
+                    "assert _byok_profile_name == 'byok', f'Expected byok, got {_byok_profile_name}'\n"
                     "assert _byok_profile is not None"
                 ),
             ],
             capture_output=True,
             text=True,
-            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode == 0, f"byok profile test failed: {result.stderr}"
 


### PR DESCRIPTION
## Summary
- Add deterministic lightweight SDK stubs in `test_omi_qos_tiers.py` for the LLM client dependencies that are absent in the Windows backend unit venv.
- Restore real `utils` / `utils.llm` package paths and drop stale `utils.llm.clients` / `utils.llm.usage_tracker` stubs before importing the real QoS client module.
- Run the import-time profile selection subprocess checks through `sys.executable` with the same lightweight bootstrap, and read source scan targets as UTF-8.

## Why
On Windows, this test did not reliably import the real `utils.llm.clients` module. In isolation, collection failed when optional SDKs such as `anthropic` were missing. After earlier tests, stale lightweight `utils.llm.clients` or `utils.llm.usage_tracker` entries in `sys.modules` could also shadow the real module, causing `MODEL_QOS_PROFILES` or `get_usage_callback` import errors before the QoS assertions ran.

## Validation
- Before fix: `python -m pytest backend\tests\unit\test_omi_qos_tiers.py --collect-only -q --tb=short` -> `ModuleNotFoundError: No module named 'anthropic'`
- Before fix: `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_omi_qos_tiers.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'MODEL_QOS_PROFILES' from 'utils.llm.clients'`
- `python -m pytest backend\tests\unit\test_omi_qos_tiers.py -q --tb=short` -> 89 passed
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_omi_qos_tiers.py -q --tb=short` -> 115 passed
- `python -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_omi_qos_tiers.py -q --tb=short` -> 98 passed
- `python -m pytest backend\tests\unit\test_fair_use_classifier.py backend\tests\unit\test_omi_qos_tiers.py -q --tb=short` -> 105 passed
- `python -m py_compile backend\tests\unit\test_omi_qos_tiers.py`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_omi_qos_tiers.py`
- `git diff --check`
- `bash scripts/pre-commit`