### PR TITLE
fix: disable 'Update App' button when no changes are made + fix iOS '+' button tap

### DIFF
--- a/app/lib/pages/apps/providers/add_app_provider.dart
+++ b/app/lib/pages/apps/providers/add_app_provider.dart
@@ -76,7 +76,10 @@ class AddAppProvider extends ChangeNotifier {
   bool isUpdating = false;
   bool isSubmitting = false;
   bool isValid = false;
+  bool hasChanges = false;
   bool isGenratingDescription = false;
+
+  App? _originalApp;
 
   bool allowPaidApps = false;
 
@@ -214,7 +217,9 @@ class AddAppProvider extends ChangeNotifier {
     thumbnailUrls = app.thumbnailUrls;
     thumbnailIds = app.thumbnailIds;
 
+    _originalApp = app;
     isValid = false;
+    hasChanges = false;
     setIsLoading(false);
     notifyListeners();
   }
@@ -338,49 +343,33 @@ class AddAppProvider extends ChangeNotifier {
   }
 
   bool hasDataChanged(App app, String category) {
-    if (imageFile != null) {
-      return true;
-    }
-    if (appNameController.text != app.name) {
-      return true;
-    }
-    if (appDescriptionController.text != app.description) {
-      return true;
-    }
-    if (makeAppPublic != !app.private) {
-      return true;
-    }
-    if (appCategory != category) {
-      return true;
-    }
-    if (selectedCapabilities.length != app.capabilities.length) {
-      return true;
-    }
+    if (imageFile != null) return true;
+    if (appNameController.text != app.name.decodeString) return true;
+    if (appDescriptionController.text != app.description.decodeString) return true;
+    if (makeAppPublic != !app.private) return true;
+    if (appCategory != category) return true;
+    if (selectedCapabilities.length != app.capabilities.length) return true;
     if (app.externalIntegration != null) {
-      if (triggerEvent != app.externalIntegration!.triggersOn) {
-        return true;
-      }
-      if (webhookUrlController.text != app.externalIntegration!.webhookUrl) {
-        return true;
-      }
-      if (setupCompletedController.text != app.externalIntegration!.setupCompletedUrl) {
-        return true;
-      }
-      if (instructionsController.text != app.externalIntegration!.setupInstructionsFilePath) {
-        return true;
-      }
+      if (triggerEvent != app.externalIntegration!.triggersOn) return true;
+      if (webhookUrlController.text != app.externalIntegration!.webhookUrl) return true;
+      if (setupCompletedController.text != app.externalIntegration!.setupCompletedUrl) return true;
+      if (instructionsController.text != app.externalIntegration!.setupInstructionsFilePath) return true;
+      if (appHomeUrlController.text != app.externalIntegration!.appHomeUrl) return true;
+      if (chatToolsManifestUrlController.text != app.externalIntegration!.chatToolsManifestUrl) return true;
     }
-    if (chatPromptController.text != app.chatPrompt) {
-      return true;
-    }
-    if (conversationPromptController.text != app.conversationPrompt) {
-      return true;
-    }
+    if (chatPromptController.text != (app.chatPrompt ?? '').decodeString) return true;
+    if (conversationPromptController.text != (app.conversationPrompt ?? '').decodeString) return true;
+    if (sourceCodeUrlController.text != (app.sourceCodeUrl ?? '')) return true;
+    if (isPaid != app.isPaid) return true;
+    if (selectePaymentPlan != app.paymentPlan) return true;
+    if (priceController.text != app.price.toString()) return true;
+    if (!listEquals(thumbnailIds, app.thumbnailIds)) return true;
     return false;
   }
 
   void checkValidity() {
     isValid = isFormValid();
+    hasChanges = _originalApp != null && hasDataChanged(_originalApp!, _originalApp!.category);
     notifyListeners();
   }
 

--- a/app/lib/pages/apps/update_app.dart
+++ b/app/lib/pages/apps/update_app.dart
@@ -464,7 +464,7 @@ class _UpdateAppPageState extends State<UpdateAppPage> {
                       ),
                     ),
                     child: GestureDetector(
-                      onTap: !provider.isValid
+                      onTap: !provider.isValid || !provider.hasChanges
                           ? null
                           : () {
                               var isValid = provider.validateForm();
@@ -488,12 +488,12 @@ class _UpdateAppPageState extends State<UpdateAppPage> {
                                 );
                               }
                             },
-                      child: Container(
-                        padding: const EdgeInsets.all(12.0),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(12.0),
-                          color: provider.isValid ? Colors.white : Colors.grey.shade700,
-                        ),
+                        child: Container(
+                          padding: const EdgeInsets.all(12.0),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12.0),
+                            color: provider.isValid && provider.hasChanges ? Colors.white : Colors.grey.shade700,
+                          ),
                         child: Text(
                           context.l10n.updateApp,
                           style: const TextStyle(color: Colors.black, fontSize: 16),

--- a/app/lib/pages/settings/widgets/developer_api_keys_section.dart
+++ b/app/lib/pages/settings/widgets/developer_api_keys_section.dart
@@ -35,24 +35,28 @@ class DeveloperApiKeysSection extends StatelessWidget {
   }
 
   Widget _buildCreateKeyButton(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        final provider = Provider.of<DevApiKeyProvider>(context, listen: false);
-        CreateDevApiKeySheet.show(context, provider);
-      },
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(color: Colors.white.withOpacity(0.1), borderRadius: BorderRadius.circular(20)),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const FaIcon(FontAwesomeIcons.plus, color: Colors.white, size: 10),
-            const SizedBox(width: 6),
-            Text(
-              context.l10n.createKey,
-              style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w500),
-            ),
-          ],
+    return Material(
+      color: Colors.white.withOpacity(0.1),
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        onTap: () {
+          final provider = Provider.of<DevApiKeyProvider>(context, listen: false);
+          CreateDevApiKeySheet.show(context, provider);
+        },
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const FaIcon(FontAwesomeIcons.plus, color: Colors.white, size: 10),
+              const SizedBox(width: 6),
+              Text(
+                context.l10n.createKey,
+                style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w500),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #3559, Fixes #4465

## Changes

### Issue #4465 - iOS '+' button not tappable
Replaced bare GestureDetector with Material+InkWell for the developer API key create button to fix iOS tap handling.

### Issue #3559 - Disable Update App button when no changes
- Store original app reference during prepareUpdate
- Added hasChanges flag computed by comparing current form against original app data
- Button is disabled when \!isValid || !hasChanges\
- Visual state reflects disabled state (grey when disabled)