### PR TITLE
[codex] Isolate Windows helper tests from Firebase

### DIFF
--- a/desktop/windows/src/renderer/src/lib/appMemories.test.ts
+++ b/desktop/windows/src/renderer/src/lib/appMemories.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { appMemoryIdsToDelete, APP_MEMORY_TAG } from './appMemories'
 import type { Memory } from '../hooks/useMemories'
+
+vi.mock('./apiClient', () => ({
+  omiApi: {
+    get: vi.fn(),
+    delete: vi.fn()
+  }
+}))
 
 function mem(id: string, tags?: string[]): Memory {
   return { id, uid: 'u', content: 'Uses Whatever', tags, created_at: '', updated_at: '' } as Memory

--- a/desktop/windows/src/renderer/src/lib/calendarExtract.test.ts
+++ b/desktop/windows/src/renderer/src/lib/calendarExtract.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildCalendarPrompt, parseCalendarTasks } from './calendarExtract'
 import type { CalendarItem } from '../../../shared/types'
+
+vi.mock('./apiClient', () => ({
+  desktopApi: {
+    post: vi.fn()
+  }
+}))
 
 const ev = (over: Partial<CalendarItem>): CalendarItem => ({
   id: 'e1',

--- a/desktop/windows/src/renderer/src/lib/gmailExtract.test.ts
+++ b/desktop/windows/src/renderer/src/lib/gmailExtract.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildGmailPrompt, parseGmailMemories } from './gmailExtract'
 import type { GmailItem } from '../../../shared/types'
+
+vi.mock('./apiClient', () => ({
+  desktopApi: {
+    post: vi.fn()
+  }
+}))
 
 const item = (over: Partial<GmailItem>): GmailItem => ({
   id: 'm1',

--- a/desktop/windows/src/renderer/src/lib/goals.test.ts
+++ b/desktop/windows/src/renderer/src/lib/goals.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildGoalPrompt, parseTargetValue } from './goals'
+
+vi.mock('./apiClient', () => ({
+  omiApi: {
+    post: vi.fn()
+  }
+}))
+
+vi.mock('./agentLLM', () => ({
+  callAgentLLM: vi.fn()
+}))
 
 describe('buildGoalPrompt', () => {
   it('includes the apps the user works with', () => {


### PR DESCRIPTION
## Summary
- Mock unused API client imports in pure Windows renderer helper tests.
- Mock the agent LLM import in goal helper tests.
- Keep these tests from initializing Firebase Auth during Vitest collection.

## Why
These tests exercise prompt builders, parsers, and tag helpers, but importing the modules also pulled in `apiClient` / `agentLLM`, which initializes Firebase Auth through `firebase.ts`. On a fresh Windows test run without real Vite Firebase env values, Vitest failed at collection with `FirebaseError: Firebase: Error (auth/invalid-api-key)` before assertions could run.

## Validation
- Before the fix: `npx --yes pnpm@11.6.0 test` failed 4 suites with `auth/invalid-api-key`.
- `npx --yes pnpm@11.6.0 exec vitest run src/renderer/src/lib/appMemories.test.ts src/renderer/src/lib/calendarExtract.test.ts src/renderer/src/lib/gmailExtract.test.ts src/renderer/src/lib/goals.test.ts` -> 4 files passed, 18 tests passed.
- `npx --yes pnpm@11.6.0 test` -> 76 files passed, 1 skipped; 508 tests passed, 3 skipped.
- `npx --yes pnpm@11.6.0 run typecheck` -> passed.
- `npx --yes pnpm@11.6.0 exec prettier --check src/renderer/src/lib/appMemories.test.ts src/renderer/src/lib/calendarExtract.test.ts src/renderer/src/lib/gmailExtract.test.ts src/renderer/src/lib/goals.test.ts` -> passed.
- `git diff --check` -> passed.

## Note
`npx --yes pnpm@11.6.0 run lint` still fails on this Windows checkout because of existing CRLF Prettier warnings and pre-existing lint errors outside these changed files; this PR keeps scope to the Firebase import-time test failure.