### PR TITLE
fix(admin): show all data — define active user as any macOS event, not removed 'App Became Active'

### DIFF
--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -42,10 +42,9 @@ export async function GET(request: NextRequest) {
       SELECT
         toDate(timestamp) as day,
         countIf(event = 'App Crash Detected') as crashes,
-        countIf(DISTINCT distinct_id, event = 'App Became Active') as users
+        count(DISTINCT distinct_id) as users
       FROM events
-      WHERE (event = 'App Crash Detected' OR event = 'App Became Active')
-        AND properties.$os_name = 'macOS'
+      WHERE properties.$os_name = 'macOS'
         AND timestamp >= now() - interval ${days} day
       GROUP BY day
       ORDER BY day
@@ -97,8 +96,7 @@ export async function GET(request: NextRequest) {
               query: `
                 SELECT toDate(timestamp) as day, count(DISTINCT distinct_id) as users
                 FROM events
-                WHERE event = 'App Became Active'
-                  AND properties.$os_name = 'macOS'
+                WHERE properties.$os_name = 'macOS'
                   AND timestamp >= now() - interval ${days} day
                 GROUP BY day ORDER BY day
               `,

--- a/web/admin/app/api/omi/stats/dau-trends/route.ts
+++ b/web/admin/app/api/omi/stats/dau-trends/route.ts
@@ -30,14 +30,14 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ data: cache.data, days });
     }
 
-    // Use PostHog HogQL for daily unique macOS users with "App Became Active"
+    // Daily unique macOS users = distinct clients emitting ANY event (rename-proof;
+    // the old `App Became Active` lifecycle event was removed from the desktop app).
     const hogql = `
       SELECT
         toDate(timestamp) as day,
         count(DISTINCT distinct_id) as users
       FROM events
-      WHERE event = 'App Became Active'
-        AND properties.$os_name = 'macOS'
+      WHERE properties.$os_name = 'macOS'
         AND timestamp >= now() - interval ${days} day
       GROUP BY day
       ORDER BY day

--- a/web/admin/app/api/omi/stats/macos-versions/route.ts
+++ b/web/admin/app/api/omi/stats/macos-versions/route.ts
@@ -125,8 +125,7 @@ export async function GET(request: NextRequest) {
           timestamp
         ) AS app_version
       FROM events
-      WHERE event = 'App Became Active'
-        AND properties.$os_name = 'macOS'
+      WHERE properties.$os_name = 'macOS'
         AND toDate(timestamp) = today()
       GROUP BY actor_id
       ORDER BY actor_id ASC

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -60,7 +60,7 @@ export async function GET(request: NextRequest) {
           COALESCE(person_id, distinct_id) AS actor_id,
           min(toDate(timestamp)) AS cohort_date
         FROM events
-        WHERE event = 'App Became Active'
+        WHERE 1 = 1
           ${eventFilter}
         GROUP BY actor_id
         HAVING cohort_date >= today() - INTERVAL ${days} DAY
@@ -95,7 +95,7 @@ export async function GET(request: NextRequest) {
           COALESCE(person_id, distinct_id) AS actor_id,
           toDate(timestamp) AS event_date
         FROM events
-        WHERE event = 'App Became Active'
+        WHERE 1 = 1
           ${eventFilter}
           AND COALESCE(person_id, distinct_id) IN (${actorIds})
           AND timestamp >= today() - INTERVAL ${days} DAY

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -80,8 +80,7 @@ export async function GET(request: NextRequest) {
           toMonday(toDate(timestamp)) as week,
           count(DISTINCT distinct_id) as active_users
         FROM events
-        WHERE event = 'App Became Active'
-          AND properties.$os_name = 'macOS'
+        WHERE properties.$os_name = 'macOS'
           AND timestamp >= now() - interval ${days} day
         GROUP BY week
         ORDER BY week
@@ -96,16 +95,14 @@ export async function GET(request: NextRequest) {
         FROM (
           SELECT distinct_id as did, toMonday(toDate(timestamp)) as week
           FROM events
-          WHERE event = 'App Became Active'
-            AND properties.$os_name = 'macOS'
+          WHERE properties.$os_name = 'macOS'
             AND timestamp >= now() - interval ${days} day
           GROUP BY did, week
         ) curr
         INNER JOIN (
           SELECT distinct_id as did, toMonday(toDate(timestamp)) as week
           FROM events
-          WHERE event = 'App Became Active'
-            AND properties.$os_name = 'macOS'
+          WHERE properties.$os_name = 'macOS'
             AND timestamp >= now() - interval ${days + 7} day
           GROUP BY did, week
         ) prev ON curr.did = prev.did AND prev.week = curr.week - interval 7 day
@@ -119,8 +116,7 @@ export async function GET(request: NextRequest) {
           toDate(timestamp) as day,
           count(DISTINCT distinct_id) as dau
         FROM events
-        WHERE event = 'App Became Active'
-          AND properties.$os_name = 'macOS'
+        WHERE properties.$os_name = 'macOS'
           AND timestamp >= now() - interval ${days} day
         GROUP BY day
         ORDER BY day
@@ -136,8 +132,7 @@ export async function GET(request: NextRequest) {
             distinct_id,
             count(DISTINCT toDate(timestamp)) as days_active
           FROM events
-          WHERE event = 'App Became Active'
-            AND properties.$os_name = 'macOS'
+          WHERE properties.$os_name = 'macOS'
             AND timestamp >= now() - interval 30 day
           GROUP BY distinct_id
         )
@@ -188,8 +183,7 @@ export async function GET(request: NextRequest) {
       hogql(apiKey, projectId, host, `
         SELECT count(DISTINCT distinct_id)
         FROM events
-        WHERE event = 'App Became Active'
-          AND properties.$os_name = 'macOS'
+        WHERE properties.$os_name = 'macOS'
           AND timestamp >= now() - interval 7 day
       `),
 
@@ -197,8 +191,7 @@ export async function GET(request: NextRequest) {
       hogql(apiKey, projectId, host, `
         SELECT count(DISTINCT distinct_id)
         FROM events
-        WHERE event = 'App Became Active'
-          AND properties.$os_name = 'macOS'
+        WHERE properties.$os_name = 'macOS'
           AND timestamp >= now() - interval 30 day
       `),
     ]);


### PR DESCRIPTION
## Problem
admin.omi.me panels (DAU trend, **14-day retention**, viral/growth-accounting, macOS active versions, crash-free rate) counted *active users* via `event = 'App Became Active'`. The desktop app **removed** that lifecycle event, so every metric that used it as the active-user denominator collapsed toward zero — the dashboard stopped "showing all data".

## Fix
Define active user **rename-proof**: distinct macOS clients emitting **any** event (`properties.$os_name = 'macOS'`, no event predicate). Routes fixed:
- `stats/dau-trends` — daily DAU
- `stats/retention/posthog` — cohort + return now any-event; platform toggle preserved via `WHERE 1 = 1 ${eventFilter}` (macOS / All Platforms both work)
- `stats/viral-metrics` — 7 active-user denominators (WAU, MAU, weekly active, retained, daily DAU, power-user curve)
- `stats/macos-versions` — active-version distribution
- `stats/crash-rate` — crash-free denominator (`countIf(DISTINCT …)` → `count(DISTINCT distinct_id)`)

**Unchanged** (genuinely event-specific): `Sign In Completed` (new users), `Memory Created` (activation), `App Crash Detected` (crashes).

## Verify
- `tsc --noEmit` clean for all changed routes (only stale pre-existing `.next/types` error for the already-deleted mixpanel route).
- ⚠️ Live PostHog confirmation was rate-limited (429) at author time; fix follows the documented guardrail in the team's analytics notes (active = any macOS event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

