### PR TITLE
fix(app) fix PlatformException crash when exporting device diagnostics

### DIFF
--- a/app/lib/pages/settings/device_diagnostics.dart
+++ b/app/lib/pages/settings/device_diagnostics.dart
@@ -120,7 +120,8 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
     final dir = await getTemporaryDirectory();
     final file = File('${dir.path}/omi_diagnostics_${DateTime.now().millisecondsSinceEpoch}.json');
     await file.writeAsString(json);
-    await SharePlus.instance.share(ShareParams(files: [XFile(file.path)], subject: 'Omi Device Diagnostics'));
+    await SharePlus.instance.share(
+        ShareParams(files: [XFile(file.path)], title: 'Omi Device Diagnostics', subject: 'Omi Device Diagnostics'));
     PlatformManager.instance.analytics.track(
       'Diagnostics Exported',
       properties: {


### PR DESCRIPTION
## Summary

- `ShareParams` in `_exportDiagnostics` was missing a `title`, causing `share_plus` to throw `PlatformException(error, Non-empty title expected, null, null)` on iOS every time a user tapped the export button on the Device Diagnostics screen.
- Fix: pass `title: 'Omi Device Diagnostics'` alongside the existing `subject`.

## Crash

```
Fatal Exception: FlutterError
PlatformException(error, Non-empty title expected, null, null)
package:share_plus_platform_interface/method_channel/method_channel_share.dart:25

0  StandardMethodCodec.decodeEnvelope  (message_codecs.dart:653)
1  MethodChannel._invokeMethod          (platform_channel.dart:367)
2  MethodChannelShare.share             (method_channel_share.dart:25)
3  _DeviceDiagnosticsState._exportDiagnostics (device_diagnostics.dart:123)
```

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/40d960fea757d7ea8a9d0c02bec36346

## Test plan

- [ ] Open Device Diagnostics page and tap the export (share) button — verify the native share sheet opens without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

