### PR TITLE
fix(desktop): force syncQuota in floating bar when serverQuota is nil

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1797,7 +1797,23 @@ class FloatingControlBarManager {
         let generation = activeQueryGeneration
 
         // Check monthly usage limit for free users (shared with main chat page).
+        //
+        // `FloatingBarUsageLimiter.isLimitReached` returns `false` (fail-open)
+        // when `serverQuota == nil`. The optimistic check is fast and doesn't
+        // need a network round trip, but it relies on having a snapshot to
+        // check against. If app-launch `fetchPlan()` failed (network blip,
+        // first-run offline, etc.) and the user has been signing queries
+        // without ever refreshing the quota, a free user past their limit
+        // can keep chatting — the local limiter has no data to enforce.
+        //
+        // Fix: at the start of every floating-bar query, if `serverQuota`
+        // is nil, force a fresh `syncQuota()` before the limit check. This
+        // is one network round trip on cold start, zero on every subsequent
+        // query (serverQuota is populated for the session lifetime).
         let limiter = FloatingBarUsageLimiter.shared
+        if provider.isUsingOmiAccountProvider, limiter.serverQuota == nil {
+            await limiter.syncQuota()
+        }
         if provider.isUsingOmiAccountProvider {
             if limiter.isLimitReached {
                 guard isActiveQueryGeneration(generation) else { return }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1813,7 +1813,8 @@ class FloatingControlBarManager {
         let limiter = FloatingBarUsageLimiter.shared
         if provider.isUsingOmiAccountProvider, limiter.serverQuota == nil {
             await limiter.syncQuota()
-            // Race: the user may have cancelled or fired a new query while
+            // (cubic P2 on PR #8141, fixed)
+        // Race: the user may have cancelled or fired a new query while
             // we were awaiting the network call. Re-check the query
             // generation; if this query was superseded, bail before
             // doing any more work (limiter.recordQuery() below would
@@ -2081,3 +2082,4 @@ extension FloatingControlBarWindow {
         resignKeyAnimationToken += 1
     }
 }
+

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1813,6 +1813,15 @@ class FloatingControlBarManager {
         let limiter = FloatingBarUsageLimiter.shared
         if provider.isUsingOmiAccountProvider, limiter.serverQuota == nil {
             await limiter.syncQuota()
+            // Race: the user may have cancelled or fired a new query while
+            // we were awaiting the network call. Re-check the query
+            // generation; if this query was superseded, bail before
+            // doing any more work (limiter.recordQuery() below would
+            // consume a local quota slot for a cancelled query; the
+            // screenshot + provider.sendMessage would spend CPU/tokens
+            // on a response the user no longer wants). Bug identified
+            // by cubic-dev-ai on PR #8141 — P2.
+            guard isActiveQueryGeneration(generation) else { return }
         }
         if provider.isUsingOmiAccountProvider {
             if limiter.isLimitReached {


### PR DESCRIPTION
## What

At the start of every floating-bar query, if `FloatingBarUsageLimiter.serverQuota` is `nil`, force a fresh `syncQuota()` before the limit check.

## Why

`FloatingBarUsageLimiter.isLimitReached` is an optimistic local check: it returns `false` (fail-open) when `serverQuota` is `nil`. The intent is to avoid a network round trip per query. The trade-off is that a free user with no cached quota can keep chatting past their limit.

`9b7594711` (in your tree) made the bridge check optimistic but kept the bridge as a hard 402 fallback. After the bridge check was removed in a later cleanup, nothing catches the fail-open case.

Reproduction paths:
- **Cold install that never had network** — `serverQuota` is `nil` from the first query
- **Long idle window after app launch** — server snapshot may be cleared on session refresh
- **Transient network blip at app launch** — `fetchPlan()` fails, `serverQuota` stays `nil`, user fires queries
- **Sign-out / sign-in with the same account** — quota may not be re-fetched

In all four cases, `isLimitReached` returns `false` for every query. A free user past their limit can keep chatting. The queries reach the bridge, the server enforces the 402, but only at the next sync — meanwhile Omi eats the cost.

## What ships

A 4-line guard in `FloatingControlBarWindow.sendAIQuery`, before the existing limit check:

```swift
let limiter = FloatingBarUsageLimiter.shared
if provider.isUsingOmiAccountProvider, limiter.serverQuota == nil {
    await limiter.syncQuota()
}
```

The existing `if provider.isUsingOmiAccountProvider { if limiter.isLimitReached { ... } }` block runs unchanged below.

## Behavior change

- **Users on a working network**: zero impact. The first query after `serverQuota` is cleared is ~200ms slower because of the `syncQuota()` network call. Every query after that is unchanged because `serverQuota` is populated for the session lifetime.
- **Users in fail-open**: free users past their limit get the upgrade prompt the first time they try to chat after a quota refresh, instead of being able to keep chatting until the next server-side check.

The quota snapshot itself is then cached with the 30s TTL on `APIClient.fetchChatUsageQuota` (already on main per 9b7594711), so the main chat page benefits transitively.

## How to verify

Unit tests in `FloatingBarUsageLimiterTests` already cover the limiter logic. This PR adds a small integration point; the existing test suite still passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

