### PR TITLE
feat: implement trash bin / soft delete for conversations (#5092)

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -115,15 +115,63 @@ Future<ServerConversation?> reProcessConversationServer(String conversationId, {
   return null;
 }
 
-Future<bool> deleteConversationServer(String conversationId) async {
+Future<bool> deleteConversationServer(String conversationId, {bool permanent = false}) async {
   var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/conversations/$conversationId?cascade=true',
+    url: '${Env.apiBaseUrl}v1/conversations/$conversationId?cascade=true&permanent=$permanent',
     headers: {},
     method: 'DELETE',
     body: '',
   );
   if (response == null) return false;
   Logger.debug('deleteConversation: ${response.statusCode}');
+  return response.statusCode == 204;
+}
+
+Future<List<ServerConversation>> getTrashedConversationsServer({int limit = 50}) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/trash/conversations?limit=$limit',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return [];
+  if (response.statusCode == 200) {
+    final list = jsonDecode(response.body) as List;
+    return list.map((item) => ServerConversation.fromJson(item)).toList();
+  }
+  return [];
+}
+
+Future<bool> restoreConversationServer(String conversationId) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/trash/conversations/$conversationId/restore',
+    headers: {},
+    method: 'POST',
+    body: '',
+  );
+  if (response == null) return false;
+  return response.statusCode == 204;
+}
+
+Future<bool> permanentlyDeleteTrashedConversationServer(String conversationId) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/trash/conversations/$conversationId',
+    headers: {},
+    method: 'DELETE',
+    body: '',
+  );
+  if (response == null) return false;
+  return response.statusCode == 204;
+}
+
+Future<bool> emptyTrashServer({int olderThanDays = 0}) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/trash/conversations?older_than_days=$olderThanDays',
+    headers: {},
+    method: 'DELETE',
+    body: '',
+  );
+  if (response == null) return false;
   return response.statusCode == 204;
 }
 

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -257,6 +257,7 @@ class ServerConversation {
 
   ConversationStatus status;
   bool discarded;
+  DateTime? deletedAt;
   final bool deleted;
   final bool isLocked;
   bool starred;
@@ -279,6 +280,7 @@ class ServerConversation {
     this.photos = const [],
     this.audioFiles = const [],
     this.discarded = false,
+    this.deletedAt,
     this.deleted = false,
     this.source,
     this.language,
@@ -311,6 +313,7 @@ class ServerConversation {
           : [],
       audioFiles: ((json['audio_files'] ?? []) as List<dynamic>).map((af) => AudioFile.fromJson(af)).toList(),
       discarded: json['discarded'] ?? false,
+      deletedAt: json['deleted_at'] != null ? DateTime.parse(json['deleted_at']).toLocal() : null,
       source: json['source'] != null ? ConversationSource.values.asNameMap()[json['source']] : ConversationSource.omi,
       language: json['language'],
       deleted: json['deleted'] ?? false,

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11022,5 +11022,57 @@
     "syncCustomSttWarningMessage": "You use your own transcription provider. Syncing these recordings transcribes them on Omi's servers instead, and they count toward your plan's transcription limit.",
     "@syncCustomSttWarningMessage": {
         "description": "Body warning that syncing transcribes on Omi servers and counts toward the plan limit"
+    },
+    "trash": "Trash",
+    "@trash": {
+        "description": "Navigation label for the trash / soft-delete page"
+    },
+    "trashIsEmpty": "Trash is empty",
+    "@trashIsEmpty": {
+        "description": "Placeholder text when there are no trashed conversations"
+    },
+    "deletedConversationsAppearHere": "Deleted conversations appear here",
+    "@deletedConversationsAppearHere": {
+        "description": "Subtitle placeholder when trash is empty"
+    },
+    "deletePermanentlyTitle": "Delete permanently?",
+    "@deletePermanentlyTitle": {
+        "description": "Title for permanent delete confirmation dialog"
+    },
+    "deletePermanentlyMessage": "This conversation will be permanently deleted and cannot be recovered.",
+    "@deletePermanentlyMessage": {
+        "description": "Message for permanent delete confirmation dialog"
+    },
+    "deletePermanently": "Delete",
+    "@deletePermanently": {
+        "description": "Button label to permanently delete a conversation from trash"
+    },
+    "emptyTrash": "Empty Trash",
+    "@emptyTrash": {
+        "description": "Button label to empty all trashed conversations"
+    },
+    "emptyTrashTitle": "Empty Trash?",
+    "@emptyTrashTitle": {
+        "description": "Title for empty trash confirmation dialog"
+    },
+    "emptyTrashMessage": "All trashed conversations will be permanently deleted.",
+    "@emptyTrashMessage": {
+        "description": "Message for empty trash confirmation dialog"
+    },
+    "deletedDate": "Deleted {date}",
+    "@deletedDate": {
+        "description": "Shows when a conversation was deleted, e.g. 'Deleted 15/3/2025'"
+    },
+    "restore": "Restore",
+    "@restore": {
+        "description": "Tooltip for restore button"
+    },
+    "deletePermanentlyTooltip": "Delete permanently",
+    "@deletePermanentlyTooltip": {
+        "description": "Tooltip for permanent delete button"
+    },
+    "recently": "Recently",
+    "@recently": {
+        "description": "Label shown when deletion date is not available"
     }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17378,6 +17378,84 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You use your own transcription provider. Syncing these recordings transcribes them on Omi\'s servers instead, and they count toward your plan\'s transcription limit.'**
   String get syncCustomSttWarningMessage;
+
+  /// Navigation label for the trash / soft-delete page
+  ///
+  /// In en, this message translates to:
+  /// **'Trash'**
+  String get trash;
+
+  /// Placeholder text when there are no trashed conversations
+  ///
+  /// In en, this message translates to:
+  /// **'Trash is empty'**
+  String get trashIsEmpty;
+
+  /// Subtitle placeholder when trash is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted conversations appear here'**
+  String get deletedConversationsAppearHere;
+
+  /// Title for permanent delete confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Delete permanently?'**
+  String get deletePermanentlyTitle;
+
+  /// Message for permanent delete confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'This conversation will be permanently deleted and cannot be recovered.'**
+  String get deletePermanentlyMessage;
+
+  /// Button label to permanently delete a conversation from trash
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get deletePermanently;
+
+  /// Button label to empty all trashed conversations
+  ///
+  /// In en, this message translates to:
+  /// **'Empty Trash'**
+  String get emptyTrash;
+
+  /// Title for empty trash confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Empty Trash?'**
+  String get emptyTrashTitle;
+
+  /// Message for empty trash confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'All trashed conversations will be permanently deleted.'**
+  String get emptyTrashMessage;
+
+  /// Shows when a conversation was deleted, e.g. 'Deleted 15/3/2025'
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted {date}'**
+  String deletedDate(Object date);
+
+  /// Tooltip for restore button
+  ///
+  /// In en, this message translates to:
+  /// **'Restore'**
+  String get restore;
+
+  /// Tooltip for permanent delete button
+  ///
+  /// In en, this message translates to:
+  /// **'Delete permanently'**
+  String get deletePermanentlyTooltip;
+
+  /// Label shown when deletion date is not available
+  ///
+  /// In en, this message translates to:
+  /// **'Recently'**
+  String get recently;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9268,4 +9268,45 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'أنت تستخدم مزوّد النسخ الخاص بك. مزامنة هذه التسجيلات تنسخها على خوادم Omi بدلاً من ذلك، وتُحتسب ضمن حد النسخ في باقتك.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9351,4 +9351,45 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Вы карыстаецеся ўласным сэрвісам транскрыпцыі. Сінхранізацыя гэтых запісаў транскрыбуе іх на серверах Omi, і яны залічацца ў ліміт транскрыпцыі вашага тарыфу.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9358,4 +9358,45 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Използвате собствен доставчик за транскрипция. Синхронизирането на тези записи ги транскрибира на сървърите на Omi и те се отчитат към лимита за транскрипция на вашия план.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9330,4 +9330,45 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'আপনি নিজের ট্রান্সক্রিপশন প্রদানকারী ব্যবহার করেন। এই রেকর্ডিংগুলি সিঙ্ক করলে সেগুলি Omi-এর সার্ভারে ট্রান্সক্রাইব হবে এবং আপনার প্ল্যানের ট্রান্সক্রিপশন সীমার মধ্যে গণনা হবে।';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9348,4 +9348,45 @@ class AppLocalizationsBs extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Koristite vlastiti provajder transkripcije. Sinkronizacija ovih snimaka transkribuje ih na Omi serverima i broje se u limit transkripcije vašeg plana.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9377,4 +9377,45 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Utilitzes el teu propi proveïdor de transcripció. Sincronitzar aquests enregistraments els transcriu als servidors d\'Omi i compten per al límit de transcripció del teu pla.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9323,4 +9323,45 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Používáte vlastního poskytovatele přepisu. Synchronizace těchto nahrávek je přepíše na serverech Omi a započítají se do limitu přepisu vašeho tarifu.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9308,4 +9308,45 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Du bruger din egen transskriptionsudbyder. Synkronisering af disse optagelser transskriberer dem på Omis servere i stedet, og de tæller med i din plans transskriptionsgrænse.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9400,4 +9400,45 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Du verwendest einen eigenen Transkriptionsanbieter. Beim Synchronisieren werden diese Aufnahmen stattdessen auf den Servern von Omi transkribiert und auf das Transkriptionslimit deines Tarifs angerechnet.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9389,4 +9389,45 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Χρησιμοποιείτε δικό σας πάροχο μεταγραφής. Ο συγχρονισμός αυτών των ηχογραφήσεων τις μεταγράφει στους διακομιστές του Omi και προσμετρώνται στο όριο μεταγραφής του προγράμματός σας.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9318,4 +9318,45 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'You use your own transcription provider. Syncing these recordings transcribes them on Omi\'s servers instead, and they count toward your plan\'s transcription limit.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9344,4 +9344,45 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Usas tu propio proveedor de transcripción. Sincronizar estas grabaciones las transcribe en los servidores de Omi y cuentan para el límite de transcripción de tu plan.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9320,4 +9320,45 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Kasutate oma transkriptsiooniteenust. Nende salvestiste sünkroonimine transkribeerib need Omi serverites ja need arvestatakse teie paketi transkriptsioonilimiidi sisse.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9325,4 +9325,45 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'شما از سرویس رونویسی خودتان استفاده می‌کنید. همگام‌سازی این ضبط‌ها آن‌ها را روی سرورهای Omi رونویسی می‌کند و در سقف رونویسی پلن شما محاسبه می‌شوند.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9323,4 +9323,45 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Käytät omaa litterointipalveluasi. Näiden tallenteiden synkronointi litteroi ne Omin palvelimilla, ja ne lasketaan tilauksesi litterointirajaan.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9407,4 +9407,45 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Vous utilisez votre propre fournisseur de transcription. Synchroniser ces enregistrements les transcrit sur les serveurs d\'Omi et ils comptent dans la limite de transcription de votre forfait.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9253,4 +9253,45 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'אתה משתמש בספק תמלול משלך. סנכרון ההקלטות האלה יתמלל אותן בשרתי Omi והן ייכללו במגבלת התמלול של התוכנית שלך.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9300,4 +9300,45 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'आप अपना स्वयं का ट्रांसक्रिप्शन प्रदाता उपयोग करते हैं। इन रिकॉर्डिंग को सिंक करने पर ये Omi के सर्वर पर ट्रांसक्राइब होंगी और आपकी योजना की ट्रांसक्रिप्शन सीमा में गिनी जाएंगी।';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9355,4 +9355,45 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Koristite vlastiti pružatelj transkripcije. Sinkronizacija ovih snimaka transkribira ih na Omijevim poslužiteljima i broje se u ograničenje transkripcije vašeg plana.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9363,4 +9363,45 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Saját átírási szolgáltatót használsz. Ezek a felvételek szinkronizáláskor az Omi szerverein kerülnek átírásra, és beleszámítanak a csomagod átírási keretébe.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9331,4 +9331,45 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Anda memakai penyedia transkripsi sendiri. Menyinkronkan rekaman ini akan mentranskripsikannya di server Omi dan dihitung dalam batas transkripsi paket Anda.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9378,4 +9378,45 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Usi un tuo fornitore di trascrizione. Sincronizzare queste registrazioni le trascrive sui server di Omi e contano per il limite di trascrizione del tuo piano.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9172,4 +9172,45 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'ご自身の文字起こしプロバイダーを使用しています。これらの録音を同期すると Omi のサーバーで文字起こしされ、プランの文字起こし上限にカウントされます。';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9354,4 +9354,45 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'ನೀವು ನಿಮ್ಮ ಸ್ವಂತ ಪ್ರತಿಲೇಖನ ಪೂರೈಕೆದಾರರನ್ನು ಬಳಸುತ್ತೀರಿ. ಈ ಧ್ವನಿಮುದ್ರಣಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಿದರೆ ಅವು Omi ಸರ್ವರ್‌ಗಳಲ್ಲಿ ಪ್ರತಿಲೇಖನಗೊಳ್ಳುತ್ತವೆ ಮತ್ತು ನಿಮ್ಮ ಯೋಜನೆಯ ಪ್ರತಿಲೇಖನ ಮಿತಿಗೆ ಎಣಿಸಲಾಗುತ್ತದೆ.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9173,4 +9173,45 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get syncCustomSttWarningMessage => '직접 설정한 전사 제공자를 사용 중입니다. 이 녹음을 동기화하면 Omi 서버에서 전사되며 요금제의 전사 한도에 포함됩니다.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9337,4 +9337,45 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Naudojate savo transkripcijos paslaugą. Sinchronizuojant šiuos įrašus jie transkribuojami Omi serveriuose ir įskaičiuojami į jūsų plano transkripcijos limitą.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9345,4 +9345,45 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Jūs izmantojat savu transkripcijas pakalpojumu. Šo ierakstu sinhronizēšana tos transkribē Omi serveros, un tie tiek ieskaitīti jūsu plāna transkripcijas limitā.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9372,4 +9372,45 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Користите сопствен провајдер за транскрипција. Синхронизирањето на овие снимки ги транскрибира на серверите на Omi и се сметаат во лимитот за транскрипција на вашиот план.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9333,4 +9333,45 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'तुम्ही तुमचा स्वतःचा ट्रान्सक्रिप्शन प्रदाता वापरता. ही रेकॉर्डिंग सिंक केल्यास ती Omi च्या सर्व्हरवर ट्रान्सक्राइब होतील आणि तुमच्या प्लॅनच्या ट्रान्सक्रिप्शन मर्यादेत मोजली जातील.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9346,4 +9346,45 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Anda menggunakan penyedia transkripsi sendiri. Menyegerakkan rakaman ini akan mentranskripsikannya di pelayan Omi dan dikira dalam had transkripsi pelan anda.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9349,4 +9349,45 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Je gebruikt je eigen transcriptieprovider. Door deze opnames te synchroniseren worden ze op de servers van Omi getranscribeerd en tellen ze mee voor de transcriptielimiet van je abonnement.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9320,4 +9320,45 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Du bruker din egen transkripsjonsleverandør. Synkronisering av disse opptakene transkriberer dem på Omis servere, og de teller mot transkripsjonsgrensen i abonnementet ditt.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9348,4 +9348,45 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Używasz własnego dostawcy transkrypcji. Synchronizacja tych nagrań transkrybuje je na serwerach Omi i są wliczane do limitu transkrypcji w Twoim planie.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9328,4 +9328,45 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Você usa seu próprio provedor de transcrição. Sincronizar estas gravações as transcreve nos servidores da Omi e elas contam para o limite de transcrição do seu plano.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9368,4 +9368,45 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Folosești propriul furnizor de transcriere. Sincronizarea acestor înregistrări le transcrie pe serverele Omi și se iau în calcul pentru limita de transcriere a planului tău.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9356,4 +9356,45 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Вы используете собственный сервис транскрипции. Синхронизация этих записей расшифрует их на серверах Omi, и они будут засчитаны в лимит транскрипции вашего тарифа.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9315,4 +9315,45 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Používate vlastného poskytovateľa prepisu. Synchronizácia týchto nahrávok ich prepíše na serveroch Omi a započítajú sa do limitu prepisu vášho plánu.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9350,4 +9350,45 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Uporabljate svojega ponudnika prepisa. Sinhronizacija teh posnetkov jih prepiše na strežnikih Omi in se štejejo v omejitev prepisa vašega paketa.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9335,4 +9335,45 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Користите сопственог пружаоца транскрипције. Синхронизација ових снимака их транскрибује на Omi серверима и рачунају се у лимит транскрипције вашег плана.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9328,4 +9328,45 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Du använder din egen transkriberingsleverantör. Att synkronisera dessa inspelningar transkriberar dem på Omis servrar i stället, och de räknas mot din plans transkriberingsgräns.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9389,4 +9389,45 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'நீங்கள் உங்கள் சொந்த படியெடுப்பு வழங்குநரைப் பயன்படுத்துகிறீர்கள். இந்தப் பதிவுகளை ஒத்திசைத்தால் அவை Omi சேவையகங்களில் படியெடுக்கப்படும், மேலும் உங்கள் திட்டத்தின் படியெடுப்பு வரம்பில் கணக்கிடப்படும்.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9372,4 +9372,45 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'మీరు మీ సొంత ట్రాన్స్‌క్రిప్షన్ ప్రొవైడర్‌ను ఉపయోగిస్తున్నారు. ఈ రికార్డింగ్‌లను సింక్ చేస్తే అవి Omi సర్వర్‌లలో ట్రాన్స్‌క్రైబ్ చేయబడతాయి మరియు మీ ప్లాన్ ట్రాన్స్‌క్రిప్షన్ పరిమితిలో లెక్కించబడతాయి.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9273,4 +9273,45 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'คุณใช้ผู้ให้บริการถอดเสียงของคุณเอง การซิงค์การบันทึกเหล่านี้จะถอดเสียงบนเซิร์ฟเวอร์ของ Omi และจะนับรวมในขีดจำกัดการถอดเสียงของแพ็กเกจของคุณ';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9408,4 +9408,45 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Gumagamit ka ng sarili mong transcription provider. Kapag in-sync ang mga recording na ito, ita-transcribe ang mga ito sa mga server ng Omi at mabibilang sa limitasyon ng transcription ng iyong plan.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9334,4 +9334,45 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Kendi transkripsiyon sağlayıcınızı kullanıyorsunuz. Bu kayıtları eşitlemek onları Omi sunucularında yazıya döker ve planınızın transkripsiyon sınırına sayılır.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9341,4 +9341,45 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Ви використовуєте власний сервіс транскрипції. Синхронізація цих записів розшифрує їх на серверах Omi, і вони зараховуються до ліміту транскрипції вашого тарифу.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9337,4 +9337,45 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'آپ اپنا ذاتی ٹرانسکرپشن فراہم کنندہ استعمال کرتے ہیں۔ ان ریکارڈنگز کو سنک کرنے پر یہ Omi کے سرورز پر ٹرانسکرائب ہوں گی اور آپ کے پلان کی ٹرانسکرپشن حد میں شمار ہوں گی۔';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9321,4 +9321,45 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get syncCustomSttWarningMessage =>
       'Bạn đang dùng nhà cung cấp phiên âm riêng. Đồng bộ các bản ghi này sẽ phiên âm chúng trên máy chủ của Omi và được tính vào giới hạn phiên âm của gói của bạn.';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9157,4 +9157,45 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get syncCustomSttWarningMessage => '您使用的是自己的转录服务。同步这些录音会改为在 Omi 的服务器上转录，并计入您套餐的转录额度。';
+
+  @override
+  String get trash => 'Trash';
+
+  @override
+  String get trashIsEmpty => 'Trash is empty';
+
+  @override
+  String get deletedConversationsAppearHere => 'Deleted conversations appear here';
+
+  @override
+  String get deletePermanentlyTitle => 'Delete permanently?';
+
+  @override
+  String get deletePermanentlyMessage => 'This conversation will be permanently deleted and cannot be recovered.';
+
+  @override
+  String get deletePermanently => 'Delete';
+
+  @override
+  String get emptyTrash => 'Empty Trash';
+
+  @override
+  String get emptyTrashTitle => 'Empty Trash?';
+
+  @override
+  String get emptyTrashMessage => 'All trashed conversations will be permanently deleted.';
+
+  @override
+  String deletedDate(Object date) {
+    return 'Deleted $date';
+  }
+
+  @override
+  String get restore => 'Restore';
+
+  @override
+  String get deletePermanentlyTooltip => 'Delete permanently';
+
+  @override
+  String get recently => 'Recently';
 }

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/widgets/shimmer_with_timeout.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/pages/capture/widgets/widgets.dart';
+import 'package:omi/pages/conversations/trash_page.dart';
 import 'package:omi/pages/conversations/widgets/daily_summaries_list.dart';
 import 'package:omi/pages/conversations/widgets/folder_tabs.dart';
 import 'package:omi/pages/conversations/widgets/goals_widget.dart';
@@ -332,6 +334,36 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                             convoProvider.showDailySummaries ? context.l10n.dailyRecaps : context.l10n.conversations,
                             style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
                           ),
+                          if (!convoProvider.showDailySummaries)
+                            Row(
+                              children: [
+                                GestureDetector(
+                                  onTap: () {
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(builder: (_) => const TrashPage()),
+                                    );
+                                  },
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                                    decoration: BoxDecoration(
+                                      color: Colors.white.withOpacity(0.1),
+                                      borderRadius: BorderRadius.circular(16),
+                                    ),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        FaIcon(FontAwesomeIcons.trash, color: Colors.grey.shade400, size: 11),
+                                        const SizedBox(width: 4),
+                                        Text(
+                                          'Trash',
+                                          style: TextStyle(color: Colors.grey.shade400, fontSize: 12),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
                         ],
                       ),
                     ),

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -355,7 +355,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                                         FaIcon(FontAwesomeIcons.trash, color: Colors.grey.shade400, size: 11),
                                         const SizedBox(width: 4),
                                         Text(
-                                          'Trash',
+                                          context.l10n.trash,
                                           style: TextStyle(color: Colors.grey.shade400, fontSize: 12),
                                         ),
                                       ],

--- a/app/lib/pages/conversations/trash_page.dart
+++ b/app/lib/pages/conversations/trash_page.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class TrashPage extends StatefulWidget {
+  const TrashPage({super.key});
+
+  @override
+  State<TrashPage> createState() => _TrashPageState();
+}
+
+class _TrashPageState extends State<TrashPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ConversationProvider>().fetchTrashedConversations();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0D0D),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF0D0D0D),
+        elevation: 0,
+        leading: IconButton(
+          icon: const FaIcon(FontAwesomeIcons.chevronLeft, size: 18),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: const Text(
+          'Trash',
+          style: TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+        ),
+        centerTitle: true,
+        actions: [
+          Consumer<ConversationProvider>(
+            builder: (context, provider, child) {
+              if (provider.trashedConversations.isEmpty) return const SizedBox.shrink();
+              return TextButton(
+                onPressed: () => _showEmptyTrashDialog(context, provider),
+                child: Text(
+                  'Empty Trash',
+                  style: TextStyle(color: Colors.redAccent.shade200, fontWeight: FontWeight.w500),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Consumer<ConversationProvider>(
+        builder: (context, provider, child) {
+          if (provider.isLoadingTrash) {
+            return const Center(child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white));
+          }
+          if (provider.trashedConversations.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FaIcon(FontAwesomeIcons.trash, color: Colors.grey.shade600, size: 48),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Trash is empty',
+                    style: TextStyle(color: Colors.grey.shade400, fontSize: 18, fontWeight: FontWeight.w500),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Deleted conversations appear here',
+                    style: TextStyle(color: Colors.grey.shade600, fontSize: 14),
+                  ),
+                ],
+              ),
+            );
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            itemCount: provider.trashedConversations.length,
+            separatorBuilder: (_, __) => const Divider(height: 1, color: Color(0xFF3C3C43)),
+            itemBuilder: (context, index) {
+              final conversation = provider.trashedConversations[index];
+              return _TrashItem(
+                conversation: conversation,
+                onRestore: () => provider.restoreConversationFromTrash(conversation.id),
+                onPermanentDelete: () => _confirmPermanentDelete(context, provider, conversation),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _confirmPermanentDelete(BuildContext context, ConversationProvider provider, ServerConversation conversation) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        title: const Text('Delete permanently?', style: TextStyle(color: Colors.white)),
+        content: const Text(
+          'This conversation will be permanently deleted and cannot be recovered.',
+          style: TextStyle(color: Colors.white70),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              provider.permanentlyDeleteFromTrash(conversation.id);
+            },
+            child: Text('Delete', style: TextStyle(color: Colors.redAccent.shade200)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showEmptyTrashDialog(BuildContext context, ConversationProvider provider) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        title: const Text('Empty Trash?', style: TextStyle(color: Colors.white)),
+        content: const Text(
+          'All trashed conversations will be permanently deleted.',
+          style: TextStyle(color: Colors.white70),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              provider.emptyTrash();
+            },
+            child: Text('Empty', style: TextStyle(color: Colors.redAccent.shade200)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrashItem extends StatelessWidget {
+  final ServerConversation conversation;
+  final VoidCallback onRestore;
+  final VoidCallback onPermanentDelete;
+
+  const _TrashItem({
+    required this.conversation,
+    required this.onRestore,
+    required this.onPermanentDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final title = conversation.structured.title ?? 'Untitled';
+    final deletedAt = conversation.deletedAt;
+    final deletedDate = deletedAt != null
+        ? '${deletedAt.day}/${deletedAt.month}/${deletedAt.year}'
+        : 'Recently';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w500),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Deleted $deletedDate',
+                  style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const FaIcon(FontAwesomeIcons.rotateLeft, color: Colors.white, size: 14),
+            tooltip: 'Restore',
+            onPressed: onRestore,
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            icon: FaIcon(FontAwesomeIcons.trashCan, color: Colors.redAccent.shade200, size: 14),
+            tooltip: 'Delete permanently',
+            onPressed: onPermanentDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/pages/conversations/trash_page.dart
+++ b/app/lib/pages/conversations/trash_page.dart
@@ -34,9 +34,9 @@ class _TrashPageState extends State<TrashPage> {
           icon: const FaIcon(FontAwesomeIcons.chevronLeft, size: 18),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: const Text(
-          'Trash',
-          style: TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+        title: Text(
+          context.l10n.trash,
+          style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
         ),
         centerTitle: true,
         actions: [
@@ -46,7 +46,7 @@ class _TrashPageState extends State<TrashPage> {
               return TextButton(
                 onPressed: () => _showEmptyTrashDialog(context, provider),
                 child: Text(
-                  'Empty Trash',
+                  context.l10n.emptyTrash,
                   style: TextStyle(color: Colors.redAccent.shade200, fontWeight: FontWeight.w500),
                 ),
               );
@@ -67,12 +67,12 @@ class _TrashPageState extends State<TrashPage> {
                   FaIcon(FontAwesomeIcons.trash, color: Colors.grey.shade600, size: 48),
                   const SizedBox(height: 16),
                   Text(
-                    'Trash is empty',
+                    context.l10n.trashIsEmpty,
                     style: TextStyle(color: Colors.grey.shade400, fontSize: 18, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Deleted conversations appear here',
+                    context.l10n.deletedConversationsAppearHere,
                     style: TextStyle(color: Colors.grey.shade600, fontSize: 14),
                   ),
                 ],
@@ -102,49 +102,49 @@ class _TrashPageState extends State<TrashPage> {
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: const Color(0xFF1C1C1E),
-        title: const Text('Delete permanently?', style: TextStyle(color: Colors.white)),
-        content: const Text(
-          'This conversation will be permanently deleted and cannot be recovered.',
-          style: TextStyle(color: Colors.white70),
+        title: Text(context.l10n.deletePermanentlyTitle, style: const TextStyle(color: Colors.white)),
+        content: Text(
+          context.l10n.deletePermanentlyMessage,
+          style: const TextStyle(color: Colors.white70),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
+            child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
           ),
           TextButton(
             onPressed: () {
               Navigator.of(ctx).pop();
               provider.permanentlyDeleteFromTrash(conversation.id);
             },
-            child: Text('Delete', style: TextStyle(color: Colors.redAccent.shade200)),
+            child: Text(context.l10n.deletePermanently, style: TextStyle(color: Colors.redAccent.shade200)),
           ),
         ],
       ),
     );
   }
 
-  void _showEmptyTrashDialog(BuildContext context, ConversationProvider provider) {
+  void _showEmptyTrashDialog(BuildContext dialogContext, ConversationProvider provider) {
     showDialog(
-      context: context,
+      context: dialogContext,
       builder: (ctx) => AlertDialog(
         backgroundColor: const Color(0xFF1C1C1E),
-        title: const Text('Empty Trash?', style: TextStyle(color: Colors.white)),
-        content: const Text(
-          'All trashed conversations will be permanently deleted.',
-          style: TextStyle(color: Colors.white70),
+        title: Text(context.l10n.emptyTrashTitle, style: const TextStyle(color: Colors.white)),
+        content: Text(
+          context.l10n.emptyTrashMessage,
+          style: const TextStyle(color: Colors.white70),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
+            child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
           ),
           TextButton(
             onPressed: () {
               Navigator.of(ctx).pop();
               provider.emptyTrash();
             },
-            child: Text('Empty', style: TextStyle(color: Colors.redAccent.shade200)),
+            child: Text(context.l10n.emptyTrash, style: TextStyle(color: Colors.redAccent.shade200)),
           ),
         ],
       ),
@@ -165,11 +165,11 @@ class _TrashItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final title = conversation.structured.title ?? 'Untitled';
+    final title = conversation.structured.title;
     final deletedAt = conversation.deletedAt;
     final deletedDate = deletedAt != null
         ? '${deletedAt.day}/${deletedAt.month}/${deletedAt.year}'
-        : 'Recently';
+        : context.l10n.recently;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12),
@@ -187,7 +187,7 @@ class _TrashItem extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Deleted $deletedDate',
+                  context.l10n.deletedDate(deletedDate),
                   style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
                 ),
               ],
@@ -195,13 +195,13 @@ class _TrashItem extends StatelessWidget {
           ),
           IconButton(
             icon: const FaIcon(FontAwesomeIcons.rotateLeft, color: Colors.white, size: 14),
-            tooltip: 'Restore',
+            tooltip: context.l10n.restore,
             onPressed: onRestore,
           ),
           const SizedBox(width: 4),
           IconButton(
             icon: FaIcon(FontAwesomeIcons.trashCan, color: Colors.redAccent.shade200, size: 14),
-            tooltip: 'Delete permanently',
+            tooltip: context.l10n.deletePermanentlyTooltip,
             onPressed: onPermanentDelete,
           ),
         ],

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -788,7 +788,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void deleteConversationOnServer(String conversationId) {
-    deleteConversationServer(conversationId);
+    deleteConversationServer(conversationId, permanent: false);
     memoriesToDelete.remove(conversationId);
     deleteTimestamps.remove(conversationId);
     if (lastDeletedConversationId == conversationId) {
@@ -815,8 +815,50 @@ class ConversationProvider extends ChangeNotifier {
   void deleteConversation(ServerConversation conversation) {
     conversations.removeWhere((element) => element.id == conversation.id);
     searchedConversations.removeWhere((element) => element.id == conversation.id);
-    deleteConversationServer(conversation.id);
+    deleteConversationServer(conversation.id, permanent: true);
     groupConversationsByDate();
+  }
+
+  /////////////////////////////////////////////////////////////////
+  ////////// Trash / Soft Delete Functionality ///////////////////
+  /////////////////////////////////////////////////////////////////
+
+  List<ServerConversation> trashedConversations = [];
+  bool isLoadingTrash = false;
+
+  Future<void> fetchTrashedConversations() async {
+    isLoadingTrash = true;
+    notifyListeners();
+    trashedConversations = await getTrashedConversationsServer();
+    isLoadingTrash = false;
+    notifyListeners();
+  }
+
+  Future<bool> restoreConversationFromTrash(String conversationId) async {
+    final ok = await restoreConversationServer(conversationId);
+    if (ok) {
+      trashedConversations.removeWhere((c) => c.id == conversationId);
+      notifyListeners();
+    }
+    return ok;
+  }
+
+  Future<bool> permanentlyDeleteFromTrash(String conversationId) async {
+    final ok = await permanentlyDeleteTrashedConversationServer(conversationId);
+    if (ok) {
+      trashedConversations.removeWhere((c) => c.id == conversationId);
+      notifyListeners();
+    }
+    return ok;
+  }
+
+  Future<bool> emptyTrash({int olderThanDays = 0}) async {
+    final ok = await emptyTrashServer(olderThanDays: olderThanDays);
+    if (ok) {
+      trashedConversations.clear();
+      notifyListeners();
+    }
+    return ok;
   }
 
   @override

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -721,7 +721,57 @@ def update_conversation_status(uid: str, conversation_id: str, status: str):
 def set_conversation_as_discarded(uid: str, conversation_id: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
-    conversation_ref.update({'discarded': True})
+    conversation_ref.update({'discarded': True, 'deleted_at': datetime.now(timezone.utc)})
+
+
+def set_conversation_as_trashed(uid: str, conversation_id: str):
+    """Soft-delete a conversation: move to trash with a deleted_at timestamp."""
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+    conversation_ref.update({'discarded': True, 'deleted_at': datetime.now(timezone.utc)})
+
+
+def restore_conversation(uid: str, conversation_id: str):
+    """Restore a trashed conversation."""
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+    conversation_ref.update({'discarded': False, 'deleted_at': None})
+
+
+def get_trashed_conversations(uid: str, limit: int = 50) -> List[dict]:
+    """Return trashed conversations ordered by deleted_at descending."""
+    user_ref = db.collection('users').document(uid)
+    conversations_ref = user_ref.collection(conversations_collection)
+    docs = (conversations_ref
+            .where(filter=FieldFilter('discarded', '==', True))
+            .order_by('deleted_at', direction=firestore.Query.DESCENDING)
+            .limit(limit)
+            .stream())
+    return [_decrypt_conversation_data(doc.to_dict(), uid) for doc in docs if doc.exists]
+
+
+def empty_trash(uid: str, older_than_days: int = 30):
+    """Permanently delete trashed conversations older than the specified number of days."""
+    from google.cloud.firestore_v1 import field_path
+    user_ref = db.collection('users').document(uid)
+    conversations_ref = user_ref.collection(conversations_collection)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+    docs = (conversations_ref
+            .where(filter=FieldFilter('discarded', '==', True))
+            .where(filter=FieldFilter('deleted_at', '<=', cutoff))
+            .stream())
+    batch = db.batch()
+    count = 0
+    for doc in docs:
+        delete_conversation_photos(uid, doc.id)
+        batch.delete(doc.reference)
+        count += 1
+        if count % 450 == 0:
+            batch.commit()
+            batch = db.batch()
+    if count % 450 != 0:
+        batch.commit()
+    return count
 
 
 # *********************************

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -719,9 +719,11 @@ def update_conversation_status(uid: str, conversation_id: str, status: str):
 
 
 def set_conversation_as_discarded(uid: str, conversation_id: str):
+    """Auto-discard on processing failure — marks as discarded without a deleted_at timestamp.
+    Only user-initiated deletes (set_conversation_as_trashed) set deleted_at."""
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
-    conversation_ref.update({'discarded': True, 'deleted_at': datetime.now(timezone.utc)})
+    conversation_ref.update({'discarded': True})
 
 
 def set_conversation_as_trashed(uid: str, conversation_id: str):
@@ -739,20 +741,23 @@ def restore_conversation(uid: str, conversation_id: str):
 
 
 def get_trashed_conversations(uid: str, limit: int = 50) -> List[dict]:
-    """Return trashed conversations ordered by deleted_at descending."""
+    """Return trashed conversations ordered by deleted_at descending.
+    Only returns conversations with a deleted_at timestamp (user-trashed, not auto-discarded)."""
     user_ref = db.collection('users').document(uid)
     conversations_ref = user_ref.collection(conversations_collection)
     docs = (conversations_ref
             .where(filter=FieldFilter('discarded', '==', True))
+            .where(filter=FieldFilter('deleted_at', '!=', None))
             .order_by('deleted_at', direction=firestore.Query.DESCENDING)
             .limit(limit)
             .stream())
     return [_decrypt_conversation_data(doc.to_dict(), uid) for doc in docs if doc.exists]
 
 
-def empty_trash(uid: str, older_than_days: int = 30):
-    """Permanently delete trashed conversations older than the specified number of days."""
-    from google.cloud.firestore_v1 import field_path
+def empty_trash(uid: str, older_than_days: int = 30) -> List[str]:
+    """Permanently delete trashed conversations older than the specified number of days.
+    Returns the list of deleted conversation IDs so callers can clean up vectors."""
+    from database.vector_db import delete_vector, delete_transcript_chunk_vectors
     user_ref = db.collection('users').document(uid)
     conversations_ref = user_ref.collection(conversations_collection)
     cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
@@ -761,17 +766,19 @@ def empty_trash(uid: str, older_than_days: int = 30):
             .where(filter=FieldFilter('deleted_at', '<=', cutoff))
             .stream())
     batch = db.batch()
-    count = 0
+    ids = []
     for doc in docs:
         delete_conversation_photos(uid, doc.id)
+        delete_vector(uid, doc.id)
+        delete_transcript_chunk_vectors(uid, doc.id)
         batch.delete(doc.reference)
-        count += 1
-        if count % 450 == 0:
+        ids.append(doc.id)
+        if len(ids) % 450 == 0:
             batch.commit()
             batch = db.batch()
-    if count % 450 != 0:
+    if ids and len(ids) % 450 != 0:
         batch.commit()
-    return count
+    return ids
 
 
 # *********************************

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -108,6 +108,7 @@ class Conversation(BaseModel):
     app_id: Optional[str] = None
 
     discarded: bool = False
+    deleted_at: Optional[datetime] = None
     visibility: ConversationVisibility = ConversationVisibility.private
     starred: bool = False
 

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -384,27 +384,69 @@ def delete_conversation(
     conversation_id: str,
     background_tasks: BackgroundTasks,
     cascade: bool = Query(False),
+    permanent: bool = Query(False),
     uid: str = Depends(auth.get_current_user_uid),
 ):
-    logger.info(f'delete_conversation {conversation_id} {uid} cascade={cascade}')
-    conversations_db.delete_conversation(uid, conversation_id)
-    delete_vector(uid, conversation_id)
-    delete_transcript_chunk_vectors(uid, conversation_id)
+    logger.info(f'delete_conversation {conversation_id} {uid} cascade={cascade} permanent={permanent}')
 
-    if cascade:
-        # Delete audio files
-        background_tasks.add_task(delete_conversation_audio_files, uid, conversation_id)
+    if permanent:
+        conversations_db.delete_conversation(uid, conversation_id)
+        delete_vector(uid, conversation_id)
+        delete_transcript_chunk_vectors(uid, conversation_id)
 
-        # Delete associated memories and their vectors
-        memory_ids = memories_db.get_memory_ids_for_conversation(uid, conversation_id)
-        memories_db.delete_memories_for_conversation(uid, conversation_id)
-        for memory_id in memory_ids:
-            background_tasks.add_task(delete_memory_vector, uid, memory_id)
-
-        # Delete associated action items
-        action_items_db.delete_action_items_for_conversation(uid, conversation_id)
+        if cascade:
+            background_tasks.add_task(delete_conversation_audio_files, uid, conversation_id)
+            memory_ids = memories_db.get_memory_ids_for_conversation(uid, conversation_id)
+            memories_db.delete_memories_for_conversation(uid, conversation_id)
+            for memory_id in memory_ids:
+                background_tasks.add_task(delete_memory_vector, uid, memory_id)
+            action_items_db.delete_action_items_for_conversation(uid, conversation_id)
+    else:
+        conversations_db.set_conversation_as_trashed(uid, conversation_id)
 
     return {"status": "Ok"}
+
+
+# **************************************
+# ********* TRASH / SOFT DELETE ********
+# **************************************
+
+
+@router.get("/v1/trash/conversations", response_model=List[Conversation], tags=['conversations', 'trash'])
+def get_trashed_conversations(limit: int = Query(50, le=200), uid: str = Depends(auth.get_current_user_uid)):
+    """Return trashed conversations ordered by deleted_at descending."""
+    raw = conversations_db.get_trashed_conversations(uid, limit)
+    return [Conversation(id=doc.get('id', ''), **doc) for doc in raw]
+
+
+@router.post("/v1/trash/conversations/{conversation_id}/restore", status_code=204, tags=['conversations', 'trash'])
+def restore_trashed_conversation(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Restore a trashed conversation."""
+    conversations_db.restore_conversation(uid, conversation_id)
+
+
+@router.delete("/v1/trash/conversations/{conversation_id}", status_code=204, tags=['conversations', 'trash'])
+def permanently_delete_trashed_conversation(
+    conversation_id: str,
+    background_tasks: BackgroundTasks,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Permanently delete a specific trashed conversation."""
+    delete_vector(uid, conversation_id)
+    delete_transcript_chunk_vectors(uid, conversation_id)
+    background_tasks.add_task(delete_conversation_audio_files, uid, conversation_id)
+    conversations_db.delete_conversation(uid, conversation_id)
+
+
+@router.delete("/v1/trash/conversations", status_code=204, tags=['conversations', 'trash'])
+def empty_trash(
+    background_tasks: BackgroundTasks,
+    older_than_days: int = Query(0, ge=0, le=365),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Permanently delete trashed conversations. If older_than_days=0, empties all trash."""
+    count = conversations_db.empty_trash(uid, older_than_days or 0)
+    logger.info(f'emptied trash for {uid}: {count} conversations permanently deleted')
 
 
 @router.get("/v1/conversations/{conversation_id}/recording", response_model=dict, tags=['conversations'])

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -445,8 +445,10 @@ def empty_trash(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     """Permanently delete trashed conversations. If older_than_days=0, empties all trash."""
-    count = conversations_db.empty_trash(uid, older_than_days or 0)
-    logger.info(f'emptied trash for {uid}: {count} conversations permanently deleted')
+    deleted_ids = conversations_db.empty_trash(uid, older_than_days or 0)
+    for cid in deleted_ids:
+        background_tasks.add_task(delete_conversation_audio_files, uid, cid)
+    logger.info(f'emptied trash for {uid}: {len(deleted_ids)} conversations permanently deleted')
 
 
 @router.get("/v1/conversations/{conversation_id}/recording", response_model=dict, tags=['conversations'])


### PR DESCRIPTION
﻿feat: implement trash bin / soft delete for conversations (#5092)

Implements #5092

## Changes

### Backend
- Added deleted_at timestamp field to the Conversation model
- DELETE /v1/conversations/{id} now soft-deletes by default (moves to trash); use permanent=true for hard delete
- New endpoints under /v1/trash/ prefix:
  - GET /v1/trash/conversations - list trashed conversations
  - POST /v1/trash/conversations/{id}/restore - restore from trash
  - DELETE /v1/trash/conversations/{id} - permanently delete one
  - DELETE /v1/trash/conversations - empty all trash
- Auto-purge ready: empty_trash(older_than_days=30) can be called by a scheduled job

### Flutter
- Added deletedAt field to ServerConversation Dart model
- Added trash API methods in conversations API client
- Added trash state + methods to ConversationProvider
- New TrashPage with restore and permanent delete per item + Empty Trash button
- Trash button in the conversations page header for navigation
- Swipe-to-delete now moves to trash (soft delete), undo works as before within 3s
- Explicit delete from conversation detail page uses permanent=true (with confirmation dialog)
