### PR TITLE
fix(desktop): keep main window from collapsing below its minimum size

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -381,6 +381,10 @@ struct DesktopHomeView: View {
       // Removing .minSize from sizingOptions prevents this full-tree traversal.
       // The window's min size is enforced at the AppKit level instead.
       enforceMainWindowMinimumSize()
+      // SwiftUI's automatic resizability later re-derives the window min from content
+      // extrema and resets our pin, after which the window can be dragged small enough
+      // to hide content. Re-pin on every live resize so AppKit keeps clamping the drag.
+      installMinimumSizeGuardIfNeeded()
       // Redirect if current page isn't visible at current tier
       redirectIfPageHidden()
       reportAutomationState()
@@ -389,7 +393,12 @@ struct DesktopHomeView: View {
       redirectIfPageHidden()
       reportAutomationState()
     }
-    .onChange(of: selectedIndex) { _, _ in reportAutomationState() }
+    .onChange(of: selectedIndex) { _, _ in
+      // Page nav recreates the content hosting view with default sizingOptions, which
+      // resets the window min — re-pin + re-disable to hold the minimum.
+      enforceMainWindowMinimumSize()
+      reportAutomationState()
+    }
     .onChange(of: selectedSettingsSection) { _, _ in reportAutomationState() }
     .onChange(of: highlightedSettingId) { _, _ in reportAutomationState() }
     .onChange(of: authState.isSignedIn) { _, _ in reportAutomationState() }
@@ -433,6 +442,30 @@ struct DesktopHomeView: View {
         // Search contentView itself + all descendants.
         Self.disableMinSizeComputation(in: window)
       }
+    }
+  }
+
+  /// Re-pin the window minimum on every live resize. SwiftUI's `.automatic` window
+  /// resizability periodically recomputes content-size extrema and overwrites the
+  /// one-shot pin from `enforceMainWindowMinimumSize()`, after which the window can be
+  /// dragged small enough to hide content. Observing `didResize` and re-pinning keeps
+  /// AppKit clamping the live drag at the minimum. Installed once for the app's lifetime.
+  private static var minimumSizeGuardInstalled = false
+  private func installMinimumSizeGuardIfNeeded() {
+    guard !Self.minimumSizeGuardInstalled else { return }
+    Self.minimumSizeGuardInstalled = true
+    let minimumContentSize = NSSize(width: minimumWindowWidth, height: minimumWindowHeight)
+    NotificationCenter.default.addObserver(
+      forName: NSWindow.didResizeNotification, object: nil, queue: .main
+    ) { note in
+      guard let window = note.object as? NSWindow,
+        window.title.lowercased().hasPrefix("omi")
+      else { return }
+      let frameMin = window.frameRect(
+        forContentRect: NSRect(origin: .zero, size: minimumContentSize)
+      ).size
+      if window.contentMinSize != minimumContentSize { window.contentMinSize = minimumContentSize }
+      if window.minSize != frameMin { window.minSize = frameMin }
     }
   }
 


### PR DESCRIPTION
## Problem
The macOS main window could be dragged small enough that the dashboard's side content (Connect data / Connect your AI columns) gets clipped and hidden.

The window minimum (1200×680 content) was pinned once in `onAppear`, but SwiftUI's automatic resizability re-derives the window min from content-size extrema on later updates — **page navigation recreates the content hosting view with default `sizingOptions`, which resets the pin** — so after navigating, the window could be collapsed past the content width.

## Fix
Re-pin the minimum so it can't drift:
- **On page nav** (`onChange(of: selectedIndex)`) → re-run `enforceMainWindowMinimumSize()` (re-pins `minSize`/`contentMinSize` + re-disables the hosting views' min computation).
- **On every live resize** (a one-time `NSWindow.didResizeNotification` observer) → re-pin so AppKit keeps clamping the drag at the minimum.

Single-file, additive change. Existing one-shot pin + app-activate re-pin + grow-if-below all kept.

## Verification
- Clean debug + release builds pass.
- Named test bundle (`omi-minsize`, latest `main` + this fix): window launches at 1200×680 and **stays 1200×680 after navigating across 6 pages** (Home→Settings→Memories→Tasks→Conversations→Apps→Home) — no drift. User-confirmed the window no longer collapses past the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

