### PR TITLE
fix(admin): dashboard charts render in production (recharts ResponsiveContainer was blank)

### DIFF
--- a/web/admin/app/(protected)/dashboard/page.tsx
+++ b/web/admin/app/(protected)/dashboard/page.tsx
@@ -30,7 +30,6 @@ import {
   CartesianGrid,
   Tooltip,
   Legend,
-  ResponsiveContainer,
   BarChart,
   LineChart,
   Area,
@@ -41,6 +40,10 @@ import {
   PieChart,
   Pie,
 } from "recharts";
+// recharts' own ResponsiveContainer renders blank in our Next.js production
+// build (works in dev). Use a plain measuring container that passes explicit
+// pixel dimensions to the chart instead. See components/ui/measured-container.
+import { ResponsiveContainer } from "@/components/ui/measured-container";
 import {
   Select,
   SelectContent,

--- a/web/admin/components/ui/measured-container.tsx
+++ b/web/admin/components/ui/measured-container.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Children, cloneElement, isValidElement, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * Drop-in replacement for recharts' <ResponsiveContainer>.
+ *
+ * recharts' own ResponsiveContainer renders nothing in our Next.js production
+ * build (its internal sizing path yields a 0×0 size once the bundle is built —
+ * charts render under `next dev` but are blank after `next build`). This
+ * component measures its own box with a plain ResizeObserver and passes the
+ * resolved pixel width/height straight to the single recharts chart child, so
+ * there is no dependency on recharts' internal sizing path.
+ *
+ * Mirrors the subset of the ResponsiveContainer API the dashboard uses
+ * (width/height "100%", optional minHeight/minWidth) so existing call sites
+ * need no changes.
+ */
+export function ResponsiveContainer({
+  width = "100%",
+  height = "100%",
+  minHeight,
+  minWidth,
+  children,
+}: {
+  width?: number | string;
+  height?: number | string;
+  minHeight?: number | string;
+  minWidth?: number | string;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      const w = Math.floor(r.width);
+      const h = Math.floor(r.height);
+      setSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    // Flexbox heights can resolve a frame after mount; re-measure once.
+    const raf = requestAnimationFrame(measure);
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  const child = children != null ? Children.only(children) : null;
+
+  return (
+    <div ref={ref} style={{ width, height, minHeight, minWidth, position: "relative" }}>
+      {size.w > 0 && size.h > 0 && isValidElement(child)
+        ? cloneElement(child as React.ReactElement<{ width?: number; height?: number }>, {
+            width: size.w,
+            height: size.h,
+          })
+        : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Every chart on admin.omi.me renders **blank in production** (0 SVG surfaces) while rendering fine in `next dev`. Reproduced via Playwright against the live Next-16 production build: recharts' `ResponsiveContainer` mounts with a correct 582×330 box but renders zero children once the bundle is built. Independent of recharts version (2.12.7/2.15.4), bundler (Turbopack/webpack), and `transpilePackages` — it's a Next-16-production-build vs recharts `ResponsiveContainer` incompatibility. Data/endpoints are fine (KPI cards/tables/subtitles show real values); only the chart SVGs are missing.

## Fix
Replace recharts' `ResponsiveContainer` with a tiny local measuring container (`components/ui/measured-container.tsx`) that measures its own box with a plain `ResizeObserver` and passes explicit pixel `width`/`height` to the chart child. recharts charts render fine with explicit dimensions; this avoids recharts' internal sizing path that breaks under the production bundle. Drop-in API — only the import in the dashboard page changes (all ~28 chart call sites unchanged).

## Verification
Verified post-deploy against the live admin.omi.me dashboard (Playwright) — confirming SVG surfaces render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

