### PR TITLE
perf(backend): reuse listen startup preference projection

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -356,10 +356,13 @@ async def _stream_handler(
         lc3_chunk_size = 30  # 30 bytes per frame
         lc3_frame_duration_us = 10000  # 10ms = 10000 microseconds
 
-    # Fetch user transcription preferences
+    # Fetch user transcription preferences once and reuse its embedded language
+    # projection below for translation targeting. Avoid a second user preference
+    # read on the hot WebSocket startup path.
     transcription_prefs = get_user_transcription_preferences(uid)
     single_language_mode = transcription_prefs.get('single_language_mode', False)
     vocabulary = transcription_prefs.get('vocabulary', [])
+    user_language_preference = transcription_prefs.get('language', '')
 
     # Stamp mobile custom-STT usage onto the user doc so these users are queryable
     # and meterable (#7690) — the app otherwise only signals it per-session via the
@@ -405,7 +408,6 @@ async def _stream_handler(
         translation_language = None
     elif stt_language == 'multi':
         if language == "multi":
-            user_language_preference = user_db.get_user_language_preference(uid)
             if user_language_preference:
                 translation_language = user_language_preference
         else:

--- a/backend/tests/unit/test_firestore_cache.py
+++ b/backend/tests/unit/test_firestore_cache.py
@@ -156,3 +156,11 @@ def test_ai_profile_update_bypasses_cached_getter_for_merge_safety():
 
     assert '_get_ai_user_profile_from_firestore(uid)' in block
     assert 'get_ai_user_profile(uid)' not in block
+
+
+def test_listen_reuses_transcription_projection_language_without_second_user_read():
+    source = open('routers/transcribe.py').read()
+
+    assert source.count('get_user_transcription_preferences(uid)') == 1
+    assert "transcription_prefs.get('language', '')" in source
+    assert 'get_user_language_preference' not in source

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -16,8 +16,10 @@ description: "Sequence diagrams for the /v4/listen WebSocket and Pusher processi
 
 The STT provider is selected at session start via `STT_SERVICE_MODELS` env var
 (e.g., `modulate-velma-2,dg-nova-3`). The first provider supporting the
-requested language wins. All providers implement the `STTSocket` ABC and are
-wrapped by the universal `GatedSTTSocket` VAD gate.
+requested language wins. Listen startup loads transcription preferences once and
+reuses the embedded user language for translation targeting, avoiding a second
+user-preference read on WebSocket startup. All providers implement the
+`STTSocket` ABC and are wrapped by the universal `GatedSTTSocket` VAD gate.
 
 Segments buffered in `realtime_segment_buffers` are sorted by `start` time
 before processing — this corrects non-deterministic WebSocket arrival order


### PR DESCRIPTION
## Summary

Follow-up to #7958's projection-based Firestore cache foundation.

This PR takes the 80/20 low-risk next step recommended by Oracle: `/v4/listen` startup already fetches `get_user_transcription_preferences(uid)`, whose safe projection includes `language`, so reuse that embedded language for translation targeting instead of issuing a second `get_user_language_preference(uid)` lookup.

## Changes

- Reuse `transcription_prefs["language"]` in listen startup translation selection.
- Add a source-level regression test that guards against reintroducing the second language projection read in `routers/transcribe.py`.
- Update listen/pusher pipeline docs to document that startup preferences are loaded once and reused.

## What this intentionally does not include

- No cache rollout flag changes.
- No TTL/metrics/invalidation changes.
- No high-risk entitlement, BYOK, privacy, data-protection, or full-user-doc caching.
- No `utils/chat.py` behavior changes; Oracle recommended keeping this PR scoped to the hottest `/v4/listen` path.

## Validation

```bash
cd backend && ../.venv/bin/python -m pytest tests/unit/test_firestore_cache.py -v --tb=short
```

Result: **9 passed in 0.05s**

```bash
cd backend && ../.venv/bin/python -m black routers/transcribe.py tests/unit/test_firestore_cache.py --check
```

Result: **2 files would be left unchanged**

```bash
./.venv/bin/python backend/scripts/scan_async_blockers.py
```

Result: completed with the existing async-blocker report; no new category of blocker introduced by this PR.

## Oracle review

Oracle plan recommended this exact PR scope: reuse the transcription projection in `/v4/listen`, add a regression guard, update docs, and exclude broader rollout/high-risk projections.

Final Oracle patch review: **APPROVED**

> No blocking correctness issue. Both getters read the same top-level `language` field and return `''` when absent; `set_user_language_preference()` invalidates both cache projections. Reusing the already-loaded transcription projection therefore preserves translation-selection behavior while eliminating the duplicate startup lookup.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

