### PR TITLE
fix(desktop): warm up backend on PTT setup (kill first-query cold start)

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -63,7 +63,22 @@ class PushToTalkManager: ObservableObject {
     self.barState = barState
     hasMicPermission = AudioCaptureService.checkPermission()
     installEventMonitors()
+    warmUpBackend()
     log("PushToTalkManager: setup complete, micPermission=\(hasMicPermission)")
+  }
+
+  /// Pre-warm the desktop-backend connection (DNS + TLS + Cloud Run cold start)
+  /// so the FIRST PTT query doesn't pay ~2-3s of cold-start latency on top of the
+  /// normal response time (measured: cold first call ~4.2s vs ~1.5-2.2s warm).
+  /// Fire-and-forget; any failure is harmless.
+  private func warmUpBackend() {
+    Task.detached(priority: .utility) {
+      let base = await APIClient.shared.rustBackendURL
+      guard !base.isEmpty, let url = URL(string: base) else { return }
+      var req = URLRequest(url: url, timeoutInterval: 5)
+      req.httpMethod = "HEAD"
+      _ = try? await URLSession.shared.data(for: req)
+    }
   }
 
   func cleanup() {


### PR DESCRIPTION
First PTT after launch measured ~4.2s (Cloud Run/TLS cold start) vs ~1.5–2.2s warm — over the <3s budget. Adds a fire-and-forget HEAD to the desktop-backend on PTT setup so the first real query is warm. Additive, low-risk. swift build verified. Found via autonomous real-voice PTT test (10/10 transcripts, 6/6 warm end-to-end <3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

