### PR TITLE
fix null crash in AddAppProvider.updateApp

### DIFF
--- a/app/lib/pages/apps/providers/add_app_provider.dart
+++ b/app/lib/pages/apps/providers/add_app_provider.dart
@@ -618,17 +618,23 @@ class AddAppProvider extends ChangeNotifier {
         data['proactive_notification']['scopes'] = selectedScopes.map((e) => e.id).toList();
       }
     }
+    final successMsg = globalNavigatorKey.currentContext?.l10n.addAppUpdatedSuccess;
+    final failMsg = globalNavigatorKey.currentContext?.l10n.addAppUpdateFailed;
     var success = false;
     var res = await updateAppServer(imageFile, data);
     if (res) {
-      await appProvider!.getApps();
-      var app = await getAppDetailsServer(updateAppId!);
-      appProvider!.updateLocalApp(App.fromJson(app!));
-      AppSnackbar.showSnackbarSuccess(globalNavigatorKey.currentContext!.l10n.addAppUpdatedSuccess);
+      await appProvider?.getApps();
+      if (updateAppId != null) {
+        var app = await getAppDetailsServer(updateAppId!);
+        if (app != null) {
+          appProvider?.updateLocalApp(App.fromJson(app));
+        }
+      }
+      if (successMsg != null) AppSnackbar.showSnackbarSuccess(successMsg);
       clear();
       success = true;
     } else {
-      AppSnackbar.showSnackbarError(globalNavigatorKey.currentContext!.l10n.addAppUpdateFailed);
+      if (failMsg != null) AppSnackbar.showSnackbarError(failMsg);
       success = false;
     }
     checkValidity();


### PR DESCRIPTION
## Summary

Fixes a production crash: `Null check operator used on a null value` in `AddAppProvider.updateApp`.

- Replace `appProvider!` with `appProvider?` — provider may not be set yet
- Guard `updateAppId!` with a null check before use
- Guard `app!` (result of `getAppDetailsServer`) — server may return null
- Capture l10n strings from `globalNavigatorKey.currentContext` before `await` calls to avoid async-gap BuildContext access

## Test plan

- [ ] Update an existing app — success snackbar appears and app list refreshes
- [ ] Simulate failure (wrong server) — error snackbar appears, no crash
- [ ] No regression on add app flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

