### PR TITLE
fix unhandled exception crash when sharing WAL audio file

### DIFF
--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -28,7 +28,6 @@ class WalItemDetailPage extends StatefulWidget {
 class _WalItemDetailPageState extends State<WalItemDetailPage> {
   List<double>? _waveformData;
   bool _isProcessingWaveform = false;
-  bool _isSharing = false;
   SyncProvider? _syncProvider;
 
   /// Returns true if WAL is still on device storage (SD card or flash page) and needs transfer
@@ -601,7 +600,6 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
   }
 
   Future<void> _handleShare(SyncProvider syncProvider) async {
-    setState(() => _isSharing = true);
     try {
       await syncProvider.shareWalAsWav(widget.wal);
     } catch (e) {
@@ -610,10 +608,6 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
         AppSnackbar.showSnackbarError(
           context.l10n.audioPlaybackFailed,
         );
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _isSharing = false);
       }
     }
   }

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/models/playback_state.dart';
@@ -602,6 +604,13 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
     setState(() => _isSharing = true);
     try {
       await syncProvider.shareWalAsWav(widget.wal);
+    } catch (e) {
+      Logger.error('AudioPlayerUtils: Failed to share WAL audio: $e');
+      if (mounted) {
+        AppSnackbar.showSnackbarError(
+          context.l10n.audioPlaybackFailed,
+        );
+      }
     } finally {
       if (mounted) {
         setState(() => _isSharing = false);


### PR DESCRIPTION
## Problem

Crashlytics reported a fatal crash when sharing WAL audio files:

```
Fatal Exception: FlutterError - Exception: Unable to create shareable audio file
  AudioPlayerUtils.shareAsAudio (audio_player_utils.dart:200)
  SyncProvider.shareWalAsWav (sync_provider.dart:553)
  _WalItemDetailPageState._handleShare (wal_item_detail_page.dart:604)
```

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/f0be1b339c31954195a689fc6c4765ff

`_handleShare` had a `try/finally` but no `catch` — the exception thrown by `shareAsAudio` when the audio file can't be created propagated as an unhandled `FlutterError` and crashed the app.

## Fix

- Add a `catch` block in `_handleShare` to show a snackbar error instead of crashing
- Remove dead `_isSharing` field and its two `setState` calls — the field was written but never read in the UI

## Test plan

- [ ] Share a WAL audio file — works normally
- [ ] Simulate failure (corrupted/missing file) — shows error snackbar, no crash
- [ ] Verify Crashlytics issue stops reproducing after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

