### PR TITLE
[codex] Restore prompt caching test model imports

### DIFF
--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -34,6 +34,25 @@ def _ensure_package(name: str, path: Path) -> ModuleType:
 
 _ensure_package("utils", BACKEND_DIR / "utils")
 llm_package = _ensure_package("utils.llm", BACKEND_DIR / "utils" / "llm")
+_ensure_package("models", BACKEND_DIR / "models")
+
+
+def _drop_module_if_missing_attrs(module_name, required_attrs):
+    module = sys.modules.get(module_name)
+    if module is None or all(hasattr(module, name) for name in required_attrs):
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_drop_module_if_missing_attrs("models.conversation_enums", ("CategoryEnum",))
+_drop_module_if_missing_attrs(
+    "models.structured",
+    ("ActionItem", "ActionItemsExtraction", "Event", "Structured"),
+)
 
 _conversation_processing_stub = sys.modules.get("utils.llm.conversation_processing")
 if _conversation_processing_stub is not None and not hasattr(


### PR DESCRIPTION
## Summary
- restore the real `models` package path in `test_prompt_caching.py` before importing conversation processing helpers
- drop stale `models.conversation_enums` and `models.structured` stubs when prior tests leave incomplete modules in `sys.modules`
- keeps the fix limited to test isolation so production code is unchanged

## Root cause
`test_merge_validation.py` installs lightweight `models` stubs for a pure-function test and leaves them in `sys.modules` during collection. When `test_prompt_caching.py` is collected after it on Windows, the prompt caching test imports real conversation processing helpers through the stale `models` module graph, causing collection to fail on missing real model symbols such as `models.calendar_context`, `CategoryEnum`, or `ActionItem`.

## Validation
- `python -m pytest backend/tests/unit/test_merge_validation.py backend/tests/unit/test_prompt_caching.py --collect-only -q --tb=short`
- `python -m pytest backend/tests/unit/test_prompt_caching.py backend/tests/unit/test_merge_validation.py --collect-only -q --tb=short`
- `python -m pytest backend/tests/unit/test_merge_validation.py backend/tests/unit/test_prompt_caching.py -q --tb=short` (60 passed)
- `python -m pytest backend/tests/unit/test_prompt_caching.py -q --tb=short` (24 passed)
- `python -m pytest backend/tests/unit/test_conversations_to_string.py backend/tests/unit/test_prompt_caching.py --collect-only -q --tb=short`
- `python -m pytest backend/tests/unit/test_conversation_redact_enrich.py backend/tests/unit/test_prompt_caching.py --collect-only -q --tb=short`
- `python -m pytest backend/tests/unit/test_conversation_render_factory.py backend/tests/unit/test_prompt_caching.py --collect-only -q --tb=short`
- `python -m py_compile backend/tests/unit/test_prompt_caching.py`
- `python -m black --line-length 120 --skip-string-normalization --check backend/tests/unit/test_prompt_caching.py`
- `git diff --check`
- `scripts/pre-commit`