### PR TITLE
fix(desktop): retry ffmpeg start cleanly on failure in VideoChunkEncoder (#8127)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Stopped reporting expected realtime voice session closes (idle timeouts, cancellations) as errors"
+    "Stopped reporting expected realtime voice session closes (idle timeouts, cancellations) as errors",
+    "Fixed Rewind screen recording dropping ~2.5s of footage and logging spurious errors when the video encoder failed to start, by retrying immediately on the next frame instead of waiting for an emergency reset"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -173,6 +173,18 @@ actor VideoChunkEncoder {
                 consecutiveWriteFailures += 1
                 logError("VideoChunkEncoder: Failed to start ffmpeg (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
 
+                // Reset the half-initialized chunk state so the NEXT frame cleanly retries
+                // starting ffmpeg. Without this, currentChunkStartTime stays set while
+                // ffmpegStdin is nil, so every subsequent frame skips the start path and
+                // fails inside writeFrame() with "FFmpeg not ready" — needlessly dropping
+                // ~5 frames (2.5s of Rewind footage) and emitting misleading write-failure
+                // errors until the emergency-reset threshold finally clears the state.
+                currentChunkStartTime = nil
+                currentChunkPath = nil
+                currentChunkInputSize = nil
+                currentOutputSize = nil
+                frameOffsetInChunk = 0
+
                 if consecutiveWriteFailures >= maxConsecutiveFailures {
                     logError("VideoChunkEncoder: Too many ffmpeg failures, performing emergency reset")
                     try await emergencyReset()


### PR DESCRIPTION
## Bug
Part of the desktop app-hang / Rewind-encoder Sentry cluster in #8127 (`VideoChunkEncoder` "too many write failures / emergency reset" and "FFmpeg not ready" — ~33k events each).

## Root cause
In `VideoChunkEncoder.addFrame()`, when starting a new chunk the encoder sets `currentChunkStartTime` / `currentChunkPath` / `currentChunkInputSize` **before** calling `startFFmpegProcess(...)`. If the ffmpeg start throws (e.g. `POSIX bad address`, binary not found, pipe failure), those fields stay set while `ffmpegStdin` is left `nil`.

On the **next** frame, `currentChunkStartTime != nil`, so the start path is skipped and the frame falls straight into `writeFrame()`, which fails its `guard let stdin = ffmpegStdin` with `"FFmpeg not ready"`. This repeats for every frame (~2 FPS) until `consecutiveWriteFailures` reaches the threshold (5) and `emergencyReset()` finally clears the state — so a single transient ffmpeg start hiccup needlessly drops ~5 frames (~2.5s of Rewind footage) and emits a burst of misleading write-failure errors before recovering.

## Fix
Reset the half-initialized chunk state (`currentChunkStartTime`, `currentChunkPath`, `currentChunkInputSize`, `currentOutputSize`, `frameOffsetInChunk`) in the start-failure `catch` block, so the very next frame cleanly re-enters the start path and retries ffmpeg immediately. The existing failure counter + emergency-reset bound is unchanged. Directly serves the issue's acceptance criterion that "FFmpeg-not-ready loops are bounded and recover cleanly."

Note: Sentry volume itself is already collapsed by `logError`'s 5-minute digit-normalized dedup, so this targets the actual recovery bug (dropped footage + wasted retries), not log noise.

+18/-1, one source file + changelog. Scoped to the start-failure path; no signature/behavior changes elsewhere.

UNVERIFIED at runtime (requires reproducing an ffmpeg start failure on a live capture session).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

