### PR TITLE
[codex] Stabilize backend unit import isolation

### DIFF
--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -95,6 +95,10 @@ llm_clients_stub.parser = MagicMock()
 _stub_package("models")
 sys.modules["models"].__path__ = [str(BACKEND_DIR / "models")]
 
+_conversation_processing_stub = sys.modules.get("utils.llm.conversation_processing")
+if _conversation_processing_stub is not None and not hasattr(_conversation_processing_stub, "_local_started_at_iso"):
+    sys.modules.pop("utils.llm.conversation_processing", None)
+
 conv_proc = _load_module_from_file(
     "utils.llm.conversation_processing",
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",

--- a/backend/tests/unit/test_kg_user_type_mismatch.py
+++ b/backend/tests/unit/test_kg_user_type_mismatch.py
@@ -12,9 +12,12 @@ import os
 import sys
 import types
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
@@ -27,6 +30,16 @@ def _stub_module(name: str) -> types.ModuleType:
         mod = types.ModuleType(name)
         sys.modules[name] = mod
     return sys.modules[name]
+
+
+def _ensure_package_path(name: str, path: Path) -> types.ModuleType:
+    mod = _stub_module(name)
+    mod.__path__ = [str(path)]
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent = _stub_module(parent_name)
+        setattr(parent, child_name, mod)
+    return mod
 
 
 # Stub database package and submodules
@@ -100,6 +113,8 @@ memories_mod.save_memories = MagicMock()
 memories_mod.delete_memory = MagicMock()
 
 # Stub utils modules
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.conversations", BACKEND_DIR / "utils" / "conversations")
 for name in [
     "utils.apps",
     "utils.analytics",
@@ -224,6 +239,15 @@ import importlib
 
 process_conversation = importlib.import_module("utils.conversations.process_conversation")
 from models.memories import MemoryDB
+
+
+@pytest.fixture(autouse=True)
+def _restore_module_bindings():
+    if "models.memories" not in sys.modules:
+        importlib.import_module("models.memories")
+    setattr(sys.modules["models"], "memories", sys.modules["models.memories"])
+    auth_mod.get_user_name = MagicMock(return_value="The User")
+    process_conversation.get_user_name = auth_mod.get_user_name
 
 
 def _make_conversation_mock():

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -11,13 +11,44 @@ import inspect
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
 # Mock modules that initialize GCP clients or require API keys at import time
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+def _ensure_package(name: str, path: Path) -> ModuleType:
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+_ensure_package("utils", BACKEND_DIR / "utils")
+llm_package = _ensure_package("utils.llm", BACKEND_DIR / "utils" / "llm")
+
+_conversation_processing_stub = sys.modules.get("utils.llm.conversation_processing")
+if _conversation_processing_stub is not None and not hasattr(
+    _conversation_processing_stub, "_build_conversation_context"
+):
+    sys.modules.pop("utils.llm.conversation_processing", None)
+
 sys.modules.setdefault("database._client", MagicMock())
-_mock_clients = MagicMock()
-sys.modules.setdefault("utils.llm.clients", _mock_clients)
+_mock_clients = sys.modules.get("utils.llm.clients")
+if not isinstance(_mock_clients, ModuleType):
+    _mock_clients = ModuleType("utils.llm.clients")
+    sys.modules["utils.llm.clients"] = _mock_clients
+_mock_clients.get_llm = MagicMock()
+_mock_clients.parser = MagicMock()
+setattr(llm_package, "clients", _mock_clients)
 
 
 class _FakePydanticOutputParser:


### PR DESCRIPTION
## Summary
- Restore real package paths before tests import backend modules that earlier tests may have stubbed in `sys.modules`.
- Replace incomplete `utils.llm.conversation_processing` / `utils.llm.clients` stubs when prompt caching and timezone tests need the real implementation.
- Rebind KG test module-level mocks at test execution time so later-collected tests cannot desynchronize patch targets.

## Why
On Windows, collecting these backend unit tests in the same Python process can leave empty package stubs from earlier test modules. That made later modules fail depending on collection order, for example `utils.conversations.process_conversation` not being found, or `conversation_processing` resolving to a stub without the helper under test.

## Validation
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_kg_user_type_mismatch.py backend\tests\unit\test_conversation_structure_timezone.py backend\tests\unit\test_prompt_caching.py -q --tb=short`
- `python -m py_compile backend\tests\unit\test_prompt_caching.py backend\tests\unit\test_kg_user_type_mismatch.py backend\tests\unit\test_conversation_structure_timezone.py`
- `git diff --check`
- `scripts/pre-commit`