### PR TITLE
fix(desktop): clamp Goal.progress to its documented 0-100 range

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed goal progress rings and labels showing an incorrect value when a tracked value dropped below its starting point"
+  ],
   "releases": [
     {
       "version": "0.11.467",

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -2727,7 +2727,8 @@ struct Goal: Codable, Identifiable {
   /// Progress as a percentage (0-100), based on targetValue
   var progress: Double {
     guard targetValue != minValue else { return 0 }
-    return ((currentValue - minValue) / (targetValue - minValue)) * 100.0
+    let pct = ((currentValue - minValue) / (targetValue - minValue)) * 100.0
+    return min(max(pct, 0), 100)
   }
 
   /// Whether the goal is completed

--- a/desktop/macos/Desktop/Tests/GoalProgressTests.swift
+++ b/desktop/macos/Desktop/Tests/GoalProgressTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Unit tests for `Goal.progress`, which must stay within its documented
+/// 0-100 range. Regression coverage for a bug where `current_value` below
+/// `min_value` produced a negative percentage that leaked into the goal
+/// progress ring (`Path.trim`) and the "% complete" prompt text.
+final class GoalProgressTests: XCTestCase {
+
+  /// Decode a `Goal` from minimal JSON. Dates are omitted so they fall back
+  /// to the decoder defaults — `progress` does not depend on them.
+  private func makeGoal(min: Double, target: Double, current: Double) throws -> Goal {
+    let json = """
+      {
+        "id": "g1",
+        "goal_type": "numeric",
+        "min_value": \(min),
+        "target_value": \(target),
+        "current_value": \(current)
+      }
+      """
+    return try JSONDecoder().decode(Goal.self, from: Data(json.utf8))
+  }
+
+  func testProgressMidRange() throws {
+    let goal = try makeGoal(min: 0, target: 10, current: 5)
+    XCTAssertEqual(goal.progress, 50, accuracy: 0.0001)
+  }
+
+  func testProgressClampsNegativeToZero() throws {
+    // current below min would yield (2-5)/(15-5)*100 = -30 without clamping.
+    let goal = try makeGoal(min: 5, target: 15, current: 2)
+    XCTAssertEqual(goal.progress, 0, accuracy: 0.0001, "Progress must not go below 0")
+  }
+
+  func testProgressClampsOverachievementToHundred() throws {
+    // current above target would yield 200 without clamping.
+    let goal = try makeGoal(min: 0, target: 10, current: 20)
+    XCTAssertEqual(goal.progress, 100, accuracy: 0.0001, "Progress must not exceed 100")
+  }
+
+  func testProgressIsZeroWhenTargetEqualsMin() throws {
+    // Guard against divide-by-zero when the range is degenerate.
+    let goal = try makeGoal(min: 5, target: 5, current: 5)
+    XCTAssertEqual(goal.progress, 0, accuracy: 0.0001)
+  }
+}


### PR DESCRIPTION
## What

`Goal.progress` (in `desktop/macos/Desktop/Sources/APIClient.swift`) is documented as returning a percentage in the range **0-100**, but it only guarded against divide-by-zero — it did not clamp the result:

```swift
// before
var progress: Double {
  guard targetValue != minValue else { return 0 }
  return ((currentValue - minValue) / (targetValue - minValue)) * 100.0
}
```

When `currentValue` is below `minValue` (e.g. a goal whose baseline is above zero, or a value that regresses below its starting point), this returns a **negative** percentage. Consumers only clamp the *upper* bound:

- `MainWindow/Components/GoalsWidget.swift:164` → `min(goal.progress / 100.0, 1.0)`
- `MainWindow/Components/GoalsWidget.swift:775` → `.trim(from: 0, to: min(goal.progress / 100, 1.0))`
- `ProactiveAssistants/.../TaskPrioritizationService.swift:185` → `"(\(Int(goal.progress))% complete)"`

So a negative value passes straight through: `Path.trim(from: 0, to: <negative>)` renders an empty/inverted arc, and the prompt text reads e.g. `"(-40% complete)"`.

## Fix

Clamp at the source so the getter honors its own `0-100` contract:

```swift
// after
var progress: Double {
  guard targetValue != minValue else { return 0 }
  let pct = ((currentValue - minValue) / (targetValue - minValue)) * 100.0
  return min(max(pct, 0), 100)
}
```

For all in-range values the output is identical — only out-of-range inputs change, toward the documented contract. Existing caller-side upper-bound clamps are left in place (harmless/defensive).

## Tests

Adds `Desktop/Tests/GoalProgressTests.swift` (decoder-based, matching the repo's existing test style):
- mid-range → 50
- `currentValue < minValue` → **0** (the regression)
- `currentValue > targetValue` → **100**
- `targetValue == minValue` → 0 (divide-by-zero guard)

## Verification

- Pure-value clamp; no schema/IO/migration. Revertible in one commit.
- ⚠️ Not compiled/run locally — authored in a Linux container with no Apple SDK. Needs a macOS build (`xcrun swift test --package-path Desktop --filter GoalProgressTests`) / CI to confirm.

Draft until a macOS build/test pass confirms it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6oBTTKdSzfrvKNg1yXnuB)_