### PR TITLE
Fix #7113 – Sync view recordings sorted oldest-first instead of newest-first

### DIFF
--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -249,7 +249,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   bool get isFetchingConversations => _syncState.isFetchingConversations;
   double get walsSyncedProgress => _syncState.progress;
   double? get syncSpeedKBps => _syncState.speedKBps;
-  List<SyncedConversationPointer> get syncedConversationsPointers => _syncState.syncedConversations;
+  List<SyncedConversationPointer> get syncedConversationsPointers {
+    final sorted = List<SyncedConversationPointer>.from(_syncState.syncedConversations);
+    sorted.sort((a, b) => (b.conversation.createdAt).compareTo(a.conversation.createdAt));
+    return sorted;
+  }
   String? get syncError => _syncState.errorMessage;
   Wal? get failedWal => _syncState.failedWal;
   SyncMethod? get currentSyncMethod => _syncState.syncMethod;


### PR DESCRIPTION
## Problem

Recordings in the sync processed-conversations view were displayed in insertion order (oldest-first) because \syncedConversationsPointers\ was a direct pass-through of the underlying list with no sort applied.

**Root cause:** The \ConversationSyncUtils.processConversationIds()\ builds the list by iterating \
ewConversationIds\ first, then \updatedConversationIds\. No sorting is applied anywhere in the pipeline, so the list appears in whichever order IDs were processed — oldest-first for most users.

## Fix

Added a descending sort by \conversation.createdAt\ (newest first) to the \syncedConversationsPointers\ getter in \SyncProvider\, matching the sort order of the main conversation list.

**File changed:** \pp/lib/providers/sync_provider.dart:252\

Closes #7113