### PR TITLE
desktop: show "Omi Beta (dev)" for local hot-swap builds

### DIFF
--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -21,10 +21,16 @@ enum UpdateChannel: String, CaseIterable {
     }
   }
 
-  /// App display name based on update channel: "omi" for stable, "Omi Beta" for beta
+  /// App display name based on update channel: "omi" for stable, "Omi Beta" for beta.
+  /// Local hot-swap builds (self-beta.sh) stamp `OMISelfBuild=true` into Info.plist, so
+  /// they show "Omi Beta (dev)" — a clear signal you're on a locally-rebuilt bundle, not a
+  /// Codemagic-distributed one. A real Codemagic build never sets the key, and when it later
+  /// replaces the hot-swap bundle via Sparkle the suffix disappears.
   static var appDisplayName: String {
     let channel = UserDefaults.standard.string(forKey: "update_channel") ?? "stable"
-    return (channel == "beta" || channel == "staging") ? "Omi Beta" : "omi"
+    let base = (channel == "beta" || channel == "staging") ? "Omi Beta" : "omi"
+    let isSelfBuild = (Bundle.main.object(forInfoDictionaryKey: "OMISelfBuild") as? Bool) ?? false
+    return isSelfBuild ? "\(base) (dev)" : base
   }
 }
 


### PR DESCRIPTION
Local hot-swap builds (self-beta.sh) and Codemagic builds both showed "Omi Beta v…" — no way to tell which you were running. Now `appDisplayName` appends "(dev)" when Info.plist has `OMISelfBuild=true` (stamped only by self-beta.sh, never Codemagic). Reverts automatically when a real Codemagic build replaces the bundle.

Verified: compiles; hot-swap `--selftest` stamps the key with codesign still valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

