### PR TITLE
desktop: re-warm realtime hub on system wake (fix dead PTT after sleep)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed voice replies sometimes doing nothing after the Mac wakes from sleep \u2014 the realtime voice session now refreshes on wake instead of using a stale connection"
+  ],
   "releases": [
     {
       "version": "0.11.498",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 import CoreGraphics
 import Foundation
@@ -132,9 +133,33 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     NotificationCenter.default.addObserver(
       self, selector: #selector(settingsChanged),
       name: .realtimeOmniSettingsDidChange, object: nil)
+    // After the Mac sleeps, a long-lived WS can come back a "zombie": still open at the
+    // socket level (so PTT routes a turn to it), but the server is gone — the turn commits
+    // and silently never replies, with no close event to trigger reconnect or fallback. The
+    // only reliable recovery today is a manual app restart. Observe system wake and drop +
+    // rebuild the session once, so the first PTT after sleep gets a fresh socket. Rare,
+    // discrete event (not a timer) → no reconnect churn. Register exactly once.
+    NSWorkspace.shared.notificationCenter.removeObserver(
+      self, name: NSWorkspace.didWakeNotification, object: nil)
+    NSWorkspace.shared.notificationCenter.addObserver(
+      self, selector: #selector(systemDidWake),
+      name: NSWorkspace.didWakeNotification, object: nil)
     // Expose the headless E2E action (omi-ctl action hub_test_turn pcm=… provider=…).
     RealtimeHubTestHarness.registerAutomationAction()
     refreshAboutUserCard()
+  }
+
+  /// System woke from sleep — proactively replace a possibly-stale socket so the first PTT
+  /// after sleep doesn't hit a zombie session (commit → no reply → no fallback → hang).
+  /// Only acts when idle: a live session exists and we're neither mid-reply nor mid-mint, so
+  /// this never interrupts an active turn or races a connect already in flight. teardown
+  /// forces session=nil so ensureWarm() rebuilds (it would otherwise treat the stale socket
+  /// as already-warm and no-op).
+  @objc private func systemDidWake() {
+    guard session != nil, !responding, !minting else { return }
+    log("RealtimeHub: system woke — re-warming session (dropping possibly-stale socket)")
+    teardownSession()
+    ensureWarm()
   }
 
   @objc private func settingsChanged() {


### PR DESCRIPTION
## Problem
After the Mac sleeps, the long-lived realtime voice WebSocket comes back a **zombie** — still open at the socket level (so PTT routes a turn to it) but the server is gone. The turn commits and **silently never replies**, with no close event to trigger reconnect or fallback. Only a manual app restart fixes it (a *fresh* connect always works). This is the recurring "first PTT after overnight does nothing" report.

## Fix (deliberately minimal — not the reverted #8061)
Observe `NSWorkspace.didWakeNotification` and, when idle, drop + rebuild the session **once** so the first PTT after sleep uses a fresh socket.
- **No timer, no relentless reconnect, no `didBecomeActive`** — a single discrete wake event, so it can't cause the reconnect churn that broke #8061.
- Reuses the **exact `teardownSession()+ensureWarm()` path** that `settingsChanged()` already runs on every voice-model change (proven code).
- Guarded on `!responding && !minting` → never interrupts an active turn or races a connect in flight.

## Verified
- Compiles clean.
- **Happy-path hub turn still returns transcript + reply + audio** (no regression) on a named build.
- The wake trigger itself fires on real sleep/wake (standard documented API); the mechanism it runs is already proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

