### PR TITLE
Fix desktop agent interrupt wait

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -610,6 +610,10 @@ actor AgentBridge {
     guard isRunning else { return }
     isInterrupted = true
     sendLine("{\"type\":\"interrupt\"}")
+    if let continuation = messageContinuation {
+      messageContinuation = nil
+      continuation.resume(throwing: BridgeError.stopped)
+    }
   }
 
   /// Push a refreshed Firebase ID token to the bridge (piMono mode only).


### PR DESCRIPTION
## Summary
- Resume the pending desktop agent bridge message wait when `interrupt()` is called.
- Prevent an interrupted chat/tool run from leaving the Swift caller suspended until timeout or process teardown.

## Scope
- macOS desktop only.
- One production file changed: `desktop/macos/Desktop/Sources/Chat/AgentBridge.swift`.
- No docs, tests, backend, mobile, workflow, route, shortcut, or API contract changes.

## Verification
- `git fetch upstream` confirmed latest `upstream/main` at `815f5e610` before branching.
- `git diff --check` passed.
- `xcrun swift build -c debug --package-path Desktop` passed.
- `xcrun swift test --package-path Desktop --filter PiMonoWiringTests` passed: 14 tests.
- `./test.sh` Rust section passed: 259 tests. Swift section hit an existing headless Firebase bootstrap crash in `QueryTracerTests/testClosureBasedSpanAsync`, unrelated to this diff.
- Named bundle QA passed with `OMI_APP_NAME="omi-macos-redesign"`, bundle id `com.omi.omi-macos-redesign`, automation bridge on port `47888`; app launched signed in, main window loaded, routes/actions were discoverable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

