### PR TITLE
[codex] Guard transcribe cache NotFound test stub

### DIFF
--- a/backend/tests/unit/test_transcribe_conversation_cache.py
+++ b/backend/tests/unit/test_transcribe_conversation_cache.py
@@ -4,10 +4,20 @@ Verifies cache refresh on ID change, 30s staleness, translation persist uses cac
 and cleanup on disconnect.
 """
 
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
-from google.api_core.exceptions import NotFound
+try:
+    from google.api_core.exceptions import NotFound
+except ImportError:
+    # Some lightweight tests leave an empty google.api_core.exceptions stub behind.
+    class NotFound(Exception):
+        pass
+
+    exceptions_module = sys.modules.get('google.api_core.exceptions')
+    if exceptions_module is not None:
+        exceptions_module.NotFound = NotFound
 
 
 class FakeConversationsDb:


### PR DESCRIPTION
## Summary

- Keep `test_transcribe_conversation_cache.py` importable when earlier lightweight tests leave an empty `google.api_core.exceptions` stub in `sys.modules`.
- Prefer the real `google.api_core.exceptions.NotFound` when available, and only install a test-local fallback on import failure.
- Leave production transcribe/cache code unchanged.

## Root Cause

`test_firestore_read_ops_cache.py` stubs several Google modules, including `google.api_core.exceptions`, without adding `NotFound`. When pytest collects `test_transcribe_conversation_cache.py` later in the same process, `from google.api_core.exceptions import NotFound` fails even though the test passes in isolation.

Before this change:

- `python -m pytest backend\tests\unit\test_firestore_read_ops_cache.py backend\tests\unit\test_transcribe_conversation_cache.py --collect-only -q --tb=short` -> `ImportError: cannot import name 'NotFound' from 'google.api_core.exceptions'`

## Validation

- `python -m pytest backend\tests\unit\test_transcribe_conversation_cache.py -q --tb=short` -> 17 passed, 1 warning
- `python -m pytest backend\tests\unit\test_firestore_read_ops_cache.py backend\tests\unit\test_transcribe_conversation_cache.py --collect-only -q --tb=short` -> 68 tests collected
- `python -m pytest backend\tests\unit\test_transcribe_conversation_cache.py backend\tests\unit\test_firestore_read_ops_cache.py --collect-only -q --tb=short` -> 68 tests collected
- `python -m py_compile backend\tests\unit\test_transcribe_conversation_cache.py`
- `python -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_transcribe_conversation_cache.py`
- `git diff --check`
- `scripts/pre-commit` with local Dart SDK + backend venv on PATH