### PR TITLE
[codex] Isolate Parakeet stream language detection tests

### DIFF
--- a/backend/tests/unit/test_parakeet_stream_session.py
+++ b/backend/tests/unit/test_parakeet_stream_session.py
@@ -29,6 +29,19 @@ mock_transcribe._model = None
 mock_transcribe.INFERENCE_MODE = "nemo"
 sys.modules['transcribe'] = mock_transcribe
 
+_langdetect = types.ModuleType('langdetect')
+_langdetect_exceptions = types.ModuleType('langdetect.lang_detect_exception')
+
+
+class _LangDetectException(Exception):
+    pass
+
+
+_langdetect.detect = MagicMock(return_value='en')
+_langdetect_exceptions.LangDetectException = _LangDetectException
+sys.modules.setdefault('langdetect', _langdetect)
+sys.modules.setdefault('langdetect.lang_detect_exception', _langdetect_exceptions)
+
 _scipy = types.ModuleType('scipy')
 _scipy_spatial = types.ModuleType('scipy.spatial')
 _scipy_distance = types.ModuleType('scipy.spatial.distance')


### PR DESCRIPTION
## Summary
- Add a lightweight `langdetect` / `LangDetectException` stub to `test_parakeet_stream_session.py`.
- Keep Parakeet stream-session tests runnable in lightweight Windows backend unit environments without installing the full language-detection dependency.
- Preserve the file's existing `transcribe`, Scipy, and torch stubs.

## Root cause
`stream_handler.py` imports `langdetect` at module import time for detected-language metadata. In a lightweight Windows backend unit venv without full backend requirements installed, `test_parakeet_stream_session.py` could not collect even though the tested session behavior does not require the real language detector.

Before this change:
- `python -m pytest backend\tests\unit\test_parakeet_stream_session.py --collect-only -q --tb=short` -> `ModuleNotFoundError: No module named 'langdetect'`

## Validation
- `python -m pytest backend\tests\unit\test_parakeet_stream_session.py --collect-only -q --tb=short` -> `14 tests collected`
- `python -m pytest backend\tests\unit\test_parakeet_stream_session.py -q --tb=short` -> `14 passed`
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_parakeet_stream_session.py -q --tb=short` -> `40 passed`
- `python -m black --check --line-length 120 --skip-string-normalization backend\tests\unit\test_parakeet_stream_session.py`
- `python -m py_compile backend\tests\unit\test_parakeet_stream_session.py`
- `git diff --check`
- `scripts/pre-commit`