### PR TITLE
[codex] Keep Windows app checkouts on LF

### DIFF
--- a/desktop/windows/.gitattributes
+++ b/desktop/windows/.gitattributes
@@ -1,0 +1,2 @@
+# Keep Windows app text files aligned with .editorconfig and Prettier.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Add a scoped `.gitattributes` file under `desktop/windows`.
- Force text files in the Windows app subtree to check out with LF line endings.
- Keep Git checkout behavior aligned with the existing `.editorconfig` and Prettier setup.

## Why
On this Windows checkout, `desktop/windows` files were written with CRLF because `core.autocrlf=true`. The Windows app already declares `end_of_line = lf` in `.editorconfig`, so ESLint/Prettier reported almost every line as `Delete CR`, hiding the real lint findings.

This keeps the policy local to `desktop/windows` instead of changing the whole repository or weakening Prettier with `endOfLine: auto`.

## Refresh
- Rebased on `main` at `b781d91767ac96a20f2305614eb50c7744a8a6c3`.
- Current head: `6b6ec716e1e6bab9d215658f3238c64e9fe4036f`.
- GitHub currently reports this PR as mergeable.

## Validation
- `git check-attr -a -- desktop/windows/electron.vite.config.ts desktop/windows/eslint.config.mjs desktop/windows/.prettierrc.yaml desktop/windows/src/renderer/src/lib/goals.test.ts` -> `text: auto`, `eol: lf` for all four files
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `scripts/pre-commit` with `PYTHONUTF8=1` -> passed
- `scripts/pre-push` with `PYTHONUTF8=1` -> passed