### PR TITLE
Lazy conversation processing for freemium/Neo desktop users

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -711,6 +711,10 @@ def get_processing_conversations(uid: str):
         filter=FieldFilter('status', '==', 'processing')
     )
     conversations = [doc.to_dict() for doc in conversations_ref.stream()]
+    # Exclude lazy-deferred conversations: they intentionally sit in `processing` (no LLM summary
+    # yet) until the user opens them, where they're enriched on demand. They must NOT be swept
+    # back to pusher for background processing — that would defeat the freemium cost saving.
+    conversations = [c for c in conversations if not c.get('deferred')]
     return conversations
 
 

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -118,6 +118,10 @@ class Conversation(BaseModel):
 
     status: Optional[ConversationStatus] = ConversationStatus.completed
     is_locked: bool = False
+    # Lazy processing (freemium cost cut): True when this desktop conversation was stored as a
+    # raw transcript with no LLM enrichment yet — enrichment runs on first open
+    # (get_conversation_by_id → process_conversation). Cleared once enriched.
+    deferred: bool = False
     data_protection_level: Optional[str] = None
     folder_id: Optional[str] = Field(default=None, description="ID of the folder this conversation belongs to")
     call_id: Optional[str] = Field(default=None, description="Twilio call SID for phone call conversations")

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -71,6 +71,33 @@ def _get_valid_conversation_by_id(uid: str, conversation_id: str) -> dict:
     return conversation
 
 
+def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
+    """First open of a lazily-deferred desktop conversation: run the full LLM enrichment now
+    (summary, action items, memories, embeddings, app results), clear the `deferred` flag, and
+    return the enriched conversation. The flag is flipped off first so concurrent opens don't
+    double-process. On any failure, re-arm the flag and return the raw conversation so the user
+    still sees their transcript."""
+    conversation_id = conversation.get('id')
+    try:
+        conversations_db.update_conversation(uid, conversation_id, {'deferred': False})
+        conv_obj = deserialize_conversation(conversation)
+        conv_obj.deferred = False
+        enriched = process_conversation(
+            uid, conv_obj.language or 'en', conv_obj, force_process=True, is_reprocess=False
+        )
+        result = enriched.dict()
+        result['deferred'] = False
+        return result
+    except Exception as e:
+        logger.error(f"lazy enrich failed uid={uid} conv={conversation_id}: {e}")
+        try:
+            conversations_db.update_conversation(uid, conversation_id, {'deferred': True})
+        except Exception:
+            pass
+        conversation['deferred'] = True
+        return conversation
+
+
 class ProcessConversationRequest(BaseModel):
     calendar_meeting_context: Optional[CalendarMeetingContext] = None
 
@@ -179,7 +206,12 @@ def get_conversations_count(
 @router.get("/v1/conversations/{conversation_id}", response_model=Conversation, tags=['conversations'])
 def get_conversation_by_id(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
     logger.info(f'get_conversation_by_id {uid} {conversation_id}')
-    return _get_valid_conversation_by_id(uid, conversation_id)
+    conversation = _get_valid_conversation_by_id(uid, conversation_id)
+    # Lazy processing: a desktop conversation stored raw (deferred) for a freemium/Neo user is
+    # enriched on first open. Other conversations are returned unchanged.
+    if conversation.get('deferred'):
+        conversation = _enrich_deferred_conversation(uid, conversation)
+    return conversation
 
 
 @router.patch("/v1/conversations/{conversation_id}/title", tags=['conversations'])

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -39,6 +39,7 @@ from models.transcript_segment import TranscriptSegment
 from models.other import Person
 
 from utils.conversations.process_conversation import process_conversation, retrieve_in_progress_conversation
+from utils.executors import postprocess_executor, submit_with_context
 from utils.conversations.search import search_conversations
 from utils.llm.conversation_processing import generate_summary_with_prompt
 from utils.speaker_identification import extract_speaker_samples
@@ -72,30 +73,38 @@ def _get_valid_conversation_by_id(uid: str, conversation_id: str) -> dict:
 
 
 def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
-    """First open of a lazily-deferred desktop conversation: run the full LLM enrichment now
-    (summary, action items, memories, embeddings, app results), clear the `deferred` flag, and
-    return the enriched conversation. The flag is flipped off first so concurrent opens don't
-    double-process. On any failure, re-arm the flag and return the raw conversation so the user
-    still sees their transcript."""
+    """First open of a lazily-deferred desktop conversation. The LLM enrichment (summary, action
+    items, memories, embeddings, app results) takes ~10s, so we run it in the BACKGROUND and return
+    the conversation immediately: the client gets an instant open (transcript already present) and
+    polls until `status` flips to `completed`. The `deferred` flag is cleared first so the poll's
+    repeated GETs don't each kick off another enrichment. On enrichment failure the flag is
+    re-armed and status reset to completed so the next open retries cleanly instead of spinning."""
     conversation_id = conversation.get('id')
     try:
         conversations_db.update_conversation(uid, conversation_id, {'deferred': False})
-        conv_obj = deserialize_conversation(conversation)
-        conv_obj.deferred = False
-        enriched = process_conversation(
-            uid, conv_obj.language or 'en', conv_obj, force_process=True, is_reprocess=False
-        )
-        result = enriched.dict()
-        result['deferred'] = False
-        return result
     except Exception as e:
-        logger.error(f"lazy enrich failed uid={uid} conv={conversation_id}: {e}")
-        try:
-            conversations_db.update_conversation(uid, conversation_id, {'deferred': True})
-        except Exception:
-            pass
-        conversation['deferred'] = True
+        logger.error(f"lazy enrich claim failed uid={uid} conv={conversation_id}: {e}")
         return conversation
+
+    def _run_enrichment():
+        try:
+            conv_obj = deserialize_conversation(conversation)
+            conv_obj.deferred = False
+            process_conversation(uid, conv_obj.language or 'en', conv_obj, force_process=True, is_reprocess=False)
+            logger.info(f"lazy enrich complete uid={uid} conv={conversation_id}")
+        except Exception as e:
+            logger.error(f"lazy enrich failed uid={uid} conv={conversation_id}: {e}")
+            try:
+                conversations_db.update_conversation(
+                    uid, conversation_id, {'deferred': True, 'status': ConversationStatus.completed.value}
+                )
+            except Exception:
+                pass
+
+    submit_with_context(postprocess_executor, _run_enrichment)
+    # Return immediately — still status=processing, no summary yet; the client polls for completion.
+    conversation['deferred'] = False
+    return conversation
 
 
 class ProcessConversationRequest(BaseModel):

--- a/backend/tests/unit/test_lazy_conversation_processing.py
+++ b/backend/tests/unit/test_lazy_conversation_processing.py
@@ -1,0 +1,112 @@
+"""Unit tests for lazy desktop conversation processing (freemium cost cut).
+
+Validates `should_defer_desktop_processing`: desktop users on a non-desktop-entitled plan
+(basic / Neo) without BYOK are deferred (raw transcript on capture, enriched on first open);
+Operator/Architect and BYOK users are processed normally; lookups fail safe to "process".
+
+Uses sys.modules stubs so importing utils.subscription doesn't trigger Firestore/Firebase init.
+"""
+
+import sys
+import types
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestShouldDeferDesktopProcessing:
+    @pytest.fixture(autouse=True)
+    def _setup_subscription(self):
+        def _stub(name):
+            if name not in sys.modules:
+                sys.modules[name] = types.ModuleType(name)
+            return sys.modules[name]
+
+        saved = {}
+        stubs = [
+            'google.cloud',
+            'google.cloud.firestore',
+            'google.cloud.firestore_v1',
+            'firebase_admin',
+            'firebase_admin.auth',
+            'firebase_admin.firestore',
+            'database._client',
+            'database.redis_db',
+            'database.users',
+            'database.user_usage',
+            'database.announcements',
+        ]
+        for name in stubs:
+            saved[name] = sys.modules.get(name)
+            mod = _stub(name)
+            if name == 'database._client':
+                mod.db = MagicMock()
+            elif name == 'database.redis_db':
+                mod.get_generic_cache = MagicMock(return_value=None)
+                mod.set_generic_cache = MagicMock()
+                mod.delete_generic_cache = MagicMock()
+            elif name == 'database.users':
+                mod.get_user_valid_subscription = MagicMock(return_value=None)
+                mod.is_byok_active = MagicMock(return_value=False)
+            elif name == 'database.announcements':
+                mod.compare_versions = MagicMock()
+            elif name == 'firebase_admin.auth':
+                mod.get_user = MagicMock()
+
+        if 'utils.subscription' in sys.modules:
+            del sys.modules['utils.subscription']
+        import utils.subscription as sub
+
+        self._sub = sub
+        self._users = sys.modules['database.users']
+        yield
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+        sys.modules.pop('utils.subscription', None)
+
+    def _sub_with_plan(self, plan):
+        s = MagicMock()
+        s.plan = plan
+        return s
+
+    def test_basic_plan_is_deferred(self):
+        from models.users import PlanType
+
+        self._users.is_byok_active.return_value = False
+        self._users.get_user_valid_subscription.return_value = None  # no sub => basic
+        assert self._sub.should_defer_desktop_processing('uid') is True
+
+    def test_neo_unlimited_is_deferred(self):
+        from models.users import PlanType
+
+        self._users.is_byok_active.return_value = False
+        self._users.get_user_valid_subscription.return_value = self._sub_with_plan(PlanType.unlimited)
+        assert self._sub.should_defer_desktop_processing('uid') is True
+
+    def test_operator_is_not_deferred(self):
+        from models.users import PlanType
+
+        self._users.is_byok_active.return_value = False
+        self._users.get_user_valid_subscription.return_value = self._sub_with_plan(PlanType.operator)
+        assert self._sub.should_defer_desktop_processing('uid') is False
+
+    def test_architect_is_not_deferred(self):
+        from models.users import PlanType
+
+        self._users.is_byok_active.return_value = False
+        self._users.get_user_valid_subscription.return_value = self._sub_with_plan(PlanType.architect)
+        assert self._sub.should_defer_desktop_processing('uid') is False
+
+    def test_byok_basic_is_not_deferred(self):
+        from models.users import PlanType
+
+        self._users.is_byok_active.return_value = True
+        self._users.get_user_valid_subscription.return_value = None
+        assert self._sub.should_defer_desktop_processing('uid') is False
+
+    def test_lookup_error_fails_safe_to_not_deferred(self):
+        self._users.is_byok_active.side_effect = RuntimeError("firestore down")
+        assert self._sub.should_defer_desktop_processing('uid') is False

--- a/backend/tests/unit/test_lazy_conversation_processing.py
+++ b/backend/tests/unit/test_lazy_conversation_processing.py
@@ -110,3 +110,30 @@ class TestShouldDeferDesktopProcessing:
     def test_lookup_error_fails_safe_to_not_deferred(self):
         self._users.is_byok_active.side_effect = RuntimeError("firestore down")
         assert self._sub.should_defer_desktop_processing('uid') is False
+
+
+class TestDeferredNotRequeuedBySweeper:
+    """Deferred conversations sit in status=processing until opened — they must NOT be returned by
+    get_processing_conversations (the listen-session sweeper re-sends those to pusher, which would
+    background-process deferred rows and defeat the cost saving)."""
+
+    def test_get_processing_conversations_excludes_deferred(self):
+        import database.conversations as cdb
+
+        def _doc(d):
+            m = MagicMock()
+            m.to_dict.return_value = d
+            return m
+
+        docs = [
+            _doc({'id': 'a', 'deferred': True}),  # deferred -> excluded
+            _doc({'id': 'b', 'deferred': False}),  # not deferred -> kept
+            _doc({'id': 'c'}),  # no deferred field (normal processing) -> kept
+        ]
+        chain = MagicMock()
+        chain.stream.return_value = docs
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.collection.return_value.where.return_value = chain
+        with __import__('unittest.mock', fromlist=['patch']).patch.object(cdb, 'db', mock_db):
+            result = cdb.get_processing_conversations('uid-x')
+        assert [c['id'] for c in result] == ['b', 'c']

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -159,6 +159,7 @@ utils_calendar_linking.write_conversation_link_to_calendar_event = MagicMock()
 
 utils_subscription = sys.modules["utils.subscription"]
 utils_subscription.is_trial_paywalled = MagicMock(return_value=False)
+utils_subscription.should_defer_desktop_processing = MagicMock(return_value=False)
 
 utils_executors = sys.modules["utils.executors"]
 utils_executors.db_executor = MagicMock()

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -44,7 +44,7 @@ from models.conversation import (
 )
 from models.conversation_enums import ConversationSource, ConversationStatus, ExternalIntegrationConversationSource
 from utils.conversations.factory import deserialize_conversation
-from utils.subscription import is_trial_paywalled
+from utils.subscription import is_trial_paywalled, should_defer_desktop_processing
 from models.other import Person
 from models.structured import Structured
 from utils.notifications import send_important_conversation_message
@@ -720,6 +720,36 @@ def _update_personas_async(uid: str):
         logger.info(f"[PERSONAS] Finished persona updates in background thread for uid={uid}")
 
 
+def _build_deferred_structured(conversation) -> Structured:
+    """A cheap, no-LLM placeholder Structured for a lazily-deferred conversation. The title is
+    the first few words of the transcript so the conversation list stays usable until the user
+    opens it (which triggers the real enrichment). A non-empty title is required — an empty one
+    marks the conversation discarded in `_get_conversation_obj`."""
+    text = ''
+    for seg in getattr(conversation, 'transcript_segments', None) or []:
+        seg_text = (getattr(seg, 'text', '') or '').strip()
+        if seg_text:
+            text = seg_text
+            break
+    words = text.split()
+    title = ' '.join(words[:8]).strip() if words else ''
+    return Structured(title=title or 'Recording')
+
+
+def _store_deferred_conversation(uid: str, conversation):
+    """Persist a desktop conversation with a cheap (no-LLM) title and `deferred=True`, skipping
+    all enrichment. Mirrors the tail of process_conversation's persistence (cheap structured →
+    `_get_conversation_obj` → upsert) without any LLM / Pinecone / app work. The enrichment runs
+    later via the lazy trigger in `get_conversation_by_id`."""
+    structured = _build_deferred_structured(conversation)
+    conversation = _get_conversation_obj(uid, structured, conversation)
+    conversation.deferred = True
+    conversation.status = ConversationStatus.completed
+    conversations_db.upsert_conversation(uid, conversation.dict())
+    logger.info("lazy: stored deferred desktop conversation uid=%s conv=%s", uid, conversation.id)
+    return conversation
+
+
 def process_conversation(
     uid: str,
     language_code: str,
@@ -755,6 +785,22 @@ def process_conversation(
             except Exception:
                 pass
         return conversation
+
+    # Lazy desktop processing (freemium cost cut): desktop users without a desktop-entitled
+    # paid plan (basic / Neo) get ONLY the raw transcript on capture. The expensive LLM
+    # enrichment (summary, action items, memories, embeddings, app results) is deferred until
+    # they first OPEN the conversation (get_conversation_by_id reprocesses it with
+    # force_process=True). Paid desktop plans (Operator / Architect), BYOK users, and all
+    # non-desktop sources are processed normally here. force_process / is_reprocess — the lazy
+    # trigger and manual reprocess — bypass this so the enrichment actually runs.
+    if (
+        not force_process
+        and not is_reprocess
+        and hasattr(conversation, 'source')
+        and conversation.source == ConversationSource.desktop
+        and should_defer_desktop_processing(uid)
+    ):
+        return _store_deferred_conversation(uid, conversation)
 
     # Fetch meeting context from Firestore if meeting_id is associated with this conversation
     if hasattr(conversation, 'id') and conversation.id:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -744,7 +744,11 @@ def _store_deferred_conversation(uid: str, conversation):
     structured = _build_deferred_structured(conversation)
     conversation = _get_conversation_obj(uid, structured, conversation)
     conversation.deferred = True
-    conversation.status = ConversationStatus.completed
+    # `processing` (not completed) is the user-facing "awaiting enrichment" state. Unlike the
+    # `deferred` flag it survives the desktop's local conversation cache, so the client shows a
+    # processing indicator and re-fetches on open to trigger enrichment. The lazy enrich sets it
+    # back to `completed`.
+    conversation.status = ConversationStatus.processing
     conversations_db.upsert_conversation(uid, conversation.dict())
     logger.info("lazy: stored deferred desktop conversation uid=%s conv=%s", uid, conversation.id)
     return conversation

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -68,6 +68,27 @@ def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]
     return subscription.current_period_end
 
 
+def should_defer_desktop_processing(uid: str) -> bool:
+    """True for desktop users on a non-desktop-entitled plan (basic / Neo) without active
+    BYOK — their conversations are stored as raw transcript on capture and the expensive LLM
+    enrichment is deferred until they first open the conversation (freemium cost cut).
+
+    Operator / Architect (desktop-entitled) and BYOK users (who pay their own LLM bill) are
+    processed normally. The caller restricts this to `source == desktop`. Fails safe to False
+    (process normally) on any error so a Firestore blip never silently strips a paid user's
+    summaries.
+    """
+    try:
+        if users_db.is_byok_active(uid):
+            return False
+        subscription = users_db.get_user_valid_subscription(uid)
+        plan = subscription.plan if subscription else PlanType.basic
+        return plan not in DESKTOP_ENTITLED_PLAN_TYPES
+    except Exception as e:
+        logger.warning("should_defer_desktop_processing lookup failed for uid=%s: %s", uid, e)
+        return False
+
+
 # Desktop-only 3-day trial paywall.
 #
 # Applies to desktop users without a desktop-entitled plan (basic OR Neo) once

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -684,6 +684,9 @@ struct ServerConversation: Codable, Identifiable, Equatable {
   var starred: Bool
   let folderId: String?
   let inputDeviceName: String?
+  // Lazy processing: true while only the raw transcript is stored (no LLM summary yet);
+  // cleared once enriched on first open (get_conversation_by_id).
+  let deferred: Bool
 
   enum CodingKeys: String, CodingKey {
     case id
@@ -704,6 +707,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     case starred
     case folderId = "folder_id"
     case inputDeviceName = "input_device_name"
+    case deferred
   }
 
   init(from decoder: Decoder) throws {
@@ -728,6 +732,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     starred = try container.decodeIfPresent(Bool.self, forKey: .starred) ?? false
     folderId = try container.decodeIfPresent(String.self, forKey: .folderId)
     inputDeviceName = try container.decodeIfPresent(String.self, forKey: .inputDeviceName)
+    deferred = try container.decodeIfPresent(Bool.self, forKey: .deferred) ?? false
   }
 
   /// Memberwise initializer for creating from local storage
@@ -749,7 +754,8 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     isLocked: Bool,
     starred: Bool,
     folderId: String?,
-    inputDeviceName: String?
+    inputDeviceName: String?,
+    deferred: Bool = false
   ) {
     self.id = id
     self.createdAt = createdAt
@@ -769,6 +775,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     self.starred = starred
     self.folderId = folderId
     self.inputDeviceName = inputDeviceName
+    self.deferred = deferred
   }
 
   /// Returns the title from structured data, or a fallback

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -29,6 +29,8 @@ struct ConversationDetailView: View {
     // Full conversation loaded from API (with transcript segments)
     @State private var loadedConversation: ServerConversation?
     @State private var isLoadingConversation = false
+    // True while a lazily-deferred conversation is being enriched (polled) on first open.
+    @State private var isEnrichingDeferred = false
 
     // Action states
     @State private var showDeleteConfirmation = false
@@ -172,6 +174,29 @@ struct ConversationDetailView: View {
             await appProvider.fetchApps()
             await onFetchPeople?()
             AnalyticsManager.shared.conversationDetailOpened(conversationId: conversation.id)
+
+            // Lazy processing: a deferred conversation (status=processing, only its raw transcript)
+            // enriches in the background on first open. The first fetch kicks it off and returns
+            // immediately (instant open); we then poll until status flips to completed, showing a
+            // loader meanwhile. Capped at ~30s so the loader never spins forever (e.g. on error).
+            if conversation.deferred || conversation.status == .processing {
+                isEnrichingDeferred = true
+                var attempts = 0
+                while attempts < 15 {
+                    do {
+                        let fetched = try await APIClient.shared.getConversation(id: conversation.id)
+                        loadedConversation = fetched
+                        if fetched.status != .processing { break }
+                    } catch {
+                        logError("ConversationDetail: failed to enrich deferred conversation", error: error)
+                        break
+                    }
+                    attempts += 1
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                }
+                isEnrichingDeferred = false
+                return
+            }
 
             // Load segments from local database if not already present
             // Segments are stored locally but not loaded with the list view for performance
@@ -559,6 +584,13 @@ struct ConversationDetailView: View {
 
     @ViewBuilder
     private var summaryContent: some View {
+        // Lazy processing: while the deferred conversation is being enriched (polled) on first
+        // open, show a loader where the summary will appear. Cleared when enrichment completes or
+        // the poll times out, so it never spins forever.
+        if isEnrichingDeferred {
+            deferredProcessingSection
+        }
+
         // Overview section
         if !displayConversation.overview.isEmpty {
             overviewSection
@@ -741,6 +773,29 @@ struct ConversationDetailView: View {
         } catch {
             logError("ConversationDetail: Failed to persist speaker assignment locally", error: error)
         }
+    }
+
+    // MARK: - Deferred Processing Loader
+
+    /// Shown while a lazily-deferred conversation is being enriched on first open.
+    private var deferredProcessingSection: some View {
+        HStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.small)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Processing conversation…")
+                    .scaledFont(size: 14, weight: .semibold)
+                    .foregroundColor(OmiColors.textPrimary)
+                Text("Generating summary and action items")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(OmiColors.backgroundTertiary.opacity(0.5))
+        .cornerRadius(12)
     }
 
     // MARK: - Overview Section


### PR DESCRIPTION
## What
Desktop conversations from non-desktop-entitled users (basic / Neo, no BYOK) are stored as a **raw transcript on capture with zero LLM cost**, and enriched (summary, action items, memories, embeddings) **lazily on first open**. Operator/Architect, BYOK, and all non-desktop sources are processed normally.

## How
- `should_defer_desktop_processing` gates on plan entitlement (fails safe to *process* on error).
- Deferred convos are stored with a cheap first-words title + `deferred=True` + `status=processing` (the processing status survives the desktop's local conversation cache and shows a processing indicator; `deferred` drives the backend enrich logic).
- `get_processing_conversations` **excludes deferred rows** so the listen-session sweeper never background-reprocesses them (would defeat the cost saving).
- First open (`get_conversation_by_id`) kicks off enrichment in the **background** and returns immediately → **instant open**; the desktop polls until `status=completed` (capped so the loader never spins forever).
- Desktop: `ConversationDetailView` shows a "Processing conversation…" loader + polls; `ServerConversation.deferred` added.

## Verified
- Unit tests: defer gate (basic/Neo→defer, Operator/Architect/BYOK→no), deferred excluded from sweeper. Each test file green in isolation.
- End-to-end against real Firestore/OpenAI: capture→`deferred` (no LLM, 0.45s open) → poll → enriched summary + 3 action items in ~10s. Confirmed in the desktop UI (instant open, loader, summary fills in).

## Note
Dormant until the backend is deployed + freemium re-enabled; the gate is flag-independent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

