### PR TITLE
[codex] Restore MCP retrieval test imports

### DIFF
--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -17,6 +17,8 @@ import pytest
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
 
 class _AutoMockModule(ModuleType):
     def __getattr__(self, name):
@@ -26,6 +28,44 @@ class _AutoMockModule(ModuleType):
         setattr(self, name, mock)
         return mock
 
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module(
+    'utils.retrieval.hybrid',
+    os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'),
+)
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+_drop_stale_module('models.conversation_enums', os.path.join(_BACKEND_DIR, 'models', 'conversation_enums.py'))
+_drop_stale_module('models.mcp_api_key', os.path.join(_BACKEND_DIR, 'models', 'mcp_api_key.py'))
 
 _stubs = [
     'database._client',
@@ -83,6 +123,8 @@ for mod_name in _stubs:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = _AutoMockModule(mod_name)
 
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
 sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
 sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
 sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -13,6 +13,8 @@ from types import ModuleType
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
 
 class _AutoMockModule(ModuleType):
     def __getattr__(self, name):
@@ -22,6 +24,44 @@ class _AutoMockModule(ModuleType):
         setattr(self, name, mock)
         return mock
 
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module(
+    'utils.retrieval.hybrid',
+    os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'),
+)
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+_drop_stale_module('models.conversation_enums', os.path.join(_BACKEND_DIR, 'models', 'conversation_enums.py'))
+_drop_stale_module('models.mcp_api_key', os.path.join(_BACKEND_DIR, 'models', 'mcp_api_key.py'))
 
 _stubs = [
     'database._client',
@@ -77,6 +117,8 @@ for mod_name in _stubs:
     if mod_name not in sys.modules:
         sys.modules[mod_name] = _AutoMockModule(mod_name)
 
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
 sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
 sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
 sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)

--- a/backend/tests/unit/test_memory_temporal_brain.py
+++ b/backend/tests/unit/test_memory_temporal_brain.py
@@ -14,6 +14,44 @@ os.environ.setdefault('ENCRYPTION_SECRET', 'omi_test_secret_key_for_unit_tests_o
 
 # Stub database._client so importing models.memories doesn't spin up Firestore.
 _BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module(
+    'utils.retrieval.hybrid',
+    os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'),
+)
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+
 database_pkg = sys.modules.setdefault('database', ModuleType('database'))
 database_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
 _client_stub = ModuleType('database._client')


### PR DESCRIPTION
## Summary
- restore real `utils`, `utils.retrieval`, and `models` package paths before MCP and temporal-memory tests import real retrieval/model modules
- discard stale `utils.retrieval.hybrid` and memory/MCP model stubs left by earlier stub-heavy tests
- provide the lightweight `database._client.document_id_from_seed` surface only when the test is using a stubbed `_client` module

## Root cause
Several Windows unit tests install lightweight `utils.retrieval` or `models` stubs during collection. When `test_memory_temporal_brain.py`, `test_mcp_data_endpoints.py`, or `test_mcp_search_memories.py` are collected later, Python resolves imports through those stale stubs instead of the real backend package tree. That makes `utils.retrieval.hybrid` unreachable, and in the MCP tests can also leave `database._client` without the `document_id_from_seed` helper required by `models.memories`.

## Validation
- `python -m pytest backend/tests/unit/test_memory_temporal_brain.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py -q --tb=short` (49 passed, 1 warning)
- `python -m pytest backend/tests/unit/test_action_item_date_validation.py backend/tests/unit/test_memory_temporal_brain.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py -q --tb=short` (75 passed, 1 warning)
- `python -m pytest backend/tests/unit/test_action_item_date_validation.py backend/tests/unit/test_memory_temporal_brain.py --collect-only -q --tb=short --continue-on-collection-errors` (36 collected)
- `python -m pytest backend/tests/unit/test_action_item_date_validation.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py --collect-only -q --tb=short --continue-on-collection-errors` (65 collected)
- `python -m pytest backend/tests/unit/test_desktop_transcribe.py backend/tests/unit/test_memory_temporal_brain.py --collect-only -q --tb=short --continue-on-collection-errors` now collects the 10 temporal-memory tests; the command still exits 1 on current `main` because `test_desktop_transcribe.py` has the existing unrelated missing `fal_client` collection error
- `python -m pytest backend/tests/unit/test_desktop_transcribe.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py --collect-only -q --tb=short --continue-on-collection-errors` now collects the 39 MCP tests; the command still exits 1 on current `main` because of the same unrelated `test_desktop_transcribe.py` `fal_client` error
- full backend unit collect with `--continue-on-collection-errors` now lists these three target files as collected instead of reporting `utils.retrieval.hybrid` errors
- `python -m py_compile backend/tests/unit/test_memory_temporal_brain.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py`
- `python -m black --line-length 120 --skip-string-normalization --check backend/tests/unit/test_memory_temporal_brain.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_search_memories.py`
- `git diff --check`
- `scripts/pre-commit`