### PR TITLE
fix(apps): capture AppProvider before await to avoid read on disposed context

### DIFF
--- a/app/lib/pages/apps/widgets/capability_category_section.dart
+++ b/app/lib/pages/apps/widgets/capability_category_section.dart
@@ -131,8 +131,10 @@ class CapabilitySectionAppItemCard extends StatelessWidget {
         return GestureDetector(
           onTap: () async {
             PlatformManager.instance.analytics.pageOpened('App Detail');
+            // Capture before navigating; this card can be disposed while AppDetailPage is open.
+            final appProvider = context.read<AppProvider>();
             await routeToPage(context, AppDetailPage(app: app));
-            context.read<AppProvider>().filterApps();
+            appProvider.filterApps();
           },
           child: Container(
             padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),


### PR DESCRIPTION
## Crash

```
Fatal Exception: Null check operator used on a null value
  at Element.widget(framework.dart:3598)
  at Provider._inheritedElementOf(provider.dart:377)
  at Provider.of / ReadContext.read
  at CapabilitySectionAppItemCard.build.<fn>.<fn>(capability_category_section.dart:135)
```

## Root cause

The card's `onTap` did:

```dart
onTap: () async {
  await routeToPage(context, AppDetailPage(app: app));
  context.read<AppProvider>().filterApps();   // line 135
},
```

It calls `context.read<AppProvider>()` **after** awaiting navigation to
`AppDetailPage`. While the detail page is open, this card's element can be disposed
(the list rebuilds / the card scrolls out of view / the apps page is popped). When
the await returns, `context.read` resolves against a defunct element — and
`Element.widget` does `_widget!`, which is null after unmount → "Null check operator
used on a null value".

## Fix

Capture the provider **before** navigating and call `filterApps()` on the captured
reference, so no `context` lookup happens after the async gap:

```dart
final appProvider = context.read<AppProvider>();
await routeToPage(context, AppDetailPage(app: app));
appProvider.filterApps();
```

`AppProvider` outlives the card, so the refresh still runs correctly even if the
card was disposed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

