### PR TITLE
fix(app) fix LateInitializationError crash in BackgroundService when mic was never started

### DIFF
--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_background_service/flutter_background_service.dart';
 import 'package:flutter_sound/flutter_sound.dart';
 
-import 'package:omi/backend/http/shared.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/devices.dart';
 import 'package:omi/services/sockets.dart';

--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -176,6 +176,7 @@ class BackgroundService {
 
   void stop() {
     Logger.debug("invoke stop");
+    if (_status == null) return;
     _service.invoke("stop");
   }
 
@@ -229,6 +230,7 @@ class BackgroundService {
   }
 
   void stopRecorder() {
+    if (_status == null) return;
     _service.invoke("recorder.stop");
   }
 }


### PR DESCRIPTION
## Summary

- `BackgroundService` declares `_service` as a `late` field, initialized only inside `init()` / `ensureRunning()`.
- When a user taps close/skip during onboarding before the mic was ever started, `SpeechProfileProvider.close()` → `_stopPhoneMicStreaming()` → `MicRecorderBackgroundService.stop()` → `BackgroundService.stopRecorder()` is called while `_service` is still uninitialized — producing a `LateInitializationError`.
- Fix: guard `stop()` and `stopRecorder()` with `if (_status == null) return;`. `_status` is `null` iff `init()` was never called, so this is a reliable sentinel without changing the existing API.
- Also removes an unused `package:omi/backend/http/shared.dart` import from the same file.

## Crash

```
Fatal Exception: FlutterError
LateInitializationError: Field '_service@1489031061' has not been initialized.
package:omi/services/services.dart

0  BackgroundService.stopRecorder               (services.dart)
1  MicRecorderBackgroundService.stop + 280      (services.dart:280)
2  SpeechProfileProvider._stopPhoneMicStreaming  (speech_profile_provider.dart:222)
3  SpeechProfileProvider.close                  (speech_profile_provider.dart:413)
4  _OnboardingWrapperState.build.<fn>           (wrapper.dart:473)
```

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/d55812826a4ed2693249a434a764a7f3

## Test plan

- [ ] Start the speech profile onboarding flow with phone mic enabled, then immediately tap close/skip before the mic starts recording — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

