### PR TITLE
fix(desktop): fix corrupted Rewind OCR that breaks screen search (#8130)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed corrupted screenshot OCR that broke screen search by defaulting Rewind OCR to Accurate mode and enabling Vision language correction"
+  ],
   "releases": [
     {
       "version": "0.11.495",

--- a/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
@@ -183,7 +183,7 @@ struct RewindSettingsView: View {
     @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
     @AppStorage("rewindRetentionDays") private var retentionDays = 7
     @AppStorage("rewindCaptureInterval") private var captureInterval = 1.0
-    @AppStorage("rewindOCRFast") private var ocrFast = true
+    @AppStorage("rewindOCRFast") private var ocrFast = false
 
     @State private var excludedApps: [String] = []
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -408,7 +408,7 @@ class RewindSettings: ObservableObject {
         // Load settings with defaults
         self.retentionDays = defaults.object(forKey: "rewindRetentionDays") as? Int ?? 7
         self.captureInterval = defaults.object(forKey: "rewindCaptureInterval") as? Double ?? 3.0
-        self.ocrRecognitionFast = defaults.object(forKey: "rewindOCRFast") as? Bool ?? true
+        self.ocrRecognitionFast = defaults.object(forKey: "rewindOCRFast") as? Bool ?? false
         self.pauseOCROnBattery = defaults.object(forKey: "rewindPauseOCROnBattery") as? Bool ?? true
         self.removedDefaults = Set(defaults.array(forKey: "rewindRemovedDefaultApps") as? [String] ?? [])
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -161,7 +161,7 @@ actor RewindOCRService {
 
     /// Extract text with bounding boxes from a CGImage
     func extractTextWithBounds(from cgImage: CGImage) async throws -> OCRResult {
-        let useFastOCR = UserDefaults.standard.object(forKey: "rewindOCRFast") as? Bool ?? true
+        let useFastOCR = UserDefaults.standard.object(forKey: "rewindOCRFast") as? Bool ?? false
         let modeName = useFastOCR ? "fast" : "accurate"
         let recognitionLevel: VNRequestTextRecognitionLevel = useFastOCR ? .fast : .accurate
 
@@ -224,7 +224,9 @@ actor RewindOCRService {
             }
 
             request.recognitionLevel = recognitionLevel
-            request.usesLanguageCorrection = false
+            // Vision defaults this to true; language correction fixes the o/0, m/rn, l/i, $/s
+            // character-substitution errors that otherwise corrupt OCR text and break screen search.
+            request.usesLanguageCorrection = true
             request.recognitionLanguages = Self.recognitionLanguages
 
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])


### PR DESCRIPTION
## Bug (#8130)
Desktop Rewind's local screenshot OCR produces heavily corrupted text for readable macOS screenshots (`omi CLI` → `¢%miCLP`, `you` → `w)u`, `Omi Stability` → `OmSStalxllty`), which also breaks local screen search/recall — exact visible phrases return no results because the indexed OCR text is mangled.

## Root cause
`RewindOCRService.extractTextWithBounds` is configured for maximum speed at the expense of fidelity:
- `recognitionLevel = .fast` by default (`rewindOCRFast` defaults to `true`). Vision's `.fast` path is character-detection based and produces exactly the reported `o`/`0`, `m`/`rn`, `l`/`i`, `$`/`s` substitution soup.
- `usesLanguageCorrection = false` — this **overrides Vision's own framework default of `true`**, removing the language-model post-processing that fixes those substitution errors.

Together they give the worst-possible OCR fidelity for the dominant Rewind content (UI/chat/prose), and the garbled text is what gets indexed for search and embeddings.

## Fix
- Re-enable `usesLanguageCorrection = true` (restores Vision's default; directly reduces substitution errors).
- Default the OCR Quality setting to **Accurate** (`rewindOCRFast` default `true` → `false`) across the three sites that read it (`RewindOCRService`, `RewindModels` settings model, `RewindOnlyView` picker). The existing **Settings → OCR Quality: Fast / Accurate** picker still lets users choose Fast ("less CPU") if they prefer.

Perf is bounded: OCR is already throttled (every-Nth-frame + perceptual dedup), runs at `.utility`/`.background` priority off the main thread, and is **paused on battery** by default (`pauseOCROnBattery`), so accurate OCR mostly runs on AC power. This is a different subsystem from the VideoChunkEncoder/memory cluster in #8127.

## Verification
- `xcrun swift build -c debug` — **build complete**, no new warnings/errors.
- Runtime OCR-quality comparison on live screenshots: **UNVERIFIED** (no signed-in capture session exercised in this run).

## Note for reviewers
The `.fast` → `.accurate` default flip is a deliberate CPU/battery-vs-accuracy tradeoff. Given screen search is currently non-functional for visible text, defaulting to Accurate seems right, but the tradeoff is your call — the language-correction line alone is a safe, isolated subset if you'd rather not flip the default.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

