### PR TITLE
fix(desktop): stop reporting benign sign-out races to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -154,6 +154,11 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   // Swift structured-concurrency cancellation: thrown when a Task/operation is
   // cancelled (assistant stopped, frame superseded). Expected, not an app bug.
   if error is CancellationError { return true }
+  // Benign sign-out race: background loops (conversation/advice/goals refresh,
+  // upload retries) pass an isSignedIn guard, then the token is cleared mid-cycle
+  // and the awaited request throws AuthError.notSignedIn. Expected when the user
+  // signs out or runs signed-out — floods Sentry without indicating a bug.
+  if case AuthError.notSignedIn = error { return true }
   let nsError = error as NSError
   switch nsError.domain {
   case NSURLErrorDomain:


### PR DESCRIPTION
## Problem
Several desktop background loops (conversation/advice/goals refresh, transcription upload retries) check `AuthState.isSignedIn`, then `await` an API call. If the user signs out mid-cycle the token is cleared and the request throws `AuthError.notSignedIn`. `logError` forwarded these to Sentry, flooding it with non-actionable "User is not signed in" events:

- OMI-COMPUTER-CN — `AuthError: notSignedIn` (~11.4k events)
- OMI-COMPUTER-6EY — Failed to fetch conversations: User is not signed in
- OMI-COMPUTER-1HQ — Advice: Failed to sync from backend: User is not signed in
- OMI-COMPUTER-6DA — Task: Failed to refresh goals: User is not signed in
- OMI-COMPUTER-6BM — TranscriptionRetryService: Upload failed: User is not signed in

None indicate a bug — they're expected when the user signs out or runs signed-out.

## Fix
Treat `AuthError.notSignedIn` as a non-actionable transient in the central `isNonActionableTransient` noise filter in `Logger.swift`, alongside `CancellationError` and offline/timeout network codes. These are still written to the local log and added as a Sentry breadcrumb for context — they're just not captured as error events.

This generalizes the per-call-site chat-poll fix (c34a35bf6) to the source so every signed-out race is covered with one minimal change.

## Verification
`xcrun swift build -c debug --package-path Desktop` — builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

