### PR TITLE
feat(desktop): default System Audio to "Only during meetings"

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Recording now captures audio only during meetings by default — the mic and other apps' audio are captured only while you're in a call. Change this anytime in Settings → General → System Audio (Always / Only during meetings / Never)"
+  ],
   "releases": [
     {
       "version": "0.11.467",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
@@ -6,8 +6,8 @@ class AssistantSettings {
     static let shared = AssistantSettings()
 
     /// Controls when system audio (audio from other apps — calls, videos, music) is captured
-    /// during a recording. `always` = capture for the whole recording (default, prior behavior);
-    /// `onlyDuringMeetings` = capture only while a conferencing call is detected; `never` = never.
+    /// during a recording. `always` = capture for the whole recording; `onlyDuringMeetings` =
+    /// capture only while a conferencing call is detected (default); `never` = never.
     enum SystemAudioCaptureMode: String {
         case always
         case onlyDuringMeetings
@@ -40,7 +40,7 @@ class AssistantSettings {
     private let defaultTranscriptionVocabulary: [String] = []
     private let defaultVadGateEnabled = false
     private let defaultBatchTranscriptionEnabled = false
-    private let defaultSystemAudioCaptureMode: SystemAudioCaptureMode = .always
+    private let defaultSystemAudioCaptureMode: SystemAudioCaptureMode = .onlyDuringMeetings
 
     private init() {
         // Register defaults


### PR DESCRIPTION
## What
Flip the default **System Audio** capture mode from **Always** → **Only during meetings**.

`AssistantSettings.defaultSystemAudioCaptureMode: .always → .onlyDuringMeetings`

## Behavior
In *Only during meetings* mode the **entire recording (mic + system audio) is gated** by `MeetingDetector` — nothing is captured unless a conferencing call (Zoom/Teams/FaceTime/Meet, etc.) is detected. Making it the default means, out of the box, Omi captures only during calls.

## Rollout — everyone switches (no migration)
The default is read via `register(defaults:)`, so this applies to **both new installs and existing users who never explicitly chose a mode** (on next launch they move from Always → Only-during-meetings). Users who already picked a mode keep their choice. Anyone can change it in **Settings → General → System Audio** (Always / Only during meetings / Never). This is intentional per product direction (less intrusive desktop, lower always-on capture).

## Notes
- The meeting-gated System Audio feature itself already shipped (v0.11.464); this PR only changes the **default**.
- Supersedes the original feature PR #7629, which was branched off the pre-`desktop/macos/` layout and is now stale/conflicting.

## Verification
- Clean release build of the `Desktop` package (`xcrun swift build -c release --package-path Desktop`).
- The picker ↔ default ↔ helper-text ↔ runtime gating chain was verified end-to-end on a named bundle previously; this is a one-line constant flip with no logic/type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)