### PR TITLE
fix(language-dialog): guard l10n after await against disposed context (null-check crash)

### DIFF
--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -225,7 +225,8 @@ class LanguageSelectionDialog {
                             selectedLanguage!,
                             userProvider: userProvider,
                           );
-                          if (success && context.mounted) {
+                          if (!context.mounted) return;
+                          if (success) {
                             Provider.of<CaptureProvider>(context, listen: false).onRecordProfileSettingChanged();
                             Navigator.of(context).pop();
                             AppSnackbar.showSnackbarSuccess(context.l10n.languageSetTo(selectedLanguageName!));


### PR DESCRIPTION
## Crash

```
Fatal Exception: Null check operator used on a null value
  at AppLocalizations.of(app_localizations.dart:117)
  at LocalizationExtension.l10n(l10n_extensions.dart:21)
  at LanguageSelectionDialog.show.<fn>.<fn>.<fn>(language_selection_dialog.dart:233)
```

## Root cause

The confirm button's `onPressed` is async:

```dart
final success = await homeProvider.updateUserPrimaryLanguage(...);
if (success && context.mounted) {
  ... Navigator.pop(); AppSnackbar.showSnackbarSuccess(context.l10n...);
} else {
  AppSnackbar.showSnackbarError(context.l10n.failedToSetLanguage);   // line 233
}
```

The success branch checks `context.mounted`, but the **else branch does not**. If
the dialog is dismissed while `updateUserPrimaryLanguage` is awaiting, the dialog's
`context` is defunct, so `context.l10n` → `AppLocalizations.of(context)` →
`Localizations.of<AppLocalizations>(...)` returns null and the generated `!` throws
"Null check operator used on a null value".

## Fix

Replace the per-branch `success && context.mounted` check with a single
`if (!context.mounted) return;` right after the await, so **both** branches are
guarded before any `context.l10n` / `Navigator` / `Provider.of` use. No behavior
change on the normal path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

