### PR TITLE
[codex] Stub conversation folder import in timezone tests

### DIFF
--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -91,6 +91,11 @@ llm_clients_stub = _stub_module("utils.llm.clients")
 llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
 llm_clients_stub.parser = MagicMock()
 
+conversation_folder_stub = _stub_module("utils.llm.conversation_folder")
+conversation_folder_stub.FolderAssignment = MagicMock()
+conversation_folder_stub.assign_conversation_to_folder = MagicMock(return_value=(None, 0.0, "test stub"))
+conversation_folder_stub.build_folders_context = MagicMock(return_value="")
+
 # Real models (pure pydantic) resolve from the models package directory.
 _stub_package("models")
 sys.modules["models"].__path__ = [str(BACKEND_DIR / "models")]


### PR DESCRIPTION
## Summary
- stub `utils.llm.conversation_folder` in `test_conversation_structure_timezone.py`
- keep the timezone tests focused on `conversation_processing.py` without importing the folder-assignment route dependencies

## Why
The timezone tests load `conversation_processing.py` directly while stubbing `utils.llm` as an empty package. After `conversation_processing.py` added a top-level `conversation_folder` import, lightweight collection failed before these timezone regression tests could run. The folder-assignment symbols are not exercised in this test, so a narrow stub keeps the import boundary isolated.

## Validation
- `python -m pytest tests\unit\test_conversation_structure_timezone.py --collect-only -q --tb=short` -> 12 tests collected
- `python -m pytest tests\unit\test_conversation_structure_timezone.py -q --tb=short` -> 12 passed
- `python -m py_compile tests\unit\test_conversation_structure_timezone.py`
- `python -m black --line-length 120 --skip-string-normalization tests\unit\test_conversation_structure_timezone.py`
- `git diff --check`
- `scripts/pre-commit`
- `python -m pytest tests\unit --collect-only -q --tb=short` now collects `test_conversation_structure_timezone.py`; this branch still stops on other existing collection errors, with `test_phone_calls.py` and `test_auth_redirect_uri.py` addressed separately in #8144 and #8145.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

