### PR TITLE
fix(desktop): PTT always answers — fall back to Deepgram when the omni relay dies mid-turn

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Added a What's New link in Settings \u2192 About that opens the release notes for your version",
+    "Push-to-talk now always answers — if the realtime voice connection drops mid-turn (or sends nothing usable), it falls back to Deepgram transcription instead of failing silently",
+    "Added a What's New link in Settings → About that opens the release notes for your version",
     "Show a What's New popup in the corner after the app updates to a new version"
   ],
   "releases": [
@@ -22,7 +23,7 @@
       "version": "0.11.480",
       "date": "2026-06-20",
       "changes": [
-        "Fixed push-to-talk voice responses falling back to the slower model \u2014 the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
+        "Fixed push-to-talk voice responses falling back to the slower model — the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
       ]
     },
     {
@@ -86,7 +87,7 @@
       "version": "0.11.468",
       "date": "2026-06-18",
       "changes": [
-        "Recording now captures audio only during meetings by default \u2014 the mic and other apps' audio are captured only while you're in a call. Change this anytime in Settings \u2192 General \u2192 System Audio (Always / Only during meetings / Never)"
+        "Recording now captures audio only during meetings by default — the mic and other apps' audio are captured only while you're in a call. Change this anytime in Settings → General → System Audio (Always / Only during meetings / Never)"
       ]
     },
     {
@@ -94,7 +95,7 @@
       "date": "2026-06-17",
       "changes": [
         "Faster, cheaper assistant responses via Anthropic prompt caching of the system+tools prefix and conversation history",
-        "Added an experimental Realtime Voice Hub (Settings \u2192 Floating Bar): the realtime model handles your whole voice turn \u2014 listening, deciding, and speaking \u2014 for noticeably faster replies",
+        "Added an experimental Realtime Voice Hub (Settings → Floating Bar): the realtime model handles your whole voice turn — listening, deciding, and speaking — for noticeably faster replies",
         "Redesigned the floating bar voice indicator with smooth, distinct idle, listening, thinking, and speaking states so you always know whether the assistant is working or done",
         "Voice (push-to-talk) conversations now appear in your chat history",
         "Fixed older chat messages failing to load in long chats"
@@ -154,17 +155,17 @@
       "version": "0.11.457",
       "date": "2026-06-09",
       "changes": [
-        "Fixed the floating bar reappearing after you turned off \u201cShow floating bar\u201d \u2014 it now stays hidden even while a background browser action runs",
+        "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs",
         "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active",
         "Restored the Device settings page so you can pair and manage a Bluetooth device from Settings",
-        "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription"
+        "Recording no longer goes blank if on-device transcription fails to load — it automatically falls back to cloud transcription"
       ]
     },
     {
       "version": "0.11.455",
       "date": "2026-06-09",
       "changes": [
-        "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request"
+        "Improved chat and voice reliability — the backend now retries transient AI provider errors instead of failing the request"
       ]
     },
     {
@@ -185,7 +186,7 @@
       "version": "0.11.452",
       "date": "2026-06-07",
       "changes": [
-        "Proactive notifications are now off by default \u2014 turn them on anytime in Settings"
+        "Proactive notifications are now off by default — turn them on anytime in Settings"
       ]
     },
     {
@@ -208,8 +209,8 @@
       "changes": [
         "Fixed drag handle on Tasks page not appearing when hovering over a row",
         "Fixed drag-to-reorder on Tasks page not persisting when date filters are active",
-        "Fixed drag-to-reorder on Tasks page \u2014 dragged row now visually dims while in flight",
-        "Fixed manual tasks producing duplicate rows on every backend sync \u2014 orphan adoption now matches by description only, since the backend does not preserve the client-side source value",
+        "Fixed drag-to-reorder on Tasks page — dragged row now visually dims while in flight",
+        "Fixed manual tasks producing duplicate rows on every backend sync — orphan adoption now matches by description only, since the backend does not preserve the client-side source value",
         "Fixed Floating Bar positioning so the input field is no longer hidden behind the macOS Dock"
       ]
     },
@@ -426,7 +427,7 @@
       "version": "0.11.414",
       "date": "2026-05-21",
       "changes": [
-        "Fixed memories created on desktop showing up under \"Manual\" on mobile \u2014 they now appear under \"About You\" or \"Insights\" based on their type",
+        "Fixed memories created on desktop showing up under \"Manual\" on mobile — they now appear under \"About You\" or \"Insights\" based on their type",
         "Screen Capture and Microphone menu bar toggles now show as off when your trial has expired or you hit your usage limit, and tapping them brings up the upgrade prompt"
       ]
     },
@@ -441,14 +442,14 @@
       "version": "0.11.411",
       "date": "2026-05-18",
       "changes": [
-        "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+        "Fixed BYOK keys not being used for Gemini and Anthropic requests — users who bring their own API keys now bypass server keys and rate limits for all AI features"
       ]
     },
     {
       "version": "0.11.409",
       "date": "2026-05-18",
       "changes": [
-        "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+        "Fixed BYOK keys not being used for Gemini and Anthropic requests — users who bring their own API keys now bypass server keys and rate limits for all AI features"
       ]
     },
     {
@@ -462,7 +463,7 @@
       "version": "0.11.407",
       "date": "2026-05-16",
       "changes": [
-        "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured \u2014 request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
+        "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured — request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
       ]
     },
     {
@@ -483,7 +484,7 @@
       "version": "0.11.404",
       "date": "2026-05-15",
       "changes": [
-        "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
+        "Task notifications fire within seconds instead of waiting up to 5 minutes — promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
       ]
     },
     {
@@ -497,7 +498,7 @@
       "version": "0.11.402",
       "date": "2026-05-15",
       "changes": [
-        "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks"
+        "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first — a chat asking for two unrelated deliverables in one message creates two tasks"
       ]
     },
     {
@@ -518,7 +519,7 @@
       "version": "0.11.398",
       "date": "2026-05-14",
       "changes": [
-        "Smarter task analyzer dedupe \u2014 per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
+        "Smarter task analyzer dedupe — per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
       ]
     },
     {
@@ -616,7 +617,7 @@
       "version": "0.11.380",
       "date": "2026-05-10",
       "changes": [
-        "Beta builds now talk to the development backend for faster fixes \u2014 your data still lives in production"
+        "Beta builds now talk to the development backend for faster fixes — your data still lives in production"
       ]
     },
     {
@@ -686,7 +687,7 @@
       "version": "0.11.370",
       "date": "2026-04-29",
       "changes": [
-        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents \u2014 Claude Haiku decides whether each message is a quick answer or a real task"
+        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents — Claude Haiku decides whether each message is a quick answer or a real task"
       ]
     },
     {
@@ -707,7 +708,7 @@
       "version": "0.11.367",
       "date": "2026-04-26",
       "changes": [
-        "Stop creating up to 5 tasks (and notifications) on every app launch \u2014 task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
+        "Stop creating up to 5 tasks (and notifications) on every app launch — task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
       ]
     },
     {
@@ -729,7 +730,7 @@
       "date": "2026-04-26",
       "changes": [
         "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
-        "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
+        "Added Execute button on floating-bar notification cards and task rows — one click spawns an agent that handles the item end-to-end"
       ]
     },
     {
@@ -814,7 +815,7 @@
       "version": "0.11.350",
       "date": "2026-04-21",
       "changes": [
-        "Auto-updates no longer install during an active conversation \u2014 the app waits for 2 minutes of silence before restarting"
+        "Auto-updates no longer install during an active conversation — the app waits for 2 minutes of silence before restarting"
       ]
     },
     {
@@ -829,7 +830,7 @@
       "date": "2026-04-21",
       "changes": [
         "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen",
-        "Usage-based overage on Operator plan \u2014 chat past 500 questions is billed as real provider cost + 15% at end of cycle"
+        "Usage-based overage on Operator plan — chat past 500 questions is billed as real provider cost + 15% at end of cycle"
       ]
     },
     {
@@ -2052,8 +2053,8 @@
       "version": "0.11.134",
       "date": "2026-03-18",
       "changes": [
-        "Removed intro video from Rewind tab \u2014 screenshots are shown immediately",
-        "Fixed delayed screenshot capture after onboarding \u2014 first screenshot is now taken instantly"
+        "Removed intro video from Rewind tab — screenshots are shown immediately",
+        "Fixed delayed screenshot capture after onboarding — first screenshot is now taken instantly"
       ]
     },
     {
@@ -2457,8 +2458,8 @@
         "Added live 3D knowledge graph visualization during onboarding that builds incrementally as AI discovers information about you",
         "Added interaction hints to onboarding knowledge graph (drag, zoom, pan)",
         "Fixed onboarding resuming after Quit & Reopen for screen recording permission",
-        "Parallel AI exploration during onboarding \u2014 builds your digital profile and knowledge graph while you set up permissions",
-        "Automated release notes \u2014 changes are now tracked as they happen"
+        "Parallel AI exploration during onboarding — builds your digital profile and knowledge graph while you set up permissions",
+        "Automated release notes — changes are now tracked as they happen"
       ]
     },
     {
@@ -2534,9 +2535,9 @@
         "If the Install button fails, download manually from <a href='https://macos.omi.me' style='font-weight:bold'>macos.omi.me</a> (known issue on macOS 26)",
         "Task chat session history: resume previous AI conversations about tasks across app restarts",
         "Dedicated task chat side panel with better layout isolation and session ID display",
-        "Add task button in toolbar (\u2318N) for quick inline task creation",
+        "Add task button in toolbar (⌘N) for quick inline task creation",
         "File graph keyboard hints: drag to rotate, right-drag to pan, scroll to zoom",
-        "Removed per-message timeouts in AI bridge \u2014 long-running tools no longer fail prematurely",
+        "Removed per-message timeouts in AI bridge — long-running tools no longer fail prematurely",
         "Chat memory capped at 200 messages to prevent unbounded growth",
         "Auto-restart memory threshold lowered from 4GB to 3GB for safer recovery",
         "Fixed PostHog lifecycle capture causing 2-second XPC hangs to Spotlight",
@@ -2551,7 +2552,7 @@
       "version": "0.10.9",
       "date": "2026-02-23",
       "changes": [
-        "<span style='color:red;font-size:16px;font-weight:bold'>\u26a0\ufe0f AUTO-UPDATE IS BROKEN \u2014 YOU MUST DOWNLOAD MANUALLY</span>",
+        "<span style='color:red;font-size:16px;font-weight:bold'>⚠️ AUTO-UPDATE IS BROKEN — YOU MUST DOWNLOAD MANUALLY</span>",
         "<span style='color:red'>The Install button will NOT work.</span> Please download the new version here: <a href='https://macos.omi.me' style='color:red;font-weight:bold;font-size:15px'>macos.omi.me</a>",
         "Steps: 1) Click the link above or open <a href='https://macos.omi.me'>macos.omi.me</a> in your browser  2) Download the DMG  3) Open it and drag Omi to Applications  4) Replace the existing app when prompted",
         "This is a one-time fix. After installing manually, all future updates will work normally.",
@@ -2796,7 +2797,7 @@
         "Hardware-accelerated screen recording (hevc_videotoolbox) for lower CPU usage",
         "Auto-detects video calls (Zoom, Teams, Meet) and reduces capture frequency to avoid slowdowns",
         "Floating bar shows OMI logo and no longer drifts across the screen or off-screen on monitor disconnect",
-        "AI agent turn limit removed \u2014 tasks can run as many steps as needed",
+        "AI agent turn limit removed — tasks can run as many steps as needed",
         "Capped in-memory embeddings to 5,000 entries to prevent unbounded memory growth",
         "Fixed database crashes from concurrent sync operations during memory and action item writes",
         "Reduced error noise: cleaner Sentry logs, quieter Crisp polling, slower recovery retries"
@@ -2825,7 +2826,7 @@
         "Accessibility permission reset: detects broken state after macOS updates and offers one-click fix",
         "Database upgraded to connection pool for better performance during concurrent reads",
         "Automation permission check now handles System Events not running (fixes -600 error)",
-        "Onboarding no longer blocks on permissions \u2014 grant them later from Settings",
+        "Onboarding no longer blocks on permissions — grant them later from Settings",
         "Hiding the floating bar now persists across app restarts",
         "Native notifications when support replies in Help chat",
         "Faster conversation sync by skipping unchanged sessions"
@@ -2839,7 +2840,7 @@
         "Model picker: switch between Sonnet and Opus directly from the floating bar",
         "Voice follow-up: use push-to-talk while viewing an AI response to continue the conversation",
         "Batch transcription mode: record first, transcribe after for better accuracy (Settings > Shortcuts)",
-        "Customizable Ask Omi shortcut: choose \u2318Enter, \u2318\u21e7Enter, \u2318J, or \u2318O (Settings > Shortcuts)",
+        "Customizable Ask Omi shortcut: choose ⌘Enter, ⌘⇧Enter, ⌘J, or ⌘O (Settings > Shortcuts)",
         "Push-to-talk sounds can now be toggled off in settings",
         "AI chat now includes your tasks for more context-aware responses",
         "Long chat messages are auto-truncated with Show more/less toggle",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -587,6 +587,13 @@ class PushToTalkManager: ObservableObject {
 
     // Realtime omni: commit the turn and wait for the final transcript.
     if isOmniSTT {
+      // The relay already died this turn (omniDidError nilled it) — don't wait on a dead
+      // socket; transcribe the buffered turn audio via Deepgram now so PTT still answers.
+      if realtimeOmniService == nil {
+        log("PushToTalkManager: omni relay unavailable — transcribing turn via Deepgram")
+        fallBackToDeepgram()
+        return
+      }
       // QueryTracer: the omni provider's post-commit finalization (VAD close +
       // final STT inference + round-trip) — closed at the top of sendTranscript().
       activeTracer?.begin(
@@ -596,8 +603,11 @@ class PushToTalkManager: ObservableObject {
       let timeout = DispatchWorkItem { [weak self] in
         Task { @MainActor in
           guard let self, self.state == .finalizing else { return }
-          log("PushToTalkManager: omni finalization timeout — sending transcript")
-          self.sendTranscript()
+          // No clean final transcript from the relay in time — don't ship the garbage
+          // interim it may have left behind; fall back to Deepgram on the full buffered
+          // turn audio. fallBackToDeepgram() no-ops if the turn was already sent.
+          log("PushToTalkManager: omni finalization timeout — falling back to Deepgram")
+          self.fallBackToDeepgram()
         }
       }
       liveFinalizationTimeout = timeout
@@ -1174,14 +1184,23 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
 
   func omniDidError(_ message: String) {
     logError("PushToTalkManager: omni STT error: \(message)")
-    // If the omni model already gave us a transcript this turn, the error is a
-    // benign teardown — ignore it. Otherwise the relay is unreachable (e.g. the
-    // backend isn't on prod yet): fall back to Deepgram so PTT never breaks.
-    guard !omniReceivedTranscript,
+    // Benign ONLY if the turn already completed (final transcript sent). A mid-turn relay
+    // death — even after a spurious interim like "Olha olha" that set omniReceivedTranscript
+    // — must NOT be ignored, or the turn is lost (garbage/no reply). The full turn audio is
+    // always buffered in batchAudioBuffer, so we re-transcribe it via Deepgram.
+    guard !omniTurnSent,
           state == .listening || state == .lockedListening
             || state == .pendingLockDecision || state == .finalizing
     else { return }
-    fallBackToDeepgram()
+    // Kill the dead relay so finalize() doesn't wait on it; the mic keeps buffering.
+    realtimeOmniService?.stop()
+    realtimeOmniService = nil
+    // If the user already released, transcribe the buffered turn now. If they're still
+    // holding, keep capturing — finalize()'s dead-relay branch falls back to Deepgram with
+    // the full turn audio (avoids cutting them off mid-sentence).
+    if state == .finalizing {
+      fallBackToDeepgram()
+    }
   }
 
   /// Transcribe the buffered turn audio via Deepgram when omni is unavailable.


### PR DESCRIPTION
## Problem (the real "PTT with fallbacks" bug)
The floating-bar PTT uses the realtime omni STT relay (Gemini Live). It only fell back to Deepgram when the relay **never started**. But the flaky relay commonly sends a **spurious interim** (e.g. "Olha olha olha") and then drops (`1008`/`1001`) **without a final transcript**. The old guard `!omniReceivedTranscript` treated that stray interim as success → **suppressed the Deepgram fallback** → the turn shipped garbage or nothing. The 8s finalize timeout did the same (shipped the garbage interim).

So when the realtime hub isn't connected (the ~91% case) and the omni relay flakes, the user got **no useful reply** — the "fallback" never caught.

## Fix (failure-path only)
Any omni failure that hasn't produced a *sent* final (`!omniTurnSent`) now re-transcribes the **full buffered turn audio** via Deepgram:
- `omniDidError`: guard `!omniReceivedTranscript` → `!omniTurnSent`; kills the dead relay; transcribes now if the user already released, else defers to `finalize()` so a mid-hold death doesn't cut them off.
- `finalize()`: if the relay died this turn (service nil) → Deepgram immediately; the 8s no-final timeout → Deepgram instead of shipping the garbage interim.

Routes to the **existing, already-proven** `fallBackToDeepgram()`. The realtime hub and the omni happy path are **untouched** — a working turn can't be made worse.

## Verification
- Clean compile.
- Named build (`omi-ptt-fb`) runs healthy; omni STT happy path returns the correct transcript (no regression).
- ⚠️ The fallback-*firing* path needs a real human PTT press to fully confirm (the test harness doesn't exercise the live PushToTalkManager path, and omni/Deepgram share the backend URL so it can't be force-failed headlessly). Failure-path-only + routes to a proven function = low risk; rollback/watcher ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

