### PR TITLE
fix(desktop): remove the PTT-release sound cues

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -50,12 +50,6 @@ class PushToTalkManager: ObservableObject {
   /// it uses the realtime omni STT and routes the transcript into the pill's agent
   /// session (RealtimeHub pipeline), NOT the floating bar or the hub model.
   private var followUpPill: AgentPill?
-  // Cached local cue for the instant PTT-up ack (preloaded so play() never hits disk).
-  private lazy var ackSound: NSSound? = {
-    let s = NSSound(named: "Pop")
-    s?.volume = 0.35
-    return s
-  }()
   // Mic chunks captured before the relay finishes connecting (raw 16k PCM),
   // flushed once the service exists so the user's first words aren't clipped.
   private var omniPreconnectBuffer: [Data] = []
@@ -556,9 +550,8 @@ class PushToTalkManager: ObservableObject {
         updateBarState()  // clears the listening UI (no "…")
         return
       }
-      // Real speech — instant local ack + commit. The hub speaks the reply and
-      // dispatches tools itself; no transcript/router/LLM hop here.
-      if ShortcutSettings.shared.pttSoundsEnabled { ackSound?.play() }
+      // Real speech — commit. The hub speaks the reply and dispatches tools
+      // itself; no transcript/router/LLM hop here.
       RealtimeHubController.shared.commitTurn()
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
@@ -591,12 +584,6 @@ class PushToTalkManager: ObservableObject {
       }
     }
 
-    // Play end-of-PTT sound
-    if ShortcutSettings.shared.pttSoundsEnabled {
-      let sound = NSSound(named: "Bottle")
-      sound?.volume = 0.3
-      sound?.play()
-    }
 
     // Realtime omni: commit the turn and wait for the final transcript.
     if isOmniSTT {


### PR DESCRIPTION
Removes the two sounds that fired on **push-to-talk release** — the new instant-ack `Pop` and the end-of-PTT `Bottle` — which read as a 'cancel' blip. The realtime hub speaks its reply as audio, so the extra release cues are just noise. The **press** cue (`Funk`) is unchanged. Also drops the now-unused `ackSound`.

Verified locally: built + ran the named bundle, drove a real hub turn through the modified `finalize()` path (commits + returns native audio, no error); only the press cue remains in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

