### PR TITLE
[codex] Clarify Windows MCP docs

### DIFF
--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -52,7 +52,8 @@ The fastest way to get started — no installation required.
 
     **Config file location:**
     - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-    - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+    - Windows PowerShell: `$env:APPDATA\Claude\claude_desktop_config.json`
+    - Windows cmd: `%APPDATA%\Claude\claude_desktop_config.json`
   </Tab>
   <Tab title="Cursor" icon="i-cursor">
     Go to **Cursor Settings → MCP** and add a new server:

--- a/docs/doc/developer/mcp/troubleshooting.mdx
+++ b/docs/doc/developer/mcp/troubleshooting.mdx
@@ -86,8 +86,8 @@ description: "Debug and fix common MCP connection issues"
     # macOS
     tail -n 20 -f ~/Library/Logs/Claude/mcp-server-omi.log
 
-    # Windows
-    type %APPDATA%\Claude\logs\mcp-server-omi.log
+    # Windows PowerShell
+    Get-Content "$env:APPDATA\Claude\logs\mcp-server-omi.log" -Tail 20 -Wait
     ```
   </Tab>
 </Tabs>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -98,8 +98,17 @@ cd path/to/servers/src/omi
 npx @modelcontextprotocol/inspector uv run mcp-server-omi
 ```
 
-Running `tail -n 20 -f ~/Library/Logs/Claude/mcp-server-omi.log` will show the logs from the server and may
-help you debug any issues.
+To follow Claude Desktop logs while debugging:
+
+```bash
+# macOS
+tail -n 20 -f ~/Library/Logs/Claude/mcp-server-omi.log
+```
+
+```powershell
+# Windows PowerShell
+Get-Content "$env:APPDATA\Claude\logs\mcp-server-omi.log" -Tail 20 -Wait
+```
 
 ## Advanced
 


### PR DESCRIPTION
## Summary
- Split the Claude Desktop config path into Windows PowerShell and cmd variants.
- Replace the Windows MCP log command with a PowerShell `Get-Content -Tail 20 -Wait` example.
- Add the same Windows log-follow command to `mcp/README.md` alongside the macOS command.

## Why
The MCP docs mixed shell conventions in Windows examples. `%APPDATA%` is useful for cmd, but users copying from a PowerShell-oriented workflow need `$env:APPDATA`; `type` also does not follow logs like the macOS `tail -f` command shown next to it.

## Refresh
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`.
- Current head: `3f21fda3d5ce4b6e3f350fe2cc6d846f795c6051`.
- Existing approval remains on the PR; review threads are empty.

## Validation
- Reviewed public docs diff for repo-boundary leakage; content stays limited to developer-facing setup/troubleshooting commands.
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit`

Docs-only change; no runtime tests run.