### PR TITLE
fix(desktop): add Task.isCancelled guard in sendAIQuery

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1788,6 +1788,17 @@ class FloatingControlBarManager {
     }
 
     private func sendAIQuery(_ message: String, barWindow: FloatingControlBarWindow, provider: ChatProvider) async {
+        // Defensive cancellation guard. `sendAIQuery` is a long async function
+        // (screenshot capture, limiter check, provider.sendMessage). If a parent
+        // task cancels us (e.g. closeAIConversation racing, the user firing a
+        // second query, a future refactor that runs the router in parallel),
+        // we should bail before doing setup work — especially before
+        // `limiter.recordQuery()` (which would consume a local quota slot)
+        // and before the screenshot capture. This matches the pattern used
+        // elsewhere in the codebase (OnboardingChatView, FileIndexingView,
+        // DesktopHomeView) and is cheap insurance against future refactors.
+        guard !Task.isCancelled else { return }
+
         // QueryTracer: `pre_llm` brackets everything between query submission and
         // the ChatProvider call (screenshot capture, usage checks, filler audio).
         let currentTracer = QueryTracerContext.current
@@ -1795,6 +1806,9 @@ class FloatingControlBarManager {
         let queryFromVoice = barWindow.state.currentQueryFromVoice
         prepareVisibleQueryState(message, in: barWindow, fromVoice: queryFromVoice)
         let generation = activeQueryGeneration
+
+        // Re-check after the await-free setup work above.
+        guard !Task.isCancelled else { return }
 
         // Check monthly usage limit for free users (shared with main chat page).
         let limiter = FloatingBarUsageLimiter.shared


### PR DESCRIPTION
## What

Two `Task.isCancelled` guards added to `FloatingControlBarWindow.sendAIQuery`:
1. At the top, before any setup work
2. After `prepareVisibleQueryState`, before the limiter check

## Why

`sendAIQuery` is a long async function (screenshot capture, limiter check, provider.sendMessage). If a parent task cancels us (closeAIConversation racing, the user firing a second query, a future refactor that runs the router in parallel), we should bail before doing setup work — especially before `limiter.recordQuery()` (which would consume a local quota slot) and before the screenshot capture.

The pattern is already used elsewhere in the codebase:
- `OnboardingChatView.swift:725`: `guard !Task.isCancelled else { return }`
- `FileIndexingView.swift:362`: `while !Task.isCancelled`
- `DesktopHomeView.swift:318`: `while !Task.isCancelled`

The current `routeQuery` is sequential (no parent Task), so this guard is no-op today. The fix is for robustness: if a future refactor launches `sendAIQuery` in a child Task that can be cancelled (e.g. parallel router), the guard prevents wasted work and incorrect local state.

## What ships

Two `guard !Task.isCancelled else { return }` lines + comments. No tests — the guard is structurally trivial and trivially correct (Task.isCancelled is part of Swift Concurrency).

## Behavior change

Zero. In the current sequential flow, no parent Task cancels `sendAIQuery`. The guard is a future-proofing change.

## How to verify

```bash
cd desktop/macos && bash test.sh
# All existing tests pass.
```

A focused manual test (not automated because it requires a custom race condition): force `sendAIQuery` to be called inside a Task that you immediately cancel, and confirm the function returns immediately without doing the limiter check or screenshot capture. The 'no behavior change in current flow' claim is verified by the existing test suite passing unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

