### PR TITLE
fix(app) prevent concurrent AudioPlayer init causing Platform player already exists crash

### DIFF
--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -209,7 +209,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
   Future<void> _initAudioIfNeeded() async {
     if (!mounted) return;
-    if (_isAudioInitialized || widget.conversation == null || !widget.conversation!.hasAudio()) {
+    if (_isAudioInitialized || _isAudioLoading || widget.conversation == null || !widget.conversation!.hasAudio()) {
       return;
     }
 

--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -58,6 +60,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
   AudioPlayer? _audioPlayer;
   bool _isAudioLoading = false;
   bool _isAudioInitialized = false;
+  Completer<void>? _initCompleter;
   Duration _totalDuration = Duration.zero;
   List<Duration> _trackStartOffsets = [];
 
@@ -209,9 +212,19 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
   Future<void> _initAudioIfNeeded() async {
     if (!mounted) return;
-    if (_isAudioInitialized || _isAudioLoading || widget.conversation == null || !widget.conversation!.hasAudio()) {
+    if (_isAudioInitialized || widget.conversation == null || !widget.conversation!.hasAudio()) {
       return;
     }
+
+    // If a concurrent init is already in flight, wait for it instead of starting
+    // a second one — otherwise both calls would create/init the same AudioPlayer
+    // and trigger PlatformException "Platform player already exists".
+    if (_initCompleter != null) {
+      await _initCompleter!.future;
+      return;
+    }
+
+    _initCompleter = Completer<void>();
 
     setState(() {
       _isAudioLoading = true;
@@ -270,11 +283,14 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
       Logger.debug('Error initializing audio: $e');
       AnalyticsManager().audioPlaybackFailed(conversationId: widget.conversation?.id ?? '', reason: e.toString());
     } finally {
+      final completer = _initCompleter;
+      _initCompleter = null;
       if (mounted) {
         setState(() {
           _isAudioLoading = false;
         });
       }
+      completer?.complete();
     }
   }
 


### PR DESCRIPTION
## Summary

`_initAudioIfNeeded` in `ConversationBottomBar` was not guarded against concurrent invocations. The method checks `_isAudioInitialized` at the top, but when two callers (e.g. rapid taps on `seekToTranscriptSegment`) entered concurrently:

1. Both passed the `_isAudioInitialized == false` guard
2. The second call overwrote `_audioPlayer` with a new `AudioPlayer()` instance
3. Both async continuations then called `setAudioSource` on the **same** player object (the second one)
4. `just_audio` internally called `MethodChannelJustAudio.init` twice with the same player UUID → crash

**Fix**: add `_isAudioLoading` to the early-return guard so any concurrent call is a no-op while init is already in flight.

## Crash

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: PlatformException(Platform player fb079159-f829-45e5-9a2d-791cb638476d already exists, null, null, null)
       at StandardMethodCodec.decodeEnvelope(message_codecs.dart:653)
       at MethodChannel._invokeMethod(platform_channel.dart:367)
       at MethodChannelJustAudio.init(method_channel_just_audio.dart:13)
       at AudioPlayer._setPlatformActive.setPlatform(just_audio.dart:1425)
```

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/294ecb294f6be3c6cc3e55dfe25c8363?time=7d&types=crash&sessionEventKey=6A3363D0007D00084BB5B644BA2657CB_2231015546684629264

## Test plan

- [ ] Open a conversation with audio, rapidly tap multiple transcript segments while audio is loading — verify no crash and audio plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

