### PR TITLE
desktop: bias realtime voice replies to the user's language (fix wrong-language replies)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Fixed push-to-talk voice responses falling back to the slower model \u2014 the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
+    "Fixed push-to-talk voice responses falling back to the slower model \u2014 the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)",
+    "Voice replies now follow your language setting by default (fixes occasional replies in the wrong language) while still letting you switch languages mid-conversation"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -272,8 +272,22 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
   }
 
+  /// The user's configured language as an English display name (e.g. "English"), or nil
+  /// when on auto-detect (multi) — passed to the system instruction to bias the reply
+  /// language without hard-pinning it, so a mis-detected utterance defaults to the user's
+  /// language while they can still switch languages mid-conversation.
+  private static func primaryLanguageName() -> String? {
+    let s = AssistantSettings.shared
+    if s.effectiveTranscriptionLanguage == "multi" { return nil }  // auto-detect → pure detection
+    let code = s.transcriptionLanguage
+    guard !code.isEmpty, code != "multi", code != "auto" else { return nil }
+    let base = String(code.prefix(2))
+    return Locale(identifier: "en").localizedString(forLanguageCode: base)?.capitalized
+  }
+
   private func startSession(provider: RealtimeHubProvider, auth: HubAuth) {
-    let instructions = RealtimeHubTools.systemInstruction(aboutUser: aboutUserCard)
+    let instructions = RealtimeHubTools.systemInstruction(
+      aboutUser: aboutUserCard, primaryLanguage: Self.primaryLanguageName())
     let s = RealtimeHubSession(provider: provider, auth: auth, instructions: instructions, delegate: self)
     session = s
     sessionProvider = provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -54,14 +54,27 @@ enum HubTool: String {
 
 enum RealtimeHubTools {
 
-  static func systemInstruction(aboutUser: String) -> String {
-    """
+  static func systemInstruction(aboutUser: String, primaryLanguage: String? = nil) -> String {
+    // Soft language default: bias toward the user's configured language so a short or
+    // accented utterance isn't mis-detected into the wrong language (e.g. English heard as
+    // Spanish), WITHOUT hard-pinning it — a user who clearly switches languages is still
+    // matched. Users on auto-detect (multi) get pure detection (primaryLanguage == nil).
+    let languageLine: String
+    if let lang = primaryLanguage, !lang.isEmpty {
+      languageLine =
+        "The user's primary language is \(lang). Reply in \(lang) by default, and when "
+        + "you're unsure which language you heard, use \(lang). Only reply in another "
+        + "language when the user clearly speaks a full sentence in it."
+    } else {
+      languageLine = "Reply in the same language the user is speaking."
+    }
+    return """
     You are Omi, a fast spoken-voice assistant on the user's Mac and the single hub \
     for their voice requests. You hear the user's microphone; reply by speaking, \
     conversationally. Default to one or two sentences, but when the user asks for \
     something longer or creative (a story, a detailed explanation, brainstorming), \
     give the full answer yourself — don't shorten it and don't offload it. \
-    Reply in the same language the user is speaking.
+    \(languageLine)
 
     \(aboutUser)
 


### PR DESCRIPTION
## Problem
Realtime voice occasionally replies in the wrong language — reported: spoke English, got a full Spanish reply. The hub's only language guidance was *"reply in the same language the user is speaking"* (pure auto-detect, no anchor), so Gemini Live native-audio mis-detected a short/accented English utterance and ran the whole reply in another language.

## Fix (soft default, not a hard pin)
Pass the user's configured language into the system instruction: *"your primary language is X; reply in X by default and when unsure, but switch if the user clearly speaks a full sentence in another language."*
- Users on **auto-detect (`multi`) keep pure detection** — unchanged.
- Anyone can still **switch languages mid-conversation** — not locked to one language.
- No `speechConfig` hard-pin.

## Verified end-to-end (named build, `com.omi.omi-rt-hub`)
`"What are my tasks today?"` → English STT → `get_tasks` tool call → **English** spoken reply (217KB audio, no timeout).

Separate from / on top of the hub-reconnect resilience fixes (#8061).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

