### PR TITLE
fix plaud _parseAudioChunk RangeError on truncated BLE packets

### DIFF
--- a/app/lib/services/devices/plaud_connection.dart
+++ b/app/lib/services/devices/plaud_connection.dart
@@ -72,6 +72,7 @@ class PlaudDeviceConnection extends DeviceConnection {
     if (position == 0xFFFFFFFF) return null; // End marker
 
     final length = payload[8];
+    if (9 + length > payload.length) return null;
     return payload.sublist(9, 9 + length);
   }
 
@@ -287,7 +288,8 @@ class PlaudDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;
@@ -319,15 +321,15 @@ class PlaudDeviceConnection extends DeviceConnection {
   List<int> _toBytes32(int v) => [v & 0xFF, (v >> 8) & 0xFF, (v >> 16) & 0xFF, (v >> 24) & 0xFF];
 
   List<int> _toBytes64(int v) => [
-    v & 0xFF,
-    (v >> 8) & 0xFF,
-    (v >> 16) & 0xFF,
-    (v >> 24) & 0xFF,
-    (v >> 32) & 0xFF,
-    (v >> 40) & 0xFF,
-    (v >> 48) & 0xFF,
-    (v >> 56) & 0xFF,
-  ];
+        v & 0xFF,
+        (v >> 8) & 0xFF,
+        (v >> 16) & 0xFF,
+        (v >> 24) & 0xFF,
+        (v >> 32) & 0xFF,
+        (v >> 40) & 0xFF,
+        (v >> 48) & 0xFF,
+        (v >> 56) & 0xFF,
+      ];
 
   int _toInt32(List<int> b) => b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24);
 }


### PR DESCRIPTION
## Crash

`PlaudDeviceConnection._parseAudioChunk` — `RangeError (end): Invalid value: Not in inclusive range 9..189: 255`

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/89db02e25fcf378409caf8a02d4d59ca?time=7d&types=crash&sessionEventKey=5daa07a501fd4234b65d76937d9783ca_2230583383207987879

```
Fatal Exception: FlutterError
0  ???   0x0 _TypedIntListMixin.sublist (dart:typed_data)
1  ???   0x0 PlaudDeviceConnection._parseAudioChunk + 75 (plaud_connection.dart:75)
2  ???   0x0 PlaudDeviceConnection._handleNotification + 58 (plaud_connection.dart:58)
```

## Cause

`_parseAudioChunk` reads byte 8 of the BLE notification payload as the audio data length, then calls `payload.sublist(9, 9 + length)` without checking that the slice fits within the buffer. When a truncated or malformed packet arrives, the length byte can describe more bytes than are actually present — in this case a length of 246 on a 189-byte payload gives an end index of 255, which is out of range.

## Fix

Added a single bounds check before the `sublist` call. If `9 + length > payload.length`, the packet is silently discarded (returns `null`) so the app continues normally rather than crashing.

```dart
final length = payload[8];
if (9 + length > payload.length) return null;
return payload.sublist(9, 9 + length);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)