### PR TITLE
fix(app) fix audio share failing with wrong MIME type and silent null failure

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -543,7 +543,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
           Navigator.maybeOf(sheetContext)?.pop();
         }
 
-        await Share.shareXFiles([XFile(file.path, mimeType: 'audio/wav')]);
+        final mimeType = file.path.endsWith('.mp3') ? 'audio/mpeg' : 'audio/wav';
+        await Share.shareXFiles([XFile(file.path, mimeType: mimeType)]);
 
         // Track successful completion
         final durationSeconds = DateTime.now().difference(startTime).inSeconds;
@@ -556,6 +557,11 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
 
         await service.cleanup();
       } else {
+        currentState = AudioDownloadState.error;
+        updateSheet?.call(() {});
+
+        await Future.delayed(const Duration(seconds: 2));
+
         if (sheetContext.mounted) {
           Navigator.maybeOf(sheetContext)?.pop();
         }
@@ -565,6 +571,15 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
           conversationId: provider.conversation.id,
           errorMessage: 'No audio files available',
         );
+
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(context.l10n.audioDownloadFailed),
+              action: SnackBarAction(label: context.l10n.retry, onPressed: () => _downloadAudio(context, provider)),
+            ),
+          );
+        }
       }
     } catch (e) {
       Logger.debug('Error downloading audio: $e');


### PR DESCRIPTION
## Summary

- `Share.shareXFiles` was hardcoded to `mimeType: 'audio/wav'` even when the downloaded file is an MP3 (the artifact-backed path now produces MP3s by default). On Android, `share_plus` propagates this MIME mismatch as an exception that was caught and surfaced as "Failed to download audio" — even though the download itself succeeded. Fixed by deriving the MIME type from the file extension.
- When `downloadAndCombineAudio` returns `null` (no cached audio available after the 60s polling timeout), the progress sheet was silently closing with no user feedback. Now shows the error state and the same retry snackbar as real failures.

## Test plan

- [ ] Share audio from a conversation — verify the share sheet opens with the correct file type on both iOS and Android
- [ ] Trigger the null path (conversation with no cached audio) — verify error state shows and retry snackbar appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

