### PR TITLE
fix developer settings API key containers not stretching full width

### DIFF
--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -255,6 +255,7 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
       builder: (context, provider, child) {
         if (provider.isLoading && provider.keys.isEmpty) {
           return Container(
+            width: double.infinity,
             padding: const EdgeInsets.all(24),
             decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(12)),
             child: const Center(child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)),
@@ -262,6 +263,7 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
         }
         if (provider.error != null) {
           return Container(
+            width: double.infinity,
             padding: const EdgeInsets.all(24),
             decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(12)),
             child: Center(
@@ -271,6 +273,7 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
         }
         if (provider.keys.isEmpty) {
           return Container(
+            width: double.infinity,
             padding: const EdgeInsets.all(24),
             decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(12)),
             child: Column(


### PR DESCRIPTION
Added `width: double.infinity` to the loading, error, and empty-state containers in the Developer Settings API key section so they stretch to fill the available width.

**Before:**

<img width="1206" height="600" alt="IMG_E69C1BA3D3F0-1" src="https://github.com/user-attachments/assets/444eaabd-d219-476e-a18a-f1b5c45e2c69" />

**After:**

<img width="1206" height="706" alt="524F1576-0B92-4751-B525-1F186470A4BB_1_201_a" src="https://github.com/user-attachments/assets/d6b3f2ad-d836-4fb9-9152-48f3e6f7a243" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)