### PR TITLE
fix(backend): disable keep-alive on auth httpx client to stop intermittent OAuth 500s

### DIFF
--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -260,12 +260,23 @@ def get_maps_client() -> httpx.AsyncClient:
 
 
 def get_auth_client() -> httpx.AsyncClient:
-    """Return a shared async HTTP client for OAuth/auth token exchanges."""
+    """Return a shared async HTTP client for OAuth/auth token exchanges.
+
+    Keep-alive is disabled (`max_keepalive_connections=0`) for the same reason
+    as `get_tts_client()`: in Cloud Run we observed stale keep-alive sockets
+    being reused after the remote (Google/Apple/Firebase token endpoints) or an
+    intermediate NAT silently dropped them, raising asyncio's "handler is
+    closed" RuntimeError mid-request. That surfaced as intermittent HTTP 500s
+    on `/v1/auth/callback/{google,apple}` and `/v1/auth/token`, breaking both
+    Sign in with Google and Sign in with Apple (both providers share this
+    client). Auth token-exchange volume is low, so paying a TLS handshake per
+    request is a fine trade for eliminating the stale-socket failures.
+    """
     global _auth_client
     if _auth_client is None:
         _auth_client = httpx.AsyncClient(
             timeout=httpx.Timeout(10.0, connect=2.0),
-            limits=httpx.Limits(max_connections=20, max_keepalive_connections=8),
+            limits=httpx.Limits(max_connections=20, max_keepalive_connections=0),
         )
     return _auth_client
 


### PR DESCRIPTION
## Problem

Intermittent **HTTP 500s on `/v1/auth/callback/{google,apple}` and `/v1/auth/token`**, breaking both *Sign in with Google* and *Sign in with Apple* (both providers share one HTTP client). Observed traceback:

```
routers/auth.py:432  _exchange_google_code_for_oauth_credentials
  await client.post("https://oauth2.googleapis.com/token", ...)
RuntimeError: unable to perform operation on <TCPTransport closed=True ...>; the handler is closed
```

`get_auth_client()` is a process-wide httpx singleton with a keep-alive pool (`max_keepalive_connections=8`). On Cloud Run, an idle pooled socket gets silently dropped by the remote (Google/Apple/Firebase token endpoints) or an intermediate NAT; the next sign-in reuses/reaps the dead connection and httpcore raises asyncio's "handler is closed" `RuntimeError` mid-request → 500. Probabilistic, so it surfaces as intermittent sign-in failures.

This is the **same failure already documented and fixed for `get_tts_client()`** — which sets `max_keepalive_connections=0` for exactly this reason. The auth client never got the same treatment.

## Blast radius (last 7 days, prod `api.omi.me`)

- **41 auth sign-in 500s** (25 Google + 16 Apple), ~6/day, across many users — real stable-desktop users, not a one-off.
- Dev/beta backend: 2 (small population).

## Fix

`get_auth_client()` → `max_keepalive_connections=0`, matching `get_tts_client()`. Auth token-exchange volume is low, so a TLS handshake per request is a fine trade for eliminating the stale-socket 500s. One-line config change; no other clients touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)