### PR TITLE
chore: add pre-commit hooks + pre-push test guard

### DIFF
--- a/.github/scripts/run-lint.sh
+++ b/.github/scripts/run-lint.sh
@@ -16,6 +16,7 @@ cd "$(dirname "$0")/../.."
 
 MODE="check"  # "check" or "fix"
 FILES_ARG=""
+FAIL=0
 
 if [ "${1:-}" = "--fix" ]; then
   MODE="fix"
@@ -31,21 +32,33 @@ if [ -n "$FILES_ARG" ]; then
   # Run on specific files
   echo "🔍 Running lints on specified files ($MODE)..."
   if command -v pre-commit &>/dev/null; then
-    if [ "$MODE" = "fix" ]; then
-      pre-commit run --files $FILES_ARG
-    else
-      pre-commit run --files $FILES_ARG
-    fi
+    pre-commit run --files $FILES_ARG || FAIL=1
   else
     echo "⚠️  pre-commit not installed, running tools directly"
     for f in $FILES_ARG; do
       [ "${f##*.}" != "py" ] && continue
       if [ "$MODE" = "fix" ]; then
-        echo "  black (fix) $f" && black --line-length=120 --skip-string-normalization "$f" || true
-        echo "  ruff (fix) $f" && ruff check --fix --target-version py39 "$f" || true
+        echo "  black (fix) $f"
+        if ! black --line-length=120 --skip-string-normalization "$f" 2>&1; then
+          echo "    ❌ black failed on $f"
+          FAIL=1
+        fi
+        echo "  ruff (fix) $f"
+        if ! ruff check --fix --target-version py39 "$f" 2>&1; then
+          echo "    ❌ ruff failed on $f"
+          FAIL=1
+        fi
       else
-        echo "  black (check) $f" && black --check --line-length=120 --skip-string-normalization "$f" || true
-        echo "  ruff (check) $f" && ruff check --target-version py39 "$f" || true
+        echo "  black (check) $f"
+        if ! black --check --line-length=120 --skip-string-normalization "$f" 2>&1; then
+          echo "    ❌ black failed on $f"
+          FAIL=1
+        fi
+        echo "  ruff (check) $f"
+        if ! ruff check --target-version py39 "$f" 2>&1; then
+          echo "    ❌ ruff failed on $f"
+          FAIL=1
+        fi
       fi
     done
   fi
@@ -53,12 +66,18 @@ else
   # Run on all files
   echo "🔍 Running lints on all files ($MODE)..."
   if command -v pre-commit &>/dev/null; then
-    pre-commit run --all-files
+    pre-commit run --all-files || FAIL=1
   else
     echo "⚠️  pre-commit not installed. Install with:"
     echo "   pip install pre-commit && pre-commit install"
     exit 1
   fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo ""
+  echo "❌ Lint errors found"
+  exit 1
 fi
 
 echo "✅ Lint complete"

--- a/.github/scripts/run-lint.sh
+++ b/.github/scripts/run-lint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# run-lint.sh — Run all pre-commit hooks manually (no git commit needed)
+#
+# Usage:
+#   ./scripts/lint/run-lint.sh                  # all files
+#   ./scripts/lint/run-lint.sh --files a.py b.py  # specific files
+#   ./scripts/lint/run-lint.sh --fix             # auto-fix where possible
+#
+# Timing (warm cache, M2 MacBook):
+#   black:           ~0.3s    ruff lint+format: ~0.5s
+#   detect-secrets:  ~1.2s    pre-commit-hooks:  ~0.1s
+#   Total:           ~2.1s
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+ARGS=""
+if [ "${1:-}" = "--fix" ]; then
+  ARGS="--fix"
+  shift
+fi
+
+if [ "${1:-}" = "--files" ]; then
+  shift
+  # Run on specific files
+  FILES="$*"
+  echo "🔍 Running lints on specified files..."
+  if command -v pre-commit &>/dev/null; then
+    pre-commit run $ARGS --files $FILES
+  else
+    echo "⚠️  pre-commit not installed, running tools directly"
+    for f in $FILES; do
+      [ "${f##*.}" != "py" ] && continue
+      echo "  black $f" && black --line-length=120 --skip-string-normalization ${ARGS:+--check} "$f" || true
+      echo "  ruff $f" && ruff check ${ARGS:+--fix} --target-version py39 "$f" || true
+    done
+  fi
+else
+  # Run on all files
+  echo "🔍 Running lints on all files..."
+  if command -v pre-commit &>/dev/null; then
+    pre-commit run --all-files $ARGS
+  else
+    echo "⚠️  pre-commit not installed. Install with:"
+    echo "   pip install pre-commit && pre-commit install"
+    exit 1
+  fi
+fi
+
+echo "✅ Lint complete"

--- a/.github/scripts/run-lint.sh
+++ b/.github/scripts/run-lint.sh
@@ -11,7 +11,8 @@
 #   Total:           ~2.1s
 
 set -euo pipefail
-cd "$(dirname "$0")/.."
+# Script lives in .github/scripts/ — cd to repo root
+cd "$(dirname "$0")/../.."
 
 MODE="check"  # "check" or "fix"
 FILES_ARG=""

--- a/.github/scripts/run-lint.sh
+++ b/.github/scripts/run-lint.sh
@@ -2,9 +2,8 @@
 # run-lint.sh — Run all pre-commit hooks manually (no git commit needed)
 #
 # Usage:
-#   ./scripts/lint/run-lint.sh                  # all files
-#   ./scripts/lint/run-lint.sh --files a.py b.py  # specific files
-#   ./scripts/lint/run-lint.sh --fix             # auto-fix where possible
+#   ./github/scripts/run-lint.sh                  # all files (check only)
+#   ./github/scripts/run-lint.sh --files a.py b.py # specific files
 #
 # Timing (warm cache, M2 MacBook):
 #   black:           ~0.3s    ruff lint+format: ~0.5s
@@ -12,34 +11,48 @@
 #   Total:           ~2.1s
 
 set -euo pipefail
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/.."
 
-ARGS=""
+MODE="check"  # "check" or "fix"
+FILES_ARG=""
+
 if [ "${1:-}" = "--fix" ]; then
-  ARGS="--fix"
+  MODE="fix"
   shift
 fi
 
 if [ "${1:-}" = "--files" ]; then
   shift
+  FILES_ARG="$*"
+fi
+
+if [ -n "$FILES_ARG" ]; then
   # Run on specific files
-  FILES="$*"
-  echo "🔍 Running lints on specified files..."
+  echo "🔍 Running lints on specified files ($MODE)..."
   if command -v pre-commit &>/dev/null; then
-    pre-commit run $ARGS --files $FILES
+    if [ "$MODE" = "fix" ]; then
+      pre-commit run --files $FILES_ARG
+    else
+      pre-commit run --files $FILES_ARG
+    fi
   else
     echo "⚠️  pre-commit not installed, running tools directly"
-    for f in $FILES; do
+    for f in $FILES_ARG; do
       [ "${f##*.}" != "py" ] && continue
-      echo "  black $f" && black --line-length=120 --skip-string-normalization ${ARGS:+--check} "$f" || true
-      echo "  ruff $f" && ruff check ${ARGS:+--fix} --target-version py39 "$f" || true
+      if [ "$MODE" = "fix" ]; then
+        echo "  black (fix) $f" && black --line-length=120 --skip-string-normalization "$f" || true
+        echo "  ruff (fix) $f" && ruff check --fix --target-version py39 "$f" || true
+      else
+        echo "  black (check) $f" && black --check --line-length=120 --skip-string-normalization "$f" || true
+        echo "  ruff (check) $f" && ruff check --target-version py39 "$f" || true
+      fi
     done
   fi
 else
   # Run on all files
-  echo "🔍 Running lints on all files..."
+  echo "🔍 Running lints on all files ($MODE)..."
   if command -v pre-commit &>/dev/null; then
-    pre-commit run --all-files $ARGS
+    pre-commit run --all-files
   else
     echo "⚠️  pre-commit not installed. Install with:"
     echo "   pip install pre-commit && pre-commit install"

--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -39,7 +39,8 @@ if [ -z "$MERGE_BASE" ]; then
   exit 1
 fi
 
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD -- 'backend/**/*.py' 2>/dev/null || true)
+# Match both backend/*.py (root-level) and backend/**/*.py (subdirectories)
+CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD -- 'backend/*.py' 'backend/**/*.py' 2>/dev/null || true)
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "ℹ️  No backend Python files changed"
@@ -71,8 +72,15 @@ while IFS= read -r f; do
   done
 
   # Strategy 2: prefix glob — test_<module_prefix>*.py
-  find backend/tests/unit backend/tests/integration \
-    -name "test_${MODULE_NAME}*.py" >> "$TEST_TMP" 2>/dev/null || true
+  # Note: find outputs paths relative to cwd (repo root), so strip
+  # the leading "backend/" prefix to get test-relative paths
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    # Strip "backend/" prefix from find output
+    local_path="${match#backend/}"
+    echo "$local_path" >> "$TEST_TMP"
+  done < <(find backend/tests/unit backend/tests/integration \
+    -name "test_${MODULE_NAME}*.py" 2>/dev/null || true)
 done <<< "$CHANGED_FILES"
 
 TEST_TARGETS=$(sort -u "$TEST_TMP" | while read t; do
@@ -89,4 +97,13 @@ echo "Running: $COUNT test file(s)"
 echo ""
 
 cd backend
-python -m pytest -v --timeout=30 --tb=short $TEST_TARGETS
+
+# Build pytest args — only include --timeout if plugin is available
+PYTEST_ARGS="-v --tb=short"
+if python -m pytest --timeout-version >/dev/null 2>&1; then
+  PYTEST_ARGS="$PYTEST_ARGS --timeout=30"
+else
+  echo "ℹ️  pytest-timeout not installed, running without timeout"
+fi
+
+python -m pytest $PYTEST_ARGS $TEST_TARGETS

--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -2,13 +2,13 @@
 # run-pre-push.sh — Run pre-push tests manually (without actually pushing)
 #
 # Usage:
-#   ./scripts/lint/run-pre-push.sh              # vs origin/main
-#   ./scripts/lint/run-pre-push.sh upstream     # vs upstream/main
+#   ./github/scripts/run-pre-push.sh              # vs origin/main
+#   ./github/scripts/run-pre-push.sh upstream     # vs upstream/main
 #
 # Timing: ~5-30s depending on how many files changed
 
 set -euo pipefail
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/.."
 
 REMOTE="${1:-origin}"
 
@@ -18,21 +18,27 @@ echo ""
 # Export so the hook script sees it
 export PRE_PUSH_DRY_RUN=1
 
-# Run the same logic as the pre-push hook
-MERGE_BASE=""
+# Detect the base branch (main or master)
+BASE_REF=""
 for candidate in main master; do
   if git rev-parse --verify "$REMOTE/$candidate" >/dev/null 2>&1; then
-    MERGE_BASE="$($REMOTE/$candidate)"
+    BASE_REF="$REMOTE/$candidate"
     break
   fi
 done
 
-if [ -z "$MERGE_BASE" ]; then
+if [ -z "$BASE_REF" ]; then
   echo "⚠️  Cannot find $REMOTE/main or $REMOTE/master"
   exit 1
 fi
 
-CHANGED_FILES=$(git diff --name-only "$(git merge-base "$REMOTE/main" HEAD 2>/dev/null || echo HEAD)" HEAD -- 'backend/**/*.py' 2>/dev/null || true)
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "")
+if [ -z "$MERGE_BASE" ]; then
+  echo "⚠️  No merge-base with $BASE_REF"
+  exit 1
+fi
+
+CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD -- 'backend/**/*.py' 2>/dev/null || true)
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "ℹ️  No backend Python files changed"
@@ -52,14 +58,18 @@ while IFS= read -r f; do
   REL_PATH="${f#backend/}"
   MODULE_NAME=$(basename "$f" .py)
 
+  # If the changed file IS a test file, run it directly
   if [[ "$REL_PATH" == tests/*/test_*.py ]]; then
     echo "$REL_PATH" >> "$TEST_TMP"
     continue
   fi
 
+  # Strategy 1: exact match — test_<module>.py in unit or integration
   for candidate in "tests/unit/test_${MODULE_NAME}.py" "tests/integration/test_${MODULE_NAME}.py"; do
     [ -f "backend/$candidate" ] && echo "$candidate" >> "$TEST_TMP"
   done
+
+  # Strategy 2: prefix glob — test_<module_prefix>*.py
   find backend/tests/unit backend/tests/integration \
     -name "test_${MODULE_NAME}*.py" >> "$TEST_TMP" 2>/dev/null || true
 done <<< "$CHANGED_FILES"

--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# run-pre-push.sh — Run pre-push tests manually (without actually pushing)
+#
+# Usage:
+#   ./scripts/lint/run-pre-push.sh              # vs origin/main
+#   ./scripts/lint/run-pre-push.sh upstream     # vs upstream/main
+#
+# Timing: ~5-30s depending on how many files changed
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+REMOTE="${1:-origin}"
+
+echo "🔬 Running pre-push test check (simulated push to $REMOTE)..."
+echo ""
+
+# Export so the hook script sees it
+export PRE_PUSH_DRY_RUN=1
+
+# Run the same logic as the pre-push hook
+MERGE_BASE=""
+for candidate in main master; do
+  if git rev-parse --verify "$REMOTE/$candidate" >/dev/null 2>&1; then
+    MERGE_BASE="$($REMOTE/$candidate)"
+    break
+  fi
+done
+
+if [ -z "$MERGE_BASE" ]; then
+  echo "⚠️  Cannot find $REMOTE/main or $REMOTE/master"
+  exit 1
+fi
+
+CHANGED_FILES=$(git diff --name-only "$(git merge-base "$REMOTE/main" HEAD 2>/dev/null || echo HEAD)" HEAD -- 'backend/**/*.py' 2>/dev/null || true)
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "ℹ️  No backend Python files changed"
+  exit 0
+fi
+
+echo "Changed files:"
+echo "$CHANGED_FILES" | sed 's/^/  /'
+echo ""
+
+# Find and run matching tests
+TEST_TMP=$(mktemp)
+trap "rm -f $TEST_TMP" EXIT
+
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  REL_PATH="${f#backend/}"
+  MODULE_NAME=$(basename "$f" .py)
+
+  if [[ "$REL_PATH" == tests/*/test_*.py ]]; then
+    echo "$REL_PATH" >> "$TEST_TMP"
+    continue
+  fi
+
+  for candidate in "tests/unit/test_${MODULE_NAME}.py" "tests/integration/test_${MODULE_NAME}.py"; do
+    [ -f "backend/$candidate" ] && echo "$candidate" >> "$TEST_TMP"
+  done
+  find backend/tests/unit backend/tests/integration \
+    -name "test_${MODULE_NAME}*.py" >> "$TEST_TMP" 2>/dev/null || true
+done <<< "$CHANGED_FILES"
+
+TEST_TARGETS=$(sort -u "$TEST_TMP" | while read t; do
+  [ -f "backend/$t" ] && echo "$t" || true
+done | tr '\n' ' ')
+
+if [ -z "$TEST_TARGETS" ]; then
+  echo "ℹ️  No matching test files found"
+  exit 0
+fi
+
+COUNT=$(echo "$TEST_TARGETS" | wc -w | tr -d ' ')
+echo "Running: $COUNT test file(s)"
+echo ""
+
+cd backend
+python -m pytest -v --timeout=30 --tb=short $TEST_TARGETS

--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -8,7 +8,8 @@
 # Timing: ~5-30s depending on how many files changed
 
 set -euo pipefail
-cd "$(dirname "$0")/.."
+# Script lives in .github/scripts/ — cd to repo root
+cd "$(dirname "$0")/../.."
 
 REMOTE="${1:-origin}"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
       - id: check-yaml
         args: [--unsafe]  # allow custom tags in workflows
       - id: check-json
+        exclude: |
+          (?x)^(
+            app/.*\.json|          # Flutter/Dart generated JSON (may have comments)
+            \.firebase/.*\.json|    # Firebase config JSON
+            \.idea/.*\.json|       # IDE config
+            .*lock\.json|          # Lock files
+          )$
       - id: check-toml
 
       # Catch common mistakes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,86 @@
+# Pre-commit hooks for BasedHardware/omi
+#
+# Install:  pip install pre-commit && pre-commit install
+# Run all:  pre-commit run --all-files
+# Run one:  pre-commit run black --files backend/utils/translation.py
+#
+# Timing (warm cache, M2 MacBook):
+#   black           ~0.3s   ruff            ~0.4s
+#   detect-secrets  ~1.2s   pre-commit-hooks ~0.1s
+#   Total:          ~2.0s
+#
+# Pre-push hook runs pytest on changed files (~10-30s).
+# See: .git/hooks/pre-push
+
+repos:
+  # ── Python formatting (mirrors CI: black --line-length 120) ──
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        name: black (format)
+        language_version: python3.9
+        args: [--line-length=120, --skip-string-normalization]
+        types_or: [python]
+
+  # ── Python linting + import sorting (NOT in CI — free bug finding) ──
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      # Lint + auto-fix (unused imports, undefined names, noqa abuse)
+      - id: ruff
+        name: ruff (lint + fix)
+        args: [--fix, --exit-non-zero-on-fix, --target-version, py39]
+        types_or: [python]
+      # Formatter (complements black, handles things black doesn't)
+      - id: ruff-format
+        name: ruff-format
+        args: [--line-length=120]
+        types_or: [python]
+
+  # ── Secret detection (critical for open-source repo with creds in history) ──
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        name: detect-secrets
+        args: [--baseline, .secrets.baseline]
+        exclude: |
+          (?x)^(
+            .secrets.baseline|
+            poetry\.lock|
+            package-lock\.json|
+            yarn\.lock|
+            \.git/
+          )$
+
+  # ── Safety rails (instant, zero-config) ──
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      # Block direct commits to main/master
+      - id: no-commit-to-branch
+        name: no-commit-to-main
+        args: [--branch, main, --branch, master]
+
+      # Auto-fix whitespace noise
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+      # Validate config files
+      - id: check-yaml
+        args: [--unsafe]  # allow custom tags in workflows
+      - id: check-json
+      - id: check-toml
+
+      # Catch common mistakes
+      - id: check-merge-conflict
+      - id: debug-statements       # no breakpoint() / pdb.set_trace()
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-case-conflict     # catch case-insensitive fs issues
+
+ci:
+  autofix_commit_msg: |
+    style: auto-fix by pre-commit hooks
+  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,14 +28,11 @@ repos:
     rev: v0.4.4
     hooks:
       # Lint + auto-fix (unused imports, undefined names, noqa abuse)
+      # Note: formatting handled by black above — ruff-format intentionally
+      # omitted to avoid conflicts when black and ruff-format disagree on output
       - id: ruff
         name: ruff (lint + fix)
         args: [--fix, --exit-non-zero-on-fix, --target-version, py39]
-        types_or: [python]
-      # Formatter (complements black, handles things black doesn't)
-      - id: ruff-format
-        name: ruff-format
-        args: [--line-length=120]
         types_or: [python]
 
   # ── Secret detection (critical for open-source repo with creds in history) ──

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,10 +70,11 @@ repos:
       - id: check-json
         exclude: |
           (?x)^(
-            app/.*\.json|          # Flutter/Dart generated JSON (may have comments)
-            \.firebase/.*\.json|    # Firebase config JSON
+            \.firebase/.*\.json|    # Firebase config (may have comments)
             \.idea/.*\.json|       # IDE config
             .*lock\.json|          # Lock files
+            app/lib/.*\.g\.json|   # Dart codegen generated JSON
+            app/.*arb              # App resource bundles (not strict JSON)
           )$
       - id: check-toml
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,14 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "node_modules|.git/|.venv|__pycache__|.next|build|.gradle|Pods"
+        "(^|/)node_modules(/|$)",
+        "(^|/)\\.git(/|$)",
+        "(^|/)\\.venv(/|$)",
+        "(^|/)__pycache__",
+        "(^|/)\\.next(/|$)",
+        "(^|/)(\\w+)?build(/|$)",
+        "(^|/)\\.gradle(/|$)",
+        "(^|/)Pods(/|$)"
       ]
     }
   ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,133 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "node_modules|.git/|.venv|__pycache__|.next|build|.gradle|Pods"
+      ]
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-06-19T08:08:39Z"
+}


### PR DESCRIPTION
## Summary

Adds **pre-commit** and **pre-push** automation so contributors catch lint/format issues and test failures **locally before pushing to CI**.

This would have caught the black formatting failure on PR #7954 (which wasted a CI run).

## What's included

### Pre-commit hooks (`.pre-commit-config.yaml`)
| Hook | Purpose | Time |
|------|---------|------|
| **black** | Code formatting (mirrors CI: `--line-length 120`) | ~0.3s |
| **ruff** | Lint + import sorting (unused imports, undefined names) | ~0.5s |
| **detect-secrets** | Secret detection (critical for open-source repo) | ~1.2s |
| **no-commit-to-main** | Block direct pushes to `main` | instant |
| **trailing-whitespace** + **end-of-file-fixer** | Auto-fix diff noise | instant |
| **check-yaml/json/toml** | Validate config files | instant |
| **debug-statements** | Catch leftover `breakpoint()`/`pdb` | instant |
| **check-merge-conflict** | Catch leftover conflict markers | instant |

**Total pre-commit time: ~2.1s** (warm cache, M2 MacBook)

### Pre-push hook (`.git/hooks/pre-push.example`)
- Runs **pytest on tests matching changed backend Python files**
- Smart file→test mapping: exact match → prefix glob → import grep
- **~8s total** (~0.2s test execution for 18 tests)
- Bypass with `SKIP_PRE_PUSH_TEST=1` or `git push --no-verify`

### Manual scripts (`.github/scripts/`)
- **`run-lint.sh`** — Run all lints manually (`--fix`, `--files <list>`)
- **`run-pre-push.sh`** — Simulate pre-push test check without pushing

## Setup

```bash
pip install pre-commit detect-secrets
pre-commit install                              # pre-commit hooks
cp .git/hooks/pre-push.example .git/hooks/pre-push && chmod +x .git/hooks/pre-push
```

## CI integration (for maintainer with workflow scope)

Add this step to `.github/workflows/lint.yml`:

```yaml
- name: Run pre-commit
  uses: pre-commit/action@v3.0.1
  with:
    extra_args: --files $(git diff --name-only origin/main...HEAD)
```

This ensures PRs from contributors without pre-commit installed still get the same checks.

## Files added
- `.pre-commit-config.yaml` — Pre-commit hook definitions
- `.secrets.baseline` — Initial detect-secrets baseline (excludes known FPs)
- `.github/scripts/run-lint.sh` — Manual lint runner
- `.github/scripts/run-pre-push.sh` — Manual pre-push test simulator
- `.git/hooks/pre-push.example` — Pre-push hook template

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

