### PR TITLE
Add desktop Rewind encoder diagnostics and bounds

### DIFF
--- a/desktop/macos/Desktop/Sources/ResourceMonitor.swift
+++ b/desktop/macos/Desktop/Sources/ResourceMonitor.swift
@@ -151,11 +151,20 @@ class ResourceMonitor {
     components["liveNotes_notesContext"] = liveNotes.existingNotesContextCount
     components["liveNotes_notesCount"] = liveNotes.notes.count
 
-    // VideoChunkEncoder buffer (actor — await)
+    // VideoChunkEncoder buffer/lifecycle (actor — await)
     let bufferStatus = await VideoChunkEncoder.shared.getBufferStatus()
     components["videoEncoder_frameCount"] = bufferStatus.frameCount
+    components["videoEncoder_maxBufferFrames"] = bufferStatus.maxBufferFrames
+    components["videoEncoder_isFFmpegRunning"] = bufferStatus.isFFmpegRunning
+    components["videoEncoder_consecutiveWriteFailures"] = bufferStatus.consecutiveWriteFailures
+    components["videoEncoder_restartCount"] = bufferStatus.encoderRestartCount
+    components["videoEncoder_emergencyResetCount"] = bufferStatus.emergencyResetCount
+    components["videoEncoder_ffmpegNotReadyCount"] = bufferStatus.ffmpegNotReadyCount
     if let age = bufferStatus.oldestFrameAge {
       components["videoEncoder_oldestFrameAgeSec"] = Int(age)
+    }
+    if let age = bufferStatus.currentChunkAge {
+      components["videoEncoder_currentChunkAgeSec"] = Int(age)
     }
 
     // FocusAssistant pending tasks (actor — await, optional since it may not be initialized)
@@ -168,6 +177,12 @@ class ResourceMonitor {
     let plugin = ProactiveAssistantsPlugin.shared
     components["rewind_droppedFrames"] = plugin.droppedFrameCount
     components["rewind_isProcessing"] = plugin.isProcessingRewindFrame
+    components["rewind_isMonitoring"] = plugin.isMonitoring
+    components["rewind_captureIntervalSec"] = RewindSettings.shared.captureInterval
+    components["rewind_effectiveCaptureIntervalSec"] = RewindSettings.shared.effectiveCaptureInterval(
+      isOnBattery: PowerMonitor.cachedBatteryState())
+    components["rewind_retentionDays"] = RewindSettings.shared.retentionDays
+    components["system_memoryPressurePercent"] = snapshot.systemMemoryPressure
 
     // Thread count is already in snapshot
     components["threadCount"] = snapshot.threadCount
@@ -352,7 +367,9 @@ class ResourceMonitor {
     onMemoryPressureTrimTranscript?()
 
     Task {
-      // Flush VideoChunkEncoder and await completion
+      // Flush VideoChunkEncoder and await completion. If ffmpeg is wedged, the
+      // encoder's watchdog will kill it; ResourceMonitor records the reset counters
+      // in component diagnostics so hang/memory Sentry events can be correlated.
       _ = try? await VideoChunkEncoder.shared.flushCurrentChunk()
 
       // Clear focus assistant pending tasks specifically

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -44,6 +44,10 @@ actor VideoChunkEncoder {
     /// Maximum consecutive ffmpeg failures before emergency reset
     private let maxConsecutiveFailures = 5
 
+    /// Consecutive nil-process/stdin states that force an encoder reset. This keeps
+    /// "FFmpeg not ready" loops bounded instead of emitting one Sentry event per frame.
+    private let maxConsecutiveNotReadyFailures = 3
+
     // MARK: - State
 
     /// Buffer stores only timestamps, not CGImages (memory optimization)
@@ -52,6 +56,9 @@ actor VideoChunkEncoder {
 
     /// Track consecutive ffmpeg write failures for recovery
     private var consecutiveWriteFailures = 0
+    private var encoderRestartCount = 0
+    private var emergencyResetCount = 0
+    private var ffmpegNotReadyCount = 0
 
     /// Pending aspect ratio debounce state
     private var pendingAspectRatioSize: CGSize?
@@ -117,7 +124,7 @@ actor VideoChunkEncoder {
         if frameTimestamps.count >= maxBufferFrames {
             log("VideoChunkEncoder: Buffer exceeded \(maxBufferFrames) frames, forcing flush to prevent memory leak")
             logError("VideoChunkEncoder: Emergency buffer flush triggered - \(frameTimestamps.count) frames")
-            try await emergencyReset()
+            try await emergencyReset(reason: "buffer_overflow")
         }
 
         // Check if aspect ratio changed significantly.
@@ -169,13 +176,15 @@ actor VideoChunkEncoder {
                     imageSize: newFrameSize
                 )
                 consecutiveWriteFailures = 0 // Reset on successful start
+                ffmpegNotReadyCount = 0
+                encoderRestartCount += 1
             } catch {
                 consecutiveWriteFailures += 1
                 logError("VideoChunkEncoder: Failed to start ffmpeg (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
 
                 if consecutiveWriteFailures >= maxConsecutiveFailures {
                     logError("VideoChunkEncoder: Too many ffmpeg failures, performing emergency reset")
-                    try await emergencyReset()
+                    try await emergencyReset(reason: "ffmpeg_start_failure")
                 }
                 throw error
             }
@@ -203,7 +212,7 @@ actor VideoChunkEncoder {
 
             if consecutiveWriteFailures >= maxConsecutiveFailures {
                 logError("VideoChunkEncoder: Too many write failures, performing emergency reset")
-                try await emergencyReset()
+                try await emergencyReset(reason: "write_failure")
             }
             throw error
         }
@@ -319,6 +328,15 @@ actor VideoChunkEncoder {
         guard let stdin = ffmpegStdin,
               let outputSize = currentOutputSize
         else {
+            ffmpegNotReadyCount += 1
+
+            if ffmpegNotReadyCount >= maxConsecutiveNotReadyFailures {
+                logError("VideoChunkEncoder: FFmpeg not ready \(ffmpegNotReadyCount)x, resetting encoder state")
+                try await emergencyReset(reason: "ffmpeg_not_ready_loop")
+            } else {
+                log("VideoChunkEncoder: FFmpeg not ready (\(ffmpegNotReadyCount)/\(maxConsecutiveNotReadyFailures))")
+            }
+
             throw RewindError.storageError("FFmpeg not ready")
         }
 
@@ -374,7 +392,7 @@ actor VideoChunkEncoder {
             if process.terminationStatus != 0 {
                 logError("VideoChunkEncoder: FFmpeg exited with status \(process.terminationStatus)")
             } else {
-                log("VideoChunkEncoder: Finalized chunk with \(frameCount) frames")
+                log("VideoChunkEncoder: Finalized chunk with \(frameCount) frames (restartCount=\(encoderRestartCount), emergencyResets=\(emergencyResetCount))")
             }
 
             ffmpegProcess = nil
@@ -573,27 +591,34 @@ actor VideoChunkEncoder {
         currentOutputSize = nil
         currentChunkInputSize = nil
         consecutiveWriteFailures = 0
+        ffmpegNotReadyCount = 0
     }
 
     /// Emergency reset when ffmpeg fails repeatedly or buffer overflows
     /// Clears all state and allows fresh start on next frame
-    private func emergencyReset() async throws {
+    private func emergencyReset(reason: String = "failure_threshold") async throws {
         stalenessCheckTask?.cancel()
         stalenessCheckTask = nil
 
         let droppedFrames = frameTimestamps.count
+        emergencyResetCount += 1
 
         // Report to Sentry for monitoring
         let breadcrumb = Breadcrumb(level: .error, category: "video_encoder")
         breadcrumb.message = "Emergency reset triggered"
         breadcrumb.data = [
+            "reason": reason,
             "dropped_frames": droppedFrames,
             "consecutive_failures": consecutiveWriteFailures,
+            "ffmpeg_not_ready_count": ffmpegNotReadyCount,
+            "encoder_restart_count": encoderRestartCount,
+            "emergency_reset_count": emergencyResetCount,
+            "buffer_limit": maxBufferFrames,
             "chunk_path": currentChunkPath ?? "none"
         ]
         SentrySDK.addBreadcrumb(breadcrumb)
 
-        logError("VideoChunkEncoder: Emergency reset - dropping \(droppedFrames) frames to prevent memory leak")
+        logError("VideoChunkEncoder: Emergency reset (reason=\(reason)) - dropping \(droppedFrames) frames to prevent memory leak")
 
         // Close stdin first (don't wait for ffmpeg to finish - it may be hung)
         if let stdin = ffmpegStdin {
@@ -628,14 +653,36 @@ actor VideoChunkEncoder {
         currentOutputSize = nil
         currentChunkInputSize = nil
         consecutiveWriteFailures = 0
+        ffmpegNotReadyCount = 0
 
         log("VideoChunkEncoder: Emergency reset complete, ready for new frames")
     }
 
-    /// Get current buffer status for debugging
-    func getBufferStatus() -> (frameCount: Int, oldestFrameAge: TimeInterval?) {
-        let count = frameTimestamps.count
-        let age = frameTimestamps.first.map { Date().timeIntervalSince($0) }
-        return (count, age)
+    struct EncoderStatus {
+        let frameCount: Int
+        let maxBufferFrames: Int
+        let oldestFrameAge: TimeInterval?
+        let currentChunkAge: TimeInterval?
+        let isFFmpegRunning: Bool
+        let consecutiveWriteFailures: Int
+        let encoderRestartCount: Int
+        let emergencyResetCount: Int
+        let ffmpegNotReadyCount: Int
+    }
+
+    /// Get current buffer and lifecycle status for memory diagnostics.
+    func getBufferStatus() -> EncoderStatus {
+        let now = Date()
+        return EncoderStatus(
+            frameCount: frameTimestamps.count,
+            maxBufferFrames: maxBufferFrames,
+            oldestFrameAge: frameTimestamps.first.map { now.timeIntervalSince($0) },
+            currentChunkAge: currentChunkStartTime.map { now.timeIntervalSince($0) },
+            isFFmpegRunning: ffmpegProcess?.isRunning ?? false,
+            consecutiveWriteFailures: consecutiveWriteFailures,
+            encoderRestartCount: encoderRestartCount,
+            emergencyResetCount: emergencyResetCount,
+            ffmpegNotReadyCount: ffmpegNotReadyCount
+        )
     }
 }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -355,6 +355,7 @@ actor VideoChunkEncoder {
         // Write to ffmpeg stdin
         do {
             try stdin.write(contentsOf: pngData)
+            ffmpegNotReadyCount = 0
         } catch {
             throw RewindError.storageError("Failed to write frame to ffmpeg: \(error.localizedDescription)")
         }

--- a/desktop/macos/Desktop/Tests/RewindEncoderDiagnosticsSourceTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindEncoderDiagnosticsSourceTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+final class RewindEncoderDiagnosticsSourceTests: XCTestCase {
+  func testEncoderStatusExposesBoundedLifecycleCounters() throws {
+    let source = try readSource("Sources/Rewind/Core/VideoChunkEncoder.swift")
+
+    XCTAssertTrue(source.contains("struct EncoderStatus"))
+    XCTAssertTrue(source.contains("maxBufferFrames"))
+    XCTAssertTrue(source.contains("encoderRestartCount"))
+    XCTAssertTrue(source.contains("emergencyResetCount"))
+    XCTAssertTrue(source.contains("ffmpegNotReadyCount"))
+    XCTAssertTrue(source.contains("maxConsecutiveNotReadyFailures"))
+    XCTAssertTrue(source.contains("ffmpeg_not_ready_loop"))
+    XCTAssertTrue(source.contains("buffer_overflow"))
+    XCTAssertTrue(source.contains("ffmpeg_start_failure"))
+    XCTAssertTrue(source.contains("write_failure"))
+  }
+
+  func testResourceMonitorPublishesRewindAndEncoderDiagnostics() throws {
+    let source = try readSource("Sources/ResourceMonitor.swift")
+
+    XCTAssertTrue(source.contains("videoEncoder_maxBufferFrames"))
+    XCTAssertTrue(source.contains("videoEncoder_isFFmpegRunning"))
+    XCTAssertTrue(source.contains("videoEncoder_restartCount"))
+    XCTAssertTrue(source.contains("videoEncoder_emergencyResetCount"))
+    XCTAssertTrue(source.contains("videoEncoder_ffmpegNotReadyCount"))
+    XCTAssertTrue(source.contains("rewind_isMonitoring"))
+    XCTAssertTrue(source.contains("rewind_effectiveCaptureIntervalSec"))
+    XCTAssertTrue(source.contains("system_memoryPressurePercent"))
+  }
+
+  private func readSource(_ relativePath: String) throws -> String {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+    let file = desktopDir.appendingPathComponent(relativePath)
+    return try String(contentsOf: file, encoding: .utf8)
+  }
+}


### PR DESCRIPTION
## Summary
- Add Rewind/FFmpeg encoder lifecycle counters to ResourceMonitor diagnostics: buffer limit/depth, restart count, emergency reset count, not-ready count, current chunk age, and process state
- Add Rewind capture state and memory-pressure context to diagnostics so hang/memory Sentry events have the right operational context
- Bound repeated `FFmpeg not ready` loops by resetting the encoder after 3 consecutive not-ready states, with explicit reset reasons for buffer overflow, start failure, write failure, and not-ready loops
- Add source-level regression tests to guard the diagnostic fields and bounded-reset symbols

Closes #8127

## Validation
- [x] `git diff --check`
- [x] `xcrun swiftc -parse desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift desktop/macos/Desktop/Sources/ResourceMonitor.swift desktop/macos/Desktop/Tests/RewindEncoderDiagnosticsSourceTests.swift`
- [x] `xcrun swift package --package-path Desktop describe`
- [x] Source-level diagnostics assertion script for the new test invariants

Note: I did not rerun full SwiftPM tests locally because prior targeted runs in this repo spent the tool budget downloading SwiftPM binary artifacts and hung in GitHub keychain lookup; parse/package validation completed successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

