### PR TITLE
fix(desktop): stop reporting Swift CancellationError as a Sentry error

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -151,6 +151,9 @@ func log(_ message: String) {
 /// We still write them to the local log + breadcrumbs for debugging context.
 private func isNonActionableTransient(_ error: Error?) -> Bool {
   guard let error = error else { return false }
+  // Swift structured-concurrency cancellation: thrown when a Task/operation is
+  // cancelled (assistant stopped, frame superseded). Expected, not an app bug.
+  if error is CancellationError { return true }
   let nsError = error as NSError
   switch nsError.domain {
   case NSURLErrorDomain:


### PR DESCRIPTION
## Problem
`isNonActionableTransient` (Logger.swift) already filters URL/POSIX cancellations from Sentry, but missed Swift structured-concurrency `CancellationError`. That error is thrown routinely when a proactive assistant stops or an in-flight frame analysis is superseded — not an app bug.

As a result these flooded Sentry over the last 24h:
- **OMI-COMPUTER-59F** — `Swift.CancellationError: CancellationError()` (~2007 events)
- **OMI-COMPUTER-6D0** — `Advice extraction error: …(Swift.CancellationError error 1.)` (287 events)

## Fix
One guard: treat `error is CancellationError` as non-actionable transient — kept as local log + breadcrumb, not a Sentry capture. Matches the function's existing documented intent ("cancellations … not actionable").

Compile-checked clean (`xcrun swift build -c debug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

