### PR TITLE
[codex] Guard optional audio codec imports

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -30,7 +30,14 @@ from utils.executors import (
 
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, Header, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
-from opuslib import Decoder
+
+try:
+    from opuslib import Decoder
+except Exception as e:
+    Decoder = None
+    _OPUS_IMPORT_ERROR = e
+else:
+    _OPUS_IMPORT_ERROR = None
 from pydub import AudioSegment
 
 from database import conversations as conversations_db
@@ -119,6 +126,15 @@ AUDIO_SAMPLE_RATE = 16000
 _V1_DEPRECATION_HEADERS = {'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'}
 
 router = APIRouter()
+
+
+def _get_opus_decoder_class():
+    if Decoder is None:
+        raise RuntimeError(
+            'Opus sync decoding requires opuslib and the native libopus library. '
+            'Install the OS-level Opus package before processing .opus sync files.'
+        ) from _OPUS_IMPORT_ERROR
+    return Decoder
 
 
 # **********************************************
@@ -601,7 +617,7 @@ def decode_opus_file_to_wav(opus_file_path, wav_file_path, sample_rate=16000, ch
         logger.warning(f"File not found: {sanitize(opus_file_path)}")
         return False
 
-    decoder = Decoder(sample_rate, channels)
+    decoder = _get_opus_decoder_class()(sample_rate, channels)
     frame_count = 0
 
     try:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -18,12 +18,22 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import av
 import numpy as np
-import opuslib  # type: ignore
+
+try:
+    import opuslib  # type: ignore
+except Exception as e:
+    opuslib = None
+    _OPUS_IMPORT_ERROR = e
+else:
+    _OPUS_IMPORT_ERROR = None
 
 try:
     import lc3  # lc3py
-except ImportError:
+except Exception as e:
     lc3 = None
+    _LC3_IMPORT_ERROR = e
+else:
+    _LC3_IMPORT_ERROR = None
 
 from fastapi import APIRouter, Depends
 from fastapi.websockets import WebSocket, WebSocketDisconnect
@@ -131,6 +141,23 @@ from utils.log_sanitizer import sanitize, sanitize_pii
 from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, wait_for_event
 
 logger = logging.getLogger(__name__)
+
+
+def _get_opuslib():
+    if opuslib is None:
+        raise RuntimeError(
+            'Opus streaming requires opuslib and the native libopus library. '
+            'Install the OS-level Opus package before using the opus codec.'
+        ) from _OPUS_IMPORT_ERROR
+    return opuslib
+
+
+def _get_lc3():
+    if lc3 is None:
+        message = 'LC3 streaming requires lc3py and its native codec library. Install lc3py before using the lc3 codec.'
+        raise RuntimeError(message) from _LC3_IMPORT_ERROR
+    return lc3
+
 
 router = APIRouter()
 
@@ -290,7 +317,7 @@ async def _stream_handler(
         channel_id_to_index = {ch.channel_id: i for i, ch in enumerate(channel_configs)}
         stt_sockets_multi = [None] * len(channel_configs)
         if codec == 'opus':
-            multi_opus_decoders = [opuslib.Decoder(sample_rate, 1) for _ in channel_configs]
+            multi_opus_decoders = [_get_opuslib().Decoder(sample_rate, 1) for _ in channel_configs]
         else:
             multi_opus_decoders = [None] * len(channel_configs)
         channel_mix_buffers = [bytearray() for _ in channel_configs]
@@ -2415,7 +2442,7 @@ async def _stream_handler(
     lc3_decoder = None
 
     if codec == 'opus':
-        opus_decoder = opuslib.Decoder(sample_rate, 1)
+        opus_decoder = _get_opuslib().Decoder(sample_rate, 1)
     elif codec == 'aac':
         aac_decoder = AACDecoder(uid=uid, session_id=session_id, sample_rate=sample_rate, channels=channels)
     elif codec == 'lc3':
@@ -2424,7 +2451,7 @@ async def _stream_handler(
             logger.error(f"LC3 codec requested but lc3py is not installed {uid} {session_id}")
             await websocket.close(code=websocket_close_code, reason="LC3 codec is not available")
             return
-        lc3_decoder = lc3.Decoder(lc3_frame_duration_us, sample_rate)
+        lc3_decoder = _get_lc3().Decoder(lc3_frame_duration_us, sample_rate)
 
     async def receive_data(stt_socket):
         nonlocal websocket_active, websocket_close_code, last_audio_received_time, last_activity_time, current_conversation_id

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -66,6 +66,7 @@ pytest tests/unit/test_transcribe_conversation_cache.py -v
 pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
 pytest tests/unit/test_pusher_batch_upload.py -v
 pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
+pytest tests/unit/test_optional_audio_codecs.py -v
 pytest tests/unit/test_storage_opus_encoding.py -v
 pytest tests/unit/test_speech_profile_existence.py -v
 pytest tests/unit/test_storage_fanout_limits.py -v

--- a/backend/tests/unit/test_optional_audio_codecs.py
+++ b/backend/tests/unit/test_optional_audio_codecs.py
@@ -7,6 +7,33 @@ from unittest.mock import MagicMock
 import pytest
 
 MISSING_OPUS_MESSAGE = "native libopus"
+_MISSING = object()
+
+
+def _capture_module(name: str):
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    parent_attr = getattr(parent, attr, _MISSING) if parent is not None else _MISSING
+    return sys.modules.get(name, _MISSING), parent_attr
+
+
+def _restore_module(name: str, captured):
+    module, parent_attr = captured
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+
+    if module is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = module
+
+    if parent is None:
+        return
+    if parent_attr is _MISSING:
+        if hasattr(parent, attr):
+            delattr(parent, attr)
+    else:
+        setattr(parent, attr, parent_attr)
 
 
 def _drop_module(name: str):
@@ -113,26 +140,34 @@ def _install_sync_import_stubs(monkeypatch):
 
 
 def test_storage_import_defers_missing_native_opus(monkeypatch):
+    captured_storage = _capture_module("utils.other.storage")
     _install_storage_import_stubs(monkeypatch)
     monkeypatch.setitem(sys.modules, "opuslib", None)
-    _drop_module("utils.other.storage")
+    try:
+        _drop_module("utils.other.storage")
 
-    storage = importlib.import_module("utils.other.storage")
+        storage = importlib.import_module("utils.other.storage")
 
-    assert storage.opuslib is None
-    with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
-        storage.encode_pcm_to_opus(b"\x00" * 640)
+        assert storage.opuslib is None
+        with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
+            storage.encode_pcm_to_opus(b"\x00" * 640)
+    finally:
+        _restore_module("utils.other.storage", captured_storage)
 
 
 def test_sync_import_defers_missing_native_opus(monkeypatch, tmp_path):
+    captured_sync = _capture_module("routers.sync")
     _install_sync_import_stubs(monkeypatch)
     monkeypatch.setitem(sys.modules, "opuslib", None)
-    _drop_module("routers.sync")
+    try:
+        _drop_module("routers.sync")
 
-    sync = importlib.import_module("routers.sync")
-    opus_path = tmp_path / "audio.opus"
-    opus_path.write_bytes(b"\x00\x00\x00\x00")
+        sync = importlib.import_module("routers.sync")
+        opus_path = tmp_path / "audio.opus"
+        opus_path.write_bytes(b"\x00\x00\x00\x00")
 
-    assert sync.Decoder is None
-    with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
-        sync.decode_opus_file_to_wav(str(opus_path), str(tmp_path / "audio.wav"))
+        assert sync.Decoder is None
+        with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
+            sync.decode_opus_file_to_wav(str(opus_path), str(tmp_path / "audio.wav"))
+    finally:
+        _restore_module("routers.sync", captured_sync)

--- a/backend/tests/unit/test_optional_audio_codecs.py
+++ b/backend/tests/unit/test_optional_audio_codecs.py
@@ -1,0 +1,126 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+MISSING_OPUS_MESSAGE = "native libopus"
+
+
+def _drop_module(name: str):
+    sys.modules.pop(name, None)
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and hasattr(parent, attr):
+        delattr(parent, attr)
+
+
+def _module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for attr, value in attrs.items():
+        setattr(module, attr, value)
+    return module
+
+
+def _install_storage_import_stubs(monkeypatch):
+    gcs_storage = _module("google.cloud.storage", Client=MagicMock(return_value=MagicMock()))
+    gcs_exceptions = _module("google.cloud.exceptions", NotFound=type("NotFound", (Exception,), {}))
+    google_cloud = _module("google.cloud", storage=gcs_storage, exceptions=gcs_exceptions)
+    service_account = _module("google.oauth2.service_account", Credentials=MagicMock())
+    google_oauth2 = _module("google.oauth2", service_account=service_account)
+
+    for name, module in {
+        "google.cloud": google_cloud,
+        "google.cloud.storage": gcs_storage,
+        "google.cloud.exceptions": gcs_exceptions,
+        "google.oauth2": google_oauth2,
+        "google.oauth2.service_account": service_account,
+        "database.redis_db": _module(
+            "database.redis_db",
+            cache_signed_url=MagicMock(),
+            get_cached_signed_url=MagicMock(),
+        ),
+        "database.users": _module("database.users"),
+        "utils.encryption": _module("utils.encryption"),
+        "utils.cloud_tasks": _module(
+            "utils.cloud_tasks",
+            enqueue_audio_merge_job=MagicMock(),
+            is_audio_merge_dispatch_enabled=MagicMock(return_value=False),
+        ),
+        "utils.other.deferred_delete": _module(
+            "utils.other.deferred_delete",
+            DeferredDeleter=MagicMock(),
+        ),
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _install_sync_import_stubs(monkeypatch):
+    for name in [
+        "database._client",
+        "database.redis_db",
+        "database.fair_use",
+        "database.users",
+        "database.user_usage",
+        "database.conversations",
+        "database.cache",
+        "database.sync_jobs",
+        "firebase_admin",
+        "firebase_admin.messaging",
+        "models.conversation",
+        "models.conversation_enums",
+        "models.transcript_segment",
+        "utils.conversations.process_conversation",
+        "utils.conversations.factory",
+        "utils.other.endpoints",
+        "utils.other.storage",
+        "utils.encryption",
+        "utils.analytics",
+        "utils.byok",
+        "utils.cloud_tasks",
+        "utils.http_client",
+        "utils.stt.pre_recorded",
+        "utils.stt.vad",
+        "utils.speaker_assignment",
+        "utils.speaker_identification",
+        "utils.stt.speaker_embedding",
+        "utils.fair_use",
+        "utils.subscription",
+        "utils.log_sanitizer",
+        "utils.executors",
+        "pydub",
+        "numpy",
+        "httpx",
+    ]:
+        monkeypatch.setitem(sys.modules, name, MagicMock())
+
+    sys.modules["database.redis_db"].r = MagicMock()
+    sys.modules["database._client"].db = MagicMock()
+    sys.modules["utils.log_sanitizer"].sanitize = lambda value: value
+
+
+def test_storage_import_defers_missing_native_opus(monkeypatch):
+    _install_storage_import_stubs(monkeypatch)
+    monkeypatch.setitem(sys.modules, "opuslib", None)
+    _drop_module("utils.other.storage")
+
+    storage = importlib.import_module("utils.other.storage")
+
+    assert storage.opuslib is None
+    with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
+        storage.encode_pcm_to_opus(b"\x00" * 640)
+
+
+def test_sync_import_defers_missing_native_opus(monkeypatch, tmp_path):
+    _install_sync_import_stubs(monkeypatch)
+    monkeypatch.setitem(sys.modules, "opuslib", None)
+    _drop_module("routers.sync")
+
+    sync = importlib.import_module("routers.sync")
+    opus_path = tmp_path / "audio.opus"
+    opus_path.write_bytes(b"\x00\x00\x00\x00")
+
+    assert sync.Decoder is None
+    with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
+        sync.decode_opus_file_to_wav(str(opus_path), str(tmp_path / "audio.wav"))

--- a/backend/tests/unit/test_optional_audio_codecs.py
+++ b/backend/tests/unit/test_optional_audio_codecs.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import sys
 import types
 from unittest.mock import MagicMock
@@ -21,6 +22,15 @@ def _module(name: str, **attrs):
     for attr, value in attrs.items():
         setattr(module, attr, value)
     return module
+
+
+def _install_python_multipart_stub(monkeypatch):
+    if "python_multipart" in sys.modules:
+        return
+    if importlib.util.find_spec("python_multipart") is not None:
+        return
+
+    monkeypatch.setitem(sys.modules, "python_multipart", _module("python_multipart", __version__="0.0.20"))
 
 
 def _install_storage_import_stubs(monkeypatch):
@@ -57,6 +67,8 @@ def _install_storage_import_stubs(monkeypatch):
 
 
 def _install_sync_import_stubs(monkeypatch):
+    _install_python_multipart_stub(monkeypatch)
+
     for name in [
         "database._client",
         "database.redis_db",

--- a/backend/tests/unit/test_storage_opus_encoding.py
+++ b/backend/tests/unit/test_storage_opus_encoding.py
@@ -21,6 +21,7 @@ os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 
 # Mock heavy dependencies at sys.modules level before importing storage
 sys.modules.setdefault("database._client", MagicMock())
+sys.modules.setdefault("database.users", MagicMock())
 
 _mock_gcs_storage = MagicMock()
 _mock_gcs_client_instance = MagicMock()
@@ -30,10 +31,16 @@ sys.modules.setdefault("google.cloud.storage.transfer_manager", MagicMock())
 sys.modules.setdefault("google.cloud.exceptions", MagicMock())
 sys.modules.setdefault("google.oauth2", MagicMock())
 sys.modules.setdefault("google.oauth2.service_account", MagicMock())
+sys.modules.setdefault("utils.cloud_tasks", MagicMock())
+sys.modules["utils.cloud_tasks"].enqueue_audio_merge_job = MagicMock()
+sys.modules["utils.cloud_tasks"].is_audio_merge_dispatch_enabled = MagicMock(return_value=False)
 
 from utils.other import storage as storage_mod
 
+requires_native_opus = pytest.mark.skipif(storage_mod.opuslib is None, reason="native libopus is not installed")
 
+
+@requires_native_opus
 class TestOpusEncodeDecode:
     """Tests for encode_pcm_to_opus and decode_opus_to_pcm."""
 
@@ -151,6 +158,7 @@ class TestExtensionHelpers:
         assert storage_mod._strip_extension("file.unknown") == "file"
 
 
+@requires_native_opus
 class TestUploadOpusEncoding:
     """Tests for upload_audio_chunk with always-on Opus encoding."""
 
@@ -344,6 +352,7 @@ class TestDownloadFallbackPath:
         with pytest.raises(FileNotFoundError):
             storage_mod.download_audio_chunks_and_merge('uid', 'conv', [1000.0], fill_gaps=False)
 
+    @requires_native_opus
     @patch.object(storage_mod, 'NotFound', _FakeNotFound)
     def test_opus_decode_success_no_fallback(self):
         """When .opus chunk is valid, uses it without trying .bin."""
@@ -584,6 +593,7 @@ class TestDownloadBatchBlobs:
         assert len(batch_downloads) == 1
 
     @patch.object(storage_mod, 'NotFound', type('FakeNotFound', (Exception,), {}))
+    @requires_native_opus
     def test_mixed_single_and_batch_download(self):
         """Mix of single-chunk and batch blobs downloads correctly."""
         mock_bucket = MagicMock()

--- a/backend/tests/unit/test_transcribe_lc3_optional.py
+++ b/backend/tests/unit/test_transcribe_lc3_optional.py
@@ -10,7 +10,9 @@ def _read_source() -> str:
 def test_lc3_import_is_optional():
     source = _read_source()
 
-    assert 'try:\n    import lc3  # lc3py\nexcept ImportError:\n    lc3 = None' in source
+    assert 'try:\n    import lc3  # lc3py' in source
+    assert 'except Exception as e:\n    lc3 = None\n    _LC3_IMPORT_ERROR = e' in source
+    assert 'else:\n    _LC3_IMPORT_ERROR = None' in source
 
 
 def test_lc3_codec_closes_cleanly_when_dependency_missing():
@@ -20,3 +22,4 @@ def test_lc3_codec_closes_cleanly_when_dependency_missing():
     assert 'if lc3 is None:' in source
     assert 'LC3 codec requested but lc3py is not installed' in source
     assert 'await websocket.close(code=websocket_close_code, reason="LC3 codec is not available")' in source
+    assert '_get_lc3().Decoder(lc3_frame_duration_us, sample_rate)' in source

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -11,7 +11,13 @@ from concurrent.futures import as_completed, wait, FIRST_COMPLETED
 
 from utils.executors import postprocess_executor, storage_executor
 
-import opuslib
+try:
+    import opuslib
+except Exception as e:
+    opuslib = None
+    _OPUS_IMPORT_ERROR = e
+else:
+    _OPUS_IMPORT_ERROR = None
 from google.cloud import storage
 from google.oauth2 import service_account
 from google.cloud.exceptions import NotFound as BlobNotFound
@@ -67,6 +73,15 @@ chat_files_bucket = os.getenv('BUCKET_CHAT_FILES')
 desktop_updates_bucket = os.getenv('BUCKET_DESKTOP_UPDATES')
 
 _did_warn_missing_speech_profiles_bucket = False
+
+
+def _get_opuslib():
+    if opuslib is None:
+        raise RuntimeError(
+            'Opus support requires opuslib and the native libopus library. '
+            'Install the OS-level Opus package before encoding or decoding .opus audio.'
+        ) from _OPUS_IMPORT_ERROR
+    return opuslib
 
 
 def _get_speech_profiles_bucket(required: bool = False):
@@ -410,7 +425,8 @@ def encode_pcm_to_opus(pcm_data: bytes, sample_rate: int = OPUS_SAMPLE_RATE, cha
     Returns:
         Length-prefixed Opus packets as bytes
     """
-    encoder = opuslib.Encoder(sample_rate, channels, opuslib.APPLICATION_VOIP)
+    opus = _get_opuslib()
+    encoder = opus.Encoder(sample_rate, channels, opus.APPLICATION_VOIP)
     frame_size = sample_rate * OPUS_FRAME_DURATION_MS // 1000
     bytes_per_frame = frame_size * channels * 2  # 16-bit = 2 bytes per sample
 
@@ -456,7 +472,6 @@ def decode_opus_to_pcm(opus_data: bytes, sample_rate: int = OPUS_SAMPLE_RATE, ch
     if len(opus_data) < 8:
         raise ValueError(f"Opus data too short: {len(opus_data)} bytes (need at least 8 for header)")
 
-    decoder = opuslib.Decoder(sample_rate, channels)
     frame_size = sample_rate * OPUS_FRAME_DURATION_MS // 1000
 
     offset = 0
@@ -465,7 +480,7 @@ def decode_opus_to_pcm(opus_data: bytes, sample_rate: int = OPUS_SAMPLE_RATE, ch
     original_pcm_len = struct.unpack_from('<I', opus_data, offset)[0]
     offset += 4
 
-    pcm_parts = []
+    packets = []
     for i in range(packet_count):
         if offset + 2 > len(opus_data):
             raise ValueError(f"Truncated Opus data: expected packet {i}/{packet_count} length at offset {offset}")
@@ -475,8 +490,14 @@ def decode_opus_to_pcm(opus_data: bytes, sample_rate: int = OPUS_SAMPLE_RATE, ch
             raise ValueError(
                 f"Truncated Opus data: packet {i} needs {pkt_len} bytes at offset {offset}, only {len(opus_data) - offset} available"
             )
-        pkt_data = opus_data[offset : offset + pkt_len]
+        packets.append(opus_data[offset : offset + pkt_len])
         offset += pkt_len
+
+    opus = _get_opuslib()
+    decoder = opus.Decoder(sample_rate, channels)
+
+    pcm_parts = []
+    for pkt_data in packets:
         decoded = decoder.decode(pkt_data, frame_size)
         pcm_parts.append(decoded)
 


### PR DESCRIPTION
## Summary
- Defer missing native Opus failures in `utils.other.storage` and `routers.sync` until code actually needs Opus encode/decode.
- Guard `routers.transcribe` Opus and LC3 imports so missing optional codec libraries do not block non-codec module import paths.
- Preserve the current main-branch LC3 websocket close behavior when LC3 is requested but unavailable.
- Validate malformed Opus packet structure before creating the native decoder.
- Add Windows-focused regression coverage for missing native `opuslib`, skip storage tests that require real libopus when the native library is unavailable, and restore module stubs so the new import tests do not pollute later pytest modules.

## Root cause
On Windows, installing the `opuslib` Python package is not enough if the native libopus DLL is missing. Importing `opuslib` can raise during module import, which previously prevented backend modules such as `utils.other.storage` and `routers.sync` from loading even when the current path did not need Opus processing.

## Refresh
- Rebased on `main` at `1a5824403b`.
- Current head: `1b5e3970a5`.
- Added cleanup around the new module-import regression tests so they restore any existing `utils.other.storage` / `routers.sync` module objects after injecting lightweight Windows stubs.
- Updated the existing LC3 optional-import source assertion to match the broader native-loader failure guard.

## Validation
- `python -m pytest backend\tests\unit\test_optional_audio_codecs.py backend\tests\unit\test_storage_opus_encoding.py backend\tests\unit\test_sync_opus_decode.py backend\tests\unit\test_transcribe_lc3_optional.py -q --tb=short` -> 61 passed, 11 skipped, 2 warnings
- `python -m py_compile backend\utils\other\storage.py backend\routers\sync.py backend\routers\transcribe.py backend\tests\unit\test_optional_audio_codecs.py backend\tests\unit\test_storage_opus_encoding.py backend\tests\unit\test_transcribe_lc3_optional.py`
- `python -m black --check --line-length 120 --skip-string-normalization backend\utils\other\storage.py backend\routers\sync.py backend\routers\transcribe.py backend\tests\unit\test_optional_audio_codecs.py backend\tests\unit\test_storage_opus_encoding.py backend\tests\unit\test_transcribe_lc3_optional.py`
- `PYTHONUTF8=1 python backend\scripts\scan_async_blockers.py` -> exit 0; reports existing broader async findings, no new blocker from this diff
- `git diff --check origin/main...HEAD`
- `bash -n backend/test.sh`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`

Related: #7628