### PR TITLE
fix(desktop): make staged-task markSynced idempotent on duplicate backendId (#8128)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,7 +1,8 @@
 {
   "unreleased": [
     "Stopped reporting expected realtime voice session closes (idle timeouts, cancellations) as errors",
-    "Fixed Rewind screen recording dropping ~2.5s of footage and logging spurious errors when the video encoder failed to start, by retrying immediately on the next frame instead of waiting for an emergency reset"
+    "Fixed Rewind screen recording dropping ~2.5s of footage and logging spurious errors when the video encoder failed to start, by retrying immediately on the next frame instead of waiting for an emergency reset",
+    "Fixed a task-sync crash that could fail with a database UNIQUE constraint error when a task was synced more than once"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
@@ -92,10 +92,19 @@ actor StagedTaskStorage {
             record.backendId = backendId
             record.backendSynced = true
             record.updatedAt = Date()
-            try record.update(database)
+            do {
+                try record.update(database)
+                log("StagedTaskStorage: Marked staged task \(id) as synced (backendId: \(backendId))")
+            } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
+                // Another local staged row already holds this backendId (duplicate sync, or
+                // backend dedup returned an existing task's id). The UNIQUE index on
+                // staged_tasks.backendId would otherwise crash the sync-status update.
+                // Make it idempotent: drop this freshly-extracted duplicate and keep the
+                // existing canonical row that already represents the backend task.
+                try database.execute(sql: "DELETE FROM staged_tasks WHERE id = ?", arguments: [id])
+                log("StagedTaskStorage: backendId \(backendId) already present; removed duplicate staged task \(id)")
+            }
         }
-
-        log("StagedTaskStorage: Marked staged task \(id) as synced (backendId: \(backendId))")
     }
 
     /// Get unsynced staged tasks for retry


### PR DESCRIPTION
## Bug
Part of #8128 (Desktop local SQLite data-integrity failures). Sentry **OMI-DESKTOP-8E** — `UNIQUE constraint failed: staged_tasks.backendId` — **1,169 events / 225 users**, still active in production.

## Root cause
`StagedTaskStorage.markSynced(id:backendId:)` set `record.backendId` and then did a blind `record.update(database)`. The `staged_tasks.backendId` column has a **UNIQUE index** (`RewindDatabase.swift`, `t.column("backendId", .text).unique()`). When another local staged row already holds that `backendId` — a duplicate sync, or the backend deduplicating an extracted task to an existing task's id — the update throws `SQLITE_CONSTRAINT` and the task sync-status update fails.

The sibling `ActionItemStorage` already handles exactly this race (catches `SQLITE_CONSTRAINT` and reconciles); the staged-task path was missing the same guard.

## Fix
Catch `DatabaseError` with `resultCode == .SQLITE_CONSTRAINT` in `markSynced` and make it idempotent: drop the freshly-extracted duplicate row and keep the existing canonical synced row (which already represents that backend task). The FTS `AFTER DELETE` trigger keeps `staged_tasks_fts` consistent. No behavior change on the normal (non-conflicting) path. +9/-1, 1 file.

## Verification
- `xcrun swift build -c debug` — **Build complete** (exit 0).
- Mirrors the proven conflict-handling pattern in `ActionItemStorage.syncActionItem`.
- UNVERIFIED at runtime (requires a live duplicate-sync repro); the crashing line is gated behind the new catch and the constraint logic matches the existing action_items handling.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

