### PR TITLE
fix(desktop): handle embedding 402/429 as product states, stop OCR retry storm (#8126)

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -268,6 +268,8 @@ actor EmbeddingService {
       if totalProcessed > 0 {
         log("EmbeddingService: Backfill complete — \(totalProcessed) items embedded")
       }
+    } catch let error as EmbeddingError where error.isExpectedBackendState {
+      log("EmbeddingService: Backfill stopped after \(totalProcessed) items — backend gating/limit: \(error.localizedDescription)")
     } catch {
       logError("EmbeddingService: Backfill failed after \(totalProcessed) items", error: error)
     }
@@ -330,6 +332,16 @@ actor EmbeddingService {
       case .invalidResponse: return "AI service returned an unexpected response. Please try again."
       case .serverError(let statusCode, let body): return "Embedding API error (HTTP \(statusCode)): \(body)"
       }
+    }
+
+    /// Expected product-gating / backend-limit states (paywall/trial-expired, rate-limited).
+    /// These are not actionable bugs: they should be logged locally rather than reported to
+    /// Sentry as high-priority errors, and must not drive tight retry loops.
+    var isExpectedBackendState: Bool {
+      if case .serverError(let statusCode, _) = self {
+        return statusCode == 402 || statusCode == 429
+      }
+      return false
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
@@ -144,6 +144,12 @@ actor OCREmbeddingService {
                 }
 
                 log("OCREmbeddingService: Batch embedded \(chunk.count) unique items (applied to \(chunk.reduce(0) { $0 + (duplicateGroups[$1.contentHash]?.count ?? 1) }) screenshots)")
+            } catch let error as EmbeddingService.EmbeddingError where error.isExpectedBackendState {
+                // Expected product-gating/limit (e.g. trial expired, rate limited): drop this
+                // batch instead of re-queueing. Re-queueing here tight-loops the 60s flush
+                // forever while gated, flooding Sentry; missing screenshots get re-embedded
+                // via backfill once the user is un-gated.
+                log("OCREmbeddingService: Skipping batch of \(chunk.count) items — backend gating/limit: \(error.localizedDescription)")
             } catch {
                 logError("OCREmbeddingService: Batch embed failed for \(chunk.count) items", error: error)
                 // Re-queue failed items for next flush
@@ -188,6 +194,10 @@ actor OCREmbeddingService {
                 let embeddings: [[Float]]
                 do {
                     embeddings = try await EmbeddingService.shared.embedBatch(texts: texts, taskType: "RETRIEVAL_DOCUMENT")
+                } catch let error as EmbeddingService.EmbeddingError where error.isExpectedBackendState {
+                    log("OCREmbeddingService: Backfill paused at \(totalProcessed) items — backend gating/limit: \(error.localizedDescription)")
+                    hitError = true
+                    break
                 } catch {
                     logError("OCREmbeddingService: Batch embed failed at \(totalProcessed) items, will retry on next launch", error: error)
                     hitError = true
@@ -224,6 +234,8 @@ actor OCREmbeddingService {
                 log("OCREmbeddingService: Backfill complete — \(totalProcessed) items embedded")
             }
 
+        } catch let error as EmbeddingService.EmbeddingError where error.isExpectedBackendState {
+            log("OCREmbeddingService: Backfill stopped — backend gating/limit: \(error.localizedDescription)")
         } catch {
             logError("OCREmbeddingService: Backfill failed", error: error)
         }


### PR DESCRIPTION
## Bug

Part of #8126 (acceptance criterion #1). Omi Desktop floods Sentry with high-priority "AI/embedding backend failure" issues that are actually **expected product-gating states** — chiefly HTTP 402 \`trial_expired\` from the embedding proxy:

- \`OMI-DESKTOP-2AE\` — embedding backfill failed with HTTP 402 \`trial_expired\` (27 events / 8 users)
- \`OMI-DESKTOP-C\` — embedding backfill "unexpected response" (14,207 events / 638 users)

## Root cause

When `EmbeddingService.embedBatch` returns a non-200 it throws `EmbeddingError.serverError(statusCode:body:)`. Every embedding call site treated this as an actionable error:

- `OCREmbeddingService.flushPendingEmbeddings` caught the failure, **re-queued the batch and restarted the 60s flush timer** — so a trial-expired user tight-loops forever, re-hitting the (still-402) proxy every 60s and capturing a fresh Sentry error each time. This is the retry storm behind the high event counts.
- The two backfill paths (`OCREmbeddingService.backfillIfNeeded`, `EmbeddingService.backfillIfNeeded`) `logError(...)` — which captures to Sentry as `.error`.

A 402 (paywall/trial-expired) or 429 (rate-limited) is an expected product/backoff state, not a bug.

## Fix (+24 lines, 2 files)

- Add `EmbeddingError.isExpectedBackendState` → true for HTTP **402** and **429**.
- All four embedding catch sites now branch on it: expected gating/limit states are `log(...)` locally (breadcrumb only, no Sentry capture); genuinely unexpected failures keep the existing `logError(...)` path.
- `flushPendingEmbeddings` **drops** the gated batch instead of re-queueing — no more tight 60s loop. Screenshots left without embeddings are picked up by `backfillIfNeeded` once the user is un-gated (5xx and other errors retain the existing re-queue/retry behavior).

5xx is intentionally left as an actionable error (could be a real backend bug worth Sentry).

## Verification

- `xcrun swift build -c debug` — **Build complete** (clean compile).
- UNVERIFIED at runtime: reproducing requires a live trial-expired account driving the Rewind embedding path; logic is a localized error-classification change mirroring the existing `isNonActionableTransient` pattern in `Logger.swift`.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

