### PR TITLE
fix usage page share crash Non-empty title expected

### DIFF
--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -200,7 +200,11 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       shareText = baseText;
     }
 
-    await SharePlus.instance.share(ShareParams(files: [XFile(file.path)], subject: periodTitle, text: shareText));
+    await SharePlus.instance.share(ShareParams(
+      files: [XFile(file.path)],
+      subject: periodTitle.isEmpty ? null : periodTitle,
+      text: shareText.isEmpty ? null : shareText,
+    ));
   }
 
   String _getPeriodForIndex(int index) {
@@ -311,8 +315,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       ),
       body: Consumer<UsageProvider>(
         builder: (context, provider, child) {
-          final hasAnyData =
-              provider.todayUsage != null ||
+          final hasAnyData = provider.todayUsage != null ||
               provider.monthlyUsage != null ||
               provider.yearlyUsage != null ||
               provider.allTimeUsage != null;
@@ -1142,8 +1145,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                 builder: (context) {
                   final minutesUsed = (subscription.transcriptionSecondsUsed / 60).round();
                   final minutesLimit = (subscription.transcriptionSecondsLimit / 60).round();
-                  final percentage = (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit)
-                      .clamp(0.0, 1.0);
+                  final percentage =
+                      (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit).clamp(0.0, 1.0);
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [


### PR DESCRIPTION
MethodChannelShare.share
FlutterError - PlatformException(error, Non-empty title expected, null, null)

package:share_plus_platform_interface/method_channel/method_channel_share.dart:25

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/40d960fea757d7ea8a9d0c02bec36346?time=7d&types=crash&sessionEventKey=360a70d8129943bcac9c1cdd41f87ab6_2229656897544065193

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 StandardMethodCodec.decodeEnvelope + 653 (message_codecs.dart:653)
1  ???                            0x0 MethodChannel._invokeMethod + 367 (platform_channel.dart:367)
2  ???                            0x0 MethodChannelShare.share + 25 (method_channel_share.dart:25)
3  ???                            0x0 _UsagePageState._shareUsage + 203 (usage_page.dart:203)
```

Fix:

The iOS share_plus plugin (FPPSharePlusPlugin.m) throws PlatformException "Non-empty title expected" when the subject field in the method channel arguments is a present-but-empty NSString rather than nil. A previous commit added subject: periodTitle to the ShareParams call without guarding against empty strings. periodTitle comes from l10n keys (l10n.today, l10n.thisMonth, etc.) which can be empty in locales where a translation is missing. When the empty string is sent over the method channel, the iOS native layer receives it as @"" (truthy but zero-length), triggering the guard.

Fixed by coercing both periodTitle and shareText to null when empty so the keys are omitted from the platform map entirely, matching the defensive pattern applied to every other Share callsite in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)