### PR TITLE
fix: replace GestureDetector with Material+InkWell for developer API key '+' button on iOS

### DIFF
--- a/app/lib/pages/settings/widgets/developer_api_keys_section.dart
+++ b/app/lib/pages/settings/widgets/developer_api_keys_section.dart
@@ -35,24 +35,28 @@ class DeveloperApiKeysSection extends StatelessWidget {
   }
 
   Widget _buildCreateKeyButton(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        final provider = Provider.of<DevApiKeyProvider>(context, listen: false);
-        CreateDevApiKeySheet.show(context, provider);
-      },
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(color: Colors.white.withOpacity(0.1), borderRadius: BorderRadius.circular(20)),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const FaIcon(FontAwesomeIcons.plus, color: Colors.white, size: 10),
-            const SizedBox(width: 6),
-            Text(
-              context.l10n.createKey,
-              style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w500),
-            ),
-          ],
+    return Material(
+      color: Colors.white.withOpacity(0.1),
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        onTap: () {
+          final provider = Provider.of<DevApiKeyProvider>(context, listen: false);
+          CreateDevApiKeySheet.show(context, provider);
+        },
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const FaIcon(FontAwesomeIcons.plus, color: Colors.white, size: 10),
+              const SizedBox(width: 6),
+              Text(
+                context.l10n.createKey,
+                style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w500),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #4465

## Problem
The '+' button in Developer API Keys section is not tappable on iPhone.

## Root Cause
The button uses bare GestureDetector which doesn't handle iOS tap events reliably in this layout context. The MCP section uses the same pattern but works because it has a different parent widget structure.

## Fix
Replaced GestureDetector with Material + InkWell (matching the _buildDocsButton pattern in the same file). This provides:
- Proper iOS hit testing
- Visual tap feedback (ink splash)
- Consistent behavior with the Docs button in the same header row