### PR TITLE
Add legacy macOS Home toggle

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -48,6 +48,9 @@ struct DesktopAutomationSnapshot: Codable {
   var selectedTabIndex: Int?
   var selectedSettingsSection: String?
   var highlightedSettingId: String?
+  var usesLegacyHomeDesign: Bool
+  var showsPrimarySidebar: Bool
+  var isSidebarCollapsed: Bool
   var hasCompletedOnboarding: Bool
   var isSignedIn: Bool
   var isRestoringAuth: Bool
@@ -119,6 +122,9 @@ actor DesktopAutomationStateStore {
     selectedTabIndex: nil,
     selectedSettingsSection: nil,
     highlightedSettingId: nil,
+    usesLegacyHomeDesign: false,
+    showsPrimarySidebar: false,
+    isSidebarCollapsed: true,
     hasCompletedOnboarding: false,
     isSignedIn: false,
     isRestoringAuth: true,

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -30,6 +30,7 @@ struct DesktopHomeView: View {
   @AppStorage("currentTierLevel") private var currentTierLevel = 0
   @AppStorage("onboardingStep") private var onboardingStep = 0
   @AppStorage("onboardingJustCompleted") private var onboardingJustCompleted = false
+  @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
 
   // Settings sidebar state
   @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
@@ -495,7 +496,7 @@ struct DesktopHomeView: View {
   }
 
   private var showsPrimarySidebar: Bool {
-    false
+    useLegacyHomeDesign && !hideSidebar
   }
 
   private var currentAppStateLabel: String {
@@ -520,6 +521,9 @@ struct DesktopHomeView: View {
       selectedTabIndex: selectedIndex,
       selectedSettingsSection: isInSettings ? selectedSettingsSection.rawValue : nil,
       highlightedSettingId: highlightedSettingId,
+      usesLegacyHomeDesign: useLegacyHomeDesign,
+      showsPrimarySidebar: showsPrimarySidebar,
+      isSidebarCollapsed: isSidebarCollapsed,
       hasCompletedOnboarding: appState.hasCompletedOnboarding,
       isSignedIn: authState.isSignedIn,
       isRestoringAuth: authState.isRestoringAuth,
@@ -631,18 +635,30 @@ struct DesktopHomeView: View {
       // removed, its .help() tooltip graph nodes get invalidated, but the macOS tooltip
       // tracking system still tries to evaluate them during window key state changes.
       if isInSettings {
-        SettingsSidebar(
-          selectedSection: $selectedSettingsSection,
-          highlightedSettingId: $highlightedSettingId,
-          onBack: {
-            withAnimation(.easeInOut(duration: 0.2)) {
-              selectedIndex =
-                previousIndexBeforeSettings == SidebarNavItem.settings.rawValue
-                ? SidebarNavItem.dashboard.rawValue
-                : previousIndexBeforeSettings
-            }
+        ZStack {
+          if showsPrimarySidebar {
+            SidebarView(
+              selectedIndex: $selectedIndex,
+              isCollapsed: $isSidebarCollapsed,
+              appState: appState
+            )
+            .opacity(0)
+            .allowsHitTesting(false)
           }
-        )
+
+          SettingsSidebar(
+            selectedSection: $selectedSettingsSection,
+            highlightedSettingId: $highlightedSettingId,
+            onBack: {
+              withAnimation(.easeInOut(duration: 0.2)) {
+                selectedIndex =
+                  previousIndexBeforeSettings == SidebarNavItem.settings.rawValue
+                  ? SidebarNavItem.dashboard.rawValue
+                  : previousIndexBeforeSettings
+              }
+            }
+          )
+        }
         .fixedSize(horizontal: true, vertical: false)
         .clipped()
       } else if showsPrimarySidebar {
@@ -686,7 +702,7 @@ struct DesktopHomeView: View {
         // Extracted into a separate struct so that pages like TasksPage
         // are not re-rendered when AppState publishes unrelated changes.
         VStack(spacing: 0) {
-          if selectedIndex != SidebarNavItem.dashboard.rawValue {
+          if !useLegacyHomeDesign && selectedIndex != SidebarNavItem.dashboard.rawValue {
             PageChromeBar(
               onHome: {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -838,7 +854,13 @@ struct DesktopHomeView: View {
       // Only auto-refresh stores when their pages are visible
       updateStoreActivity(for: newValue)
     }
+    .onChange(of: useLegacyHomeDesign) { _, newValue in
+      withAnimation(.easeInOut(duration: 0.2)) {
+        isSidebarCollapsed = !newValue
+      }
+    }
     .onAppear {
+      isSidebarCollapsed = !useLegacyHomeDesign
       updateStoreActivity(for: selectedIndex)
       // Restore window width if the user quit with task chat panel open.
       // The chat panel is never open on startup (showChatPanel defaults to false),

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -211,6 +211,7 @@ struct DashboardPage: View {
     @AppStorage("dashboardWidgetsCollapsed") private var widgetsCollapsed = false
     @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
     @AppStorage("transcriptionEnabled") private var transcriptionEnabled = true
+    @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
 
     private var selectedApp: OmiApp? {
         guard let appId = chatProvider.selectedAppId else { return nil }
@@ -234,9 +235,15 @@ struct DashboardPage: View {
     }
 
     var body: some View {
-        redesignedHome
+        Group {
+            if useLegacyHomeDesign {
+                legacyHome
+            } else {
+                redesignedHome
+            }
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(HomePalette.paper)
+        .background(useLegacyHomeDesign ? Color.clear : HomePalette.paper)
         .sheet(item: $citedConversation) { conversation in
             ConversationDetailView(
                 conversation: conversation,
@@ -284,6 +291,80 @@ struct DashboardPage: View {
         .onReceive(NotificationCenter.default.publisher(for: .screenCaptureKitBroken)) { _ in
             syncCaptureState()
         }
+    }
+
+    private var legacyHome: some View {
+        VStack(spacing: 0) {
+            dashboardWidgets
+
+            ChatMessagesView(
+                messages: chatProvider.messages,
+                isSending: chatProvider.isSending,
+                hasMoreMessages: chatProvider.hasMoreMessages,
+                isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
+                isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)
+                    && !chatProvider.isClearing,
+                app: selectedApp,
+                onLoadMore: { await chatProvider.loadMoreMessages() },
+                onRate: { messageId, rating in
+                    Task { await chatProvider.rateMessage(messageId, rating: rating) }
+                },
+                onCitationTap: { citation in
+                    handleCitationTap(citation)
+                },
+                sessionsLoadError: chatProvider.sessionsLoadError,
+                onRetry: { Task { await chatProvider.retryLoad() } },
+                welcomeContent: { dashboardChatWelcome }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .mask(
+                LinearGradient(
+                    stops: [
+                        .init(color: .clear, location: 0.0),
+                        .init(color: .black, location: 0.08),
+                        .init(color: .black, location: 0.92),
+                        .init(color: .clear, location: 1.0),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+
+            ChatInputView(
+                onSend: { text in
+                    AnalyticsManager.shared.chatMessageSent(
+                        messageLength: text.count,
+                        hasContext: selectedApp != nil,
+                        source: "dashboard_chat"
+                    )
+                    Task { await chatProvider.sendMessage(text) }
+                },
+                onFollowUp: { text in
+                    Task { await chatProvider.sendFollowUp(text) }
+                },
+                onStop: {
+                    chatProvider.stopAgent()
+                },
+                isSending: chatProvider.isSending,
+                isStopping: chatProvider.isStopping,
+                placeholder: "Ask omi anything",
+                mode: $chatProvider.chatMode,
+                inputText: $chatProvider.draftText,
+                attachments: $chatProvider.pendingAttachments,
+                onAttachmentsAdded: { urls in
+                    let toAdd = urls.compactMap { ChatAttachment.from(url: $0) }
+                    chatProvider.addAttachments(toAdd)
+                },
+                onAttachmentRemoved: { id in
+                    chatProvider.removePendingAttachment(id: id)
+                }
+            )
+            .padding(.horizontal, 30)
+            .padding(.top, 12)
+            .padding(.bottom, 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.clear)
     }
 
     // MARK: - Redesigned Home

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -268,6 +268,7 @@ struct SettingsContentView: View {
   // Multi-chat mode setting
   @AppStorage("multiChatEnabled") private var multiChatEnabled = false
   @AppStorage("conversationsCompactView") private var conversationsCompactView = true
+  @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
 
   // AI Chat settings
   @AppStorage("chatBridgeMode") private var chatBridgeMode: String = "piMono"
@@ -5042,6 +5043,31 @@ struct SettingsContentView: View {
 
           Toggle("", isOn: $multiChatEnabled)
             .toggleStyle(.switch)
+            .labelsHidden()
+        }
+      }
+
+      settingsCard(settingId: "advanced.preferences.legacyhome") {
+        HStack(spacing: 16) {
+          Image(systemName: "rectangle.split.2x1")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Use old Home design")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text("Show the previous chat-first dashboard instead of the simplified Home")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Toggle("", isOn: $useLegacyHomeDesign)
+            .toggleStyle(.checkbox)
             .labelsHidden()
         }
       }


### PR DESCRIPTION
## Summary
- add an unchecked Advanced Settings checkbox for using the old macOS Home design
- route the Home page between the redesigned Home and the previous chat-first Home
- restore the primary sidebar shell in legacy mode and hide the new per-page Home button
- expose legacy/sidebar state in the local automation bridge for verification

## Verification
- xcrun swift build -c debug --package-path Desktop
- git diff --check
- launched /Applications/omi-lahore-home.app with automation bridge
- verified legacy enabled state reports usesLegacyHomeDesign=true, showsPrimarySidebar=true, isSidebarCollapsed=false
- verified default unchecked state after relaunch reports usesLegacyHomeDesign=false, showsPrimarySidebar=false, isSidebarCollapsed=true
- generated fresh UI artifact at .cross-review-verify.png

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

