### PR TITLE
fix(desktop): actually enforce Rewind data-retention (cleanup was never running)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Fixed paid subscribers seeing a bogus \"Upgrade Required\" prompt when opening or using chat"
+    "Fixed paid subscribers seeing a bogus \"Upgrade Required\" prompt when opening or using chat",
+    "Screen recordings are now actually deleted once they pass your Data Retention window (cleanup was never running, so recordings accumulated indefinitely)"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -438,6 +438,10 @@ actor RewindStorage {
     }
 
     private func cleanupEmptySubdirectories(in directory: URL) throws {
+        // The legacy Screenshots dir may not exist for video-only users — skip it
+        // rather than aborting the whole cleanup sweep.
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+
         let contents = try fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.isDirectoryKey],

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -27,6 +27,12 @@ actor RewindIndexer {
     private var nextRetryTime: Date = .distantPast
     private static let maxBackoffSeconds: Double = 300 // Cap at 5 minutes
 
+    /// Retention enforcement: prune screenshots/video older than the user's
+    /// `rewindRetentionDays` setting. `.distantPast` means the first frame after
+    /// launch runs cleanup immediately; afterwards it runs at most every 6h.
+    private var lastRetentionCleanupAt: Date = .distantPast
+    private let retentionCleanupInterval: TimeInterval = 6 * 60 * 60
+
     // MARK: - Initialization
 
     private init() {}
@@ -142,6 +148,7 @@ actor RewindIndexer {
     func processFrame(_ frame: CapturedFrame) async {
         // Ensure initialized with backoff
         guard await ensureInitialized() else { return }
+        scheduleRetentionCleanupIfDue()
 
         do {
             // Convert JPEG to CGImage for video encoding.
@@ -238,6 +245,7 @@ actor RewindIndexer {
     /// Process a frame directly from a CGImage (macOS 14+ path, avoids JPEG decode round-trip)
     func processFrame(cgImage: CGImage, appName: String, windowTitle: String?, captureTime: Date) async {
         guard await ensureInitialized() else { return }
+        scheduleRetentionCleanupIfDue()
 
         do {
             // Add frame to video encoder (CGImage directly, no decode needed)
@@ -318,6 +326,7 @@ actor RewindIndexer {
     /// Process a frame with additional metadata (focus status, etc.)
     func processFrame(_ frame: CapturedFrame, focusStatus: String?, extractedTasks: [String]?, insight: String?) async {
         guard await ensureInitialized() else { return }
+        scheduleRetentionCleanupIfDue()
 
         do {
             // Convert JPEG to CGImage for video encoding.
@@ -422,6 +431,16 @@ actor RewindIndexer {
     }
 
     // MARK: - Cleanup
+
+    /// Enforce the data-retention window if a cleanup is due. Throttled to once
+    /// per `retentionCleanupInterval` and fire-and-forget so frame ingestion is
+    /// never blocked by deletion. Called from the frame pipeline; the first frame
+    /// after launch prunes anything past the retention setting.
+    private func scheduleRetentionCleanupIfDue() {
+        guard Date().timeIntervalSince(lastRetentionCleanupAt) >= retentionCleanupInterval else { return }
+        lastRetentionCleanupAt = Date()
+        Task { await self.runCleanup() }
+    }
 
     /// Run cleanup to remove old screenshots
     func runCleanup() async {

--- a/desktop/macos/Desktop/Tests/RewindRetentionCleanupTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindRetentionCleanupTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression test for the Rewind data-retention bug: `RewindIndexer.runCleanup()`
+/// existed and was correct, but was never called from anywhere, so screen
+/// recordings accumulated forever regardless of the "Data Retention" setting.
+///
+/// This exercises the real cleanup path (DB delete → orphaned-chunk detection →
+/// on-disk file deletion) against an isolated throwaway user directory and asserts
+/// that chunks older than the retention window are physically removed while
+/// in-window chunks are kept.
+final class RewindRetentionCleanupTests: XCTestCase {
+
+  private var testUserId: String!
+  private var userDir: URL!
+  private var savedRetentionDays: Int = 7
+
+  override func setUp() async throws {
+    try await super.setUp()
+
+    // Isolate all Rewind storage to a unique throwaway user so we never touch
+    // real recordings (storage is keyed by userId, not bundle id).
+    testUserId = "retention-test-\(UUID().uuidString)"
+    RewindDatabase.currentUserId = testUserId
+    try await RewindDatabase.shared.initialize()
+    try await RewindStorage.shared.initialize()
+
+    let appSupport = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+
+    // Pin retention to a known value so the test is deterministic.
+    savedRetentionDays = RewindSettings.shared.retentionDays
+    RewindSettings.shared.retentionDays = 7
+  }
+
+  override func tearDown() async throws {
+    RewindSettings.shared.retentionDays = savedRetentionDays
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    RewindDatabase.currentUserId = nil
+    try await super.tearDown()
+  }
+
+  func testRunCleanupDeletesChunksOlderThanRetentionAndKeepsRecentOnes() async throws {
+    let fm = FileManager.default
+    let videosDir = userDir.appendingPathComponent("Videos", isDirectory: true)
+
+    let retentionDays = RewindSettings.shared.retentionDays
+    let oldDate = Calendar.current.date(byAdding: .day, value: -(retentionDays + 30), to: Date())!
+    let recentDate = Date()
+
+    let oldChunkRel = "2000-01-01/chunk_old.mp4"
+    let recentChunkRel = "2099-01-01/chunk_recent.mp4"
+
+    // Lay down two real on-disk chunk files.
+    for rel in [oldChunkRel, recentChunkRel] {
+      let full = videosDir.appendingPathComponent(rel)
+      try fm.createDirectory(
+        at: full.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try Data("fake-mp4-bytes".utf8).write(to: full)
+    }
+    let oldPath = videosDir.appendingPathComponent(oldChunkRel).path
+    let recentPath = videosDir.appendingPathComponent(recentChunkRel).path
+    XCTAssertTrue(fm.fileExists(atPath: oldPath), "precondition: old chunk written")
+    XCTAssertTrue(fm.fileExists(atPath: recentPath), "precondition: recent chunk written")
+
+    // Reference each chunk from a screenshot row with the matching timestamp.
+    _ = try await RewindDatabase.shared.insertScreenshot(
+      Screenshot(
+        timestamp: oldDate, appName: "RetentionTest", videoChunkPath: oldChunkRel,
+        frameOffset: 0, isIndexed: true))
+    _ = try await RewindDatabase.shared.insertScreenshot(
+      Screenshot(
+        timestamp: recentDate, appName: "RetentionTest", videoChunkPath: recentChunkRel,
+        frameOffset: 0, isIndexed: true))
+
+    // Exercise the exact production cleanup that the fix now schedules.
+    await RewindIndexer.shared.runCleanup()
+
+    XCTAssertFalse(
+      fm.fileExists(atPath: oldPath),
+      "retention cleanup must delete the chunk whose frames are older than the retention window")
+    XCTAssertTrue(
+      fm.fileExists(atPath: recentPath),
+      "retention cleanup must keep chunks within the retention window")
+  }
+}


### PR DESCRIPTION
## Problem
Omi has a **Data Retention** setting (`rewindRetentionDays`, default 7 days) and a `RewindIndexer.runCleanup()` that correctly deletes recordings past that window — but `runCleanup()` had **zero callers anywhere**. So screen recordings accumulated forever regardless of the setting (a real user had **98 days / 8.5 GB / 23k .mp4 chunks** despite the 7-day default).

## Fix
- Throttled, fire-and-forget `scheduleRetentionCleanupIfDue()` on the `RewindIndexer` actor: runs `runCleanup()` at most once per 6h; the first frame after launch prunes the backlog. Called from all three `processFrame` entry points after init.
- Hardened `cleanupEmptySubdirectories` to skip a missing legacy `Screenshots/` dir instead of aborting the sweep.

## Verification
New unit test `RewindRetentionCleanupTests` drives the real `runCleanup()` against an isolated temp user dir → asserts a chunk older than the window is physically deleted and an in-window chunk is kept. **Passes** (`RewindStorage: Deleted video chunk … / Cleaned up 1 old JPEGs and 1 video chunks`). Independent review approved (retention is a fixed 3/7/14/30 picker → no "delete-everything" risk; multi-frame chunks only deleted when fully orphaned).

## Blast radius
On next launch this deletes recordings past each user's retention setting — i.e. it makes an existing, user-facing setting finally work. Reclaims ~8 GB for the reporting user.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

