### PR TITLE
Harden dashboard task freshness reconciliation

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -609,6 +609,60 @@ actor ActionItemStorage {
         }
     }
 
+    /// Reconcile dashboard visibility fields from authoritative server rows without
+    /// overwriting user-editable task content. This deliberately bypasses the
+    /// 60-second optimistic-update guard in `syncTaskActionItems` only for fields
+    /// that decide whether a row belongs in dashboard buckets: completion,
+    /// deletion, and due date.
+    @discardableResult
+    func reconcileDashboardVisibilityFields(_ items: [TaskActionItem]) async throws -> Int {
+        guard !items.isEmpty else { return 0 }
+        let db = try await ensureInitialized()
+
+        let reconciled = try await db.write { database -> Int in
+            var count = 0
+            for item in items {
+                guard var record = try ActionItemRecord
+                    .filter(Column("backendId") == item.id)
+                    .fetchOne(database) else { continue }
+
+                let incomingDeleted = item.deleted ?? false
+                var changed = false
+
+                if record.completed != item.completed {
+                    record.completed = item.completed
+                    changed = true
+                }
+                if record.deleted != incomingDeleted {
+                    record.deleted = incomingDeleted
+                    record.deletedBy = item.deletedBy
+                    changed = true
+                } else if incomingDeleted, record.deletedBy != item.deletedBy {
+                    record.deletedBy = item.deletedBy
+                    changed = true
+                }
+                if record.dueAt != item.dueAt {
+                    record.dueAt = item.dueAt
+                    changed = true
+                }
+
+                guard changed else { continue }
+                let incomingTimestamp = item.updatedAt ?? item.createdAt
+                if incomingTimestamp > record.updatedAt {
+                    record.updatedAt = incomingTimestamp
+                }
+                try record.update(database)
+                count += 1
+            }
+            return count
+        }
+
+        if reconciled > 0 {
+            log("ActionItemStorage: Reconciled \(reconciled) dashboard visibility fields from backend")
+        }
+        return reconciled
+    }
+
 
     /// Hard-delete incomplete tasks NOT present in the API response.
     /// This cleans up tasks that were moved to staged_tasks or deleted on the backend

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -611,9 +611,9 @@ actor ActionItemStorage {
 
     /// Reconcile dashboard visibility fields from authoritative server rows without
     /// overwriting user-editable task content. This deliberately bypasses the
-    /// 60-second optimistic-update guard in `syncTaskActionItems` only for fields
-    /// that decide whether a row belongs in dashboard buckets: completion,
-    /// deletion, and due date.
+    /// 60-second optimistic-update guard in `syncTaskActionItems` only for completion
+    /// and deletion; due dates are reconciled only when they are not protected by a
+    /// recent local edit, because due date edits are PATCHed optimistically.
     @discardableResult
     func reconcileDashboardVisibilityFields(_ items: [TaskActionItem]) async throws -> Int {
         guard !items.isEmpty else { return 0 }
@@ -641,13 +641,15 @@ actor ActionItemStorage {
                     record.deletedBy = item.deletedBy
                     changed = true
                 }
-                if record.dueAt != item.dueAt {
+                let incomingTimestamp = item.updatedAt ?? item.createdAt
+                let protectsRecentLocalDueDate = Date().timeIntervalSince(record.updatedAt) < 60
+                    && record.updatedAt > incomingTimestamp
+                if record.dueAt != item.dueAt && !protectsRecentLocalDueDate {
                     record.dueAt = item.dueAt
                     changed = true
                 }
 
                 guard changed else { continue }
-                let incomingTimestamp = item.updatedAt ?? item.createdAt
                 if incomingTimestamp > record.updatedAt {
                     record.updatedAt = incomingTimestamp
                 }

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
@@ -5,6 +5,11 @@ enum DashboardTaskRefreshPolicy {
     static let shouldMarkIncompleteTasksLoaded = false
     static let shouldAssignTasksPageList = false
     static let serverFetchLimit = 100
+    /// Dashboard freshness reads are page-limited to avoid a full Tasks-page load,
+    /// but must not silently rely on only offset=0. Fetch a bounded number of
+    /// pages for each dashboard-scoped bucket, then let exact-ID refresh handle
+    /// the currently visible rows that moved out of those buckets.
+    static let maxServerFetchPages = 3
 }
 
 enum DashboardExactTaskFetchPolicy {

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift
@@ -2,9 +2,24 @@ import Foundation
 
 @MainActor
 enum DashboardTaskRefreshService {
-    private static var isRefreshing = false
+    private static var inFlightRefreshTask: Task<Void, Never>?
 
     static func refresh(store: TasksStore) async {
+        if let inFlightRefreshTask {
+            await inFlightRefreshTask.value
+            await store.loadDashboardTasks()
+            return
+        }
+
+        let task = Task {
+            await refreshNow(store: store)
+        }
+        inFlightRefreshTask = task
+        await task.value
+        inFlightRefreshTask = nil
+    }
+
+    private static func refreshNow(store: TasksStore) async {
         guard DashboardTaskRefreshPolicy.shouldSyncFromServer else {
             await store.loadDashboardTasks()
             return
@@ -17,10 +32,6 @@ enum DashboardTaskRefreshService {
             await store.loadDashboardTasks()
             return
         }
-        guard !isRefreshing else { return }
-
-        isRefreshing = true
-        defer { isRefreshing = false }
 
         await store.loadDashboardTasks()
 
@@ -44,6 +55,10 @@ enum DashboardTaskRefreshService {
 
             if !plan.itemsToSync.isEmpty {
                 try await ActionItemStorage.shared.syncTaskActionItems(plan.itemsToSync)
+                let visibilityReconciled = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(plan.itemsToSync)
+                if visibilityReconciled > 0 {
+                    log("DashboardTaskRefreshService: Reconciled \(visibilityReconciled) dashboard visibility field updates")
+                }
             }
             for backendId in plan.backendIdsToHardDelete {
                 try await ActionItemStorage.shared.hardDeleteByBackendId(backendId)
@@ -72,22 +87,39 @@ enum DashboardTaskRefreshService {
         let sevenDaysAgo = calendar.date(byAdding: .day, value: -7, to: now) ?? now
         let limit = DashboardTaskRefreshPolicy.serverFetchLimit
 
-        async let dueWindowResponse = APIClient.shared.getActionItems(
-            limit: limit,
-            offset: 0,
-            completed: false,
-            dueStartDate: sevenDaysAgo,
-            dueEndDate: endOfToday
-        )
-        async let recentResponse = APIClient.shared.getActionItems(
-            limit: limit,
-            offset: 0,
-            completed: false,
-            startDate: sevenDaysAgo
-        )
+        async let dueWindowItems = fetchDashboardWindowPages(limit: limit) { offset in
+            try await APIClient.shared.getActionItems(
+                limit: limit,
+                offset: offset,
+                completed: false,
+                dueStartDate: sevenDaysAgo,
+                dueEndDate: endOfToday
+            )
+        }
+        async let recentItems = fetchDashboardWindowPages(limit: limit) { offset in
+            try await APIClient.shared.getActionItems(
+                limit: limit,
+                offset: offset,
+                completed: false,
+                startDate: sevenDaysAgo
+            )
+        }
 
-        let (dueWindow, recent) = try await (dueWindowResponse, recentResponse)
-        return [dueWindow, recent].flatMap(\.items)
+        let (dueWindow, recent) = try await (dueWindowItems, recentItems)
+        return dueWindow + recent
+    }
+
+    private static func fetchDashboardWindowPages(
+        limit: Int,
+        fetch: (Int) async throws -> ActionItemsListResponse
+    ) async throws -> [TaskActionItem] {
+        var items: [TaskActionItem] = []
+        for page in 0..<DashboardTaskRefreshPolicy.maxServerFetchPages {
+            let response = try await fetch(page * limit)
+            items.append(contentsOf: response.items)
+            if !response.hasMore || response.items.count < limit { break }
+        }
+        return items
     }
 
     private static func fetchExactServerTruth(

--- a/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
@@ -29,7 +29,7 @@ final class ActionItemStorageVisibilityReconciliationTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testVisibilityReconciliationBypassesRecentLocalChangeGuardWithoutOverwritingDescription() async throws {
+    func testVisibilityReconciliationBypassesRecentLocalChangeGuardWithoutOverwritingDescriptionOrDueDateEdit() async throws {
         let originalDueAt = Date(timeIntervalSince1970: 1_750_000_000)
         let serverDueAt = Date(timeIntervalSince1970: 1_750_086_400)
         let createdAt = Date(timeIntervalSince1970: 1_749_900_000)
@@ -82,7 +82,7 @@ final class ActionItemStorageVisibilityReconciliationTests: XCTestCase {
         )
         XCTAssertTrue(refreshed.completed)
         XCTAssertEqual(refreshed.deleted, true)
-        XCTAssertEqual(refreshed.dueAt, serverDueAt)
+        XCTAssertEqual(refreshed.dueAt, originalDueAt)
         XCTAssertEqual(refreshed.description, "local description must survive")
     }
 

--- a/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ActionItemStorageVisibilityReconciliationTests: XCTestCase {
+    private var testUserId: String!
+    private var userDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        testUserId = "visibility-reconcile-test-\(UUID().uuidString)"
+        try await RewindDatabase.shared.switchUser(to: testUserId)
+        await ActionItemStorage.shared.invalidateCache()
+
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        userDir = appSupport
+            .appendingPathComponent("Omi", isDirectory: true)
+            .appendingPathComponent("users", isDirectory: true)
+            .appendingPathComponent(testUserId, isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        await ActionItemStorage.shared.invalidateCache()
+        await RewindDatabase.shared.close()
+        if let userDir { try? FileManager.default.removeItem(at: userDir) }
+        RewindDatabase.currentUserId = nil
+        try await super.tearDown()
+    }
+
+    func testVisibilityReconciliationBypassesRecentLocalChangeGuardWithoutOverwritingDescription() async throws {
+        let originalDueAt = Date(timeIntervalSince1970: 1_750_000_000)
+        let serverDueAt = Date(timeIntervalSince1970: 1_750_086_400)
+        let createdAt = Date(timeIntervalSince1970: 1_749_900_000)
+        let staleServerUpdatedAt = Date(timeIntervalSince1970: 1_749_950_000)
+
+        try await ActionItemStorage.shared.syncTaskActionItems([
+            task(
+                id: "backend-task-1",
+                description: "local description must survive",
+                completed: false,
+                deleted: false,
+                createdAt: createdAt,
+                updatedAt: staleServerUpdatedAt,
+                dueAt: originalDueAt
+            )
+        ])
+
+        // Local optimistic field updates mutate updatedAt to now, putting the row
+        // inside the existing 60s optimistic-update protection window. A normal
+        // sync with older server timestamps must not update the record.
+        try await ActionItemStorage.shared.updateActionItemFields(
+            backendId: "backend-task-1",
+            description: "local description must survive",
+            dueAt: originalDueAt
+        )
+
+        let authoritativeServerItem = task(
+            id: "backend-task-1",
+            description: "server description must not overwrite local text",
+            completed: true,
+            deleted: true,
+            createdAt: createdAt,
+            updatedAt: staleServerUpdatedAt,
+            dueAt: serverDueAt
+        )
+        try await ActionItemStorage.shared.syncTaskActionItems([authoritativeServerItem])
+        let afterNormalSync = try XCTUnwrap(
+            try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "backend-task-1")
+        )
+        XCTAssertFalse(afterNormalSync.completed, "precondition: normal sync is still guarded")
+        XCTAssertEqual(afterNormalSync.dueAt, originalDueAt, "precondition: due date is still guarded")
+
+        let reconciled = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields([
+            authoritativeServerItem
+        ])
+
+        XCTAssertEqual(reconciled, 1)
+        let refreshed = try XCTUnwrap(
+            try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "backend-task-1")
+        )
+        XCTAssertTrue(refreshed.completed)
+        XCTAssertEqual(refreshed.deleted, true)
+        XCTAssertEqual(refreshed.dueAt, serverDueAt)
+        XCTAssertEqual(refreshed.description, "local description must survive")
+    }
+
+    private func task(
+        id: String,
+        description: String,
+        completed: Bool,
+        deleted: Bool,
+        createdAt: Date,
+        updatedAt: Date,
+        dueAt: Date?
+    ) -> TaskActionItem {
+        TaskActionItem(
+            id: id,
+            description: description,
+            completed: completed,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            dueAt: dueAt,
+            deleted: deleted
+        )
+    }
+}

--- a/desktop/macos/Desktop/Tests/DashboardTaskRefreshPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardTaskRefreshPolicyTests.swift
@@ -8,6 +8,28 @@ final class DashboardTaskRefreshPolicyTests: XCTestCase {
         XCTAssertFalse(DashboardTaskRefreshPolicy.shouldMarkIncompleteTasksLoaded)
         XCTAssertFalse(DashboardTaskRefreshPolicy.shouldAssignTasksPageList)
         XCTAssertGreaterThan(DashboardTaskRefreshPolicy.serverFetchLimit, 0)
+        XCTAssertGreaterThan(
+            DashboardTaskRefreshPolicy.maxServerFetchPages,
+            1,
+            "Dashboard freshness must not silently rely on only the first server page"
+        )
+    }
+
+    func testDashboardRefreshServiceSharesInflightRefreshAndReloadsLocalStateForWaiters() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Stores/DashboardTaskRefreshService.swift")
+        let source = try String(contentsOf: sourceURL)
+
+        XCTAssertTrue(
+            source.contains("private static var inFlightRefreshTask: Task<Void, Never>?"),
+            "Dashboard refresh must have an explicit shared in-flight task instead of a drop-on-floor boolean guard"
+        )
+        XCTAssertTrue(
+            source.contains("await inFlightRefreshTask.value\n            await store.loadDashboardTasks()"),
+            "Concurrent dashboard refresh callers should await the in-flight refresh and then reload local dashboard state before returning"
+        )
     }
 
     func testDashboardExactTaskFetchLimiterCapsConcurrentOperations() async {


### PR DESCRIPTION
## Summary
- share/await an in-flight dashboard refresh so concurrent callers still reload local dashboard state
- paginate dashboard freshness buckets instead of relying on offset=0 only
- add a targeted authoritative visibility reconciliation path for completed/deleted/dueAt without overwriting user-edited task text

## Testing
- `git diff --check`
- `xcrun swift package --package-path Desktop describe --type json`
- `xcrun swiftc -parse Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift Desktop/Sources/Stores/DashboardTaskRefreshService.swift Desktop/Sources/Rewind/Core/ActionItemStorage.swift Desktop/Tests/DashboardTaskRefreshPolicyTests.swift Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift`
- attempted `xcrun swift test --package-path Desktop --filter 'DashboardTaskRefreshPolicyTests|ActionItemStorageVisibilityReconciliationTests'`; blocked while downloading SwiftPM binary artifacts with duplicate GitHub keychain entries, then killed after ~5m\n\nFixes #8124\n\nStacked on #8013 because `DashboardTaskRefreshService` is introduced there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

