### PR TITLE
dev: per-worktree isolation for run.sh + local backends (no more port/process collisions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ app/macos/Runner/LocalDev.entitlements
 # Generated browser snapshots (contain PII)
 builds-snapshot.md
 *-snapshot.md
+
+# Per-worktree dev isolation (pidfiles, scratch) — scripts/dev-instance.sh
+.dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ The desktop app is a **Swift Package Manager** project (no Xcode project, no `.x
 - `cd desktop/macos && ./run.sh` — full local dev (build Swift app + Rust backend + Cloudflare tunnel + launch).
 - `cd desktop/macos && ./run.sh --yolo` — quick start against the prod backend, no local services.
 - `OMI_SKIP_BACKEND=1` — app only, use remote backend via `OMI_DESKTOP_API_URL`. `OMI_SKIP_TUNNEL=1` — no Cloudflare tunnel.
+- **Parallel worktrees auto-isolate.** `scripts/dev-instance.sh` derives a unique instance from each linked git worktree, so `run.sh` (and `backend/scripts/dev-serve.sh`) pick per-worktree ports (Rust 10201+, Python 8080+, automation 47777+) and bundle name (`omi-<worktree>`). Kills are pidfile-scoped (never the global `omi-desktop-backend` name), and a taken port fails loud instead of clobbering. The primary checkout is unchanged (`Omi Dev`, 10201/8080/47777). Override any of `OMI_INSTANCE` / `PORT` / `PYTHON_PORT` / `OMI_AUTOMATION_PORT` / `OMI_APP_NAME` to opt out.
+- Local Python backend (per-worktree port): `cd backend && ./scripts/dev-serve.sh`.
 - Compile-only check: `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` (the `xcrun` prefix is required to match the SDK).
 - **DO NOT** use bare `swift build`, `xcodebuild`, or launch from `build/` directly. Always launch via `cd desktop/macos && ./run.sh` (installs to `/Applications/` and registers with LaunchServices, required for permission "Quit & Reopen").
 - Release builds are handled entirely by Codemagic CI (no local release script).

--- a/backend/scripts/dev-serve.sh
+++ b/backend/scripts/dev-serve.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run the local Python backend on a PER-WORKTREE port so parallel agents/worktrees don't
+# fight over 8080 (which silently clobbers each other). Derives PYTHON_PORT from the current
+# worktree via scripts/dev-instance.sh, kills only its OWN previous instance, and refuses to
+# steal a port another worktree owns.
+#
+#   cd backend && ./scripts/dev-serve.sh [extra uvicorn args]
+#
+# The primary checkout keeps port 8080; linked worktrees get 8080+offset.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../../scripts/dev-instance.sh"
+cd "$BACKEND_DIR"
+
+PIDFILE="$OMI_DEV_DIR/python-backend.pid"
+
+# Reclaim only our own previous backend (never another worktree's).
+if [ -f "$PIDFILE" ]; then
+  OLD="$(cat "$PIDFILE" 2>/dev/null || true)"
+  if [ -n "$OLD" ] && kill -0 "$OLD" 2>/dev/null; then
+    echo "dev-serve: stopping our old backend (pid $OLD, port $PYTHON_PORT)"
+    kill "$OLD" 2>/dev/null || true
+    sleep 0.5
+  fi
+  rm -f "$PIDFILE"
+fi
+
+# Fail loud if the port is held by something else — likely another worktree's backend.
+HOLDER="$(lsof -ti tcp:"$PYTHON_PORT" -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+if [ -n "$HOLDER" ]; then
+  echo "ERROR: Python backend port $PYTHON_PORT (instance '$OMI_INSTANCE') is in use by pid $HOLDER:"
+  echo "  $(ps -o command= -p "$HOLDER" 2>/dev/null)"
+  echo "  Another worktree probably owns it. Stop it, or run with PYTHON_PORT=<free> / OMI_INSTANCE=<name>."
+  exit 1
+fi
+
+# Activate a local venv if one exists.
+for v in .venv venv; do
+  [ -f "$v/bin/activate" ] && { source "$v/bin/activate"; break; }
+done
+
+echo "dev-serve: instance='$OMI_INSTANCE' → http://127.0.0.1:$PYTHON_PORT"
+echo $$ > "$PIDFILE"  # exec keeps this PID, so the pidfile points at uvicorn
+exec python3 -m uvicorn main:app --host 0.0.0.0 --port "$PYTHON_PORT" "$@"

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -99,6 +99,13 @@ substep() {
     printf "[%6.1fs]   ├─ %s\n" "$total_elapsed" "$1"
 }
 
+# Per-worktree isolation: derive unique ports + bundle name so parallel worktrees don't
+# collide. Sets OMI_INSTANCE / RUST_PORT / PYTHON_PORT / AUTOMATION_PORT / OMI_APP_NAME /
+# OMI_DEV_DIR (explicit overrides always win; the primary checkout keeps "Omi Dev" + 10201).
+source "$(dirname "$0")/../../scripts/dev-instance.sh"
+BACKEND_PORT="${PORT:-$RUST_PORT}"
+export PORT="$BACKEND_PORT"
+
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
 APP_NAME="${OMI_APP_NAME:-Omi Dev}"
@@ -146,7 +153,7 @@ if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
 fi
 AUTOMATION_ARGS=()
 if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
-    AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-47777}"
+    AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-${AUTOMATION_PORT:-47777}}"
     AUTOMATION_ARGS+=(--automation-bridge "--automation-port=$AUTOMATION_PORT")
 fi
 
@@ -184,11 +191,16 @@ auth_debug "BEFORE pkill: ALL_KEYS=$(defaults read "$BUNDLE_ID" 2>&1 | grep -E '
 # Only kill the dev app — never touch Omi Beta (production)
 pkill -f "$APP_NAME.app" 2>/dev/null || true
 # Note: don't pkill cloudflared here — other agents may have tunnels running on this machine
-# Kill any old Rust backend by process name (port-agnostic)
-pgrep -f "omi-desktop-backend" 2>/dev/null | while read pid; do
-    substep "Killing old backend (PID: $pid)"
-    kill -9 "$pid" 2>/dev/null || true
-done
+# Kill only THIS instance's old Rust backend (tracked via pidfile) — never other
+# worktrees' backends. (Previously `pkill -f omi-desktop-backend` killed every agent's.)
+if [ -f "$OMI_DEV_DIR/rust-backend.pid" ]; then
+    OLD_BACKEND_PID="$(cat "$OMI_DEV_DIR/rust-backend.pid" 2>/dev/null)"
+    if [ -n "$OLD_BACKEND_PID" ] && kill -0 "$OLD_BACKEND_PID" 2>/dev/null; then
+        substep "Killing our old backend (PID: $OLD_BACKEND_PID, port $BACKEND_PORT)"
+        kill -9 "$OLD_BACKEND_PID" 2>/dev/null || true
+    fi
+    rm -f "$OMI_DEV_DIR/rust-backend.pid"
+fi
 sleep 0.5  # Let cfprefsd flush after process death
 auth_debug "AFTER pkill: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
 auth_debug "AFTER pkill: ALL_KEYS=$(defaults read "$BUNDLE_ID" 2>&1 | grep -E 'auth_|hasCompleted|hasLaunched|currentTier|userShow' || true)"
@@ -297,9 +309,7 @@ if [ "$1" = "--yolo" ]; then
     apply_yolo_env
 fi
 
-# Read backend PORT from env (default: 10201, never use 8080)
-BACKEND_PORT="${PORT:-10201}"
-export PORT="$BACKEND_PORT"
+# BACKEND_PORT / PORT already derived per-worktree near the top (scripts/dev-instance.sh).
 
 # Validate credentials (needed for both backend and auth)
 CREDS_PATH="$BACKEND_DIR/google-credentials.json"
@@ -337,6 +347,16 @@ if [ "${OMI_SKIP_BACKEND:-0}" != "1" ]; then
     step "Starting Rust backend..."
     cd "$BACKEND_DIR"
 
+    # Fail loud (don't clobber) if our derived port is already held — another worktree
+    # likely owns it (or a stale process). Better to stop than to silently steal it.
+    PORT_HOLDER="$(lsof -ti tcp:"$BACKEND_PORT" -sTCP:LISTEN 2>/dev/null | head -1)"
+    if [ -n "$PORT_HOLDER" ]; then
+        echo "ERROR: backend port $BACKEND_PORT (instance '$OMI_INSTANCE') is already in use by pid $PORT_HOLDER:"
+        echo "  $(ps -o command= -p "$PORT_HOLDER" 2>/dev/null)"
+        echo "  Another worktree probably owns it. Stop that process, or run with PORT=<free> / OMI_INSTANCE=<name>."
+        exit 1
+    fi
+
     # Build if binary doesn't exist or source is newer
     if [ ! -f "target/release/omi-desktop-backend" ] || [ -n "$(find src -newer target/release/omi-desktop-backend 2>/dev/null)" ]; then
         step "Building Rust backend (cargo build --release)..."
@@ -345,6 +365,7 @@ if [ "${OMI_SKIP_BACKEND:-0}" != "1" ]; then
 
     ./target/release/omi-desktop-backend &
     BACKEND_PID=$!
+    echo "$BACKEND_PID" > "$OMI_DEV_DIR/rust-backend.pid"
     cd - > /dev/null
 
     step "Waiting for backend to start..."

--- a/scripts/dev-instance.sh
+++ b/scripts/dev-instance.sh
@@ -26,7 +26,9 @@ _omi_wt="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 # (comparing `git rev-parse --git-dir` vs `--git-common-dir` is NOT — they can return
 # different absolute/relative formats from a subdir and give a false positive).
 _omi_linked=0
-[ -f "$_omi_wt/.git" ] && _omi_linked=1
+# `if`, not `[ -f ] && …` — the latter returns non-zero when false and would trip a
+# caller's `set -e` (run.sh has it) on the primary checkout, aborting it instantly.
+if [ -f "$_omi_wt/.git" ]; then _omi_linked=1; fi
 
 : "${OMI_INSTANCE:=$(basename "$_omi_wt")}"
 

--- a/scripts/dev-instance.sh
+++ b/scripts/dev-instance.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# Per-worktree dev isolation — source this (don't execute it).
+#
+# Multiple agents/worktrees building the macOS app used to collide: they all grabbed
+# the same ports (Python 8080, Rust 10201, automation 47777), the same bundle name
+# ("Omi Dev"), and run.sh killed *every* backend by process name. This derives a
+# stable, unique "instance" from the current git worktree so each one gets its own
+# ports, its own bundle, and its own pidfile — zero cross-talk, automatically.
+#
+# Exports (an explicit override always wins — set any of these to opt out):
+#   OMI_INSTANCE      stable id (git worktree basename)
+#   RUST_PORT         desktop Rust backend port   (10201 + offset)
+#   PYTHON_PORT       local Python backend port   (8080  + offset)
+#   AUTOMATION_PORT   in-app automation bridge     (47777 + offset)
+#   OMI_APP_NAME      named bundle                 (omi-<instance>)
+#   OMI_DEV_DIR       per-instance pidfile/scratch dir (<worktree>/.dev)
+#
+# The PRIMARY worktree (a normal `git clone`, not a linked `git worktree add`) keeps
+# the historical defaults — offset 0, app name "Omi Dev" — so the main checkout is
+# unchanged. Only linked worktrees get isolated values.
+
+_omi_wt="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Linked worktree iff its top-level `.git` is a FILE (a gitdir pointer); the primary
+# checkout's `.git` is a directory. Robust regardless of the current subdirectory
+# (comparing `git rev-parse --git-dir` vs `--git-common-dir` is NOT — they can return
+# different absolute/relative formats from a subdir and give a false positive).
+_omi_linked=0
+[ -f "$_omi_wt/.git" ] && _omi_linked=1
+
+: "${OMI_INSTANCE:=$(basename "$_omi_wt")}"
+
+if [ "$_omi_linked" = "1" ]; then
+  # Deterministic offset in [1,199] from the instance name (stable across runs/machines).
+  # +1 so a linked worktree never lands on the primary's offset-0 ports.
+  _omi_off=$(printf '%s' "$OMI_INSTANCE" | cksum | awk '{print ($1 % 199) + 1}')
+  : "${OMI_APP_NAME:=omi-$OMI_INSTANCE}"
+else
+  _omi_off=0
+  : "${OMI_APP_NAME:=Omi Dev}"
+fi
+
+: "${RUST_PORT:=$((10201 + _omi_off))}"
+: "${PYTHON_PORT:=$((8080 + _omi_off))}"
+: "${AUTOMATION_PORT:=${OMI_AUTOMATION_PORT:-$((47777 + _omi_off))}}"
+
+OMI_DEV_DIR="$_omi_wt/.dev"
+mkdir -p "$OMI_DEV_DIR" 2>/dev/null || true
+
+export OMI_INSTANCE RUST_PORT PYTHON_PORT AUTOMATION_PORT OMI_APP_NAME OMI_DEV_DIR


### PR DESCRIPTION
## Problem
Multiple agents/worktrees building the macOS app collide: they all grab the same ports (Python 8080, Rust 10201, automation 47777), the same bundle name (\`Omi Dev\`), and \`run.sh\` killed **every** backend by process name (\`pkill -f omi-desktop-backend\`). Real example: a backend from one worktree bound 8080 and silently clobbered another's.

## Fix — derive everything from the git worktree
- **\`scripts/dev-instance.sh\`** (sourced by run.sh + backend helper): each *linked* worktree gets a unique offset → \`RUST_PORT\`/\`PYTHON_PORT\`/\`AUTOMATION_PORT\` + bundle \`omi-<worktree>\`. The **primary checkout is unchanged** (\`Omi Dev\`, 10201/8080/47777). Explicit \`OMI_INSTANCE\`/\`PORT\`/\`OMI_APP_NAME\`/… overrides always win.
- **\`run.sh\`**: pidfile-scoped backend kill (never the global name), and **fail-loud** if the derived port is already owned (instead of clobbering).
- **\`backend/scripts/dev-serve.sh\`**: runs the local Python backend on the per-worktree port.

## Tested
- ✅ Derivation: primary → \`Omi Dev\`/10201; linked → \`omi-dev-isolation\`/10350.
- ✅ Live: \`run.sh\` in a worktree starts its Rust backend on **:10350**; the other worktree's **:8080** backend stays untouched (scoped kill).
- ✅ \`set -e\` safe on both paths (fixed a real bug: \`[ -f .git ] && …\` aborted the primary checkout under run.sh's \`set -e\`).
- ✅ Fail-loud port detection; syntax checks pass.

Local-dev only — does not touch the release/CI pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

