### PR TITLE
[codex] Isolate conversation count FieldFilter import

### DIFF
--- a/backend/tests/unit/test_conversations_count.py
+++ b/backend/tests/unit/test_conversations_count.py
@@ -16,7 +16,16 @@ os.environ.setdefault(
 
 from unittest.mock import MagicMock
 
-from google.cloud.firestore_v1 import FieldFilter
+try:
+    from google.cloud.firestore_v1 import FieldFilter
+except ImportError:
+    # Lightweight test runs may not install Firestore, or may inherit an empty stub from another test.
+
+    class FieldFilter:
+        def __init__(self, field_path, op_string, value):
+            self.field_path = field_path
+            self.op_string = op_string
+            self.value = value
 
 
 def _stub_module(name):


### PR DESCRIPTION
## Summary
- Add a local `FieldFilter` fallback in `test_conversations_count.py` when `google.cloud.firestore_v1` is unavailable.
- Keep using the real Firestore `FieldFilter` when the dependency is installed.
- Cover the case where another lightweight test leaves an empty `google.cloud.firestore_v1` stub in `sys.modules` before this file is collected.

## Why
This test validates query-building logic using only the `field_path` and `value` attributes of `FieldFilter`. On a lightweight Windows backend environment, collection failed before any assertions ran because `google.cloud.firestore_v1` was not installed. Running after another stub-heavy test can also produce an import-name failure from an empty stub module. The fallback keeps this unit test self-contained without changing production code.

## Validation
- `python -m pytest backend\tests\unit\test_conversations_count.py --collect-only -q --tb=short`
- `python -m pytest backend\tests\unit\test_conversations_count.py -q --tb=short`
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_conversations_count.py -q --tb=short`
- `python -m pytest backend\tests\unit\test_conversations_count.py backend\tests\unit\test_action_item_date_validation.py -q --tb=short`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_conversations_count.py`
- `python -m py_compile backend\tests\unit\test_conversations_count.py`
- `git diff --check`
- `scripts\pre-commit`