### PR TITLE
feat(app): PostHog analytics for Transcribe Later (enable/use/disable)

### DIFF
--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -330,6 +330,7 @@ class _ProfilePageState extends State<ProfilePage> {
             final enabled = SharedPreferencesUtil().batchModeEnabled;
             Future<void> setEnabled(bool value) async {
               SharedPreferencesUtil().batchModeEnabled = value;
+              PlatformManager.instance.analytics.transcribeLaterToggled(enabled: value);
               final docs = await getApplicationDocumentsDirectory();
               await SharedPreferencesUtil().saveString('batchAudioDir', docs.path);
               // Batch capture takes precedence over background streaming.

--- a/app/lib/providers/local_recordings_provider.dart
+++ b/app/lib/providers/local_recordings_provider.dart
@@ -14,6 +14,7 @@ import 'package:omi/utils/audio_player_utils.dart';
 import 'package:omi/utils/batch_recording.dart';
 import 'package:omi/utils/conversation_sync_utils.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/waveform_utils.dart';
 
 /// Owns the batch/offline-mode recordings captured natively to the phone.
@@ -80,7 +81,11 @@ class LocalRecordingsProvider extends ChangeNotifier {
     _conversationProvider = provider;
   }
 
-  void _onRecordingFinalized(String _) => refresh();
+  void _onRecordingFinalized(String fileName) {
+    refresh().then((_) {
+      PlatformManager.instance.analytics.transcribeLaterRecordingCaptured(durationSeconds: _secondsByFile[fileName]);
+    });
+  }
 
   // ───────────────────────── scanning ─────────────────────────
 
@@ -220,6 +225,9 @@ class LocalRecordingsProvider extends ChangeNotifier {
       _isUploading = false;
       _uploadingName = null;
       await refresh();
+    }
+    if (outcome == LocalUploadOutcome.started) {
+      PlatformManager.instance.analytics.transcribeLaterRecordingProcessed();
     }
     return outcome;
   }

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -244,12 +244,12 @@ class AnalyticsManager {
       track('User Acquisition Source', properties: {'source': source});
 
   void settingsSaved({bool hasWebhookConversationCreated = false, bool hasWebhookTranscriptReceived = false}) => track(
-    'Developer Settings Saved',
-    properties: {
-      'has_webhook_memory_created': hasWebhookConversationCreated,
-      'has_webhook_transcript_received': hasWebhookTranscriptReceived,
-    },
-  );
+        'Developer Settings Saved',
+        properties: {
+          'has_webhook_memory_created': hasWebhookConversationCreated,
+          'has_webhook_transcript_received': hasWebhookTranscriptReceived,
+        },
+      );
 
   void pageOpened(String name) => track('$name Opened');
 
@@ -278,6 +278,15 @@ class AnalyticsManager {
   void phoneMicRecordingStarted() => track('Phone Mic Recording Started');
 
   void phoneMicRecordingStopped() => track('Phone Mic Recording Stopped');
+
+  // Transcribe Later (batch / offline capture)
+  void transcribeLaterToggled({required bool enabled}) =>
+      track('Transcribe Later Toggled', properties: {'enabled': enabled});
+
+  void transcribeLaterRecordingCaptured({int? durationSeconds}) =>
+      track('Transcribe Later Recording Captured', properties: {'duration_seconds': durationSeconds});
+
+  void transcribeLaterRecordingProcessed() => track('Transcribe Later Recording Processed');
 
   // Phone Calls (VoIP)
   void phoneCallPageOpened() => track('Phone Call Page Opened');
@@ -457,18 +466,19 @@ class AnalyticsManager {
     required String chatTargetId,
     required bool isPersonaChat,
     required bool isVoiceInput,
-  }) => track(
-    'Chat Message Sent',
-    properties: {
-      'message_length': message.length,
-      'message_word_count': message.split(' ').length,
-      'includes_files': includesFiles,
-      'number_of_files': numberOfFiles,
-      'chat_target_id': chatTargetId,
-      'is_persona_chat': isPersonaChat,
-      'is_voice_input': isVoiceInput,
-    },
-  );
+  }) =>
+      track(
+        'Chat Message Sent',
+        properties: {
+          'message_length': message.length,
+          'message_word_count': message.split(' ').length,
+          'includes_files': includesFiles,
+          'number_of_files': numberOfFiles,
+          'chat_target_id': chatTargetId,
+          'is_persona_chat': isPersonaChat,
+          'is_voice_input': isVoiceInput,
+        },
+      );
 
   void chatVoiceInputUsed({required String chatTargetId, required bool isPersonaChat}) {
     track('Chat Voice Input Used', properties: {'chat_target_id': chatTargetId, 'is_persona_chat': isPersonaChat});
@@ -489,9 +499,9 @@ class AnalyticsManager {
       track('Show Discarded Conversations Toggled', properties: {'show_discarded': showDiscarded});
 
   void shortConversationThresholdChanged(int thresholdSeconds) => track(
-    'Short Conversation Threshold Changed',
-    properties: {'threshold_seconds': thresholdSeconds, 'threshold_minutes': thresholdSeconds ~/ 60},
-  );
+        'Short Conversation Threshold Changed',
+        properties: {'threshold_seconds': thresholdSeconds, 'threshold_minutes': thresholdSeconds ~/ 60},
+      );
 
   void voiceResponseToggled(bool enabled) => track('Voice Response Audio Toggled', properties: {'enabled': enabled});
 
@@ -506,28 +516,28 @@ class AnalyticsManager {
   void conversationMergeSelectionModeExited() => track('Conversation Merge Selection Mode Exited');
 
   void conversationSelectedForMerge(String conversationId, int totalSelected) => track(
-    'Conversation Selected For Merge',
-    properties: {'conversation_id': conversationId, 'total_selected': totalSelected},
-  );
+        'Conversation Selected For Merge',
+        properties: {'conversation_id': conversationId, 'total_selected': totalSelected},
+      );
 
   void conversationMergeInitiated(List<String> conversationIds) => track(
-    'Conversation Merge Initiated',
-    properties: {'conversation_count': conversationIds.length, 'conversation_ids': conversationIds},
-  );
+        'Conversation Merge Initiated',
+        properties: {'conversation_count': conversationIds.length, 'conversation_ids': conversationIds},
+      );
 
   void conversationMergeCompleted(String mergedConversationId, List<String> removedConversationIds) => track(
-    'Conversation Merge Completed',
-    properties: {
-      'merged_conversation_id': mergedConversationId,
-      'removed_count': removedConversationIds.length,
-      'removed_conversation_ids': removedConversationIds,
-    },
-  );
+        'Conversation Merge Completed',
+        properties: {
+          'merged_conversation_id': mergedConversationId,
+          'removed_count': removedConversationIds.length,
+          'removed_conversation_ids': removedConversationIds,
+        },
+      );
 
   void conversationMergeFailed(List<String> conversationIds) => track(
-    'Conversation Merge Failed',
-    properties: {'conversation_count': conversationIds.length, 'conversation_ids': conversationIds},
-  );
+        'Conversation Merge Failed',
+        properties: {'conversation_count': conversationIds.length, 'conversation_ids': conversationIds},
+      );
 
   // Important Conversation Share Events
   void importantConversationNotificationReceived(String conversationId) =>
@@ -537,14 +547,14 @@ class AnalyticsManager {
       track('Share To Contacts Sheet Opened', properties: {'conversation_id': conversationId});
 
   void shareToContactsSelected(String conversationId, int contactCount) => track(
-    'Share To Contacts Selected',
-    properties: {'conversation_id': conversationId, 'contact_count': contactCount},
-  );
+        'Share To Contacts Selected',
+        properties: {'conversation_id': conversationId, 'contact_count': contactCount},
+      );
 
   void shareToContactsSmsOpened(String conversationId, int contactCount) => track(
-    'Share To Contacts SMS Opened',
-    properties: {'conversation_id': conversationId, 'contact_count': contactCount},
-  );
+        'Share To Contacts SMS Opened',
+        properties: {'conversation_id': conversationId, 'contact_count': contactCount},
+      );
 
   void chatMessageConversationClicked(ServerConversation conversation) =>
       track('Chat Message Memory Clicked', properties: getConversationEventProperties(conversation));
@@ -681,11 +691,11 @@ class AnalyticsManager {
       track('Delete Account Kept Account', properties: {'step': step, 'reason': reason});
 
   void deleteUser() => PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
-    final adapter = _adapter;
-    if (adapter == null) return;
-    adapter.track(eventName: 'User Deleted');
-    adapter.reset();
-  });
+        final adapter = _adapter;
+        if (adapter == null) return;
+        adapter.track(eventName: 'User Deleted');
+        adapter.reset();
+      });
 
   // Apps Filter
   void appsFilterOpened() => track('Apps Filter Opened');


### PR DESCRIPTION
## Summary

Adds PostHog analytics for the **Transcribe Later** (batch / offline capture) feature — previously untracked, so we had no idea how many people enable, use, or abandon it.

## Events

| Event | Properties | Fired when |
|---|---|---|
| `Transcribe Later Toggled` | `enabled: bool` | User flips the toggle in Settings (one event for enable **and** disable — filter by `enabled`) |
| `Transcribe Later Recording Captured` | `duration_seconds` | A recording is finalized natively (rotation / gap / stop / manual cut / disconnect) |
| `Transcribe Later Recording Processed` | — | A recording is successfully sent to transcribe via **Process Now** (200/202) |

Together these give a funnel: **enabled → captured → processed**, plus disable counts.

## Where

- `AnalyticsManager` — three new helper methods next to the other recording events.
- `profile.dart` — fires `Toggled` in the Transcribe Later settings switch.
- `LocalRecordingsProvider` — fires `Captured` on the native finalize callback (duration pulled from the per-file cache) and `Processed` when `upload()` returns a started outcome.

## Notes
- Follows the existing `track(eventName, properties)` pattern; null properties are dropped by `track()`, so `duration_seconds` is simply omitted when unknown.
- `flutter analyze` clean. No new strings / no l10n impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

