### PR TITLE
fix: disable 'Update App' button when no changes are made

### DIFF
--- a/app/lib/pages/apps/providers/add_app_provider.dart
+++ b/app/lib/pages/apps/providers/add_app_provider.dart
@@ -76,7 +76,10 @@ class AddAppProvider extends ChangeNotifier {
   bool isUpdating = false;
   bool isSubmitting = false;
   bool isValid = false;
+  bool hasChanges = false;
   bool isGenratingDescription = false;
+
+  App? _originalApp;
 
   bool allowPaidApps = false;
 
@@ -214,7 +217,9 @@ class AddAppProvider extends ChangeNotifier {
     thumbnailUrls = app.thumbnailUrls;
     thumbnailIds = app.thumbnailIds;
 
+    _originalApp = app;
     isValid = false;
+    hasChanges = false;
     setIsLoading(false);
     notifyListeners();
   }
@@ -338,49 +343,33 @@ class AddAppProvider extends ChangeNotifier {
   }
 
   bool hasDataChanged(App app, String category) {
-    if (imageFile != null) {
-      return true;
-    }
-    if (appNameController.text != app.name) {
-      return true;
-    }
-    if (appDescriptionController.text != app.description) {
-      return true;
-    }
-    if (makeAppPublic != !app.private) {
-      return true;
-    }
-    if (appCategory != category) {
-      return true;
-    }
-    if (selectedCapabilities.length != app.capabilities.length) {
-      return true;
-    }
+    if (imageFile != null) return true;
+    if (appNameController.text != app.name.decodeString) return true;
+    if (appDescriptionController.text != app.description.decodeString) return true;
+    if (makeAppPublic != !app.private) return true;
+    if (appCategory != category) return true;
+    if (selectedCapabilities.length != app.capabilities.length) return true;
     if (app.externalIntegration != null) {
-      if (triggerEvent != app.externalIntegration!.triggersOn) {
-        return true;
-      }
-      if (webhookUrlController.text != app.externalIntegration!.webhookUrl) {
-        return true;
-      }
-      if (setupCompletedController.text != app.externalIntegration!.setupCompletedUrl) {
-        return true;
-      }
-      if (instructionsController.text != app.externalIntegration!.setupInstructionsFilePath) {
-        return true;
-      }
+      if (triggerEvent != app.externalIntegration!.triggersOn) return true;
+      if (webhookUrlController.text != app.externalIntegration!.webhookUrl) return true;
+      if (setupCompletedController.text != app.externalIntegration!.setupCompletedUrl) return true;
+      if (instructionsController.text != app.externalIntegration!.setupInstructionsFilePath) return true;
+      if (appHomeUrlController.text != app.externalIntegration!.appHomeUrl) return true;
+      if (chatToolsManifestUrlController.text != app.externalIntegration!.chatToolsManifestUrl) return true;
     }
-    if (chatPromptController.text != app.chatPrompt) {
-      return true;
-    }
-    if (conversationPromptController.text != app.conversationPrompt) {
-      return true;
-    }
+    if (chatPromptController.text != (app.chatPrompt ?? '').decodeString) return true;
+    if (conversationPromptController.text != (app.conversationPrompt ?? '').decodeString) return true;
+    if (sourceCodeUrlController.text != (app.sourceCodeUrl ?? '')) return true;
+    if (isPaid != app.isPaid) return true;
+    if (selectePaymentPlan != app.paymentPlan) return true;
+    if (priceController.text != app.price.toString()) return true;
+    if (!listEquals(thumbnailIds, app.thumbnailIds)) return true;
     return false;
   }
 
   void checkValidity() {
     isValid = isFormValid();
+    hasChanges = _originalApp != null && hasDataChanged(_originalApp!, _originalApp!.category);
     notifyListeners();
   }
 

--- a/app/lib/pages/apps/providers/add_app_provider.dart
+++ b/app/lib/pages/apps/providers/add_app_provider.dart
@@ -348,14 +348,17 @@ class AddAppProvider extends ChangeNotifier {
     if (appDescriptionController.text != app.description.decodeString) return true;
     if (makeAppPublic != !app.private) return true;
     if (appCategory != category) return true;
-    if (selectedCapabilities.length != app.capabilities.length) return true;
+    if (!listEquals(
+      selectedCapabilities.map((c) => c.id).toList()..sort(),
+      app.capabilities.map((c) => c.id).toList()..sort(),
+    )) return true;
     if (app.externalIntegration != null) {
       if (triggerEvent != app.externalIntegration!.triggersOn) return true;
-      if (webhookUrlController.text != app.externalIntegration!.webhookUrl) return true;
-      if (setupCompletedController.text != app.externalIntegration!.setupCompletedUrl) return true;
-      if (instructionsController.text != app.externalIntegration!.setupInstructionsFilePath) return true;
-      if (appHomeUrlController.text != app.externalIntegration!.appHomeUrl) return true;
-      if (chatToolsManifestUrlController.text != app.externalIntegration!.chatToolsManifestUrl) return true;
+      if (webhookUrlController.text != (app.externalIntegration!.webhookUrl ?? '')) return true;
+      if (setupCompletedController.text != (app.externalIntegration!.setupCompletedUrl ?? '')) return true;
+      if (instructionsController.text != (app.externalIntegration!.setupInstructionsFilePath ?? '')) return true;
+      if (appHomeUrlController.text != (app.externalIntegration!.appHomeUrl ?? '')) return true;
+      if (chatToolsManifestUrlController.text != (app.externalIntegration!.chatToolsManifestUrl ?? '')) return true;
     }
     if (chatPromptController.text != (app.chatPrompt ?? '').decodeString) return true;
     if (conversationPromptController.text != (app.conversationPrompt ?? '').decodeString) return true;

--- a/app/lib/pages/apps/update_app.dart
+++ b/app/lib/pages/apps/update_app.dart
@@ -464,7 +464,7 @@ class _UpdateAppPageState extends State<UpdateAppPage> {
                       ),
                     ),
                     child: GestureDetector(
-                      onTap: !provider.isValid
+                      onTap: !provider.isValid || !provider.hasChanges
                           ? null
                           : () {
                               var isValid = provider.validateForm();
@@ -488,12 +488,12 @@ class _UpdateAppPageState extends State<UpdateAppPage> {
                                 );
                               }
                             },
-                      child: Container(
-                        padding: const EdgeInsets.all(12.0),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(12.0),
-                          color: provider.isValid ? Colors.white : Colors.grey.shade700,
-                        ),
+                        child: Container(
+                          padding: const EdgeInsets.all(12.0),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12.0),
+                            color: provider.isValid && provider.hasChanges ? Colors.white : Colors.grey.shade700,
+                          ),
                         child: Text(
                           context.l10n.updateApp,
                           style: const TextStyle(color: Colors.black, fontSize: 16),


### PR DESCRIPTION
Fixes #3559

## Problem
The 'Update App' button appears enabled even when the user has not changed any fields, allowing no-op updates.

## Changes
- Store original app reference (_originalApp) when prepareUpdate is called
- Added hasChanges flag to AddAppProvider that compares current form state against original app data
- Button is now disabled when !isValid || !hasChanges
- Visual state (color) reflects the disabled state (grey when disabled)