### PR TITLE
fix(desktop): default voice model to Auto (was GPT Realtime 2)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -272,7 +272,7 @@ struct SettingsContentView: View {
 
   // AI Chat settings
   @AppStorage("chatBridgeMode") private var chatBridgeMode: String = "piMono"
-  @AppStorage("realtimeOmniProvider") private var realtimeOmniProvider: String = RealtimeOmniProvider.gptRealtime2.rawValue
+  @AppStorage("realtimeOmniProvider") private var realtimeOmniProvider: String = RealtimeOmniProvider.auto.rawValue
   @AppStorage("askModeEnabled") private var askModeEnabled = false
   @AppStorage("claudeMdEnabled") private var claudeMdEnabled = true
   @AppStorage("projectClaudeMdEnabled") private var projectClaudeMdEnabled = true

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniSettings.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniSettings.swift
@@ -59,9 +59,11 @@ final class RealtimeOmniSettings {
 
     private init() {
         UserDefaults.standard.register(defaults: [
-            // Default to OpenAI (GPT Realtime 2); the user can switch to Gemini or Auto
-            // in Advanced → Voice Model. This default also drives the realtime hub provider.
-            providerKey: RealtimeOmniProvider.gptRealtime2.rawValue,
+            // Default to Auto: AutoModelSelector picks the best provider (currently Gemini),
+            // and the hub fails over to the other realtime model (GPT Realtime), then the
+            // Claude cascade, if it can't connect. The user can pin a provider in
+            // Advanced → Voice Model. This default also drives the realtime hub provider.
+            providerKey: RealtimeOmniProvider.auto.rawValue,
             enabledKey: false,
         ])
     }


### PR DESCRIPTION
New desktop installs defaulted the realtime-voice provider to **GPT Realtime 2** instead of **Auto** (seen in the field — a new user had "GPT Realtime" selected by default). 

Defaulting to **Auto** means `AutoModelSelector` picks the best provider (currently Gemini) and the hub's failover chain (#8036) kicks in if it can't connect: **Auto→Gemini → GPT Realtime → Claude cascade** — instead of pinning one provider with no fallback. Two registered-default values flipped to `.auto`; users who explicitly picked a provider keep their choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

