### PR TITLE
Freemium: disable desktop trial paywall + fix desktop chat-quota metering

### DIFF
--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -33,6 +33,17 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
             continue
         data = snap.to_dict() or {}
         for key, value in data.items():
+            # The Rust desktop-backend commits desktop_chat usage via dotted Firestore
+            # fieldPaths (e.g. "desktop_chat.call_count"), which Firestore materializes
+            # as a NESTED map ({desktop_chat: {call_count, cost_usd, ...}}) — not the flat
+            # dotted string keys the Python backend writes. Read the grand-total
+            # `desktop_chat` map here; the `desktop_chat_*` prefixed maps (per-account /
+            # realtime breakdowns) are already summed into it, so don't double-count them.
+            if isinstance(value, dict):
+                if key == 'desktop_chat':
+                    questions += int(value.get('call_count', 0) or 0)
+                    cost_usd += float(value.get('cost_usd', 0) or 0)
+                continue
             if not isinstance(value, (int, float)):
                 continue
             if key.startswith('desktop_chat'):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -43,6 +43,7 @@ pytest tests/unit/test_process_conversation_usage_context.py -v
 pytest tests/unit/test_high_priority_usage_tracking.py -v
 pytest tests/unit/test_new_usage_tracking_gaps.py -v
 pytest tests/unit/test_llm_usage_db.py -v
+pytest tests/unit/test_user_usage.py -v
 pytest tests/unit/test_llm_usage_endpoints.py -v
 pytest tests/unit/test_app_uid_keyerror.py -v
 pytest tests/unit/test_daily_summary_race_condition.py -v

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -325,6 +325,10 @@ class TestIsTrialPaywalledBehavioral:
 
         import utils.subscription as sub
 
+        # The trial paywall is OFF by default (freemium). Force it on so the delegation
+        # logic under test is reachable.
+        sub.TRIAL_PAYWALL_ENABLED = True
+
         self._sub = sub
         self._mock_expired = MagicMock(return_value=True)
         self._orig_expired = sub._is_trial_expired_cached
@@ -444,6 +448,9 @@ class TestByokRequestEscapeHatch:
 
         import utils.subscription as sub
         from utils import byok
+
+        # Paywall is OFF by default (freemium); force it on for these BYOK-bypass tests.
+        sub.TRIAL_PAYWALL_ENABLED = True
 
         self._sub = sub
         self._byok = byok

--- a/backend/tests/unit/test_trial_metadata.py
+++ b/backend/tests/unit/test_trial_metadata.py
@@ -131,6 +131,9 @@ def _get_trial_metadata_fn():
         'get_plan_display_name': lambda p: 'Free' if p == PlanType.basic else p.value.capitalize(),
         'FREE_CHAT_QUESTIONS_PER_MONTH': 30,
         '_request_has_all_byok_keys': lambda: False,
+        # These tests exercise the trial-expiry computation, which only runs when the
+        # paywall is enabled (it's OFF by default in prod / freemium).
+        'TRIAL_PAYWALL_ENABLED': True,
     }
     exec(compile(cutoff_line, '<subscription.py>', 'exec'), namespace)
 

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -1,0 +1,95 @@
+"""Unit tests for get_monthly_chat_usage — the freemium chat-question quota source.
+
+Regression coverage for the nested-vs-flat bug: the Rust desktop-backend commits
+desktop_chat usage via dotted Firestore fieldPaths, which Firestore materializes as a
+NESTED map ({desktop_chat: {call_count, ...}}), whereas the Python backend writes flat
+dotted keys ("chat.<model>.call_count"). The reader must count both, count the
+grand-total `desktop_chat` map only (not its `desktop_chat_*` per-account/realtime
+breakdowns, which would double-count), and exclude company-driven keys (conv_*, memories.*).
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+mock_db = MagicMock()
+_mock_client_module = MagicMock()
+_mock_client_module.db = mock_db
+sys.modules["database._client"] = _mock_client_module
+sys.modules["stripe"] = MagicMock()
+
+from database import user_usage  # noqa: E402
+
+
+class _Snap:
+    def __init__(self, data):
+        self._d = data
+        self.exists = True
+
+    def to_dict(self):
+        return self._d
+
+
+class _DocRef:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+
+    def get(self):
+        return _Snap(self._data)
+
+
+def _setup_docs(docs):
+    refs = [_DocRef(k, v) for k, v in docs.items()]
+    llm_usage_ref = MagicMock()
+    llm_usage_ref.list_documents.return_value = refs
+    mock_db.collection.return_value.document.return_value.collection.return_value = llm_usage_ref
+
+
+NOW = datetime(2026, 6, 23, tzinfo=timezone.utc)
+
+
+def test_counts_nested_desktop_chat_plus_flat_backend_chat():
+    _setup_docs(
+        {
+            "2026-06-23": {
+                "desktop_chat": {"call_count": 5, "cost_usd": 1.5},  # nested (Rust) — counted
+                "desktop_chat_omi": {"call_count": 3},  # breakdown — must NOT double-count
+                "desktop_chat_realtime": {"call_count": 2},  # PTT breakdown — must NOT double-count
+                "chat.gpt-4.call_count": 4,  # flat backend chat — counted
+                "conv_apps.gpt-5.call_count": 100,  # proactive/processing — excluded
+                "memories.gpt-4.call_count": 50,  # excluded
+                "date": "2026-06-23",
+            },
+            "2026-05-30": {"desktop_chat": {"call_count": 999}},  # other month — excluded
+        }
+    )
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    # 5 (grand-total desktop_chat) + 4 (flat chat.*); breakdowns + proactive excluded; other month excluded
+    assert r["questions"] == 9, r
+    assert r["cost_usd"] == 1.5, r
+
+
+def test_realtime_ptt_included_via_grand_total():
+    # A pure-PTT month: only realtime turns. record_llm_usage always bumps the grand-total
+    # desktop_chat too, so it must be counted even with zero typed chat.
+    _setup_docs(
+        {
+            "2026-06-10": {
+                "desktop_chat": {"call_count": 7, "cost_usd": 0.4},
+                "desktop_chat_realtime": {"call_count": 7},
+            }
+        }
+    )
+    assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 7
+
+
+def test_only_proactive_counts_zero():
+    _setup_docs({"2026-06-23": {"conv_apps.gpt-5.call_count": 100, "memories.gpt-4.call_count": 50}})
+    assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 0

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -77,6 +77,14 @@ def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]
 # exempt.
 TRIAL_LENGTH_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
+# Master switch for the desktop trial paywall. Default OFF: basic/Neo desktop users are
+# never locked out (no 402) AND the client never sees `trial_expired=True`, so the
+# "you've hit your monthly limit" upgrade popup does not fire just from account age — only
+# the actual chat-question quota (30/mo) gates them. Set TRIAL_PAYWALL_ENABLED=true to
+# restore the 3-day trial lockout. NOTE: this changes ONLY the trial paywall — plan limits
+# (Neo questions, data-intake caps) are untouched.
+TRIAL_PAYWALL_ENABLED = os.getenv('TRIAL_PAYWALL_ENABLED', 'false').lower() == 'true'
+
 # Platform identifiers that count as desktop for paywall purposes. The Swift
 # client sends X-App-Platform: macos and the listen WS uses source=desktop.
 # Anything else (ios, android, omi device, phone_call, unknown) is exempt.
@@ -162,6 +170,8 @@ def is_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
     `source` query param for the listen WebSocket. Mobile (ios/android),
     Omi devices, and any unknown/missing platform are never paywalled.
     """
+    if not TRIAL_PAYWALL_ENABLED:
+        return False  # trial paywall disabled — never block on account age
     if not platform or platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS:
         return False
     return _is_trial_expired_cached(uid)
@@ -182,6 +192,17 @@ def get_trial_metadata(uid: str) -> TrialMetadata:
     and benefits from the same Redis cache for the expensive bits.
     """
     try:
+        # Trial paywall disabled → there is no trial to expire. Report an always-active
+        # (non-expired) trial so the desktop client never renders the "trial expired /
+        # you've hit your monthly limit" upgrade popup from account age alone.
+        if not TRIAL_PAYWALL_ENABLED:
+            return TrialMetadata(
+                trial_expired=False,
+                trial_duration_seconds=TRIAL_LENGTH_SECONDS,
+                trial_features=TRIAL_FEATURES,
+                plan_after_trial=get_plan_display_name(PlanType.basic),
+            )
+
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
 

--- a/desktop/macos/Backend-Rust/src/paywall.rs
+++ b/desktop/macos/Backend-Rust/src/paywall.rs
@@ -80,6 +80,17 @@ impl PaywallChecker {
         request_headers: &HeaderMap,
         byok_stripped: bool,
     ) -> bool {
+        // Master switch: the trial paywall is OFF by default (freemium). When disabled,
+        // no user is ever paywalled by account age — mirrors the Python backend's
+        // TRIAL_PAYWALL_ENABLED flag. Set TRIAL_PAYWALL_ENABLED=true to restore the
+        // 3-day desktop trial lockout.
+        if !std::env::var("TRIAL_PAYWALL_ENABLED")
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+        {
+            return false;
+        }
+
         // BYOK escape hatch: a request carrying all 4 BYOK provider headers
         // is never paywalled, regardless of cached state. This handles the
         // race where Firestore hasn't caught up after BYOK activation.
@@ -151,7 +162,11 @@ impl PaywallChecker {
         let plan = match self.firestore.get_user_effective_plan(uid).await {
             Ok(p) => p,
             Err(e) => {
-                tracing::warn!("paywall: failed to read subscription plan for uid={}: {}", uid, e);
+                tracing::warn!(
+                    "paywall: failed to read subscription plan for uid={}: {}",
+                    uid,
+                    e
+                );
                 return None;
             }
         };
@@ -190,7 +205,11 @@ impl PaywallChecker {
                 return None;
             }
             Err(e) => {
-                tracing::warn!("paywall: failed to get creation time for uid={}: {}", uid, e);
+                tracing::warn!(
+                    "paywall: failed to get creation time for uid={}: {}",
+                    uid,
+                    e
+                );
                 return None;
             }
         };
@@ -275,24 +294,21 @@ mod tests {
     #[test]
     fn basic_plan_old_account_no_byok_paywalled() {
         // Account created 10 days ago → past 3-day trial
-        let ten_days_ago_ms =
-            (chrono::Utc::now().timestamp() - 10 * 24 * 60 * 60) * 1000;
+        let ten_days_ago_ms = (chrono::Utc::now().timestamp() - 10 * 24 * 60 * 60) * 1000;
         assert!(is_trial_expired("basic", false, Some(ten_days_ago_ms)));
     }
 
     #[test]
     fn basic_plan_exactly_3_days_not_paywalled() {
         // Account created exactly 3 days ago → age == TRIAL_LENGTH, not > TRIAL_LENGTH
-        let exactly_3d_ms =
-            (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS) * 1000;
+        let exactly_3d_ms = (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS) * 1000;
         assert!(!is_trial_expired("basic", false, Some(exactly_3d_ms)));
     }
 
     #[test]
     fn basic_plan_just_over_3_days_paywalled() {
         // Account created 3 days + 1 second ago
-        let just_over_3d_ms =
-            (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS - 1) * 1000;
+        let just_over_3d_ms = (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS - 1) * 1000;
         assert!(is_trial_expired("basic", false, Some(just_over_3d_ms)));
     }
 
@@ -340,7 +356,10 @@ mod tests {
         let byok_stripped = true;
         // The escape hatch condition:
         let would_escape = !byok_stripped && byok::has_all_byok_keys(&h);
-        assert!(!would_escape, "stripped headers must not trigger escape hatch");
+        assert!(
+            !would_escape,
+            "stripped headers must not trigger escape hatch"
+        );
     }
 
     #[test]
@@ -348,6 +367,9 @@ mod tests {
         let h = all_byok_headers();
         let byok_stripped = false;
         let would_escape = !byok_stripped && byok::has_all_byok_keys(&h);
-        assert!(would_escape, "validated headers should trigger escape hatch");
+        assert!(
+            would_escape,
+            "validated headers should trigger escape hatch"
+        );
     }
 }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -486,16 +486,20 @@ class AppState: ObservableObject {
     // (ProactiveAssistantsPlugin, isPaywalledEffective) keep blocking until
     // didSet writes the new value. Only basic-tier users have a legitimate
     // pre-fetch paywalled state to preserve.
-    let cachedPlan = UserDefaults.standard.string(forKey: "floatingBar_cachedPlan")
-    let cachedPlanIsPaid = cachedPlan != nil && cachedPlan != "basic"
-    if APIKeyService.isByokActive || cachedPlanIsPaid {
-      self.isPaywalled = false
-      // didSet doesn't fire from init, so flush UserDefaults explicitly for
-      // singletons that read the key directly.
-      UserDefaults.standard.set(false, forKey: "desktop_isPaywalled")
-    } else {
-      self.isPaywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
-    }
+    // Freemium: the desktop trial paywall is disabled by default
+    // (backend TRIAL_PAYWALL_ENABLED off), so a stale cached
+    // `desktop_isPaywalled=true` from a pre-freemium session must not gate
+    // anything on launch. Previously basic-tier users trusted that cache and
+    // flashed the "monthly limit" popup until fetchTrialMetadata refreshed
+    // (~1-2s) — and synchronous readers (ProactiveAssistantsPlugin,
+    // isPaywalledEffective) blocked for that whole window. Always start
+    // non-paywalled and let the backend's trial metadata be authoritative:
+    // fetchTrialMetadata re-sets isPaywalled only if the backend genuinely
+    // reports trial_expired (it won't under freemium).
+    self.isPaywalled = false
+    // didSet doesn't fire from init, so flush UserDefaults explicitly for
+    // singletons that read the key directly.
+    UserDefaults.standard.set(false, forKey: "desktop_isPaywalled")
 
     // Resolve beta/stable before loading backend URLs so beta releases use dev services.
     AppBuild.prepareUpdateChannelForBackendRouting()


### PR DESCRIPTION
Surgical freemium reactivation for desktop, replacing the reverted bundle (#8161).

## Backend (Python)
- **`TRIAL_PAYWALL_ENABLED` flag (default off)** gates BOTH `is_trial_paywalled` (the 402 block) AND `get_trial_metadata` (the client popup driver). With it off, basic/Neo desktop users are never blocked and `trial_expired` is always false → no "you've hit your monthly limit" popup from account age. Only the 30-question chat quota gates them. No Neo or data-intake changes.
- **Fix `get_monthly_chat_usage`** to count the Rust desktop-backend's NESTED `desktop_chat` map (committed via dotted Firestore fieldPaths). Previously the reader expected flat dotted keys and silently counted 0 for ALL desktop chat — so the freemium 30/month limit was never enforced on desktop (free desktop users had unlimited chat). Now counts the grand-total `desktop_chat` map (PTT/realtime included; per-account breakdowns excluded to avoid double-count). Regression test added.

## Desktop
- **Rust `paywall.rs`**: same `TRIAL_PAYWALL_ENABLED` gate (default off), mirroring Python — the native trial check that 402'd the realtime mint.
- **Swift `AppState.swift`**: don't trust the stale cached `desktop_isPaywalled` on launch (it flashed the popup for free users until `fetchTrialMetadata` refreshed). Always start non-paywalled; the backend's trial metadata is authoritative.

## Verified
- Popup: poisoned-cache restart test — cache `true` → reset to 0, no popup.
- Usage counter: text AND PTT increment the 30/mo count (verified live: `desktop_chat_omi` + `desktop_chat_realtime` summed; UI card moved 0/30 → 10/30).
- Backend tests pass; clean `swift build -c release` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

