### PR TITLE
[codex] Fix floating chat response actions layout

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -500,18 +500,17 @@ struct MessageHoverOverlay<Content: View>: View {
         (isHovered || isBarHovered || showInfoPopover) && !message.isStreaming
     }
 
-    private var actionBarWidth: CGFloat {
-        message.metadata == nil ? 56 : 76
-    }
-
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        VStack(alignment: .leading, spacing: 4) {
             VStack(alignment: .leading, spacing: 8) {
                 content()
             }
-            .padding(.trailing, actionBarWidth)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            actionBar
+            if shouldShowBar {
+                actionBar
+                    .transition(.opacity)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
@@ -542,77 +541,77 @@ struct MessageHoverOverlay<Content: View>: View {
         // `self.message` happens to point to when the click is dispatched.
         let messageText = message.text
         let currentRating = message.rating
-        return VStack(alignment: .trailing, spacing: 2) {
-            HStack(spacing: 6) {
-                // Thumbs up
-                Button(action: { [currentRating] in
-                    let newRating = currentRating == 1 ? nil : 1
-                    guard newRating != lastSubmittedRating else { return }
-                    lastSubmittedRating = newRating
-                    onRate(newRating)
-                    if newRating != nil { showRatingFeedbackBriefly() }
-                }) {
-                    Image(systemName: currentRating == 1 ? "hand.thumbsup.fill" : "hand.thumbsup")
-                        .scaledFont(size: 11)
-                        .foregroundColor(currentRating == 1 ? .green : .secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Helpful response")
+        return HStack(alignment: .top, spacing: 6) {
+            Spacer(minLength: 0)
 
-                // Thumbs down
-                Button(action: { [currentRating] in
-                    let newRating = currentRating == -1 ? nil : -1
-                    guard newRating != lastSubmittedRating else { return }
-                    lastSubmittedRating = newRating
-                    onRate(newRating)
-                    if newRating != nil { showRatingFeedbackBriefly() }
-                }) {
-                    Image(systemName: currentRating == -1 ? "hand.thumbsdown.fill" : "hand.thumbsdown")
-                        .scaledFont(size: 11)
-                        .foregroundColor(currentRating == -1 ? .red : .secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Not helpful")
-
-                // Copy — captures `messageText` explicitly so we always copy the
-                // message this button was drawn for, even if SwiftUI reuses the
-                // overlay view across re-renders.
-                Button(action: { [messageText] in copyText(messageText) }) {
-                    Image(systemName: showCopied ? "checkmark" : "doc.on.doc")
-                        .scaledFont(size: 11)
-                        .foregroundColor(showCopied ? .green : .secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Copy response")
-
-                // Info (developer context)
-                if message.metadata != nil {
-                    Button(action: { showInfoPopover.toggle() }) {
-                        Image(systemName: "info.circle")
+            VStack(alignment: .trailing, spacing: 2) {
+                HStack(spacing: 6) {
+                    // Thumbs up
+                    Button(action: { [currentRating] in
+                        let newRating = currentRating == 1 ? nil : 1
+                        guard newRating != lastSubmittedRating else { return }
+                        lastSubmittedRating = newRating
+                        onRate(newRating)
+                        if newRating != nil { showRatingFeedbackBriefly() }
+                    }) {
+                        Image(systemName: currentRating == 1 ? "hand.thumbsup.fill" : "hand.thumbsup")
                             .scaledFont(size: 11)
-                            .foregroundColor(showInfoPopover ? .white : .secondary)
+                            .foregroundColor(currentRating == 1 ? .green : .secondary)
                     }
                     .buttonStyle(.plain)
-                    .help("View response context")
-                    .popover(isPresented: $showInfoPopover, arrowEdge: .bottom) {
-                        MessageMetadataPopover(metadata: message.metadata!)
+                    .help("Helpful response")
+
+                    // Thumbs down
+                    Button(action: { [currentRating] in
+                        let newRating = currentRating == -1 ? nil : -1
+                        guard newRating != lastSubmittedRating else { return }
+                        lastSubmittedRating = newRating
+                        onRate(newRating)
+                        if newRating != nil { showRatingFeedbackBriefly() }
+                    }) {
+                        Image(systemName: currentRating == -1 ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+                            .scaledFont(size: 11)
+                            .foregroundColor(currentRating == -1 ? .red : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Not helpful")
+
+                    // Copy — captures `messageText` explicitly so we always copy the
+                    // message this button was drawn for, even if SwiftUI reuses the
+                    // overlay view across re-renders.
+                    Button(action: { [messageText] in copyText(messageText) }) {
+                        Image(systemName: showCopied ? "checkmark" : "doc.on.doc")
+                            .scaledFont(size: 11)
+                            .foregroundColor(showCopied ? .green : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Copy response")
+
+                    // Info (developer context)
+                    if message.metadata != nil {
+                        Button(action: { showInfoPopover.toggle() }) {
+                            Image(systemName: "info.circle")
+                                .scaledFont(size: 11)
+                                .foregroundColor(showInfoPopover ? .white : .secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("View response context")
+                        .popover(isPresented: $showInfoPopover, arrowEdge: .bottom) {
+                            MessageMetadataPopover(metadata: message.metadata!)
+                        }
                     }
                 }
-            }
 
-            if showRatingFeedback {
-                Text("Thank you!")
-                    .scaledFont(size: 9)
-                    .foregroundColor(.secondary)
-                    .transition(.opacity)
+                if showRatingFeedback {
+                    Text("Thank you!")
+                        .scaledFont(size: 9)
+                        .foregroundColor(.secondary)
+                        .transition(.opacity)
+                }
             }
         }
         .animation(.easeInOut(duration: 0.2), value: showRatingFeedback)
-        .frame(width: actionBarWidth, alignment: .trailing)
-        .padding(.top, 1)
-        .opacity(shouldShowBar ? 1 : 0)
-        .allowsHitTesting(shouldShowBar)
-        .animation(.easeInOut(duration: 0.15), value: shouldShowBar)
+        .frame(maxWidth: .infinity, alignment: .trailing)
         .onHover { hovering in
             isBarHovered = hovering
             if hovering {


### PR DESCRIPTION
## Summary
- Move floating-bar response actions out of the top-trailing overlay and into a trailing row below the message text.
- Remove the reserved right-side gutter that forced long AI responses to wrap early and made the action icons appear beside the paragraph.

## Root Cause
`MessageHoverOverlay` used a `ZStack(alignment: .topTrailing)` and always padded the response content by the action-bar width. That reserved space on the right even when the buttons were hidden, so long responses wrapped around a phantom action column. When the hover buttons appeared, they were anchored at the top/right of the message instead of below the response.

## Verification
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`
- Launched named bundle `/Applications/omi-floating-actions.app` with `OMI_APP_NAME="omi-floating-actions" ./run.sh --yolo`.
- Verified the named bundle booted signed-in and the local automation bridge accepted `omi-ctl action ask query="which claude model"`.

## Notes
- Visual screenshot capture was blocked in this local environment: `screencapture` failed with `could not create image from display`, and `agent-swift screenshot` could not capture the floating panel even after activating the named bundle. The app launch and automation path were still exercised.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

