### PR TITLE
[codex] Restore async app integration test package path

### DIFF
--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -61,6 +61,21 @@ _RESTORED_MODULES = tuple(_database_stubs + _utils_stubs + ["utils.app_integrati
 # "database" is restored because this test temporarily replaces that parent.
 _MISSING = object()
 _saved_modules = {name: sys.modules.get(name, _MISSING) for name in _RESTORED_MODULES}
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, types.ModuleType) or not hasattr(module, '__path__'):
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, module)
+    return module
 
 
 def _install_module(name, module):
@@ -91,6 +106,8 @@ def _restore_stub_modules():
                 if parent is not None:
                     setattr(parent, attr, original)
 
+
+_ensure_package("utils", os.path.join(_BACKEND_DIR, "utils"))
 
 # Stub database modules
 _db_pkg = types.ModuleType("database")


### PR DESCRIPTION
## Summary

- Restore the real `utils` package path before importing `utils.app_integrations` in `test_async_app_integrations.py`.
- Keep the test's child module stubs scoped while avoiding parent-package pollution from prior tests.
- Make the async app integration tests order-tolerant when collected after `test_action_item_date_validation.py`.

## Root Cause

`test_action_item_date_validation.py` stubs `utils` as an empty package. When pytest later collects `test_async_app_integrations.py` in the same process, `importlib.import_module("utils.app_integrations")` can no longer find the real `backend/utils` package path. Restoring the package `__path__` before the import keeps this test independent of collection order.

## Current status

- Rebased on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`.
- Head refreshed to `5f42f9aa15f6287d4207609f6d17fa9a82728c1e`.
- GitHub currently reports the PR as mergeable.
- Review threads are empty.
- GitHub Actions `Lint Check` run `27683709629` completed successfully on this head.

## Validation

- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_async_app_integrations.py -q --tb=short` -> 9 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_action_item_date_validation.py backend\tests\unit\test_async_app_integrations.py -q --tb=short` -> 35 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_async_app_integrations.py backend\tests\unit\test_action_item_date_validation.py -q --tb=short` -> 35 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_async_app_integrations.py --collect-only -q --tb=short` -> 9 tests collected
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\tests\unit\test_async_app_integrations.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_async_app_integrations.py`
  - 1 file would be left unchanged
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`