### PR TITLE
Revert realtime-hub changes (#8061, #8063) — broke PTT on beta

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -852,11 +852,6 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
-    // Hub wasn't connected for this turn → kick a re-warm now so the NEXT turn lands on
-    // realtime instead of silently staying on the slow cascade. Non-blocking + idempotent
-    // (no-op if already warming); this turn still uses the cascade below.
-    RealtimeHubController.shared.ensureWarm()
-
     // The floating bar's STT is the realtime omni model (replaces Deepgram):
     // one omni model transcribes; reasoning/tools/TTS are untouched (the final
     // transcript still goes to ChatProvider via sendTranscript()/sendQuery()).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -272,22 +272,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
   }
 
-  /// The user's configured language as an English display name (e.g. "English"), or nil
-  /// when on auto-detect (multi) — passed to the system instruction to bias the reply
-  /// language without hard-pinning it, so a mis-detected utterance defaults to the user's
-  /// language while they can still switch languages mid-conversation.
-  private static func primaryLanguageName() -> String? {
-    let s = AssistantSettings.shared
-    if s.effectiveTranscriptionLanguage == "multi" { return nil }  // auto-detect → pure detection
-    let code = s.transcriptionLanguage
-    guard !code.isEmpty, code != "multi", code != "auto" else { return nil }
-    let base = String(code.prefix(2))
-    return Locale(identifier: "en").localizedString(forLanguageCode: base)?.capitalized
-  }
-
   private func startSession(provider: RealtimeHubProvider, auth: HubAuth) {
-    let instructions = RealtimeHubTools.systemInstruction(
-      aboutUser: aboutUserCard, primaryLanguage: Self.primaryLanguageName())
+    let instructions = RealtimeHubTools.systemInstruction(aboutUser: aboutUserCard)
     let s = RealtimeHubSession(provider: provider, auth: auth, instructions: instructions, delegate: self)
     session = s
     sessionProvider = provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import AppKit
 import CoreGraphics
 import Foundation
 
@@ -47,14 +46,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Consecutive failed (re)connects with no surviving session — caps churn on a hard
   /// failure. Reset when a socket survives past the idle window or a turn completes.
   private var hubReconnectStrikes = 0
-  /// Caps the reconnect backoff growth (strikes index the exponential delay). The hub
-  /// NEVER permanently gives up re-warming — it's the default voice path, so a dropped
-  /// socket must always self-heal; the cap just bounds the retry rate on a hard failure
-  /// (e.g. a revoked key) to one attempt per ~15s.
-  private static let maxBackoffStrikes = 5
-  /// Belt-and-suspenders ticker: re-warms the session if it's ever found cold, so the
-  /// hub stays connected even if some path nilled the socket without scheduling a retry.
-  private var warmKeeper: Timer?
+  /// After this many consecutive fast failures (e.g. a stale/revoked key failing auth),
+  /// the hub stops re-warming so it doesn't hammer a dead endpoint.
+  private static let maxReconnectStrikes = 5
   /// True only while a session is connected + authenticated for `sessionProvider`. This is
   /// what gates `isActive`: a PTT turn enters hub mode only when the hub is genuinely
   /// connected right now; otherwise it transparently uses the legacy cascade. Set in
@@ -141,77 +135,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     // Expose the headless E2E action (omi-ctl action hub_test_turn pcm=… provider=…).
     RealtimeHubTestHarness.registerAutomationAction()
     refreshAboutUserCard()
-    // Re-warm whenever the app comes back to front or the machine wakes from sleep —
-    // both kill the realtime socket silently, and without this the hub stays cold
-    // (PTT falls to the slow Claude cascade) until the next error happens to fire.
-    NotificationCenter.default.removeObserver(
-      self, name: NSApplication.didBecomeActiveNotification, object: nil)
-    NotificationCenter.default.addObserver(
-      self, selector: #selector(rewarmOnLifecycle),
-      name: NSApplication.didBecomeActiveNotification, object: nil)
-    NSWorkspace.shared.notificationCenter.removeObserver(
-      self, name: NSWorkspace.didWakeNotification, object: nil)
-    NSWorkspace.shared.notificationCenter.addObserver(
-      self, selector: #selector(rewarmOnLifecycle),
-      name: NSWorkspace.didWakeNotification, object: nil)
-    // Keep a warm session alive proactively so the hub is essentially always connected.
-    startWarmKeeper()
-    ensureWarm()
-  }
-
-  @objc private func rewarmOnLifecycle() {
-    hubReconnectStrikes = 0  // fresh chance — reset backoff
-    if session == nil { ensureWarm() }
-  }
-
-  /// Periodically guarantee a warm session exists (default voice path). Covers provider
-  /// idle-closes and any path that nilled the socket without scheduling a reconnect, so
-  /// the steady state is "connected" rather than "silently on the Claude cascade".
-  private func startWarmKeeper() {
-    warmKeeper?.invalidate()
-    warmKeeper = Timer.scheduledTimer(withTimeInterval: 25, repeats: true) { [weak self] _ in
-      Task { @MainActor in
-        guard let self else { return }
-        let canConnect =
-          APIKeyService.byokKey(self.effectiveProvider.byokProvider) != nil
-          || AuthService.shared.isSignedIn
-        guard canConnect else { return }
-        // (a) Cold socket → warm it.
-        if self.session == nil {
-          guard !self.reconnectPending, !self.minting else { return }
-          self.ensureWarm()
-          return
-        }
-        // (b) Proactive pre-cap re-warm: managed (ephemeral) sessions are killed at a hard
-        // 30-min server cap (SESSION_MAX_MIN in realtime.rs). Re-mint + reconnect BEFORE
-        // that boundary, while idle between turns, so a press never lands mid-cap on the
-        // slow cascade. Gated on !responding so it never cuts an in-flight reply. (A fresh
-        // mint is required — the ephemeral token is single-use.)
-        if !self.responding, !self.minting, let warmedAt = self.lastWarmAt,
-          Date().timeIntervalSince(warmedAt) > 27 * 60
-        {
-          log("RealtimeHub: proactive re-warm before 30-min session cap")
-          self.teardownSession()
-          self.ensureWarm()
-        }
-      }
-    }
-  }
-
-  /// Re-warm with capped exponential backoff. NEVER permanently gives up (the old
-  /// maxReconnectStrikes bail silently stranded users on the Claude cascade for the rest
-  /// of the session). Backoff: 0.5s, 1, 2, 4, 8, …capped at 15s — bounding the rate on a
-  /// hard failure without ever stopping.
-  private func scheduleReconnect() {
-    guard !reconnectPending, session == nil else { return }
-    let delay = min(0.5 * pow(2.0, Double(min(hubReconnectStrikes, Self.maxBackoffStrikes))), 15.0)
-    hubReconnectStrikes += 1
-    reconnectPending = true
-    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-      guard let self else { return }
-      self.reconnectPending = false
-      if self.session == nil { self.ensureWarm() }
-    }
   }
 
   @objc private func settingsChanged() {
@@ -378,7 +301,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   func hubDidConnect() {
     lastWarmAt = Date()
     hubConnected = true  // authenticated + ready — PTT may now route turns to the hub
-    hubReconnectStrikes = 0  // a successful connect proves the path works — reset backoff
     log("RealtimeHub: connected (\(sessionProvider?.displayName ?? "?"))")
   }
 
@@ -679,10 +601,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       hubReconnectStrikes = 0
       fallbackProvider = nil
     }
-    // Always re-warm — the hub must self-heal so the next PTT turn stays on realtime
-    // instead of silently sinking to the slow Claude cascade. scheduleReconnect uses
-    // capped backoff and never permanently gives up.
-    scheduleReconnect()
+    guard !reconnectPending, hubReconnectStrikes < Self.maxReconnectStrikes else { return }
+    hubReconnectStrikes += 1
+    reconnectPending = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+      guard let self else { return }
+      self.reconnectPending = false
+      if self.session == nil { self.ensureWarm() }
+    }
   }
 
   /// Return the floating bar from its PTT voice state to compact after a hub turn.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -73,10 +73,6 @@ final class RealtimeHubSession: NSObject {
   private let q = DispatchQueue(label: "omi.realtime-hub.session")
 
   private var task: URLSessionWebSocketTask?
-  /// OpenAI keepalive: URLSession's WS task has no built-in ping, so an idle socket
-  /// (between bursty PTT turns) gets closed by the provider. A periodic ping keeps it
-  /// warm. (Gemini's RawWebSocket pings itself.)
-  private var pingTimer: DispatchSourceTimer?
   private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
   // Gemini's Live endpoint rejects both of Apple's WebSocket stacks, so it uses a
   // hand-rolled RFC 6455 client (RawWebSocket). OpenAI uses URLSession.
@@ -170,28 +166,9 @@ final class RealtimeHubSession: NSObject {
     q.async { [weak self] in self?.delegate = nil }
   }
 
-  /// OpenAI only: ping the WS every 20s while open so an idle socket isn't dropped by
-  /// the provider between PTT turns. Must be started on `q` after the task opens.
-  private func startPingKeepalive() {
-    guard provider == .openai else { return }
-    pingTimer?.cancel()
-    let timer = DispatchSource.makeTimerSource(queue: q)
-    timer.schedule(deadline: .now() + 20, repeating: 20)
-    timer.setEventHandler { [weak self] in
-      guard let self, let task = self.task, !self.terminated else { return }
-      task.sendPing { [weak self] error in
-        if let error { self?.q.async { self?.notifyError("keepalive ping failed: \(error.localizedDescription)") } }
-      }
-    }
-    timer.resume()
-    pingTimer = timer
-  }
-
   func stop() {
     q.async { [weak self] in
       guard let self else { return }
-      self.pingTimer?.cancel()
-      self.pingTimer = nil
       self.task?.cancel(with: .goingAway, reason: nil)
       self.task = nil
       self.rawWS?.close()
@@ -807,7 +784,6 @@ extension RealtimeHubSession: URLSessionWebSocketDelegate {
     q.async {
       self.receiveLoop()
       self.sendSessionSetup()
-      self.startPingKeepalive()
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -54,27 +54,14 @@ enum HubTool: String {
 
 enum RealtimeHubTools {
 
-  static func systemInstruction(aboutUser: String, primaryLanguage: String? = nil) -> String {
-    // Soft language default: bias toward the user's configured language so a short or
-    // accented utterance isn't mis-detected into the wrong language (e.g. English heard as
-    // Spanish), WITHOUT hard-pinning it — a user who clearly switches languages is still
-    // matched. Users on auto-detect (multi) get pure detection (primaryLanguage == nil).
-    let languageLine: String
-    if let lang = primaryLanguage, !lang.isEmpty {
-      languageLine =
-        "The user's primary language is \(lang). Reply in \(lang) by default, and when "
-        + "you're unsure which language you heard, use \(lang). Only reply in another "
-        + "language when the user clearly speaks a full sentence in it."
-    } else {
-      languageLine = "Reply in the same language the user is speaking."
-    }
-    return """
+  static func systemInstruction(aboutUser: String) -> String {
+    """
     You are Omi, a fast spoken-voice assistant on the user's Mac and the single hub \
     for their voice requests. You hear the user's microphone; reply by speaking, \
     conversationally. Default to one or two sentences, but when the user asks for \
     something longer or creative (a story, a detailed explanation, brainstorming), \
     give the full answer yourself — don't shorten it and don't offload it. \
-    \(languageLine)
+    Reply in the same language the user is speaking.
 
     \(aboutUser)
 


### PR DESCRIPTION
Reverts PR #8061 (hub reconnect resilience) and #8063 (voice language bias). v0.11.480 broke push-to-talk on beta. Reverting both to restore working PTT; will re-approach test-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

