### PR TITLE
fix(desktop): show true totals on 'What omi knows' dashboard (was showing loaded page)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Screen recordings are now actually deleted once they pass your Data Retention window (cleanup was never running, so recordings accumulated indefinitely)"
+    "Screen recordings are now actually deleted once they pass your Data Retention window (cleanup was never running, so recordings accumulated indefinitely)",
+    "Fixed the \"What omi knows\" dashboard under-counting Conversations, Memories, and Tasks (it showed only the loaded page instead of your real totals)"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -205,6 +205,11 @@ struct DashboardPage: View {
     @State private var citedConversation: ServerConversation? = nil
     @State private var isLoadingCitation = false
     @State private var screenshotCount: Int?
+    // True totals for the "What omi knows" tiles. Without these the tiles showed
+    // only the loaded page (~50 conversations, ~100 memories), badly undercounting.
+    @State private var conversationCount: Int?
+    @State private var memoryCount: Int?
+    @State private var taskCount: Int?
     @State private var isCaptureMonitoring = false
     @State private var isTogglingCapture = false
     @State private var isTogglingListening = false
@@ -275,12 +280,14 @@ struct DashboardPage: View {
             }
             syncCaptureState()
             Task { await loadScreenshotCount() }
+            Task { await loadKnowledgeCounts() }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshGoals()
             appState.checkAllPermissions()
             syncCaptureState()
             Task { await loadScreenshotCount() }
+            Task { await loadKnowledgeCounts() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
             syncCaptureState()
@@ -556,13 +563,15 @@ struct DashboardPage: View {
             HStack(spacing: 8) {
                 HomeCenterMetricTile(
                     title: "Conversations",
-                    value: formattedCount(appState.conversations.count),
+                    value: formattedCount(
+                        conversationCount ?? appState.totalConversationsCount
+                            ?? appState.conversations.count),
                     systemImage: "text.bubble.fill",
                     action: { navigate(to: .conversations) }
                 )
                 HomeCenterMetricTile(
                     title: "Tasks",
-                    value: formattedCount(incompleteTaskCount),
+                    value: formattedCount(taskCount ?? incompleteTaskCount),
                     systemImage: "checklist",
                     action: { navigate(to: .tasks) }
                 )
@@ -571,7 +580,11 @@ struct DashboardPage: View {
             HStack(spacing: 8) {
                 HomeCenterMetricTile(
                     title: "Memories",
-                    value: formattedCount(memoriesViewModel.memories.count),
+                    value: formattedCount(
+                        memoryCount
+                            ?? (memoriesViewModel.totalMemoriesCount > 0
+                                ? memoriesViewModel.totalMemoriesCount
+                                : memoriesViewModel.memories.count)),
                     systemImage: "brain",
                     action: { navigate(to: .memories) }
                 )
@@ -710,6 +723,23 @@ struct DashboardPage: View {
         let stats = await RewindIndexer.shared.getStats()
         await MainActor.run {
             screenshotCount = stats?.total
+        }
+    }
+
+    /// Load the true totals behind the "What omi knows" tiles. Conversations come
+    /// from the server count endpoint (not stored locally); memories and tasks are
+    /// counted from the synced local DB — the same totals the detail pages show.
+    private func loadKnowledgeCounts() async {
+        async let convos = try? APIClient.shared.getConversationsCount(includeDiscarded: false)
+        async let mems = try? MemoryStorage.shared.getLocalMemoriesCount()
+        // Open tasks only (matches the "Tasks" label and the old tile's intent —
+        // the old value just under-counted, capping each bucket at a 7-day window).
+        async let tasks = try? ActionItemStorage.shared.getLocalActionItemsCount(completed: false)
+        let (c, m, t) = await (convos, mems, tasks)
+        await MainActor.run {
+            if let c { conversationCount = c }
+            if let m { memoryCount = m }
+            if let t { taskCount = t }
         }
     }
 


### PR DESCRIPTION
## Problem
The "What omi knows" dashboard tiles showed the **loaded page length**, not real totals. On a real account: Conversations showed **50** (actual **6,840**), Memories **100** (actual **5,802**), Tasks **62** (a 7-day-windowed subset; actual open tasks **174**). Only Screenshots (368,690) was correct — because it already used a real DB `COUNT`.

## Fix
Mirror the working `screenshotCount` pattern: load true counts async on `.onAppear`/`didBecomeActive` into `@State`, with a graceful fallback to the loaded count until they resolve.
- Conversations → `getConversationsCount(includeDiscarded: false)` (server; conversations aren't stored locally) — same source as `appState.totalConversationsCount`.
- Memories → `MemoryStorage.getLocalMemoriesCount()` (local DB) — same total the Memories page shows.
- Tasks → `getLocalActionItemsCount(completed: false)` (open tasks) — same filter as the Tasks page "To Do" count.

## Verification
Each displayed value was confirmed by running the **exact** query/endpoint the code uses against the real account: Conversations 6,840, Memories 5,802, open Tasks 174, Screenshots 368,690. Builds clean; independent review confirmed each tile matches the detail page it navigates to. (Visual capture was blocked by a host Screen-Recording permission; running a 2nd instance as the live account would risk DB contention, so verification is data-level + the rendering pattern is identical to the already-correct Screenshots tile.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

