### PR TITLE
[codex] Clarify Windows backend setup docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,10 +28,10 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
    Replace `<project-id>` with your Google Cloud Project ID.
    This should generate the `application_default_credentials.json` file in the `~/.config/gcloud` directory. This file is read automatically by gcloud in Python.
 
-4. Install Python
-   - Mac: `brew install python`
-   - Windows: `choco install python`
-   - Nix envdir: It should be pre-installed
+4. Install Python 3.11
+   - Mac: `brew install python@3.11`
+   - Windows: Install Python 3.11 from [python.org](https://www.python.org/downloads/windows/), then verify `python --version` prints `3.11.x`
+   - Nix envdir: It should be pre-installed; verify `python --version` prints `3.11.x`
 
 5. Install `pip` if it doesn't exist (follow instructions on [pip installation page](https://pip.pypa.io/en/stable/installation/))
 
@@ -65,6 +65,9 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
 
     **Option A: Using a virtual environment (recommended)**
     ```bash
+    # Verify Python 3.11 before creating the virtual environment
+    python --version
+
     # Create a virtual environment
     python -m venv venv
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,7 +42,9 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
 
 7. Install `opus` (required for audio processing)
    - Mac: `brew install opus`
-   - Windows: You should already have it if you're on Windows 10 version 1903 and above
+   - Windows: install a native `libopus` build and make sure its DLL directory is on `PATH`
+     - MSYS2 UCRT64 example: `pacman -S mingw-w64-ucrt-x86_64-opus`
+     - Add `C:\msys64\ucrt64\bin` to `PATH`, then verify from a new shell with `where.exe opus.dll`
 
 8. Move to the backend directory: `cd backend`
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,7 +26,7 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
    gcloud auth application-default login --project <project-id>
    ```
    Replace `<project-id>` with your Google Cloud Project ID.
-   This should generate the `application_default_credentials.json` file in the `~/.config/gcloud` directory. This file is read automatically by gcloud in Python.
+   This should generate the `application_default_credentials.json` file in the gcloud config directory (`~/.config/gcloud` on macOS/Linux or `%APPDATA%\gcloud` on Windows). This file is read automatically by gcloud in Python.
 
 4. Install Python 3.11
    - Mac: `brew install python@3.11`

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -257,7 +257,11 @@ OAuth is required for user authentication. You need to configure both Google and
         choco install git.install ffmpeg
         python --version  # should print 3.11.x
         ```
-        <Note>Opus is included in Windows 10 version 1903 and above.</Note>
+        <Note>
+          The Python `opuslib` package still needs a native `libopus` DLL on `PATH`. One common setup is MSYS2 UCRT64:
+          install MSYS2, run `pacman -S mingw-w64-ucrt-x86_64-opus`, add `C:\msys64\ucrt64\bin` to `PATH`,
+          then open a new shell and verify with `where.exe opus.dll`.
+        </Note>
       </Tab>
       <Tab title="Linux/Nix">
         Python, Git, and FFmpeg are typically pre-installed. Install opus via your package manager if needed.

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -242,15 +242,20 @@ OAuth is required for user authentication. You need to configure both Google and
     ```
   </Step>
   <Step title="Install System Dependencies" icon="box">
+    The backend Docker images run Python 3.11, so use Python 3.11 locally as well. If your package manager installs a newer default Python, install or select Python 3.11 before creating the virtual environment.
+
     <Tabs>
       <Tab title="macOS">
         ```bash
-        brew install python git ffmpeg opus
+        brew install python@3.11 git ffmpeg opus
         ```
       </Tab>
       <Tab title="Windows">
+        Install Python 3.11 from [python.org](https://www.python.org/downloads/windows/), then install the remaining system tools:
+
         ```powershell
-        choco install python git.install ffmpeg
+        choco install git.install ffmpeg
+        python --version  # should print 3.11.x
         ```
         <Note>Opus is included in Windows 10 version 1903 and above.</Note>
       </Tab>
@@ -265,7 +270,8 @@ OAuth is required for user authentication. You need to configure both Google and
     </Tip>
 
     ```bash
-    # Create virtual environment (use Python 3.9-3.12)
+    # Create virtual environment with Python 3.11
+    python --version
     python -m venv venv
     ```
 
@@ -427,7 +433,7 @@ OAuth is required for user authentication. You need to configure both Google and
   </Accordion>
   <Accordion title="Virtual environment not activating" icon="terminal">
     - On Windows, you may need to enable script execution: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
-    - Make sure you're using Python 3.9-3.12
+    - Make sure you're using Python 3.11
   </Accordion>
 </AccordionGroup>
 

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -143,7 +143,7 @@ New to backend development? Install [Homebrew](https://docs.brew.sh/Installation
       </Tab>
       <Tab title="Windows">
         ```powershell
-        copy %APPDATA%\gcloud\application_default_credentials.json google-credentials.json
+        Copy-Item "$env:APPDATA\gcloud\application_default_credentials.json" .\google-credentials.json
         ```
       </Tab>
     </Tabs>


### PR DESCRIPTION
## Summary
- Update the backend README quick setup to install and verify Python 3.11.
- Align the Mintlify backend setup guide with the backend Docker images' Python 3.11 runtime.
- Replace the outdated `Python 3.9-3.12` troubleshooting guidance with Python 3.11.
- Document the Windows gcloud ADC path and use PowerShell `Copy-Item` syntax in the Windows credentials copy step.
- Keep the Windows Opus note aligned with #7929 so this PR does not reintroduce the old Windows 10 1903+ claim.

## Why
The backend Docker images and `backend/AGENTS.md` use Python 3.11. The public setup guide still allowed Python 3.9-3.12, which can send Windows contributors into a mismatched local environment before they create their virtualenv. The Windows credential copy example was also under a PowerShell tab but used cmd-style `%APPDATA%` expansion.

## Refresh
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`.
- Current head: `452ec2b781aa4c91cfeb2ba44dd34ac82f0de2a8`.
- Existing approval remains on the PR; review threads are empty.

## Validation
- Confirmed Python 3.11 basis against `backend/AGENTS.md` and `backend/Dockerfile`.
- Reviewed public docs diff for repo-boundary leakage; content stays limited to developer-facing setup guidance.
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit`

Docs-only change; no backend tests run.