### PR TITLE
ci: catch conflict markers and check desktop rust

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,9 +136,12 @@ jobs:
 
       - name: Check desktop Rust backend
         if: steps.changed.outputs.has_desktop_rust == 'true'
-        working-directory: desktop/macos/Backend-Rust
         run: |
-          cargo fmt --check
+          FILES=$(grep -E '^desktop/macos/Backend-Rust/.*\.rs$' /tmp/changed-files.txt || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | xargs rustfmt --check
+          fi
+          cd desktop/macos/Backend-Rust
           cargo check --locked
 
       # -- Frontend --

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,24 @@ jobs:
           echo "has_firmware=$(echo "$FILES" | grep -qE '^(omi|omiGlass)/.*\.(c|cpp|cc|cxx|h|hpp)$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_frontend=$(echo "$FILES" | grep -q '^web/frontend/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Also run the Rust check when this workflow changes so CI PRs dogfood
+          # the new guard instead of only validating YAML syntax.
+          echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/.*\.rs$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      # -- Universal source hygiene --
+      - name: Check merge conflict markers
+        run: |
+          failed=0
+          while IFS= read -r file; do
+            if [ -f "$file" ] && grep -I -nE '^(<<<<<<<|>>>>>>>)' "$file"; then
+              failed=1
+            fi
+          done < /tmp/changed-files.txt
+
+          if [ "$failed" -eq 1 ]; then
+            echo "FAIL: unresolved merge conflict markers found in changed files"
+            exit 1
+          fi
 
       # -- Dart --
       - name: Setup Flutter
@@ -102,6 +120,26 @@ jobs:
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs clang-format --dry-run --Werror
           fi
+
+      # -- Desktop Rust backend --
+      - name: Cache desktop Rust backend build
+        if: steps.changed.outputs.has_desktop_rust == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/macos/Backend-Rust/target
+          key: ${{ runner.os }}-desktop-rust-${{ hashFiles('desktop/macos/Backend-Rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-desktop-rust-
+
+      - name: Check desktop Rust backend
+        if: steps.changed.outputs.has_desktop_rust == 'true'
+        working-directory: desktop/macos/Backend-Rust
+        run: |
+          cargo fmt --check
+          cargo check --locked
 
       # -- Frontend --
       - name: Setup Node.js

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           FILES=$(grep -E '^desktop/macos/Backend-Rust/.*\.rs$' /tmp/changed-files.txt || true)
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs rustfmt --check
+            echo "$FILES" | xargs rustfmt --edition 2021 --check
           fi
           cd desktop/macos/Backend-Rust
           cargo check --locked

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
-          echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/.*\.rs$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
 
       # -- Universal source hygiene --
       - name: Check merge conflict markers

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -112,7 +112,10 @@ if [ -n "$STAGED_DESKTOP_RUST_INPUTS" ]; then
   if [ -n "$STAGED_DESKTOP_RUST_FILES" ]; then
     while IFS= read -r file; do
       [ -n "$file" ] || continue
-      rustfmt "$file"
+      if ! rustfmt --edition 2021 "$file"; then
+        echo "rustfmt failed for $file" >&2
+        exit 1
+      fi
       git add "$file"
     done <<EOF
 $STAGED_DESKTOP_RUST_FILES

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,7 +4,17 @@
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
 if [ -n "$STAGED_FILES" ]; then
-  if git grep --cached -n -I -E '^(<<<<<<<|>>>>>>>)' -- $STAGED_FILES; then
+  conflict_found=0
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    if git grep --cached -n -I -E '^(<<<<<<<|>>>>>>>)' -- "$file"; then
+      conflict_found=1
+    fi
+  done <<EOF
+$STAGED_FILES
+EOF
+
+  if [ "$conflict_found" -eq 1 ]; then
     echo "Unresolved merge conflict markers found in staged files" >&2
     exit 1
   fi
@@ -90,20 +100,30 @@ if [ -n "$STAGED_C_FILES" ]; then
 fi
 
 # Rust formatting/checking for desktop backend.
-STAGED_DESKTOP_RUST_FILES=$(git diff --cached --name-only --diff-filter=ACM "desktop/macos/Backend-Rust/**.rs")
+STAGED_DESKTOP_RUST_INPUTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^desktop/macos/Backend-Rust/' || true)
+STAGED_DESKTOP_RUST_FILES=$(printf '%s\n' "$STAGED_DESKTOP_RUST_INPUTS" | grep -E '\.rs$' || true)
 
-if [ -n "$STAGED_DESKTOP_RUST_FILES" ]; then
+if [ -n "$STAGED_DESKTOP_RUST_INPUTS" ]; then
   echo "Checking desktop Rust backend..."
   if ! command -v cargo >/dev/null 2>&1; then
     echo "cargo is not installed. Please install Rust/Cargo first" >&2
     exit 1
   fi
-  echo "$STAGED_DESKTOP_RUST_FILES" | xargs rustfmt
-  echo "$STAGED_DESKTOP_RUST_FILES" | xargs git add
-  (
+  if [ -n "$STAGED_DESKTOP_RUST_FILES" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] || continue
+      rustfmt "$file"
+      git add "$file"
+    done <<EOF
+$STAGED_DESKTOP_RUST_FILES
+EOF
+  fi
+  if ! (
     cd desktop/macos/Backend-Rust && \
       cargo check --locked
-  )
+  ); then
+    exit 1
+  fi
 fi
 
 exit 0

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -98,9 +98,10 @@ if [ -n "$STAGED_DESKTOP_RUST_FILES" ]; then
     echo "cargo is not installed. Please install Rust/Cargo first" >&2
     exit 1
   fi
+  echo "$STAGED_DESKTOP_RUST_FILES" | xargs rustfmt
+  echo "$STAGED_DESKTOP_RUST_FILES" | xargs git add
   (
     cd desktop/macos/Backend-Rust && \
-      cargo fmt --check && \
       cargo check --locked
   )
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Universal source hygiene: fail fast on unresolved merge conflict markers.
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -n "$STAGED_FILES" ]; then
+  if git grep --cached -n -I -E '^(<<<<<<<|>>>>>>>)' -- $STAGED_FILES; then
+    echo "Unresolved merge conflict markers found in staged files" >&2
+    exit 1
+  fi
+fi
+
 # Dart formatting for app/
 STAGED_DART_FILES=$(git diff --cached --name-only --diff-filter=ACM "app/**.dart" | grep -v -e '\.gen\.dart$' -e '\.g\.dart$')
 
@@ -77,6 +87,22 @@ if [ -n "$STAGED_C_FILES" ]; then
   fi
   echo "$STAGED_C_FILES" | xargs clang-format -i
   echo "$STAGED_C_FILES" | xargs git add
+fi
+
+# Rust formatting/checking for desktop backend.
+STAGED_DESKTOP_RUST_FILES=$(git diff --cached --name-only --diff-filter=ACM "desktop/macos/Backend-Rust/**.rs")
+
+if [ -n "$STAGED_DESKTOP_RUST_FILES" ]; then
+  echo "Checking desktop Rust backend..."
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo is not installed. Please install Rust/Cargo first" >&2
+    exit 1
+  fi
+  (
+    cd desktop/macos/Backend-Rust && \
+      cargo fmt --check && \
+      cargo check --locked
+  )
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

Adds static guards for the failure mode caught on #7951:

- fail CI/pre-commit when changed/staged files contain unresolved merge conflict markers (`<<<<<<<` / `>>>>>>>`)
- run `rustfmt` on changed macOS desktop Rust backend files
- run `cargo check --locked` for macOS desktop Rust backend changes
- dogfood the Rust check when `.github/workflows/lint.yml` itself changes, so this PR measures the new CI cost
- cache Cargo registry/git/target directories in CI to reduce repeat-run cost

## Why

The existing lint workflow only covered Dart, backend Python, ARB, firmware C/C++, and selected web packages. Rust files under `desktop/macos/Backend-Rust/**/*.rs` could pass PR lint even with syntax errors or conflict markers.

## Local validation / timing

```bash
sh -n scripts/pre-commit
python3 - <<'PY'
import yaml
with open('.github/workflows/lint.yml') as f:
    yaml.safe_load(f)
print('lint.yml parses as YAML')
PY
```

Result: passed.

Conflict-marker scan over this PR's changed files:

```bash
/usr/bin/time -f 'elapsed=%E user=%U sys=%S' <scan command>
```

Result: `elapsed=0:00.00 user=0.00 sys=0.00`

Pre-commit hook on this PR's staged files (no Rust files staged, so conflict scan only):

```bash
/usr/bin/time -f 'elapsed=%E user=%U sys=%S' scripts/pre-commit
```

Result: `elapsed=0:00.01 user=0.00 sys=0.01`

I also verified the new conflict-marker pattern catches the current #7951 markers in `desktop/macos/Backend-Rust/src/routes/chat_completions.rs`.

## CI timing from this PR

This PR intentionally ran the desktop Rust backend guard because `.github/workflows/lint.yml` changed.

- First attempt using `cargo fmt --check` across the whole crate failed in **43s** due to existing unrelated rustfmt drift.
- Final implementation limits formatting to changed Rust files and keeps full `cargo check --locked`.
- Final `Lint & Format Check`: **passed in 1m33s**.
- `Check desktop Rust backend` step: **48s**.

The universal conflict-marker CI step completed within the same second as changed-file detection in GitHub's step timestamps.
