### PR TITLE
fix(backend): stop leaking thinking_budget into Gemini OpenAI-compat fallback (#7898)

### DIFF
--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -933,3 +933,76 @@ class TestStructuredOutputFeatureTracking:
         profile = MODEL_QOS_PROFILES['byok']
         for feature in _STRUCTURED_OUTPUT_FEATURES:
             assert profile[feature][1] == 'openai', f'byok {feature} should be openai, got {profile[feature][1]}'
+
+
+class TestGeminiThinkingBudget:
+    """thinking_budget is a native google-genai SDK param — it must never reach the OpenAI-compat fallback.
+
+    Regression for the pusher crash: pusher has no GEMINI_API_KEY/USE_VERTEX_AI, so the Gemini client
+    resolves to the ChatOpenAI OpenAI-compat fallback. Passing thinking_budget there leaks it into
+    model_kwargs and crashes at invoke ("Completions.parse() got an unexpected keyword argument
+    'thinking_budget'"), disabling trends/memory-discard for all users.
+    """
+
+    def test_openai_compat_fallback_omits_thinking_budget(self):
+        from unittest.mock import patch as _patch
+
+        saved = dict(_llm_cache)
+        _llm_cache.clear()
+        captured = {}
+
+        def fake_openai(*args, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        try:
+            with _patch.dict(os.environ, {'GEMINI_API_KEY': '', 'USE_VERTEX_AI': ''}), _patch(
+                'utils.llm.clients.ChatOpenAI', side_effect=fake_openai
+            ), _patch('utils.llm.clients.ChatGoogleGenerativeAI', side_effect=lambda *a, **k: MagicMock()):
+                _get_or_create_gemini_llm('gemini-2.5-flash-lite', thinking_budget=0)
+            assert 'thinking_budget' not in captured, 'thinking_budget must not reach the ChatOpenAI fallback'
+        finally:
+            _llm_cache.clear()
+            _llm_cache.update(saved)
+
+    def test_native_gemini_receives_thinking_budget(self):
+        from unittest.mock import patch as _patch
+
+        saved = dict(_llm_cache)
+        _llm_cache.clear()
+        captured = {}
+
+        def fake_genai(*args, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        try:
+            with _patch.dict(os.environ, {'GEMINI_API_KEY': 'test-key', 'USE_VERTEX_AI': ''}), _patch(
+                'utils.llm.clients.ChatGoogleGenerativeAI', side_effect=fake_genai
+            ), _patch('utils.llm.clients.ChatOpenAI', side_effect=lambda *a, **k: MagicMock()):
+                _get_or_create_gemini_llm('gemini-2.5-flash-lite', thinking_budget=0)
+            assert captured.get('thinking_budget') == 0, 'native ChatGoogleGenerativeAI must receive thinking_budget'
+        finally:
+            _llm_cache.clear()
+            _llm_cache.update(saved)
+
+    def test_non_25_model_omits_thinking_budget(self):
+        from unittest.mock import patch as _patch
+
+        saved = dict(_llm_cache)
+        _llm_cache.clear()
+        captured = {}
+
+        def fake_genai(*args, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        try:
+            with _patch.dict(os.environ, {'GEMINI_API_KEY': 'test-key', 'USE_VERTEX_AI': ''}), _patch(
+                'utils.llm.clients.ChatGoogleGenerativeAI', side_effect=fake_genai
+            ), _patch('utils.llm.clients.ChatOpenAI', side_effect=lambda *a, **k: MagicMock()):
+                _get_or_create_gemini_llm('gemini-3-flash-preview', thinking_budget=0)
+            assert 'thinking_budget' not in captured, 'thinking_budget only applies to gemini-2.5* models'
+        finally:
+            _llm_cache.clear()
+            _llm_cache.update(saved)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -530,17 +530,23 @@ def _get_or_create_gemini_llm(
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback], 'timeout': 120, 'max_retries': 1}
         if streaming:
             kwargs['streaming'] = True
+
+        # thinking_budget is a native google-genai SDK construction param. It must only go to
+        # ChatGoogleGenerativeAI — passing it to the OpenAI-compat ChatOpenAI fallback leaks it into
+        # model_kwargs and crashes at invoke time ("Completions.parse() got an unexpected keyword
+        # argument 'thinking_budget'"). Keep it scoped to the native-SDK branches only.
+        gemini_kwargs = dict(kwargs)
         if thinking_budget is not None and model_name.startswith('gemini-2.5'):
-            kwargs['thinking_budget'] = thinking_budget
+            gemini_kwargs['thinking_budget'] = thinking_budget
 
         if gcp_project:
             gcp_location = os.environ.get('GCP_LOCATION', 'us-central1')
             _llm_cache[key] = ChatGoogleGenerativeAI(
-                model=model_name, project=gcp_project, location=gcp_location, **kwargs
+                model=model_name, project=gcp_project, location=gcp_location, **gemini_kwargs
             )
         elif gemini_key:
-            kwargs['google_api_key'] = gemini_key
-            _llm_cache[key] = ChatGoogleGenerativeAI(model=model_name, **kwargs)
+            gemini_kwargs['google_api_key'] = gemini_key
+            _llm_cache[key] = ChatGoogleGenerativeAI(model=model_name, **gemini_kwargs)
         else:
             logger.warning('No USE_VERTEX_AI or GEMINI_API_KEY — Gemini calls will fail at invoke time')
             _llm_cache[key] = ChatOpenAI(


### PR DESCRIPTION
## Bug (#7898)

`utils.llm.trends` memory-discard / trend detection fails for **all** users in the **pusher** service, spamming logs continuously:

```
ERROR:utils.llm.trends:Error determining memory discard: Completions.parse() got an unexpected keyword argument 'thinking_budget'
```

The `except Exception` in `trends.py:86-88` swallows it and returns `[]`, so no trends are ever detected.

## Root cause

`thinking_budget` is a **native google-genai SDK** construction param (caps Gemini 2.5 "thinking" tokens). In `_get_or_create_gemini_llm` (`utils/llm/clients.py`) it was added to a shared `kwargs` dict used by **all three** client constructions, including the OpenAI-compat `ChatOpenAI` fallback.

The pusher deployment has **no** `GEMINI_API_KEY` and **no** `USE_VERTEX_AI` (confirmed in `charts/pusher/prod_omi_pusher_values.yaml` — neither var is set, unlike `charts/backend-listen` which sets both). So `_get_or_create_gemini_llm` falls into the `else` branch and builds a `ChatOpenAI` against the Gemini OpenAI-compat endpoint. `ChatOpenAI` moves the unknown `thinking_budget` kwarg into `model_kwargs`, which is then forwarded to `Completions.parse()` when `'trends'` calls `.with_structured_output()` → the crash above.

The native `ChatGoogleGenerativeAI` path (main backend / backend-listen, which have the key) is unaffected — it accepts `thinking_budget` — which is why this only manifests in pusher.

## Fix

Scope `thinking_budget` to the native-SDK branches only (`gemini_kwargs`); never pass it to the `ChatOpenAI` fallback. Surgical, behavior-preserving for every path that already worked. +3 regression tests in `test_omi_qos_tiers.py` (registered in `test.sh`): fallback omits it, native path receives it, non-2.5 models omit it.

Branch logic verified locally with a standalone replica of all branches (pytest/langchain not installed locally; CI runs the suite).

## Scope note (not fixed here — infra, out of watchdog scope)

This stops the crash and the log spam. Pusher still has no Gemini credential, so after this fix the fallback call would return a clean auth error instead of trends results until pusher is given a `GEMINI_API_KEY`/`USE_VERTEX_AI` (a helm/secret change in `charts/pusher`, deliberately left for a human). Flagging for @kodjima33.

🤖 automated by hourly watchdog; opened for review, not merged.
