### PR TITLE
fix(desktop): surface server errors from EmbeddingService.embedBatch

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -119,7 +119,14 @@ actor EmbeddingService {
     request.timeoutInterval = 60
     request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-    let (data, _) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await URLSession.shared.data(for: request)
+
+    // Check HTTP status before parsing — non-JSON error bodies (HTML 401/500)
+    // cause "data couldn't be read" errors that mask the real problem.
+    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+      let body = String(data: data.prefix(200), encoding: .utf8) ?? "<non-utf8>"
+      throw EmbeddingError.serverError(statusCode: httpResponse.statusCode, body: body)
+    }
 
     guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
       let embeddings = json["embeddings"] as? [[String: Any]]


### PR DESCRIPTION
## Problem
`EmbeddingService.embed()` checks the HTTP status before parsing and throws a descriptive `serverError(statusCode:body:)` so non-JSON error bodies (HTML 401/500) don't get masked. Its batch sibling `embedBatch()` was **missing that guard** — it discarded the `URLResponse` (`let (data, _) =`) and parsed the body directly, so any non-200 response surfaced as the opaque `EmbeddingError.invalidResponse`.

This floods Sentry with non-actionable events that hide the real HTTP status:
- **OMI-COMPUTER-14H** — `EmbeddingError: invalidResponse` (~3.1k events)
- **OMI-COMPUTER-66F** — `EmbeddingService: Backfill failed after 100 items: AI service returned an unexpected response` (backfill uses `embedBatch`)

## Fix
Mirror the existing, already-reviewed HTTP-status guard from `embed()` so batch server errors carry the status code and body. Minimal, low-risk — identical to the sibling code path.

## Verification
`xcrun swift build -c debug --package-path Desktop` → Build complete (only pre-existing unrelated warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

