### PR TITLE
fix(admin): bound retention cohort scan so 14-day retention loads

### DIFF
--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
           COALESCE(person_id, distinct_id) AS actor_id,
           min(toDate(timestamp)) AS cohort_date
         FROM events
-        WHERE 1 = 1
+        WHERE timestamp >= today() - INTERVAL ${days} DAY
           ${eventFilter}
         GROUP BY actor_id
         HAVING cohort_date >= today() - INTERVAL ${days} DAY


### PR DESCRIPTION
#8106's any-event change made the retention cohort query a full-history scan (`min(timestamp)` over every event per actor), which times out under PostHog throttling — 14-day retention never loaded. Bound the cohort scan to the last `days` window (cohorts only begin there; the event query was already bounded). Completes fast, caches via #8158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

