### PR TITLE
test(backend): isolate phone and notification stubs

### DIFF
--- a/backend/tests/unit/test_notification_token_cleanup.py
+++ b/backend/tests/unit/test_notification_token_cleanup.py
@@ -1,12 +1,57 @@
 import os
 import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _set_module(name, module):
+    sys.modules[name] = module
+    parent_name, _, attr_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        setattr(parent, attr_name, module)
+
+
+def _drop_module(name):
+    module = sys.modules.pop(name, None)
+    parent_name, _, attr_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if module is not None and parent is not None and getattr(parent, attr_name, None) is module:
+        delattr(parent, attr_name)
+    return module
+
+
+def _restore_module(name, module):
+    if module is None:
+        _drop_module(name)
+        return
+    _set_module(name, module)
+
+
+def _ensure_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, types.ModuleType):
+        module = types.ModuleType(name)
+        _set_module(name, module)
+    module.__path__ = [str(path)]
+    parent_name, _, attr_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        setattr(parent, attr_name, module)
+    return module
+
+
+_ensure_package("database", BACKEND_DIR / "database")
+_ensure_package("utils", BACKEND_DIR / "utils")
+_ensure_package("utils.llm", BACKEND_DIR / "utils" / "llm")
 
 
 class _FakeMessagingException(Exception):
@@ -47,14 +92,10 @@ firebase_admin.messaging = types.SimpleNamespace(
     WebpushFCMOptions=lambda **kwargs: kwargs,
     Message=lambda **kwargs: kwargs,
 )
-sys.modules["firebase_admin"] = firebase_admin
-sys.modules["firebase_admin.auth"] = firebase_admin.auth
-sys.modules["firebase_admin.messaging"] = firebase_admin.messaging
 
 notification_db = types.ModuleType("database.notifications")
 notification_db.get_all_tokens = MagicMock()
 notification_db.remove_bulk_tokens = MagicMock()
-sys.modules["database.notifications"] = notification_db
 
 redis_db = types.ModuleType("database.redis_db")
 for attr in [
@@ -64,11 +105,9 @@ for attr in [
     "has_silent_user_notification_been_sent",
 ]:
     setattr(redis_db, attr, MagicMock())
-sys.modules["database.redis_db"] = redis_db
 
 auth_db = types.ModuleType("database.auth")
 auth_db.get_user_from_uid = MagicMock()
-sys.modules["database.auth"] = auth_db
 
 llm_notifications = types.ModuleType("utils.llm.notifications")
 for attr in [
@@ -77,9 +116,26 @@ for attr in [
     "generate_silent_user_notification",
 ]:
     setattr(llm_notifications, attr, MagicMock())
-sys.modules["utils.llm.notifications"] = llm_notifications
+
+_module_overrides = {
+    "firebase_admin": firebase_admin,
+    "firebase_admin.auth": firebase_admin.auth,
+    "firebase_admin.messaging": firebase_admin.messaging,
+    "database.notifications": notification_db,
+    "database.redis_db": redis_db,
+    "database.auth": auth_db,
+    "utils.llm.notifications": llm_notifications,
+}
+_previous_modules = {name: sys.modules.get(name) for name in [*list(_module_overrides), "utils.notifications"]}
+
+_drop_module("utils.notifications")
+for _name, _module in _module_overrides.items():
+    _set_module(_name, _module)
 
 from utils import notifications
+
+for _name, _module in _previous_modules.items():
+    _restore_module(_name, _module)
 
 
 def setup_function():

--- a/backend/tests/unit/test_phone_calls.py
+++ b/backend/tests/unit/test_phone_calls.py
@@ -4,7 +4,14 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from tests.unit.twilio_stub import install_twilio_stub, prepare_twilio_service_import
+
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault('TWILIO_ACCOUNT_SID', 'ACtest123')
+os.environ.setdefault('TWILIO_AUTH_TOKEN', 'test_auth_token')
+os.environ.setdefault('TWILIO_API_KEY_SID', 'SKtest123')
+os.environ.setdefault('TWILIO_API_KEY_SECRET', 'test_api_secret')
+os.environ.setdefault('TWILIO_TWIML_APP_SID', 'APtest123')
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
@@ -60,96 +67,13 @@ def _rate_limit_dependency(**_kwargs):
 
 _endpoints.rate_limit_dependency = _rate_limit_dependency
 
-_twilio_service = _install_module("utils.twilio_service")
-for _attr in [
-    "generate_access_token",
-    "start_caller_id_verification",
-    "check_caller_id_verified",
-    "delete_caller_id",
-    "get_caller_id",
-    "validate_twilio_signature",
-]:
-    setattr(_twilio_service, _attr, MagicMock())
-
 # Mock modules that initialize GCP/Firebase clients at import time
 _mock_firebase = MagicMock()
 sys.modules.setdefault("database._client", MagicMock())
 sys.modules.setdefault("firebase_admin", _mock_firebase)
 sys.modules.setdefault("firebase_admin.auth", _mock_firebase.auth)
-
-
-class _TwilioRestException(Exception):
-    def __init__(self, status=None, uri=None, msg='', code=None, method=None, details=None):
-        super().__init__(msg)
-        self.status = status
-        self.uri = uri
-        self.msg = msg
-        self.code = code
-        self.method = method
-        self.details = details
-
-
-class _VoiceResponse:
-    def __init__(self):
-        self._children = []
-
-    def say(self, message):
-        self._children.append(f'<Say>{message}</Say>')
-
-    def append(self, child):
-        self._children.append(str(child))
-
-    def __str__(self):
-        return '<Response>' + ''.join(self._children) + '</Response>'
-
-
-class _Dial:
-    def __init__(self, caller_id=None, time_limit=None, **_kwargs):
-        self._caller_id = caller_id
-        self._time_limit = time_limit
-        self._numbers = []
-
-    def number(self, number):
-        self._numbers.append(number)
-
-    def __str__(self):
-        attrs = []
-        if self._caller_id is not None:
-            attrs.append(f'callerId="{self._caller_id}"')
-        if self._time_limit is not None:
-            attrs.append(f'timeLimit="{self._time_limit}"')
-        attrs_text = (' ' + ' '.join(attrs)) if attrs else ''
-        numbers = ''.join(f'<Number>{number}</Number>' for number in self._numbers)
-        return f'<Dial{attrs_text}>{numbers}</Dial>'
-
-
-_twilio = ModuleType('twilio')
-_twilio_base = ModuleType('twilio.base')
-_twilio_base_exceptions = ModuleType('twilio.base.exceptions')
-_twilio_base_exceptions.TwilioRestException = _TwilioRestException
-_twilio_twiml = ModuleType('twilio.twiml')
-_twilio_twiml_voice_response = ModuleType('twilio.twiml.voice_response')
-_twilio_twiml_voice_response.VoiceResponse = _VoiceResponse
-_twilio_twiml_voice_response.Dial = _Dial
-_twilio_rest = ModuleType('twilio.rest')
-_twilio_rest.Client = MagicMock
-_twilio_jwt = ModuleType('twilio.jwt')
-_twilio_jwt_access_token = ModuleType('twilio.jwt.access_token')
-_twilio_jwt_access_token.AccessToken = MagicMock
-_twilio_jwt_access_token_grants = ModuleType('twilio.jwt.access_token.grants')
-_twilio_jwt_access_token_grants.VoiceGrant = MagicMock
-_twilio_request_validator = ModuleType('twilio.request_validator')
-_twilio_request_validator.RequestValidator = MagicMock
-sys.modules.setdefault('twilio', _twilio)
-sys.modules.setdefault('twilio.base', _twilio_base)
-sys.modules.setdefault('twilio.base.exceptions', _twilio_base_exceptions)
-sys.modules.setdefault('twilio.twiml', _twilio_twiml)
-sys.modules.setdefault('twilio.twiml.voice_response', _twilio_twiml_voice_response)
-sys.modules.setdefault('twilio.rest', _twilio_rest)
-sys.modules.setdefault('twilio.jwt', _twilio_jwt)
-sys.modules.setdefault('twilio.jwt.access_token', _twilio_jwt_access_token)
-sys.modules.setdefault('twilio.jwt.access_token.grants', _twilio_jwt_access_token_grants)
-sys.modules.setdefault('twilio.request_validator', _twilio_request_validator)
+install_twilio_stub()
+prepare_twilio_service_import()
 
 import pytest
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- reuse the shared Twilio test stub in `test_phone_calls.py` instead of installing an incomplete local Twilio/module stub
- stop `test_phone_calls.py` from overwriting `utils.twilio_service` at import time
- scope `test_notification_token_cleanup.py` module overrides to its own `utils.notifications` import, then restore prior `sys.modules` entries

## Why
These tests passed when run one file at a time, but polluted adjacent tests when pytest collected multiple files in one process. This helps Windows/local contributors run grouped backend unit tests without order-dependent failures.

## Validation
- `pytest backend/tests/unit/test_phone_calls.py backend/tests/unit/test_twilio_service.py -q --tb=short` -> 23 passed
- `pytest backend/tests/unit/test_twilio_service.py backend/tests/unit/test_phone_calls.py -q --tb=short` -> 23 passed
- `pytest backend/tests/unit/test_high_priority_usage_tracking.py backend/tests/unit/test_notification_token_cleanup.py -q --tb=short` -> 23 passed
- `pytest backend/tests/unit/test_notification_token_cleanup.py backend/tests/unit/test_high_priority_usage_tracking.py -q --tb=short` -> 23 passed
- grouped 14-file run from the backend CI coverage audit -> 175 passed
- `python -m black --check --line-length 120 --skip-string-normalization backend/tests/unit/test_phone_calls.py backend/tests/unit/test_notification_token_cleanup.py`
- `git diff --check`
- `scripts/pre-commit`