### PR TITLE
fix(desktop): unify agent tools and floating pills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Rules:
 Agents can and should self-test the running app — don't stop at a successful compile. The fast path skips the slow parts (web login, sidebar click-through):
 
 1. **Build + launch a named bundle:** `cd desktop/macos && OMI_APP_NAME="omi-<feature>" ./run.sh` (add `OMI_SKIP_TUNNEL=1` for a local backend without a tunnel; `OMI_SKIP_BACKEND=1 OMI_DESKTOP_API_URL=…` to point at a remote backend).
-2. **Boot signed-in (no browser):** sign into "Omi Dev" once, then clone the session into the named bundle **before launch** (UserDefaults is read at startup):
+2. **Boot signed-in (no browser):** sign into "Omi Dev" once; `./run.sh` auto-clones auth/onboarding into named bundles **before launch** (UserDefaults is read at startup). To do it manually:
    ```bash
    cd desktop/macos && ./scripts/omi-auth-dump.sh                  # capture the Omi Dev session
    ./scripts/omi-auth-seed.sh com.omi.omi-<feature>          # replay into the test bundle

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -127,9 +127,9 @@ This creates `/Applications/omi-fix-rewind.app` with bundle ID `com.omi.omi-fix-
 - NEVER use the default `./run.sh` (which overwrites "Omi Dev") when testing a specific feature — always set `OMI_APP_NAME`
 - **ALWAYS prefix the name with `omi-`** (e.g., `omi-fix-rewind`, `omi-6512-polling`, `omi-vision-test`) so named bundles are visually grouped in `/Applications/` alongside "Omi Dev" and "Omi Beta"
 - Keep the name short and descriptive (it becomes both the app name and bundle ID suffix)
-- The named bundle gets its own permissions, database, and auth state — the user may need to re-grant permissions and sign in
+- The named bundle gets its own permissions and database. `./run.sh` auto-seeds auth/onboarding from "Omi Dev" unless `OMI_SKIP_AUTH_SEED=1` is set.
 - To connect agent-swift: `agent-swift connect --bundle-id com.omi.omi-fix-rewind`
-- **Skip the web login:** sign into "Omi Dev" once, then `./scripts/omi-auth-dump.sh && ./scripts/omi-auth-seed.sh com.omi.omi-fix-rewind` clones the session so the named bundle boots signed-in
+- **Skip the web login:** sign into "Omi Dev" once; named bundles launched by `./run.sh` clone that session before launch.
 - **Jump to a screen without clicking:** the automation bridge auto-enables on non-prod bundles — `./scripts/omi-ctl navigate <screen>` (e.g. `rewind`, `memories`, `settings rewind`). See "Fast-Path for Local Iteration" in `e2e/SKILL.md`.
 
 ### After Implementing Changes

--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -474,65 +474,7 @@ struct ChatPrompts {
     </critical_accuracy_rules>
 
     <tools>
-    You have 7 tools. ALWAYS use them before answering — don't guess when you can look it up.
-
-    **execute_sql**: Run SQL on the local omi.db database.
-    - Supports: SELECT, INSERT, UPDATE, DELETE
-    - SELECT auto-limits to 200 rows. UPDATE/DELETE require WHERE. DROP/ALTER/CREATE blocked.
-    - Use for: personal facts, app usage stats, time queries, task management, aggregations, anything structured.
-    - Supports FTS5 MATCH queries for keyword search (see schema for FTS tables and patterns).
-
-    **semantic_search**: Vector similarity search on screen history.
-    - Use for: fuzzy conceptual queries where exact SQL keywords won't work.
-    - e.g. "reading about machine learning", "working on design mockups"
-    - Parameters: query (required), days (default 7), app_filter (optional)
-
-    **search_tasks**: Vector similarity search on tasks (action_items + staged_tasks).
-    - Use for: finding tasks by meaning, not just keywords.
-    - e.g. "tasks about shopping", "anything related to the presentation"
-    - Parameters: query (required), include_completed (default false)
-    - More reliable than hand-writing MATCH queries for task search.
-
-    **get_daily_recap**: Pre-formatted activity recap (apps, conversations, tasks, focus, memories, observations).
-    - Use for: "what did I do today/yesterday/this week" — single tool call, much faster than multiple SQL queries.
-    - Parameters: days_ago (0=today, 1=yesterday, 7=past week, default: 1)
-
-    **complete_task**: Toggle a task's completion status.
-    - Takes: task_id (the backendId from action_items table)
-    - Use for: marking tasks done or uncompleting them
-    - First use execute_sql to find the task, then use this tool with its backendId
-
-    **delete_task**: Delete a task permanently.
-    - Takes: task_id (the backendId from action_items table)
-    - Use for: removing tasks the user no longer needs
-    - First use execute_sql to find the task, then use this tool with its backendId
-
-    **save_knowledge_graph**: Save a knowledge graph of entities and relationships extracted from the user's data.
-    - Parameters: nodes (array of {id, label, node_type, aliases}), edges (array of {source_id, target_id, label})
-    - node_type must be one of: person, organization, place, thing, concept
-    - Use when: exploring the user's files during onboarding to build their knowledge graph
-    - Deduplication is handled automatically — just provide all entities you find
-
-    **CRITICAL — When to use tools proactively:**
-    The <user_facts> section above only contains a SAMPLE of {user_name}'s memories. The full set is in the database.
-    For ANY personal question (age, preferences, relationships, habits, past events, "what do you know about me", etc.):
-    1. FIRST check <user_facts> — if the answer is there, use it directly.
-    2. If NOT in <user_facts>, ALWAYS query the memories table before saying you don't know.
-    3. For questions about past events or conversations, query transcription_sessions/transcription_segments.
-    NEVER say "I don't know" or "I don't have that info" without checking the database first.
-
-    **When to use which tool:**
-    - "how old am I?" / "what's my name?" / personal facts → execute_sql (query memories table)
-    - "what did I do yesterday?" → get_daily_recap (single tool call, returns formatted summary)
-    - "what apps did I use most?" → execute_sql (GROUP BY appName, COUNT)
-    - "find where I was reading about AI" → semantic_search (conceptual)
-    - "find tasks about shopping" → search_tasks (semantic task search)
-    - "create a task to buy milk" → execute_sql (INSERT INTO action_items)
-    - "what are my tasks?" → execute_sql (SELECT FROM action_items)
-    - "complete the first task" → execute_sql to find backendId, then complete_task
-    - "delete that task" → execute_sql to find backendId, then delete_task
-    - "show my conversations" → execute_sql (SELECT FROM transcription_sessions)
-    - "what did I talk about with John?" → execute_sql (search transcription_segments)
+    \(DesktopCapabilityRegistry.desktopToolPrompt)
 
     {database_schema}
 

--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -273,6 +273,11 @@ struct ChatPrompts {
       * "Do I like dogs?" → get_memories_tool (FACT/preference)
       * "When did a dog bite me?" → search_conversations_tool (EVENT)
 
+    **Task-Agent Awareness:**
+    - Omi can run local task-chat agents/subagents in the desktop task panel. If the user says "your subagents", "task agents", "running agents", or mentions task-agent errors/timeouts, do NOT deny that you have subagents.
+    - Call get_task_agent_status to inspect the current Omi task-agent registry before answering.
+    - If a task agent timed out or failed, summarize the affected task and error, then suggest a concrete retry/recovery step.
+
     **Limit and Transcript Guidance:**
     - **Summarization queries** ("summarize my week", "recap my month"): set limit=5000, include_transcript=false to get all conversations without flooding context.
     - **Normal queries**: limit=20 (default) is fine for most questions.

--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -38,7 +38,9 @@ enum DesktopCapabilityRegistry {
       surfaces: [.desktopChat],
       summary: "Run SQL on the local omi.db database for structured local data.",
       bullets: [
-        "Use for local app usage stats, exact counts, task lookups, conversations, memories, and aggregations.",
+        "Supports SELECT, INSERT, UPDATE, DELETE.",
+        "Use for personal facts, app usage stats, time queries, task lookups, conversations, memories, aggregations, and anything structured.",
+        "Supports FTS5 MATCH queries for keyword search; see the schema footer for FTS tables and patterns.",
         "SELECT queries auto-limit to 200 rows. UPDATE/DELETE require WHERE. DROP/ALTER/CREATE are blocked.",
         "Prefer semantic_search for fuzzy screen-history questions and backend task tools for creating/updating tasks."
       ]),
@@ -49,7 +51,8 @@ enum DesktopCapabilityRegistry {
       surfaces: [.desktopChat],
       summary: "Vector similarity search on the user's screen history.",
       bullets: [
-        "Use for fuzzy/conceptual questions about what the user saw, read, or worked on.",
+        "Use for fuzzy/conceptual questions about what the user saw, read, or worked on where exact SQL keywords will not work.",
+        "Examples: \"reading about machine learning\", \"working on design mockups\".",
         "Parameters: query (required), days (default 7), app_filter (optional)."
       ]),
     Capability(
@@ -79,7 +82,9 @@ enum DesktopCapabilityRegistry {
       summary: "Vector similarity search on tasks (action_items + staged_tasks).",
       bullets: [
         "Use for finding tasks by meaning, not exact keywords, e.g. \"find tasks about shopping\".",
-        "Parameters: query (required), include_completed (default false)."
+        "Examples: \"tasks about shopping\", \"anything related to the presentation\".",
+        "Parameters: query (required), include_completed (default false).",
+        "More reliable than hand-writing MATCH queries for task search."
       ]),
     Capability(
       toolName: "get_tasks",
@@ -137,6 +142,18 @@ enum DesktopCapabilityRegistry {
       summary: "Delete a task permanently by backendId.",
       bullets: [
         "Use after finding the task with execute_sql or search_tasks."
+      ]),
+    Capability(
+      toolName: "save_knowledge_graph",
+      title: "Save Knowledge Graph",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Save a knowledge graph of entities and relationships extracted from the user's data.",
+      bullets: [
+        "Parameters: nodes (array of {id, label, node_type, aliases}), edges (array of {source_id, target_id, label}).",
+        "node_type must be one of: person, organization, place, thing, concept.",
+        "Use when exploring the user's files during onboarding to build their knowledge graph.",
+        "Deduplication is handled automatically; provide all entities you find."
       ]),
     Capability(
       toolName: "get_conversations",
@@ -232,7 +249,7 @@ enum DesktopCapabilityRegistry {
       .map(toolDoc)
       .joined(separator: "\n\n")
     return """
-    These Omi data/status tools are documented for desktop chat. Use them before answering when the question depends on the user's personal data, tasks, conversations, memories, app/screen activity, or task-agent state. Do not call tools for simple chit-chat or general knowledge that does not depend on the user's data.
+    These Omi data/status tools are documented for desktop chat. Use them before answering when the question depends on the user's personal data, tasks, conversations, memories, app/screen activity, or task-agent state. Do not guess when you can look it up. Do not call tools for simple chit-chat or general knowledge that does not depend on the user's data.
 
     \(docs)
 
@@ -242,8 +259,12 @@ enum DesktopCapabilityRegistry {
     - Call get_task_agent_status before answering those questions.
 
     **CRITICAL -- When to use tools proactively:**
-    The <user_facts> section above only contains a SAMPLE of the user's memories. The full set is available through the memory tools and local database.
-    For personal questions, first check <user_facts>; if the answer is not there, use get_memories/search_memories or execute_sql before saying you do not know.
+    The <user_facts> section above only contains a SAMPLE of {user_name}'s memories. The full set is available through the memory tools and local database.
+    For ANY personal question (age, preferences, relationships, habits, past events, "what do you know about me", etc.):
+    1. FIRST check <user_facts> — if the answer is there, use it directly.
+    2. If NOT in <user_facts>, use get_memories/search_memories or execute_sql over memories before saying you don't know.
+    3. For questions about past events or conversations, query search_conversations/get_conversations or transcription_sessions/transcription_segments.
+    NEVER say "I don't know" or "I don't have that info" without checking first.
 
     **When to use which tool:**
     - Personal facts/preferences -> get_memories, search_memories, or execute_sql over memories.
@@ -252,9 +273,10 @@ enum DesktopCapabilityRegistry {
     - App usage counts or exact local stats -> execute_sql.
     - Fuzzy screen-history questions -> semantic_search.
     - Find tasks by meaning -> search_tasks.
-    - Create/update tasks -> create_action_item/update_action_item when available; use execute_sql only for exact local inspection.
+    - Create/update tasks -> create_action_item/update_action_item when available; use execute_sql only for exact local inspection or legacy local writes.
     - Complete/delete local tasks -> find the backendId, then complete_task/delete_task.
     - Subagents/task-agent status -> get_task_agent_status.
+    - Onboarding knowledge graph -> save_knowledge_graph.
     """
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -197,19 +197,31 @@ enum DesktopCapabilityRegistry {
       title: "Task Agent Status",
       latency: .fastLocal,
       surfaces: [.desktopChat, .realtimeHub],
-      summary: "Inspect Omi's local task-chat agents/subagents.",
+      summary: "Inspect Omi's local task-chat agents/subagents and floating agent pills.",
       bullets: [
-        "Use when the user asks about your subagents, task agents, background agents, running agents, errors, or timeouts.",
-        "Call this before claiming there are no subagents or before diagnosing a task-agent timeout."
+        "Use when the user asks about your subagents, task agents, background agents, running agents, finished agents, errors, or timeouts.",
+        "Call this before claiming there are no subagents or before diagnosing a task-agent timeout.",
+        "Returns both task_agents and floating_agent_pills; floating_agent_pills are the circular agent pills below the floating bar."
       ]),
     Capability(
       toolName: "spawn_agent",
       title: "Spawn Agent",
       latency: .asyncBackground,
-      surfaces: [.realtimeHub],
-      summary: "Hand multi-step work to a background agent and return immediately.",
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Hand multi-step work to a floating background agent pill and return immediately.",
       bullets: [
-        "Use for acting in other apps or multi-step work. This is the only realtime tool that starts a background agent."
+        "Use when the user explicitly asks you to run, start, spawn, or launch a subagent/background agent, or for acting in other apps or multi-step work.",
+        "The only way to start a floating-bar subagent is to call spawn_agent; saying you will start one does not start it."
+      ]),
+    Capability(
+      toolName: "manage_agent_pills",
+      title: "Manage Agent Pills",
+      latency: .fastLocal,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "List, dismiss, or clear completed floating agent pills.",
+      bullets: [
+        "Use after get_task_agent_status when the user asks to manage the circular floating agent pills.",
+        "Actions: list, dismiss with agent_id, or clear_completed."
       ]),
     Capability(
       toolName: "ask_higher_model",
@@ -276,6 +288,8 @@ enum DesktopCapabilityRegistry {
     - Create/update tasks -> create_action_item/update_action_item when available; use execute_sql only for exact local inspection or legacy local writes.
     - Complete/delete local tasks -> find the backendId, then complete_task/delete_task.
     - Subagents/task-agent status -> get_task_agent_status.
+    - Start a floating-bar subagent/background agent -> spawn_agent.
+    - Dismiss/list/clear circular floating agent pills -> manage_agent_pills.
     - Onboarding knowledge graph -> save_knowledge_graph.
     """
   }
@@ -284,7 +298,8 @@ enum DesktopCapabilityRegistry {
     """
     Omi capability model:
     - You can read Omi data quickly with fast tools: tasks, memories, conversations, daily recaps, and screen history.
-    - You can inspect your local task-chat agents/subagents with get_task_agent_status. If the user asks about your subagents, background agents, running agents, or task-agent errors/timeouts, call it before answering.
+    - You can inspect your local task-chat agents/subagents and floating agent pills with get_task_agent_status. If the user asks about your subagents, background agents, running agents, finished agents, or task-agent errors/timeouts, call it before answering.
+    - You can manage circular floating agent pills with manage_agent_pills after checking status.
     - You can start a background agent with spawn_agent for multi-step work or acting in the user's other apps. Merely saying you will start an agent does not start one; emitting spawn_agent does.
     """
   }

--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -1,0 +1,285 @@
+import Foundation
+
+/// Model-visible capability docs for Omi desktop surfaces.
+///
+/// This intentionally does not own provider-specific tool schemas yet: pi-mono,
+/// ACP MCP, and realtime use different schema shapes. Keep capability semantics
+/// here, then project them into each surface prompt so tool docs do not drift.
+enum DesktopCapabilityRegistry {
+  enum Surface {
+    case desktopChat
+    case realtimeHub
+  }
+
+  enum LatencyClass: String {
+    case fastLocal = "fast local"
+    case fastNetwork = "fast network"
+    case asyncBackground = "async background"
+  }
+
+  struct Capability {
+    let toolName: String
+    let title: String
+    let latency: LatencyClass
+    let surfaces: Set<Surface>
+    let summary: String
+    let bullets: [String]
+
+    func supports(_ surface: Surface) -> Bool {
+      surfaces.contains(surface)
+    }
+  }
+
+  static let capabilities: [Capability] = [
+    Capability(
+      toolName: "execute_sql",
+      title: "Execute SQL",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Run SQL on the local omi.db database for structured local data.",
+      bullets: [
+        "Use for local app usage stats, exact counts, task lookups, conversations, memories, and aggregations.",
+        "SELECT queries auto-limit to 200 rows. UPDATE/DELETE require WHERE. DROP/ALTER/CREATE are blocked.",
+        "Prefer semantic_search for fuzzy screen-history questions and backend task tools for creating/updating tasks."
+      ]),
+    Capability(
+      toolName: "semantic_search",
+      title: "Semantic Search",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Vector similarity search on the user's screen history.",
+      bullets: [
+        "Use for fuzzy/conceptual questions about what the user saw, read, or worked on.",
+        "Parameters: query (required), days (default 7), app_filter (optional)."
+      ]),
+    Capability(
+      toolName: "search_screen_history",
+      title: "Search Screen History",
+      latency: .fastLocal,
+      surfaces: [.realtimeHub],
+      summary: "Search the user's on-screen history by meaning.",
+      bullets: [
+        "Use for what the user saw, read, or worked on. Speak a short summary of the result."
+      ]),
+    Capability(
+      toolName: "get_daily_recap",
+      title: "Daily Recap",
+      latency: .fastLocal,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Pre-formatted activity recap: apps, conversations, tasks, focus, memories, and observations.",
+      bullets: [
+        "Use for what the user did today/yesterday/this week; it is faster than composing many SQL queries.",
+        "Parameters: days_ago (0=today, 1=yesterday, 7=past week; default 1)."
+      ]),
+    Capability(
+      toolName: "search_tasks",
+      title: "Search Tasks",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Vector similarity search on tasks (action_items + staged_tasks).",
+      bullets: [
+        "Use for finding tasks by meaning, not exact keywords, e.g. \"find tasks about shopping\".",
+        "Parameters: query (required), include_completed (default false)."
+      ]),
+    Capability(
+      toolName: "get_tasks",
+      title: "Get Tasks",
+      latency: .fastLocal,
+      surfaces: [.realtimeHub],
+      summary: "Read the user's overdue and due-today tasks locally.",
+      bullets: [
+        "Use for plain voice questions like what are my tasks, what's due today, or what's on my list.",
+        "Prefer get_action_items for completed tasks, date ranges, or the full list."
+      ]),
+    Capability(
+      toolName: "get_action_items",
+      title: "Get Action Items",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Retrieve the user's tasks with optional completion and due-date filters.",
+      bullets: [
+        "Use for completed tasks, date ranges, or the full task list.",
+        "For voice, prefer get_tasks for plain overdue/due-today questions."
+      ]),
+    Capability(
+      toolName: "create_action_item",
+      title: "Create Action Item",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Create a new task, to-do, or reminder.",
+      bullets: [
+        "Use when the user explicitly asks to add something to their list.",
+        "Pass a concise description and due_at only when the user gave a time."
+      ]),
+    Capability(
+      toolName: "update_action_item",
+      title: "Update Action Item",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Update an existing task's status, description, or due date.",
+      bullets: [
+        "Find the task first, then update the matching id. Do not guess task ids."
+      ]),
+    Capability(
+      toolName: "complete_task",
+      title: "Complete Task",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Toggle a task's completion status by backendId.",
+      bullets: [
+        "Use after finding the task with execute_sql or search_tasks."
+      ]),
+    Capability(
+      toolName: "delete_task",
+      title: "Delete Task",
+      latency: .fastLocal,
+      surfaces: [.desktopChat],
+      summary: "Delete a task permanently by backendId.",
+      bullets: [
+        "Use after finding the task with execute_sql or search_tasks."
+      ]),
+    Capability(
+      toolName: "get_conversations",
+      title: "Get Conversations",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Retrieve conversations by recency or date range.",
+      bullets: [
+        "Use for latest/recent conversations and time-based conversation retrieval.",
+        "For voice, this returns summaries only and should be spoken briefly."
+      ]),
+    Capability(
+      toolName: "search_conversations",
+      title: "Search Conversations",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Semantic search across the user's past conversations.",
+      bullets: [
+        "Use for specific topics, decisions, or events discussed in conversations."
+      ]),
+    Capability(
+      toolName: "get_memories",
+      title: "Get Memories",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Retrieve stored facts, preferences, habits, people, and background about the user.",
+      bullets: [
+        "Use for broad 'what do you know about me' questions or personal facts."
+      ]),
+    Capability(
+      toolName: "search_memories",
+      title: "Search Memories",
+      latency: .fastNetwork,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Semantic search across user memories.",
+      bullets: [
+        "Use for a specific personal fact that is not already in the visible user context."
+      ]),
+    Capability(
+      toolName: "get_task_agent_status",
+      title: "Task Agent Status",
+      latency: .fastLocal,
+      surfaces: [.desktopChat, .realtimeHub],
+      summary: "Inspect Omi's local task-chat agents/subagents.",
+      bullets: [
+        "Use when the user asks about your subagents, task agents, background agents, running agents, errors, or timeouts.",
+        "Call this before claiming there are no subagents or before diagnosing a task-agent timeout."
+      ]),
+    Capability(
+      toolName: "spawn_agent",
+      title: "Spawn Agent",
+      latency: .asyncBackground,
+      surfaces: [.realtimeHub],
+      summary: "Hand multi-step work to a background agent and return immediately.",
+      bullets: [
+        "Use for acting in other apps or multi-step work. This is the only realtime tool that starts a background agent."
+      ]),
+    Capability(
+      toolName: "ask_higher_model",
+      title: "Ask Higher Model",
+      latency: .fastNetwork,
+      surfaces: [.realtimeHub],
+      summary: "Get a second opinion from the larger model when the user pushes back or current facts are needed.",
+      bullets: [
+        "Use sparingly; answer simple or creative requests yourself."
+      ]),
+    Capability(
+      toolName: "screenshot",
+      title: "Screenshot",
+      latency: .fastLocal,
+      surfaces: [.realtimeHub],
+      summary: "Capture the user's current screen.",
+      bullets: [
+        "Use when the user asks about what is on screen."
+      ]),
+    Capability(
+      toolName: "point_click",
+      title: "Point Click",
+      latency: .fastLocal,
+      surfaces: [.realtimeHub],
+      summary: "Click at on-screen pixel coordinates.",
+      bullets: [
+        "Use only when the user clearly asks you to click something."
+      ])
+  ]
+
+  static func capabilities(for surface: Surface) -> [Capability] {
+    capabilities.filter { $0.supports(surface) }
+  }
+
+  static var desktopToolPrompt: String {
+    let docs = capabilities(for: .desktopChat)
+      .map(toolDoc)
+      .joined(separator: "\n\n")
+    return """
+    These Omi data/status tools are documented for desktop chat. Use them before answering when the question depends on the user's personal data, tasks, conversations, memories, app/screen activity, or task-agent state. Do not call tools for simple chit-chat or general knowledge that does not depend on the user's data.
+
+    \(docs)
+
+    **Task-Agent Awareness:**
+    - Omi can run local task-chat agents/subagents in the desktop task panel.
+    - If the user says "your subagents", "task agents", "running agents", "background agents", or mentions task-agent errors/timeouts, do NOT deny that you have subagents.
+    - Call get_task_agent_status before answering those questions.
+
+    **CRITICAL -- When to use tools proactively:**
+    The <user_facts> section above only contains a SAMPLE of the user's memories. The full set is available through the memory tools and local database.
+    For personal questions, first check <user_facts>; if the answer is not there, use get_memories/search_memories or execute_sql before saying you do not know.
+
+    **When to use which tool:**
+    - Personal facts/preferences -> get_memories, search_memories, or execute_sql over memories.
+    - Specific past conversations/events -> search_conversations or get_conversations.
+    - What the user did today/yesterday/this week -> get_daily_recap.
+    - App usage counts or exact local stats -> execute_sql.
+    - Fuzzy screen-history questions -> semantic_search.
+    - Find tasks by meaning -> search_tasks.
+    - Create/update tasks -> create_action_item/update_action_item when available; use execute_sql only for exact local inspection.
+    - Complete/delete local tasks -> find the backendId, then complete_task/delete_task.
+    - Subagents/task-agent status -> get_task_agent_status.
+    """
+  }
+
+  static var realtimeSelfModelPrompt: String {
+    """
+    Omi capability model:
+    - You can read Omi data quickly with fast tools: tasks, memories, conversations, daily recaps, and screen history.
+    - You can inspect your local task-chat agents/subagents with get_task_agent_status. If the user asks about your subagents, background agents, running agents, or task-agent errors/timeouts, call it before answering.
+    - You can start a background agent with spawn_agent for multi-step work or acting in the user's other apps. Merely saying you will start an agent does not start one; emitting spawn_agent does.
+    """
+  }
+
+  static var desktopToolNames: [String] {
+    capabilities(for: .desktopChat).map(\.toolName)
+  }
+
+  static var realtimeToolNames: [String] {
+    capabilities(for: .realtimeHub).map(\.toolName)
+  }
+
+  private static func toolDoc(_ capability: Capability) -> String {
+    let bullets = capability.bullets.map { "- \($0)" }.joined(separator: "\n")
+    return """
+    **\(capability.toolName)** (\(capability.latency.rawValue)): \(capability.summary)
+    \(bullets)
+    """
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -104,6 +104,7 @@ final class AgentPillsManager: ObservableObject {
     private var providersByPill: [UUID: ChatProvider] = [:]
     private var streamsByPill: [UUID: AnyCancellable] = [:]
     private var messageCountByPill: [UUID: Int] = [:]
+    private var runTasksByPill: [UUID: Task<Void, Never>] = [:]
     private var bootChain: Task<Void, Never> = Task {}
 
     /// Which pill (if any) is currently capturing a voice follow-up — drives the
@@ -404,12 +405,15 @@ final class AgentPillsManager: ObservableObject {
             }
         }
 
-        Task { [weak self, weak pill, weak provider] in
+        let runTask = Task { [weak self, weak pill, weak provider] in
             await myBoot.value
+            guard !Task.isCancelled else { return }
             guard let self, let pill, let provider else { return }
             // Bridge is up; flip to running and fire the prompt. Concurrent
             // with any other pill that's already past this point.
             pill.status = .running
+            pill.completedAt = nil
+            pill.suggestedFollowUps = []
             await provider.sendMessage(
                 pill.query,
                 model: pill.model,
@@ -417,8 +421,10 @@ final class AgentPillsManager: ObservableObject {
                 systemPromptStyle: .floating,
                 sessionKey: "agent-\(pill.id.uuidString)"
             )
+            guard !Task.isCancelled else { return }
             self.complete(pill: pill, provider: provider)
         }
+        runTasksByPill[pill.id] = runTask
 
         return pill
     }
@@ -450,14 +456,19 @@ final class AgentPillsManager: ObservableObject {
             return
         }
         pill.status = .running
+        pill.completedAt = nil
+        pill.suggestedFollowUps = []
         pill.latestActivity = "Working on your follow-up…"
-        Task { @MainActor [weak self, weak pill, weak provider] in
+        runTasksByPill[pill.id]?.cancel()
+        let runTask = Task { @MainActor [weak self, weak pill, weak provider] in
             guard let self, let pill, let provider else { return }
             await provider.sendMessage(
                 text, model: pill.model, systemPromptStyle: .floating,
                 sessionKey: "agent-\(pill.id.uuidString)")
+            guard !Task.isCancelled else { return }
             self.complete(pill: pill, provider: provider)
         }
+        runTasksByPill[pill.id] = runTask
     }
 
     /// Force-dismiss a pill.
@@ -474,6 +485,13 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private func cleanup(pillID: UUID) {
+        if recordingPillID == pillID {
+            recordingPillID = nil
+            PushToTalkManager.shared.cancelPillFollowUp(for: pillID)
+        }
+        runTasksByPill[pillID]?.cancel()
+        runTasksByPill[pillID] = nil
+        providersByPill[pillID]?.stopAgent()
         streamsByPill[pillID]?.cancel()
         streamsByPill[pillID] = nil
         providersByPill[pillID] = nil

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -22,6 +22,23 @@ final class AgentPill: ObservableObject, Identifiable {
             case .failed: return "Failed"
             }
         }
+
+        var machineLabel: String {
+            switch self {
+            case .queued: return "queued"
+            case .starting: return "starting"
+            case .running: return "running"
+            case .done: return "done"
+            case .failed: return "failed"
+            }
+        }
+
+        var isFinished: Bool {
+            switch self {
+            case .done, .failed: return true
+            default: return false
+            }
+        }
     }
 
     let id = UUID()
@@ -105,6 +122,16 @@ final class AgentPillsManager: ObservableObject {
         let route: Route
         let title: String?
         let ack: String?
+    }
+
+    struct Snapshot: Encodable {
+        let id: String
+        let title: String
+        let status: String
+        let latestActivity: String
+        let query: String
+        let createdAt: String
+        let completedAt: String?
     }
 
     /// Ask Claude Haiku whether the message is a quick info question (→ chat)
@@ -440,6 +467,12 @@ final class AgentPillsManager: ObservableObject {
         if pinnedPillID == pillID { pinnedPillID = nil }
     }
 
+    func dismiss(pillIdString: String) -> Bool {
+        guard let id = findPillId(from: pillIdString) else { return false }
+        dismiss(pillID: id)
+        return true
+    }
+
     private func cleanup(pillID: UUID) {
         streamsByPill[pillID]?.cancel()
         streamsByPill[pillID] = nil
@@ -450,14 +483,85 @@ final class AgentPillsManager: ObservableObject {
 
     /// Remove all completed (done or failed) pills.
     func clearCompleted() {
-        pills.removeAll { isFinished($0.status) }
+        let ids = pills.filter { $0.status.isFinished }.map(\.id)
+        for id in ids {
+            cleanup(pillID: id)
+        }
     }
 
     private func isFinished(_ status: AgentPill.Status) -> Bool {
-        switch status {
-        case .done, .failed: return true
-        default: return false
+        status.isFinished
+    }
+
+    func snapshots(limit: Int = 20) -> [Snapshot] {
+        let formatter = ISO8601DateFormatter()
+        return pills
+            .sorted { $0.createdAt > $1.createdAt }
+            .prefix(limit)
+            .map { pill in
+                Snapshot(
+                    id: pill.id.uuidString,
+                    title: pill.title,
+                    status: pill.status.machineLabel,
+                    latestActivity: pill.latestActivity,
+                    query: pill.query,
+                    createdAt: formatter.string(from: pill.createdAt),
+                    completedAt: pill.completedAt.map { formatter.string(from: $0) }
+                )
+            }
+    }
+
+    func snapshotJSON(limit: Int = 20) -> String {
+        let payload: [String: [Snapshot]] = ["floating_agent_pills": snapshots(limit: limit)]
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(payload), let json = String(data: data, encoding: .utf8) else {
+            return "{\"floating_agent_pills\":[]}"
         }
+        return json
+    }
+
+    func statusSummary(limit: Int = 8) -> String {
+        let recent = snapshots(limit: limit)
+        guard !recent.isEmpty else {
+            return "No floating agent pills are running or recently finished."
+        }
+        let lines = recent.map { snapshot in
+            "- \(snapshot.title) [\(snapshot.id.prefix(8))]: \(snapshot.status); \(snapshot.latestActivity)"
+        }
+        return "Floating agent pills:\n" + lines.joined(separator: "\n")
+    }
+
+    func manage(action: String, agentId: String?) -> String {
+        switch action.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "list", "status":
+            return statusSummary()
+        case "dismiss":
+            guard let agentId, !agentId.isEmpty else {
+                return "Missing agent_id. Call get_task_agent_status first and pass the floating_agent_pills id."
+            }
+            return dismiss(pillIdString: agentId)
+                ? "Dismissed floating agent pill \(agentId)."
+                : "No floating agent pill matched \(agentId)."
+        case "clear_completed":
+            let count = pills.filter { $0.status.isFinished }.count
+            clearCompleted()
+            return "Cleared \(count) completed floating agent pill(s)."
+        default:
+            return "Unknown action. Use list, dismiss, or clear_completed."
+        }
+    }
+
+    private func findPillId(from text: String) -> UUID? {
+        let needle = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return nil }
+        if let exact = UUID(uuidString: text) {
+            return pills.first(where: { $0.id == exact })?.id
+        }
+        return pills.first { pill in
+            let id = pill.id.uuidString.lowercased()
+            return id == needle || id.hasPrefix(needle)
+        }?.id
     }
 
     private func handle(messages: [ChatMessage], since: Int, for pill: AgentPill) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -379,6 +379,13 @@ class PushToTalkManager: ObservableObject {
     finalize()
   }
 
+  /// Cancel an in-progress voice follow-up for a pill that was dismissed.
+  func cancelPillFollowUp(for pillID: UUID) {
+    guard followUpPill?.id == pillID else { return }
+    log("PushToTalkManager: voice follow-up CANCEL for dismissed agent")
+    stopListening()
+  }
+
   private var finalizedMode: String = "hold"
 
   // MARK: - QueryTracer

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -474,7 +474,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       log("RealtimeHub[\(providerTag)]: tool get_task_agent_status")
       session?.sendToolResult(callId: callId, name: name, output: result)
     case .manageAgentPills:
-      let action = arg("action").isEmpty ? "list" : arg("action")
+      let action = ((arguments["action"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines))
+        .flatMap { $0.isEmpty ? nil : $0 } ?? "list"
       let agentId = (arguments["agent_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
       let result = AgentPillsManager.shared.manage(action: action, agentId: agentId)
       log("RealtimeHub[\(providerTag)]: tool manage_agent_pills action=\(action)")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -469,6 +469,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
           limit: 25, completed: completed, dueStartDate: dueStart, dueEndDate: dueEnd
         ).resultText
       }
+    case .getTaskAgentStatus:
+      let result = TaskAgentStatusRegistry.shared.voiceSummary()
+      log("RealtimeHub[\(providerTag)]: tool get_task_agent_status")
+      session?.sendToolResult(callId: callId, name: name, output: result)
     case .searchScreenHistory:
       // Fast LOCAL semantic search over screen history (same executor as chat).
       let query = arg("query")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -470,8 +470,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         ).resultText
       }
     case .getTaskAgentStatus:
-      let result = TaskAgentStatusRegistry.shared.voiceSummary()
+      let result = TaskAgentStatusRegistry.shared.combinedSummary()
       log("RealtimeHub[\(providerTag)]: tool get_task_agent_status")
+      session?.sendToolResult(callId: callId, name: name, output: result)
+    case .manageAgentPills:
+      let action = arg("action").isEmpty ? "list" : arg("action")
+      let agentId = (arguments["agent_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let result = AgentPillsManager.shared.manage(action: action, agentId: agentId)
+      log("RealtimeHub[\(providerTag)]: tool manage_agent_pills action=\(action)")
       session?.sendToolResult(callId: callId, name: name, output: result)
     case .searchScreenHistory:
       // Fast LOCAL semantic search over screen history (same executor as chat).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -127,6 +127,7 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .searchConversations: stub = "On Monday you discussed the launch timeline."
     case .getConversations: stub = "Most recent: today, 'Standup notes'. Before that: yesterday, 'Design review'."
     case .getActionItems: stub = "Open: Buy milk (due tomorrow). Completed: Ship the PR."
+    case .getTaskAgentStatus: stub = #"{"task_agents":[]}"#
     case .getDailyRecap: stub = "Yesterday: 3 hrs in Xcode, 1 hr in Safari; 2 conversations; 1 task created."
     case .searchScreenHistory: stub = "Found it: yesterday afternoon you were reading the launch doc in Safari."
     case .createActionItem: stub = "Created task: Example task."

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -127,7 +127,8 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .searchConversations: stub = "On Monday you discussed the launch timeline."
     case .getConversations: stub = "Most recent: today, 'Standup notes'. Before that: yesterday, 'Design review'."
     case .getActionItems: stub = "Open: Buy milk (due tomorrow). Completed: Ship the PR."
-    case .getTaskAgentStatus: stub = #"{"task_agents":[]}"#
+    case .getTaskAgentStatus: stub = #"{"task_agents":[],"floating_agent_pills":[]}"#
+    case .manageAgentPills: stub = "No floating agent pills are running or recently finished."
     case .getDailyRecap: stub = "Yesterday: 3 hrs in Xcode, 1 hr in Safari; 2 conversations; 1 task created."
     case .searchScreenHistory: stub = "Found it: yesterday afternoon you were reading the launch doc in Safari."
     case .createActionItem: stub = "Created task: Example task."

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -24,6 +24,8 @@ enum HubTool: String {
   /// due-date range). Fast READ — use for completed tasks, date ranges, or the whole list
   /// (get_tasks only covers overdue + due-today).
   case getActionItems = "get_action_items"
+  /// Inspect Omi's local task-chat/background agents. Fast local READ.
+  case getTaskAgentStatus = "get_task_agent_status"
   /// Read what Omi knows about the user (memories / facts) and return it inline to speak.
   /// Fast synchronous READ — the answer to "who am I" / "what do you know about me".
   case getMemories = "get_memories"
@@ -64,6 +66,8 @@ enum RealtimeHubTools {
     Reply in the same language the user is speaking.
 
     \(aboutUser)
+
+    \(DesktopCapabilityRegistry.realtimeSelfModelPrompt)
 
     IMPORTANT: You CAN read the user's Omi data directly with fast tools — their tasks \
     (get_tasks), what Omi knows about them / their memories & facts (get_memories, \
@@ -299,6 +303,15 @@ enum RealtimeHubTools {
             ],
           ],
         ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.getTaskAgentStatus.rawValue,
+        "description":
+          "Inspect Omi's local task-chat/background agents and return recent status/errors. "
+          + "Use when the user asks about your subagents, task agents, background agents, "
+          + "running agents, errors, or timeouts. Fast local read.",
+        "parameters": ["type": "object", "properties": [:]],
       ],
       [
         "type": "function",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -26,6 +26,8 @@ enum HubTool: String {
   case getActionItems = "get_action_items"
   /// Inspect Omi's local task-chat/background agents. Fast local READ.
   case getTaskAgentStatus = "get_task_agent_status"
+  /// Manage floating-bar agent pills. Fast local action.
+  case manageAgentPills = "manage_agent_pills"
   /// Read what Omi knows about the user (memories / facts) and return it inline to speak.
   /// Fast synchronous READ — the answer to "who am I" / "what do you know about me".
   case getMemories = "get_memories"
@@ -308,10 +310,32 @@ enum RealtimeHubTools {
         "type": "function",
         "name": HubTool.getTaskAgentStatus.rawValue,
         "description":
-          "Inspect Omi's local task-chat/background agents and return recent status/errors. "
+          "Inspect Omi's local task-chat/background agents and floating agent pills, including recent completed/failed ones. "
           + "Use when the user asks about your subagents, task agents, background agents, "
-          + "running agents, errors, or timeouts. Fast local read.",
+          + "running agents, finished agents, errors, or timeouts. Fast local read.",
         "parameters": ["type": "object", "properties": [:]],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.manageAgentPills.rawValue,
+        "description":
+          "Manage the circular floating agent pills shown below the floating bar. Use to list pills, dismiss one by id, "
+          + "or clear completed pills after checking get_task_agent_status.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "action": [
+              "type": "string",
+              "enum": ["list", "dismiss", "clear_completed"],
+              "description": "Management action to perform.",
+            ],
+            "agent_id": [
+              "type": "string",
+              "description": "Floating agent pill id from get_task_agent_status; required for dismiss.",
+            ],
+          ],
+          "required": ["action"],
+        ],
       ],
       [
         "type": "function",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -109,6 +109,30 @@ final class TaskAgentStatusRegistry {
     return json
   }
 
+  func voiceSummary() -> String {
+    let recent = entries.values
+      .sorted { $0.updatedAt > $1.updatedAt }
+      .prefix(5)
+
+    guard !recent.isEmpty else {
+      return "No task agents are running or recently finished."
+    }
+
+    let lines = recent.map { entry -> String in
+      let title = (entry.title?.isEmpty == false ? entry.title! : "Untitled task")
+      var parts = ["\(title): \(entry.status.rawValue.replacingOccurrences(of: "_", with: " "))"]
+      if let statusText = entry.statusText, !statusText.isEmpty {
+        parts.append(statusText)
+      }
+      if let lastError = entry.lastError, !lastError.isEmpty {
+        parts.append("error: \(lastError)")
+      }
+      return "- " + parts.joined(separator: "; ")
+    }
+
+    return "Recent task agents:\n" + lines.joined(separator: "\n")
+  }
+
   private func update(
     taskId: String,
     title: String? = nil,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -59,6 +59,7 @@ final class TaskAgentStatusRegistry {
     }
     entry.updatedAt = Date()
     entries[taskId] = entry
+    pruneIfNeeded()
   }
 
   func markRunning(taskId: String, title: String? = nil, statusText: String = "Responding...") {
@@ -70,6 +71,7 @@ final class TaskAgentStatusRegistry {
     entry.statusText = statusText
     entry.updatedAt = Date()
     entries[taskId] = entry
+    pruneIfNeeded()
   }
 
   func markCompleted(taskId: String) {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// In-memory status surface for Omi task-chat agents.
+///
+/// Main/floating chat runs in a separate bridge from task chats, so without a
+/// small shared registry the assistant cannot answer questions like "what are
+/// your subagents doing?" or diagnose task-agent timeouts/errors.
+@MainActor
+final class TaskAgentStatusRegistry {
+  static let shared = TaskAgentStatusRegistry()
+
+  enum Status: String {
+    case idle
+    case running
+    case completed
+    case failed
+    case timedOut = "timed_out"
+  }
+
+  struct Snapshot: Encodable {
+    let taskId: String
+    let title: String?
+    let status: String
+    let statusText: String?
+    let lastError: String?
+    let updatedAt: String
+  }
+
+  private struct Entry {
+    var taskId: String
+    var title: String?
+    var status: Status
+    var statusText: String?
+    var lastError: String?
+    var updatedAt: Date
+  }
+
+  private var entries: [String: Entry] = [:]
+  private let encoder: JSONEncoder
+
+  private init() {
+    encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+  }
+
+  func registerTask(taskId: String, title: String?) {
+    var entry = entries[taskId] ?? Entry(
+      taskId: taskId,
+      title: nil,
+      status: .idle,
+      statusText: nil,
+      lastError: nil,
+      updatedAt: Date())
+    if let title, !title.isEmpty {
+      entry.title = title
+    }
+    entry.updatedAt = Date()
+    entries[taskId] = entry
+  }
+
+  func markRunning(taskId: String, title: String? = nil, statusText: String = "Responding...") {
+    update(taskId: taskId, title: title, status: .running, statusText: statusText, lastError: nil)
+  }
+
+  func updateStatus(taskId: String, statusText: String?) {
+    guard var entry = entries[taskId] else { return }
+    entry.statusText = statusText
+    entry.updatedAt = Date()
+    entries[taskId] = entry
+  }
+
+  func markCompleted(taskId: String) {
+    update(taskId: taskId, status: .completed, statusText: nil, lastError: nil)
+  }
+
+  func markFailed(taskId: String, error: String) {
+    let lower = error.lowercased()
+    let status: Status = lower.contains("took too long") || lower.contains("timeout") ? .timedOut : .failed
+    update(taskId: taskId, status: status, statusText: nil, lastError: error)
+  }
+
+  func snapshotJSON() -> String {
+    let snapshots = entries.values
+      .sorted { $0.updatedAt > $1.updatedAt }
+      .map { entry in
+        Snapshot(
+          taskId: entry.taskId,
+          title: entry.title,
+          status: entry.status.rawValue,
+          statusText: entry.statusText,
+          lastError: entry.lastError,
+          updatedAt: ISO8601DateFormatter().string(from: entry.updatedAt))
+      }
+
+    let payload: [String: [Snapshot]] = ["task_agents": snapshots]
+    guard let data = try? encoder.encode(payload), let json = String(data: data, encoding: .utf8) else {
+      return "{\"task_agents\":[]}"
+    }
+    return json
+  }
+
+  private func update(
+    taskId: String,
+    title: String? = nil,
+    status: Status,
+    statusText: String?,
+    lastError: String?
+  ) {
+    var entry = entries[taskId] ?? Entry(
+      taskId: taskId,
+      title: nil,
+      status: .idle,
+      statusText: nil,
+      lastError: nil,
+      updatedAt: Date())
+    if let title, !title.isEmpty {
+      entry.title = title
+    }
+    entry.status = status
+    entry.statusText = statusText
+    entry.lastError = lastError
+    entry.updatedAt = Date()
+    entries[taskId] = entry
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -89,22 +89,25 @@ final class TaskAgentStatusRegistry {
   }
 
   func snapshotJSON() -> String {
-    let snapshots = entries.values
-      .sorted { $0.updatedAt > $1.updatedAt }
-      .prefix(maxSnapshotEntries)
-      .map { entry in
-        Snapshot(
-          taskId: entry.taskId,
-          title: entry.title,
-          status: entry.status.rawValue,
-          statusText: entry.statusText,
-          lastError: entry.lastError,
-          updatedAt: ISO8601DateFormatter().string(from: entry.updatedAt))
-      }
-
-    let payload: [String: [Snapshot]] = ["task_agents": snapshots]
+    let payload: [String: [Snapshot]] = ["task_agents": snapshots()]
     guard let data = try? encoder.encode(payload), let json = String(data: data, encoding: .utf8) else {
       return "{\"task_agents\":[]}"
+    }
+    return json
+  }
+
+  func combinedSnapshotJSON() -> String {
+    struct CombinedSnapshot: Encodable {
+      let task_agents: [Snapshot]
+      let floating_agent_pills: [AgentPillsManager.Snapshot]
+    }
+
+    let payload = CombinedSnapshot(
+      task_agents: snapshots(),
+      floating_agent_pills: AgentPillsManager.shared.snapshots()
+    )
+    guard let data = try? encoder.encode(payload), let json = String(data: data, encoding: .utf8) else {
+      return "{\"task_agents\":[],\"floating_agent_pills\":[]}"
     }
     return json
   }
@@ -131,6 +134,27 @@ final class TaskAgentStatusRegistry {
     }
 
     return "Recent task agents:\n" + lines.joined(separator: "\n")
+  }
+
+  func combinedSummary() -> String {
+    let taskSummary = voiceSummary()
+    let pillSummary = AgentPillsManager.shared.statusSummary()
+    return "\(taskSummary)\n\n\(pillSummary)"
+  }
+
+  private func snapshots() -> [Snapshot] {
+    entries.values
+      .sorted { $0.updatedAt > $1.updatedAt }
+      .prefix(maxSnapshotEntries)
+      .map { entry in
+        Snapshot(
+          taskId: entry.taskId,
+          title: entry.title,
+          status: entry.status.rawValue,
+          statusText: entry.statusText,
+          lastError: entry.lastError,
+          updatedAt: ISO8601DateFormatter().string(from: entry.updatedAt))
+      }
   }
 
   private func update(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -40,10 +40,20 @@ final class TaskAgentStatusRegistry {
   private let maxSnapshotEntries = 20
   private let maxRetainedEntries = 100
   private let encoder: JSONEncoder
+  private var signOutObserver: NSObjectProtocol?
 
   private init() {
     encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    signOutObserver = NotificationCenter.default.addObserver(
+      forName: .userDidSignOut,
+      object: nil,
+      queue: nil
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.reset()
+      }
+    }
   }
 
   func registerTask(taskId: String, title: String?) {
@@ -86,6 +96,10 @@ final class TaskAgentStatusRegistry {
 
   func markStopped(taskId: String) {
     update(taskId: taskId, status: .stopped, statusText: nil, lastError: "Stopped by user")
+  }
+
+  func reset() {
+    entries.removeAll()
   }
 
   func snapshotJSON() -> String {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskAgentStatusRegistry.swift
@@ -14,6 +14,7 @@ final class TaskAgentStatusRegistry {
     case running
     case completed
     case failed
+    case stopped
     case timedOut = "timed_out"
   }
 
@@ -36,6 +37,8 @@ final class TaskAgentStatusRegistry {
   }
 
   private var entries: [String: Entry] = [:]
+  private let maxSnapshotEntries = 20
+  private let maxRetainedEntries = 100
   private let encoder: JSONEncoder
 
   private init() {
@@ -79,9 +82,14 @@ final class TaskAgentStatusRegistry {
     update(taskId: taskId, status: status, statusText: nil, lastError: error)
   }
 
+  func markStopped(taskId: String) {
+    update(taskId: taskId, status: .stopped, statusText: nil, lastError: "Stopped by user")
+  }
+
   func snapshotJSON() -> String {
     let snapshots = entries.values
       .sorted { $0.updatedAt > $1.updatedAt }
+      .prefix(maxSnapshotEntries)
       .map { entry in
         Snapshot(
           taskId: entry.taskId,
@@ -121,5 +129,17 @@ final class TaskAgentStatusRegistry {
     entry.lastError = lastError
     entry.updatedAt = Date()
     entries[taskId] = entry
+    pruneIfNeeded()
+  }
+
+  private func pruneIfNeeded() {
+    guard entries.count > maxRetainedEntries else { return }
+    let retainedIds = Set(
+      entries.values
+        .sorted { $0.updatedAt > $1.updatedAt }
+        .prefix(maxRetainedEntries)
+        .map(\.taskId)
+    )
+    entries = entries.filter { retainedIds.contains($0.key) }
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
@@ -65,10 +65,14 @@ class TaskChatCoordinator: ObservableObject {
                 guard let self else { return }
                 if isSending {
                     self.streamingTaskIds.insert(taskId)
+                    TaskAgentStatusRegistry.shared.markRunning(taskId: taskId)
                 } else {
                     // Streaming finished — remove from active set
                     self.streamingTaskIds.remove(taskId)
                     self.streamingStatuses.removeValue(forKey: taskId)
+                    if state.errorMessage == nil {
+                        TaskAgentStatusRegistry.shared.markCompleted(taskId: taskId)
+                    }
                     // Mark unread if panel not showing this task
                     if !self.isPanelOpen || self.activeTaskId != taskId {
                         self.unreadTaskIds.insert(taskId)
@@ -84,6 +88,7 @@ class TaskChatCoordinator: ObservableObject {
                 guard let self, let state, state.isSending,
                       self.streamingTaskIds.contains(taskId) else { return }
                 self.streamingStatuses[taskId] = self.deriveStreamingStatus(from: messages)
+                TaskAgentStatusRegistry.shared.updateStatus(taskId: taskId, statusText: self.streamingStatuses[taskId])
             }
             .store(in: &subs)
 
@@ -144,6 +149,7 @@ class TaskChatCoordinator: ObservableObject {
 
         activeTaskId = task.id
         markAsRead(task.id)
+        TaskAgentStatusRegistry.shared.registerTask(taskId: task.id, title: task.description)
 
         // Get or create TaskChatState
         let state: TaskChatState

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
@@ -70,9 +70,8 @@ class TaskChatCoordinator: ObservableObject {
                     // Streaming finished — remove from active set
                     self.streamingTaskIds.remove(taskId)
                     self.streamingStatuses.removeValue(forKey: taskId)
-                    if state.errorMessage == nil {
-                        TaskAgentStatusRegistry.shared.markCompleted(taskId: taskId)
-                    }
+                    // Terminal task-agent status is owned by TaskChatState (completed/failed/stopped).
+                    // Do not infer completion here; stopped runs have no error but are not completed.
                     // Mark unread if panel not showing this task
                     if !self.isPanelOpen || self.activeTaskId != taskId {
                         self.unreadTaskIds.insert(taskId)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
@@ -196,6 +196,7 @@ class TaskChatCoordinator: ObservableObject {
     /// Uses the agent bridge via TaskChatState. Skips tasks already sending.
     func investigateInBackground(for task: TaskActionItem) async {
         log("TaskChatCoordinator: investigateInBackground for \(task.id)")
+        TaskAgentStatusRegistry.shared.registerTask(taskId: task.id, title: task.description)
 
         let state: TaskChatState
         if let existing = taskStates[task.id] {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -286,7 +286,7 @@ class TaskChatState: ObservableObject {
             }
 
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
-                // User stopped — no error
+                TaskAgentStatusRegistry.shared.markStopped(taskId: taskId)
             } else {
                 errorMessage = error.localizedDescription
                 TaskAgentStatusRegistry.shared.markFailed(taskId: taskId, error: error.localizedDescription)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -139,6 +139,7 @@ class TaskChatState: ObservableObject {
         } catch {
             logError("TaskChatState[\(taskId)]: Failed to start bridge", error: error)
             errorMessage = "AI not available: \(error.localizedDescription)"
+            TaskAgentStatusRegistry.shared.markFailed(taskId: taskId, error: errorMessage ?? error.localizedDescription)
             return false
         }
     }
@@ -190,6 +191,7 @@ class TaskChatState: ObservableObject {
 
         do {
             let systemPrompt = systemPromptBuilder?() ?? ""
+            let currentChatMode = chatMode
 
             let textDeltaHandler: @Sendable (String) -> Void = { [weak self] delta in
                 Task { @MainActor [weak self] in
@@ -198,7 +200,7 @@ class TaskChatState: ObservableObject {
             }
             let toolCallHandler: @Sendable (String, String, [String: Any]) async -> String = { callId, name, input in
                 let toolCall = ToolCall(name: name, arguments: input, thoughtSignature: nil)
-                let result = await ChatToolExecutor.execute(toolCall)
+                let result = await ChatToolExecutor.execute(toolCall, originatingChatMode: currentChatMode)
                 log("TaskChat OMI tool \(name) executed for callId=\(callId)")
                 return result
             }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -164,6 +164,7 @@ class TaskChatState: ObservableObject {
 
         isSending = true
         errorMessage = nil
+        TaskAgentStatusRegistry.shared.markRunning(taskId: taskId)
 
         // Add user message to local messages and persist
         // Skip for follow-ups — sendFollowUp() already added and persisted it
@@ -268,6 +269,7 @@ class TaskChatState: ObservableObject {
             }
 
             log("TaskChatState[\(taskId)]: response complete (cost=$\(queryResult.costUsd))")
+            TaskAgentStatusRegistry.shared.markCompleted(taskId: taskId)
         } catch {
             streamingFlushWorkItem?.cancel()
             streamingFlushWorkItem = nil
@@ -287,6 +289,7 @@ class TaskChatState: ObservableObject {
                 // User stopped — no error
             } else {
                 errorMessage = error.localizedDescription
+                TaskAgentStatusRegistry.shared.markFailed(taskId: taskId, error: error.localizedDescription)
             }
             logError("TaskChatState[\(taskId)]: query failed", error: error)
         }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -335,6 +335,7 @@ struct MessageMetadata {
         return [
             "execute_sql",
             "semantic_search",
+            "get_task_agent_status",
             "search_tasks",
             "get_daily_recap",
             "complete_task",

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1920,6 +1920,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         }
 
         do {
+            let currentChatMode = chatMode
             let result = try await agentBridge.query(
                 prompt: question,
                 systemPrompt: systemPrompt,
@@ -1928,7 +1929,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 onTextDelta: { _ in },
                 onToolCall: { callId, name, input in
                     let toolCall = ToolCall(name: name, arguments: input, thoughtSignature: nil)
-                    let result = await ChatToolExecutor.execute(toolCall)
+                    let result = await ChatToolExecutor.execute(toolCall, originatingChatMode: currentChatMode)
                     log("ChatLab: tool \(name) executed")
                     return result
                 },
@@ -2957,6 +2958,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // text-streaming window so the `generation` span excludes tool time.
             var isFirstResponse = true
             var isGenerating = false
+            let currentChatMode = chatMode
             let textDeltaHandler: AgentBridge.TextDeltaHandler = { [weak self] delta in
                 if isFirstResponse {
                     isFirstResponse = false
@@ -2976,7 +2978,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 // QueryTracer: time the actual tool execution (client-side run of the
                 // tool, distinct from the model-visible tool span in toolActivity).
                 let toolStart = ContinuousClock.now
-                let result = await ChatToolExecutor.execute(toolCall)
+                let result = await ChatToolExecutor.execute(toolCall, originatingChatMode: currentChatMode)
                 if let tracer {
                     let toolDurMs = (ContinuousClock.now - toolStart).milliseconds
                     let inputJson =

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -113,6 +113,9 @@ enum ChatContentBlock: Identifiable {
         switch cleanName {
         case "execute_sql": return "Querying database"
         case "semantic_search": return "Searching conversations"
+        case "get_task_agent_status": return "Checking agents"
+        case "spawn_agent": return "Starting agent"
+        case "manage_agent_pills": return "Managing agents"
         case "search_tasks": return "Searching tasks"
         case "Read": return "Reading file"
         case "Write": return "Writing file"
@@ -165,6 +168,18 @@ enum ChatContentBlock: Identifiable {
             }
         case "semantic_search":
             summary = input["query"] as? String
+        case "spawn_agent":
+            summary = (input["brief"] ?? input["query"]) as? String
+        case "manage_agent_pills":
+            if let action = input["action"] as? String {
+                if let agentId = input["agent_id"] as? String, !agentId.isEmpty {
+                    summary = "\(action) \(agentId)"
+                } else {
+                    summary = action
+                }
+            } else {
+                summary = nil
+            }
         case "search_tasks":
             summary = input["query"] as? String
         case "request_permission":
@@ -336,6 +351,8 @@ struct MessageMetadata {
             "execute_sql",
             "semantic_search",
             "get_task_agent_status",
+            "spawn_agent",
+            "manage_agent_pills",
             "search_tasks",
             "get_daily_recap",
             "complete_task",

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -44,6 +44,9 @@ class ChatToolExecutor {
     case "get_local_status":
       return await executeLocalStatus()
 
+    case "get_task_agent_status":
+      return await executeTaskAgentStatus()
+
     case "execute_sql":
       return await executeSQL(toolCall.arguments)
 
@@ -418,6 +421,12 @@ class ChatToolExecutor {
     }
 
     return "OK: \(changes) row(s) affected"
+  }
+
+  // MARK: - Task Agent Status
+
+  private static func executeTaskAgentStatus() async -> String {
+    return TaskAgentStatusRegistry.shared.snapshotJSON()
   }
 
   // MARK: - Local Status

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -37,7 +37,7 @@ class ChatToolExecutor {
   }
 
   /// Execute a tool call and return the result as a string
-  static func execute(_ toolCall: ToolCall) async -> String {
+  static func execute(_ toolCall: ToolCall, originatingChatMode: ChatMode? = nil) async -> String {
     log("Executing tool: \(toolCall.name) with args: \(toolCall.arguments)")
 
     switch toolCall.name {
@@ -48,7 +48,7 @@ class ChatToolExecutor {
       return await executeTaskAgentStatus()
 
     case "spawn_agent":
-      return await executeSpawnAgent(toolCall.arguments)
+      return await executeSpawnAgent(toolCall.arguments, originatingChatMode: originatingChatMode)
 
     case "manage_agent_pills":
       return await executeManageAgentPills(toolCall.arguments)
@@ -435,7 +435,10 @@ class ChatToolExecutor {
     return TaskAgentStatusRegistry.shared.combinedSnapshotJSON()
   }
 
-  private static func executeSpawnAgent(_ args: [String: Any]) async -> String {
+  private static func executeSpawnAgent(_ args: [String: Any], originatingChatMode: ChatMode?) async -> String {
+    if originatingChatMode == .ask {
+      return "Error: spawn_agent is unavailable in Ask mode. Switch to Act mode before starting a background agent."
+    }
     let brief = ((args["brief"] as? String) ?? (args["query"] as? String) ?? "")
       .trimmingCharacters(in: .whitespacesAndNewlines)
     guard !brief.isEmpty else {

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -47,6 +47,12 @@ class ChatToolExecutor {
     case "get_task_agent_status":
       return await executeTaskAgentStatus()
 
+    case "spawn_agent":
+      return await executeSpawnAgent(toolCall.arguments)
+
+    case "manage_agent_pills":
+      return await executeManageAgentPills(toolCall.arguments)
+
     case "execute_sql":
       return await executeSQL(toolCall.arguments)
 
@@ -426,7 +432,37 @@ class ChatToolExecutor {
   // MARK: - Task Agent Status
 
   private static func executeTaskAgentStatus() async -> String {
-    return TaskAgentStatusRegistry.shared.snapshotJSON()
+    return TaskAgentStatusRegistry.shared.combinedSnapshotJSON()
+  }
+
+  private static func executeSpawnAgent(_ args: [String: Any]) async -> String {
+    let brief = ((args["brief"] as? String) ?? (args["query"] as? String) ?? "")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !brief.isEmpty else {
+      return "Error: Missing brief. Pass a clear, self-contained task brief."
+    }
+    let title = (args["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let model = ShortcutSettings.shared.selectedModel.isEmpty
+      ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
+    let pill = AgentPillsManager.shared.spawnFromUserQuery(
+      brief,
+      model: model,
+      fromVoice: false,
+      preFetchedTitle: (title?.isEmpty == false) ? title : nil
+    )
+    return """
+    Agent started as a floating agent pill.
+    id: \(pill.id.uuidString)
+    title: \(pill.title)
+    status: \(pill.status.displayLabel)
+    """
+  }
+
+  private static func executeManageAgentPills(_ args: [String: Any]) async -> String {
+    let action = ((args["action"] as? String) ?? "list")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let agentId = (args["agent_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return AgentPillsManager.shared.manage(action: action, agentId: agentId)
   }
 
   // MARK: - Local Status

--- a/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
@@ -118,6 +118,15 @@ final class ChatDiscoverabilityTests: XCTestCase {
         XCTAssertTrue(prompt.contains("**get_task_agent_status**"))
         XCTAssertTrue(prompt.contains("your subagents"))
         XCTAssertTrue(prompt.contains("Call get_task_agent_status"))
+        XCTAssertTrue(prompt.contains("floating_agent_pills"))
+    }
+
+    func testDesktopPromptCanSpawnAndManageFloatingAgents() {
+        let prompt = ChatPrompts.desktopChat
+        XCTAssertTrue(prompt.contains("**spawn_agent**"))
+        XCTAssertTrue(prompt.contains("call spawn_agent"))
+        XCTAssertTrue(prompt.contains("**manage_agent_pills**"))
+        XCTAssertTrue(prompt.contains("circular floating agent pills"))
     }
 
     func testDesktopPromptPreservesLegacyToolBehaviorGuidance() {

--- a/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
@@ -120,6 +120,25 @@ final class ChatDiscoverabilityTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Call get_task_agent_status"))
     }
 
+    func testDesktopPromptPreservesLegacyToolBehaviorGuidance() {
+        let prompt = ChatPrompts.desktopChat
+        XCTAssertTrue(prompt.contains("Do not guess when you can look it up"))
+        XCTAssertTrue(prompt.contains("Supports SELECT, INSERT, UPDATE, DELETE"))
+        XCTAssertTrue(prompt.contains("Supports FTS5 MATCH queries"))
+        XCTAssertTrue(prompt.contains("More reliable than hand-writing MATCH queries for task search"))
+        XCTAssertTrue(prompt.contains("**save_knowledge_graph**"))
+        XCTAssertTrue(prompt.contains("Deduplication is handled automatically"))
+    }
+
+    func testDesktopPromptPreservesPersonalDataLookupContract() {
+        let prompt = ChatPrompts.desktopChat
+        XCTAssertTrue(prompt.contains("For ANY personal question"))
+        XCTAssertTrue(prompt.contains("FIRST check <user_facts>"))
+        XCTAssertTrue(prompt.contains("before saying you don't know"))
+        XCTAssertTrue(prompt.contains("transcription_sessions/transcription_segments"))
+        XCTAssertTrue(prompt.contains("NEVER say \"I don't know\""))
+    }
+
     func testDesktopCapabilitiesExistInAgentToolDeclarations() throws {
         let declaredTools = try readToolNames(from: "pi-mono-extension/index.ts")
             .union(readToolNames(from: "agent/src/omi-tools-stdio.ts"))

--- a/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
@@ -95,14 +95,52 @@ final class ChatDiscoverabilityTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Vector similarity search on tasks"))
     }
 
-    func testToolPromptHas7Tools() {
+    func testToolPromptDoesNotPinStaleToolCount() {
         let prompt = ChatPrompts.desktopChat
-        XCTAssertTrue(prompt.contains("You have 7 tools"))
+        XCTAssertFalse(prompt.contains("You have 7 tools"))
+        XCTAssertFalse(prompt.contains("You have \(DesktopCapabilityRegistry.desktopToolNames.count) Omi tools"))
     }
 
     func testToolPromptListsSearchTasksInWhenToUse() {
         let prompt = ChatPrompts.desktopChat
         XCTAssertTrue(prompt.contains("find tasks about shopping"))
+    }
+
+    func testDesktopPromptMentionsEveryDesktopCapability() {
+        let prompt = ChatPrompts.desktopChat
+        for toolName in DesktopCapabilityRegistry.desktopToolNames {
+            XCTAssertTrue(prompt.contains("**\(toolName)**"), "Missing desktop capability \(toolName)")
+        }
+    }
+
+    func testDesktopPromptMentionsTaskAgentStatus() {
+        let prompt = ChatPrompts.desktopChat
+        XCTAssertTrue(prompt.contains("**get_task_agent_status**"))
+        XCTAssertTrue(prompt.contains("your subagents"))
+        XCTAssertTrue(prompt.contains("Call get_task_agent_status"))
+    }
+
+    func testDesktopCapabilitiesExistInAgentToolDeclarations() throws {
+        let declaredTools = try readToolNames(from: "pi-mono-extension/index.ts")
+            .union(readToolNames(from: "agent/src/omi-tools-stdio.ts"))
+
+        for toolName in DesktopCapabilityRegistry.desktopToolNames {
+            XCTAssertTrue(declaredTools.contains(toolName), "Missing agent tool declaration for \(toolName)")
+        }
+    }
+
+    private func readToolNames(from relativePath: String) throws -> Set<String> {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+        let macOSDir = desktopDir.deletingLastPathComponent()
+        let file = macOSDir.appendingPathComponent(relativePath)
+        let text = try String(contentsOf: file)
+        let regex = try NSRegularExpression(pattern: #"name:\s*"([^"]+)""#)
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return Set(regex.matches(in: text, range: range).compactMap { match in
+            guard let nameRange = Range(match.range(at: 1), in: text) else { return nil }
+            return String(text[nameRange])
+        })
     }
 
     // MARK: - Table Annotations Completeness

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -10,6 +10,8 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertFalse(instr.contains("Always reply in English"))             // old rule gone
         XCTAssertTrue(instr.contains("spawn_agent"))                          // guardrails preserved
         XCTAssertTrue(instr.contains("get_task_agent_status"))
+        XCTAssertTrue(instr.contains("manage_agent_pills"))
+        XCTAssertTrue(instr.contains("floating agent pills"))
         XCTAssertTrue(instr.contains("subagents"))
         XCTAssertTrue(instr.contains("get_daily_recap"))
         XCTAssertTrue(instr.contains("ask_higher_model"))
@@ -26,5 +28,14 @@ final class HubSystemInstructionTests: XCTestCase {
         let statusTool = tools.first { ($0["name"] as? String) == HubTool.getTaskAgentStatus.rawValue }
         XCTAssertNotNil(statusTool)
         XCTAssertTrue((statusTool?["description"] as? String ?? "").contains("subagents"))
+        XCTAssertTrue((statusTool?["description"] as? String ?? "").contains("floating agent pills"))
+    }
+
+    func testRealtimeAgentPillManagementToolIsExposed() {
+        let tools = RealtimeHubTools.openAITools
+        let manageTool = tools.first { ($0["name"] as? String) == HubTool.manageAgentPills.rawValue }
+        XCTAssertNotNil(manageTool)
+        XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("dismiss"))
+        XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("clear completed"))
     }
 }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -9,8 +9,22 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertTrue(instr.lowercased().contains("language the user"))        // reply-in-user-language
         XCTAssertFalse(instr.contains("Always reply in English"))             // old rule gone
         XCTAssertTrue(instr.contains("spawn_agent"))                          // guardrails preserved
+        XCTAssertTrue(instr.contains("get_task_agent_status"))
+        XCTAssertTrue(instr.contains("subagents"))
         XCTAssertTrue(instr.contains("get_daily_recap"))
         XCTAssertTrue(instr.contains("ask_higher_model"))
         XCTAssertTrue(instr.contains("ANSWER YOURSELF"))
+    }
+
+    func testRealtimeToolSurfaceMatchesCapabilityRegistry() {
+        let toolNames = Set(RealtimeHubTools.openAITools.compactMap { $0["name"] as? String })
+        XCTAssertEqual(toolNames, Set(DesktopCapabilityRegistry.realtimeToolNames))
+    }
+
+    func testRealtimeTaskAgentStatusToolIsExposed() {
+        let tools = RealtimeHubTools.openAITools
+        let statusTool = tools.first { ($0["name"] as? String) == HubTool.getTaskAgentStatus.rawValue }
+        XCTAssertNotNil(statusTool)
+        XCTAssertTrue((statusTool?["description"] as? String ?? "").contains("subagents"))
     }
 }

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -746,6 +746,15 @@ async function handleJsonRpc(
             result: { content: [{ type: "text", text: result }] },
           });
         }
+      } else if (toolName === "get_task_agent_status") {
+        const result = await requestSwiftTool("get_task_agent_status", {});
+        if (!isNotification) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            result: { content: [{ type: "text", text: result }] },
+          });
+        }
       } else if (toolName === "search_tasks") {
         const input: Record<string, unknown> = { query: args.query };
         if (args.include_completed) input.include_completed = args.include_completed;

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -220,18 +220,66 @@ Parameter guidance:
   },
   {
     name: "get_task_agent_status",
-    description: `Inspect Omi's local task-chat agents/subagents.
+    description: `Inspect Omi's local task-chat agents/subagents and floating agent pills.
 
 Use when:
 - User asks about "your subagents", "task agents", running agents, background agents, errors, or timeouts
-- User wants to know which Omi task-agent chats are running, completed, failed, or timed out
+- User wants to know which Omi task-agent chats or floating agent pills are running, completed, failed, or timed out
 - User asks you to recover from or diagnose "Response took too long" in a task-agent chat
 
-Returns JSON with recent task_agents: taskId, title, status, statusText, lastError, updatedAt.`,
+Returns JSON with recent task_agents and floating_agent_pills. floating_agent_pills are the circular agent UI below the floating bar.`,
     inputSchema: {
       type: "object" as const,
       properties: {},
       required: [],
+    },
+  },
+  {
+    name: "spawn_agent",
+    description: `Start a floating background agent pill.
+
+Use when:
+- User explicitly asks to run, start, spawn, or launch a subagent/background agent
+- User asks for multi-step work in other apps/browser/files
+
+Calling this tool is the only way to start the circular floating-bar subagent. Saying you will start one does not start it.`,
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        brief: {
+          type: "string" as const,
+          description: "Clear, self-contained task brief for the background agent.",
+        },
+        title: {
+          type: "string" as const,
+          description: "Short Title Case label for the agent pill.",
+        },
+      },
+      required: ["brief"],
+    },
+  },
+  {
+    name: "manage_agent_pills",
+    description: `List, dismiss, or clear completed floating agent pills shown below the floating bar.
+
+Actions:
+- list: return current floating pill status
+- dismiss: dismiss one pill by agent_id
+- clear_completed: clear finished pills`,
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string" as const,
+          enum: ["list", "dismiss", "clear_completed"],
+          description: "Management action.",
+        },
+        agent_id: {
+          type: "string" as const,
+          description: "Floating agent pill id from get_task_agent_status; required for dismiss.",
+        },
+      },
+      required: ["action"],
     },
   },
   {
@@ -748,6 +796,24 @@ async function handleJsonRpc(
         }
       } else if (toolName === "get_task_agent_status") {
         const result = await requestSwiftTool("get_task_agent_status", {});
+        if (!isNotification) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            result: { content: [{ type: "text", text: result }] },
+          });
+        }
+      } else if (toolName === "spawn_agent") {
+        const result = await requestSwiftTool("spawn_agent", args);
+        if (!isNotification) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            result: { content: [{ type: "text", text: result }] },
+          });
+        }
+      } else if (toolName === "manage_agent_pills") {
+        const result = await requestSwiftTool("manage_agent_pills", args);
         if (!isNotification) {
           send({
             jsonrpc: "2.0",

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -219,6 +219,22 @@ Parameter guidance:
     },
   },
   {
+    name: "get_task_agent_status",
+    description: `Inspect Omi's local task-chat agents/subagents.
+
+Use when:
+- User asks about "your subagents", "task agents", running agents, background agents, errors, or timeouts
+- User wants to know which Omi task-agent chats are running, completed, failed, or timed out
+- User asks you to recover from or diagnose "Response took too long" in a task-agent chat
+
+Returns JSON with recent task_agents: taskId, title, status, statusText, lastError, updatedAt.`,
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
     name: "search_tasks",
     description: `Vector similarity search on tasks (action_items + staged_tasks).
 

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -927,8 +927,8 @@ function createMockBridge(): { server: Server; sockPath: string } {
   return { server, sockPath };
 }
 
-test("OMI_TOOLS: exactly 14 tools defined via defineTool()", () => {
-  assert.equal(OMI_TOOLS.length, 14);
+test("OMI_TOOLS: exactly 17 tools defined via defineTool()", () => {
+  assert.equal(OMI_TOOLS.length, 17);
 });
 
 test("OMI_TOOLS: all tools have name, label, description, parameters, execute", () => {
@@ -972,6 +972,9 @@ test("OMI_TOOLS: required fields match expected per tool", () => {
     execute_sql: ["query"],
     semantic_search: ["query"],
     get_daily_recap: [],
+    get_task_agent_status: [],
+    spawn_agent: ["brief"],
+    manage_agent_pills: ["action"],
     search_tasks: ["query"],
     complete_task: ["task_id"],
     delete_task: ["task_id"],

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -927,8 +927,8 @@ function createMockBridge(): { server: Server; sockPath: string } {
   return { server, sockPath };
 }
 
-test("OMI_TOOLS: exactly 17 tools defined via defineTool()", () => {
-  assert.equal(OMI_TOOLS.length, 17);
+test("OMI_TOOLS: exactly 18 tools defined via defineTool()", () => {
+  assert.equal(OMI_TOOLS.length, 18);
 });
 
 test("OMI_TOOLS: all tools have name, label, description, parameters, execute", () => {
@@ -978,6 +978,7 @@ test("OMI_TOOLS: required fields match expected per tool", () => {
     search_tasks: ["query"],
     complete_task: ["task_id"],
     delete_task: ["task_id"],
+    save_knowledge_graph: ["nodes", "edges"],
     get_conversations: [],
     search_conversations: ["query"],
     get_memories: [],

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -566,6 +566,18 @@ export const OMI_TOOLS = [
     required: [],
   }),
   omiTool({
+    name: "get_task_agent_status",
+    label: "Task Agent Status",
+    description: "Inspect Omi's local task-chat agents/subagents. Use when the user asks about your subagents, task agents, running agents, errors, or timeouts.",
+    promptSnippet: "get_task_agent_status - Inspect Omi task-chat agent status/errors/timeouts",
+    promptGuidelines: [
+      "If the user says 'your subagents', interpret that as Omi task-chat agents, not Cursor or external IDE agents.",
+      "Call this before claiming there are no subagents or before diagnosing a task-agent timeout.",
+    ],
+    properties: {},
+    required: [],
+  }),
+  omiTool({
     name: "search_tasks",
     label: "Search Tasks",
     description: "Vector similarity search on tasks. Find tasks by meaning or topic.",

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -640,6 +640,33 @@ export const OMI_TOOLS = [
     required: ["task_id"],
   }),
   omiTool({
+    name: "save_knowledge_graph",
+    label: "Save Knowledge Graph",
+    description: "Save a knowledge graph of entities and relationships discovered about the user.",
+    promptSnippet: "save_knowledge_graph - Save entities and relationships to the user's knowledge graph",
+    promptGuidelines: [
+      "Use when exploring the user's files during onboarding or knowledge-graph building.",
+      "Deduplication is handled automatically; include all meaningful entities and relationships you found.",
+    ],
+    properties: {
+      nodes: Type.Array(Type.Object({
+        id: Type.String({ description: "Stable node id, referenced by edges." }),
+        label: Type.String({ description: "Human-readable entity label." }),
+        node_type: Type.String({
+          enum: ["person", "organization", "place", "thing", "concept"],
+          description: "Entity type.",
+        }),
+        aliases: Type.Optional(Type.Array(Type.String({ description: "Alternate labels for the same entity." }))),
+      })),
+      edges: Type.Array(Type.Object({
+        source_id: Type.String({ description: "Source node id." }),
+        target_id: Type.String({ description: "Target node id." }),
+        label: Type.String({ description: "Relationship label, such as works_on, uses, built_with, part_of, or knows." }),
+      })),
+    },
+    required: ["nodes", "edges"],
+  }),
+  omiTool({
     name: "get_conversations",
     label: "Get Conversations",
     description: "Retrieve user conversations with summaries, action items, metadata. Use for time-based queries or recaps.",

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -568,14 +568,45 @@ export const OMI_TOOLS = [
   omiTool({
     name: "get_task_agent_status",
     label: "Task Agent Status",
-    description: "Inspect Omi's local task-chat agents/subagents. Use when the user asks about your subagents, task agents, running agents, errors, or timeouts.",
-    promptSnippet: "get_task_agent_status - Inspect Omi task-chat agent status/errors/timeouts",
+    description: "Inspect Omi's local task-chat agents/subagents and floating agent pills. Use when the user asks about your subagents, task agents, running agents, finished agents, errors, or timeouts.",
+    promptSnippet: "get_task_agent_status - Inspect Omi task-chat agents and floating agent pills",
     promptGuidelines: [
       "If the user says 'your subagents', interpret that as Omi task-chat agents, not Cursor or external IDE agents.",
       "Call this before claiming there are no subagents or before diagnosing a task-agent timeout.",
+      "The floating_agent_pills array is the circular agent UI below the floating bar, and includes running and finished pill agents.",
     ],
     properties: {},
     required: [],
+  }),
+  omiTool({
+    name: "spawn_agent",
+    label: "Spawn Agent",
+    description: "Start a floating background agent pill. Use when the user explicitly asks to run, start, spawn, or launch a subagent/background agent, or for multi-step work in other apps/browser/files.",
+    promptSnippet: "spawn_agent - Start a floating background agent pill",
+    promptGuidelines: [
+      "Calling spawn_agent is the only way to start the circular floating-bar subagent; saying you will start one does not start it.",
+      "Return immediately after spawning; the pill keeps working in the background.",
+    ],
+    properties: {
+      brief: Type.String({ description: "Clear, self-contained task brief for the background agent." }),
+      title: Type.Optional(Type.String({ description: "Short Title Case label for the agent pill." })),
+    },
+    required: ["brief"],
+  }),
+  omiTool({
+    name: "manage_agent_pills",
+    label: "Manage Agent Pills",
+    description: "List, dismiss, or clear completed floating agent pills shown below the floating bar.",
+    promptSnippet: "manage_agent_pills - List, dismiss, or clear completed floating agent pills",
+    promptGuidelines: [
+      "Call get_task_agent_status first when dismissing a specific pill so you have its id.",
+      "Use clear_completed only when the user asks to clear finished/done agents.",
+    ],
+    properties: {
+      action: Type.String({ enum: ["list", "dismiss", "clear_completed"], description: "Management action." }),
+      agent_id: Type.Optional(Type.String({ description: "Floating agent pill id from get_task_agent_status; required for dismiss." })),
+    },
+    required: ["action"],
   }),
   omiTool({
     name: "search_tasks",

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -18,6 +18,7 @@ Options (via environment variables):
   OMI_SKIP_TUNNEL=1        Skip Cloudflare tunnel (use OMI_DESKTOP_API_URL from .env directly)
   PORT=10201                Rust backend port (default: 10201, never use 8080)
   OMI_APP_NAME="Omi Dev"   App name (default: "Omi Dev")
+  OMI_SKIP_AUTH_SEED=1     Do not copy auth/onboarding from Omi Dev into named bundles
   OMI_PYTHON_API_URL="..."  Python backend URL (subscriptions, payments, etc; default: https://api.omi.me)
   OMI_SIGN_IDENTITY="..."  Code signing identity (auto-detected if not set)
   OMI_ENABLE_LOCAL_AUTOMATION=1   Force the automation bridge on (auto-on for non-prod bundles; see scripts/omi-ctl)
@@ -670,6 +671,17 @@ for stale in /private/tmp/omi-dmg-staging-*/Omi\ Beta.app; do
 done
 # Register the /Applications/ copy as the canonical bundle for this bundle ID
 $LSREGISTER -f "$APP_PATH" 2>/dev/null || true
+
+if [ "$IS_NAMED_BUNDLE" = true ] && [ "${OMI_SKIP_AUTH_SEED:-0}" != "1" ]; then
+    step "Seeding auth from Omi Dev..."
+    AUTH_CACHE="$(dirname "$0")/tmp/desktop-auth.json"
+    if ./scripts/omi-auth-dump.sh com.omi.desktop-dev "$AUTH_CACHE"; then
+        ./scripts/omi-auth-seed.sh "$BUNDLE_ID" "$AUTH_CACHE"
+        auth_debug "AFTER auth seed: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
+    else
+        echo "Warning: could not seed auth from Omi Dev. Launching cold."
+    fi
+fi
 
 step "Starting app..."
 

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -155,9 +155,13 @@ BACKEND_DIR="$(cd "$(dirname "$0")/Backend-Rust" && pwd)"
 BACKEND_PID=""
 TUNNEL_PID=""
 TUNNEL_URL="${TUNNEL_URL:-}"
+AUTH_CACHE=""
 
 # Cleanup function to stop backend, auth, and tunnel on exit
 cleanup() {
+    if [ -n "$AUTH_CACHE" ]; then
+        rm -f "$AUTH_CACHE"
+    fi
     if [ -n "$TUNNEL_PID" ] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
         echo "Stopping tunnel (PID: $TUNNEL_PID)..."
         kill "$TUNNEL_PID" 2>/dev/null || true
@@ -674,12 +678,20 @@ $LSREGISTER -f "$APP_PATH" 2>/dev/null || true
 
 if [ "$IS_NAMED_BUNDLE" = true ] && [ "${OMI_SKIP_AUTH_SEED:-0}" != "1" ]; then
     step "Seeding auth from Omi Dev..."
-    AUTH_CACHE="$(dirname "$0")/tmp/desktop-auth.json"
-    if ./scripts/omi-auth-dump.sh com.omi.desktop-dev "$AUTH_CACHE"; then
-        ./scripts/omi-auth-seed.sh "$BUNDLE_ID" "$AUTH_CACHE"
-        auth_debug "AFTER auth seed: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
+    if AUTH_CACHE="$(mktemp "${TMPDIR:-/tmp}/omi-desktop-auth.XXXXXX")"; then
+        if ./scripts/omi-auth-dump.sh com.omi.desktop-dev "$AUTH_CACHE"; then
+            if ./scripts/omi-auth-seed.sh "$BUNDLE_ID" "$AUTH_CACHE"; then
+                auth_debug "AFTER auth seed: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
+            else
+                echo "Warning: could not seed auth into $BUNDLE_ID. Launching cold."
+            fi
+        else
+            echo "Warning: could not seed auth from Omi Dev. Launching cold."
+        fi
+        rm -f "$AUTH_CACHE"
+        AUTH_CACHE=""
     else
-        echo "Warning: could not seed auth from Omi Dev. Launching cold."
+        echo "Warning: could not create temporary auth cache. Launching cold."
     fi
 fi
 


### PR DESCRIPTION
## Summary
- add an in-memory macOS task-agent status registry for Omi task-chat agents
- expose `get_task_agent_status` across desktop chat and realtime PTT so Omi can inspect running/completed/failed/timed-out task agents
- add a desktop capability registry for model-visible prompt docs, then project those docs into desktop/floating prompts instead of maintaining a stale hard-coded tool list
- preserve legacy desktop-chat behavior guidance while deduplicating prompt docs, including SQL/FTS affordances, semantic task-search guidance, knowledge-graph docs, and personal-data lookup rules
- expose `spawn_agent` and `manage_agent_pills` to floating text chat so typed Ask Omi can start, inspect, dismiss, and clear the same circular floating agent pills that PTT uses
- include floating agent pills in `get_task_agent_status` for both typed chat and realtime PTT, including recently finished/failed pills
- fix floating pill cleanup so dismissed/trimmed running pills interrupt their provider, cancel their run task, and cancel any active pill voice follow-up
- auto-seed auth/onboarding from `Omi Dev` into named desktop test bundles to reduce local cold starts, using a private temporary cache that is deleted after seeding

## Why
Omi had multiple agent/tool surfaces with hand-maintained prompt docs. That let the actual callable tools diverge from the assistant's self-model: PTT could spawn background agent pills, desktop chat could receive status tools, and text Ask Omi still claimed it could not spawn or manage subagents.

This keeps surface-specific latency/product behavior, but centralizes model-visible capability docs for overlapping desktop surfaces and adds drift guards so prompt docs stay backed by real agent tool declarations. The desktop prompt keeps its prior chat-specific routing contract instead of silently inheriting realtime voice behavior or losing old data-lookup guidance.

## Review Follow-up
- addressed current Codex/cubic review comments around temp auth-token persistence, auth seed failure handling, sign-out status cleanup, bridge-start failure reporting, Ask-mode `spawn_agent` gating, realtime `manage_agent_pills` action parsing, and missing pi-mono `save_knowledge_graph`
- verified older unresolved threads for stdio forwarding, retention pruning, background title registration, and realtime floating-pill status are already addressed by the current diff

## Testing
- `git diff --check`
- `bash -n desktop/macos/run.sh`
- `xcrun swift test --package-path Desktop --filter 'ChatDiscoverabilityTests|HubSystemInstructionTests'`
- `npm run build` in `desktop/macos/agent`
- `npm test` in `desktop/macos/pi-mono-extension` with the sibling agent `node_modules` symlink and `TMPDIR=/private/tmp`
- rebuilt and launched `/Applications/Omi Dev.app` via `./run.sh --yolo`
- dogfooded typed floating Ask Omi through `./scripts/omi-ctl action ask ...`; logs showed Omi tools registered, `spawn_agent` used, and `get_task_agent_status` / `manage_agent_pills` used against floating pills

## Review
- pre-implementation subagent critique completed; scope narrowed to model-visible capability docs plus drift guards, not full cross-language schema generation
- post-implementation subagent review completed; fixed false-authority wording/tests and changed realtime status from raw JSON to a voice-friendly summary
- follow-up subagent review completed for floating pill scope; fixed lifecycle findings around dismiss/trim interrupting live providers, stale `completedAt` during follow-ups, and dismissing a recording pill voice follow-up
