### PR TITLE
fix(admin): cache remaining PostHog routes (notifications/floating-bar/ratings graphs)

### DIFF
--- a/web/admin/app/api/omi/stats/floating-bar-usage/route.ts
+++ b/web/admin/app/api/omi/stats/floating-bar-usage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { cachedPosthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -71,32 +72,11 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const [totalRes, voiceRes, sessionsRes] = await Promise.all([
-      fetch(`${host}/api/projects/${projectId}/query/`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query: { kind: "HogQLQuery", query: totalQuery } }),
-      }),
-      fetch(`${host}/api/projects/${projectId}/query/`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query: { kind: "HogQLQuery", query: voiceQuery } }),
-      }),
-      fetch(`${host}/api/projects/${projectId}/query/`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query: { kind: "HogQLQuery", query: sessionsQuery } }),
-      }),
-    ]);
+    // Sequential (not Promise.all) so we don't burst the rate-limited PostHog key;
+    // each is Firestore-cached + stale-on-throttle via cachedPosthogFetch.
+    const totalRes = await cachedPosthogFetch(host, projectId, apiKey, totalQuery);
+    const voiceRes = await cachedPosthogFetch(host, projectId, apiKey, voiceQuery);
+    const sessionsRes = await cachedPosthogFetch(host, projectId, apiKey, sessionsQuery);
 
     if (!totalRes.ok || !voiceRes.ok || !sessionsRes.ok) {
       const failedRes = !totalRes.ok ? totalRes : !voiceRes.ok ? voiceRes : sessionsRes;

--- a/web/admin/app/api/omi/stats/message-ratings/route.ts
+++ b/web/admin/app/api/omi/stats/message-ratings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { cachedPosthogFetch } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
@@ -44,16 +45,7 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: { kind: "HogQLQuery", query: hogql },
-      }),
-    });
+    const response = await cachedPosthogFetch(host, projectId, apiKey, hogql);
 
     if (!response.ok) {
       const text = await response.text();

--- a/web/admin/app/api/omi/stats/notifications/route.ts
+++ b/web/admin/app/api/omi/stats/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
+import { cachedPosthogFetch } from '@/lib/posthog';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,15 +29,7 @@ type FloatingBarCtrStats = {
 };
 
 async function queryPostHog(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
-    signal: AbortSignal.timeout(15000),
-  });
+  const response = await cachedPosthogFetch(host, projectId, apiKey, query);
 
   if (!response.ok) {
     const text = await response.text();

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -72,6 +72,47 @@ export async function posthogFetch(
 }
 
 /**
+ * Drop-in replacement for `fetch(<posthog query endpoint>, {...})` that adds
+ * Firestore result caching + stale-on-throttle, returning a `Response` whose
+ * body is always `{ results: [...] }`. Lets routes with many inline query
+ * fetches (notifications, floating-bar-usage, message-ratings) get caching
+ * without restructuring — just swap the `fetch(...)` call for this and keep the
+ * existing `.ok` / `.json()` handling.
+ */
+export async function cachedPosthogFetch(
+  host: string,
+  projectId: string,
+  apiKey: string,
+  query: string,
+  opts: { softTtlMs?: number } = {},
+): Promise<Response> {
+  const softTtlMs = opts.softTtlMs ?? SOFT_TTL_MS;
+  const key = createHash("sha1").update(`${projectId}|${query}`).digest("hex");
+  const hit = (results: unknown[]) =>
+    new Response(JSON.stringify({ results }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  const cached = await readCache(key);
+  if (cached && Date.now() - cached.freshAt < softTtlMs) return hit(cached.results);
+
+  const res = await posthogFetch(host, projectId, apiKey, query);
+  if (res.ok) {
+    try {
+      const raw = await res.clone().json();
+      const results = Array.isArray(raw.results) ? raw.results : [];
+      await writeCache(key, results);
+    } catch {
+      // ignore caching errors; return the live response below
+    }
+    return res;
+  }
+  if (cached) return hit(cached.results); // serve last good through the throttle
+  return res; // no cache to fall back on — surface the error
+}
+
+/**
  * Run a HogQL query and return its `results` array, cached in Firestore.
  * - Fresh cache (< soft TTL): returned without touching PostHog.
  * - Stale/miss: query PostHog (with 429 backoff); on success refresh the cache.


### PR DESCRIPTION
The notification, floating-bar, and chat-ratings graphs were still blank — those routes queried PostHog directly with no cache and kept 429ing on the throttled shared key. Adds `cachedPosthogFetch()` (drop-in for the raw query fetch: Firestore-cached + stale-on-throttle, returns `{results}`) and routes notifications/floating-bar-usage/message-ratings through it. floating-bar-usage now sequential (not Promise.all) to avoid bursting the key.

tsc clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

