### PR TITLE
Suppress httpx INFO logging in parakeet service

### DIFF
--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -29,6 +29,7 @@ from transcribe import (
 from stream_handler import StreamSession, warmup_rnnt_decoder
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 _ASR_BUCKETS = (0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0)


### PR DESCRIPTION
## Summary
- Suppress httpx logger to WARNING level in parakeet `main.py`
- httpx logs every outbound HTTP request at INFO, generating ~1,118 lines/min at peak (82% of all parakeet logs) from diarizer embedding calls
- These have zero diagnostic value — they only confirm diarizer responded 200
- This log volume is causing 35h lag in the signal log ingestion pipeline

## Changes
One line in `backend/parakeet/main.py`: `logging.getLogger("httpx").setLevel(logging.WARNING)`

Covers all httpx calls across parakeet modules (transcribe.py diarizer embeddings, stream_handler.py speaker embeddings, NIM mode requests).

## Test plan
- [ ] Verify parakeet pod starts without errors
- [ ] Verify diarizer embedding calls still work (httpx functionality unchanged, only logging suppressed)
- [ ] Verify remaining logs are all useful: transcribe access logs, batch flushes, health probes, errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

