### PR TITLE
fix opus corrupted frame crash during WAL audio playback

### DIFF
--- a/app/lib/utils/audio_player_utils.dart
+++ b/app/lib/utils/audio_player_utils.dart
@@ -287,10 +287,11 @@ class AudioPlayerUtils extends ChangeNotifier {
 
     List<Uint8List> pcmFrames = [];
     for (final opusFrame in opusFrames) {
-      final pcmFrame = decoder.decode(input: opusFrame);
-      if (pcmFrame != null) {
-        final uint8Frame = Uint8List.fromList(pcmFrame.buffer.asUint8List());
-        pcmFrames.add(uint8Frame);
+      try {
+        final pcmFrame = decoder.decode(input: opusFrame);
+        pcmFrames.add(Uint8List.fromList(pcmFrame.buffer.asUint8List()));
+      } catch (e) {
+        Logger.warning('AudioPlayerUtils: skipping corrupted Opus frame for WAL ${wal.id}: $e');
       }
     }
 


### PR DESCRIPTION
## Problem

Crashlytics reported a fatal crash when playing back WAL audio files:

```
Fatal Exception: FlutterError - OpusException -4: corrupted stream
  SimpleOpusDecoder.decode (opus_dart_decoder.dart:127)
  AudioPlayerUtils._decodeOpusToWav (audio_player_utils.dart:290)
  AudioPlayerUtils._getOrCreateAudioFile (audio_player_utils.dart:229)
  AudioPlayerUtils._startPlayback (audio_player_utils.dart:131)
  AudioPlayerUtils.togglePlayback (audio_player_utils.dart:110)
  SyncProvider.toggleWalPlayback (sync_provider.dart:549)
  _WalItemDetailPageState._handlePlayPause (wal_item_detail_page.dart:506)
```

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/1fc7aaf32b545d656157b5455b184239

WAL binary files recorded over BLE can contain partially written or corrupted Opus frames (e.g. device disconnect mid-write, storage issues). `SimpleOpusDecoder.decode` throws `OpusException -4` on any such frame, propagating as an unhandled `FlutterError` and crashing the app.

## Fix

Wrap `decoder.decode` in a try-catch inside `_decodeOpusToWav`. Corrupted frames are skipped with a warning log; valid frames are decoded and played back normally — resulting in a small audio gap rather than a crash.

## Test plan

- [ ] Play back a WAL audio file on device — playback works without crash
- [ ] Verify Crashlytics issue stops reproducing after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

