### PR TITLE
fix(desktop): pin OCR recognitionLanguages to process lifetime to stop SIGTRAP

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -75,6 +75,18 @@ struct OCRResult: Codable, Equatable {
 actor RewindOCRService {
     static let shared = RewindOCRService()
 
+    /// Recognition languages passed to `VNRecognizeTextRequest`.
+    ///
+    /// Held as a process-lifetime constant so the bridged NSArray backing storage
+    /// can never be released while Vision's TextRecognition framework enumerates
+    /// it asynchronously on `com.apple.root.utility-qos.cooperative`. A Swift
+    /// array literal assigned to `recognitionLanguages` has its storage tied to
+    /// the call frame; once the request is dispatched to a background queue the
+    /// storage can be freed, leaving TextRecognition iterating an
+    /// `__EmptyArrayStorage` and tripping `_assertionFailure` (EXC_BREAKPOINT /
+    /// SIGTRAP). Pinning the array breaks that race. See #5891, #5151.
+    private static let recognitionLanguages: [String] = ["en-US"]
+
     private init() {}
 
     // MARK: - Frame Deduplication
@@ -213,7 +225,7 @@ actor RewindOCRService {
 
             request.recognitionLevel = recognitionLevel
             request.usesLanguageCorrection = false
-            request.recognitionLanguages = ["en-US"]
+            request.recognitionLanguages = Self.recognitionLanguages
 
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
 


### PR DESCRIPTION
## Summary

- Fixes a recurring `EXC_BREAKPOINT (SIGTRAP)` crash in the macOS desktop app triggered from `VNRecognizeTextRequest` during screenshot OCR.
- Hoists `request.recognitionLanguages = ["en-US"]` to a `static let` on `RewindOCRService` so the Swift array's bridged NSArray storage lives for the lifetime of the process.

## Crash signature

Reported from the installed app on macOS 26.3 (`Omi Computer` v0.11.463, `com.omi.computer-macos`):

```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Triggered by Thread: 18, queue: com.apple.root.utility-qos.cooperative

Thread 18:
  _assertionFailure(_:_:file:line:flags:)
  closure #1 in __SwiftNativeNSArrayWithContiguousStorage._objectAt(_:)
  __EmptyArrayStorage._withVerbatimBridgedUnsafeBuffer<A>(_:)
  __ContiguousArrayStorageBase.withUnsafeBufferOfObjects<A>(_:)
  @objc __SwiftNativeNSArrayWithContiguousStorage.objectAtSubscript(_:)
  <TextRecognition.framework>
  <TextRecognition.framework>
  ...
  completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*)
```

`TextRecognition` enumerates what it believes is a non-empty Swift-bridged `NSArray`, but the backing storage has become `__EmptyArrayStorage`, so `_objectAt(0)` trips Swift's bounds-check `_assertionFailure` and the process is killed with SIGTRAP. The crash is uncatchable from Swift.

## Root cause

In `RewindOCRService.extractTextWithBounds(from:)`:

```swift
request.recognitionLanguages = ["en-US"]
```

The `["en-US"]` literal is a Swift `[String]` whose storage is tied to the call frame. After the closure returns and `VNImageRequestHandler.perform([request])` dispatches to Vision's `com.apple.root.utility-qos.cooperative` queue, the literal's storage can be deallocated. When `TextRecognition` later enumerates the languages array, the storage has been replaced with `__EmptyArrayStorage`, producing the SIGTRAP above.

The output side of this same bug class is already handled defensively (see `Array(observations)` with the comment referencing #5891, #5151), but the input side — the `recognitionLanguages` array — was left as a per-call literal.

## Fix

Pin the languages array to a process-lifetime `static let`:

```swift
actor RewindOCRService {
    static let shared = RewindOCRService()

    /// Recognition languages passed to VNRecognizeTextRequest.
    ///
    /// Held as a process-lifetime constant so the bridged NSArray backing storage
    /// can never be released while Vision's TextRecognition framework enumerates
    /// it asynchronously on com.apple.root.utility-qos.cooperative. ...
    private static let recognitionLanguages: [String] = ["en-US"]
    ...
}
```

```diff
-            request.recognitionLanguages = ["en-US"]
+            request.recognitionLanguages = Self.recognitionLanguages
```

No behavior change for callers — same languages, same order. The only difference is the storage lifetime.

## Test plan

- [ ] `./run.sh` boots the dev app and a screenshot OCR cycle completes without `_assertionFailure` in Console.app.
- [ ] Stress: capture screens for ~10 minutes with rapid content changes; no SIGTRAP in `~/Library/Logs/DiagnosticReports/`.
- [ ] Verify on macOS 14.x and macOS 26.x.
- [ ] Spot-check that `OCRResult.blocks` is still populated for screenshots containing English text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)