### PR TITLE
[codex] Read prompt cache source fixtures as UTF-8

### DIFF
--- a/backend/tests/unit/test_prompt_cache_optimization.py
+++ b/backend/tests/unit/test_prompt_cache_optimization.py
@@ -112,17 +112,17 @@ langsmith_prompts_mod.get_prompt_metadata = MagicMock(return_value=(None, None, 
 
 def _read_clients_source() -> str:
     backend_dir = Path(__file__).resolve().parent.parent.parent
-    return (backend_dir / "utils" / "llm" / "clients.py").read_text()
+    return (backend_dir / "utils" / "llm" / "clients.py").read_text(encoding="utf-8")
 
 
 def _read_agentic_source() -> str:
     backend_dir = Path(__file__).resolve().parent.parent.parent
-    return (backend_dir / "utils" / "retrieval" / "agentic.py").read_text()
+    return (backend_dir / "utils" / "retrieval" / "agentic.py").read_text(encoding="utf-8")
 
 
 def _read_chat_source() -> str:
     backend_dir = Path(__file__).resolve().parent.parent.parent
-    return (backend_dir / "utils" / "llm" / "chat.py").read_text()
+    return (backend_dir / "utils" / "llm" / "chat.py").read_text(encoding="utf-8")
 
 
 def test_qos_cache_key_in_clients():


### PR DESCRIPTION
## Summary
- Read prompt cache source files with `encoding="utf-8"` in `test_prompt_cache_optimization.py`.

## Why
On Windows, Python defaults to the active ANSI code page for `Path.read_text()`. These source files contain UTF-8 characters, so the test file failed with `UnicodeDecodeError` under the default Windows encoding.

## Validation
- `python -m pytest backend\tests\unit\test_prompt_cache_optimization.py -q --tb=short`
- `python -m py_compile backend\tests\unit\test_prompt_cache_optimization.py`
- `git diff --check`
- `scripts/pre-commit`