### PR TITLE
fix(admin): Redis-cache PostHog results so dashboard panels survive throttling

### DIFF
--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { posthogFetch } from "@/lib/posthog";
+import { posthogResults } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -51,77 +51,11 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const response = await posthogFetch(host, projectId, apiKey, hogql);
-
-    if (!response.ok) {
-      // HogQL countIf with DISTINCT might not be supported — fall back to two queries
-      const [crashRes, dauRes] = await Promise.allSettled([
-        fetch(`${host}/api/projects/${projectId}/query/`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            query: {
-              kind: "HogQLQuery",
-              query: `
-                SELECT toDate(timestamp) as day, count() as crashes
-                FROM events
-                WHERE event = 'App Crash Detected'
-                  AND properties.$os_name = 'macOS'
-                  AND timestamp >= now() - interval ${days} day
-                GROUP BY day ORDER BY day
-              `,
-            },
-          }),
-        }),
-        fetch(`${host}/api/projects/${projectId}/query/`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            query: {
-              kind: "HogQLQuery",
-              query: `
-                SELECT toDate(timestamp) as day, count(DISTINCT distinct_id) as users
-                FROM events
-                WHERE properties.$os_name = 'macOS'
-                  AND timestamp >= now() - interval ${days} day
-                GROUP BY day ORDER BY day
-              `,
-            },
-          }),
-        }),
-      ]);
-
-      const crashMap: Record<string, number> = {};
-      const dauMap: Record<string, number> = {};
-
-      if (crashRes.status === "fulfilled" && crashRes.value.ok) {
-        const raw = await crashRes.value.json();
-        for (const [date, count] of raw.results || []) {
-          crashMap[date] = count;
-        }
-      }
-
-      if (dauRes.status === "fulfilled" && dauRes.value.ok) {
-        const raw = await dauRes.value.json();
-        for (const [date, count] of raw.results || []) {
-          dauMap[date] = count;
-        }
-      }
-
-      const data = buildDateSeries(days, crashMap, dauMap);
-      cache = { data, days, timestamp: Date.now() };
-      return NextResponse.json({ data, days });
-    }
-
-    // Single-query path succeeded
-    const raw = await response.json();
-    const results: [string, number, number][] = raw.results || [];
+    const results = (await posthogResults(host, projectId, apiKey, hogql)) as [
+      string,
+      number,
+      number,
+    ][];
 
     const crashMap: Record<string, number> = {};
     const dauMap: Record<string, number> = {};

--- a/web/admin/app/api/omi/stats/dau-trends/route.ts
+++ b/web/admin/app/api/omi/stats/dau-trends/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { posthogFetch } from "@/lib/posthog";
+import { posthogResults } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -44,19 +44,13 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const response = await posthogFetch(host, projectId, apiKey, hogql);
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error("PostHog query error:", response.status, text);
-      return NextResponse.json(
-        { error: `PostHog API error: ${response.status}` },
-        { status: 502 }
-      );
+    let results: [string, number][];
+    try {
+      results = (await posthogResults(host, projectId, apiKey, hogql)) as [string, number][];
+    } catch (err) {
+      console.error("PostHog query error:", err);
+      return NextResponse.json({ error: "PostHog API error" }, { status: 502 });
     }
-
-    const raw = await response.json();
-    const results: [string, number][] = raw.results || [];
 
     // Build map from results
     const dateMap: Record<string, number> = {};

--- a/web/admin/app/api/omi/stats/macos-versions/route.ts
+++ b/web/admin/app/api/omi/stats/macos-versions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin, { getDb } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
-import { posthogFetch } from "@/lib/posthog";
+import { posthogResults } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -32,15 +32,7 @@ type Breakdown = {
 };
 
 async function posthogQuery(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await posthogFetch(host, projectId, apiKey, query);
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`PostHog API error: ${response.status} ${text}`);
-  }
-
-  const raw = await response.json();
-  return Array.isArray(raw.results) ? raw.results : [];
+  return posthogResults(host, projectId, apiKey, query);
 }
 
 function chunk<T>(items: T[], size: number) {

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -1,21 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
-import { posthogFetch } from '@/lib/posthog';
+import { posthogResults } from '@/lib/posthog';
 export const dynamic = 'force-dynamic';
 
 type RetentionPoint = { day: number; retention: number };
 type CohortRow = { date: string; users: number; data: RetentionPoint[] };
 
-async function posthogQuery(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await posthogFetch(host, projectId, apiKey, query);
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`PostHog API error: ${response.status} ${text}`);
-  }
-
-  const raw = await response.json();
-  return Array.isArray(raw.results) ? raw.results : [];
+async function posthogQuery(host: string, projectId: string, apiKey: string, query: string): Promise<any[]> {
+  return (await posthogResults(host, projectId, apiKey, query)) as any[];
 }
 
 export async function GET(request: NextRequest) {

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { posthogFetch } from "@/lib/posthog";
+import { posthogResults } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -8,13 +8,7 @@ let cache: { data: any; days: number; timestamp: number } | null = null;
 const CACHE_TTL = 30 * 60 * 1000;
 
 async function hogql(apiKey: string, projectId: string, host: string, query: string) {
-  const resp = await posthogFetch(host, projectId, apiKey, query);
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`PostHog query error ${resp.status}: ${text.slice(0, 200)}`);
-  }
-  const raw = await resp.json();
-  return raw.results || [];
+  return posthogResults(host, projectId, apiKey, query);
 }
 
 export async function GET(request: NextRequest) {

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -1,17 +1,23 @@
-// Shared PostHog HogQL fetch with 429 backoff.
+// Shared PostHog HogQL access with 429 backoff + Redis result caching.
 //
-// PostHog's query endpoint is aggressively burst-rate-limited (HTTP 429,
-// "Request was throttled. Expected available in 1 second."). The dashboard
-// fires ~8 stat routes at once on load, so without retry these queries 429
-// and the panels render errors / empty. Retrying with short backoff lets the
-// burst drain and the per-route caches populate.
+// PostHog's query endpoint is aggressively rate-limited. The dashboard fires
+// ~8 HogQL queries on every load; without caching, reloads + SWR retries blow
+// the personal-API-key quota and every panel 429s.
+//
+// `posthogResults` caches each query's result in Redis (shared across Cloud
+// Run instances), so a given query hits PostHog at most once per soft-TTL
+// window instead of on every load. On throttle/error it serves the last good
+// cached value (bounded by a hard TTL) rather than failing the panel.
+
+import { createHash } from "crypto";
+import { getJsonCache, setJsonCache } from "@/lib/redis";
 
 export async function posthogFetch(
   host: string,
   projectId: string,
   apiKey: string,
   query: string,
-  { maxRetries = 5 }: { maxRetries?: number } = {},
+  { maxRetries = 2 }: { maxRetries?: number } = {},
 ): Promise<Response> {
   const url = `${host}/api/projects/${projectId}/query/`;
   let res!: Response;
@@ -26,9 +32,50 @@ export async function posthogFetch(
       body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
     });
     if (res.status !== 429 || attempt === maxRetries) return res;
-    // Burst throttle clears in ~1s; back off linearly with jitter.
-    const waitMs = 1000 * (attempt + 1) + Math.floor(Math.random() * 400);
+    const waitMs = 800 * (attempt + 1) + Math.floor(Math.random() * 300);
     await new Promise((r) => setTimeout(r, waitMs));
   }
   return res;
+}
+
+type CachedResults = { results: unknown[]; freshAt: number };
+
+const SOFT_TTL_MS = 30 * 60 * 1000; // serve cached without re-querying for 30 min
+const HARD_TTL_S = 6 * 60 * 60; // keep last-good up to 6h to survive throttling
+
+/**
+ * Run a HogQL query and return its `results` array, cached in Redis.
+ * - Fresh cache (< soft TTL): returned without touching PostHog.
+ * - Stale/miss: query PostHog (with 429 backoff); on success refresh the cache.
+ * - On PostHog error/throttle: fall back to the last good cached value if any
+ *   (within hard TTL), otherwise throw so the route surfaces the failure.
+ */
+export async function posthogResults(
+  host: string,
+  projectId: string,
+  apiKey: string,
+  query: string,
+  opts: { softTtlMs?: number; hardTtlS?: number } = {},
+): Promise<unknown[]> {
+  const softTtlMs = opts.softTtlMs ?? SOFT_TTL_MS;
+  const hardTtlS = opts.hardTtlS ?? HARD_TTL_S;
+  const key = `admin:ph:${createHash("sha1").update(`${projectId}|${query}`).digest("hex")}`;
+
+  const cached = await getJsonCache<CachedResults>(key);
+  if (cached && Date.now() - cached.freshAt < softTtlMs) return cached.results;
+
+  try {
+    const res = await posthogFetch(host, projectId, apiKey, query);
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`PostHog API error: ${res.status} ${text.slice(0, 160)}`);
+    }
+    const raw = await res.json();
+    const results = Array.isArray(raw.results) ? raw.results : [];
+    await setJsonCache(key, { results, freshAt: Date.now() }, hardTtlS);
+    return results;
+  } catch (err) {
+    if (cached) return cached.results; // serve last good value through the throttle
+    throw err;
+  }
 }


### PR DESCRIPTION
Final fix in the admin-data series (#8106 any-event, #8107 deploy unblock, #8119 backoff). Live verification showed PostHog throttles the personal key at a **sustained** level (a single `dau-trends` call ran 16.7s through all retries, still 429) — retry can't beat a quota cap, and ~8 live HogQL queries per dashboard load (×retries×reloads) is what exhausts it.

Adds `posthogResults()`: **Redis-cached** query results (30 min soft TTL, 6 h hard) with **serve-last-good-on-throttle**, and routes dau-trends / retention / viral-metrics / macos-versions / crash-rate through it. Each query now hits PostHog at most once per soft-TTL window instead of every load, so the quota holds. Also trims `posthogFetch` retries 5→2 (stop amplifying load) and removes crash-rate's stale countIf-DISTINCT fallback so it never serves zeros on failure (per admin AGENTS).

tsc clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

