### PR TITLE
[codex] Always speak push-to-talk responses

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -357,15 +357,8 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(draggableBarEnabled, forKey: "shortcut_draggableBarEnabled") }
     }
 
-    /// When true, floating-bar replies are spoken aloud.
-    @Published var floatingBarVoiceAnswersEnabled: Bool {
-        didSet {
-            UserDefaults.standard.set(floatingBarVoiceAnswersEnabled, forKey: "shortcut_floatingBarVoiceAnswersEnabled")
-            if !hasAnyFloatingBarVoiceAnswersEnabled {
-                FloatingBarVoicePlaybackService.shared.stop()
-            }
-        }
-    }
+    /// Push-to-talk replies are always spoken aloud.
+    let floatingBarVoiceAnswersEnabled: Bool = true
 
     /// When true, typed floating-bar questions receive spoken replies.
     @Published var floatingBarTypedQuestionVoiceAnswersEnabled: Bool {
@@ -503,11 +496,11 @@ class ShortcutSettings: ObservableObject {
     }
 
     var hasAnyFloatingBarVoiceAnswersEnabled: Bool {
-        floatingBarVoiceAnswersEnabled || floatingBarTypedQuestionVoiceAnswersEnabled
+        true
     }
 
     func shouldSpeakFloatingBarResponse(forVoiceQuery: Bool) -> Bool {
-        forVoiceQuery ? floatingBarVoiceAnswersEnabled : floatingBarTypedQuestionVoiceAnswersEnabled
+        forVoiceQuery || floatingBarTypedQuestionVoiceAnswersEnabled
     }
 
     var askOmiUsesCustomShortcut: Bool {
@@ -548,7 +541,6 @@ class ShortcutSettings: ObservableObject {
             self.pttTranscriptionMode = .batch
         }
         self.draggableBarEnabled = UserDefaults.standard.object(forKey: "shortcut_draggableBarEnabled") as? Bool ?? false
-        self.floatingBarVoiceAnswersEnabled = UserDefaults.standard.object(forKey: "shortcut_floatingBarVoiceAnswersEnabled") as? Bool ?? true
         self.floatingBarTypedQuestionVoiceAnswersEnabled =
             UserDefaults.standard.object(forKey: "shortcut_floatingBarTypedQuestionVoiceAnswersEnabled") as? Bool ?? false
         self.voicePlaybackSpeed = UserDefaults.standard.object(forKey: "shortcut_voicePlaybackSpeed") as? Float ?? 1.4

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -2491,23 +2491,6 @@ struct SettingsContentView: View {
         }
       }
 
-      settingsCard(settingId: "floatingbar.voiceanswers") {
-        HStack(spacing: 16) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Voice Questions")
-              .scaledFont(size: 16, weight: .semibold)
-              .foregroundColor(OmiColors.textPrimary)
-            Text("Speak answers aloud when you ask with push to talk.")
-              .scaledFont(size: 13)
-              .foregroundColor(OmiColors.textSecondary)
-          }
-          Spacer()
-          Toggle("", isOn: floatingBarVoiceAnswersBinding)
-            .toggleStyle(.switch)
-            .tint(OmiColors.purplePrimary)
-        }
-      }
-
       settingsCard(settingId: "floatingbar.typedvoiceanswers") {
         HStack(spacing: 16) {
           VStack(alignment: .leading, spacing: 4) {
@@ -5715,20 +5698,6 @@ struct SettingsContentView: View {
     case .failed:
       Text("Invalid").scaledFont(size: 11, weight: .semibold).foregroundColor(OmiColors.warning)
     }
-  }
-
-  private var floatingBarVoiceAnswersBinding: Binding<Bool> {
-    Binding(
-      get: { shortcutSettings.floatingBarVoiceAnswersEnabled },
-      set: { newValue in
-        shortcutSettings.floatingBarVoiceAnswersEnabled = newValue
-        SettingsSyncManager.shared.pushPartialUpdate(
-          AssistantSettingsResponse(
-            floatingBar: FloatingBarSettingsResponse(voiceAnswersEnabled: newValue)
-          )
-        )
-      }
-    )
   }
 
   private var floatingBarTypedVoiceAnswersBinding: Binding<Bool> {

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -256,11 +256,6 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["drag", "move", "reposition", "draggable"], section: .floatingBar,
       icon: "sparkles", settingId: "floatingbar.draggable"),
     SettingsSearchItem(
-      name: "Voice Questions", subtitle: "Speak replies aloud for push-to-talk questions",
-      keywords: ["voice", "speech", "tts", "audio answers", "push to talk"],
-      section: .floatingBar,
-      icon: "sparkles", settingId: "floatingbar.voiceanswers"),
-    SettingsSearchItem(
       name: "Typed Questions", subtitle: "Speak replies aloud for typed floating-bar questions",
       keywords: ["typed", "text", "speech", "tts", "audio answers"], section: .floatingBar,
       icon: "sparkles", settingId: "floatingbar.typedvoiceanswers"),

--- a/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
@@ -16,7 +16,6 @@ struct OnboardingVoiceDemoView: View {
     @State private var waitingForResponse = false
     @State private var showContinue = false
     @State private var previousTranscriptionMode: ShortcutSettings.PTTTranscriptionMode?
-    @State private var voiceResponsesEnabled: Bool = ShortcutSettings.shared.floatingBarVoiceAnswersEnabled
 
     var body: some View {
         VStack(spacing: 0) {
@@ -52,24 +51,6 @@ struct OnboardingVoiceDemoView: View {
                         .foregroundColor(OmiColors.textSecondary)
                         .multilineTextAlignment(.center)
                 }
-
-                // Voice responses checkbox
-                HStack(spacing: 8) {
-                    Toggle("", isOn: $voiceResponsesEnabled)
-                        .toggleStyle(.checkbox)
-                        .onChange(of: voiceResponsesEnabled) { _, newValue in
-                            ShortcutSettings.shared.floatingBarVoiceAnswersEnabled = newValue
-                            SettingsSyncManager.shared.pushPartialUpdate(
-                                AssistantSettingsResponse(
-                                    floatingBar: FloatingBarSettingsResponse(voiceAnswersEnabled: newValue)
-                                )
-                            )
-                        }
-                    Text("Speak answers aloud for voice questions")
-                        .font(.system(size: 14))
-                        .foregroundColor(OmiColors.textSecondary)
-                }
-                .padding(.top, 4)
 
                 if !observedShortcutPress {
                     VStack(spacing: 12) {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -92,11 +92,8 @@ class SettingsSyncManager {
             if let v = memory.excludedApps { MemoryAssistantSettings.shared.excludedApps = Set(v) }
         }
 
-        if let floatingBar = remote.floatingBar {
-            if let v = floatingBar.voiceAnswersEnabled {
-                ShortcutSettings.shared.floatingBarVoiceAnswersEnabled = v
-            }
-        }
+        // Push-to-talk voice replies are no longer configurable. Ignore the legacy
+        // server field so old synced `false` values cannot suppress spoken answers.
 
         // Update channel (server-authoritative override)
         // Note: updateChannel.didSet already calls checkForUpdatesInBackground()

--- a/desktop/macos/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
@@ -41,24 +41,20 @@ final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
         XCTAssertEqual(voice.openAIVoice, "shimmer")
     }
 
-    func testVoiceQueryUsesVoiceToggle() {
+    func testVoiceQueryAlwaysSpeaksAndTypedQueryUsesToggle() {
         let settings = ShortcutSettings.shared
-        let originalVoiceSetting = settings.floatingBarVoiceAnswersEnabled
         let originalTypedSetting = settings.floatingBarTypedQuestionVoiceAnswersEnabled
 
         defer {
-            settings.floatingBarVoiceAnswersEnabled = originalVoiceSetting
             settings.floatingBarTypedQuestionVoiceAnswersEnabled = originalTypedSetting
         }
 
-        settings.floatingBarVoiceAnswersEnabled = true
         settings.floatingBarTypedQuestionVoiceAnswersEnabled = false
         XCTAssertTrue(settings.shouldSpeakFloatingBarResponse(forVoiceQuery: true))
         XCTAssertFalse(settings.shouldSpeakFloatingBarResponse(forVoiceQuery: false))
 
-        settings.floatingBarVoiceAnswersEnabled = false
         settings.floatingBarTypedQuestionVoiceAnswersEnabled = true
-        XCTAssertFalse(settings.shouldSpeakFloatingBarResponse(forVoiceQuery: true))
+        XCTAssertTrue(settings.shouldSpeakFloatingBarResponse(forVoiceQuery: true))
         XCTAssertTrue(settings.shouldSpeakFloatingBarResponse(forVoiceQuery: false))
     }
 }


### PR DESCRIPTION
## Summary
- remove the push-to-talk spoken-answer toggle from onboarding and Floating Bar settings/search
- make voice-query floating-bar responses always speak aloud while keeping typed-question voice replies configurable
- ignore legacy synced `voice_answers_enabled=false` values and keep local sync reporting voice answers enabled

## Root cause
The old onboarding/settings toggle could persist `voice_answers_enabled=false`, which suppressed spoken push-to-talk replies until the user manually re-enabled the checkbox.

## Validation
- Local read-only review of the scoped diff found no blocking issues
- `git diff --check`
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test -c debug --package-path Desktop --filter FloatingBarVoiceResponseSettingsTests`
- Live named bundle verification: Floating Bar settings no longer show the Voice Questions row

## Residual risk
- The legacy sync ignore path is simple and covered by code review/stale-reference search, but does not have a dedicated unit test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

