### PR TITLE
[codex] Read dev API lock source as UTF-8

### DIFF
--- a/backend/tests/unit/test_dev_api_lock_bypass.py
+++ b/backend/tests/unit/test_dev_api_lock_bypass.py
@@ -460,7 +460,7 @@ class TestProcessConversationKGLockEnforcement:
             / 'conversations'
             / 'process_conversation.py'
         )
-        tree = ast.parse(src.read_text(), filename=str(src))
+        tree = ast.parse(src.read_text(encoding="utf-8"), filename=str(src))
 
         found = False
         for node in ast.walk(tree):


### PR DESCRIPTION
## Summary
- Read `process_conversation.py` as UTF-8 in the dev API lock bypass AST test.

## Why
On Windows, `Path.read_text()` uses the active ANSI code page by default. The source file contains UTF-8 characters, so the AST-based lock enforcement test failed with `UnicodeDecodeError` before reaching its assertion.

## Validation
- `python -m pytest backend\tests\unit\test_dev_api_lock_bypass.py -q --tb=short`
- `python -m py_compile backend\tests\unit\test_dev_api_lock_bypass.py`
- `git diff --check`
- `scripts/pre-commit`