### PR TITLE
fix(desktop): dedup staged-task backendId collisions in task sync (#8128)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed AI-extracted tasks repeatedly failing to sync when the server returned a duplicate task ID"
+  ],
   "releases": [
     {
       "version": "0.11.495",

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
@@ -89,6 +89,20 @@ actor StagedTaskStorage {
                 throw ActionItemStorageError.recordNotFound
             }
 
+            // The backend deduplicates tasks and can return a backendId that another
+            // local staged row already owns. Assigning it here would violate the
+            // UNIQUE(backendId) constraint and fail the sync-status update forever
+            // (Sentry OMI-DESKTOP-8E). Resolve idempotently: this row is a duplicate
+            // of an already-synced task, so drop it instead of crashing.
+            let backendIdTaken = try StagedTaskRecord
+                .filter(Column("backendId") == backendId)
+                .filter(Column("id") != id)
+                .fetchCount(database) > 0
+            if backendIdTaken {
+                try record.delete(database)
+                return
+            }
+
             record.backendId = backendId
             record.backendSynced = true
             record.updatedAt = Date()


### PR DESCRIPTION
## Bug
Sentry **OMI-DESKTOP-8E** — `UNIQUE constraint failed: staged_tasks.backendId` (1,169 events / 225 users, first seen 2026-03-24, still firing). Reported in #8128 as a top desktop data-integrity issue (p1).

## Root cause
`StagedTaskStorage.markSynced(id:backendId:)` (`Rewind/Core/StagedTaskStorage.swift`) sets `record.backendId = backendId` and `UPDATE`s the row unconditionally. The backend deduplicates AI-extracted tasks, so two locally-staged rows (e.g. duplicate extractions) can be assigned the **same** `backendId`. The second `markSynced` then violates the `UNIQUE(backendId)` constraint on `staged_tasks`, and since the sync is retried, it throws on every attempt — an error storm rather than a one-off.

## Fix
Make `markSynced` idempotent: before assigning, check whether the `backendId` is already owned by a *different* row. If so, this row is a duplicate of an already-synced task — delete it instead of crashing. The own-row case (`id` already holds this `backendId`) is excluded by the `id != id` filter, so re-calls still no-op cleanly. `updateEmbedding` is a raw `UPDATE … WHERE id = ?`, so it harmlessly no-ops if the embedding job lands after the duplicate row is removed.

Scoped to the one failing path (~13 lines, 1 source file + changelog). The mirror `ActionItemStorage.markSynced` is left untouched — it is not in the Sentry evidence and this keeps the change surgical.

## Verification
- Logic mirrors existing GRDB idioms in the same file (`filter`/`fetchCount`/`delete`).
- Not built locally (no SPM build cache in the watchdog worktree; clean build is slow). **Compile UNVERIFIED locally — CI compiles it.** UNVERIFIED at runtime against a live dedup collision.

🤖 automated by hourly watchdog; opened for review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

