### PR TITLE
desktop: gate proactive Gemini analysis on notifications

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Proactive assistants (Insights, Focus, Tasks, Memory) now pause when their notifications are off \u2014 no background screen analysis unless you turn notifications on, saving battery and cost"
+  ],
   "releases": [
     {
       "version": "0.11.499",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -10,7 +10,10 @@ actor FocusAssistant: ProactiveAssistant {
     var isEnabled: Bool {
         get async {
             await MainActor.run {
+                // Gate the Gemini screen analysis on notifications (off by default) — no
+                // notification, no Gemini call. Re-enabling notifications resumes analysis.
                 FocusAssistantSettings.shared.isEnabled
+                    && FocusAssistantSettings.shared.notificationsEnabled
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -12,7 +12,12 @@ actor InsightAssistant: ProactiveAssistant {
     var isEnabled: Bool {
         get async {
             await MainActor.run {
+                // Gate the Gemini screen analysis on notifications: if this assistant's
+                // notifications are off (the default), don't spend a Gemini call analyzing
+                // screenshots. Proactive assistants only run when notifications are enabled;
+                // re-enabling notifications in Settings resumes analysis.
                 InsightAssistantSettings.shared.isEnabled
+                    && InsightAssistantSettings.shared.notificationsEnabled
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -10,7 +10,10 @@ actor MemoryAssistant: ProactiveAssistant {
     var isEnabled: Bool {
         get async {
             await MainActor.run {
+                // Gate the Gemini screen analysis on notifications (off by default) — no
+                // notification, no Gemini call. Re-enabling notifications resumes analysis.
                 MemoryAssistantSettings.shared.isEnabled
+                    && MemoryAssistantSettings.shared.notificationsEnabled
             }
         }
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -11,7 +11,10 @@ actor TaskAssistant: ProactiveAssistant {
     var isEnabled: Bool {
         get async {
             await MainActor.run {
+                // Gate the Gemini screen analysis on notifications (off by default) — no
+                // notification, no Gemini call. Re-enabling notifications resumes analysis.
                 TaskAssistantSettings.shared.isEnabled
+                    && TaskAssistantSettings.shared.notificationsEnabled
             }
         }
     }


### PR DESCRIPTION
Proactive assistants (Insight/Focus/Task/Memory) were calling Gemini on every cycle regardless of notification state — only the *send* was gated. Notifications are off by default, so this burned Gemini + battery for output nobody saw.

Each assistant's `isEnabled` (checked by the coordinator before `analyze()`) now also requires `notificationsEnabled`. Off → no Gemini call (`Skipping analysis (disabled)`). Re-enabling notifications resumes it.

**Verified** on a named build: notifications off → zero Gemini analysis calls over ~3 min (prod fires ~1/min); skip is driven by the gated `isEnabled`. LiveNotesMonitor (per-recording-session) is separate/unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

