### PR TITLE
fix(apps): default app author when Firebase display name is null (fixes 'Failed to create template')

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -474,9 +474,11 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
     data['id'] = str(ULID())
     data['uid'] = uid
     if not data.get('author') and not data.get('email'):
-        user = get_user_from_uid(uid)
-        data['author'] = user.get('display_name', '')
-        data['email'] = user['email']
+        user = get_user_from_uid(uid) or {}
+        email = user.get('email')
+        # author is required + non-null on AppCreate; display_name/email can both be null.
+        data['author'] = user.get('display_name') or (email.split('@')[0] if email else None) or 'Anonymous'
+        data['email'] = email
     if not data.get('is_paid'):
         data['is_paid'] = False
     else:


### PR DESCRIPTION
## Problem

Users get **"Failed to create template"** (and the equivalent on mobile) every time
they try to save a conversation-prompt template / app — but only *some* users.

## Root cause

Neither the web "Create Custom Template" flow nor the mobile app-creation flow sends
an `author` field; both POST to `/v1/apps` with only `uid`. So `create_app` derives it:

```python
data['author'] = user.get('display_name', '')   # display_name is None for some accounts
data['email']  = user['email']
```

`get_user_from_uid` returns Firebase's `user.display_name`, which is **`None`** for
accounts with no display name (phone-auth, Apple "Hide My Email"/no-name, some
email/password sign-ups). The `''` default doesn't help — the key is present with
value `None`. `AppCreate.author` is a **required, non-null `str`**, so
`model_validate` raises → `HTTPException(422)` → client shows the failure. It happens
on **every** attempt for any user without a display name, on **both web and mobile**
(verified: neither client supplies `author`, and mobile has no author input field).

(`user['email']` was also an unguarded access — a `get_user_from_uid` returning `None`
would `AttributeError` → 500.)

## Fix

In `create_app`, null-guard the user lookup and give `author` a safe fallback chain:
display name → email local-part → terminal `'Anonymous'`, so it's never null.

```python
user = get_user_from_uid(uid) or {}
email = user.get('email')
data['author'] = user.get('display_name') or (email.split('@')[0] if email else None) or 'Anonymous'
data['email'] = email
```

Backend-only fix → covers web, mobile, and any future client in one place (no
frontend changes needed).

## Verification

```
display_name='Jane Doe'  email='j@x.com'                  -> author='Jane Doe'
display_name=None        email='brian.meyer.68@gmail.com' -> author='brian.meyer.68'
display_name=None        email=None                       -> author='Anonymous'
```
`py_compile` clean; black formatted.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

