### PR TITLE
fix(desktop): stop showing paid users the $50 Omi AI 'Upgrade Required' chat alert

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed paid subscribers seeing a bogus \"Upgrade Required\" prompt when opening or using chat"
+  ],
   "releases": [
     {
       "version": "0.11.472",

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -583,6 +583,17 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         bridgeMode != BridgeMode.userClaude.rawValue
     }
 
+    /// The legacy "$50 lifetime Omi AI spend" upgrade nudge (`showOmiThresholdAlert`)
+    /// must never fire for users who already pay — paid subscribers and BYOK users
+    /// aren't capped by the free Omi quota. `omiAICumulativeCostUsd` is seeded from the
+    /// backend *lifetime* total, so without this guard any heavy paying user (e.g. on
+    /// Operator/Architect) trips $50 and gets a bogus "Upgrade Required" alert even
+    /// while well within their plan. The authoritative free-tier block is the
+    /// server-side quota in `FloatingBarUsageLimiter`; this is just a soft nudge.
+    var isExemptFromOmiUpgradeNudge: Bool {
+        FloatingBarUsageLimiter.shared.hasPaidPlan || APIKeyService.isByokActive
+    }
+
     /// Whether the agent bridge requires authentication (shown as sheet in UI)
     @Published var isClaudeAuthRequired = false
     /// Auth methods returned by agent bridge
@@ -1929,12 +1940,17 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         Task.detached(priority: .background) { [weak self] in
             guard let serverCost = await APIClient.shared.fetchTotalOmiAICost() else { return }
             guard let self else { return }
+            // Make sure the user's plan is known before deciding whether to nudge —
+            // otherwise a cold plan cache could flash the upgrade alert at a paid user.
+            await FloatingBarUsageLimiter.shared.fetchPlan()
             await MainActor.run {
                 // Always trust the server value — it's the authoritative total
                 self.omiAICumulativeCostUsd = serverCost
                 log("ChatProvider: Seeded Omi AI cumulative cost from backend: $\(String(format: "%.4f", serverCost))")
-                // Show upgrade prompt if over threshold but don't block chat
-                if self.bridgeMode != BridgeMode.userClaude.rawValue && serverCost >= 50.0 {
+                // Show upgrade prompt if over threshold but don't block chat. Never for
+                // paid/BYOK users — they aren't subject to the free Omi spend cap.
+                if self.bridgeMode != BridgeMode.userClaude.rawValue && serverCost >= 50.0
+                    && !self.isExemptFromOmiUpgradeNudge {
                     log("ChatProvider: Omi AI cost at $\(String(format: "%.2f", serverCost)) on startup — showing upgrade prompt")
                     self.showOmiThresholdAlert = true
                 }
@@ -2709,8 +2725,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         }
         tracer?.end("bridge_ensure", metadata: ["status": "ok"])
 
-        // Show upgrade prompt if over threshold but don't block the message
-        if bridgeMode != BridgeMode.userClaude.rawValue && omiAICumulativeCostUsd >= 50.0 {
+        // Show upgrade prompt if over threshold but don't block the message.
+        // Never for paid/BYOK users — they aren't subject to the free Omi spend cap.
+        if bridgeMode != BridgeMode.userClaude.rawValue && omiAICumulativeCostUsd >= 50.0
+            && !isExemptFromOmiUpgradeNudge {
             showOmiThresholdAlert = true
         }
 
@@ -3238,7 +3256,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 sessionTokensUsed += queryResult.inputTokens + queryResult.outputTokens
                 omiAICumulativeCostUsd += queryResult.costUsd
                 // Show the upgrade flow when the free Omi usage threshold is reached.
-                if omiAICumulativeCostUsd >= 50.0 {
+                // Never for paid/BYOK users — they aren't subject to the free Omi spend cap.
+                if omiAICumulativeCostUsd >= 50.0 && !isExemptFromOmiUpgradeNudge {
                     showOmiThresholdAlert = true
                 }
             }


### PR DESCRIPTION
## Problem

Paid subscribers (e.g. the reporting account on the **Operator** plan, 35/500 questions used this month — well within limits) get a bogus **"Upgrade Required — Upgrade to Omi Pro for \$199/month to continue chatting"** alert when opening or using chat on desktop.

## Root cause

`ChatProvider.showOmiThresholdAlert` was set `true` at 3 sites whenever `omiAICumulativeCostUsd >= 50.0` (and not BYOK-Claude). `omiAICumulativeCostUsd` is seeded from the backend **lifetime** total (`v1/users/me/llm-usage/total`) — it only ever grows — so any heavy paying user eventually crosses \$50 and gets nagged, regardless of subscription. The check consulted neither the plan nor BYOK. The real, subscription-aware free-tier gate is the server-side quota in `FloatingBarUsageLimiter` (which already blocks free users via `showUsageLimitPopup`).

## Fix

- New computed `isExemptFromOmiUpgradeNudge = FloatingBarUsageLimiter.shared.hasPaidPlan || APIKeyService.isByokActive`.
- Guard all three `showOmiThresholdAlert = true` triggers with `&& !isExemptFromOmiUpgradeNudge`.
- Warm the plan cache (`await fetchPlan()`) before the startup decision so a cold cache can't flash the alert at a paid user.

Free (`basic`) users still get the soft nudge; the hard free-tier block is unchanged.

## Verification (real account, prod backend)

Ran a named bundle seeded with the real reporting session (Operator, **\$153.61** lifetime cost) against the prod backend:

| | lifetime cost | plan | `showing upgrade prompt` log lines |
|---|---|---|---|
| **Unfixed** prod app | \$153.58 | Operator | **4** (alert fires) |
| **Fixed** build | \$153.61 | Operator | **0** (alert suppressed) |

Same account, same code path — only the guard differs. App confirmed signed-in and on the Chat tab with no paywall. Debug build clean; independent agent review approved.

> Note: the alert copy ("Omi Pro for \$199/month") is stale vs the current plan catalog (Operator/Architect) — pre-existing, out of scope here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

