### PR TITLE
feat(desktop): What's New changelog (Settings link + post-update corner card)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added a What's New link in Settings \u2192 About that opens the release notes for your version",
+    "Show a What's New popup in the corner after the app updates to a new version"
+  ],
   "releases": [
     {
       "version": "0.11.481",

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -35,6 +35,33 @@ enum AppBuild {
     return "omi"
   }
 
+  /// GitHub repo that hosts desktop releases (source of truth for the changelog).
+  private static let releasesBaseURL = "https://github.com/BasedHardware/omi/releases"
+
+  /// Release tag for the running build, e.g. "v0.11.475+11475-macos".
+  /// Matches the tag Codemagic publishes (`v{shortVersion}+{build}-{platform}`).
+  static var releaseTag: String? {
+    guard
+      let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+      !version.isEmpty,
+      let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+      !build.isEmpty
+    else {
+      return nil
+    }
+    return "v\(version)+\(build)-macos"
+  }
+
+  /// "What's New" target: the GitHub release page for the running build.
+  /// Real shipped builds (beta + stable both use the production bundle id) carry a
+  /// version that maps to a published tag, so deep-link to this version's notes (the
+  /// `+` in the tag must be `%2B` in the URL path). Dev/named test bundles carry a
+  /// placeholder version with no matching tag, so fall back to the releases list.
+  static var changelogURLString: String {
+    guard isProductionBundle, let tag = releaseTag else { return releasesBaseURL }
+    return "\(releasesBaseURL)/tag/\(tag.replacingOccurrences(of: "+", with: "%2B"))"
+  }
+
   static var currentUpdateChannel: String {
     let raw = UserDefaults.standard.string(forKey: updateChannelDefaultsKey) ?? "stable"
     return raw == "staging" ? "beta" : raw

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -6134,6 +6134,7 @@ struct SettingsContentView: View {
             .background(OmiColors.backgroundQuaternary)
 
           // Links
+          linkRow(title: "What's New", url: AppBuild.changelogURLString)
           linkRow(title: "Visit Website", url: "https://omi.me")
           linkRow(title: "Help Center", url: "https://help.omi.me")
           Button(action: {

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -105,6 +105,7 @@ struct OMIApp: App {
     return Window(windowTitle, id: "main") {
       DesktopHomeView()
         .withFontScaling()
+        .overlay(alignment: .bottomTrailing) { WhatsNewToastOverlay() }
         .onAppear {
           log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
         }
@@ -244,6 +245,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Refresh the "Auto" realtime-voice model pick from Artificial Analysis (daily, cached).
     AutoModelSelector.shared.refreshIfStale()
+
+    // After a Sparkle update, show a small "what's new" card in the corner of the
+    // main window once. Delayed so the window/overlay exist to render it.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+      WhatsNewToast.shared.presentIfUpdated()
+    }
 
     // Proactive notifications are now OFF by default for everyone. Run the one-time
     // migration before any assistant can fire, so existing users are flipped to Off

--- a/desktop/macos/Desktop/Sources/WhatsNewToast.swift
+++ b/desktop/macos/Desktop/Sources/WhatsNewToast.swift
@@ -1,0 +1,161 @@
+import AppKit
+import SwiftUI
+
+/// Drives the in-app "what's new" card that appears in the bottom-right corner of
+/// the main window the first time the app launches on a newer build (i.e. right
+/// after a Sparkle update). Tapping it opens the release notes for the running
+/// version; the (x) button or the auto-dismiss timer hides it.
+@MainActor
+final class WhatsNewToast: ObservableObject {
+  static let shared = WhatsNewToast()
+
+  /// Version string to show, e.g. "0.11.476". `nil` means the card is hidden.
+  @Published var version: String?
+
+  /// Highest build number we've already announced. 0 / unset means "no baseline yet".
+  private let lastShownBuildKey = "whatsNewLastShownBuild"
+
+  private init() {}
+
+  /// Show the card once when the running build is newer than the last one we
+  /// announced. Records a baseline silently on the first tracked launch so we
+  /// never show it on a fresh install — only after a real update.
+  func presentIfUpdated() {
+    guard AuthState.shared.isSignedIn else { return }  // re-evaluate on a later launch
+    guard let current = Self.currentBuild else { return }
+
+    let defaults = UserDefaults.standard
+    let last = defaults.integer(forKey: lastShownBuildKey)
+    if last == 0 {
+      defaults.set(current, forKey: lastShownBuildKey)
+      return
+    }
+    guard current > last else { return }
+    defaults.set(current, forKey: lastShownBuildKey)
+    present(version: Self.currentVersion)
+  }
+
+  func present(version: String) {
+    self.version = version
+  }
+
+  func dismiss() {
+    version = nil
+  }
+
+  private static var currentBuild: Int? {
+    (Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String).flatMap(Int.init)
+  }
+
+  private static var currentVersion: String {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+  }
+}
+
+/// Bottom-right corner overlay for the main window. Attach with
+/// `.overlay(alignment: .bottomTrailing) { WhatsNewToastOverlay() }`.
+struct WhatsNewToastOverlay: View {
+  @ObservedObject private var model = WhatsNewToast.shared
+  private let autoDismissSeconds: UInt64 = 12
+
+  var body: some View {
+    ZStack(alignment: .bottomTrailing) {
+      if let version = model.version {
+        WhatsNewToastCard(
+          version: version,
+          onOpen: {
+            if let url = URL(string: AppBuild.changelogURLString) {
+              NSWorkspace.shared.open(url)
+            }
+            model.dismiss()
+          },
+          onClose: { model.dismiss() }
+        )
+        .padding(20)
+        .transition(.move(edge: .trailing).combined(with: .opacity))
+        .task(id: version) {
+          try? await Task.sleep(nanoseconds: autoDismissSeconds * 1_000_000_000)
+          if !Task.isCancelled { model.dismiss() }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+    .allowsHitTesting(model.version != nil)
+    .animation(.spring(response: 0.4, dampingFraction: 0.85), value: model.version)
+  }
+}
+
+private struct WhatsNewToastCard: View {
+  let version: String
+  let onOpen: () -> Void
+  let onClose: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 12) {
+      logo
+
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(alignment: .top, spacing: 8) {
+          Text("omi updated")
+            .scaledFont(size: 14, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Spacer(minLength: 0)
+          closeButton
+        }
+
+        Text(version.isEmpty ? "A new version is installed" : "Now on version \(version)")
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+
+        HStack(spacing: 4) {
+          Text("See what's new")
+            .scaledFont(size: 12, weight: .medium)
+            .foregroundColor(OmiColors.purpleSecondary)
+          Image(systemName: "arrow.up.right")
+            .scaledFont(size: 10, weight: .semibold)
+            .foregroundColor(OmiColors.purpleSecondary)
+        }
+        .padding(.top, 3)
+      }
+    }
+    .padding(14)
+    .frame(width: 304, alignment: .topLeading)
+    .background(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .fill(OmiColors.backgroundRaised)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .stroke(OmiColors.border, lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(0.35), radius: 16, y: 6)
+    .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    .onTapGesture { onOpen() }
+  }
+
+  private var logo: some View {
+    Group {
+      if let url = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+        let image = NSImage(contentsOf: url)
+      {
+        Image(nsImage: image).resizable().aspectRatio(contentMode: .fit)
+      } else {
+        Image(systemName: "sparkles").resizable().aspectRatio(contentMode: .fit)
+          .foregroundColor(OmiColors.purplePrimary)
+      }
+    }
+    .frame(width: 34, height: 34)
+  }
+
+  private var closeButton: some View {
+    Button(action: onClose) {
+      Image(systemName: "xmark")
+        .scaledFont(size: 10, weight: .bold)
+        .foregroundColor(OmiColors.textTertiary)
+        .padding(4)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help("Dismiss")
+  }
+}


### PR DESCRIPTION
## What
- **Settings → About → "What's New"** link that opens the release notes for the running version (deep-links to the GitHub release tag for shipped builds; falls back to the releases list for dev/named bundles).
- **Post-update corner card**: an in-app bottom-right overlay shown once when the app launches on a newer build (after a Sparkle update). Tap to open the release notes, (x) to dismiss, auto-hides after 12s.

## Why
Surface the changelog to users without a buried link — the card appears right after an update, inside the app window.

## How it works
- `AppBuild.changelogURLString` resolves the GitHub release URL for the current build.
- `WhatsNewToast` (ObservableObject) drives an in-app `WhatsNewToastOverlay` attached to the main window; `presentIfUpdated()` shows it once per version bump (records a silent baseline on first launch, so it never fires on a fresh install — only after an update).

## Verified locally (named bundle, prod backend)
- Clean debug + release builds (`arm64`, `rm -rf .build`).
- Settings link renders and opens the correct URL (HTTP 200 for both the version-tag and releases-list cases).
- Corner card renders inside the main window bottom-right, shows the version + "See what's new", the (x) button closes it (real click → dismissed), auto-dismiss works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

