### PR TITLE
fix(admin): cache + cron-warm all remaining slow dashboard graphs

### DIFF
--- a/web/admin/app/api/internal/precompute/route.ts
+++ b/web/admin/app/api/internal/precompute/route.ts
@@ -7,27 +7,78 @@ import {
   computeInfraCosts,
   infraCostsCacheKey,
 } from "@/app/api/omi/stats/infra-costs/route";
+import {
+  computeDailyNewUsers,
+  dailyNewUsersCacheKey,
+} from "@/app/api/omi/stats/daily-new-users/route";
+import {
+  computeMacosVersions,
+  macosVersionsCacheKey,
+} from "@/app/api/omi/stats/macos-versions/route";
+import {
+  computeNotifications,
+  notificationsCacheKey,
+} from "@/app/api/omi/stats/notifications/route";
+import {
+  computeOnboarding,
+  onboardingCacheKey,
+} from "@/app/api/omi/stats/onboarding/posthog/route";
+import {
+  computeRevenue,
+  revenueCacheKey,
+} from "@/app/api/omi/stats/revenue/route";
+import {
+  computeMrrTrends,
+  mrrTrendsCacheKey,
+} from "@/app/api/omi/stats/mrr-trends/route";
+import {
+  computeSubscriptionTrends,
+  subscriptionTrendsCacheKey,
+} from "@/app/api/omi/stats/subscription-trends/route";
+import {
+  computeSubscriptions,
+  subscriptionsCacheKey,
+} from "@/app/api/omi/stats/subscriptions/route";
+import {
+  computeAppSubscriptions,
+  appSubscriptionsCacheKey,
+} from "@/app/api/omi/stats/app-subscriptions/route";
+import { computeKFactor } from "@/app/api/omi/stats/k-factor/posthog/route";
 import { setPayload } from "@/lib/payload-cache";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-// Cron-only precompute endpoint. Computes the heavy profitability + infra-costs
-// payloads off the request path (long timeout) and writes them to the Firestore
-// payload cache, so the dashboard GET routes become fast cache reads.
+// Cron-only precompute endpoint. Computes the heavy graph payloads off the
+// request path (long timeout) and writes them to the Firestore payload cache,
+// so the dashboard GET routes become fast cache reads.
 //
 // Auth: requires `x-cron-secret` header to equal `process.env.CRON_SECRET`.
 // No admin auth — this is invoked by the scheduler, not a browser.
 //
 // Params MUST match the dashboard's default/initial query so the GET handlers
 // hit the cache. From app/(protected)/dashboard/page.tsx:
-//   profitDays initial = 30; desktopCostInput "1.20" → 1.2; mobileCostInput "0.30" → 0.3
-//   → profitability: days=30&desktop_cost=1.2&mobile_cost=0.3
-//   → infra-costs:   days=30 (overhead_monthly omitted → default 57447)
+//   profitability: days=30&desktop_cost=1.2&mobile_cost=0.3
+//   infra-costs:   days=30 (overhead_monthly omitted → default 57447)
+//   daily-new-users: days=all
+//   macos-versions: (no params)
+//   notifications: days=30
+//   onboarding/posthog: days=30
+//   revenue / subscriptions / app-subscriptions: (no params)
+//   mrr-trends / subscription-trends: months=12
+//   k-factor/posthog: days=30 (no payload cache — posthogResults caches the query)
+//
+// Sequential on purpose: PostHog is aggressively rate-limited, so we must NOT
+// fire these concurrently.
 const PROFIT_DAYS = 30;
 const PROFIT_DESKTOP_COST = 1.2;
 const PROFIT_MOBILE_COST = 0.3;
 const INFRA_DAYS = 30;
+const DAILY_NEW_USERS_DAYS = "all";
+const NOTIFICATIONS_DAYS = 30;
+const ONBOARDING_DAYS = 30;
+const TRENDS_MONTHS = 12;
+const K_FACTOR_DAYS = 30;
 
 function defaultOverheadMonthly(): number {
   const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
@@ -41,46 +92,99 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const results: { profitability: string; infraCosts: string } = {
-    profitability: "ok",
-    infraCosts: "ok",
-  };
-  const ms: { profitability: number; infraCosts: number } = {
-    profitability: 0,
-    infraCosts: 0,
+  const results: Record<string, string> = {};
+  const ms: Record<string, number> = {};
+
+  const run = async (name: string, fn: () => Promise<void>) => {
+    const t0 = Date.now();
+    try {
+      await fn();
+      results[name] = "ok";
+    } catch (err: any) {
+      results[name] = err?.message || "failed";
+    }
+    ms[name] = Date.now() - t0;
   };
 
   // Profitability
-  {
-    const t0 = Date.now();
-    try {
-      const payload = await computeProfitability({
-        days: PROFIT_DAYS,
-        desktopCost: PROFIT_DESKTOP_COST,
-        mobileCost: PROFIT_MOBILE_COST,
-      });
-      await setPayload(
-        profitabilityCacheKey(PROFIT_DAYS, PROFIT_DESKTOP_COST, PROFIT_MOBILE_COST),
-        payload,
-      );
-    } catch (err: any) {
-      results.profitability = err?.message || "failed";
-    }
-    ms.profitability = Date.now() - t0;
-  }
+  await run("profitability", async () => {
+    const payload = await computeProfitability({
+      days: PROFIT_DAYS,
+      desktopCost: PROFIT_DESKTOP_COST,
+      mobileCost: PROFIT_MOBILE_COST,
+    });
+    await setPayload(
+      profitabilityCacheKey(PROFIT_DAYS, PROFIT_DESKTOP_COST, PROFIT_MOBILE_COST),
+      payload,
+    );
+  });
 
   // Infra costs
-  {
-    const t0 = Date.now();
-    try {
-      const overheadMonthly = defaultOverheadMonthly();
-      const payload = await computeInfraCosts({ days: INFRA_DAYS, overheadMonthly });
-      await setPayload(infraCostsCacheKey(INFRA_DAYS, overheadMonthly), payload);
-    } catch (err: any) {
-      results.infraCosts = err?.message || "failed";
-    }
-    ms.infraCosts = Date.now() - t0;
-  }
+  await run("infraCosts", async () => {
+    const overheadMonthly = defaultOverheadMonthly();
+    const payload = await computeInfraCosts({ days: INFRA_DAYS, overheadMonthly });
+    await setPayload(infraCostsCacheKey(INFRA_DAYS, overheadMonthly), payload);
+  });
+
+  // Daily new users
+  await run("dailyNewUsers", async () => {
+    const payload = await computeDailyNewUsers(DAILY_NEW_USERS_DAYS);
+    await setPayload(dailyNewUsersCacheKey(DAILY_NEW_USERS_DAYS), payload);
+  });
+
+  // macOS versions
+  await run("macosVersions", async () => {
+    const payload = await computeMacosVersions();
+    await setPayload(macosVersionsCacheKey(), payload);
+  });
+
+  // Notifications
+  await run("notifications", async () => {
+    const payload = await computeNotifications(NOTIFICATIONS_DAYS);
+    await setPayload(notificationsCacheKey(NOTIFICATIONS_DAYS), payload);
+  });
+
+  // Onboarding funnel
+  await run("onboarding", async () => {
+    const payload = await computeOnboarding(ONBOARDING_DAYS);
+    await setPayload(onboardingCacheKey(ONBOARDING_DAYS), payload);
+  });
+
+  // Revenue
+  await run("revenue", async () => {
+    const payload = await computeRevenue();
+    await setPayload(revenueCacheKey(), payload);
+  });
+
+  // MRR trends
+  await run("mrrTrends", async () => {
+    const payload = await computeMrrTrends(TRENDS_MONTHS);
+    await setPayload(mrrTrendsCacheKey(TRENDS_MONTHS), payload);
+  });
+
+  // Subscription trends
+  await run("subscriptionTrends", async () => {
+    const payload = await computeSubscriptionTrends(TRENDS_MONTHS);
+    await setPayload(subscriptionTrendsCacheKey(TRENDS_MONTHS), payload);
+  });
+
+  // Subscriptions
+  await run("subscriptions", async () => {
+    const payload = await computeSubscriptions();
+    await setPayload(subscriptionsCacheKey(), payload);
+  });
+
+  // App subscriptions
+  await run("appSubscriptions", async () => {
+    const payload = await computeAppSubscriptions();
+    await setPayload(appSubscriptionsCacheKey(), payload);
+  });
+
+  // k-factor: no payload cache — calling compute warms its posthogResults
+  // query cache (Firestore) so the GET serves fast from there.
+  await run("kFactor", async () => {
+    await computeKFactor(K_FACTOR_DAYS);
+  });
 
   return NextResponse.json({ ok: true, results, ms });
 }

--- a/web/admin/app/api/omi/stats/app-subscriptions/route.ts
+++ b/web/admin/app/api/omi/stats/app-subscriptions/route.ts
@@ -2,22 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import type Stripe from 'stripe';
 import { getStripe } from '@/lib/stripe';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+function cacheKey(): string {
+  return `app-subscriptions:v1`;
+}
 
-  const stripe = getStripe();
-  try {
+export { cacheKey as appSubscriptionsCacheKey };
+
+// Thrown when OMI price IDs are not configured — GET maps it to a 500.
+class PriceIdsMissingError extends Error {}
+
+export async function computeAppSubscriptions() {
+    const stripe = getStripe();
     const omiMonthlyPriceId = process.env.STRIPE_UNLIMITED_MONTHLY_PRICE_ID;
     const omiAnnualPriceId = process.env.STRIPE_UNLIMITED_ANNUAL_PRICE_ID;
 
     if (!omiMonthlyPriceId || !omiAnnualPriceId) {
-      return NextResponse.json(
-        { error: 'OMI price IDs not configured' },
-        { status: 500 }
-      );
+      throw new PriceIdsMissingError('OMI price IDs not configured');
     }
 
     // Fetch ALL active subscriptions with pagination
@@ -73,13 +77,33 @@ export async function GET(request: NextRequest) {
       });
     });
 
-    return NextResponse.json({
+    return {
       totalAppSubscriptions: appSubscriptions.length,
       uniqueCustomers: Object.keys(customerSubscriptions).length,
       priceBreakdown,
       uniquePriceIds: Object.keys(priceBreakdown).length,
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const key = cacheKey();
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeAppSubscriptions>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeAppSubscriptions();
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof PriceIdsMissingError) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
     console.error('Error fetching app subscription stats:', error);
     return NextResponse.json(
       { error: 'Failed to fetch app subscription data' },

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -1,8 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { getUserGrowthSeries, sliceSeries } from "@/lib/services/user-growth";
+import { getPayload, setPayload } from "@/lib/payload-cache";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
+
+function cacheKey(daysParam: string): string {
+  return `daily-new-users:v1:${daysParam}`;
+}
+
+export { cacheKey as dailyNewUsersCacheKey };
+
+export async function computeDailyNewUsers(daysParam: string) {
+  const series = await getUserGrowthSeries();
+  return sliceSeries(series, daysParam);
+}
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
@@ -10,8 +23,17 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const series = await getUserGrowthSeries();
-    return NextResponse.json(sliceSeries(series, searchParams.get("days")));
+    const daysParam = searchParams.get("days") || "all";
+    const key = cacheKey(daysParam);
+
+    const cached = await getPayload<ReturnType<typeof sliceSeries>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeDailyNewUsers(daysParam);
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error: any) {
     console.error("Daily new users error:", error);
     return NextResponse.json(

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -1,28 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
+import { posthogResults } from '@/lib/posthog';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+// Run the k-factor proxy HogQL query through posthogResults (Firestore
+// query-cache + 429 backoff + stale fallback) and shape the panel payload.
+// Exported so the precompute cron can warm the underlying query cache.
+export async function computeKFactor(days: number) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
 
-  try {
-    const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-    const projectId = process.env.POSTHOG_PROJECT_ID;
-    const host = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
+  if (!apiKey || !projectId) {
+    return {
+      days,
+      available: false as const,
+      kFactor: null,
+      reason: 'PostHog credentials not configured.',
+    };
+  }
 
-    if (!apiKey || !projectId) {
-      return NextResponse.json({ error: 'PostHog credentials not configured' }, { status: 500 });
-    }
-
-    const searchParams = request.nextUrl.searchParams;
-    const days = parseInt(searchParams.get('days') || '30', 10);
-    const url = `${host}/api/projects/${projectId}/query/`;
-
-    const body = {
-      query: {
-        kind: 'HogQLQuery',
-        query: `
+  const query = `
           SELECT
             event,
             uniq(COALESCE(person_id, distinct_id)) AS unique_users,
@@ -32,71 +31,68 @@ export async function GET(request: NextRequest) {
             AND timestamp >= now() - INTERVAL ${days} DAY
             AND properties.$os = 'macOS'
           GROUP BY event
-        `,
-      },
-    };
+        `;
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
+  const rows = (await posthogResults(host, projectId, apiKey, query)) as any[];
 
-    if (!response.ok) {
-      const text = await response.text();
-      console.error('PostHog k-factor API error:', response.status, text);
-      return NextResponse.json({ error: `PostHog API error: ${response.status}` }, { status: 502 });
+  let newUsers = 0;
+  let sharers = 0;
+  let shareEvents = 0;
+
+  for (const row of rows) {
+    const eventName = row[0];
+    const uniqueUsers = Number(row[1] ?? 0);
+    const totalEvents = Number(row[2] ?? 0);
+
+    if (eventName === 'Sign In Completed') {
+      newUsers = uniqueUsers;
     }
-
-    const raw = await response.json();
-    const rows = Array.isArray(raw.results) ? raw.results : [];
-
-    let newUsers = 0;
-    let sharers = 0;
-    let shareEvents = 0;
-
-    for (const row of rows) {
-      const eventName = row[0];
-      const uniqueUsers = Number(row[1] ?? 0);
-      const totalEvents = Number(row[2] ?? 0);
-
-      if (eventName === 'Sign In Completed') {
-        newUsers = uniqueUsers;
-      }
-      if (eventName === 'Memory Share Button Clicked') {
-        sharers = uniqueUsers;
-        shareEvents = totalEvents;
-      }
+    if (eventName === 'Memory Share Button Clicked') {
+      sharers = uniqueUsers;
+      shareEvents = totalEvents;
     }
+  }
 
-    const shareRatePct = newUsers > 0 ? (sharers / newUsers) * 100 : 0;
-    const sharesPerSharer = sharers > 0 ? shareEvents / sharers : 0;
-    const sharesPerNewUser = newUsers > 0 ? shareEvents / newUsers : 0;
+  const shareRatePct = newUsers > 0 ? (sharers / newUsers) * 100 : 0;
+  const sharesPerSharer = sharers > 0 ? shareEvents / sharers : 0;
+  const sharesPerNewUser = newUsers > 0 ? shareEvents / newUsers : 0;
 
+  return {
+    days,
+    available: false as const,
+    kFactor: null,
+    reason:
+      'Referral attribution is not instrumented on macOS yet. Current desktop analytics only expose sharing activity, not invite acceptance or referred sign-ups.',
+    proxy: {
+      newUsers,
+      sharers,
+      shareEvents,
+      shareRatePct: Math.round(shareRatePct * 10) / 10,
+      sharesPerSharer: Math.round(sharesPerSharer * 100) / 100,
+      sharesPerNewUser: Math.round(sharesPerNewUser * 100) / 100,
+    },
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const searchParams = request.nextUrl.searchParams;
+  const days = parseInt(searchParams.get('days') || '30', 10);
+
+  try {
+    const payload = await computeKFactor(days);
+    return NextResponse.json(payload);
+  } catch (error) {
+    // PostHog still failing (e.g. 429 with no cached fallback) — degrade
+    // gracefully so the panel never hard-errors with a 502/500.
+    console.error('Error fetching PostHog k-factor proxy:', error);
     return NextResponse.json({
       days,
-      available: false,
+      available: false as const,
       kFactor: null,
-      reason:
-        'Referral attribution is not instrumented on macOS yet. Current desktop analytics only expose sharing activity, not invite acceptance or referred sign-ups.',
-      proxy: {
-        newUsers,
-        sharers,
-        shareEvents,
-        shareRatePct: Math.round(shareRatePct * 10) / 10,
-        sharesPerSharer: Math.round(sharesPerSharer * 100) / 100,
-        sharesPerNewUser: Math.round(sharesPerNewUser * 100) / 100,
-      },
+      reason: 'PostHog data is temporarily unavailable (rate-limited). Try again shortly.',
     });
-  } catch (error) {
-    console.error('Error fetching PostHog k-factor proxy:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch PostHog k-factor proxy data' },
-      { status: 500 }
-    );
   }
 }

--- a/web/admin/app/api/omi/stats/macos-versions/route.ts
+++ b/web/admin/app/api/omi/stats/macos-versions/route.ts
@@ -2,8 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import admin, { getDb } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
+import { getPayload, setPayload } from "@/lib/payload-cache";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
+
+function cacheKey(): string {
+  return `macos-versions:v1`;
+}
+
+export { cacheKey as macosVersionsCacheKey };
 
 const VERSION_COLORS = [
   "#6366f1",
@@ -80,20 +88,16 @@ function formatTodayLabel() {
   }).format(new Date());
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+export async function computeMacosVersions() {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(/\/$/, "");
 
-  try {
-    const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-    const projectId = process.env.POSTHOG_PROJECT_ID;
-    const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(/\/$/, "");
+  if (!apiKey || !projectId) {
+    throw new Error("PostHog credentials not configured");
+  }
 
-    if (!apiKey || !projectId) {
-      return NextResponse.json({ error: "PostHog credentials not configured" }, { status: 500 });
-    }
-
-    const activeUsersQuery = `
+  const activeUsersQuery = `
       SELECT
         distinct_id AS actor_id,
         argMax(
@@ -121,12 +125,12 @@ export async function GET(request: NextRequest) {
       .filter((row) => row.userId.length > 0);
 
     if (activeUsers.length === 0) {
-      return NextResponse.json({
+      return {
         date: formatTodayLabel(),
         activeUsers: 0,
         channelBreakdown: [],
         versionBreakdown: [],
-      });
+      };
     }
 
     const channelMap = await getUserChannels(activeUsers.map((user) => user.userId));
@@ -152,12 +156,29 @@ export async function GET(request: NextRequest) {
       VERSION_COLORS
     );
 
-    return NextResponse.json({
+    return {
       date: formatTodayLabel(),
       activeUsers: activeUsers.length,
       channelBreakdown,
       versionBreakdown,
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const key = cacheKey();
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeMacosVersions>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeMacosVersions();
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error: any) {
     console.error("macOS version stats error:", error);
     return NextResponse.json(

--- a/web/admin/app/api/omi/stats/mrr-trends/route.ts
+++ b/web/admin/app/api/omi/stats/mrr-trends/route.ts
@@ -2,7 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import type Stripe from 'stripe';
 import { getOptionalStripe } from '@/lib/stripe';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
+
+function cacheKey(months: number): string {
+  return `mrr-trends:v1:${months}`;
+}
+
+export { cacheKey as mrrTrendsCacheKey };
+
+// Thrown when every Stripe leg fails — GET maps it to a 502.
+class AllSourcesFailedError extends Error {}
 
 function buildEmptyMrrData(months: number) {
   const endDate = new Date();
@@ -28,19 +39,13 @@ function buildEmptyMrrData(months: number) {
   });
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
-
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const months = parseInt(searchParams.get('months') || '12', 10);
+export async function computeMrrTrends(months: number) {
     const stripe = getOptionalStripe();
     const monthlyPriceId = process.env.STRIPE_UNLIMITED_MONTHLY_PRICE_ID;
     const annualPriceId = process.env.STRIPE_UNLIMITED_ANNUAL_PRICE_ID;
 
     if (!stripe || !monthlyPriceId || !annualPriceId) {
-      return NextResponse.json({ data: buildEmptyMrrData(months), unavailable: true });
+      return { data: buildEmptyMrrData(months), unavailable: true };
     }
 
     // Calculate date range
@@ -93,10 +98,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (results.every((r) => r.status === 'rejected')) {
-      return NextResponse.json(
-        { error: 'All MRR trend data sources failed' },
-        { status: 502 }
-      );
+      throw new AllSourcesFailedError('All MRR trend data sources failed');
     }
 
     // Group MRR by month
@@ -181,8 +183,30 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    return NextResponse.json({ data, partial });
+    return { data, partial };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const months = parseInt(searchParams.get('months') || '12', 10);
+    const key = cacheKey(months);
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeMrrTrends>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeMrrTrends(months);
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof AllSourcesFailedError) {
+      return NextResponse.json({ error: error.message }, { status: 502 });
+    }
     console.error('Error fetching MRR trends:', error);
     return NextResponse.json(
       { error: 'Failed to fetch MRR trends' },

--- a/web/admin/app/api/omi/stats/notifications/route.ts
+++ b/web/admin/app/api/omi/stats/notifications/route.ts
@@ -2,8 +2,16 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
 import { cachedPosthogFetch } from '@/lib/posthog';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
+
+function cacheKey(days: number): string {
+  return `notifications:v1:${days}`;
+}
+
+export { cacheKey as notificationsCacheKey };
 
 const MENTOR_APP_ID = 'mentor';
 const MARKETPLACE_MENTOR_APP_ID = 'omi-your-mentor-and-teacher-01JCPRSZ7FS40FHFNSJZEWR8R1';
@@ -39,14 +47,8 @@ async function queryPostHog(host: string, projectId: string, apiKey: string, que
   return response.json();
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
-
-  try {
+export async function computeNotifications(days: number) {
     const db = getDb();
-    const searchParams = request.nextUrl.searchParams;
-    const days = parseInt(searchParams.get('days') || '30', 10);
     const posthogHost = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
     const posthogApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
     const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
@@ -373,7 +375,7 @@ export async function GET(request: NextRequest) {
       total: hourlyTimeline[hk].mentor + hourlyTimeline[hk].marketplace,
     }));
 
-    return NextResponse.json({
+    return {
       dailyData,
       weeklyData,
       hourlyData,
@@ -383,7 +385,26 @@ export async function GET(request: NextRequest) {
         disabled: disabledCount,
         total: totalUsers,
       },
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const days = parseInt(searchParams.get('days') || '30', 10);
+    const key = cacheKey(days);
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeNotifications>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeNotifications(days);
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
     console.error('Error fetching notification stats:', error);
     return NextResponse.json(

--- a/web/admin/app/api/omi/stats/onboarding/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/onboarding/posthog/route.ts
@@ -1,6 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
+
+function cacheKey(days: number): string {
+  return `onboarding:v1:${days}`;
+}
+
+export { cacheKey as onboardingCacheKey };
+
+class PostHogError extends Error {
+  constructor(public status: number) {
+    super(`PostHog API error: ${status}`);
+    this.name = 'PostHogError';
+  }
+}
 
 const STEP_DEFINITIONS = [
   { key: 'name', label: 'Name', eventNames: ['Onboarding Step Name Completed'] },
@@ -86,21 +101,14 @@ const STEP_DEFINITIONS = [
   { key: 'completed', label: 'Completed', eventNames: ['Onboarding Completed'] },
 ];
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
-
-  try {
+export async function computeOnboarding(days: number) {
     const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
     const projectId = process.env.POSTHOG_PROJECT_ID;
     const host = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
 
     if (!apiKey || !projectId) {
-      return NextResponse.json({ error: 'PostHog credentials not configured' }, { status: 500 });
+      throw new Error('PostHog credentials not configured');
     }
-
-    const searchParams = request.nextUrl.searchParams;
-    const days = parseInt(searchParams.get('days') || '30', 10);
 
     const eventNames = STEP_DEFINITIONS.flatMap((step) => step.eventNames);
     const escapedEventNames = eventNames.map((name) => `'${name.replace(/'/g, "\\'")}'`).join(', ');
@@ -151,7 +159,7 @@ export async function GET(request: NextRequest) {
     if (!response.ok) {
       const text = await response.text();
       console.error('PostHog onboarding API error:', response.status, text);
-      return NextResponse.json({ error: `PostHog API error: ${response.status}` }, { status: 502 });
+      throw new PostHogError(response.status);
     }
 
     const raw = await response.json();
@@ -198,14 +206,39 @@ export async function GET(request: NextRequest) {
         totalUsers > 0 ? Math.round((usersByStep[index] / totalUsers) * 10000) / 100 : 0,
     }));
 
-    return NextResponse.json({
+    return {
       days,
       totalUsers,
       methodology:
         'First-ever entrants into the current macOS onboarding flow, using users whose earliest recorded onboarding event is Name inside the selected window.',
       steps,
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const searchParams = request.nextUrl.searchParams;
+  const days = parseInt(searchParams.get('days') || '30', 10);
+  const key = cacheKey(days);
+
+  try {
+    const cached = await getPayload<Awaited<ReturnType<typeof computeOnboarding>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeOnboarding(days);
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof PostHogError) {
+      return NextResponse.json({ error: `PostHog API error: ${error.status}` }, { status: 502 });
+    }
+    if (error instanceof Error && error.message === 'PostHog credentials not configured') {
+      return NextResponse.json({ error: 'PostHog credentials not configured' }, { status: 500 });
+    }
     console.error('Error fetching PostHog onboarding funnel:', error);
     return NextResponse.json(
       { error: 'Failed to fetch PostHog onboarding funnel data' },

--- a/web/admin/app/api/omi/stats/revenue/route.ts
+++ b/web/admin/app/api/omi/stats/revenue/route.ts
@@ -2,19 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import type Stripe from 'stripe';
 import { getOptionalStripe } from '@/lib/stripe';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+function cacheKey(): string {
+  return `revenue:v1`;
+}
 
-  try {
+export { cacheKey as revenueCacheKey };
+
+// Thrown when every Stripe leg fails — GET maps it to a 502.
+class AllSourcesFailedError extends Error {}
+
+export async function computeRevenue() {
     const stripe = getOptionalStripe();
     const monthlyPriceId = process.env.STRIPE_UNLIMITED_MONTHLY_PRICE_ID;
     const annualPriceId = process.env.STRIPE_UNLIMITED_ANNUAL_PRICE_ID;
 
     if (!stripe || !monthlyPriceId || !annualPriceId) {
-      return NextResponse.json({ mrr: 0, arr: 0, unavailable: true });
+      return { mrr: 0, arr: 0, unavailable: true };
     }
 
     // Fetch all active subscriptions with pagination
@@ -63,10 +70,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (results.every((r) => r.status === 'rejected')) {
-      return NextResponse.json(
-        { error: 'All revenue data sources failed' },
-        { status: 502 }
-      );
+      throw new AllSourcesFailedError('All revenue data sources failed');
     }
 
     let monthlyMRR = 0;
@@ -113,12 +117,32 @@ export async function GET(request: NextRequest) {
     const totalMRR = monthlyMRR + annualMRR;
     const totalARR = monthlyARR + annualARR;
 
-    return NextResponse.json({
+    return {
       mrr: totalMRR,
       arr: totalARR,
       partial,
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const key = cacheKey();
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeRevenue>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeRevenue();
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof AllSourcesFailedError) {
+      return NextResponse.json({ error: error.message }, { status: 502 });
+    }
     console.error('Error calculating revenue metrics:', error);
     return NextResponse.json(
       { error: 'Failed to calculate revenue metrics' },

--- a/web/admin/app/api/omi/stats/subscription-trends/route.ts
+++ b/web/admin/app/api/omi/stats/subscription-trends/route.ts
@@ -2,7 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import type Stripe from 'stripe';
 import { getOptionalStripe } from '@/lib/stripe';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
+
+function cacheKey(months: number): string {
+  return `subscription-trends:v1:${months}`;
+}
+
+export { cacheKey as subscriptionTrendsCacheKey };
+
+// Thrown when every Stripe leg fails — GET maps it to a 502.
+class AllSourcesFailedError extends Error {}
 
 function buildEmptySubscriptionTrendData(months: number) {
   const endDate = new Date();
@@ -29,19 +40,13 @@ function buildEmptySubscriptionTrendData(months: number) {
   });
 }
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
-
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const months = parseInt(searchParams.get('months') || '12', 10);
+export async function computeSubscriptionTrends(months: number) {
     const stripe = getOptionalStripe();
     const monthlyPriceId = process.env.STRIPE_UNLIMITED_MONTHLY_PRICE_ID;
     const annualPriceId = process.env.STRIPE_UNLIMITED_ANNUAL_PRICE_ID;
 
     if (!stripe || !monthlyPriceId || !annualPriceId) {
-      return NextResponse.json({ data: buildEmptySubscriptionTrendData(months), unavailable: true });
+      return { data: buildEmptySubscriptionTrendData(months), unavailable: true };
     }
 
     // Calculate date range
@@ -94,10 +99,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (results.every((r) => r.status === 'rejected')) {
-      return NextResponse.json(
-        { error: 'All subscription trend data sources failed' },
-        { status: 502 }
-      );
+      throw new AllSourcesFailedError('All subscription trend data sources failed');
     }
 
     // Group subscriptions by month created
@@ -150,8 +152,30 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    return NextResponse.json({ data, partial });
+    return { data, partial };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const months = parseInt(searchParams.get('months') || '12', 10);
+    const key = cacheKey(months);
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeSubscriptionTrends>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeSubscriptionTrends(months);
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof AllSourcesFailedError) {
+      return NextResponse.json({ error: error.message }, { status: 502 });
+    }
     console.error('Error fetching subscription trends:', error);
     return NextResponse.json(
       { error: 'Failed to fetch subscription trends' },

--- a/web/admin/app/api/omi/stats/subscriptions/route.ts
+++ b/web/admin/app/api/omi/stats/subscriptions/route.ts
@@ -1,24 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getOptionalStripe } from '@/lib/stripe';
+import { getPayload, setPayload } from '@/lib/payload-cache';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 3600;
 
-export async function GET(request: NextRequest) {
-  const authResult = await verifyAdmin(request);
-  if (authResult instanceof NextResponse) return authResult;
+function cacheKey(): string {
+  return `subscriptions:v1`;
+}
 
-  try {
+export { cacheKey as subscriptionsCacheKey };
+
+// Thrown when every Stripe leg fails — GET maps it to a 502.
+class AllSourcesFailedError extends Error {}
+
+export async function computeSubscriptions() {
     const stripe = getOptionalStripe();
     const priceIdOne = process.env.STRIPE_UNLIMITED_MONTHLY_PRICE_ID;
     const priceIdTwo = process.env.STRIPE_UNLIMITED_ANNUAL_PRICE_ID;
 
     if (!stripe || !priceIdOne || !priceIdTwo) {
-      return NextResponse.json({
+      return {
         totalSubscriptions: 0,
         priceIdOne: { count: 0, priceId: priceIdOne || '' },
         priceIdTwo: { count: 0, priceId: priceIdTwo || '' },
         unavailable: true,
-      });
+      };
     }
 
     // Fetch all active subscriptions for both price IDs with pagination
@@ -65,18 +72,15 @@ export async function GET(request: NextRequest) {
       console.error('Error fetching annual subscriptions:', results[1].reason);
     }
 
-    // If ALL legs failed, return an error — don't serve fabricated zeros
+    // If ALL legs failed, throw — don't serve fabricated zeros (GET maps to 502)
     if (results.every((r) => r.status === 'rejected')) {
-      return NextResponse.json(
-        { error: 'All subscription data sources failed' },
-        { status: 502 }
-      );
+      throw new AllSourcesFailedError('All subscription data sources failed');
     }
 
     const partial = results.some((r) => r.status === 'rejected');
     const totalSubscriptions = subscriptionsOne.length + subscriptionsTwo.length;
 
-    return NextResponse.json({
+    return {
       totalSubscriptions,
       partial,
       priceIdOne: {
@@ -87,8 +91,28 @@ export async function GET(request: NextRequest) {
         count: subscriptionsTwo.length,
         priceId: priceIdTwo,
       },
-    });
+    };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const key = cacheKey();
+
+    const cached = await getPayload<Awaited<ReturnType<typeof computeSubscriptions>>>(key);
+    if (cached) {
+      return NextResponse.json(cached.data);
+    }
+
+    const payload = await computeSubscriptions();
+    await setPayload(key, payload);
+    return NextResponse.json(payload);
   } catch (error) {
+    if (error instanceof AllSourcesFailedError) {
+      return NextResponse.json({ error: error.message }, { status: 502 });
+    }
     console.error('Error fetching subscription stats:', error);
     return NextResponse.json(
       { error: 'Failed to fetch subscription data' },


### PR DESCRIPTION
Follow-up to #8169. Brings every remaining dashboard graph route onto the Firestore payload cache + precompute warming, so the dashboard cold-load is all fast cache reads instead of 10–41s live queries (or 502s).

- **k-factor/posthog**: was returning **502** (direct PostHog call dying on 429). Now routes through `posthogResults` (cache + backoff) and degrades to a graceful `200 {available:false}` instead of hard-erroring.
- **Payload-cache + precompute-warm** (serve cached at any age; cron refreshes every 30 min): daily-new-users (~41s→cache), macos-versions (~38s, per-user Firestore lookups), notifications (~37s, collectionGroup scan), revenue/mrr-trends/subscription-trends/subscriptions/app-subscriptions (Stripe, 10–32s), onboarding.
- `precompute` endpoint now warms all of the above sequentially (PostHog rate-limit safe).

Verified: `tsc --noEmit` clean, `npm run build` clean. Post-deploy: run precompute, then confirm every dashboard graph renders fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

