### PR TITLE
fix(desktop): clear reason+hint when a Rewind screenshot can't be loaded (#8188)

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Local agent API now returns a clear reason and hint when a Rewind screenshot image can not be loaded (pending/orphaned/retained-out) instead of a generic error"
+  ],
   "releases": [
     {
       "version": "0.11.507",

--- a/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+++ b/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
@@ -278,11 +278,18 @@ final class LocalAgentAPIServer {
       return errorResponse("screenshot_id is required", statusCode: 400)
     }
 
+    let screenshot: Screenshot?
     do {
-      guard let screenshot = try await RewindDatabase.shared.getScreenshot(id: screenshotID) else {
-        return errorResponse("screenshot_not_found: \(screenshotID)", statusCode: 404)
-      }
+      screenshot = try await RewindDatabase.shared.getScreenshot(id: screenshotID)
+    } catch {
+      logError("LocalAgentAPIServer: get_screenshot lookup failed", error: error)
+      return errorResponse("failed_to_load_screenshot: \(error.localizedDescription)", statusCode: 500)
+    }
+    guard let screenshot else {
+      return errorResponse("screenshot_not_found: \(screenshotID)", statusCode: 404)
+    }
 
+    do {
       let imageData = try await loadScreenshotDataEnsuringStorage(for: screenshot)
       let metadata = screenshotMetadata(screenshot, imageByteCount: imageData.count)
       return jsonResponse([
@@ -293,9 +300,56 @@ final class LocalAgentAPIServer {
         "image_base64": imageData.base64EncodedString(),
       ])
     } catch {
+      // The image row exists but its pixels could not be loaded. Rather than a
+      // generic 500, classify why so agents get an actionable reason + hint.
+      return await screenshotUnavailableResponse(screenshot, screenshotID: screenshotID, error: error)
+    }
+  }
+
+  /// Map a screenshot load failure to a clear, structured response. Recent
+  /// screenshots commonly sit in the active (unfinalized) video chunk, which
+  /// cannot be decoded yet; other rows may be orphaned or have a file that
+  /// retention already removed. All of these previously surfaced as an opaque
+  /// `failed_to_load_screenshot: Screenshot not found` 500.
+  private func screenshotUnavailableResponse(
+    _ screenshot: Screenshot,
+    screenshotID: Int64,
+    error: Error
+  ) async -> LocalHTTPResponse {
+    let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
+
+    let code: String
+    let reason: String
+    let hint: String
+
+    if let rewindError = error as? RewindError, case .corruptedVideoChunk = rewindError {
+      code = "screenshot_chunk_corrupted"
+      reason = "The video chunk backing this screenshot is corrupted and cannot be decoded."
+      hint = "Pick a different screenshot_id; this frame's pixels are unrecoverable."
+    } else if screenshot.usesVideoStorage, let chunk = screenshot.videoChunkPath, chunk == activeChunk {
+      code = "screenshot_pending"
+      reason = "The frame is in the active recording segment that has not been flushed to disk yet."
+      hint = "Retry in ~60s, or choose an older screenshot_id whose video chunk is already finalized."
+    } else if !screenshot.usesVideoStorage, (screenshot.imagePath ?? "").isEmpty {
+      code = "screenshot_image_unavailable"
+      reason = "This screenshot row has no stored image (orphaned capture with no video chunk or image file)."
+      hint = "Pick a different screenshot_id from a recent search_screen_history result."
+    } else if error as? RewindError != nil {
+      code = "screenshot_file_missing"
+      reason = "The image data for this screenshot is no longer on disk (likely removed by retention/cleanup)."
+      hint = "Pick a more recent screenshot_id whose pixels are still retained."
+    } else {
       logError("LocalAgentAPIServer: get_screenshot failed", error: error)
       return errorResponse("failed_to_load_screenshot: \(error.localizedDescription)", statusCode: 500)
     }
+
+    return jsonResponse([
+      "ok": false,
+      "error": code,
+      "reason": reason,
+      "hint": hint,
+      "screenshot_id": screenshotID,
+    ], statusCode: 422)
   }
 
   private func loadScreenshotDataEnsuringStorage(for screenshot: Screenshot) async throws -> Data {
@@ -370,7 +424,7 @@ final class LocalAgentAPIServer {
     LocalAgentTool(
       name: "get_screenshot",
       description:
-        "Fetch a local Rewind screenshot image by screenshot_id. Use screenshot IDs returned by search_screen_history or execute_sql.",
+        "Fetch a local Rewind screenshot image by screenshot_id. Use screenshot IDs returned by search_screen_history or execute_sql. Very recent captures may return screenshot_pending (still in the active, unflushed video segment) — retry shortly or pick an older id.",
       properties: [
         "screenshot_id": ["type": "number", "description": "Screenshot ID from search_screen_history or the screenshots table"]
       ],
@@ -461,6 +515,7 @@ final class LocalAgentAPIServer {
     case 401: statusText = "Unauthorized"
     case 404: statusText = "Not Found"
     case 413: statusText = "Payload Too Large"
+    case 422: statusText = "Unprocessable Entity"
     default: statusText = "Internal Server Error"
     }
 


### PR DESCRIPTION
## Bug
Issue #8188: agents calling the local Desktop API `get_screenshot` (`omi local screenshot <id>`) on a recent screenshot ID get an opaque `failed_to_load_screenshot: Screenshot not found` **500** even though the screenshot row exists and is indexed.

## Root cause
Modern Rewind stores screenshots as **frames inside video chunks** (`videoChunkPath` + `frameOffset`), not standalone JPEGs — so `imagePath` is empty for ~all rows (matches the issue's `with_image_path = 0`). Several distinct, benign states all collapse to `RewindError.screenshotNotFound` → the same generic 500 in `LocalAgentAPIServer.screenshotToolResponse`:

1. **Pending** — the frame is in the *active, not-yet-flushed* video segment. The most recent screenshots (which the reporter queried via `ORDER BY timestamp DESC`) are exactly these. The Rewind UI already filters active-chunk frames out as "can't be displayed yet" (`RewindViewModel`), but the API neither filters nor explains.
2. **Orphaned** — a row with no `videoChunkPath` and no `imagePath` (a known class; there's even a cleanup migration `deleteOrphanScreenshots`).
3. **File missing** — the backing video chunk was removed by retention/cleanup.
4. **Corrupted** chunk.

## Fix (surgical, +62/-5, 1 source file)
Classify the load failure and return a structured **422** with `error` code, human `reason`, and an actionable `hint` instead of a generic 500 — directly satisfying the issue's acceptance criterion *"If raw pixels are unavailable, the CLI/API should return a clear reason and remediation hint rather than a generic 500."* Codes: `screenshot_pending`, `screenshot_image_unavailable`, `screenshot_file_missing`, `screenshot_chunk_corrupted`. Genuinely-unexpected errors still return 500. Also notes the pending behavior in the `get_screenshot` tool description so agents discover it. No change to the capture/storage pipeline.

## Verification
Clean debug `xcrun swift build` succeeds (pre-existing warnings only). **UNVERIFIED at runtime** — not exercised against a live local API session.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

