### PR TITLE
[codex] Isolate translation langdetect imports on Windows

### DIFF
--- a/backend/tests/unit/test_translation_cost_optimization.py
+++ b/backend/tests/unit/test_translation_cost_optimization.py
@@ -11,13 +11,75 @@ Covers:
 
 import asyncio
 import hashlib
+import importlib.util
 import os
 import sys
 import time
 from collections import OrderedDict
+from types import ModuleType
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _restore_package_path(name: str, path: str):
+    module = sys.modules.get(name)
+    if module is not None:
+        module.__path__ = [path]
+
+
+class _DetectedLang:
+    def __init__(self, lang: str, prob: float):
+        self.lang = lang
+        self.prob = prob
+
+
+def _guess_language(text: str) -> str:
+    lower = (text or '').lower()
+    if any(marker in lower for marker in ('bonjour', 'merci', 'revoir', 'allez', 'suis', 'content')):
+        return 'fr'
+    if any(marker in lower for marker in ('hola', 'gracias', 'adios', 'adi贸s')):
+        return 'es'
+    if 'danke' in lower:
+        return 'de'
+    return 'en'
+
+
+def _install_langdetect_stub_if_missing():
+    if 'langdetect' not in sys.modules and importlib.util.find_spec('langdetect') is not None:
+        return
+
+    langdetect_mod = sys.modules.get('langdetect') or ModuleType('langdetect')
+    exception_mod = sys.modules.get('langdetect.lang_detect_exception') or ModuleType(
+        'langdetect.lang_detect_exception'
+    )
+
+    class LangDetectException(Exception):
+        pass
+
+    class DetectorFactory:
+        seed = None
+
+    def detect(text):
+        return _guess_language(text)
+
+    def detect_langs(text):
+        return [_DetectedLang(_guess_language(text), 0.99)]
+
+    exception_mod.LangDetectException = LangDetectException
+    langdetect_mod.detect = detect
+    langdetect_mod.detect_langs = detect_langs
+    langdetect_mod.DetectorFactory = DetectorFactory
+    langdetect_mod.lang_detect_exception = exception_mod
+    sys.modules['langdetect'] = langdetect_mod
+    sys.modules['langdetect.lang_detect_exception'] = exception_mod
+
+
+_restore_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_restore_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_install_langdetect_stub_if_missing()
 
 # --- Module-level mocks for heavy dependencies (must happen before any project imports) ---
 _mock_redis = MagicMock()

--- a/backend/tests/unit/test_translation_optimization.py
+++ b/backend/tests/unit/test_translation_optimization.py
@@ -13,6 +13,8 @@ import os
 import sys
 import json
 import hashlib
+import importlib.util
+from types import ModuleType
 from unittest.mock import MagicMock, patch, PropertyMock
 
 os.environ.setdefault(
@@ -61,6 +63,67 @@ def _ensure_mock_module(name: str):
         mod.__package__ = name if '.' not in name else name.rsplit('.', 1)[0]
         sys.modules[name] = mod
     return sys.modules[name]
+
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _restore_package_path(name: str, path: str):
+    module = sys.modules.get(name)
+    if module is not None:
+        module.__path__ = [path]
+
+
+class _DetectedLang:
+    def __init__(self, lang: str, prob: float):
+        self.lang = lang
+        self.prob = prob
+
+
+def _guess_language(text: str) -> str:
+    lower = (text or '').lower()
+    if any(marker in lower for marker in ('bonjour', 'merci', 'revoir', 'allez', 'suis', 'content')):
+        return 'fr'
+    if any(marker in lower for marker in ('hola', 'gracias', 'adios', 'adi贸s')):
+        return 'es'
+    if 'danke' in lower:
+        return 'de'
+    return 'en'
+
+
+def _install_langdetect_stub_if_missing():
+    if 'langdetect' not in sys.modules and importlib.util.find_spec('langdetect') is not None:
+        return
+
+    langdetect_mod = sys.modules.get('langdetect') or ModuleType('langdetect')
+    exception_mod = sys.modules.get('langdetect.lang_detect_exception') or ModuleType(
+        'langdetect.lang_detect_exception'
+    )
+
+    class LangDetectException(Exception):
+        pass
+
+    class DetectorFactory:
+        seed = None
+
+    def detect(text):
+        return _guess_language(text)
+
+    def detect_langs(text):
+        return [_DetectedLang(_guess_language(text), 0.99)]
+
+    exception_mod.LangDetectException = LangDetectException
+    langdetect_mod.detect = detect
+    langdetect_mod.detect_langs = detect_langs
+    langdetect_mod.DetectorFactory = DetectorFactory
+    langdetect_mod.lang_detect_exception = exception_mod
+    sys.modules['langdetect'] = langdetect_mod
+    sys.modules['langdetect.lang_detect_exception'] = exception_mod
+
+
+_restore_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_restore_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_install_langdetect_stub_if_missing()
 
 
 # Stub database module and redis


### PR DESCRIPTION
## Summary
- Add a test-local `langdetect` fallback for translation optimization tests when the package is missing in lightweight backend environments.
- Restore real `utils` and `models` package paths before importing translation modules, so earlier stub-heavy tests cannot make `utils.translation` or `models.transcript_segment` unreachable.
- Keep the fallback narrow: it covers the `detect`, `detect_langs`, `DetectorFactory`, and `LangDetectException` surface used by these tests, and skips itself when the real `langdetect` package is installed.

## Root cause
The translation tests already mock Redis and Google Translate, but they still import `utils.translation`, which imports `langdetect` at module load. On this Windows lightweight backend venv, standalone collection failed before the tests could run:

```text
ModuleNotFoundError: No module named 'langdetect'
```

When collected after stub-heavy tests, a prior lightweight `utils` package stub could also hide the real `backend/utils` package, producing:

```text
ModuleNotFoundError: No module named 'utils.translation'
```

## Current status
- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`
- Head refreshed to `3d13fdd672d9a7cb36dc366333f4a5caf6c1deee`
- GitHub currently reports the PR as mergeable

## Validation
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py --collect-only -q --tb=short`
  - 175 tests collected
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py -q --tb=short`
  - 175 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_translation_cost_optimization.py backend\tests\unit\test_translation_optimization.py -q --tb=short`
  - 175 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py -q --tb=short`
  - 201 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_translation_optimization.py backend\tests\unit\test_translation_cost_optimization.py`
  - 2 files would be left unchanged
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`