### PR TITLE
fix(desktop): stop reporting backend Gemini auth-failure floods to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -365,6 +365,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
           let lower = message.lowercased()
           if lower.contains("api key expired") || lower.contains("renew the api key")
             || lower.contains("api_key_invalid")
+            // GeminiClient maps raw backend auth failures (unauthorized / permission denied /
+            // api key / forbidden) to this user-facing string before it reaches Sentry, so the
+            // raw-message checks above miss it. Same root cause (server-side key needs rotation),
+            // same flood (one bad key emits one event per task-extraction frame for every user).
+            || lower.contains("ai service authentication error")
           {
             return nil
           }


### PR DESCRIPTION
## Problem
`GeminiClient` maps raw backend auth failures (`unauthorized` / `permission denied` / `api key` / `forbidden`) to the user-facing string **"AI service authentication error. Please update the app to the latest version."** before the error is logged. The task-extraction loop forwards it via `logError`, so one bad/rotated server-side Gemini key emits **one Sentry event per analyzed frame** for the affected user — **3665 events from a single user in 24h** (`OMI-COMPUTER-66X`), with zero actionable signal.

## Fix
This is the same non-actionable backend-key class the `beforeSend` filter already drops for the raw `"api key expired"` / `"api_key_invalid"` messages; it only escapes because `GeminiClient` rewrites the message before it reaches Sentry. Extend the existing backend-auth filter in `beforeSend` to also match the mapped user-facing string. Still logged locally and as a Sentry breadcrumb — just not captured as an error event.

## Risk
Low. Sentry-reporting only; no behavior change. Mirrors the existing adjacent filter's rationale and tradeoff.

## Test
`xcrun swift build -c debug --package-path Desktop` — build complete, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

