### PR TITLE
[codex] Preserve PTT playback across audio route changes

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
@@ -1,6 +1,45 @@
 import AVFoundation
 import Foundation
 
+/// Tracks buffers that AVAudioPlayerNode owns but has not reported as played yet.
+///
+/// `AVAudioPlayerNode.stop()` discards every scheduled buffer. Route/sample-rate
+/// changes force us to stop and rebuild the node graph, so the app must own a
+/// mirror of the scheduled tail and replay it after recovery. Keep this small
+/// state machine separate from AVFoundation calls so route-change behavior is
+/// testable without real audio hardware.
+final class StreamingPCMPlaybackQueue<Buffer: AnyObject> {
+  private(set) var scheduledBuffers: [Buffer] = []
+  private(set) var generation = 0
+
+  var isEmpty: Bool { scheduledBuffers.isEmpty }
+
+  @discardableResult
+  func appendScheduled(_ buffer: Buffer) -> Int {
+    scheduledBuffers.append(buffer)
+    return generation
+  }
+
+  func markPlayed(_ buffer: Buffer, generation completionGeneration: Int) {
+    guard completionGeneration == generation else { return }
+    if let index = scheduledBuffers.firstIndex(where: { $0 === buffer }) {
+      scheduledBuffers.remove(at: index)
+    }
+  }
+
+  func buffersToReplayAfterConfigurationChange() -> [Buffer] {
+    let buffers = scheduledBuffers
+    generation += 1
+    scheduledBuffers.removeAll()
+    return buffers
+  }
+
+  func clearForExplicitStop() {
+    generation += 1
+    scheduledBuffers.removeAll()
+  }
+}
+
 /// Plays streamed mono PCM16 audio incrementally (OpenAI Realtime / Gemini Live
 /// output is 24 kHz). Feed chunks with `enqueue(_:)`; they play back-to-back in
 /// arrival order. Used by `RealtimeHubController` to play the realtime model's
@@ -13,6 +52,7 @@ final class StreamingPCMPlayer {
   private let player = AVAudioPlayerNode()
   private let format: AVAudioFormat
   private var configObserver: NSObjectProtocol?
+  private let playbackQueue = StreamingPCMPlaybackQueue<AVAudioPCMBuffer>()
 
   init(sampleRate: Double = 24000) {
     // Float32 mono at the source rate; the mixer resamples to the device rate.
@@ -32,11 +72,15 @@ final class StreamingPCMPlayer {
     ) { [weak self] _ in
       guard let self = self else { return }
       log("StreamingPCMPlayer: audio config changed — rebuilding engine")
+      let buffersToReplay = self.playbackQueue.buffersToReplayAfterConfigurationChange()
       self.player.stop()
       self.engine.stop()
       self.engine.disconnectNodeOutput(self.player)
       self.engine.connect(self.player, to: self.engine.mainMixerNode, format: self.format)
       self.ensureRunning()
+      for buffer in buffersToReplay {
+        self.schedule(buffer)
+      }
     }
   }
 
@@ -70,7 +114,6 @@ final class StreamingPCMPlayer {
 
   /// `data` = little-endian Int16 PCM, mono, at the configured sample rate.
   func enqueue(_ data: Data) {
-    ensureRunning()
     let sampleCount = data.count / 2
     guard sampleCount > 0,
       let buffer = AVAudioPCMBuffer(
@@ -84,10 +127,22 @@ final class StreamingPCMPlayer {
         channel[i] = max(-1.0, min(1.0, Float(src[i]) / 32768.0))
       }
     }
-    player.scheduleBuffer(buffer)
+    ensureRunning()
+    schedule(buffer)
+  }
+
+  private func schedule(_ buffer: AVAudioPCMBuffer) {
+    let generation = playbackQueue.appendScheduled(buffer)
+    player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self, weak buffer] _ in
+      DispatchQueue.main.async {
+        guard let self, let buffer else { return }
+        self.playbackQueue.markPlayed(buffer, generation: generation)
+      }
+    }
   }
 
   func stop() {
+    playbackQueue.clearForExplicitStop()
     player.stop()
     engine.stop()
   }

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Omi_Computer
+
+final class StreamingPCMPlaybackQueueTests: XCTestCase {
+  private final class BufferBox {}
+
+  func testConfigurationChangeReturnsScheduledTailForReplay() {
+    let queue = StreamingPCMPlaybackQueue<BufferBox>()
+    let first = BufferBox()
+    let second = BufferBox()
+
+    queue.appendScheduled(first)
+    queue.appendScheduled(second)
+
+    let replay = queue.buffersToReplayAfterConfigurationChange()
+
+    XCTAssertTrue(replay[0] === first)
+    XCTAssertTrue(replay[1] === second)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testReplayedBuffersUseNewGenerationSoStaleCompletionsCannotDropThem() {
+    let queue = StreamingPCMPlaybackQueue<BufferBox>()
+    let buffer = BufferBox()
+
+    let oldGeneration = queue.appendScheduled(buffer)
+    _ = queue.buffersToReplayAfterConfigurationChange()
+    let newGeneration = queue.appendScheduled(buffer)
+
+    queue.markPlayed(buffer, generation: oldGeneration)
+    XCTAssertFalse(
+      queue.isEmpty,
+      "A completion from the pre-rebuild player must not remove the replayed buffer"
+    )
+
+    queue.markPlayed(buffer, generation: newGeneration)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testExplicitStopClearsScheduledBuffersAndInvalidatesCompletions() {
+    let queue = StreamingPCMPlaybackQueue<BufferBox>()
+    let buffer = BufferBox()
+
+    let oldGeneration = queue.appendScheduled(buffer)
+    queue.clearForExplicitStop()
+
+    XCTAssertTrue(queue.isEmpty)
+
+    queue.appendScheduled(buffer)
+    queue.markPlayed(buffer, generation: oldGeneration)
+
+    XCTAssertFalse(
+      queue.isEmpty,
+      "A completion from before explicit stop must not mutate the next playback generation"
+    )
+  }
+
+  func testPlayedBufferIsRemovedWithoutAffectingLaterScheduledBuffers() {
+    let queue = StreamingPCMPlaybackQueue<BufferBox>()
+    let first = BufferBox()
+    let second = BufferBox()
+
+    let generation = queue.appendScheduled(first)
+    queue.appendScheduled(second)
+
+    queue.markPlayed(first, generation: generation)
+
+    XCTAssertEqual(queue.scheduledBuffers.count, 1)
+    XCTAssertTrue(queue.scheduledBuffers[0] === second)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes realtime PTT reply truncation when macOS audio route/sample-rate changes fire during streamed playback.

## Root cause

`StreamingPCMPlayer` rebuilt its `AVAudioEngine` on `AVAudioEngineConfigurationChange` by calling `AVAudioPlayerNode.stop()`. That drops every scheduled PCM buffer owned by the player node, so users could hear only the first part of a realtime voice response.

## Changes

- Adds a small `StreamingPCMPlaybackQueue` state machine that mirrors scheduled-but-not-yet-played buffers.
- Replays the unplayed scheduled tail after audio engine configuration changes instead of losing it.
- Keeps explicit `stop()` semantics separate from route-change recovery, so user/app cancellation still clears playback.
- Adds focused SwiftPM tests for config-change replay, stale completion invalidation, explicit stop, and normal played-buffer removal.

## Verification

- `xcrun swift test --package-path Desktop --filter StreamingPCMPlaybackQueueTests`
- Rebuilt, signed, installed, and launched `/Applications/Omi Dev.app` with `desktop/macos/run.sh --yolo` for local PTT testing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

