### PR TITLE
Revert freemium reactivation (#8161) — unintended prod exposure

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -242,7 +242,7 @@ env:
         name: dev-omi-backend-secrets
         key: ENCRYPTION_SECRET
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "0"
+    value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -269,7 +269,7 @@ env:
         name: prod-omi-backend-secrets
         key: ENCRYPTION_SECRET
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "0"
+    value: "600"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -220,7 +220,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_URL
     value: "https://dg.omiapi.com"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "0"
+    value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -252,7 +252,7 @@ env:
         name: prod-omi-backend-secrets
         key: STT_SERVICE_MODELS
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "0"
+    value: "600"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -325,10 +325,6 @@ class TestIsTrialPaywalledBehavioral:
 
         import utils.subscription as sub
 
-        # The trial paywall is OFF by default in prod (freemium reactivated). Force it on so
-        # the delegation logic under test is reachable.
-        sub.TRIAL_PAYWALL_ENABLED = True
-
         self._sub = sub
         self._mock_expired = MagicMock(return_value=True)
         self._orig_expired = sub._is_trial_expired_cached
@@ -448,9 +444,6 @@ class TestByokRequestEscapeHatch:
 
         import utils.subscription as sub
         from utils import byok
-
-        # Paywall is OFF by default in prod (freemium); force it on for these BYOK-bypass tests.
-        sub.TRIAL_PAYWALL_ENABLED = True
 
         self._sub = sub
         self._byok = byok

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -50,7 +50,7 @@ def test_operator_chat_cap_independent_from_unlimited(monkeypatch):
 
 
 def test_operator_and_neo_defaults(monkeypatch):
-    """Operator defaults to 500, Neo defaults to 30 (freemium-aligned)."""
+    """Operator defaults to 500, Neo defaults to 200."""
     monkeypatch.delenv("OPERATOR_CHAT_QUESTIONS_PER_MONTH", raising=False)
     monkeypatch.delenv("NEO_CHAT_QUESTIONS_PER_MONTH", raising=False)
 
@@ -63,7 +63,7 @@ def test_operator_and_neo_defaults(monkeypatch):
     unlimited_limits = sub_mod.get_plan_limits(PlanType.unlimited)
 
     assert operator_limits.chat_questions_per_month == 500
-    assert unlimited_limits.chat_questions_per_month == 30
+    assert unlimited_limits.chat_questions_per_month == 200
 
 
 def test_architect_uses_dollar_cap():

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -77,12 +77,6 @@ def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]
 # exempt.
 TRIAL_LENGTH_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
-# Master switch for the desktop trial paywall. Default OFF: freemium is reactivated —
-# basic/Neo desktop users are never locked out, they just get the metered free tier
-# (unlimited data intake + the per-plan chat-question cap). Set TRIAL_PAYWALL_ENABLED=true
-# to bring the 3-day lockout back without a code change.
-TRIAL_PAYWALL_ENABLED = os.getenv('TRIAL_PAYWALL_ENABLED', 'false').lower() == 'true'
-
 # Platform identifiers that count as desktop for paywall purposes. The Swift
 # client sends X-App-Platform: macos and the listen WS uses source=desktop.
 # Anything else (ios, android, omi device, phone_call, unknown) is exempt.
@@ -168,8 +162,6 @@ def is_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
     `source` query param for the listen WebSocket. Mobile (ios/android),
     Omi devices, and any unknown/missing platform are never paywalled.
     """
-    if not TRIAL_PAYWALL_ENABLED:
-        return False  # freemium reactivated — no desktop lockout
     if not platform or platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS:
         return False
     return _is_trial_expired_cached(uid)
@@ -510,7 +502,7 @@ BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_INSIGHTS_
 
 # Chat caps per plan. Env-overridable for ops.
 FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
-NEO_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('NEO_CHAT_QUESTIONS_PER_MONTH', '30'))
+NEO_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('NEO_CHAT_QUESTIONS_PER_MONTH', '200'))
 OPERATOR_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('OPERATOR_CHAT_QUESTIONS_PER_MONTH', '500'))
 ARCHITECT_CHAT_COST_USD_PER_MONTH = float(os.getenv('ARCHITECT_CHAT_COST_USD_PER_MONTH', '400.0'))
 


### PR DESCRIPTION
Reverts #8161. It was merged to main and went out via a prod deploy unintentionally (Neo→30 downgrade + unlimited intake + incomplete paywall flag). Prod Cloud Run rolled back to c80cacc2 separately; this reverts the code so future deploys don't re-introduce it. The proper, surgical paywall fix lands in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

