### PR TITLE
fix(desktop): stop reporting benign sign-out race in chat poll to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2357,6 +2357,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             if case APIError.unauthorized = error {
                 AuthBackoffTracker.shared.reportAuthFailure()
             }
+            // Benign sign-out race: the isSignedIn guard above passed, but the
+            // token was cleared by the time getMessages ran. Expected, not a bug
+            // — log quietly (breadcrumb only) instead of flooding Sentry.
+            if case AuthError.notSignedIn = error {
+                log("ChatProvider poll skipped: signed out mid-cycle")
+                return
+            }
             // Silent failure — polling errors shouldn't disrupt the user
             logError("ChatProvider poll failed", error: error)
         }


### PR DESCRIPTION
## Problem
`ChatProvider.pollForNewMessages` guards on `AuthState.shared.isSignedIn`, but `getMessages` is awaited afterward. If the user signs out mid-cycle, the token is cleared and the request throws `AuthError.notSignedIn`. This bubbled to `logError` and flooded Sentry (**OMI-COMPUTER-6EM**, ~347 events/24h) as `ChatProvider poll failed: User is not signed in` — a benign race, not a bug.

## Fix
Treat `AuthError.notSignedIn` in the poll catch as the expected sign-out race: log it quietly (breadcrumb only) and return, instead of reporting it as a Sentry error. Scoped to the poll site only — `notSignedIn` may be meaningful elsewhere. Mirrors the recent CancellationError noise-control change.

## Verification
`xcrun swift build -c debug --package-path desktop/macos/Desktop` — builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

