### PR TITLE
[codex] Isolate available plans Stripe imports

### DIFF
--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -121,6 +121,7 @@ sys.modules.pop("utils.subscription", None)
 
 for _name in [
     "utils.fair_use",
+    "utils.byok",
     "utils.notifications",
     "utils.apps",
     "utils.stripe",
@@ -132,6 +133,10 @@ for _name in [
     sys.modules[_name] = _m
 
 sys.modules["utils.fair_use"].clear_fair_use_on_upgrade = MagicMock()
+
+_byok_mod = sys.modules["utils.byok"]
+_byok_mod.get_byok_key = MagicMock(return_value=None)
+_byok_mod.get_byok_keys = MagicMock(return_value={})
 
 _notif_mod = sys.modules["utils.notifications"]
 _notif_mod.send_notification = MagicMock()
@@ -155,7 +160,24 @@ _endpoints_mod.get_current_user_uid_no_byok_validation = lambda: "test-user"
 # Ensure utils.other has endpoints attr for `from utils.other import endpoints`
 sys.modules["utils.other"].endpoints = _endpoints_mod
 
-# Stripe — use real module but we'll mock Price.retrieve per-test
+_stripe_mod = types.ModuleType("stripe")
+_stripe_mod.Price = types.SimpleNamespace(retrieve=MagicMock())
+_stripe_mod.Subscription = types.SimpleNamespace(retrieve=MagicMock(), modify=MagicMock(), cancel=MagicMock())
+_stripe_mod.SubscriptionSchedule = types.SimpleNamespace(
+    list=MagicMock(), create=MagicMock(), modify=MagicMock(), release=MagicMock()
+)
+_stripe_mod.PromotionCode = types.SimpleNamespace(list=MagicMock())
+_stripe_mod.checkout = types.SimpleNamespace(Session=type("Session", (), {"create": MagicMock()}))
+_stripe_mod.billing_portal = types.SimpleNamespace(Session=types.SimpleNamespace(create=MagicMock()))
+_stripe_mod.Webhook = types.SimpleNamespace(construct_event=MagicMock())
+_stripe_mod.error = types.SimpleNamespace(
+    StripeError=Exception,
+    InvalidRequestError=Exception,
+    SignatureVerificationError=Exception,
+)
+sys.modules["stripe"] = _stripe_mod
+
+# Import the stubbed module so tests and payment.py share the same object.
 import stripe
 
 stripe.api_key = "sk_test_fake"


### PR DESCRIPTION
## Summary
- Stub the Stripe module inside `test_available_plans_resilience.py` so the available-plans tests collect without the optional Stripe SDK installed.
- Restore the real `backend/utils` package path before importing `routers.payment`, while still stubbing heavy BYOK/external modules used only as import dependencies.
- Keep the tests exercising the real `get_available_plans_endpoint` behavior with explicit per-test Stripe method mocks.

## Why
On a lightweight Windows backend test environment, collecting this test file failed at `import stripe`. When another lightweight test ran first, it could also leave a stubbed `utils` package with no filesystem path, causing `utils.subscription` import failures. This PR makes the test self-contained and order-tolerant without changing production code.

## Refresh
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`.
- Current head: `737ebd77120b540056a2af7245a8d4b7edca1110`.
- GitHub currently reports the PR as mergeable.
- Existing approval remains on the PR; review threads are empty.

## Validation
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_available_plans_resilience.py --collect-only -q --tb=short` -> 5 tests collected
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_available_plans_resilience.py -q --tb=short` -> 5 passed, 2 warnings
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_available_plans_resilience.py -q --tb=short` -> 31 passed, 2 warnings
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_available_plans_resilience.py backend\tests\unit\test_action_item_date_validation.py -q --tb=short` -> 31 passed, 2 warnings
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\tests\unit\test_available_plans_resilience.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_available_plans_resilience.py`
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit`