### PR TITLE
desktop: poll for updates every 2 min on beta (faster beta delivery), stable unchanged

### DIFF
--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -326,8 +326,11 @@ final class UpdaterViewModel: ObservableObject {
     // Wire up delegate back-reference
     updaterDelegate.viewModel = self
 
-    // Check for updates every 10 minutes
-    updaterController.updater.updateCheckInterval = 600
+    // Poll faster on the beta channel so testers pick up new builds within ~2 min of
+    // publish; stable stays at the conservative 10-min cadence (unchanged for prod users).
+    // (Release builds already auto-download + silent-install on quit, so a faster poll is
+    // the only lever left for delivery latency after a build publishes.)
+    updaterController.updater.updateCheckInterval = (updateChannel == .beta) ? 120 : 600
 
     // Observe updater state changes
     updaterController.updater.publisher(for: \.canCheckForUpdates)


### PR DESCRIPTION
Beta testers waited up to the 10-min Sparkle poll for new builds. This sets `updateCheckInterval=120s` on **beta only**; **stable stays 600s (prod unchanged)**. Release builds already auto-download + silent-install, so the poll was the only post-publish delivery lever.

**Verified:** named build boots, Sparkle updater inits + runs checks cleanly, no crash. One-line, non-voice change (isolated from the reverted hub code).

Remaining levers to hit ~10-15 min total (separate, your call): Codemagic build cut (arm64-only beta + skip redundant DMG notarize) + appcast `max-age` 300→60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

