### PR TITLE
[codex] Make backend Twilio test stubs idempotent

### DIFF
--- a/backend/tests/unit/test_twilio_service.py
+++ b/backend/tests/unit/test_twilio_service.py
@@ -1,4 +1,7 @@
+import importlib.machinery
 import os
+import sys
+import types
 from unittest.mock import patch, MagicMock
 
 from tests.unit.twilio_stub import install_phone_calls_stub, install_twilio_stub, prepare_twilio_service_import
@@ -14,6 +17,8 @@ install_phone_calls_stub()
 
 from utils.twilio_service import generate_access_token, validate_twilio_signature
 
+_MISSING = object()
+
 
 @patch('twilio.jwt.access_token.AccessToken.to_jwt', return_value='mock.jwt.token')
 def test_generate_access_token(mock_jwt):
@@ -21,6 +26,87 @@ def test_generate_access_token(mock_jwt):
     assert result['access_token'] == 'mock.jwt.token'
     assert result['identity'] == 'user-abc'
     assert result['ttl'] == 600
+
+
+def test_install_twilio_stub_replaces_incomplete_existing_twilio():
+    module_names = [
+        'twilio',
+        'twilio.rest',
+        'twilio.jwt',
+        'twilio.jwt.access_token',
+        'twilio.jwt.access_token.grants',
+        'twilio.request_validator',
+        'twilio.base',
+        'twilio.base.exceptions',
+        'twilio.twiml',
+        'twilio.twiml.voice_response',
+    ]
+    originals = {name: sys.modules.get(name, _MISSING) for name in module_names}
+    try:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        sys.modules['twilio'] = MagicMock()
+
+        install_twilio_stub()
+
+        assert isinstance(sys.modules['twilio'], types.ModuleType)
+        assert sys.modules['twilio.base.exceptions'].TwilioRestException(status=400, uri='', code=21450).code == 21450
+    finally:
+        for name, module in originals.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_install_twilio_stub_replaces_meta_path_stub_without_origin():
+    module_names = [
+        'twilio',
+        'twilio.rest',
+        'twilio.jwt',
+        'twilio.jwt.access_token',
+        'twilio.jwt.access_token.grants',
+        'twilio.request_validator',
+        'twilio.base',
+        'twilio.base.exceptions',
+        'twilio.twiml',
+        'twilio.twiml.voice_response',
+    ]
+    originals = {name: sys.modules.get(name, _MISSING) for name in module_names}
+    try:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        incomplete = types.ModuleType('twilio')
+        incomplete.__spec__ = importlib.machinery.ModuleSpec('twilio', loader=None, is_package=True)
+        sys.modules['twilio'] = incomplete
+
+        install_twilio_stub()
+
+        assert sys.modules['twilio'] is not incomplete
+        assert sys.modules['twilio.base.exceptions'].TwilioRestException(status=400, uri='', code=21450).code == 21450
+    finally:
+        for name, module in originals.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_install_phone_calls_stub_completes_existing_module():
+    original = sys.modules.get('database.phone_calls', _MISSING)
+    empty_stub = types.ModuleType('database.phone_calls')
+    try:
+        sys.modules['database.phone_calls'] = empty_stub
+
+        stub = install_phone_calls_stub()
+
+        assert stub is empty_stub
+        assert stub.get_phone_numbers('uid-1') == []
+    finally:
+        if original is _MISSING:
+            sys.modules.pop('database.phone_calls', None)
+        else:
+            sys.modules['database.phone_calls'] = original
 
 
 def test_twilio_stub_dial_appends_multiple_numbers():

--- a/backend/tests/unit/twilio_stub.py
+++ b/backend/tests/unit/twilio_stub.py
@@ -34,17 +34,35 @@ def prepare_twilio_service_import():
 
 def install_phone_calls_stub():
     database_module = restore_backend_package('database')
-    if 'database.phone_calls' not in sys.modules:
+    stub = sys.modules.get('database.phone_calls')
+    if stub is None:
         stub = types.ModuleType('database.phone_calls')
-        stub.get_phone_numbers = lambda uid: []
         sys.modules['database.phone_calls'] = stub
-        setattr(database_module, 'phone_calls', stub)
-    return sys.modules['database.phone_calls']
+    if 'get_phone_numbers' not in getattr(stub, '__dict__', {}):
+        stub.get_phone_numbers = lambda uid: []
+    setattr(database_module, 'phone_calls', stub)
+    return stub
 
 
 def install_twilio_stub():
-    if 'twilio' in sys.modules or importlib.util.find_spec('twilio') is not None:
+    existing_twilio = sys.modules.get('twilio')
+    required_stub_modules = (
+        'twilio',
+        'twilio.rest',
+        'twilio.jwt.access_token',
+        'twilio.jwt.access_token.grants',
+        'twilio.request_validator',
+        'twilio.base.exceptions',
+        'twilio.twiml.voice_response',
+    )
+    if all(name in sys.modules for name in required_stub_modules):
         return
+    if existing_twilio is None and importlib.util.find_spec('twilio') is not None:
+        return
+    if isinstance(existing_twilio, types.ModuleType):
+        existing_spec = getattr(existing_twilio, '__spec__', None)
+        if existing_spec is not None and getattr(existing_spec, 'origin', None):
+            return
 
     twilio_mod = types.ModuleType('twilio')
     rest_mod = types.ModuleType('twilio.rest')
@@ -161,13 +179,13 @@ def install_twilio_stub():
     twilio_mod.twiml = twiml_mod
     twiml_mod.voice_response = voice_response_mod
 
-    sys.modules.setdefault('twilio', twilio_mod)
-    sys.modules.setdefault('twilio.rest', rest_mod)
-    sys.modules.setdefault('twilio.jwt', jwt_mod)
-    sys.modules.setdefault('twilio.jwt.access_token', access_token_mod)
-    sys.modules.setdefault('twilio.jwt.access_token.grants', grants_mod)
-    sys.modules.setdefault('twilio.request_validator', request_validator_mod)
-    sys.modules.setdefault('twilio.base', base_mod)
-    sys.modules.setdefault('twilio.base.exceptions', exceptions_mod)
-    sys.modules.setdefault('twilio.twiml', twiml_mod)
-    sys.modules.setdefault('twilio.twiml.voice_response', voice_response_mod)
+    sys.modules['twilio'] = twilio_mod
+    sys.modules['twilio.rest'] = rest_mod
+    sys.modules['twilio.jwt'] = jwt_mod
+    sys.modules['twilio.jwt.access_token'] = access_token_mod
+    sys.modules['twilio.jwt.access_token.grants'] = grants_mod
+    sys.modules['twilio.request_validator'] = request_validator_mod
+    sys.modules['twilio.base'] = base_mod
+    sys.modules['twilio.base.exceptions'] = exceptions_mod
+    sys.modules['twilio.twiml'] = twiml_mod
+    sys.modules['twilio.twiml.voice_response'] = voice_response_mod


### PR DESCRIPTION
## Summary
- make `install_twilio_stub()` repair incomplete in-memory Twilio stubs instead of returning early
- make `install_phone_calls_stub()` add the required `get_phone_numbers` attribute when another test already created `database.phone_calls`
- add regression coverage for incomplete `twilio` mocks, meta-path Twilio stubs, and existing phone-call DB stubs

## Why
A Windows backend unit collection run showed `tests/unit/test_phone_calls.py` failing during collection after earlier tests had registered incomplete `twilio`/`database.phone_calls` stubs in `sys.modules`. The helper already owns this isolation boundary, so making it idempotent keeps these tests independent of collection order.

## Validation
- `python -m pytest tests\unit\test_phone_calls.py tests\unit\test_twilio_service.py tests\unit\test_twilio_account_deletion.py -q --tb=short` -> 31 passed, 1 warning
- `python -m py_compile tests\unit\twilio_stub.py tests\unit\test_twilio_service.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\twilio_stub.py tests\unit\test_twilio_service.py`
- `git diff --check`
- `scripts/pre-commit`
- `python -m pytest tests\unit --collect-only -q --tb=short` now collects `test_phone_calls.py` and the new Twilio regression tests; the run still stops on 10 unrelated existing collection errors (`test_auth_redirect_uri.py`, `test_conversation_structure_timezone.py`, `test_desktop_migration.py`, `test_dg_start_guard.py`, `test_firestore_cache.py`, `test_modulate_stt.py`, `test_parakeet_builtin_embedding.py`, `test_parakeet_diarization.py`, `test_streaming_deepgram_backoff.py`, `test_ws_auth_handshake.py`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

