### PR TITLE
desktop: keep realtime voice hub connected (stop silent fallback to slow Claude cascade)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed push-to-talk voice responses falling back to the slower model \u2014 the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
+  ],
   "releases": [
     {
       "version": "0.11.478",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -852,6 +852,11 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
+    // Hub wasn't connected for this turn → kick a re-warm now so the NEXT turn lands on
+    // realtime instead of silently staying on the slow cascade. Non-blocking + idempotent
+    // (no-op if already warming); this turn still uses the cascade below.
+    RealtimeHubController.shared.ensureWarm()
+
     // The floating bar's STT is the realtime omni model (replaces Deepgram):
     // one omni model transcribes; reasoning/tools/TTS are untouched (the final
     // transcript still goes to ChatProvider via sendTranscript()/sendQuery()).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import AppKit
 import CoreGraphics
 import Foundation
 
@@ -46,9 +47,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Consecutive failed (re)connects with no surviving session — caps churn on a hard
   /// failure. Reset when a socket survives past the idle window or a turn completes.
   private var hubReconnectStrikes = 0
-  /// After this many consecutive fast failures (e.g. a stale/revoked key failing auth),
-  /// the hub stops re-warming so it doesn't hammer a dead endpoint.
-  private static let maxReconnectStrikes = 5
+  /// Caps the reconnect backoff growth (strikes index the exponential delay). The hub
+  /// NEVER permanently gives up re-warming — it's the default voice path, so a dropped
+  /// socket must always self-heal; the cap just bounds the retry rate on a hard failure
+  /// (e.g. a revoked key) to one attempt per ~15s.
+  private static let maxBackoffStrikes = 5
+  /// Belt-and-suspenders ticker: re-warms the session if it's ever found cold, so the
+  /// hub stays connected even if some path nilled the socket without scheduling a retry.
+  private var warmKeeper: Timer?
   /// True only while a session is connected + authenticated for `sessionProvider`. This is
   /// what gates `isActive`: a PTT turn enters hub mode only when the hub is genuinely
   /// connected right now; otherwise it transparently uses the legacy cascade. Set in
@@ -135,6 +141,77 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     // Expose the headless E2E action (omi-ctl action hub_test_turn pcm=… provider=…).
     RealtimeHubTestHarness.registerAutomationAction()
     refreshAboutUserCard()
+    // Re-warm whenever the app comes back to front or the machine wakes from sleep —
+    // both kill the realtime socket silently, and without this the hub stays cold
+    // (PTT falls to the slow Claude cascade) until the next error happens to fire.
+    NotificationCenter.default.removeObserver(
+      self, name: NSApplication.didBecomeActiveNotification, object: nil)
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(rewarmOnLifecycle),
+      name: NSApplication.didBecomeActiveNotification, object: nil)
+    NSWorkspace.shared.notificationCenter.removeObserver(
+      self, name: NSWorkspace.didWakeNotification, object: nil)
+    NSWorkspace.shared.notificationCenter.addObserver(
+      self, selector: #selector(rewarmOnLifecycle),
+      name: NSWorkspace.didWakeNotification, object: nil)
+    // Keep a warm session alive proactively so the hub is essentially always connected.
+    startWarmKeeper()
+    ensureWarm()
+  }
+
+  @objc private func rewarmOnLifecycle() {
+    hubReconnectStrikes = 0  // fresh chance — reset backoff
+    if session == nil { ensureWarm() }
+  }
+
+  /// Periodically guarantee a warm session exists (default voice path). Covers provider
+  /// idle-closes and any path that nilled the socket without scheduling a reconnect, so
+  /// the steady state is "connected" rather than "silently on the Claude cascade".
+  private func startWarmKeeper() {
+    warmKeeper?.invalidate()
+    warmKeeper = Timer.scheduledTimer(withTimeInterval: 25, repeats: true) { [weak self] _ in
+      Task { @MainActor in
+        guard let self else { return }
+        let canConnect =
+          APIKeyService.byokKey(self.effectiveProvider.byokProvider) != nil
+          || AuthService.shared.isSignedIn
+        guard canConnect else { return }
+        // (a) Cold socket → warm it.
+        if self.session == nil {
+          guard !self.reconnectPending, !self.minting else { return }
+          self.ensureWarm()
+          return
+        }
+        // (b) Proactive pre-cap re-warm: managed (ephemeral) sessions are killed at a hard
+        // 30-min server cap (SESSION_MAX_MIN in realtime.rs). Re-mint + reconnect BEFORE
+        // that boundary, while idle between turns, so a press never lands mid-cap on the
+        // slow cascade. Gated on !responding so it never cuts an in-flight reply. (A fresh
+        // mint is required — the ephemeral token is single-use.)
+        if !self.responding, !self.minting, let warmedAt = self.lastWarmAt,
+          Date().timeIntervalSince(warmedAt) > 27 * 60
+        {
+          log("RealtimeHub: proactive re-warm before 30-min session cap")
+          self.teardownSession()
+          self.ensureWarm()
+        }
+      }
+    }
+  }
+
+  /// Re-warm with capped exponential backoff. NEVER permanently gives up (the old
+  /// maxReconnectStrikes bail silently stranded users on the Claude cascade for the rest
+  /// of the session). Backoff: 0.5s, 1, 2, 4, 8, …capped at 15s — bounding the rate on a
+  /// hard failure without ever stopping.
+  private func scheduleReconnect() {
+    guard !reconnectPending, session == nil else { return }
+    let delay = min(0.5 * pow(2.0, Double(min(hubReconnectStrikes, Self.maxBackoffStrikes))), 15.0)
+    hubReconnectStrikes += 1
+    reconnectPending = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+      guard let self else { return }
+      self.reconnectPending = false
+      if self.session == nil { self.ensureWarm() }
+    }
   }
 
   @objc private func settingsChanged() {
@@ -301,6 +378,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   func hubDidConnect() {
     lastWarmAt = Date()
     hubConnected = true  // authenticated + ready — PTT may now route turns to the hub
+    hubReconnectStrikes = 0  // a successful connect proves the path works — reset backoff
     log("RealtimeHub: connected (\(sessionProvider?.displayName ?? "?"))")
   }
 
@@ -601,14 +679,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       hubReconnectStrikes = 0
       fallbackProvider = nil
     }
-    guard !reconnectPending, hubReconnectStrikes < Self.maxReconnectStrikes else { return }
-    hubReconnectStrikes += 1
-    reconnectPending = true
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
-      guard let self else { return }
-      self.reconnectPending = false
-      if self.session == nil { self.ensureWarm() }
-    }
+    // Always re-warm — the hub must self-heal so the next PTT turn stays on realtime
+    // instead of silently sinking to the slow Claude cascade. scheduleReconnect uses
+    // capped backoff and never permanently gives up.
+    scheduleReconnect()
   }
 
   /// Return the floating bar from its PTT voice state to compact after a hub turn.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -73,6 +73,10 @@ final class RealtimeHubSession: NSObject {
   private let q = DispatchQueue(label: "omi.realtime-hub.session")
 
   private var task: URLSessionWebSocketTask?
+  /// OpenAI keepalive: URLSession's WS task has no built-in ping, so an idle socket
+  /// (between bursty PTT turns) gets closed by the provider. A periodic ping keeps it
+  /// warm. (Gemini's RawWebSocket pings itself.)
+  private var pingTimer: DispatchSourceTimer?
   private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
   // Gemini's Live endpoint rejects both of Apple's WebSocket stacks, so it uses a
   // hand-rolled RFC 6455 client (RawWebSocket). OpenAI uses URLSession.
@@ -166,9 +170,28 @@ final class RealtimeHubSession: NSObject {
     q.async { [weak self] in self?.delegate = nil }
   }
 
+  /// OpenAI only: ping the WS every 20s while open so an idle socket isn't dropped by
+  /// the provider between PTT turns. Must be started on `q` after the task opens.
+  private func startPingKeepalive() {
+    guard provider == .openai else { return }
+    pingTimer?.cancel()
+    let timer = DispatchSource.makeTimerSource(queue: q)
+    timer.schedule(deadline: .now() + 20, repeating: 20)
+    timer.setEventHandler { [weak self] in
+      guard let self, let task = self.task, !self.terminated else { return }
+      task.sendPing { [weak self] error in
+        if let error { self?.q.async { self?.notifyError("keepalive ping failed: \(error.localizedDescription)") } }
+      }
+    }
+    timer.resume()
+    pingTimer = timer
+  }
+
   func stop() {
     q.async { [weak self] in
       guard let self else { return }
+      self.pingTimer?.cancel()
+      self.pingTimer = nil
       self.task?.cancel(with: .goingAway, reason: nil)
       self.task = nil
       self.rawWS?.close()
@@ -784,6 +807,7 @@ extension RealtimeHubSession: URLSessionWebSocketDelegate {
     q.async {
       self.receiveLoop()
       self.sendSessionSetup()
+      self.startPingKeepalive()
     }
   }
 


### PR DESCRIPTION
## Problem
Only ~9% of desktop users who mint a realtime session ever complete a realtime voice turn — the rest silently fall back to the slow Claude cascade for PTT. Root cause is a fragile client session lifecycle (backend mint is healthy).

## Fixes (client-only, RealtimeHubController / RealtimeHubSession / PushToTalkManager)
1. **No more permanent give-up** — the old `maxReconnectStrikes=5` bail stranded users on the cascade for the whole session. Replaced with capped exponential backoff (0.5s→15s) that never stops.
2. **Warm-keeper ticker (25s)** — re-warms any cold session; plus **proactive re-mint+reconnect before the hard 30-min server cap** (`SESSION_MAX_MIN`), gated to idle/between-turns.
3. **Lifecycle re-warm** — hub had zero wake/foreground observers; added `didBecomeActive` + `NSWorkspace.didWake → ensureWarm` (a big driver of the low connect rate).
4. **OpenAI keepalive** — its URLSession WS had no ping (idle-closed between bursty turns); added 20s `sendPing` (Gemini's RawWebSocket already pings).
5. **PTT cold-press** kicks `ensureWarm()` so the next turn recovers fast.

Every reconnect/re-warm re-mints a fresh single-use token and connects immediately (respects the 2-min start window). Recovery is reconnect-based, so it holds regardless of the exact 1008 cause and also covers transport resets (connection-reset-by-peer, 221×/24h in Sentry).

The hub is already the unconditional default voice path, so making it reliably connect + stay connected is what puts all users on realtime.

## Verification
- Compiles clean (debug build).
- Logic cross-checked against the parallel Sentry/backend investigation (re-mint-per-reconnect + 30-min cap confirmed in `realtime.rs`).

## Out of scope (separate bugs, flagged not fixed)
- Khrystyna's class: app crash-loop + broken omni-STT cascade fallback (1001).
- Possible `Auto→OpenAI` default (unverified; OpenAI has its own quota tail).

## Ship
Both channels run the same client — promote beta→stable after the beta build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

