### PR TITLE
[codex] Isolate Parakeet prerecorded test imports

### DIFF
--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -35,6 +35,10 @@ sys.modules.pop('utils.stt.pre_recorded', None)
 sys.modules.pop('utils.other.endpoints', None)
 sys.modules.pop('utils.http_client', None)
 
+_endpoints = types.ModuleType('utils.other.endpoints')
+_endpoints.timeit = lambda func: func
+sys.modules['utils.other.endpoints'] = _endpoints
+
 _database_pkg = sys.modules.setdefault('database', types.ModuleType('database'))
 _database_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
 
@@ -49,6 +53,61 @@ sys.modules['database.redis_db'] = _redis_db
 _database_users = types.ModuleType('database.users')
 _database_users.record_user_platform = MagicMock()
 sys.modules['database.users'] = _database_users
+
+_cachetools = types.ModuleType('cachetools')
+
+
+class _TTLCache(dict):
+    def __init__(self, maxsize, ttl, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.maxsize = maxsize
+        self.ttl = ttl
+
+    def __setitem__(self, key, value):
+        if len(self) >= self.maxsize and key not in self:
+            self.pop(next(iter(self)))
+        super().__setitem__(key, value)
+
+
+_cachetools.TTLCache = _TTLCache
+sys.modules.setdefault('cachetools', _cachetools)
+
+_prometheus_client = types.ModuleType('prometheus_client')
+
+
+class _Registry:
+    def __init__(self):
+        self._names_to_collectors = {}
+
+
+class _Metric:
+    def __init__(self, name, documentation, labelnames=(), **kwargs):
+        self._name = name
+        self._documentation = documentation
+        self._labelnames = labelnames
+        self._kwargs = kwargs
+
+    def labels(self, *args, **kwargs):
+        return self
+
+    def inc(self, amount=1):
+        return None
+
+    def time(self):
+        class _Timer:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        return _Timer()
+
+
+_prometheus_client.Counter = _Metric
+_prometheus_client.Histogram = _Metric
+_prometheus_client.REGISTRY = _Registry()
+sys.modules.setdefault('prometheus_client', _prometheus_client)
 
 _deepgram = types.ModuleType('deepgram')
 _deepgram.DeepgramClient = MagicMock


### PR DESCRIPTION
## Summary
- Add lightweight `cachetools.TTLCache`, `utils.other.endpoints.timeit`, and Prometheus metric stubs inside `test_parakeet_prerecorded.py`.
- Keep the Parakeet prerecorded batch STT tests runnable in a lightweight Windows backend unit venv without importing Firebase auth, cachetools, or Prometheus just to collect the test.
- Preserve the real backend package paths and existing Parakeet/Scipy/WebSocket stubs already used by this file.

## Root cause
`test_parakeet_prerecorded.py` already stubs most of the heavy STT dependencies, but importing `utils.stt.pre_recorded` still imports `utils.byok` and `utils.other.endpoints`. In a lightweight Windows unit-test environment without the full backend requirements installed, collection failed before any Parakeet assertions ran:

- `python -m pytest backend\tests\unit\test_parakeet_prerecorded.py --collect-only -q --tb=short` -> `ModuleNotFoundError: No module named 'cachetools'`

After fixing collection, the streaming factory subtests also imported `utils.async_tasks`, so the test needs a tiny Prometheus stub unless the full requirements or the shared Prometheus test fallback are already present.

## Validation
- `python -m pytest backend\tests\unit\test_parakeet_prerecorded.py --collect-only -q --tb=short` -> `31 tests collected`
- `python -m pytest backend\tests\unit\test_parakeet_prerecorded.py -q --tb=short` -> `31 passed`
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_parakeet_prerecorded.py -q --tb=short` -> `57 passed`
- `python -m black --check --line-length 120 --skip-string-normalization backend\tests\unit\test_parakeet_prerecorded.py`
- `python -m py_compile backend\tests\unit\test_parakeet_prerecorded.py`
- `git diff --check`
- `scripts/pre-commit`