### PR TITLE
fix(desktop): stop reporting expected realtime session closes as Sentry errors (#8125)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Stopped reporting expected realtime voice session closes (idle timeouts, cancellations) as errors"
+  ],
   "releases": [
     {
       "version": "0.11.498",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -591,12 +591,26 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     // released, so its death-rattle never reaches us — only the live session's errors
     // land here.
     responding = false
-    logError("RealtimeHub: session error — \(message)")
+    let aliveFor = lastWarmAt.map { Date().timeIntervalSince($0) } ?? 0
+    // Most "session error" closes are expected lifecycle events, not bugs: a socket
+    // that lived past the idle window is a normal provider idle-close (Gemini ~2.5min,
+    // 1008), and a client "operation was aborted"/cancellation is a teardown. Reporting
+    // these to Sentry as errors created the high-volume OMI-DESKTOP-27C cluster. Keep
+    // them as local logs; only capture genuine fast-fail provider errors.
+    let lower = message.lowercased()
+    let expectedClose =
+      aliveFor > 60
+      || lower.contains("aborted") || lower.contains("cancel")
+      || lower.contains("(1000)") || lower.contains("(1001)") || lower.contains("(1005)")
+    if expectedClose {
+      log("RealtimeHub: session closed (expected, alive \(Int(aliveFor))s) — \(message)")
+    } else {
+      logError("RealtimeHub: session error — \(message)")
+    }
     // The reply is dead — stop any buffered audio before collapsing.
     pcmPlayer?.stop()
     if speech.isSpeaking { speech.stopSpeaking(at: .immediate) }
     exitVoiceUI()
-    let aliveFor = lastWarmAt.map { Date().timeIntervalSince($0) } ?? 0
     teardownSession()
     // A session that died fast (connected, then the provider rejected/aborted it — e.g.
     // Gemini close 1008 / 429) is a real provider failure: try the OTHER realtime provider


### PR DESCRIPTION
## Bug (#8125)
The Sentry cluster `OMI-DESKTOP-27C` — *"RealtimeHub: session error — WebSocket closed (1008) The operation was aborted."* — is high-priority/escalating (2,442 events / 35 users at triage), continuing on prod releases 0.11.484–0.11.496 after the PTT/realtime-hub work landed.

## Root cause
`RealtimeHubController.hubDidError(_:)` reported **every** session close to Sentry via `logError(...)`, which captures an error-level event. But most of these closes are *expected lifecycle events*, not bugs:
- Gemini idle-closes the warm socket (~2.5 min, close **1008**) when no input flows — by design (see `RawWebSocket.swift` heartbeat comment).
- A client-side **"operation was aborted"/cancellation** is a teardown, not a failure.

The existing non-actionable-transient filter in `logError` (which already drops `NSURLErrorCancelled`, POSIX 89 "operation canceled", etc.) couldn't catch these because the hub close path passes a plain `String`, not an `Error` — so it bypassed the filter and flooded Sentry. The recovery logic already interprets a long-lived close (`aliveFor > 60`) as a "normal idle-close," confirming these are expected.

## Fix
Classify the close in `hubDidError` before logging:
- **Expected** (socket lived past the idle window `> 60s`, or message indicates `aborted`/`cancel`/normal close codes `1000`/`1001`/`1005`) → local `log(...)` only (still appended to the log file + breadcrumbs), no Sentry capture.
- **Genuine fast-fail provider errors** (e.g. `aliveFor < 10` rejection that triggers failover, or any unexpected close) → `logError(...)` as before.

Behavior is otherwise unchanged: failover, re-warm, and reconnect-strike logic all still run on the already-computed `aliveFor`. This is purely a telemetry-severity change — no user-facing functional change.

+~15 / -3, one file (plus a CHANGELOG line). Addresses acceptance criterion: *expected close/teardown paths no longer report as high-priority Sentry errors*; genuine unexpected closes remain captured.

Compile-checked: `xcrun swift build -c debug` succeeds (only pre-existing warnings). UNVERIFIED at runtime against a live realtime session.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

