### PR TITLE
[codex] Isolate auth redirect URI test imports

### DIFF
--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -20,6 +20,7 @@ Mapping to real-world clients:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 import types
@@ -41,6 +42,7 @@ os.environ.setdefault("BASE_API_URL", "http://localhost:8080")
 # Pre-mock heavy deps before importing the module under test (Python 3.9 compat —
 # database.redis_db uses dict | None syntax that requires 3.10+).
 BACKEND_DIR = Path(__file__).resolve().parents[2]
+_BACKEND_DIR = str(BACKEND_DIR)
 
 
 def _ensure_package(name, path):
@@ -87,6 +89,31 @@ http_client_stub.get_auth_client = MagicMock()
 
 log_sanitizer_stub = _install_module("utils.log_sanitizer")
 log_sanitizer_stub.sanitize = MagicMock(side_effect=lambda value: value)
+jwt_stub = _install_module("jwt")
+jwt_algorithms_stub = _install_module("jwt.algorithms")
+jwt_algorithms_stub.RSAAlgorithm = MagicMock()
+
+_redis_db_mod = sys.modules['database.redis_db']
+for name in ['set_auth_session', 'get_auth_session', 'set_auth_code', 'get_auth_code', 'delete_auth_code']:
+    if not hasattr(_redis_db_mod, name):
+        setattr(_redis_db_mod, name, MagicMock())
+
+_firebase_admin_mod = types.ModuleType('firebase_admin')
+_firebase_admin_mod.auth = sys.modules['firebase_admin.auth']
+sys.modules.setdefault('firebase_admin', _firebase_admin_mod)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
 
 try:
     import jinja2  # noqa: F401
@@ -100,7 +127,16 @@ except ImportError:
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from routers.auth import _validate_redirect_uri  # noqa: E402
+_utils_pkg = sys.modules.get('utils')
+if _utils_pkg is not None:
+    _utils_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'utils')]
+
+_remove_python_multipart_stub = _install_python_multipart_stub()
+try:
+    from routers.auth import _validate_redirect_uri  # noqa: E402
+finally:
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
 
 # ---------------------------------------------------------------------------
 # Acceptance — every shape an existing Omi client uses


### PR DESCRIPTION
## Summary
- Stub optional `jwt` / `jwt.algorithms.RSAAlgorithm` import surfaces in `test_auth_redirect_uri.py` so the auth redirect tests collect in lightweight Windows backend environments.
- Add a temporary `python_multipart` stub while importing `routers.auth`, matching FastAPI's import-time `Form` route check without requiring the full multipart dependency for this test.
- Restore the real `utils` package path and ensure the Redis auth helper names exist when another stub-heavy test leaves lightweight package modules in `sys.modules`.

## Root cause
`test_auth_redirect_uri.py` exercises redirect URI validation and auth-code binding, but importing `routers.auth` also imports optional Apple JWT helpers and builds FastAPI `Form` endpoints. In this Windows lightweight backend venv, standalone collection failed before any assertions ran:

```text
ModuleNotFoundError: No module named 'jwt'
```

After the JWT stub, FastAPI's route construction also required `python-multipart`. Running after `test_action_item_date_validation.py` exposed a separate order dependency where that test leaves `utils` / `database.redis_db` stubs that do not satisfy `routers.auth` imports.

## Refresh
- Rebased on `main` at `9ed12aea07`.
- Current head: `5486ea1a08`.

## Status
Superseded by #7983, which includes this Windows/lightweight-backend import isolation for `backend/tests/unit/test_auth_redirect_uri.py` plus the higher-priority PKCE auth-code fix for #7692. Closing this PR to keep the maintainer queue focused on #7983.

## Validation
- `python -m pytest backend\tests\unit\test_auth_redirect_uri.py --collect-only -q --tb=short` -> 46 tests collected
- `python -m pytest backend\tests\unit\test_auth_redirect_uri.py -q --tb=short` -> 43 passed, 3 skipped
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_auth_redirect_uri.py -q --tb=short` -> 69 passed, 3 skipped
- `python -m pytest backend\tests\unit\test_auth_redirect_uri.py backend\tests\unit\test_action_item_date_validation.py -q --tb=short` -> 69 passed, 3 skipped
- `python -m py_compile backend\tests\unit\test_auth_redirect_uri.py`
- `python -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_auth_redirect_uri.py`
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit`