### PR TITLE
Normalize desktop AI backend error states

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -163,7 +163,13 @@ private func isNonActionableTransient(_ error: Error?) -> Bool {
   // the Gemini proxy, surfaced by the proactive assistants (task/memory/advice/
   // insight extraction) after exhausting retries. Backend overload, not an app bug
   // (OMI-COMPUTER-6JK/6JR/6JM/6NC). Real auth/config/parse errors stay captured.
-  if let geminiError = error as? GeminiClient.GeminiClientError, geminiError.isTransient { return true }
+  if let geminiError = error as? GeminiClient.GeminiClientError,
+     geminiError.isTransient || geminiError.isExpectedProductState { return true }
+  // Embedding backfills/searches can hit expected backend/product states (trial
+  // expired/BYOK required, rate limit, 5xx). Keep those local-only so screenshot
+  // backfill loops don't create high-volume Sentry issues.
+  if let embeddingError = error as? EmbeddingService.EmbeddingError,
+     embeddingError.isNonActionableForSentry { return true }
   let nsError = error as NSError
   switch nsError.domain {
   case NSURLErrorDomain:

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -266,7 +266,7 @@ actor GeminiClient {
       if lower.contains("trial_expired") || lower.contains("trial expired")
         || lower.contains("payment required") || lower.contains("byok")
         || lower.contains("bring your own key") || lower.contains("usage limit")
-        || lower.contains("http 402")
+        || lower.contains("http 402") || lower.contains("quota exceeded")
       {
         return "AI features require an active plan or BYOK keys."
       }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -224,6 +224,27 @@ actor GeminiClient {
       }
     }
 
+    /// Expected product/account states should not page Sentry. They are useful in
+    /// local logs/breadcrumbs but represent paywall/BYOK state, not client bugs.
+    var isExpectedProductState: Bool {
+      switch self {
+      case .apiError(let message):
+        let lower = message.lowercased()
+        return lower.contains("trial_expired")
+          || lower.contains("trial expired")
+          || lower.contains("payment required")
+          || lower.contains("byok")
+          || lower.contains("bring your own key")
+          || lower.contains("usage limit")
+          || lower.contains("quota exceeded")
+          || lower.contains("http 402")
+      case .missingAPIKey:
+        return true
+      case .networkError, .invalidResponse:
+        return false
+      }
+    }
+
     var errorDescription: String? {
       switch self {
       case .missingAPIKey:
@@ -242,6 +263,13 @@ actor GeminiClient {
     private static func userFacingMessage(for rawMessage: String) -> String {
       let lower = rawMessage.lowercased()
 
+      if lower.contains("trial_expired") || lower.contains("trial expired")
+        || lower.contains("payment required") || lower.contains("byok")
+        || lower.contains("bring your own key") || lower.contains("usage limit")
+        || lower.contains("http 402")
+      {
+        return "AI features require an active plan or BYOK keys."
+      }
       if lower.contains("leaked") || lower.contains("api key") || lower.contains("api_key")
         || lower.contains("unauthorized") || lower.contains("permission denied")
         || lower.contains("invalid key") || lower.contains("forbidden")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -324,11 +324,53 @@ actor EmbeddingService {
     case invalidResponse
     case serverError(statusCode: Int, body: String)
 
+    var reasonCode: String {
+      switch self {
+      case .missingAPIKey:
+        return "missing_api_key"
+      case .invalidResponse:
+        return "malformed_response"
+      case .serverError(let statusCode, let body):
+        let lower = body.lowercased()
+        if statusCode == 402 || lower.contains("trial_expired") || lower.contains("trial expired")
+          || lower.contains("payment required") || lower.contains("byok")
+          || lower.contains("bring your own key") || lower.contains("usage limit")
+        {
+          return "product_gate"
+        }
+        if statusCode == 429 || lower.contains("rate limit") || lower.contains("resource exhausted") {
+          return "rate_limited"
+        }
+        if (500...599).contains(statusCode) || lower.contains("temporarily unavailable")
+          || lower.contains("service unavailable") || lower.contains("overloaded")
+        {
+          return "temporarily_unavailable"
+        }
+        return "http_\(statusCode)"
+      }
+    }
+
+    var isExpectedProductState: Bool { reasonCode == "missing_api_key" || reasonCode == "product_gate" }
+    var isTransient: Bool { reasonCode == "rate_limited" || reasonCode == "temporarily_unavailable" }
+    var isNonActionableForSentry: Bool { isExpectedProductState || isTransient }
+
     var errorDescription: String? {
       switch self {
-      case .missingAPIKey: return "AI features are not configured. Please update the app."
-      case .invalidResponse: return "AI service returned an unexpected response. Please try again."
-      case .serverError(let statusCode, let body): return "Embedding API error (HTTP \(statusCode)): \(body)"
+      case .missingAPIKey:
+        return "AI features are not configured. Please update the app."
+      case .invalidResponse:
+        return "Embedding API returned an unexpected response."
+      case .serverError:
+        switch reasonCode {
+        case "product_gate":
+          return "Embedding API unavailable: active plan or BYOK keys required."
+        case "rate_limited":
+          return "Embedding API rate limited. Will retry later."
+        case "temporarily_unavailable":
+          return "Embedding API temporarily unavailable. Will retry later."
+        default:
+          return "Embedding API error (\(reasonCode))."
+        }
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -350,7 +350,7 @@ actor EmbeddingService {
       }
     }
 
-    var isExpectedProductState: Bool { reasonCode == "missing_api_key" || reasonCode == "product_gate" }
+    var isExpectedProductState: Bool { reasonCode == "product_gate" }
     var isTransient: Bool { reasonCode == "rate_limited" || reasonCode == "temporarily_unavailable" }
     var isNonActionableForSentry: Bool { isExpectedProductState || isTransient }
 

--- a/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
+++ b/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
@@ -39,8 +39,24 @@ final class AIBackendErrorNormalizationTests: XCTestCase {
     XCTAssertFalse(error.isNonActionableForSentry)
   }
 
+  func testEmbeddingMissingConfigurationRemainsActionable() {
+    let error = EmbeddingService.EmbeddingError.missingAPIKey
+
+    XCTAssertEqual(error.reasonCode, "missing_api_key")
+    XCTAssertFalse(error.isExpectedProductState)
+    XCTAssertFalse(error.isNonActionableForSentry)
+  }
+
   func testGeminiTrialExpiredIsExpectedProductState() {
     let error = GeminiClient.GeminiClientError.apiError("HTTP 402: trial_expired")
+
+    XCTAssertTrue(error.isExpectedProductState)
+    XCTAssertFalse(error.isTransient)
+    XCTAssertEqual(error.localizedDescription, "AI features require an active plan or BYOK keys.")
+  }
+
+  func testGeminiQuotaExceededUsesProductGateMessage() {
+    let error = GeminiClient.GeminiClientError.apiError("quota exceeded")
 
     XCTAssertTrue(error.isExpectedProductState)
     XCTAssertFalse(error.isTransient)

--- a/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
+++ b/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class AIBackendErrorNormalizationTests: XCTestCase {
+  func testEmbeddingTrialExpiredIsProductGateAndNotSentryActionable() {
+    let error = EmbeddingService.EmbeddingError.serverError(
+      statusCode: 402,
+      body: #"{"error":"trial_expired"}"#)
+
+    XCTAssertEqual(error.reasonCode, "product_gate")
+    XCTAssertTrue(error.isExpectedProductState)
+    XCTAssertTrue(error.isNonActionableForSentry)
+    XCTAssertEqual(
+      error.localizedDescription,
+      "Embedding API unavailable: active plan or BYOK keys required.")
+  }
+
+  func testEmbeddingRateLimitAndUnavailableAreTransient() {
+    let rateLimited = EmbeddingService.EmbeddingError.serverError(
+      statusCode: 429,
+      body: #"{"error":"rate limit exceeded"}"#)
+    let unavailable = EmbeddingService.EmbeddingError.serverError(
+      statusCode: 503,
+      body: #"{"error":"service unavailable"}"#)
+
+    XCTAssertEqual(rateLimited.reasonCode, "rate_limited")
+    XCTAssertTrue(rateLimited.isTransient)
+    XCTAssertTrue(rateLimited.isNonActionableForSentry)
+    XCTAssertEqual(unavailable.reasonCode, "temporarily_unavailable")
+    XCTAssertTrue(unavailable.isTransient)
+    XCTAssertTrue(unavailable.isNonActionableForSentry)
+  }
+
+  func testEmbeddingMalformedResponseRemainsActionable() {
+    let error = EmbeddingService.EmbeddingError.invalidResponse
+
+    XCTAssertEqual(error.reasonCode, "malformed_response")
+    XCTAssertFalse(error.isNonActionableForSentry)
+  }
+
+  func testGeminiTrialExpiredIsExpectedProductState() {
+    let error = GeminiClient.GeminiClientError.apiError("HTTP 402: trial_expired")
+
+    XCTAssertTrue(error.isExpectedProductState)
+    XCTAssertFalse(error.isTransient)
+    XCTAssertEqual(error.localizedDescription, "AI features require an active plan or BYOK keys.")
+  }
+}


### PR DESCRIPTION
## Summary

- classify expected Gemini product-gating states (`trial_expired`, HTTP 402, BYOK/usage-limit) separately from actionable AI failures
- classify embedding backend failures into stable reason codes: `product_gate`, `rate_limited`, `temporarily_unavailable`, `malformed_response`, and `http_<status>`
- suppress Sentry capture for expected product/transient AI + embedding states while keeping malformed/unexpected responses actionable
- stop embedding server errors from including raw backend bodies in `localizedDescription`, reducing high-cardinality Sentry grouping
- add regression tests for AI/embedding error classification

Fixes #8126.

## Validation

- `git diff --check`
- `xcrun swiftc -parse` on modified source/test files
- `xcrun swift package --package-path Desktop describe --type json`
- attempted `xcrun swift test --package-path Desktop --skip-update --filter AIBackendErrorNormalizationTests`; local SwiftPM timed out after 120s while downloading binary artifacts / querying duplicate GitHub keychain credentials. CI should run with clean artifact auth.

## Notes

Malformed embedding responses remain Sentry-actionable as `malformed_response`; expected paywall/BYOK/rate-limit/temporary-unavailable states are local log/breadcrumb only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

