### PR TITLE
fix(admin): retry PostHog 429s so dashboard panels load

### DIFF
--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { posthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -50,16 +51,7 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: { kind: "HogQLQuery", query: hogql },
-      }),
-    });
+    const response = await posthogFetch(host, projectId, apiKey, hogql);
 
     if (!response.ok) {
       // HogQL countIf with DISTINCT might not be supported — fall back to two queries

--- a/web/admin/app/api/omi/stats/dau-trends/route.ts
+++ b/web/admin/app/api/omi/stats/dau-trends/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { posthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -43,16 +44,7 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: { kind: "HogQLQuery", query: hogql },
-      }),
-    });
+    const response = await posthogFetch(host, projectId, apiKey, hogql);
 
     if (!response.ok) {
       const text = await response.text();

--- a/web/admin/app/api/omi/stats/macos-versions/route.ts
+++ b/web/admin/app/api/omi/stats/macos-versions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin, { getDb } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
+import { posthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -31,20 +32,7 @@ type Breakdown = {
 };
 
 async function posthogQuery(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      query: {
-        kind: "HogQLQuery",
-        query,
-      },
-    }),
-  });
+  const response = await posthogFetch(host, projectId, apiKey, query);
 
   if (!response.ok) {
     const text = await response.text();

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -1,25 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
+import { posthogFetch } from '@/lib/posthog';
 export const dynamic = 'force-dynamic';
 
 type RetentionPoint = { day: number; retention: number };
 type CohortRow = { date: string; users: number; data: RetentionPoint[] };
 
 async function posthogQuery(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({
-      query: {
-        kind: 'HogQLQuery',
-        query,
-      },
-    }),
-  });
+  const response = await posthogFetch(host, projectId, apiKey, query);
 
   if (!response.ok) {
     const text = await response.text();

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { posthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -7,14 +8,7 @@ let cache: { data: any; days: number; timestamp: number } | null = null;
 const CACHE_TTL = 30 * 60 * 1000;
 
 async function hogql(apiKey: string, projectId: string, host: string, query: string) {
-  const resp = await fetch(`${host}/api/projects/${projectId}/query/`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
-  });
+  const resp = await posthogFetch(host, projectId, apiKey, query);
   if (!resp.ok) {
     const text = await resp.text();
     throw new Error(`PostHog query error ${resp.status}: ${text.slice(0, 200)}`);

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -1,0 +1,34 @@
+// Shared PostHog HogQL fetch with 429 backoff.
+//
+// PostHog's query endpoint is aggressively burst-rate-limited (HTTP 429,
+// "Request was throttled. Expected available in 1 second."). The dashboard
+// fires ~8 stat routes at once on load, so without retry these queries 429
+// and the panels render errors / empty. Retrying with short backoff lets the
+// burst drain and the per-route caches populate.
+
+export async function posthogFetch(
+  host: string,
+  projectId: string,
+  apiKey: string,
+  query: string,
+  { maxRetries = 5 }: { maxRetries?: number } = {},
+): Promise<Response> {
+  const url = `${host}/api/projects/${projectId}/query/`;
+  let res!: Response;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+    });
+    if (res.status !== 429 || attempt === maxRetries) return res;
+    // Burst throttle clears in ~1s; back off linearly with jitter.
+    const waitMs = 1000 * (attempt + 1) + Math.floor(Math.random() * 400);
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+  return res;
+}


### PR DESCRIPTION
Follow-up to #8106. Live verification showed the panels were **still empty** — `dau-trends` 502, `viral-metrics`/`macos-versions`/`retention` 500, `crash-rate` 200-but-all-zeros — all caused by PostHog **429 throttling** (the dashboard fires ~8 HogQL queries at once on load; none retried).

Adds `lib/posthog.ts` `posthogFetch()` with linear+jitter 429 backoff (5 retries) and routes all five PostHog stat routes through it, so queries complete and the per-route caches populate. #8106 fixed *what* the queries count (any macOS event vs the removed `App Became Active`); this fixes them *completing*.

tsc clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

