### PR TITLE
fix(sync): cap VAD segment length to prevent STT GPU OOM on long recordings

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -809,6 +809,36 @@ def decode_files_to_wav(files_path: List[str]):
     return wav_files
 
 
+# Max length of a single VAD segment / STT transcribe request. Bounds GPU memory on the
+# STT worker (~0.5 GiB VRAM per audio minute), which CUDA-OOMs on long continuous audio.
+MAX_VAD_SEGMENT_SECONDS = int(os.getenv('SYNC_MAX_VAD_SEGMENT_SECONDS', '300'))
+
+
+def _merge_and_cap_vad_segments(voice_segments: list) -> list:
+    merged = []
+    for segment in voice_segments:
+        if (
+            merged
+            and (segment['start'] - merged[-1]['end']) < 120
+            and (segment['end'] - merged[-1]['start']) <= MAX_VAD_SEGMENT_SECONDS
+        ):
+            merged[-1]['end'] = segment['end']
+        else:
+            merged.append(dict(segment))
+
+    segments = []
+    for segment in merged:
+        if segment['end'] - segment['start'] <= MAX_VAD_SEGMENT_SECONDS:
+            segments.append(segment)
+        else:
+            chunk_start = segment['start']
+            while chunk_start < segment['end']:
+                chunk_end = min(chunk_start + MAX_VAD_SEGMENT_SECONDS, segment['end'])
+                segments.append({'start': chunk_start, 'end': chunk_end})
+                chunk_start = chunk_end
+    return segments
+
+
 def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None):
     try:
         start_timestamp = get_timestamp_from_path(path)
@@ -820,22 +850,7 @@ def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None):
             errors.append(error_msg)
         raise  # Re-raise to ensure thread failure is visible
 
-    segments = []
-    # should we merge more aggressively, to avoid too many small segments? ~ not for now
-    # Pros -> lesser segments, faster, less concurrency
-    # Cons -> less accuracy.
-
-    # edge case, multiple small segments that map towards the same memory .-.
-    # so ... let's merge them if distance < 120 seconds
-    # a better option would be to keep here 1s, and merge them like that after transcribing
-    # but FAL has 10 RPS limit, **let's merge it here for simplicity for now**
-
-    for i, segment in enumerate(voice_segments):
-        if segments and (segment['start'] - segments[-1]['end']) < 120:
-            segments[-1]['end'] = segment['end']
-        else:
-            segments.append(segment)
-
+    segments = _merge_and_cap_vad_segments(voice_segments)
     logger.info(f"{path} {len(segments)}")
 
     aseg = AudioSegment.from_wav(path)

--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -215,7 +215,12 @@ sys.modules['utils.log_sanitizer'].sanitize_pii = lambda x: x
 
 _remove_python_multipart_stub = _install_python_multipart_stub()
 try:
-    from routers.sync import decode_opus_file_to_wav, decode_files_to_wav  # noqa: E402
+    from routers.sync import (  # noqa: E402
+        decode_opus_file_to_wav,
+        decode_files_to_wav,
+        _merge_and_cap_vad_segments,
+        MAX_VAD_SEGMENT_SECONDS,
+    )
 finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)
@@ -621,3 +626,49 @@ class TestDecodeFilesToWavOpus:
             assert len(wav_files) == 1
             assert not os.path.exists(valid_bin)
             assert not os.path.exists(corrupt_bin)
+
+
+class TestMergeAndCapVadSegments:
+    """VAD merge + per-segment length cap that guards the STT worker from GPU OOM."""
+
+    def _assert_within_cap(self, segments):
+        for s in segments:
+            assert s['end'] - s['start'] <= MAX_VAD_SEGMENT_SECONDS
+
+    def test_close_spans_merge(self):
+        out = _merge_and_cap_vad_segments([{'start': 0, 'end': 2}, {'start': 3, 'end': 5}])
+        assert out == [{'start': 0, 'end': 5}]
+
+    def test_far_apart_spans_not_merged(self):
+        spans = [{'start': 0, 'end': 2}, {'start': 300, 'end': 320}]
+        assert _merge_and_cap_vad_segments(spans) == [{'start': 0, 'end': 2}, {'start': 300, 'end': 320}]
+
+    def test_continuous_audio_is_capped(self):
+        # 50s spans 1s apart spanning ~900s would merge into one giant segment without the cap.
+        spans = [{'start': i, 'end': i + 50} for i in range(0, 900, 51)]
+        out = _merge_and_cap_vad_segments(spans)
+        assert len(out) > 1
+        self._assert_within_cap(out)
+        for a, b in zip(out, out[1:]):
+            assert b['start'] >= a['end']
+
+    def test_single_long_span_is_split(self):
+        out = _merge_and_cap_vad_segments([{'start': 0, 'end': 800}])
+        self._assert_within_cap(out)
+        assert out[0]['start'] == 0
+        assert out[-1]['end'] == 800
+        for a, b in zip(out, out[1:]):
+            assert b['start'] == a['end']
+
+    def test_exact_multiple_of_cap(self):
+        cap = MAX_VAD_SEGMENT_SECONDS
+        out = _merge_and_cap_vad_segments([{'start': 0, 'end': 2 * cap}])
+        assert out == [{'start': 0, 'end': cap}, {'start': cap, 'end': 2 * cap}]
+
+    def test_empty(self):
+        assert _merge_and_cap_vad_segments([]) == []
+
+    def test_input_not_mutated(self):
+        spans = [{'start': 0, 'end': 2}, {'start': 3, 'end': 5}]
+        _merge_and_cap_vad_segments(spans)
+        assert spans == [{'start': 0, 'end': 2}, {'start': 3, 'end': 5}]


### PR DESCRIPTION
## Problem

Long, continuous recordings synced via `/v2/sync-local-files` fail transcription with a Parakeet `500 Internal Server Error`. The STT worker log shows the real cause — **CUDA out of memory**:

```
ERROR:batch_engine:Batch transcription failed: CUDA out of memory.
Tried to allocate 14.86 GiB. GPU 0 ... 1.31 GiB is free.
```

Observed ~35 of these in a 12h window, clustered — when one oversized request grabs most of the GPU VRAM, concurrent transcriptions can't allocate and 500 alongside it. The pod stays healthy (this is a per-request GPU-memory failure, not the host-RAM OOMKill we throttled earlier).

## Root cause

`retrieve_vad_segments` merges VAD voice spans that are <120s apart, **with no upper bound on merged length**. A recording with only short pauses (any normal continuous conversation) collapses the *entire* recording into one segment, which is sent to the STT worker as a single transcribe request. GPU activation memory scales ~linearly with audio duration (~0.5 GiB VRAM/min — both data points, 14.86 GiB ≈ 30 min and 2.73 GiB ≈ 5–6 min, agree), so a long segment blows past the GPU.

## Fix

Cap each segment (= one transcribe request) at `MAX_VAD_SEGMENT_SECONDS` (default **300s**, override via `SYNC_MAX_VAD_SEGMENT_SECONDS`):

1. **Bounded merge** — stop merging once a segment would exceed the cap; start a new one instead.
2. **Hard-split** — slice any single span still longer than the cap (continuous speech with no internal gaps to break on).

At ~0.5 GiB/min a 5-min cap is ~2.5 GiB/request, which fits many concurrent requests on the GPU. Splits land on VAD silence in the common case, so transcription quality is unaffected.

**Downstream is unchanged**: each chunk keeps its absolute timestamp, so `_OrderedTurnstile` still assembles them into a single conversation and `_reprocess_merged_conversations` still writes one summary after all chunks finish. For normal short recordings the cap never triggers — behavior is identical.

## Tests

`TestMergeAndCapVadSegments` in `tests/unit/test_sync_opus_decode.py` (already registered in `test.sh`): close-spans merge, far-apart don't, continuous audio capped into multiple ≤cap segments, single long span split, exact-multiple boundary, empty input, input-not-mutated. Full file: **28 passed**.

## Deploy

No infra change required. Optional env `SYNC_MAX_VAD_SEGMENT_SECONDS` on `backend` / `backend-sync` to tune the cap; defaults to 300s if unset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

