### PR TITLE
[codex] Sync Windows app pnpm lockfile

### DIFF
--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.10)
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Summary
- Remove the stale `@huggingface/transformers` importer entry from `desktop/windows/pnpm-lock.yaml`.
- Bring the Windows app lockfile back in sync with `desktop/windows/package.json` without broad dependency resolution changes.

## Why
A frozen pnpm install in `desktop/windows` failed before dependency installation because the lockfile still listed `@huggingface/transformers`, which is no longer present in `package.json`.

Before:
```text
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>\package.json
Failure reason:
* 1 dependencies were removed: @huggingface/transformers@^4.2.0
```

After this change, a full frozen dependency install accepts the lockfile.

## Refresh
- Rebased on `main` at `0384a5578bb479e15583d2f6785796cfd2c32d38`.
- Current head: `f8176415b48b65cc19255da60669a2b0f287130c`.
- GitHub currently reports this PR as mergeable.

## Validation
- From `desktop/windows/`: `npx --yes pnpm@11.6.0 install --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false` -> passed
- From `desktop/windows/`: `pnpm run typecheck` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `PYTHONUTF8=1 bash scripts/pre-push` -> passed

Note: the frozen install uses local ignored `desktop/windows/node_modules/`; it is not part of this PR. A later `pnpm run typecheck` caused pnpm to run postinstall and attempt OCR helper build, but this Windows machine has no .NET SDK; the existing script treats that as non-fatal and typecheck still passed.