### PR TITLE
fix(desktop): stop reporting transient TLS handshake errors to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -158,12 +158,14 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   switch nsError.domain {
   case NSURLErrorDomain:
     // -999 cancelled, -1001 timed out, -1003 host not found, -1004 cannot connect,
-    // -1005 connection lost, -1009 offline, -1011 bad server response, -1020 not allowed.
+    // -1005 connection lost, -1009 offline, -1011 bad server response, -1020 not allowed,
+    // -1200 TLS handshake failed (transient secure-connection drop, same as -1005).
     let transient: Set<Int> = [
       NSURLErrorCancelled, NSURLErrorTimedOut, NSURLErrorCannotFindHost,
       NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
       NSURLErrorNotConnectedToInternet, NSURLErrorBadServerResponse,
       NSURLErrorDataNotAllowed, NSURLErrorResourceUnavailable,
+      NSURLErrorSecureConnectionFailed,
     ]
     return transient.contains(nsError.code)
   case NSPOSIXErrorDomain:


### PR DESCRIPTION
## Summary
`isNonActionableTransient` in `Logger.swift` filters transient `NSURLErrorDomain` network errors (timeouts, connection lost, offline, etc.) from Sentry but missed `NSURLErrorSecureConnectionFailed` (-1200, "A TLS error caused the secure connection to fail.").

This is a transient secure-connection drop — the same category as the already-filtered `-1005` (network connection lost) — not an app bug. It floods Sentry (**OMI-COMPUTER-6SN**) without being actionable.

Follow-on to aea21952 (CancellationError filtering) on the same Sentry-noise cleanup.

## Change
One entry added to the transient `NSURLErrorDomain` code set. Errors are still written to the local log + breadcrumbs for debugging context.

## Testing
`xcrun swift build -c debug --package-path Desktop` — build complete, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

