### PR TITLE
[codex] Isolate Deepgram start guard imports on Windows

### DIFF
--- a/backend/tests/unit/test_dg_start_guard.py
+++ b/backend/tests/unit/test_dg_start_guard.py
@@ -44,10 +44,32 @@ for _mod_name in [
 ]:
     sys.modules.setdefault(_mod_name, MagicMock())
 
+
+def _fill_existing_stub_attrs(module_name, attrs):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+
+    for attr in attrs:
+        if isinstance(module, MagicMock) or not hasattr(module, attr):
+            setattr(module, attr, MagicMock())
+    return module
+
+
 os.environ.setdefault('DEEPGRAM_API_KEY', 'fake-for-test')
 # NOTE: Do NOT set sys.modules['deepgram'].LiveTranscriptionEvents here.
 # MagicMock auto-generates attributes on access, and overwriting would pollute
 # shared pytest state for test_streaming_deepgram_backoff.py's close/error handler tests.
+
+_fill_existing_stub_attrs('utils.async_tasks', ['create_named_task'])
+_fill_existing_stub_attrs('utils.executors', ['sync_executor', 'run_blocking'])
+_fill_existing_stub_attrs('utils.http_client', ['get_stt_client', 'get_stt_semaphore'])
+
+_byok_module = sys.modules.get('utils.byok')
+if _byok_module is not None:
+    _get_byok_key = getattr(_byok_module, 'get_byok_key', None)
+    if isinstance(_byok_module, MagicMock) or isinstance(_get_byok_key, MagicMock) or _get_byok_key is None:
+        _byok_module.get_byok_key = MagicMock(return_value=None)
 
 _speaker_embedding = ModuleType('utils.stt.speaker_embedding')
 _speaker_embedding.SPEAKER_MATCH_THRESHOLD = 0.45


### PR DESCRIPTION
## Summary
- keep `test_dg_start_guard.py` importable when earlier tests leave partial `utils.async_tasks`, `utils.executors`, `utils.http_client`, or `utils.byok` stubs in `sys.modules`
- fill only existing stale stubs, so clean single-file runs still import the real helper modules
- keep the change scoped to test isolation; production streaming code is unchanged

## Root cause
`test_realtime_integrations_usage_tracking.py` installs lightweight utility stubs during collection. If `test_dg_start_guard.py` is collected later in the same pytest process on Windows, importing `utils.stt.streaming` can fail before the guard tests are collected because `utils.async_tasks` lacks `create_named_task`.

Before this change:
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_dg_start_guard.py --collect-only -q --tb=short --continue-on-collection-errors` -> `ImportError: cannot import name 'create_named_task' from 'utils.async_tasks'`

## Current status
- Based on `main` at `1a5824403b68ce47c3b0909577cadc1242ba0d3f`
- Head: `5d66670861e1827026eb95349520198fb163dab9`
- GitHub currently reports the PR as mergeable
- GitHub Actions `Lint Check` run `27685412799` completed successfully on this head
- Review threads are empty

## Validation
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_dg_start_guard.py --collect-only -q --tb=short --continue-on-collection-errors`
  - 6 tests collected
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_dg_start_guard.py -q --tb=short`
  - 2 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_dg_start_guard.py backend\tests\unit\test_realtime_integrations_usage_tracking.py -q --tb=short`
  - 6 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit\test_realtime_integrations_usage_tracking.py backend\tests\unit\test_dg_start_guard.py -q --tb=short`
  - 6 passed
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m py_compile backend\tests\unit\test_dg_start_guard.py`
- `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m black --line-length 120 --skip-string-normalization --check backend\tests\unit\test_dg_start_guard.py`
  - 1 file would be left unchanged
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` with the backend Windows venv and local Dart SDK on `PATH`

## Stacked Windows collect check
On a local-only integration branch containing the open Windows collect-isolation PR heads plus this PR, `D:\codex-omi-work\.venvs\omi-backend-vad-refresh\Scripts\python.exe -m pytest backend\tests\unit --collect-only -q --tb=short --continue-on-collection-errors` exits 0 with 4206 tests collected.