### PR TITLE
Scope desktop startup warmups to user sessions

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
@@ -120,7 +120,7 @@ class CrispManager: ObservableObject {
     }
 
     /// Stop observing (called on sign-out)
-    func stop() {
+    func stop(preserveReadState: Bool = false) {
         initialPollTask?.cancel()
         initialPollTask = nil
         if let obs = activationObserver { NotificationCenter.default.removeObserver(obs) }
@@ -129,10 +129,12 @@ class CrispManager: ObservableObject {
         refreshAllObserver = nil
         isStarted = false
         unreadCount = 0
-        // Clear persisted timestamps so next sign-in starts fresh
-        UserDefaults.standard.removeObject(forKey: "crisp_lastSeenTimestamp")
-        UserDefaults.standard.removeObject(forKey: "crisp_latestOperatorTimestamp")
-        notifiedMessages.removeAll()
+        if !preserveReadState {
+            // Clear persisted timestamps so next sign-in starts fresh.
+            UserDefaults.standard.removeObject(forKey: "crisp_lastSeenTimestamp")
+            UserDefaults.standard.removeObject(forKey: "crisp_latestOperatorTimestamp")
+            notifiedMessages.removeAll()
+        }
     }
 
     // MARK: - Private

--- a/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CrispManager.swift
@@ -72,7 +72,7 @@ class CrispManager: ObservableObject {
     ///     without touching the network, auth state, or firing real notifications.
     ///   - initialPollDelay: Optional delay before the initial poll. Activation and
     ///     Cmd+R events still poll immediately.
-    func start(performInitialPoll: Bool = true, initialPollDelay: TimeInterval = 0) {
+    func start(performInitialPoll: Bool = true, initialPollDelay: TimeInterval = 0, sessionUserId: String? = nil) {
         guard !isStarted else { return }
         isStarted = true
 
@@ -90,6 +90,10 @@ class CrispManager: ObservableObject {
                     try? await Task.sleep(nanoseconds: UInt64(initialPollDelay * 1_000_000_000))
                     guard !Task.isCancelled else { return }
                     guard let self, self.isStarted else { return }
+                    guard StartupWarmupSessionScope(userId: sessionUserId).matches(
+                        currentUserId: UserDefaults.standard.string(forKey: "auth_userId"),
+                        isSignedIn: AuthState.shared.isSignedIn
+                    ) else { return }
                     self.pollForMessages()
                 }
             } else {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -198,8 +198,11 @@ struct DesktopHomeView: View {
                 log("DesktopHomeView: Screen analysis disabled in settings, skipping auto-start")
               }
 
-              // Start Crisp chat in background for notifications
-              CrispManager.shared.start(initialPollDelay: StartupWarmupPolicy.crispInitialPollDelay)
+              // Start Crisp chat in background for notifications, scoped to the signed-in user
+              CrispManager.shared.start(
+                initialPollDelay: StartupWarmupPolicy.crispInitialPollDelay,
+                sessionUserId: UserDefaults.standard.string(forKey: "auth_userId")
+              )
 
               // Set up floating control bar (only show if user hasn't disabled it)
               FloatingControlBarManager.shared.setup(
@@ -268,9 +271,7 @@ struct DesktopHomeView: View {
               log(
                 "DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription"
               )
-              viewModelContainer.resetStartupState()
-              didScheduleConversationWarmup = false
-              didScheduleAgentVMProvisioning = false
+              resetSessionScopedStartupWarmups()
               appState.conversations = []
               appState.folders = []
               appState.selectedFolderId = nil
@@ -287,10 +288,15 @@ struct DesktopHomeView: View {
               log(
                 "DesktopHomeView: resetOnboardingRequested — clearing live onboarding state for current app"
               )
+              resetSessionScopedStartupWarmups()
               appState.hasCompletedOnboarding = false
               onboardingStep = 0
               onboardingJustCompleted = false
               appState.stopTranscription()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+              log("DesktopHomeView: app terminating — cancelling startup warmups")
+              resetSessionScopedStartupWarmups()
             }
             // Handle transcription toggle from menu bar
             .onReceive(NotificationCenter.default.publisher(for: .toggleTranscriptionRequested)) {
@@ -644,47 +650,43 @@ struct DesktopHomeView: View {
     }
   }
 
+  private func resetSessionScopedStartupWarmups() {
+    viewModelContainer.resetStartupState()
+    didScheduleConversationWarmup = false
+    didScheduleAgentVMProvisioning = false
+    proactiveMonitoringStartGate.finishAttempt()
+    initialFileIndexingBackfill.releaseReservation()
+    CrispManager.shared.stop()
+  }
+
   private func scheduleAgentVMProvisioning() {
     guard !didScheduleAgentVMProvisioning else { return }
     didScheduleAgentVMProvisioning = true
 
-    Task { @MainActor in
-      try? await Task.sleep(
-        nanoseconds: UInt64(StartupWarmupPolicy.agentVMProvisioningDelay * 1_000_000_000)
-      )
-      guard !Task.isCancelled else {
-        didScheduleAgentVMProvisioning = false
-        return
-      }
-      guard await AuthState.shared.isSignedIn else {
-        didScheduleAgentVMProvisioning = false
-        return
-      }
+    let scheduled = viewModelContainer.scheduleSessionWarmup(
+      id: .agentVMProvisioning,
+      delay: StartupWarmupPolicy.agentVMProvisioningDelay,
+      onCancel: { didScheduleAgentVMProvisioning = false }
+    ) {
       await AgentVMService.shared.ensureProvisioned()
     }
+    if !scheduled { didScheduleAgentVMProvisioning = false }
   }
 
   private func scheduleConversationWarmup() {
     guard !didScheduleConversationWarmup else { return }
     didScheduleConversationWarmup = true
 
-    Task { @MainActor in
-      try? await Task.sleep(
-        nanoseconds: UInt64(StartupWarmupPolicy.conversationWarmupDelay * 1_000_000_000)
-      )
-      guard !Task.isCancelled else {
-        didScheduleConversationWarmup = false
-        return
-      }
-      guard await AuthState.shared.isSignedIn else {
-        didScheduleConversationWarmup = false
-        return
-      }
-
+    let scheduled = viewModelContainer.scheduleSessionWarmup(
+      id: .conversationWarmup,
+      delay: StartupWarmupPolicy.conversationWarmupDelay,
+      onCancel: { didScheduleConversationWarmup = false }
+    ) {
       async let conversations: Void = loadConversationsIfNeeded()
       async let folders: Void = loadFoldersIfNeeded()
       _ = await (conversations, folders)
     }
+    if !scheduled { didScheduleConversationWarmup = false }
   }
 
   private func loadConversationsIfNeeded() async {
@@ -703,28 +705,13 @@ struct DesktopHomeView: View {
         hasCompletedBackfill: UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing"))
     else { return }
 
-    Task { @MainActor in
-      try? await Task.sleep(
-        nanoseconds: UInt64(StartupWarmupPolicy.initialFileIndexingDelay * 1_000_000_000)
-      )
-      guard !Task.isCancelled else {
-        initialFileIndexingBackfill.releaseReservation()
-        return
-      }
-      guard await AuthState.shared.isSignedIn else {
-        initialFileIndexingBackfill.releaseReservation()
-        return
-      }
+    let scheduled = viewModelContainer.scheduleSessionWarmup(
+      id: .initialFileIndexing,
+      delay: StartupWarmupPolicy.initialFileIndexingDelay,
+      onCancel: { initialFileIndexingBackfill.releaseReservation() }
+    ) {
       log("DesktopHomeView: Running delayed background file scan for existing user")
       await FileIndexerService.shared.backgroundRescan()
-      guard !Task.isCancelled else {
-        initialFileIndexingBackfill.releaseReservation()
-        return
-      }
-      guard await AuthState.shared.isSignedIn else {
-        initialFileIndexingBackfill.releaseReservation()
-        return
-      }
       initialFileIndexingBackfill.markScanCompleted()
       if initialFileIndexingBackfill.shouldMarkComplete {
         UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
@@ -733,24 +720,17 @@ struct DesktopHomeView: View {
         )
       }
     }
+    if !scheduled { initialFileIndexingBackfill.releaseReservation() }
   }
 
   private func scheduleProactiveMonitoringStart(reason: String) {
     guard proactiveMonitoringStartGate.reserve() else { return }
 
-    Task { @MainActor in
-      try? await Task.sleep(
-        nanoseconds: UInt64(StartupWarmupPolicy.proactiveAssistantsStartDelay * 1_000_000_000)
-      )
-      guard !Task.isCancelled else {
-        proactiveMonitoringStartGate.finishAttempt()
-        return
-      }
-      guard await AuthState.shared.isSignedIn else {
-        proactiveMonitoringStartGate.finishAttempt()
-        return
-      }
-
+    let scheduled = viewModelContainer.scheduleSessionWarmup(
+      id: .proactiveAssistantsStart,
+      delay: StartupWarmupPolicy.proactiveAssistantsStartDelay,
+      onCancel: { proactiveMonitoringStartGate.finishAttempt() }
+    ) {
       let plugin = ProactiveAssistantsPlugin.shared
       guard AssistantSettings.shared.screenAnalysisEnabled, !plugin.isMonitoring else {
         proactiveMonitoringStartGate.finishAttempt()
@@ -775,6 +755,7 @@ struct DesktopHomeView: View {
         }
       }
     }
+    if !scheduled { proactiveMonitoringStartGate.finishAttempt() }
   }
 
   private func updateStoreActivity(for index: Int) {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -271,7 +271,7 @@ struct DesktopHomeView: View {
               log(
                 "DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription"
               )
-              resetSessionScopedStartupWarmups()
+              resetSessionScopedStartupWarmups(preserveCrispReadState: false)
               appState.conversations = []
               appState.folders = []
               appState.selectedFolderId = nil
@@ -288,7 +288,7 @@ struct DesktopHomeView: View {
               log(
                 "DesktopHomeView: resetOnboardingRequested — clearing live onboarding state for current app"
               )
-              resetSessionScopedStartupWarmups()
+              resetSessionScopedStartupWarmups(preserveCrispReadState: false)
               appState.hasCompletedOnboarding = false
               onboardingStep = 0
               onboardingJustCompleted = false
@@ -296,7 +296,7 @@ struct DesktopHomeView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
               log("DesktopHomeView: app terminating — cancelling startup warmups")
-              resetSessionScopedStartupWarmups()
+              resetSessionScopedStartupWarmups(preserveCrispReadState: true)
             }
             // Handle transcription toggle from menu bar
             .onReceive(NotificationCenter.default.publisher(for: .toggleTranscriptionRequested)) {
@@ -650,13 +650,13 @@ struct DesktopHomeView: View {
     }
   }
 
-  private func resetSessionScopedStartupWarmups() {
+  private func resetSessionScopedStartupWarmups(preserveCrispReadState: Bool) {
     viewModelContainer.resetStartupState()
     didScheduleConversationWarmup = false
     didScheduleAgentVMProvisioning = false
     proactiveMonitoringStartGate.finishAttempt()
     initialFileIndexingBackfill.releaseReservation()
-    CrispManager.shared.stop(preserveReadState: true)
+    CrispManager.shared.stop(preserveReadState: preserveCrispReadState)
   }
 
   private func scheduleAgentVMProvisioning() {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -656,7 +656,7 @@ struct DesktopHomeView: View {
     didScheduleAgentVMProvisioning = false
     proactiveMonitoringStartGate.finishAttempt()
     initialFileIndexingBackfill.releaseReservation()
-    CrispManager.shared.stop()
+    CrispManager.shared.stop(preserveReadState: true)
   }
 
   private func scheduleAgentVMProvisioning() {
@@ -705,6 +705,8 @@ struct DesktopHomeView: View {
         hasCompletedBackfill: UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing"))
     else { return }
 
+    let sessionScope = StartupWarmupSessionScope(
+      userId: UserDefaults.standard.string(forKey: "auth_userId"))
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .initialFileIndexing,
       delay: StartupWarmupPolicy.initialFileIndexingDelay,
@@ -712,6 +714,14 @@ struct DesktopHomeView: View {
     ) {
       log("DesktopHomeView: Running delayed background file scan for existing user")
       await FileIndexerService.shared.backgroundRescan()
+      guard !Task.isCancelled,
+            sessionScope.matches(
+              currentUserId: UserDefaults.standard.string(forKey: "auth_userId"),
+              isSignedIn: AuthState.shared.isSignedIn)
+      else {
+        initialFileIndexingBackfill.releaseReservation()
+        return
+      }
       initialFileIndexingBackfill.markScanCompleted()
       if initialFileIndexingBackfill.shouldMarkComplete {
         UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")

--- a/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
@@ -10,6 +10,7 @@ final class StartupWarmupCoordinator {
 
     private var scheduleState = StartupWarmupScheduleState()
     private var sessionTasks: [StartupWarmupTaskID: Task<Void, Never>] = [:]
+    private var sessionTaskTokens: [StartupWarmupTaskID: UUID] = [:]
 
     init(
         tasksStore: TasksStore,
@@ -28,6 +29,7 @@ final class StartupWarmupCoordinator {
     func cancel() {
         sessionTasks.values.forEach { $0.cancel() }
         sessionTasks.removeAll()
+        sessionTaskTokens.removeAll()
     }
 
     func reset() {
@@ -46,6 +48,8 @@ final class StartupWarmupCoordinator {
         guard isCurrentSession(scope) else { return false }
 
         sessionTasks[id]?.cancel()
+        let token = UUID()
+        sessionTaskTokens[id] = token
         sessionTasks[id] = Task { [weak self] in
             guard let self else { return }
             guard await self.sleepForStartupDelay(delay) else {
@@ -57,16 +61,21 @@ final class StartupWarmupCoordinator {
                 return
             }
             await operation()
-            await MainActor.run { self.sessionTasks[id] = nil }
+            await MainActor.run {
+                guard self.sessionTaskTokens[id] == token else { return }
+                self.sessionTasks[id] = nil
+                self.sessionTaskTokens[id] = nil
+            }
         }
         return true
     }
 
     func schedulePostInteractiveWarmup(dbAvailable: Bool) {
         if scheduleState.reserveServiceWarmup() {
-            scheduleSessionWarmup(id: .serviceWarmup, delay: 0) { [weak self] in
+            let scheduled = scheduleSessionWarmup(id: .serviceWarmup, delay: 0) { [weak self] in
                 await self?.runServiceWarmup()
             }
+            if !scheduled { scheduleState.releaseServiceWarmup() }
         }
 
         scheduleDatabaseWarmup(dbAvailable: dbAvailable)
@@ -81,8 +90,12 @@ final class StartupWarmupCoordinator {
             return
         }
 
-        scheduleSessionWarmup(id: .databaseWarmup, delay: 0) { [weak self] in
+        let scheduled = scheduleSessionWarmup(id: .databaseWarmup, delay: 0) { [weak self] in
             await self?.runDatabaseWarmup()
+        }
+        guard scheduled else {
+            scheduleState.releaseDatabaseWarmup()
+            return
         }
         scheduleDashboardNetworkRefresh(dbAvailable: true)
         scheduleChatPromptContextWarmup()

--- a/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
@@ -9,11 +9,7 @@ final class StartupWarmupCoordinator {
     private let retryDatabaseInit: () async -> Bool
 
     private var scheduleState = StartupWarmupScheduleState()
-    private var serviceWarmupTask: Task<Void, Never>?
-    private var databaseWarmupTask: Task<Void, Never>?
-    private var dashboardNetworkRefreshTask: Task<Void, Never>?
-    private var chatPromptContextWarmupTask: Task<Void, Never>?
-    private var databaseRetryTask: Task<Void, Never>?
+    private var sessionTasks: [StartupWarmupTaskID: Task<Void, Never>] = [:]
 
     init(
         tasksStore: TasksStore,
@@ -30,26 +26,45 @@ final class StartupWarmupCoordinator {
     }
 
     func cancel() {
-        serviceWarmupTask?.cancel()
-        databaseWarmupTask?.cancel()
-        dashboardNetworkRefreshTask?.cancel()
-        chatPromptContextWarmupTask?.cancel()
-        databaseRetryTask?.cancel()
+        sessionTasks.values.forEach { $0.cancel() }
+        sessionTasks.removeAll()
     }
 
     func reset() {
         cancel()
-        serviceWarmupTask = nil
-        databaseWarmupTask = nil
-        dashboardNetworkRefreshTask = nil
-        chatPromptContextWarmupTask = nil
-        databaseRetryTask = nil
         scheduleState = StartupWarmupScheduleState()
+    }
+
+    @discardableResult
+    func scheduleSessionWarmup(
+        id: StartupWarmupTaskID,
+        delay: TimeInterval,
+        onCancel: (@MainActor () -> Void)? = nil,
+        operation: @MainActor @escaping () async -> Void
+    ) -> Bool {
+        let scope = currentSessionScope()
+        guard isCurrentSession(scope) else { return false }
+
+        sessionTasks[id]?.cancel()
+        sessionTasks[id] = Task { [weak self] in
+            guard let self else { return }
+            guard await self.sleepForStartupDelay(delay) else {
+                await MainActor.run { onCancel?() }
+                return
+            }
+            guard await self.isCurrentSession(scope) else {
+                await MainActor.run { onCancel?() }
+                return
+            }
+            await operation()
+            await MainActor.run { self.sessionTasks[id] = nil }
+        }
+        return true
     }
 
     func schedulePostInteractiveWarmup(dbAvailable: Bool) {
         if scheduleState.reserveServiceWarmup() {
-            serviceWarmupTask = Task { [weak self] in
+            scheduleSessionWarmup(id: .serviceWarmup, delay: 0) { [weak self] in
                 await self?.runServiceWarmup()
             }
         }
@@ -66,7 +81,7 @@ final class StartupWarmupCoordinator {
             return
         }
 
-        databaseWarmupTask = Task { [weak self] in
+        scheduleSessionWarmup(id: .databaseWarmup, delay: 0) { [weak self] in
             await self?.runDatabaseWarmup()
         }
         scheduleDashboardNetworkRefresh(dbAvailable: true)
@@ -134,10 +149,8 @@ final class StartupWarmupCoordinator {
             return
         }
 
-        dashboardNetworkRefreshTask = Task { [weak self] in
+        scheduleSessionWarmup(id: .dashboardNetworkRefresh, delay: StartupWarmupPolicy.dashboardNetworkRefreshDelay) { [weak self] in
             guard let self else { return }
-            guard await sleepForStartupDelay(StartupWarmupPolicy.dashboardNetworkRefreshDelay) else { return }
-
             await measurePerfAsync("DATA LOAD: Dashboard network refresh") {
                 await self.dashboardViewModel.loadDashboardData()
             }
@@ -145,10 +158,8 @@ final class StartupWarmupCoordinator {
     }
 
     private func scheduleChatPromptContextWarmup() {
-        chatPromptContextWarmupTask = Task { [weak self] in
+        scheduleSessionWarmup(id: .chatPromptContextWarmup, delay: StartupWarmupPolicy.chatPromptContextWarmupDelay) { [weak self] in
             guard let self else { return }
-            guard await sleepForStartupDelay(StartupWarmupPolicy.chatPromptContextWarmupDelay) else { return }
-
             await measurePerfAsync("DATA LOAD: Chat prompt context") {
                 await self.chatProvider.warmupPromptContext()
             }
@@ -157,17 +168,28 @@ final class StartupWarmupCoordinator {
 
     private func scheduleDatabaseRetryIfNeeded(dbAvailable: Bool) {
         guard !dbAvailable else { return }
-        guard databaseRetryTask == nil else { return }
+        guard sessionTasks[.databaseRetry] == nil else { return }
 
-        databaseRetryTask = Task { [weak self] in
+        let scope = currentSessionScope()
+        guard isCurrentSession(scope) else { return }
+
+        sessionTasks[.databaseRetry] = Task { [weak self] in
             guard let self else { return }
             var delay = StartupWarmupPolicy.databaseRetryInitialDelay
 
             while !Task.isCancelled {
                 guard await self.sleepForStartupDelay(delay) else { return }
+                guard await self.isCurrentSession(scope) else {
+                    await MainActor.run { self.sessionTasks[.databaseRetry] = nil }
+                    return
+                }
                 let didRecover = await self.retryDatabaseInit()
+                guard await self.isCurrentSession(scope) else {
+                    await MainActor.run { self.sessionTasks[.databaseRetry] = nil }
+                    return
+                }
                 if didRecover {
-                    self.databaseRetryTask = nil
+                    self.sessionTasks[.databaseRetry] = nil
                     return
                 }
 
@@ -177,7 +199,18 @@ final class StartupWarmupCoordinator {
     }
 
     func markDatabaseRetryComplete() {
-        databaseRetryTask = nil
+        sessionTasks[.databaseRetry] = nil
+    }
+
+    private func currentSessionScope() -> StartupWarmupSessionScope {
+        StartupWarmupSessionScope(userId: UserDefaults.standard.string(forKey: "auth_userId"))
+    }
+
+    private func isCurrentSession(_ scope: StartupWarmupSessionScope) -> Bool {
+        scope.matches(
+            currentUserId: UserDefaults.standard.string(forKey: "auth_userId"),
+            isSignedIn: AuthState.shared.isSignedIn
+        )
     }
 
     private func sleepForStartupDelay(_ seconds: TimeInterval) async -> Bool {

--- a/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
@@ -10,6 +10,10 @@ struct StartupWarmupScheduleState {
         return true
     }
 
+    mutating func releaseServiceWarmup() {
+        didScheduleServiceWarmup = false
+    }
+
     mutating func reserveDatabaseWarmup(dbAvailable: Bool) -> Bool {
         guard dbAvailable, !didScheduleDatabaseWarmup else { return false }
         didScheduleDatabaseWarmup = true

--- a/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/StartupWarmupPolicy.swift
@@ -35,6 +35,27 @@ struct RetryableDelayedStartGate {
     }
 }
 
+enum StartupWarmupTaskID: Hashable {
+    case serviceWarmup
+    case databaseWarmup
+    case dashboardNetworkRefresh
+    case chatPromptContextWarmup
+    case databaseRetry
+    case crispInitialPoll
+    case agentVMProvisioning
+    case conversationWarmup
+    case initialFileIndexing
+    case proactiveAssistantsStart
+}
+
+struct StartupWarmupSessionScope: Equatable {
+    let userId: String?
+
+    func matches(currentUserId: String?, isSignedIn: Bool) -> Bool {
+        isSignedIn && userId != nil && currentUserId == userId
+    }
+}
+
 struct DelayedFileIndexingBackfillState {
     private var isScheduled = false
     private(set) var shouldMarkComplete = false

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -101,6 +101,21 @@ class ViewModelContainer: ObservableObject {
         warmupCoordinator.schedulePostInteractiveWarmup(dbAvailable: dbAvailable)
     }
 
+    @discardableResult
+    func scheduleSessionWarmup(
+        id: StartupWarmupTaskID,
+        delay: TimeInterval,
+        onCancel: (@MainActor () -> Void)? = nil,
+        operation: @MainActor @escaping () async -> Void
+    ) -> Bool {
+        warmupCoordinator.scheduleSessionWarmup(
+            id: id,
+            delay: delay,
+            onCancel: onCancel,
+            operation: operation
+        )
+    }
+
     func resetStartupState() {
         warmupCoordinator.reset()
         tasksStore.resetSessionState()

--- a/desktop/macos/Desktop/Tests/CrispManagerLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/CrispManagerLifecycleTests.swift
@@ -86,6 +86,19 @@ final class CrispManagerLifecycleTests: XCTestCase {
         XCTAssertNil(manager.refreshAllObserver)
     }
 
+    func testStopCanPreserveReadStateForNormalTermination() {
+        let manager = CrispManager.shared
+        manager.lastSeenTimestamp = 111_111
+        manager.latestOperatorTimestamp = 222_222
+        manager.start(performInitialPoll: false)
+
+        manager.stop(preserveReadState: true)
+
+        XCTAssertFalse(manager.isStarted)
+        XCTAssertEqual(manager.lastSeenTimestamp, 111_111)
+        XCTAssertEqual(manager.latestOperatorTimestamp, 222_222)
+    }
+
     func testMarkAsReadAdvancesPersistedTimestamp() {
         let manager = CrispManager.shared
         manager.latestOperatorTimestamp = 999_999

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -220,7 +220,9 @@ final class StartupWarmupPolicyTests: XCTestCase {
         XCTAssertTrue(source.contains("id: .initialFileIndexing"))
         XCTAssertTrue(source.contains("id: .proactiveAssistantsStart"))
         XCTAssertTrue(source.contains("viewModelContainer.resetStartupState()"))
-        XCTAssertTrue(source.contains("CrispManager.shared.stop(preserveReadState: true)"))
+        XCTAssertTrue(source.contains("resetSessionScopedStartupWarmups(preserveCrispReadState: true)"))
+        XCTAssertTrue(source.contains("resetSessionScopedStartupWarmups(preserveCrispReadState: false)"))
+        XCTAssertTrue(source.contains("CrispManager.shared.stop(preserveReadState: preserveCrispReadState)"))
         XCTAssertTrue(source.contains("NSApplication.willTerminateNotification"))
     }
 

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -174,6 +174,45 @@ final class StartupWarmupPolicyTests: XCTestCase {
         XCTAssertTrue(backfill.reserveIfNeeded(hasCompletedBackfill: false))
     }
 
+    func testSessionScopeRejectsSignedOutAndMismatchedUsers() {
+        let scope = StartupWarmupSessionScope(userId: "user-a")
+
+        XCTAssertTrue(scope.matches(currentUserId: "user-a", isSignedIn: true))
+        XCTAssertFalse(scope.matches(currentUserId: "user-b", isSignedIn: true))
+        XCTAssertFalse(scope.matches(currentUserId: "user-a", isSignedIn: false))
+        XCTAssertFalse(StartupWarmupSessionScope(userId: nil).matches(currentUserId: "user-a", isSignedIn: true))
+    }
+
+    func testStartupWarmupCoordinatorUsesSessionScopedTasks() throws {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/StartupWarmupCoordinator.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("private var sessionTasks: [StartupWarmupTaskID: Task<Void, Never>]"))
+        XCTAssertTrue(source.contains("guard await self.isCurrentSession(scope) else"))
+        XCTAssertTrue(source.contains("guard isCurrentSession(scope) else { return }"))
+        XCTAssertTrue(source.contains("sessionTasks.values.forEach { $0.cancel() }"))
+        XCTAssertTrue(source.contains("sessionTasks.removeAll()"))
+    }
+
+    func testDelayedDesktopHomeWarmupsUseSessionScopedCoordinator() throws {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("id: .agentVMProvisioning"))
+        XCTAssertTrue(source.contains("id: .conversationWarmup"))
+        XCTAssertTrue(source.contains("id: .initialFileIndexing"))
+        XCTAssertTrue(source.contains("id: .proactiveAssistantsStart"))
+        XCTAssertTrue(source.contains("viewModelContainer.resetStartupState()"))
+        XCTAssertTrue(source.contains("CrispManager.shared.stop()"))
+        XCTAssertTrue(source.contains("NSApplication.willTerminateNotification"))
+    }
+
     @MainActor
     func testTasksStoreStartupMaintenanceSchedulesOnceForFirstUseLoadPath() async {
         let store = TasksStore.shared

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -116,6 +116,17 @@ final class StartupWarmupPolicyTests: XCTestCase {
         XCTAssertFalse(state.reserveDatabaseWarmup(dbAvailable: true))
     }
 
+    func testWarmupScheduleStateCanRetryServiceWarmupAfterRelease() {
+        var state = StartupWarmupScheduleState()
+
+        XCTAssertTrue(state.reserveServiceWarmup())
+        XCTAssertFalse(state.reserveServiceWarmup())
+
+        state.releaseServiceWarmup()
+
+        XCTAssertTrue(state.reserveServiceWarmup())
+    }
+
     func testWarmupScheduleStateCanRetryDatabaseWarmupAfterRelease() {
         var state = StartupWarmupScheduleState()
 
@@ -209,7 +220,7 @@ final class StartupWarmupPolicyTests: XCTestCase {
         XCTAssertTrue(source.contains("id: .initialFileIndexing"))
         XCTAssertTrue(source.contains("id: .proactiveAssistantsStart"))
         XCTAssertTrue(source.contains("viewModelContainer.resetStartupState()"))
-        XCTAssertTrue(source.contains("CrispManager.shared.stop()"))
+        XCTAssertTrue(source.contains("CrispManager.shared.stop(preserveReadState: true)"))
         XCTAssertTrue(source.contains("NSApplication.willTerminateNotification"))
     }
 


### PR DESCRIPTION
## Summary
- centralize delayed startup warmups behind a session-scoped coordinator task registry
- cancel/reset startup warmups on sign-out, onboarding reset, and app termination
- move DesktopHomeView delayed warmups through the coordinator and scope Crisp initial polling to the signed-in user
- add focused lifecycle/source-invariant tests for session scoping and cancellation hooks

## Testing
- `git diff --check`
- `sh scripts/pre-commit`
- `xcrun swiftc -parse Desktop/Sources/StartupWarmupPolicy.swift Desktop/Sources/StartupWarmupCoordinator.swift Desktop/Sources/ViewModelContainer.swift Desktop/Sources/MainWindow/DesktopHomeView.swift Desktop/Sources/MainWindow/CrispManager.swift Desktop/Tests/StartupWarmupPolicyTests.swift`
- `xcrun swift package --package-path Desktop describe`
- Attempted `xcrun swift test --package-path Desktop --filter StartupWarmupPolicyTests`; blocked/killed during SwiftPM binary artifact downloads with duplicate GitHub keychain-entry warning, same local environment blocker seen on earlier Desktop runs.

Stacked on #8013.

Fixes #8123

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

