### PR TITLE
fix(phone-calls): guard _loadContacts setState against disposed State (null-check crash)

### DIFF
--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -53,6 +53,10 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
   Future<void> _loadContacts() async {
     try {
       bool hasPermission = await FlutterContacts.requestPermission(readonly: true);
+      // The page can be popped while these awaits are in flight; calling setState
+      // on a disposed State throws "Null check operator used on a null value"
+      // (framework's internal _element!), so bail out if we're no longer mounted.
+      if (!mounted) return;
       if (!hasPermission) {
         setState(() {
           _permissionDenied = true;
@@ -65,12 +69,14 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
       contacts = contacts.where((c) => c.phones.isNotEmpty).toList();
       contacts.sort((a, b) => a.displayName.compareTo(b.displayName));
 
+      if (!mounted) return;
       setState(() {
         _contacts = contacts;
         _filteredContacts = contacts;
         _loadingContacts = false;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         _loadingContacts = false;
       });
@@ -467,10 +473,7 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
       items: [
         PopupMenuItem<String>(
           value: 'paste',
-          child: Text(
-            context.l10n.paste,
-            style: const TextStyle(color: Colors.white),
-          ),
+          child: Text(context.l10n.paste, style: const TextStyle(color: Colors.white)),
         ),
       ],
     );

--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -53,9 +53,6 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
   Future<void> _loadContacts() async {
     try {
       bool hasPermission = await FlutterContacts.requestPermission(readonly: true);
-      // The page can be popped while these awaits are in flight; calling setState
-      // on a disposed State throws "Null check operator used on a null value"
-      // (framework's internal _element!), so bail out if we're no longer mounted.
       if (!mounted) return;
       if (!hasPermission) {
         setState(() {


### PR DESCRIPTION
## Crash

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
  at State.setState(framework.dart:1219)
  at _PhoneCallsPageState._loadContacts(phone_calls_page.dart:74)
```

## Root cause

`_loadContacts()` is async and calls `setState` after two `await`s
(`FlutterContacts.requestPermission` and `FlutterContacts.getContacts`). If the
user navigates away from `PhoneCallsPage` while those awaits are in flight, the
`State` is disposed. Flutter's `setState` then runs its internal
`_element!.markNeedsBuild()` — and on a disposed `State`, `_element` is `null`,
so the `!` throws **"Null check operator used on a null value"** (surfaced as a
fatal via Crashlytics).

It hits at the `phone_calls_page.dart:74` `setState` (the `catch`-block one), but
all three `setState` calls in `_loadContacts` share the same unguarded-after-await
hazard.

## Fix

Add `if (!mounted) return;` before each post-`await` `setState` in
`_loadContacts`. No behavior change on the normal path; it just bails out when the
page is already gone.

## Notes
- `_makeCall` already does the right thing (`if (!mounted) return;` after its await) — this brings `_loadContacts` in line with that pattern.
- No repro harness for the race, but the fix is the standard Flutter guard for "setState after dispose"; verified the file formats clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

