### PR TITLE
[codex] Stub auth redirect JWT imports in backend tests

### DIFF
--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -72,6 +72,8 @@ def _install_module(name):
 _ensure_package("database", BACKEND_DIR / "database")
 _ensure_package("utils", BACKEND_DIR / "utils")
 
+firebase_admin_stub = _install_module("firebase_admin")
+firebase_admin_stub.__path__ = []
 firebase_auth_stub = _install_module("firebase_admin.auth")
 firebase_auth_stub.verify_id_token = MagicMock()
 
@@ -87,6 +89,16 @@ http_client_stub.get_auth_client = MagicMock()
 
 log_sanitizer_stub = _install_module("utils.log_sanitizer")
 log_sanitizer_stub.sanitize = MagicMock(side_effect=lambda value: value)
+
+jwt_stub = _install_module("jwt")
+jwt_stub.__path__ = []
+jwt_stub.encode = MagicMock(return_value="test-client-secret")
+jwt_stub.decode = MagicMock(return_value={})
+jwt_stub.get_unverified_header = MagicMock(return_value={"kid": "test-key"})
+
+jwt_algorithms_stub = _install_module("jwt.algorithms")
+jwt_algorithms_stub.RSAAlgorithm = MagicMock()
+jwt_algorithms_stub.RSAAlgorithm.from_jwk = MagicMock(return_value="test-public-key")
 
 try:
     import jinja2  # noqa: F401


### PR DESCRIPTION
## Summary
- stub `jwt` and `jwt.algorithms.RSAAlgorithm` before importing `routers.auth` in `test_auth_redirect_uri.py`
- register the `firebase_admin` parent package stub before `firebase_admin.auth`

## Why
The auth redirect URI tests validate redirect allowlisting and auth-code binding, but the module under test imports optional/heavy auth dependencies at module import time. In a lightweight Windows backend test environment without PyJWT installed, collection stopped before the redirect URI tests could run.

## Validation
- `python -m pytest tests\unit\test_auth_redirect_uri.py --collect-only -q --tb=short` -> 46 tests collected
- `python -m pytest tests\unit\test_auth_redirect_uri.py -q --tb=short` -> 43 passed, 3 skipped, 10 warnings
- `python -m py_compile tests\unit\test_auth_redirect_uri.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_auth_redirect_uri.py`
- `git diff --check`
- `scripts/pre-commit`
- `python -m pytest tests\unit --collect-only -q --tb=short` now collects `test_auth_redirect_uri.py`; the branch still stops on other existing collection errors, including `test_phone_calls.py` which is addressed separately in #8144.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

