### PR TITLE
fix(app) capture l10n strings before async gap in LanguageSelectionDialog

### DIFF
--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -163,9 +163,8 @@ class LanguageSelectionDialog {
 
                                 return ListTile(
                                   title: Text(language.key, style: const TextStyle(color: Colors.white)),
-                                  trailing: isSelected
-                                      ? const Icon(Icons.check_circle, color: Colors.deepPurple)
-                                      : null,
+                                  trailing:
+                                      isSelected ? const Icon(Icons.check_circle, color: Colors.deepPurple) : null,
                                   selected: isSelected,
                                   selectedTileColor: Colors.deepPurple.withOpacity(0.2),
                                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -220,6 +219,8 @@ class LanguageSelectionDialog {
                   onPressed: selectedLanguage == null
                       ? null
                       : () async {
+                          final successMsg = context.l10n.languageSetTo(selectedLanguageName!);
+                          final failMsg = context.l10n.failedToSetLanguage;
                           final userProvider = Provider.of<UserProvider>(context, listen: false);
                           final success = await homeProvider.updateUserPrimaryLanguage(
                             selectedLanguage!,
@@ -229,9 +230,9 @@ class LanguageSelectionDialog {
                           if (success) {
                             Provider.of<CaptureProvider>(context, listen: false).onRecordProfileSettingChanged();
                             Navigator.of(context).pop();
-                            AppSnackbar.showSnackbarSuccess(context.l10n.languageSetTo(selectedLanguageName!));
+                            AppSnackbar.showSnackbarSuccess(successMsg);
                           } else {
-                            AppSnackbar.showSnackbarError(context.l10n.failedToSetLanguage);
+                            AppSnackbar.showSnackbarError(failMsg);
                           }
                         },
                   style: ElevatedButton.styleFrom(

--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -37,21 +37,7 @@ class LanguageSelectionDialog {
         : null;
     String searchQuery = '';
     List<MapEntry<String, String>> filteredLanguages = List.from(languages);
-    final ScrollController _scrollController = ScrollController();
-
-    // Function to scroll to the selected language
-    void scrollToSelectedLanguage() {
-      if (selectedLanguage != null) {
-        final selectedIndex = filteredLanguages.indexWhere((lang) => lang.value == selectedLanguage);
-        if (selectedIndex != -1 && _scrollController.hasClients) {
-          _scrollController.animateTo(
-            selectedIndex * 56.0, // Approximate height of each list item
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeInOut,
-          );
-        }
-      }
-    }
+    final ScrollController scrollController = ScrollController();
 
     await showDialog(
       context: context,
@@ -155,7 +141,7 @@ class LanguageSelectionDialog {
                               child: Text(context.l10n.noLanguagesFound, style: const TextStyle(color: Colors.grey)),
                             )
                           : ListView.builder(
-                              controller: _scrollController,
+                              controller: scrollController,
                               itemCount: filteredLanguages.length,
                               itemBuilder: (context, index) {
                                 final language = filteredLanguages[index];
@@ -192,8 +178,8 @@ class LanguageSelectionDialog {
                             final selectedIndex = filteredLanguages.indexWhere(
                               (lang) => lang.value == selectedLanguage,
                             );
-                            if (selectedIndex != -1 && _scrollController.hasClients) {
-                              _scrollController.animateTo(
+                            if (selectedIndex != -1 && scrollController.hasClients) {
+                              scrollController.animateTo(
                                 selectedIndex * 56.0, // Approximate height of each list item
                                 duration: const Duration(milliseconds: 300),
                                 curve: Curves.easeInOut,


### PR DESCRIPTION
## Summary

- Fixes a null-check crash (`AppLocalizations.of(context)!` → null) reported in Crashlytics for `LanguageSelectionDialog`

AppLocalizations.of
io.flutter.plugins.firebase.crashlytics.FlutterError - Null check operator used on a null value

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/a75d7158832bb847ee24e1f0b92244e2?time=7d&types=crash&sessionEventKey=6A3124AF0208000A2A6D164758051250_2230383181922403972

Logs:

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
       at AppLocalizations.of(app_localizations.dart:117)
       at LocalizationExtension.l10n(l10n_extensions.dart:21)
       at LanguageSelectionDialog.show.<fn>.<fn>.<fn>(language_selection_dialog.dart:233)
```

- After `await homeProvider.updateUserPrimaryLanguage(...)` and `Navigator.of(context).pop()`, the dialog's `BuildContext` loses its `AppLocalizations` ancestor — calling `context.l10n` at that point throws `Null check operator used on a null value`
- Fix: capture the two translated strings (`languageSetTo` / `failedToSetLanguage`) **before** the async gap, so they are plain `String` values by the time they are used

## Test plan

- [ ] Open Language Selection dialog, pick a language, tap Confirm
- [ ] Verify success snackbar appears with correct language name
- [ ] Tap Confirm when update fails — verify error snackbar appears
- [ ] No crash in Crashlytics under `AppLocalizations.of` / `l10n_extensions.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

