### PR TITLE
fix(backend): silence httpx INFO request logs in parakeet (#8080)

### DIFF
--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -29,6 +29,10 @@ from transcribe import (
 from stream_handler import StreamSession, warmup_rnnt_decoder
 
 logging.basicConfig(level=logging.INFO)
+# httpx logs every outbound request at INFO; the per-segment diarizer embedding
+# calls (one per audio segment) flood the log pipeline with 200 OK noise. Keep
+# only warnings/errors (4xx/5xx, timeouts) from httpx. See issue #8080.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 _ASR_BUCKETS = (0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0)


### PR DESCRIPTION
## Bug (#8080)

`httpx` logs every outbound HTTP request at INFO level by default. The parakeet service makes one diarizer embedding call (`POST /v2/embedding`) per audio segment (`transcribe.py:275`, `stream_handler.py:756`), so httpx emits a `"HTTP/1.1 200 OK"` line for each.

**Impact (from the issue):**
- Peak (Jun 20 16:00 UTC): **1,118 httpx lines/min = 82% of all parakeet logs** (~18 diarize req/s).
- The signal-daemon log ingestion pipeline fell **~35h behind** purely from this volume.
- These lines have zero diagnostic value — they only confirm the diarizer returned 200.

## Root cause

httpx ships with INFO-level request logging as a library default; our code imports `httpx` and makes calls without lowering its logger level.

## Fix

One line in `backend/parakeet/main.py`, right after `logging.basicConfig(level=logging.INFO)`:

```python
logging.getLogger("httpx").setLevel(logging.WARNING)
```

This suppresses the 200-OK noise while preserving httpx logs for actual HTTP errors (4xx/5xx, timeouts, connection failures). All app-level loggers stay at INFO. Verified the noisy call sites use `httpx.Client` (so they route through the `httpx` logger); `py_compile` clean.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

