### PR TITLE
fix(desktop): stop reporting transient AI-overload errors to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -154,6 +154,11 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   // Swift structured-concurrency cancellation: thrown when a Task/operation is
   // cancelled (assistant stopped, frame superseded). Expected, not an app bug.
   if error is CancellationError { return true }
+  // Benign sign-out race: background loops (conversation/advice/goals refresh,
+  // upload retries) pass an isSignedIn guard, then the token is cleared mid-cycle
+  // and the awaited request throws AuthError.notSignedIn. Expected when the user
+  // signs out or runs signed-out — floods Sentry without indicating a bug.
+  if case AuthError.notSignedIn = error { return true }
   let nsError = error as NSError
   switch nsError.domain {
   case NSURLErrorDomain:

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -159,6 +159,11 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   // and the awaited request throws AuthError.notSignedIn. Expected when the user
   // signs out or runs signed-out — floods Sentry without indicating a bug.
   if case AuthError.notSignedIn = error { return true }
+  // Transient AI backend-capacity errors (rate limit, quota, overload, 5xx) from
+  // the Gemini proxy, surfaced by the proactive assistants (task/memory/advice/
+  // insight extraction) after exhausting retries. Backend overload, not an app bug
+  // (OMI-COMPUTER-6JK/6JR/6JM/6NC). Real auth/config/parse errors stay captured.
+  if let geminiError = error as? GeminiClient.GeminiClientError, geminiError.isTransient { return true }
   let nsError = error as NSError
   switch nsError.domain {
   case NSURLErrorDomain:

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -203,6 +203,27 @@ actor GeminiClient {
       return nil
     }
 
+    /// True for transient backend-capacity failures (rate limit, quota, overload,
+    /// 5xx, network blips) — retryable and not an app bug. Drives both retry
+    /// decisions and Sentry noise suppression (these flood without being actionable).
+    var isTransient: Bool {
+      switch self {
+      case .apiError(let message):
+        let lower = message.lowercased()
+        return lower.contains("service unavailable")
+          || lower.contains("overloaded")
+          || lower.contains("resource exhausted")
+          || lower.contains("high demand")
+          || lower.contains("503")
+          || lower.contains("429")
+          || lower.contains("internal error")
+      case .networkError:
+        return true
+      case .invalidResponse, .missingAPIKey:
+        return false
+      }
+    }
+
     var errorDescription: String? {
       switch self {
       case .missingAPIKey:
@@ -313,21 +334,7 @@ actor GeminiClient {
   /// Check if an error is transient and worth retrying
   private func isTransientError(_ error: Error) -> Bool {
     if let geminiError = error as? GeminiClientError {
-      switch geminiError {
-      case .apiError(let message):
-        let lower = message.lowercased()
-        return lower.contains("service unavailable")
-          || lower.contains("overloaded")
-          || lower.contains("resource exhausted")
-          || lower.contains("high demand")
-          || lower.contains("503")
-          || lower.contains("429")
-          || lower.contains("internal error")
-      case .networkError:
-        return true
-      case .invalidResponse, .missingAPIKey:
-        return false
-      }
+      return geminiError.isTransient
     }
     // URLSession network errors are transient
     return (error as NSError).domain == NSURLErrorDomain


### PR DESCRIPTION
## Problem

The proactive assistants (task / memory / advice / insight extraction) call `GeminiClient`, which already retries transient failures up to 3×. When the backend stays overloaded or rate-limited, the surviving `GeminiClientError` bubbles up to `logError(...)` and floods Sentry with non-actionable events:

- **OMI-COMPUTER-6JK** — Advice extraction error: AI service is busy (~1.8k/24h)
- **OMI-COMPUTER-6JM** — Memory analysis error: AI service is busy (~1.8k/24h)
- **OMI-COMPUTER-6JR** — Task extraction error: AI service is busy (~0.6k/24h)
- **OMI-COMPUTER-6NC** — Frame error / backoff: AI service is busy

These indicate backend capacity, not an app bug — together ~4.4k events/24h of pure noise.

## Fix

- Expose the existing retry classifier as `GeminiClientError.isTransient` (rate limit, quota, overload, 5xx, network) and refactor the private `isTransientError` to reuse it (DRY).
- Have the central `Logger.isNonActionableTransient` treat those as non-actionable transients — still logged locally and as a Sentry breadcrumb for context, just not captured as an error event.
- Real auth / config / parse errors stay captured.

Mirrors the sign-out-race and network-transient handling already in `isNonActionableTransient` (e7d56143e, c34a35bf6).

## Testing

`xcrun swift build -c debug --package-path Desktop` — builds clean (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

