### PR TITLE
fix(desktop): stop reporting benign sign-out race in TasksStore auto-refresh to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -267,6 +267,13 @@ class TasksStore: ObservableObject {
             if case APIError.unauthorized = error {
                 AuthBackoffTracker.shared.reportAuthFailure()
             }
+            // Benign sign-out race: the isSignedIn guard above passed, but the
+            // token was cleared by the time the request ran. Expected, not a bug
+            // — log quietly (breadcrumb only) instead of flooding Sentry.
+            if case AuthError.notSignedIn = error {
+                log("TasksStore: Auto-refresh skipped: signed out mid-cycle")
+                return
+            }
             // Silently ignore errors during auto-refresh
             logError("TasksStore: Auto-refresh failed", error: error)
         }
@@ -297,6 +304,11 @@ class TasksStore: ObservableObject {
                 let newHasMore = mergedTasks.count >= pageSize
                 if hasMoreCompletedTasks != newHasMore { hasMoreCompletedTasks = newHasMore }
             } catch {
+                // Benign sign-out race (see incomplete-tasks catch above).
+                if case AuthError.notSignedIn = error {
+                    log("TasksStore: Auto-refresh skipped: signed out mid-cycle")
+                    return
+                }
                 logError("TasksStore: Auto-refresh completed tasks failed", error: error)
             }
         }
@@ -328,6 +340,11 @@ class TasksStore: ObservableObject {
                 }
                 if hasMoreDeletedTasks != response.hasMore { hasMoreDeletedTasks = response.hasMore }
             } catch {
+                // Benign sign-out race (see incomplete-tasks catch above).
+                if case AuthError.notSignedIn = error {
+                    log("TasksStore: Auto-refresh skipped: signed out mid-cycle")
+                    return
+                }
                 logError("TasksStore: Auto-refresh deleted tasks failed", error: error)
             }
         }


### PR DESCRIPTION
## Problem
`TasksStore.autoRefresh()` guards on `AuthService.shared.isSignedIn`, but each `getActionItems` call awaits afterward. If the user signs out mid-cycle, the token is cleared and the request throws `AuthError.notSignedIn`. That bubbled to `logError` and flooded Sentry as "TasksStore: Auto-refresh failed: User is not signed in" — a benign race, not a bug.

- OMI-COMPUTER-6EN — `TasksStore: Auto-refresh failed: User is not signed in` (117 in 24h)
- OMI-COMPUTER-6EP — `TasksStore: Auto-refresh deleted tasks failed: User is not signed in` (115 in 24h)

## Fix
Mirror the already-merged `ChatProvider` poll fix (c34a35bf6): in the incomplete/completed/deleted auto-refresh catch blocks, treat `AuthError.notSignedIn` as the expected sign-out race and log it quietly (breadcrumb only) instead of as a Sentry error. No behavior change beyond log level.

## Verification
- `xcrun swift build -c debug --package-path desktop/macos/Desktop` → Build complete, no new warnings/errors.
- Pattern is textually identical to the shipped ChatProvider fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

