### PR TITLE
fix(developer): set sharePositionOrigin to stop iPad share-sheet crash

### DIFF
--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -60,6 +60,15 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
     super.initState();
   }
 
+  // iPad requires a non-zero sharePositionOrigin (popover anchor) for the share sheet.
+  Rect _shareOrigin() {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box != null && box.hasSize && box.size.width > 0 && box.size.height > 0) {
+      return box.localToGlobal(Offset.zero) & box.size;
+    }
+    return const Rect.fromLTWH(0, 0, 100, 100);
+  }
+
   Widget _buildSectionContainer({required List<Widget> children}) {
     return Container(
       decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(12)),
@@ -685,9 +694,11 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                                       return;
                                     }
                                     if (files.length == 1) {
-                                      final result = await Share.shareXFiles([
-                                        XFile(files.first.path),
-                                      ], text: 'Omi debug log');
+                                      final result = await Share.shareXFiles(
+                                        [XFile(files.first.path)],
+                                        text: 'Omi debug log',
+                                        sharePositionOrigin: _shareOrigin(),
+                                      );
                                       if (result.status == ShareResultStatus.success) {
                                         Logger.debug('Log shared');
                                       }
@@ -754,9 +765,11 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                                     );
 
                                     if (selected != null) {
-                                      final result = await Share.shareXFiles([
-                                        XFile(selected.path),
-                                      ], text: 'Omi debug log');
+                                      final result = await Share.shareXFiles(
+                                        [XFile(selected.path)],
+                                        text: 'Omi debug log',
+                                        sharePositionOrigin: _shareOrigin(),
+                                      );
                                       if (result.status == ShareResultStatus.success) {
                                         Logger.debug('Log shared');
                                       }
@@ -854,6 +867,7 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                               [XFile(exportedPath)],
                               subject: exportTitle,
                               text: exportTitle,
+                              sharePositionOrigin: _shareOrigin(),
                             );
                             if (result.status == ShareResultStatus.success) {
                               Logger.debug('Export shared');

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -62,6 +62,7 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
 
   // iPad requires a non-zero sharePositionOrigin (popover anchor) for the share sheet.
   Rect _shareOrigin() {
+    if (!mounted) return const Rect.fromLTWH(0, 0, 100, 100);
     final box = context.findRenderObject() as RenderBox?;
     if (box != null && box.hasSize && box.size.width > 0 && box.size.height > 0) {
       return box.localToGlobal(Offset.zero) & box.size;


### PR DESCRIPTION
## Crash

```
PlatformException(error, sharePositionOrigin: argument must be set,
{{0, 0}, {0, 0}} must be non-zero and within coordinate space of source view: {{0, 0}, {440, 956}})
  at MethodChannelShare.share
  at _DeveloperSettingsPageState.build.<fn>.<fn> (developer.dart:853)
```

## Root cause

On iPad the iOS share sheet is presented as a **popover**, which must be anchored
to a source rect. `share_plus` requires `sharePositionOrigin` for this; when it's
omitted (or zero), iOS throws `PlatformException("sharePositionOrigin: argument
must be set ... must be non-zero")`. (On iPhone the share sheet is a bottom modal,
so it never surfaced there.)

`developer.dart` called `Share.shareXFiles(...)` **without** `sharePositionOrigin`
in three places — the reported export-data button plus the two debug-log share
paths — so all three crash on iPad.

## Fix

Add a `_shareOrigin()` helper that returns the page's render-box rect (with a safe
non-zero fallback) and pass it as `sharePositionOrigin` at all three call sites.
No change to iPhone behavior.

## Sites fixed
- `developer.dart` debug-log share (single file)
- `developer.dart` debug-log share (selected file)
- `developer.dart` export-user-data share (the reported crash)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

