### PR TITLE
fix(macos): return false from isAppSetupCompleted for empty URL

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -3158,7 +3158,10 @@ extension APIClient {
 
   /// Checks if an external integration app's setup is complete
   func isAppSetupCompleted(url: String, uid: String) async -> Bool {
-    guard !url.isEmpty else { return true }
+    // An empty/unknown completion URL means setup cannot be verified, so report
+    // not-completed (consistent with the invalid-URL and network-failure paths
+    // below). Returning true here would wrongly mark an unconfigured app as set up.
+    guard !url.isEmpty else { return false }
     guard let fullUrl = URL(string: "\(url)?uid=\(uid)") else { return false }
     var request = URLRequest(url: fullUrl)
     request.httpMethod = "GET"

--- a/desktop/macos/Desktop/Tests/APIClientSetupCompletedTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientSetupCompletedTests.swift
@@ -11,8 +11,8 @@ import XCTest
 /// short-circuits before any network request, so this needs no HTTP mocking.
 final class APIClientSetupCompletedTests: XCTestCase {
 
-  func testEmptyURLReportsNotCompleted() async {
-    let completed = await APIClient.shared.isAppSetupCompleted(url: "", uid: "test-uid")
-    XCTAssertFalse(completed, "An empty completion URL must report setup as NOT completed")
-  }
+    func testEmptyURLReportsNotCompleted() async {
+        let completed = await APIClient.shared.isAppSetupCompleted(url: "", uid: "test-uid")
+        XCTAssertFalse(completed, "An empty completion URL must report setup as NOT completed")
+    }
 }

--- a/desktop/macos/Desktop/Tests/APIClientSetupCompletedTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientSetupCompletedTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `APIClient.isAppSetupCompleted(url:uid:)`.
+///
+/// An empty completion URL means setup cannot be verified, so the method must
+/// report `false` (not-completed) — matching its invalid-URL and
+/// network-failure paths. A previous `return true` would wrongly mark an
+/// unconfigured external integration app as already set up. The empty-URL case
+/// short-circuits before any network request, so this needs no HTTP mocking.
+final class APIClientSetupCompletedTests: XCTestCase {
+
+  func testEmptyURLReportsNotCompleted() async {
+    let completed = await APIClient.shared.isAppSetupCompleted(url: "", uid: "test-uid")
+    XCTAssertFalse(completed, "An empty completion URL must report setup as NOT completed")
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug in `APIClient.isAppSetupCompleted(url:uid:)` (macOS desktop app). When passed an **empty URL**, the method returned `true` ("setup completed") — the wrong default. An empty/unknown URL means setup *cannot be verified*, so the safe answer is `false`, consistent with every other failure path in the method (invalid URL, network error, missing/`false` JSON field all return `false`).

Returning `true` would, if reached, wrongly mark an unconfigured external integration app as already set up and auto-enable it.

## Why this is safe

Both current callers in `MainWindow/Pages/AppsPage.swift` already guard `!completionUrl.isEmpty` before calling this method (lines ~2710 and ~2777), so the bad branch is **not reachable from existing callers**. This means the fix:
- corrects the latent default and hardens the method's contract for any future caller, and
- **changes no existing runtime behavior** (current callers never pass an empty URL).

## Changes

- `desktop/macos/Desktop/Sources/APIClient.swift` — `guard !url.isEmpty else { return true }` → `return false` (+ explanatory comment).
- `desktop/macos/Desktop/Tests/APIClientSetupCompletedTests.swift` (new) — regression test asserting the empty-URL contract. The empty-URL case short-circuits before any network request, so no HTTP mocking is needed.

## Testing

- This is a macOS-only (AppKit/SwiftUI) target; it builds on macOS / Codemagic CI. The change is a one-line default flip plus a network-free unit test.
- No `CHANGELOG.json` entry: internal-only correctness fix with no user-visible behavior change (per `desktop/macos/AGENTS.md` "skip internal-only changes").

## Overlap check

No conflict with any open or recently merged PR. The only other open PR touching `APIClient.swift` is #7673 (trial opt-in), which edits a different method ~800 lines away — merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNR61x1oT6RMjPVdNsYdvE)_