### PR TITLE
ci(desktop): reliable prod promotion via workflow_dispatch (+dry_run)

### DIFF
--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -1,23 +1,36 @@
 name: Promote Desktop Backend to Prod
 
-# Deploys the desktop (Rust) backend to PRODUCTION only when a desktop release is
-# promoted to the stable channel. Merges to main deploy ONLY to development
-# (see desktop_auto_release.yml) so beta testers get every build, while prod
-# users stay on the last promoted, version-locked release.
+# Promotes the desktop (Rust) backend to PRODUCTION. Merges to main deploy ONLY
+# to development (see desktop_auto_release.yml), so beta testers get every build
+# while prod users stay on the last promoted, version-locked release.
 #
-# Trigger: editing a GitHub release's body to `channel: stable` fires
-# `release: edited`; this workflow then deploys the backend built from THAT
-# release's tag (not main HEAD), so prod only ever runs promoted code.
-# `workflow_dispatch` is a manual fallback (pass the v*-macos tag to promote).
+# RELIABLE path — `workflow_dispatch`: run this with a v*-macos tag to promote.
+# It builds + deploys the backend from THAT tag's commit (not main HEAD) and
+# (by default) flips the GitHub release to `channel: stable`, so one run does the
+# whole promotion (app channel + backend) atomically. Use `dry_run: true` to
+# build-and-verify without deploying or changing the channel.
+#
+# Best-effort path — `release: edited`: if a release is edited to
+# `channel: stable` and GitHub fires the event, this also promotes. NOTE: GitHub
+# does not reliably emit Actions runs for release edits, so do not depend on it —
+# the workflow_dispatch above is the supported promotion mechanism.
 
 on:
-  release:
-    types: [edited, released]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to promote to prod (e.g. v0.11.498+11498-macos)'
+        description: 'v*-macos tag to promote to prod (e.g. v0.11.498+11498-macos)'
         required: true
+      dry_run:
+        description: 'Build + verify only — skip the prod deploy and channel flip'
+        type: boolean
+        default: false
+      set_channel_stable:
+        description: 'Also flip the GitHub release to channel: stable (promote the app)'
+        type: boolean
+        default: true
+  release:
+    types: [edited, released]
 
 permissions:
   contents: read
@@ -31,34 +44,40 @@ env:
   REGION: us-central1
 
 jobs:
-  # Decide whether to promote and which tag, without touching prod credentials.
   gate:
     runs-on: ubuntu-latest
     outputs:
       proceed: ${{ steps.g.outputs.proceed }}
       tag: ${{ steps.g.outputs.tag }}
+      dry_run: ${{ steps.g.outputs.dry_run }}
+      flip_channel: ${{ steps.g.outputs.flip_channel }}
     steps:
-      - name: Resolve tag + gate on stable channel
+      - name: Resolve tag + gate
         id: g
         env:
           EVENT: ${{ github.event_name }}
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          DISPATCH_DRY: ${{ github.event.inputs.dry_run }}
+          DISPATCH_FLIP: ${{ github.event.inputs.set_channel_stable }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           set -euo pipefail
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "Manual promotion of $DISPATCH_TAG"
+            echo "Manual promotion of $DISPATCH_TAG (dry_run=$DISPATCH_DRY)"
             echo "tag=$DISPATCH_TAG" >> "$GITHUB_OUTPUT"
             echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "dry_run=$DISPATCH_DRY" >> "$GITHUB_OUTPUT"
+            echo "flip_channel=$DISPATCH_FLIP" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Only desktop releases (v*-macos) are relevant.
+          # release event (best-effort): only desktop tags marked channel: stable
+          echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          echo "flip_channel=false" >> "$GITHUB_OUTPUT"
           case "$RELEASE_TAG" in
             *-macos) ;;
             *) echo "Not a desktop tag ($RELEASE_TAG) — skipping."; echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
           esac
-          # Promote only when the release body declares the stable channel.
           if printf '%s\n' "$RELEASE_BODY" | grep -qiE '^[[:space:]]*channel:[[:space:]]*stable[[:space:]]*$'; then
             echo "$RELEASE_TAG is channel: stable — promoting to prod."
             echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
@@ -73,7 +92,7 @@ jobs:
     if: needs.gate.outputs.proceed == 'true'
     environment: prod
     permissions:
-      contents: read
+      contents: write
       id-token: write
     runs-on: ubuntu-latest-m
     steps:
@@ -115,7 +134,12 @@ jobs:
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
+      - name: Dry run — skip deploy
+        if: needs.gate.outputs.dry_run == 'true'
+        run: echo "🧪 dry_run: image built from ${{ needs.gate.outputs.tag }} (${{ steps.sha.outputs.sha }}); SKIPPING prod deploy + channel flip." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Deploy Desktop Backend to Production
+        if: needs.gate.outputs.dry_run != 'true'
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE }}
@@ -139,6 +163,22 @@ jobs:
             DESKTOP_LEGACY_ANTHROPIC_KEY=DESKTOP_LEGACY_ANTHROPIC_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
 
-      - name: Summary
+      - name: Promote release channel to stable
+        if: github.event_name == 'workflow_dispatch' && needs.gate.outputs.dry_run != 'true' && needs.gate.outputs.flip_channel == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.gate.outputs.tag }}
         run: |
-          echo "✅ Promoted desktop-backend to PROD from ${{ needs.gate.outputs.tag }} (${{ steps.sha.outputs.sha }})" >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          gh release view "$TAG" --json body --jq '.body' > /tmp/body.md
+          if grep -qiE '^[[:space:]]*channel:[[:space:]]*stable[[:space:]]*$' /tmp/body.md; then
+            echo "Release already channel: stable — nothing to flip."
+          else
+            sed -i -E 's/^([[:space:]]*channel:[[:space:]]*)beta([[:space:]]*)$/\1stable\2/' /tmp/body.md
+            gh release edit "$TAG" --notes-file /tmp/body.md
+            echo "Flipped $TAG to channel: stable."
+          fi
+
+      - name: Summary
+        if: needs.gate.outputs.dry_run != 'true'
+        run: echo "✅ Promoted desktop-backend to PROD from ${{ needs.gate.outputs.tag }} (${{ steps.sha.outputs.sha }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -136,7 +136,8 @@ jobs:
 
       - name: Dry run — skip deploy
         if: needs.gate.outputs.dry_run == 'true'
-        run: echo "🧪 dry_run: image built from ${{ needs.gate.outputs.tag }} (${{ steps.sha.outputs.sha }}); SKIPPING prod deploy + channel flip." >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          echo "dry_run - image built from ${{ needs.gate.outputs.tag }} (${{ steps.sha.outputs.sha }}); SKIPPING prod deploy + channel flip." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Deploy Desktop Backend to Production
         if: needs.gate.outputs.dry_run != 'true'


### PR DESCRIPTION
Follow-up to #8179. `release: edited` doesn't reliably fire Actions runs (verified empirically), so workflow_dispatch is now the supported promotion path: one run promotes the app channel→stable AND deploys the backend to prod from the chosen tag. Adds `dry_run` for safe verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

