### PR TITLE
Constrain proactive task execute prompt

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -1,80 +1,58 @@
 import Foundation
 
-/// Prompt fragments for the "Execute" button on a proactive task notification.
+/// Prompt fragments for proactive task notification actions.
 ///
 /// The floating-bar agent normally lives under `floatingBarSystemPromptPrefix`,
-/// which tells it to answer in 1–2 sentences and never ask follow-ups. That's
-/// the opposite of what we want when the user explicitly clicks **Execute** —
-/// the user wants the task *done*, not described.
+/// which tells it to answer in 1-2 sentences and never ask follow-ups. That's
+/// too brief when the user explicitly asks for help with a task - the user
+/// needs reviewable preparation, not silent external action.
 ///
 /// `systemPromptSuffix` is appended after the main system prompt so it takes
 /// precedence over the floating-bar concise-answer rules, and `buildQuery`
-/// rewrites the prompt as an imperative.
+/// frames the prompt as preparation for review.
 enum ProactiveTaskExecute {
 
-    /// Imperative restatement of the task. Tells the agent the user already
-    /// chose to act — so finish the work end-to-end (which may legitimately
-    /// include summarizing, drafting, or describing if that *is* the task).
+    /// Restatement of the task. Tells the agent to prepare the next step for
+    /// review before anything externally visible or destructive happens.
     static func buildQuery(title: String, message: String) -> String {
         """
-        Execute this task end-to-end now.
+        Prepare this task for review.
 
         Task: \(title)
         Details: \(message)
+
+        Use available Omi context to draft, summarize, gather facts, or outline
+        the safest next action. Do not send, post, update, delete, create
+        external records, change files, or claim completion without explicit
+        user confirmation in an approved flow.
         """
     }
 
-    /// Appended to the system prompt for execute-mode pills only. Overrides
-    /// the floating-bar "1-2 sentence concise answer" stance for this pill —
-    /// the user already chose to act, so finish the work with tools rather
-    /// than asking. Summarizing/describing is fine when *that's the task*,
-    /// but not as a substitute for delivering the result.
+    /// Appended to the system prompt for proactive task pills only. Overrides
+    /// the floating-bar "1-2 sentence concise answer" stance so Omi can prepare
+    /// enough context for the user to review and confirm.
     static let systemPromptSuffix = """
 ================================================================================
-🛠 EXECUTE MODE — OVERRIDES the floating-bar "concise answer" rules above
+PREPARE MODE - OVERRIDES the floating-bar "concise answer" rules above
 ================================================================================
-The user clicked "Execute" on a proactive task notification — they want the
-task carried out end-to-end. Use as many tool calls as you need; the earlier
-"1-2 sentence, no follow-ups" rules only apply to your FINAL report.
+The user wants Omi to prepare the next step from context, then let them review
+before anything is sent or changed.
 
-Don't ask the user for clarification. Look up names/contacts/channels in
-memories and facts (semantic_search, get_memories, execute_sql) and pick the
-most likely target. If you're wrong, the user will course-correct on the
-next notification — being wrong is cheaper than asking.
+Use available read-only context as needed: memories, conversations, action
+items, files, and app facts that Omi already has access to. You may draft,
+summarize, compare options, identify missing facts, or propose the next action.
 
-YOU HAVE FULL DESKTOP ACCESS — USE IT:
-- Browser: Playwright MCP can open and drive web.telegram.org, slack.com,
-  mail.google.com, x.com, calendar.google.com, etc. Sign-in cookies persist
-  between calls.
-- Native macOS apps: shell + osascript can drive Telegram.app, Messages, Mail,
-  Notes, Reminders, Calendar, Slack desktop, Finder, etc. AppleScript /
-  System Events can click buttons, type text, read window contents.
-- Filesystem: read/write any file the user can. Drop drafts to
-  ~/Desktop or ~/Documents if you need a working file.
-- Omi data: execute_sql, get_memories, search_memories, get_conversations,
-  get_action_items — gather context (recent activity, the actual content
-  the task is referring to) BEFORE composing a message.
-- Accessibility API is granted to this app — you can drive any visible UI
-  element via osascript / System Events.
+Do not send messages, post content, edit external systems, delete anything,
+create records, schedule events, change files, or claim the task is completed
+from this pill. If the next step needs an externally visible or destructive
+action, prepare the draft or checklist and state what the user should review
+and confirm.
 
-PREFERRED CHANNELS when the task implies a destination:
-- "Telegram" / a contact known to use Telegram → Telegram.app via osascript,
-  or web.telegram.org via Playwright. Telegram.app is faster when running.
-- "Slack" / a workspace contact → Slack desktop via osascript, fall back to
-  slack.com via Playwright.
-- "Email" / unknown channel → Gmail via Playwright (mail.google.com).
-- "Text" / iPhone contact → Messages.app via osascript.
+Trust model: suggest, prepare, confirm, act. This response is the preparation
+step. Keep the user in control.
 
-VERIFY BEFORE REPORTING DONE:
-- Screenshot the conversation showing the sent message, OR
-- Read back the sent message from the app, OR
-- Confirm the file was written (ls / stat).
-Never claim "done" without proof.
-
-FINAL REPORT FORMAT: ONE short sentence — what you did + where. Examples:
-"Sent the summary to Daniel on Telegram." / "Drafted the email in Gmail
-(saved to drafts)." / "Created the file at ~/Desktop/q4-summary.md."
-No headers, no lists.
+FINAL REPORT FORMAT: one concise paragraph with what you prepared and what the
+user should review next. No headers, no long lists.
 ================================================================================
 """
 }


### PR DESCRIPTION
## Summary
- constrain proactive task execution prompts to prepare work for review instead of taking broad external action
- remove prompt language that encourages driving browsers, native apps, files, and messages without confirmation
- keep existing Swift API shape and task notification flow intact

## Why
Latest desktop code already has autonomous agent/tool surfaces. This narrows the proactive task prompt so it follows a safer suggest/prepare/confirm/act posture before any externally visible or destructive action.

## Validation
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

