### PR TITLE
[codex] Isolate daily summary Redis import

### DIFF
--- a/backend/tests/unit/test_daily_summary_regenerate.py
+++ b/backend/tests/unit/test_daily_summary_regenerate.py
@@ -11,6 +11,8 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
@@ -43,6 +45,17 @@ class _BaseFilter:  # database.daily_summaries imports FieldFilter from this pat
 
 fbq_stub = _stub_module("google.cloud.firestore_v1.base_query")
 fbq_stub.FieldFilter = MagicMock()
+
+database_pkg = sys.modules.get("database")
+if database_pkg is not None:
+    database_pkg.__path__ = [os.path.join(_BACKEND_DIR, "database")]
+
+client_stub = sys.modules.get("database._client")
+if client_stub is not None:
+    client_stub.db = MagicMock()
+
+redis_stub = _stub_module("redis")
+redis_stub.Redis = MagicMock(return_value=MagicMock())
 
 import database.daily_summaries as daily_summaries  # noqa: E402
 


### PR DESCRIPTION
## Summary
- Stub `redis.Redis` inside `test_daily_summary_regenerate.py` so the daily summary regenerate tests collect in lightweight Windows backend environments without the Redis SDK installed.
- Restore the real `backend/database` package path if another stub-heavy test has already left a lightweight `database` package in `sys.modules`.
- Populate `database._client.db` only when a previous test already installed a `_client` stub, keeping normal imports on the real module path.

## Why
`test_daily_summary_regenerate.py` verifies that `update_daily_summary` preserves the existing document ID during regeneration. It does not exercise Redis, but importing `database.daily_summaries` also imports `database.redis_db`, which imports the optional Redis SDK at module import time. On this Windows lightweight backend venv, collection failed before the regression assertions could run:

```text
ModuleNotFoundError: No module named 'redis'
```

Running after another lightweight test can also leave a stubbed `database` package and `_client` module in `sys.modules`; the test now restores the package path and fills the existing client stub with the minimal `db` attribute needed by `database.daily_summaries`.

## Validation
- `python -m pytest backend\tests\unit\test_daily_summary_regenerate.py --collect-only -q --tb=short`
- `python -m pytest backend\tests\unit\test_daily_summary_regenerate.py -q --tb=short`
- `python -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_daily_summary_regenerate.py -q --tb=short`
- `python -m pytest backend\tests\unit\test_daily_summary_regenerate.py backend\tests\unit\test_action_item_date_validation.py -q --tb=short`
- `python -m black --line-length 120 --skip-string-normalization backend\tests\unit\test_daily_summary_regenerate.py`
- `python -m py_compile backend\tests\unit\test_daily_summary_regenerate.py`
- `git diff --check`
- `scripts\pre-commit`