### PR TITLE
Parakeet: add 6 observability metrics for ASR monitoring

### DIFF
--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -30,6 +30,8 @@ class BatchEngine:
         max_batch_size: int = 32,
         max_wait_seconds: float = 0.002,
         max_queue_depth: int = 4096,
+        on_batch_complete=None,
+        on_gpu_oom=None,
     ):
         self._gpu_worker = gpu_worker
         self._max_batch_size = max_batch_size
@@ -41,6 +43,8 @@ class BatchEngine:
         self._inflight_flushes: set[asyncio.Task] = set()
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._shutting_down = False
+        self._on_batch_complete = on_batch_complete
+        self._on_gpu_oom = on_gpu_oom
         self._metrics = {
             "total_requests": 0,
             "total_batches": 0,
@@ -115,8 +119,12 @@ class BatchEngine:
         self._metrics["total_files"] += len(batch)
         logger.info(f"Flushing batch: {len(batch)} files")
 
+        batch_start = time.monotonic()
+        queue_durations = [batch_start - req.submitted_at for req in batch]
+
         audio_paths = [r.audio_path for r in batch]
         timestamps = batch[0].timestamps if batch else True
+        is_oom = False
         try:
             gpu_future = self._gpu_worker.submit(
                 {
@@ -127,6 +135,10 @@ class BatchEngine:
                 self._loop,
             )
             results = await gpu_future
+            inference_duration = time.monotonic() - batch_start
+
+            if self._on_batch_complete:
+                self._on_batch_complete(queue_durations, inference_duration, len(batch))
 
             if isinstance(results, list) and len(results) == len(batch):
                 for req, result in zip(batch, results):
@@ -145,17 +157,23 @@ class BatchEngine:
                 if not req.future.done():
                     req.future.set_exception(err)
         except RuntimeError as exc:
+            if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
+                is_oom = True
             err = QueueFullError(str(exc)) if "GPU queue full" in str(exc) else exc
             logger.error(f"Batch transcription failed: {exc}")
             for req in batch:
                 if not req.future.done():
                     req.future.set_exception(err)
         except Exception as exc:
+            if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
+                is_oom = True
             logger.error(f"Batch transcription failed: {exc}")
             for req in batch:
                 if not req.future.done():
                     req.future.set_exception(exc)
         finally:
+            if is_oom and self._on_gpu_oom:
+                self._on_gpu_oom()
             for req in batch:
                 if req.owns_file:
                     _unlink_safe(req.audio_path)

--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -126,7 +126,7 @@ class BatchEngine:
         timestamps = batch[0].timestamps if batch else True
         is_oom = False
         try:
-            gpu_future = self._gpu_worker.submit(
+            gpu_future, work_item = self._gpu_worker.submit(
                 {
                     "audio_paths": audio_paths,
                     "timestamps": timestamps,
@@ -135,10 +135,10 @@ class BatchEngine:
                 self._loop,
             )
             results = await gpu_future
-            inference_duration = time.monotonic() - batch_start
+            inference_seconds = work_item.inference_seconds if work_item else 0.0
 
             if self._on_batch_complete:
-                self._on_batch_complete(queue_durations, inference_duration, len(batch))
+                self._on_batch_complete(queue_durations, inference_seconds, len(batch))
 
             if isinstance(results, list) and len(results) == len(batch):
                 for req, result in zip(batch, results):

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -31,6 +31,7 @@ class WorkItem:
     sync_result: Any = None
     sync_error: Optional[Exception] = None
     created_at: float = field(default_factory=time.monotonic)
+    inference_seconds: float = 0.0
 
 
 class GPUWorker:
@@ -72,17 +73,18 @@ class GPUWorker:
         if self._thread:
             self._thread.join(timeout=30)
 
-    def submit(self, payload: dict, loop: asyncio.AbstractEventLoop) -> asyncio.Future:
+    def submit(self, payload: dict, loop: asyncio.AbstractEventLoop) -> tuple:
         if not self.is_ready:
             fut = loop.create_future()
             fut.set_exception(RuntimeError("GPU worker not ready"))
-            return fut
+            return fut, None
         fut = loop.create_future()
+        item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
         try:
-            self._queue.put_nowait(WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop))
+            self._queue.put_nowait(item)
         except queue.Full:
             fut.set_exception(RuntimeError("GPU queue full"))
-        return fut
+        return fut, item
 
     def submit_sync(self, payload: dict, timeout: float = 120.0) -> list:
         if not self.is_ready:
@@ -128,7 +130,9 @@ class GPUWorker:
                 break
 
             try:
+                t_infer = time.monotonic()
                 result = self._batch_transcribe(item.payload)
+                item.inference_seconds = time.monotonic() - t_infer
                 self._deliver_result(item, result)
             except Exception as exc:
                 self._deliver_error(item, exc)

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -5,6 +5,7 @@ import os
 import time
 import uuid
 import logging
+import wave as _wave
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -13,7 +14,7 @@ gc.disable()
 
 from fastapi import FastAPI, Form, UploadFile, File, WebSocket, WebSocketDisconnect, Query
 from fastapi.responses import JSONResponse
-from prometheus_client import Gauge, Histogram, make_asgi_app
+from prometheus_client import Counter, Gauge, Histogram, make_asgi_app
 
 from gpu_worker import GPUWorker
 from batch_engine import BatchEngine, QueueFullError
@@ -29,6 +30,8 @@ from stream_handler import StreamSession, warmup_rnnt_decoder
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+_ASR_BUCKETS = (0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0)
+
 ACTIVE_STREAMS = Gauge('parakeet_active_streams', 'Active /v3/stream WebSocket connections')
 ACTIVE_BATCH = Gauge('parakeet_active_batch_requests', 'Active batch transcription requests')
 PENDING_REQUESTS = Gauge('parakeet_batch_pending_requests', 'Pending requests in batch engine queue')
@@ -36,7 +39,7 @@ REQUEST_DURATION = Histogram(
     'parakeet_request_duration_seconds',
     'Request latency',
     ['endpoint'],
-    buckets=[0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0],
+    buckets=_ASR_BUCKETS,
 )
 STREAM_DURATION = Histogram(
     'parakeet_stream_duration_seconds',
@@ -48,12 +51,49 @@ BATCH_SIZE_HIST = Histogram(
     'Number of files per GPU batch',
     buckets=[1, 2, 4, 8, 16, 32, 64],
 )
+RTFX = Gauge('parakeet_rtfx', 'Real-time factor of last request (audio_duration / processing_time)')
+AUDIO_DURATION = Histogram(
+    'parakeet_audio_duration_seconds',
+    'Input audio length distribution',
+    buckets=_ASR_BUCKETS,
+)
+QUEUE_DURATION = Histogram(
+    'parakeet_queue_duration_seconds',
+    'Time spent waiting in queue before batch assembly',
+    buckets=_ASR_BUCKETS,
+)
+INFERENCE_DURATION = Histogram(
+    'parakeet_inference_duration_seconds',
+    'Pure GPU inference time excluding queue and post-processing',
+    buckets=_ASR_BUCKETS,
+)
+GPU_OOM_TOTAL = Counter('parakeet_gpu_oom_total', 'CUDA out-of-memory events')
+REQUESTS_TOTAL = Counter('parakeet_requests_total', 'Total requests by status', ['endpoint', 'status'])
 
 gpu_worker: Optional[GPUWorker] = None
 batch_engine: Optional[BatchEngine] = None
 start_time: float = 0
 _diarize_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="diarize")
 _io_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="file-io")
+
+
+def _get_audio_duration(file_path: str) -> float:
+    try:
+        with _wave.open(file_path, 'rb') as wf:
+            return wf.getnframes() / wf.getframerate()
+    except Exception:
+        return 0.0
+
+
+def _on_batch_complete(queue_durations, inference_seconds, batch_size):
+    for qd in queue_durations:
+        QUEUE_DURATION.observe(qd)
+    INFERENCE_DURATION.observe(inference_seconds)
+    BATCH_SIZE_HIST.observe(batch_size)
+
+
+def _on_gpu_oom():
+    GPU_OOM_TOTAL.inc()
 
 
 @asynccontextmanager
@@ -73,6 +113,8 @@ async def lifespan(app: FastAPI):
             max_batch_size=int(os.getenv("PARAKEET_MAX_BATCH_SIZE", "32")),
             max_wait_seconds=float(os.getenv("PARAKEET_BATCH_WAIT_SECONDS", "0.002")),
             max_queue_depth=int(os.getenv("PARAKEET_MAX_QUEUE_DEPTH", "4096")),
+            on_batch_complete=_on_batch_complete,
+            on_gpu_oom=_on_gpu_oom,
         )
         await batch_engine.start()
         logger.info("Server started, GPU model loading in background...")
@@ -113,10 +155,16 @@ async def transcribe(file: UploadFile = File(...)):
     file_path = f"_temp/{upload_id}_{file.filename}"
     ACTIVE_BATCH.inc()
     t0 = time.monotonic()
+    audio_dur = 0.0
+    status = "success"
     loop = asyncio.get_running_loop()
     try:
         data = await file.read()
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
+
+        audio_dur = _get_audio_duration(file_path)
+        if audio_dur > 0:
+            AUDIO_DURATION.observe(audio_dur)
 
         if batch_engine is not None:
             PENDING_REQUESTS.set(len(batch_engine._pending))
@@ -127,9 +175,17 @@ async def transcribe(file: UploadFile = File(...)):
             result = await loop.run_in_executor(_diarize_pool, transcribe_file, file_path)
             return result
     except QueueFullError:
+        status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
+    except Exception:
+        status = "error"
+        raise
     finally:
-        REQUEST_DURATION.labels(endpoint="v1_transcribe").observe(time.monotonic() - t0)
+        elapsed = time.monotonic() - t0
+        REQUEST_DURATION.labels(endpoint="v1_transcribe").observe(elapsed)
+        REQUESTS_TOTAL.labels(endpoint="v1_transcribe", status=status).inc()
+        if status == "success" and audio_dur > 0 and elapsed > 0:
+            RTFX.set(audio_dur / elapsed)
         ACTIVE_BATCH.dec()
         if batch_engine is None:
             await loop.run_in_executor(_io_pool, _remove_file, file_path)
@@ -146,10 +202,16 @@ async def transcribe_v2(
     file_path = f"_temp/{upload_id}_{file.filename}"
     ACTIVE_BATCH.inc()
     t0 = time.monotonic()
+    audio_dur = 0.0
+    status = "success"
     loop = asyncio.get_running_loop()
     try:
         data = await file.read()
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
+
+        audio_dur = _get_audio_duration(file_path)
+        if audio_dur > 0:
+            AUDIO_DURATION.observe(audio_dur)
 
         if batch_engine is not None:
             PENDING_REQUESTS.set(len(batch_engine._pending))
@@ -164,9 +226,17 @@ async def transcribe_v2(
             )
         return result
     except QueueFullError:
+        status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
+    except Exception:
+        status = "error"
+        raise
     finally:
-        REQUEST_DURATION.labels(endpoint="v2_transcribe").observe(time.monotonic() - t0)
+        elapsed = time.monotonic() - t0
+        REQUEST_DURATION.labels(endpoint="v2_transcribe").observe(elapsed)
+        REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status=status).inc()
+        if status == "success" and audio_dur > 0 and elapsed > 0:
+            RTFX.set(audio_dur / elapsed)
         ACTIVE_BATCH.dec()
         await loop.run_in_executor(_io_pool, _remove_file, file_path)
 

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -163,7 +163,7 @@ async def transcribe(file: UploadFile = File(...)):
         data = await file.read()
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
-        audio_dur = _get_audio_duration(file_path)
+        audio_dur = await loop.run_in_executor(_io_pool, _get_audio_duration, file_path)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
 
@@ -211,7 +211,7 @@ async def transcribe_v2(
         data = await file.read()
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
-        audio_dur = _get_audio_duration(file_path)
+        audio_dur = await loop.run_in_executor(_io_pool, _get_audio_duration, file_path)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
 

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -5,6 +5,7 @@ import os
 import time
 import uuid
 import logging
+import io as _io
 import wave as _wave
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -77,9 +78,9 @@ _diarize_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="diarize")
 _io_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="file-io")
 
 
-def _get_audio_duration(file_path: str) -> float:
+def _get_audio_duration_from_bytes(data: bytes) -> float:
     try:
-        with _wave.open(file_path, 'rb') as wf:
+        with _wave.open(_io.BytesIO(data), 'rb') as wf:
             return wf.getnframes() / wf.getframerate()
     except Exception:
         return 0.0
@@ -161,11 +162,10 @@ async def transcribe(file: UploadFile = File(...)):
     loop = asyncio.get_running_loop()
     try:
         data = await file.read()
-        await loop.run_in_executor(_io_pool, _write_file, file_path, data)
-
-        audio_dur = await loop.run_in_executor(_io_pool, _get_audio_duration, file_path)
+        audio_dur = _get_audio_duration_from_bytes(data)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
+        await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
             PENDING_REQUESTS.set(len(batch_engine._pending))
@@ -209,11 +209,10 @@ async def transcribe_v2(
     loop = asyncio.get_running_loop()
     try:
         data = await file.read()
-        await loop.run_in_executor(_io_pool, _write_file, file_path, data)
-
-        audio_dur = await loop.run_in_executor(_io_pool, _get_audio_duration, file_path)
+        audio_dur = _get_audio_duration_from_bytes(data)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
+        await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
             PENDING_REQUESTS.set(len(batch_engine._pending))

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -150,6 +150,7 @@ def _remove_file(path: str) -> None:
 @app.post("/v1/transcribe")
 async def transcribe(file: UploadFile = File(...)):
     if gpu_worker is not None and not gpu_worker.is_ready:
+        REQUESTS_TOTAL.labels(endpoint="v1_transcribe", status="error").inc()
         return JSONResponse(status_code=503, content={"detail": "Model loading, try again shortly"})
     upload_id = str(uuid.uuid4())
     file_path = f"_temp/{upload_id}_{file.filename}"
@@ -197,6 +198,7 @@ async def transcribe_v2(
     diarize: bool = Form(True),
 ):
     if gpu_worker is not None and not gpu_worker.is_ready:
+        REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="error").inc()
         return JSONResponse(status_code=503, content={"detail": "Model loading, try again shortly"})
     upload_id = str(uuid.uuid4())
     file_path = f"_temp/{upload_id}_{file.filename}"

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -34,7 +34,7 @@ sys.modules["nemo.collections.asr"] = _nemo_asr
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
 
 from batch_engine import BatchEngine, QueueFullError, _unlink_safe
-from gpu_worker import GPUWorker
+from gpu_worker import GPUWorker, WorkItem, WorkType
 
 
 def _make_mock_gpu_worker(results_fn=None):
@@ -43,12 +43,14 @@ def _make_mock_gpu_worker(results_fn=None):
 
     def submit(payload, loop):
         fut = loop.create_future()
+        item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
         if results_fn:
             res = results_fn(payload)
         else:
             res = [{"text": f"ok:{p}", "timestamp": {}} for p in payload["audio_paths"]]
+        item.inference_seconds = 0.01
         loop.call_soon(fut.set_result, res)
-        return fut
+        return fut, item
 
     worker.submit.side_effect = submit
     return worker
@@ -215,8 +217,9 @@ class TestBatchEngineErrorPropagation:
 
         def submit_error(payload, loop):
             fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
             loop.call_soon(fut.set_exception, RuntimeError("GPU exploded"))
-            return fut
+            return fut, item
 
         gpu.submit.side_effect = submit_error
         engine = BatchEngine(gpu, max_batch_size=3, max_wait_seconds=0.01)
@@ -244,8 +247,9 @@ class TestBatchEngineErrorPropagation:
 
         def submit_queue_full(payload, loop):
             fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
             loop.call_soon(fut.set_exception, RuntimeError("GPU queue full"))
-            return fut
+            return fut, item
 
         gpu.submit.side_effect = submit_queue_full
         engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.01)
@@ -347,7 +351,9 @@ class TestBatchEngineShutdown:
         gpu.is_ready = True
 
         def submit_hang(payload, loop):
-            return loop.create_future()
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            return fut, item
 
         gpu.submit.side_effect = submit_hang
         engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.01)
@@ -418,8 +424,9 @@ class TestBatchEngineCallbacks:
 
         def submit_oom(payload, loop):
             fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
             loop.call_soon(fut.set_exception, RuntimeError("CUDA out of memory"))
-            return fut
+            return fut, item
 
         gpu.submit.side_effect = submit_oom
         engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.01, on_gpu_oom=on_oom)

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -375,6 +375,72 @@ class TestBatchEngineShutdown:
             loop.close()
 
 
+class TestBatchEngineCallbacks:
+
+    def test_on_batch_complete_called_with_timing(self):
+        gpu = _make_mock_gpu_worker()
+        callback_data = {}
+
+        def on_complete(queue_durations, inference_seconds, batch_size):
+            callback_data["queue_durations"] = queue_durations
+            callback_data["inference_seconds"] = inference_seconds
+            callback_data["batch_size"] = batch_size
+
+        engine = BatchEngine(gpu, max_batch_size=2, max_wait_seconds=0.01, on_batch_complete=on_complete)
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/{i}.wav", owns_file=False)) for i in range(2)]
+                    await asyncio.wait_for(asyncio.gather(*futs), timeout=5)
+                    assert "queue_durations" in callback_data
+                    assert len(callback_data["queue_durations"]) == 2
+                    assert all(d >= 0 for d in callback_data["queue_durations"])
+                    assert callback_data["inference_seconds"] >= 0
+                    assert callback_data["batch_size"] == 2
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_on_gpu_oom_called_on_cuda_oom(self):
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        oom_count = [0]
+
+        def on_oom():
+            oom_count[0] += 1
+
+        def submit_oom(payload, loop):
+            fut = loop.create_future()
+            loop.call_soon(fut.set_exception, RuntimeError("CUDA out of memory"))
+            return fut
+
+        gpu.submit.side_effect = submit_oom
+        engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.01, on_gpu_oom=on_oom)
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    with pytest.raises(RuntimeError, match="CUDA out of memory"):
+                        await asyncio.wait_for(engine.submit("/tmp/oom.wav", owns_file=False), timeout=5)
+                    assert oom_count[0] == 1
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
 class TestUnlinkSafe:
 
     def test_unlink_existing(self):

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -1,7 +1,9 @@
 import asyncio
 import io
 import os
+import struct
 import sys
+import wave
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
@@ -206,3 +208,68 @@ class TestV2TranscribeEndpoint:
             "/v2/transcribe", files={"file": ("test.wav", b"fake", "audio/wav")}, data={"diarize": "true"}
         )
         assert resp.status_code == 503
+
+
+def _make_wav_bytes(duration_s=2.0, sample_rate=16000, channels=1, sampwidth=2):
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sampwidth)
+        wf.setframerate(sample_rate)
+        n_frames = int(sample_rate * duration_s)
+        wf.writeframes(b'\x00' * n_frames * channels * sampwidth)
+    return buf.getvalue()
+
+
+class TestAudioDurationFromBytes:
+
+    def test_valid_wav_returns_positive_duration(self):
+        from main import _get_audio_duration_from_bytes
+
+        data = _make_wav_bytes(duration_s=2.0, sample_rate=16000)
+        dur = _get_audio_duration_from_bytes(data)
+        assert abs(dur - 2.0) < 0.01
+
+    def test_invalid_bytes_returns_zero(self):
+        from main import _get_audio_duration_from_bytes
+
+        assert _get_audio_duration_from_bytes(b"not a wav") == 0.0
+
+    def test_empty_bytes_returns_zero(self):
+        from main import _get_audio_duration_from_bytes
+
+        assert _get_audio_duration_from_bytes(b"") == 0.0
+
+    def test_v1_with_real_wav_observes_audio_duration(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "ok", "timestamp": {"segment": [{"segment": "ok", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+        wav_data = _make_wav_bytes(duration_s=1.5, sample_rate=16000)
+        before = mod.AUDIO_DURATION._sum.get()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("test.wav", wav_data, "audio/wav")})
+        assert resp.status_code == 200
+        after = mod.AUDIO_DURATION._sum.get()
+        assert after - before >= 1.4
+
+
+class TestMetricsEndpoint:
+
+    def test_metrics_endpoint_contains_new_series(self):
+        app, mod, _, _ = _make_app_with_mocks()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        body = resp.text
+        for name in [
+            "parakeet_rtfx",
+            "parakeet_audio_duration_seconds",
+            "parakeet_queue_duration_seconds",
+            "parakeet_inference_duration_seconds",
+            "parakeet_gpu_oom_total",
+            "parakeet_requests_total",
+        ]:
+            assert name in body, f"Missing metric: {name}"

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -168,10 +168,12 @@ class TestGPUWorkerSubmitAsync:
     def test_async_submit_delivers_result(self, worker):
         loop = asyncio.new_event_loop()
         try:
-            fut = worker.submit({"audio_paths": ["/tmp/a.wav"], "timestamps": True, "batch_size": 1}, loop)
+            fut, item = worker.submit({"audio_paths": ["/tmp/a.wav"], "timestamps": True, "batch_size": 1}, loop)
             result = loop.run_until_complete(asyncio.wait_for(fut, timeout=10))
             assert len(result) == 1
             assert result[0]["text"] == "transcribed:/tmp/a.wav"
+            assert item is not None
+            assert item.inference_seconds > 0
         finally:
             loop.close()
 
@@ -179,7 +181,8 @@ class TestGPUWorkerSubmitAsync:
         w = GPUWorker()
         loop = asyncio.new_event_loop()
         try:
-            fut = w.submit({"audio_paths": ["/tmp/a.wav"]}, loop)
+            fut, item = w.submit({"audio_paths": ["/tmp/a.wav"]}, loop)
+            assert item is None
             with pytest.raises(RuntimeError, match="not ready"):
                 loop.run_until_complete(fut)
         finally:
@@ -211,7 +214,7 @@ class TestGPUWorkerQueueFull:
 
         loop = asyncio.new_event_loop()
         try:
-            fut = worker.submit({"audio_paths": ["/tmp/a.wav"]}, loop)
+            fut, item = worker.submit({"audio_paths": ["/tmp/a.wav"]}, loop)
             with pytest.raises(RuntimeError, match="GPU queue full"):
                 loop.run_until_complete(fut)
         finally:


### PR DESCRIPTION
## Summary
Adds 6 app-level Prometheus metrics to parakeet ASR service for production monitoring dashboard.

- **`parakeet_rtfx`** (gauge) — real-time factor per request (audio_duration / processing_time)
- **`parakeet_audio_duration_seconds`** (histogram) — input audio length distribution
- **`parakeet_queue_duration_seconds`** (histogram) — time waiting in batch engine queue
- **`parakeet_inference_duration_seconds`** (histogram) — pure GPU inference time measured around `_batch_transcribe()` in GPU worker thread
- **`parakeet_gpu_oom_total`** (counter) — CUDA out-of-memory events
- **`parakeet_requests_total`** (counter, labels: endpoint, status) — request counting including model-loading 503 guard

All histograms use ASR-tuned buckets `[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0]`.

### Zero-overhead design
- Audio duration parsed from upload bytes in memory via `BytesIO` — no file I/O, no executor dispatch
- `gpu_worker.submit()` returns `(future, work_item)` tuple so `_flush_batch()` reads `work_item.inference_seconds` directly
- Callbacks (`on_batch_complete`, `on_gpu_oom`) are plain function calls — no locks, no network

Closes #7961

## Test plan
- [x] 66 tests pass (17 batch_engine + 16 endpoints + 33 gpu_worker)
- [x] Real WAV duration positive path tested (generates 2s WAV via wave module)
- [x] `/metrics` endpoint scraped, all 6 new metric names verified
- [x] `AUDIO_DURATION` histogram sum verified via real WAV upload
- [x] Inference timing, batch callbacks, OOM callbacks covered
- [x] CP7 reviewer approved (3 rounds — inference timing, test updates, zero-I/O optimization)
- [x] CP8 tester approved (TESTS_APPROVED)
- [ ] Mon to verify metrics in Prometheus after deploy and update Grafana dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_