### PR TITLE
Add torch_audiomentations to parakeet Dockerfile

### DIFF
--- a/backend/parakeet/Dockerfile
+++ b/backend/parakeet/Dockerfile
@@ -17,20 +17,36 @@ WORKDIR /app
 RUN pip install --no-cache-dir --no-deps --force-reinstall \
     "nemo_toolkit[asr] @ git+https://github.com/beastoin/NeMo.git@68d99a17944181452205dc60da21e82bf3647054"
 
-# NGC's custom torch ABI is incompatible with ALL standard torchaudio
-# wheels (PyPI, cu128 index).  NeMo imports torchaudio at module level
-# (via squim metrics) but parakeet never calls those functions.
-# Create a lightweight stub that satisfies `import torchaudio`.
-RUN mkdir -p /usr/local/lib/python3.12/dist-packages/torchaudio && \
-    printf '__version__ = "stub"\n' > \
-    /usr/local/lib/python3.12/dist-packages/torchaudio/__init__.py
+# NGC torch ABI is incompatible with standard torchaudio C extensions.
+# Install torchaudio --no-deps for the pure-Python compliance.kaldi module
+# (wespeaker needs kaldi.fbank for mel filterbank features), then patch
+# __init__.py to skip the C extension loader and only expose compliance.
+RUN pip install --no-cache-dir --no-deps torchaudio && \
+    printf '__version__ = "2.11.0-ngc-compat"\nfrom . import compliance\n' > \
+    /usr/local/lib/python3.12/dist-packages/torchaudio/__init__.py && \
+    printf '_IS_TORCHAUDIO_EXT_AVAILABLE = False\ndef fail_if_no_align(*a, **kw): pass\ndef fail_if_no_sox(*a, **kw): pass\ndef fail_if_no_ffmpeg(*a, **kw): pass\ndef fail_if_no_soundfile(*a, **kw): pass\ndef fail_if_no_kaldi(*a, **kw): pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/torchaudio/_extension/__init__.py
 
 # pyannote.audio.core.task imports torch_audiomentations for training-time
 # data augmentation. We only use Model + Inference (embedding extraction),
-# never the training pipeline. Stub the package to satisfy the import.
-RUN mkdir -p /usr/local/lib/python3.12/dist-packages/torch_audiomentations && \
-    printf '__version__ = "stub"\n' > \
-    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/__init__.py
+# never the training pipeline. Stub the package with all symbols pyannote needs.
+RUN mkdir -p /usr/local/lib/python3.12/dist-packages/torch_audiomentations/core \
+             /usr/local/lib/python3.12/dist-packages/torch_audiomentations/augmentations \
+             /usr/local/lib/python3.12/dist-packages/torch_audiomentations/utils && \
+    printf '__version__ = "stub"\nclass Identity:\n    pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/__init__.py && \
+    printf '' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/core/__init__.py && \
+    printf 'class BaseWaveformTransform:\n    pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/core/transforms_interface.py && \
+    printf '' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/augmentations/__init__.py && \
+    printf 'class Mix:\n    pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/augmentations/mix.py && \
+    printf '' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/utils/__init__.py && \
+    printf 'def from_dict(*a, **kw):\n    pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/utils/config.py
 
 # Extra deps not in the NGC image.
 # pyannote.audio and torch-dependent deps installed --no-deps to prevent
@@ -44,11 +60,15 @@ RUN pip install --no-cache-dir \
     "prometheus-client>=0.21.0" \
     "soundfile>=0.13.0"
 
+# pyannote.audio + deps. Post-install: stub telemetry (needs opentelemetry
+# OTLP exporter which we don't need for inference-only usage).
 RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0" && \
     pip install --no-cache-dir --no-deps \
     "pyannote.core" "pyannote.database" "pyannote.pipeline" \
     "speechbrain" "asteroid-filterbanks" "einops" "semver" \
-    "hf_transfer" "tensorboardX"
+    "hf_transfer" "tensorboardX" && \
+    printf 'def set_opentelemetry_log_level(*a, **kw): pass\ndef set_telemetry_metrics(*a, **kw): pass\ndef track_model_init(*a, **kw): pass\ndef track_pipeline_init(*a, **kw): pass\ndef track_pipeline_apply(*a, **kw): pass\n' > \
+    /usr/local/lib/python3.12/dist-packages/pyannote/audio/telemetry/__init__.py
 
 COPY backend/parakeet/ .
 

--- a/backend/parakeet/Dockerfile
+++ b/backend/parakeet/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0" && \
     pip install --no-cache-dir --no-deps \
     "pyannote.core" "pyannote.database" "pyannote.pipeline" \
     "speechbrain" "asteroid-filterbanks" "einops" "semver" \
-    "hf_transfer" "tensorboardX"
+    "hf_transfer" "tensorboardX" "torch_audiomentations"
 
 COPY backend/parakeet/ .
 

--- a/backend/parakeet/Dockerfile
+++ b/backend/parakeet/Dockerfile
@@ -25,6 +25,13 @@ RUN mkdir -p /usr/local/lib/python3.12/dist-packages/torchaudio && \
     printf '__version__ = "stub"\n' > \
     /usr/local/lib/python3.12/dist-packages/torchaudio/__init__.py
 
+# pyannote.audio.core.task imports torch_audiomentations for training-time
+# data augmentation. We only use Model + Inference (embedding extraction),
+# never the training pipeline. Stub the package to satisfy the import.
+RUN mkdir -p /usr/local/lib/python3.12/dist-packages/torch_audiomentations && \
+    printf '__version__ = "stub"\n' > \
+    /usr/local/lib/python3.12/dist-packages/torch_audiomentations/__init__.py
+
 # Extra deps not in the NGC image.
 # pyannote.audio and torch-dependent deps installed --no-deps to prevent
 # upgrading torch/torchvision/torchaudio in the NGC stack.
@@ -41,8 +48,7 @@ RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0" && \
     pip install --no-cache-dir --no-deps \
     "pyannote.core" "pyannote.database" "pyannote.pipeline" \
     "speechbrain" "asteroid-filterbanks" "einops" "semver" \
-    "hf_transfer" "tensorboardX" "torch_audiomentations" \
-    "julius" "torch-pitch-shift"
+    "hf_transfer" "tensorboardX"
 
 COPY backend/parakeet/ .
 

--- a/backend/parakeet/Dockerfile
+++ b/backend/parakeet/Dockerfile
@@ -41,7 +41,8 @@ RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0" && \
     pip install --no-cache-dir --no-deps \
     "pyannote.core" "pyannote.database" "pyannote.pipeline" \
     "speechbrain" "asteroid-filterbanks" "einops" "semver" \
-    "hf_transfer" "tensorboardX" "torch_audiomentations"
+    "hf_transfer" "tensorboardX" "torch_audiomentations" \
+    "julius" "torch-pitch-shift"
 
 COPY backend/parakeet/ .
 

--- a/backend/parakeet/Dockerfile
+++ b/backend/parakeet/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --no-cache-dir --no-deps --force-reinstall \
 # (wespeaker needs kaldi.fbank for mel filterbank features), then patch
 # __init__.py to skip the C extension loader and only expose compliance.
 RUN pip install --no-cache-dir --no-deps torchaudio && \
-    printf '__version__ = "2.11.0-ngc-compat"\nfrom . import compliance\n' > \
+    printf '__version__ = "2.11.0-ngc-compat"\nfrom . import compliance\nfrom . import functional\n' > \
     /usr/local/lib/python3.12/dist-packages/torchaudio/__init__.py && \
     printf '_IS_TORCHAUDIO_EXT_AVAILABLE = False\ndef fail_if_no_align(*a, **kw): pass\ndef fail_if_no_sox(*a, **kw): pass\ndef fail_if_no_ffmpeg(*a, **kw): pass\ndef fail_if_no_soundfile(*a, **kw): pass\ndef fail_if_no_kaldi(*a, **kw): pass\n' > \
     /usr/local/lib/python3.12/dist-packages/torchaudio/_extension/__init__.py
@@ -62,7 +62,7 @@ RUN pip install --no-cache-dir \
 
 # pyannote.audio + deps. Post-install: stub telemetry (needs opentelemetry
 # OTLP exporter which we don't need for inference-only usage).
-RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0" && \
+RUN pip install --no-cache-dir --no-deps "pyannote.audio>=3.1.0,<4.0" && \
     pip install --no-cache-dir --no-deps \
     "pyannote.core" "pyannote.database" "pyannote.pipeline" \
     "speechbrain" "asteroid-filterbanks" "einops" "semver" \


### PR DESCRIPTION
## Summary
Fixes parakeet Dockerfile so the built-in wespeaker speaker embedding model from PR #8082 actually activates in the NGC container. Without this, pyannote.audio fails to import and all embedding requests silently fall back to the external HTTP diarizer.

Closes #8081

## Problem
PR #8082 code deployed cleanly but the built-in embedding was inactive. Three import chain failures in the NGC container:

1. **torch_audiomentations**: `pyannote.audio.core.task` imports it for training-time augmentation — missing from container
2. **torchaudio**: wespeaker model needs `kaldi.fbank` for mel filterbank features — the old stub didn't expose the compliance module
3. **pyannote telemetry**: imports opentelemetry OTLP exporter — not installed and unnecessary for inference

## Fix (verified on dev GKE L4 GPU)

1. **torchaudio**: Install real package \`--no-deps\`, patch \`__init__.py\` to skip C extension loader and expose \`compliance\` + \`functional\` modules. Keeps NGC torch ABI intact.

2. **torch_audiomentations**: Stub package with all symbols pyannote imports — \`Identity\`, \`BaseWaveformTransform\`, \`Mix\`, \`from_dict\`. Never called at inference time.

3. **pyannote telemetry**: Post-install stub with 5 no-op functions.

4. **pyannote.audio pinned to <4.0**: Prevents untested major version upgrades that could break stubs.

## DER Benchmark (dev v7 vs prod HTTP diarizer)
| Scenario | Dev DER | Prod DER | Delta |
|---|---|---|---|
| 2-spk short | 10.8% | 11.1% | -0.3pp |
| 2-spk long | 3.4% | 3.4% | -0.0pp |
| 3-spk | 4.7% | 4.7% | +0.0pp |
| 4-spk round-robin | 17.4% | 17.4% | -0.0pp |
| 2-spk interleaved | 12.9% | 12.9% | -0.0pp |
| **Average** | **9.8%** | **9.9%** | **-0.1pp** |

## Test evidence
- 19/19 unit tests pass (test_parakeet_builtin_embedding.py)
- Dev GKE L4 GPU: pyannote import OK, wespeaker model load OK, 256-dim embedding on GPU OK
- DER identical to prod HTTP diarizer across all 5 scenarios

## Risk
- Minimal — stubs only satisfy import-time symbols for training code paths never executed at inference
- If any stub is insufficient, the existing try/except in \`get_builtin_embedding_model()\` catches the error and falls back to HTTP (no regression)
- torchaudio compliance.kaldi is pure Python — no C extension ABI risk
- pyannote.audio pinned to <4.0 prevents version drift that could break stubs

_by AI for @beastoin_