### PR TITLE
fix(admin): make profitability + infra-costs graphs work (precompute cache)

### DIFF
--- a/.github/workflows/gcp_admin.yml
+++ b/.github/workflows/gcp_admin.yml
@@ -75,8 +75,11 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
           revision_traffic: LATEST=100
           # listUsers() scans ~112K Firebase Auth users for the Cumulative
-          # Users chart; 512Mi was OOMing (SIGABRT) during the scan.
-          flags: '--memory=1Gi --cpu=1'
+          # Users chart; 512Mi was OOMing (SIGABRT) during the scan. The
+          # /api/internal/precompute route runs the heaviest aggregations
+          # (profitability/infra-costs) off the request path, so the timeout is
+          # raised to 3600s and memory to 2Gi for that job.
+          flags: '--memory=2Gi --cpu=1 --timeout=3600'
           secrets: |
             FIREBASE_PROJECT_ID=WEB_ADMIN_FIREBASE_PROJECT_ID:latest
             FIREBASE_CLIENT_EMAIL=WEB_ADMIN_FIREBASE_CLIENT_EMAIL:latest
@@ -99,6 +102,7 @@ jobs:
             POSTHOG_PROJECT_ID=WEB_ADMIN_POSTHOG_PROJECT_ID:latest
             POSTHOG_HOST=WEB_ADMIN_POSTHOG_HOST:latest
             GOAFFPRO_ACCESS_TOKEN=GOAFFPRO_ACCESS_TOKEN:latest
+            CRON_SECRET=WEB_ADMIN_CRON_SECRET:latest
 
       - name: Show Output
         run: echo ${{ steps.deploy.outputs.url }}

--- a/web/admin/app/api/internal/precompute/route.ts
+++ b/web/admin/app/api/internal/precompute/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  computeProfitability,
+  profitabilityCacheKey,
+} from "@/app/api/omi/stats/profitability/route";
+import {
+  computeInfraCosts,
+  infraCostsCacheKey,
+} from "@/app/api/omi/stats/infra-costs/route";
+import { setPayload } from "@/lib/payload-cache";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
+
+// Cron-only precompute endpoint. Computes the heavy profitability + infra-costs
+// payloads off the request path (long timeout) and writes them to the Firestore
+// payload cache, so the dashboard GET routes become fast cache reads.
+//
+// Auth: requires `x-cron-secret` header to equal `process.env.CRON_SECRET`.
+// No admin auth — this is invoked by the scheduler, not a browser.
+//
+// Params MUST match the dashboard's default/initial query so the GET handlers
+// hit the cache. From app/(protected)/dashboard/page.tsx:
+//   profitDays initial = 30; desktopCostInput "1.20" → 1.2; mobileCostInput "0.30" → 0.3
+//   → profitability: days=30&desktop_cost=1.2&mobile_cost=0.3
+//   → infra-costs:   days=30 (overhead_monthly omitted → default 57447)
+const PROFIT_DAYS = 30;
+const PROFIT_DESKTOP_COST = 1.2;
+const PROFIT_MOBILE_COST = 0.3;
+const INFRA_DAYS = 30;
+
+function defaultOverheadMonthly(): number {
+  const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
+  return Number.isFinite(envOverhead) && envOverhead >= 0 ? envOverhead : 57447;
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const provided = request.headers.get("x-cron-secret");
+  if (!secret || provided !== secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const results: { profitability: string; infraCosts: string } = {
+    profitability: "ok",
+    infraCosts: "ok",
+  };
+  const ms: { profitability: number; infraCosts: number } = {
+    profitability: 0,
+    infraCosts: 0,
+  };
+
+  // Profitability
+  {
+    const t0 = Date.now();
+    try {
+      const payload = await computeProfitability({
+        days: PROFIT_DAYS,
+        desktopCost: PROFIT_DESKTOP_COST,
+        mobileCost: PROFIT_MOBILE_COST,
+      });
+      await setPayload(
+        profitabilityCacheKey(PROFIT_DAYS, PROFIT_DESKTOP_COST, PROFIT_MOBILE_COST),
+        payload,
+      );
+    } catch (err: any) {
+      results.profitability = err?.message || "failed";
+    }
+    ms.profitability = Date.now() - t0;
+  }
+
+  // Infra costs
+  {
+    const t0 = Date.now();
+    try {
+      const overheadMonthly = defaultOverheadMonthly();
+      const payload = await computeInfraCosts({ days: INFRA_DAYS, overheadMonthly });
+      await setPayload(infraCostsCacheKey(INFRA_DAYS, overheadMonthly), payload);
+    } catch (err: any) {
+      results.infraCosts = err?.message || "failed";
+    }
+    ms.infraCosts = Date.now() - t0;
+  }
+
+  return NextResponse.json({ ok: true, results, ms });
+}

--- a/web/admin/app/api/omi/stats/infra-costs/route.ts
+++ b/web/admin/app/api/omi/stats/infra-costs/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { getDb } from "@/lib/firebase/admin";
-import { getJsonCache, setJsonCache } from "@/lib/redis";
+import { getPayload, setPayload } from "@/lib/payload-cache";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
 
 // Daily infrastructure cost, split by platform.
 //
@@ -44,7 +45,7 @@ interface ServiceCostRow {
   mobileProjectionUsd: number;
 }
 
-interface InfraCostsPayload {
+export interface InfraCostsPayload {
   days: number;
   daily: DailyCostPoint[];
   breakdown: ServiceCostRow[];
@@ -153,9 +154,6 @@ function computeMonthlyOverheadByPlatform(services: ServiceCostEntry[]): { deskt
   return { desktop, mobile, total };
 }
 
-const CACHE_PREFIX = "admin:stats:infra-costs:v3";
-const CACHE_TTL_SECONDS = 30 * 60;
-
 // User-provided April projection. Override with ADMIN_INFRA_OVERHEAD_MONTHLY
 // env var or ?overhead_monthly= query param.
 const DEFAULT_OVERHEAD_MONTHLY = 57447;
@@ -249,29 +247,31 @@ async function fetchLlmCostsPerDay(
   }
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+// Parse the infra-costs request params the same way the GET handler does, so
+// the cache key derived from them matches between the route and the precompute
+// cron. `days` is clamped 7..90; overhead falls back to the env var then the
+// hard-coded April projection.
+export function parseInfraCostsParams(searchParams: URLSearchParams): { days: number; overheadMonthly: number } {
+  const days = Math.min(Math.max(parseInt(searchParams.get("days") || "30", 10), 7), 90);
+  const overheadMonthlyParam = parseFloat(searchParams.get("overhead_monthly") || "");
+  const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
+  const overheadMonthly =
+    Number.isFinite(overheadMonthlyParam) && overheadMonthlyParam >= 0
+      ? overheadMonthlyParam
+      : Number.isFinite(envOverhead) && envOverhead >= 0
+        ? envOverhead
+        : DEFAULT_OVERHEAD_MONTHLY;
+  return { days, overheadMonthly };
+}
 
-  try {
-    const { searchParams } = new URL(request.url);
-    const days = Math.min(Math.max(parseInt(searchParams.get("days") || "30", 10), 7), 90);
-    const overheadMonthlyParam = parseFloat(searchParams.get("overhead_monthly") || "");
-    const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
-    const overheadMonthly =
-      Number.isFinite(overheadMonthlyParam) && overheadMonthlyParam >= 0
-        ? overheadMonthlyParam
-        : Number.isFinite(envOverhead) && envOverhead >= 0
-          ? envOverhead
-          : DEFAULT_OVERHEAD_MONTHLY;
+export function infraCostsCacheKey(days: number, overheadMonthly: number): string {
+  return `infra-costs:v1:${days}:${overheadMonthly}`;
+}
 
-    const cacheKey = `${CACHE_PREFIX}:${days}:${overheadMonthly}`;
-    const cached = await getJsonCache<InfraCostsPayload>(cacheKey);
-    if (cached && Date.now() - cached.generatedAt < CACHE_TTL_SECONDS * 1000) {
-      return NextResponse.json(cached);
-    }
+export async function computeInfraCosts(opts: { days: number; overheadMonthly: number }): Promise<InfraCostsPayload> {
+  const { days, overheadMonthly } = opts;
 
-    const llmByDay = await fetchLlmCostsPerDay(days);
+  const llmByDay = await fetchLlmCostsPerDay(days);
     const partial = llmByDay == null;
     const dateKeys = buildDayKeys(days);
 
@@ -349,7 +349,28 @@ export async function GET(request: NextRequest) {
       generatedAt: Date.now(),
     };
 
-    await setJsonCache(cacheKey, payload, CACHE_TTL_SECONDS);
+    return payload;
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const { days, overheadMonthly } = parseInfraCostsParams(searchParams);
+    const key = infraCostsCacheKey(days, overheadMonthly);
+
+    // Cache-first: precompute writes this off the request path. If present at
+    // any age, serve it (this route is too heavy to recompute inline).
+    const cached = await getPayload<InfraCostsPayload>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    // Cold start before the first precompute: compute inline (may be slow), cache, return.
+    const payload = await computeInfraCosts({ days, overheadMonthly });
+    await setPayload(key, payload);
     return NextResponse.json(payload);
   } catch (err: any) {
     console.error("Infra costs error:", err);

--- a/web/admin/app/api/omi/stats/profitability/route.ts
+++ b/web/admin/app/api/omi/stats/profitability/route.ts
@@ -2,10 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { getOptionalStripe } from "@/lib/stripe";
 import { getAdminAuth, getDb } from "@/lib/firebase/admin";
-import { getJsonCache, setJsonCache } from "@/lib/redis";
+import { getPayload, setPayload } from "@/lib/payload-cache";
+import { computeInfraCosts, type InfraCostsPayload } from "@/app/api/omi/stats/infra-costs/route";
 import type Stripe from "stripe";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
 
 // Per-platform profitability metrics.
 //
@@ -43,7 +45,7 @@ interface DailyPoint {
   total: number;
 }
 
-interface ProfitabilityPayload {
+export interface ProfitabilityPayload {
   days: number;
   users: DailyPoint[];
   cumulativeUsers: DailyPoint[];
@@ -85,8 +87,9 @@ interface ProfitabilityPayload {
   generatedAt: number;
 }
 
-const CACHE_PREFIX = "admin:stats:profitability:v6";
-const CACHE_TTL_SECONDS = 30 * 60;
+function cacheKey(days: number, desktopCost: number, mobileCost: number): string {
+  return `profitability:v1:${days}:${desktopCost}:${mobileCost}`;
+}
 
 // Fallback per-user infra cost when real billing data can't be pulled from
 // the infra-costs endpoint. Calibrated against the team's Apr projection
@@ -94,11 +97,6 @@ const CACHE_TTL_SECONDS = 30 * 60;
 // collection-group scan finishes.
 const DEFAULT_DESKTOP_COST = 0.2;
 const DEFAULT_MOBILE_COST = 0.2;
-
-// Name of the origin-relative infra-costs endpoint. Populates the `cost` and
-// `costPerUser` series with actual daily LLM spend from Firestore plus a
-// platform-proportional share of fixed overhead.
-const INFRA_COSTS_PATH = "/api/omi/stats/infra-costs";
 
 function parseCost(raw: string | null, fallback: number): number {
   if (raw == null) return fallback;
@@ -399,30 +397,20 @@ interface InfraCostsSnapshot {
   overheadMonthlyUsd: number;
 }
 
-// Internal fetch against the `/api/omi/stats/infra-costs` endpoint so we reuse
-// its caching + collection group scan. Sends the incoming admin auth cookie /
-// Authorization header so the call is authenticated at the proxy layer.
-async function fetchInfraCosts(request: NextRequest, days: number): Promise<InfraCostsSnapshot | null> {
+// Compute infra costs directly (no internal HTTP round-trip) so this works off
+// the request path in the precompute cron. Reuses the same collection-group
+// scan + overhead split as the infra-costs route. Uses that route's default
+// overhead (env / hard-coded April projection) by passing -1, which falls
+// through to the default inside parseInfraCostsParams-equivalent logic.
+async function fetchInfraCosts(days: number): Promise<InfraCostsSnapshot | null> {
   try {
-    const url = new URL(INFRA_COSTS_PATH, request.nextUrl.origin);
-    url.searchParams.set("days", String(days));
-    const authHeader = request.headers.get("authorization");
-    const response = await fetch(url, {
-      headers: {
-        ...(authHeader ? { Authorization: authHeader } : {}),
-      },
-      // Next's internal fetch honors cookies; infer by forwarding.
-      cache: "no-store",
-    });
-    if (!response.ok) {
-      console.warn("Infra costs fetch returned", response.status);
-      return null;
-    }
-    const raw = await response.json();
+    const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
+    const overheadMonthly = Number.isFinite(envOverhead) && envOverhead >= 0 ? envOverhead : 57447;
+    const raw: InfraCostsPayload = await computeInfraCosts({ days, overheadMonthly });
     if (!raw?.daily) return null;
     return { daily: raw.daily, overheadMonthlyUsd: raw?.summary?.assumptions?.overheadMonthlyUsd };
   } catch (err) {
-    console.error("Infra costs fetch exception:", err);
+    console.error("Infra costs compute exception:", err);
     return null;
   }
 }
@@ -527,21 +515,20 @@ async function fetchStripeSnapshot(
   return { mrrByPlatform, newPaidByDayByPlatform, activeSubs, partial };
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+export { cacheKey as profitabilityCacheKey };
 
-  try {
-    const { searchParams } = new URL(request.url);
-    const days = Math.min(Math.max(parseInt(searchParams.get("days") || "30", 10), 7), 90);
-    const desktopCost = parseCost(searchParams.get("desktop_cost"), DEFAULT_DESKTOP_COST);
-    const mobileCost = parseCost(searchParams.get("mobile_cost"), DEFAULT_MOBILE_COST);
+// Parse the profitability request params the same way the GET handler does, so
+// the cache key derived from them matches between the route and the precompute
+// cron.
+export function parseProfitabilityParams(searchParams: URLSearchParams): { days: number; desktopCost: number; mobileCost: number } {
+  const days = Math.min(Math.max(parseInt(searchParams.get("days") || "30", 10), 7), 90);
+  const desktopCost = parseCost(searchParams.get("desktop_cost"), DEFAULT_DESKTOP_COST);
+  const mobileCost = parseCost(searchParams.get("mobile_cost"), DEFAULT_MOBILE_COST);
+  return { days, desktopCost, mobileCost };
+}
 
-    const cacheKey = `${CACHE_PREFIX}:${days}:${desktopCost}:${mobileCost}`;
-    const cached = await getJsonCache<ProfitabilityPayload>(cacheKey);
-    if (cached && Date.now() - cached.generatedAt < CACHE_TTL_SECONDS * 1000) {
-      return NextResponse.json(cached);
-    }
+export async function computeProfitability(opts: { days: number; desktopCost: number; mobileCost: number }): Promise<ProfitabilityPayload> {
+  const { days, desktopCost, mobileCost } = opts;
 
     const [tokensRes, signupsRes, desktopUidsRes, mobileUidsRes, desktopActiveRes, mobileActiveRes, infraRes] = await Promise.allSettled([
       buildUserPlatformMapFromTokens(),
@@ -550,7 +537,7 @@ export async function GET(request: NextRequest) {
       fetchMobileUidsFromMixpanel(),
       fetchDesktopActivePerDay(days),
       fetchMobileActivePerDay(days),
-      fetchInfraCosts(request, days),
+      fetchInfraCosts(days),
     ]);
 
     const tokens = tokensRes.status === "fulfilled" ? tokensRes.value : null;
@@ -577,10 +564,7 @@ export async function GET(request: NextRequest) {
       mobileActive == null &&
       stripeRes == null
     ) {
-      return NextResponse.json(
-        { error: "All profitability data sources failed" },
-        { status: 502 },
-      );
+      throw new Error("All profitability data sources failed");
     }
 
     const dateKeys = buildDayKeys(days);
@@ -785,7 +769,30 @@ export async function GET(request: NextRequest) {
       generatedAt: Date.now(),
     };
 
-    await setJsonCache(cacheKey, payload, CACHE_TTL_SECONDS);
+    return payload;
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const { days, desktopCost, mobileCost } = parseProfitabilityParams(searchParams);
+    const key = cacheKey(days, desktopCost, mobileCost);
+
+    // Cache-first: precompute writes this off the request path. This route is
+    // far too heavy (full fcm_tokens collection-group scan + auth.listUsers
+    // over ~150k users + Mixpanel paging) to recompute on the request path, so
+    // if a precomputed payload exists at any age we serve it immediately.
+    const cached = await getPayload<ProfitabilityPayload>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    // Cold start before the first precompute: compute inline (slow), cache, return.
+    const payload = await computeProfitability({ days, desktopCost, mobileCost });
+    await setPayload(key, payload);
     return NextResponse.json(payload);
   } catch (err: any) {
     console.error("Profitability stats error:", err);

--- a/web/admin/lib/payload-cache.ts
+++ b/web/admin/lib/payload-cache.ts
@@ -1,0 +1,47 @@
+// Firestore payload cache for precomputed admin stats payloads.
+//
+// Separate from posthog.ts's per-query cache (`admin_stats_cache`). This stores
+// whole computed route payloads (profitability, infra-costs) keyed by their
+// request params, written off the request path by the cron precompute endpoint.
+//
+// The admin service's configured Redis (light-eel-27878.upstash.io) is dead, so
+// the old `@/lib/redis` caching was a silent no-op. Firestore is always
+// reachable here via firebase-admin (same path posthog.ts + macos-versions use).
+// Payloads are JSON-stringified to sidestep Firestore's no-nested-arrays rule.
+
+import { createHash } from "crypto";
+import { getDb } from "@/lib/firebase/admin";
+
+const CACHE_COLLECTION = "admin_stats_payload_cache";
+const MAX_PAYLOAD_CHARS = 900_000; // Firestore field cap ~1 MB; skip oversized
+
+type CacheDoc = { payload: string; freshAt: number };
+
+// Doc ids can't contain `/`. Callers use keys like
+// `profitability:v1:90:1.2:0.3` which are safe, but if a key ever contains a
+// slash we sha1-hash it to keep the write valid.
+function docId(key: string): string {
+  return key.includes("/") ? createHash("sha1").update(key).digest("hex") : key;
+}
+
+export async function getPayload<T>(key: string): Promise<{ data: T; freshAt: number } | null> {
+  try {
+    const snap = await getDb().collection(CACHE_COLLECTION).doc(docId(key)).get();
+    if (!snap.exists) return null;
+    const d = snap.data() as CacheDoc;
+    if (!d?.payload) return null;
+    return { data: JSON.parse(d.payload) as T, freshAt: d.freshAt ?? 0 };
+  } catch {
+    return null; // best-effort cache read; never throws
+  }
+}
+
+export async function setPayload(key: string, data: unknown): Promise<void> {
+  try {
+    const payload = JSON.stringify(data);
+    if (payload.length > MAX_PAYLOAD_CHARS) return;
+    await getDb().collection(CACHE_COLLECTION).doc(docId(key)).set({ payload, freshAt: Date.now() });
+  } catch {
+    // best-effort cache write; never block the response
+  }
+}


### PR DESCRIPTION
## Problem
`profitability` and `infra-costs` stat routes time out → blank graphs on admin.omi.me. Two causes:
1. They cache via `@/lib/redis`, whose `REDIS_HOST` is a **dead Upstash instance** → caching is a silent no-op.
2. Their computation (full `collectionGroup('fcm_tokens')` scan + `auth.listUsers()` over ~150k users + Mixpanel paging; per-user `llm_usage` scan) exceeds the **300s** Cloud Run request limit, so it never returns.

## Fix
- New `lib/payload-cache.ts` — Firestore payload cache (`admin_stats_payload_cache`), same reliable backend as `lib/posthog.ts`'s query cache.
- Extracted `computeProfitability()` / `computeInfraCosts()`; routes now serve the **precomputed payload** (cache-first) and only compute inline on a cold miss.
- New `POST /api/internal/precompute` (cron-only, `x-cron-secret`) computes both heavy payloads off the request path and writes the cache. Cache keys match the dashboard's default params exactly.
- `gcp_admin.yml`: raise Cloud Run timeout 300→3600s + memory 1→2Gi (for the precompute job), wire `CRON_SECRET`.

A Cloud Scheduler job POSTs the precompute endpoint every 30 min to keep the caches warm.

## Verification
- `npx tsc --noEmit` clean; `npm run build` clean.
- Post-deploy: run precompute once → confirm both endpoints return 200 with data, then wire the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

