### PR TITLE
[codex] Tolerate partial LangChain outputs stubs

### DIFF
--- a/backend/tests/unit/test_llm_usage_tracker.py
+++ b/backend/tests/unit/test_llm_usage_tracker.py
@@ -52,8 +52,8 @@ class LLMResult:
 try:
     import langchain_core.callbacks  # noqa: F401
     from langchain_core.outputs import Generation, LLMResult
-except ModuleNotFoundError as exc:
-    if exc.name is None or not exc.name.startswith("langchain_core"):
+except (ImportError, ModuleNotFoundError) as exc:
+    if isinstance(exc, ModuleNotFoundError) and (exc.name is None or not exc.name.startswith("langchain_core")):
         raise
 
     _langchain_core_module = sys.modules.setdefault("langchain_core", types.ModuleType("langchain_core"))


### PR DESCRIPTION
## Summary

- Let `test_llm_usage_tracker.py` install its existing LangChain fallback when `langchain_core.outputs` exists but lacks `Generation` / `LLMResult`.
- Preserve the current behavior when the real LangChain modules are available.
- Keep the change scoped to test import isolation; production usage tracking code is unchanged.

## Root Cause

Some lightweight Windows backend tests install partial `langchain_core.outputs` stubs. For example, `test_byok_security.py` and `test_realtime_integrations_usage_tracking.py` can leave a module with `LLMResult` but no `Generation`. When `test_llm_usage_tracker.py` is collected later, `from langchain_core.outputs import Generation, LLMResult` raises `ImportError`, but the test only handled `ModuleNotFoundError`.

Before this change:

- `python -m pytest backend\tests\unit\test_byok_security.py backend\tests\unit\test_llm_usage_tracker.py --collect-only -q --tb=short` -> `ImportError: cannot import name 'Generation' from 'langchain_core.outputs'`
- `python -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_llm_usage_tracker.py --collect-only -q --tb=short` -> same import error

## Validation

- `python -m pytest backend\tests\unit\test_llm_usage_tracker.py -q --tb=short` -> 18 passed
- `python -m pytest backend\tests\unit\test_byok_security.py backend\tests\unit\test_llm_usage_tracker.py --collect-only -q --tb=short` -> 99 tests collected
- `python -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_llm_usage_tracker.py --collect-only -q --tb=short` -> 22 tests collected
- `python -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_llm_usage_tracker.py -q --tb=short` -> 22 passed
- `python -m py_compile backend\tests\unit\test_llm_usage_tracker.py`
- `python -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_llm_usage_tracker.py`
- `git diff --check`
- `scripts/pre-commit` with local Dart SDK + backend venv on PATH

## Note

I also tried running `test_byok_security.py` plus `test_llm_usage_tracker.py` fully. Collection now passes, but `test_byok_security.py` still has unrelated runtime failures in this lightweight Windows venv from missing Firebase/subscription import surfaces, so I did not list that as a passing validation.