### PR TITLE
fix(desktop): align sidebar toggle switches to right edge

### DIFF
--- a/desktop/windows/src/renderer/src/components/layout/Sidebar.tsx
+++ b/desktop/windows/src/renderer/src/components/layout/Sidebar.tsx
@@ -126,7 +126,7 @@ export function Sidebar(): React.JSX.Element {
       {!collapsed && (
         <span
           className={cn(
-            'relative h-4 w-7 shrink-0 rounded-full transition-colors duration-200',
+            'relative ml-auto h-4 w-7 shrink-0 rounded-full transition-colors duration-200',
             on ? 'bg-[color:var(--accent)]' : 'bg-white/15'
           )}
         >


### PR DESCRIPTION
## Problem

In the desktop app sidebar, the quick-capture toggle switches (Screen recording and Microphone) were not reliably flush-right aligned within their rows. The toggle switch container relied solely on the sibling `<span>` having `flex-1` to absorb remaining space, which left the right-edge position implicit and fragile.

## Fix

Added `ml-auto` to the toggle switch `<span>` inside `toggleRow()` in `Sidebar.tsx`.

```diff
-            'relative h-4 w-7 shrink-0 rounded-full transition-colors duration-200',
+            'relative ml-auto h-4 w-7 shrink-0 rounded-full transition-colors duration-200',
```

`ml-auto` (Tailwind for `margin-left: auto`) explicitly pushes the toggle switch to the far right of the flex row, independent of label text length. Since both toggle rows use the same `toggleRow()` function, they now share the same right-edge position.

## Before / After (layout diagram)

```
Before                              After
┌──────────────────────────┐       ┌──────────────────────────┐
│ 🖥  Screen recording  ○  │       │ 🖥  Screen recording   ○  │
│ 🎤  Microphone       ○   │       │ 🎤  Microphone          ○  │
└──────────────────────────┘       └──────────────────────────┘
         ↑ toggles not at           ↑ toggles flush-right,
           same right edge           visually aligned
```

## File changed

- `desktop/windows/src/renderer/src/components/layout/Sidebar.tsx` — added `ml-auto` to toggle switch className in `toggleRow()` (line 129)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

