### PR TITLE
fix(ci+charts): GKE auth failure + GPU rolling update deadlock for GPU services

### DIFF
--- a/.github/workflows/gcp_diarizer.yml
+++ b/.github/workflows/gcp_diarizer.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
       - run: gcloud auth configure-docker
 
       - name: Build and Push Docker image
@@ -60,16 +63,20 @@ jobs:
           docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/${{ env.SERVICE }}/Dockerfile .
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
 
-      - name: Connect to GKE cluster
-        run: |
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-          sudo apt-get update && sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y
-          gcloud container clusters get-credentials ${{ vars.GKE_CLUSTER }} --region ${{ env.REGION }} --project ${{ vars.GCP_PROJECT_ID }}
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Deploy Diarizer to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-${{ env.SERVICE }} ./backend/charts/${{ env.SERVICE }} -f ./backend/charts/${{ env.SERVICE }}/${{ vars.ENV }}_omi_${{ env.SERVICE }}_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+
+      - name: Verify rollout
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_models.yml
+++ b/.github/workflows/gcp_models.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
       - run: gcloud auth configure-docker
 
       - name: Build and Push Docker image
@@ -63,16 +66,20 @@ jobs:
           docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/modal/Dockerfile .
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
 
-      - name: Connect to GKE cluster
-        run: |
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-          sudo apt-get update && sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y
-          gcloud container clusters get-credentials ${{ vars.GKE_CLUSTER }} --region ${{ env.REGION }} --project ${{ vars.GCP_PROJECT_ID }}
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Deploy VAD to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-vad ./backend/charts/vad -f ./backend/charts/vad/${{ vars.ENV }}_omi_vad_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+
+      - name: Verify rollout
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-vad --timeout=600s
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_parakeet.yml
+++ b/.github/workflows/gcp_parakeet.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
       - run: gcloud auth configure-docker
 
       - name: Build and Push Docker image
@@ -55,16 +58,20 @@ jobs:
           docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/${{ env.SERVICE }}/Dockerfile .
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
 
-      - name: Connect to GKE cluster
-        run: |
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-          sudo apt-get update && sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y
-          gcloud container clusters get-credentials ${{ vars.GKE_CLUSTER }} --region ${{ env.REGION }} --project ${{ vars.GCP_PROJECT_ID }}
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Deploy Parakeet to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-${{ env.SERVICE }} ./backend/charts/${{ env.SERVICE }} -f ./backend/charts/${{ env.SERVICE }}/${{ vars.ENV }}_omi_${{ env.SERVICE }}_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+
+      - name: Verify rollout
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/backend/charts/diarizer/dev_omi_diarizer_values.yaml
+++ b/backend/charts/diarizer/dev_omi_diarizer_values.yaml
@@ -184,3 +184,10 @@ affinity:
               operator: In
               values:
                 - dev
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/diarizer/prod_omi_diarizer_values.yaml
+++ b/backend/charts/diarizer/prod_omi_diarizer_values.yaml
@@ -184,3 +184,10 @@ affinity:
               operator: In
               values:
                 - prod
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/diarizer/templates/deployment.yaml
+++ b/backend/charts/diarizer/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "diarizer.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/backend/charts/parakeet/dev_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/dev_omi_parakeet_values.yaml
@@ -216,3 +216,10 @@ affinity:
               operator: In
               values:
                 - dev
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -213,3 +213,10 @@ affinity:
               operator: In
               values:
                 - prod
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/parakeet/templates/deployment.yaml
+++ b/backend/charts/parakeet/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "parakeet.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/backend/charts/vad/dev_omi_vad_values.yaml
+++ b/backend/charts/vad/dev_omi_vad_values.yaml
@@ -181,3 +181,10 @@ affinity:
               operator: In
               values:
                 - dev
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/vad/prod_omi_vad_values.yaml
+++ b/backend/charts/vad/prod_omi_vad_values.yaml
@@ -185,3 +185,10 @@ affinity:
               operator: In
               values:
                 - v2
+
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0

--- a/backend/charts/vad/templates/deployment.yaml
+++ b/backend/charts/vad/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vad.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
## Summary

Fixes two P1 CI/CD issues blocking GPU service deploys (parakeet, diarizer, vad).

Closes #7959

## Bug 1: GKE auth failure in GPU workflows

**Problem:** `gke-gcloud-auth-plugin` installed via apt after `gcloud auth configure-docker` creates conflicting config state on `ubuntu-latest-m` runners. All 5 recent parakeet CI runs fail at the Helm step.

**Fix:** Replace manual apt-install + `gcloud container clusters get-credentials` with `google-github-actions/get-gke-credentials@v2` action in all 3 GPU workflows:
- `gcp_parakeet.yml`
- `gcp_diarizer.yml`
- `gcp_models.yml` (VAD)

Also adds `setup-gcloud@v2` for deterministic gcloud availability, and rollout verification (`kubectl rollout status` with 600s timeout for GPU model loading).

## Bug 2: GPU rolling update deadlock on single-GPU nodes

**Problem:** Parakeet/diarizer/vad deployment templates have no `strategy` field. K8s defaults to `maxSurge=25%` (rounds to 1) + `maxUnavailable=0`, which requires 2 GPUs simultaneously — deadlocks when only 1 GPU exists.

**Fix:** Add `strategy` template block to all 3 GPU deployment templates (matching pusher/backend-listen pattern) + set `maxUnavailable: 1, maxSurge: 0` in all 6 values files (prod + dev):
- `backend/charts/parakeet/templates/deployment.yaml` + values
- `backend/charts/diarizer/templates/deployment.yaml` + values
- `backend/charts/vad/templates/deployment.yaml` + values

This codifies mon's manual `kubectl patch` that is currently active on prod.

## Files changed (12)

| File | Change |
|------|--------|
| `.github/workflows/gcp_parakeet.yml` | Replace apt-install auth with get-gke-credentials@v2 + rollout verify |
| `.github/workflows/gcp_diarizer.yml` | Same auth fix |
| `.github/workflows/gcp_models.yml` | Same auth fix (VAD) |
| `backend/charts/parakeet/templates/deployment.yaml` | Add strategy template block |
| `backend/charts/diarizer/templates/deployment.yaml` | Add strategy template block |
| `backend/charts/vad/templates/deployment.yaml` | Add strategy template block |
| `backend/charts/parakeet/{prod,dev}_omi_parakeet_values.yaml` | Set maxUnavailable=1, maxSurge=0 |
| `backend/charts/diarizer/{prod,dev}_omi_diarizer_values.yaml` | Set maxUnavailable=1, maxSurge=0 |
| `backend/charts/vad/{prod,dev}_omi_vad_values.yaml` | Set maxUnavailable=1, maxSurge=0 |

## Risks

- **Brief downtime during GPU rollout:** `maxUnavailable=1` means the old pod dies before the new one starts. Single-replica GPU services will be briefly unavailable during updates (duration depends on model load time). This is the necessary tradeoff to avoid deadlock.
- **Startup probe timeout:** GPU services have long startup probes (~600s for parakeet). The rollout verification timeout matches this.
- **No HPA impact:** When HPA has scaled above 1 replica, only one pod at a time is unavailable during rolling update.

## Test plan

- [x] `helm lint` passes for all 3 GPU charts with both dev and prod values
- [x] `helm template` renders correct strategy block (maxUnavailable=1, maxSurge=0) for all 6 combinations
- [x] `kubectl apply --dry-run=client` passes for all rendered manifests (CODEx verified)
- [x] Workflow YAML validated (syntax + action ordering)
- [x] CODEx reviewed: 3 rounds, no blocking issues
- [ ] CI: trigger dev parakeet workflow to verify GKE auth succeeds
- [ ] Cluster: verify rolling update doesn't deadlock on dev GPU node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_