### PR TITLE
fix daily recap showing wrong conversations

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -194,6 +194,7 @@ def get_conversations(
     categories: Optional[List[str]] = None,
     folder_id: Optional[str] = None,
     starred: Optional[bool] = None,
+    date_field: str = 'created_at',
 ):
     conversations_ref = db.collection('users').document(uid).collection(conversations_collection)
     if not include_discarded:
@@ -212,12 +213,13 @@ def get_conversations(
 
     # Apply date range filters if provided
     if start_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter(date_field, '>=', start_date))
     if end_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter(date_field, '<=', end_date))
 
-    # Sort
-    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    # Sort — must match the range-filter field to satisfy Firestore index requirements
+    sort_field = date_field if (start_date or end_date) else 'created_at'
+    conversations_ref = conversations_ref.order_by(sort_field, direction=firestore.Query.DESCENDING)
 
     # Limits
     conversations_ref = conversations_ref.limit(limit).offset(offset)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1349,7 +1349,9 @@ def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depen
             end_date_utc = datetime.combine(display_date, time.max).replace(tzinfo=pytz.utc)
 
     # Get conversations for the date, excluding locked conversations
-    conversations_data = conversations_db.get_conversations(uid, start_date=start_date_utc, end_date=end_date_utc)
+    conversations_data = conversations_db.get_conversations(
+        uid, start_date=start_date_utc, end_date=end_date_utc, date_field='started_at'
+    )
     if conversations_data:
         conversations_data = [c for c in conversations_data if not c.get('is_locked', False)]
 
@@ -1499,7 +1501,9 @@ def regenerate_daily_summary(summary_id: str, uid: str = Depends(auth.get_curren
         start_date_utc = datetime.combine(target_date, time.min).replace(tzinfo=pytz.utc)
         end_date_utc = datetime.combine(target_date, time.max).replace(tzinfo=pytz.utc)
 
-    conversations_data = conversations_db.get_conversations(uid, start_date=start_date_utc, end_date=end_date_utc)
+    conversations_data = conversations_db.get_conversations(
+        uid, start_date=start_date_utc, end_date=end_date_utc, date_field='started_at'
+    )
     if conversations_data:
         conversations_data = [c for c in conversations_data if not c.get('is_locked', False)]
     if not conversations_data:

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -150,7 +150,9 @@ def _send_summary_notification(user_data: tuple):
         )
         return
 
-    conversations_data = conversations_db.get_conversations(uid, start_date=start_date_utc, end_date=end_date_utc)
+    conversations_data = conversations_db.get_conversations(
+        uid, start_date=start_date_utc, end_date=end_date_utc, date_field='started_at'
+    )
     if not conversations_data or len(conversations_data) == 0:
         return
 


### PR DESCRIPTION
## Summary

- Daily recaps were including conversations from previous days because `get_conversations` filtered by `created_at` (when the record was stored in Firestore) instead of `started_at` (when the conversation actually happened)
- A conversation recorded on Monday but uploaded/processed on Wednesday would get a `created_at` of Wednesday, pulling it into Wednesday's recap even though it belongs in Monday's
- This caused highlights to describe old conversations, and clicking a highlight would open a completely different conversation than the one described

## Changes

- Added `date_field` param to `get_conversations` (defaults to `'created_at'` — all other callers unaffected)
- All three daily recap code paths (scheduled cron job, test trigger endpoint, regenerate endpoint) now pass `date_field='started_at'`
- Sort field is updated to match the filter field, as Firestore requires `order_by` to match the range-filter field

## Note

If Firestore returns index errors after deploy, a composite index on `(discarded == false, started_at)` will need to be added in the Firebase console — same pattern as the existing `(discarded, created_at)` index.

Discord thread: https://discord.com/channels/1192313062041067520/1518975073560694904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

