### PR TITLE
desktop: enforce 30-question free-tier quota on PTT (not just typed chat)

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -338,6 +338,9 @@ class AuthService {
             state.startTrialMetadataRefresh()
             TrialBannerService.shared.start(appState: state)
         }
+        // Refresh the chat usage limiter for the new account (PTT gate + floating
+        // bar read it); without this it stays nil/old until the next app launch.
+        Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
 
         if !AnalyticsManager.isDevBuild {
             let sentryUser = User(userId: userId)
@@ -460,6 +463,9 @@ class AuthService {
                 state.startTrialMetadataRefresh()
                 TrialBannerService.shared.start(appState: state)
             }
+            // Refresh the chat usage limiter for the new account (PTT gate +
+            // floating bar read it); without this it stays nil/old until launch.
+            Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
 
             // Set Sentry user context for error tracking (skip in dev builds)
             if !AnalyticsManager.isDevBuild {

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -342,6 +342,13 @@ actor AgentBridge {
     closePipes()
     isRunning = false
 
+    // Clear the cached quota. It's only valid for the user/session that fetched it;
+    // on a provider switch or account change the bridge is stopped, and a stale
+    // `allowed=false` would otherwise block the next user's chat (e.g. a fresh
+    // account inheriting the previous account's over-limit cache). The next request
+    // re-checks live (and the backend enforces the real 402 if truly over).
+    lastKnownQuota = nil
+
     messageContinuation?.resume(throwing: BridgeError.stopped)
     messageContinuation = nil
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -235,7 +235,21 @@ class PushToTalkManager: ObservableObject {
 
   // MARK: - Listening Lifecycle
 
+  /// True iff the user is on the Omi account (not BYOK) and has hit the monthly free-tier
+  /// chat-question limit. PTT turns count toward that limit (desktop_chat_realtime), so they
+  /// must be gated by it too — same as typed chat (ChatProvider / floating bar). Without this,
+  /// a free user over 30 questions could keep talking for free. Posts the same usage-limit
+  /// popup and returns true so the caller early-returns.
+  private func isBlockedByUsageLimit() -> Bool {
+    guard !APIKeyService.isByokActive, FloatingBarUsageLimiter.shared.isLimitReached else { return false }
+    log("PushToTalkManager: PTT blocked — monthly free-tier chat limit reached")
+    NotificationCenter.default.post(
+      name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "ptt"])
+    return true
+  }
+
   private func startListening() {
+    if isBlockedByUsageLimit() { return }
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
       SystemAudioMuteController.shared.muteForListening()
@@ -266,6 +280,7 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func enterLockedListening() {
+    if isBlockedByUsageLimit() { return }
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
       SystemAudioMuteController.shared.muteForListening()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -511,7 +511,13 @@ struct SettingsContentView: View {
         return
       }
       if newValue == .planUsage {
+        // Refetch everything for the CURRENT account. Without the trial + limiter
+        // refresh, switching accounts leaves the previous user's "Trial Ended" /
+        // over-limit state painted here (trialMetadata + serverQuota aren't reset
+        // per-account on a section switch).
         loadSubscriptionInfo()
+        AppState.current?.fetchTrialMetadata()
+        Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in


### PR DESCRIPTION
Follow-up to the freemium merge (#8178). PTT turns count toward the monthly 30-question chat quota (`desktop_chat_realtime`, via the usage-counter fix) but were **never gated** by it — only typed chat (`ChatProvider` / floating bar) checked `FloatingBarUsageLimiter.isLimitReached`. So a free user over 30 could keep talking via PTT for free while typed chat was blocked.

Fix: gate both PTT entry points (`startListening` + `enterLockedListening`; `startPillFollowUp` routes through `startListening`) on the same limiter, with the same BYOK bypass (`APIKeyService.isByokActive`). Over-limit PTT now posts the usage popup and refuses the turn — consistent with typed chat.

Compiles (debug + release). Behavioral verification (hold PTT while over the limit → blocked) is on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

