### PR TITLE
Fix desktop agent pill streaming activity

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -592,14 +592,18 @@ final class AgentPillsManager: ObservableObject {
             pill.status = .running
         }
 
-        let activity = describeActivity(for: aiMessage)
+        let activity = Self.describeActivity(for: aiMessage)
         if !activity.isEmpty && activity != pill.latestActivity {
             pill.latestActivity = activity
             pill.transcript.append(activity)
         }
     }
 
-    private func describeActivity(for message: ChatMessage) -> String {
+    /// Pill-bar activity string for an AI message. While a message is still
+    /// streaming, skip partial text chunks so the pill does not flicker through
+    /// mid-token labels like "O..." or "Open..." before the final response lands.
+    /// Tool calls still show immediately because they are atomic activity.
+    private static func describeActivity(for message: ChatMessage) -> String {
         for block in message.contentBlocks.reversed() {
             switch block {
             case .toolCall(_, let name, _, _, let input, _):
@@ -609,6 +613,7 @@ final class AgentPillsManager: ObservableObject {
                 }
                 return display
             case .text(_, let text):
+                guard !message.isStreaming else { continue }
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
                     return String(trimmed.prefix(110))
@@ -618,7 +623,7 @@ final class AgentPillsManager: ObservableObject {
             }
         }
         let trimmedFallback = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedFallback.isEmpty {
+        if !message.isStreaming, !trimmedFallback.isEmpty {
             return String(trimmedFallback.prefix(110))
         }
         return "Working…"


### PR DESCRIPTION
## Summary
- Keep floating agent pill activity calm while an AI message is still streaming.
- Preserve immediate tool-call activity labels so real atomic work still appears right away.
- Avoid showing partial streamed text such as `O...` / `Open...` in the pill popover before the final response lands.

## Scope
- macOS desktop only.
- One production file changed: `desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift`.
- No command IDs, handlers, shortcuts, route IDs, bridge actions, automation paths, backend contracts, mobile code, docs, or test files changed.

## Verification
- `git fetch upstream main --prune` confirmed this branch is based on latest `upstream/main` (`ec2931be87f2fd00d4316869ed9a087dde20cfae`).
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter FloatingBarHeuristicsTests` (4 tests, 0 failures)
- Named-bundle QA: launched `/Applications/omi-macos-redesign.app` with bundle id `com.omi.omi-macos-redesign` and exercised the floating-bar `ask` automation action through port `47888`.

## Visual Evidence
- Local before/after visual: `/tmp/omi-agent-pill-streaming-activity/before-after-agent-pill-popover-ui.png`
- Note: macOS overlay/window capture produced compositor-limited black captures for the nonstandard floating panel, so the local visual is an illustrative rendering of the actual `AgentPillPopover` layout and the behavior change, not a PR asset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

