### PR TITLE
[codex] Document Windows libopus setup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,7 +42,9 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
 
 7. Install `opus` (required for audio processing)
    - Mac: `brew install opus`
-   - Windows: You should already have it if you're on Windows 10 version 1903 and above
+   - Windows: install a native `libopus` build and make sure its DLL directory is on `PATH`
+     - MSYS2 UCRT64 example: `pacman -S mingw-w64-ucrt-x86_64-opus`
+     - Add `C:\msys64\ucrt64\bin` to `PATH`, then verify from a new shell with `where.exe opus.dll`
 
 8. Move to the backend directory: `cd backend`
 

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -252,7 +252,11 @@ OAuth is required for user authentication. You need to configure both Google and
         ```powershell
         choco install python git.install ffmpeg
         ```
-        <Note>Opus is included in Windows 10 version 1903 and above.</Note>
+        <Note>
+          The Python `opuslib` package still needs a native `libopus` DLL on `PATH`. One common setup is MSYS2 UCRT64:
+          install MSYS2, run `pacman -S mingw-w64-ucrt-x86_64-opus`, add `C:\msys64\ucrt64\bin` to `PATH`,
+          then open a new shell and verify with `where.exe opus.dll`.
+        </Note>
       </Tab>
       <Tab title="Linux/Nix">
         Python, Git, and FFmpeg are typically pre-installed. Install opus via your package manager if needed.


### PR DESCRIPTION
## Summary
- Replace the Windows backend setup note that said Opus is already included with Windows 10 1903+.
- Document that `opuslib` still needs a native `libopus` DLL on `PATH`.
- Add an MSYS2 UCRT64 example and a `where.exe opus.dll` verification step in both the backend README and Mintlify backend setup guide.

## Why
On Windows, the Python `opuslib` package can be installed while its native `libopus` DLL is still missing. In that state backend imports or Opus encode/decode paths fail with `Could not find Opus library`. The setup docs should point contributors at the native dependency instead of implying Windows already satisfies it.

## Refresh
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`.
- Current head: `8766d301c59246f4d36c7d8c8383099e3a052e4d`.
- Existing approval remains on the PR; review threads are empty.

## Validation
- Reviewed public docs diff for repo-boundary leakage; content stays limited to developer-facing setup guidance.
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit`

Docs-only change; no backend tests run.

Related: #7928