### PR TITLE
[codex] Default Ask Omi shortcut to Command-O

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Changed the default Ask Omi keyboard shortcut to Command-O"
+  ],
   "releases": [
     {
       "version": "0.11.507",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -268,11 +268,21 @@ class ShortcutSettings: ObservableObject {
         }
     }
 
+    static let askOmiCommandOShortcut = KeyboardShortcut(keyCode: 31, keyDisplay: "O", modifiers: .command)
+    static let askOmiCommandReturnShortcut = KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: .command)
+    static let askOmiCommandShiftReturnShortcut = KeyboardShortcut(
+        keyCode: 36,
+        keyDisplay: "↩",
+        modifiers: [.command, .shift]
+    )
+    static let askOmiCommandJShortcut = KeyboardShortcut(keyCode: 38, keyDisplay: "J", modifiers: .command)
+    static let defaultAskOmiShortcut = askOmiCommandOShortcut
+
     static let askOmiPresets: [KeyboardShortcut] = [
-        KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: .command),
-        KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: [.command, .shift]),
-        KeyboardShortcut(keyCode: 38, keyDisplay: "J", modifiers: .command),
-        KeyboardShortcut(keyCode: 31, keyDisplay: "O", modifiers: .command),
+        askOmiCommandOShortcut,
+        askOmiCommandReturnShortcut,
+        askOmiCommandShiftReturnShortcut,
+        askOmiCommandJShortcut,
     ]
 
     static let pttPresets: [KeyboardShortcut] = [
@@ -530,7 +540,7 @@ class ShortcutSettings: ObservableObject {
         self.askOmiShortcut = Self.loadShortcut(
             forKey: Self.askOmiShortcutDefaultsKey,
             legacyMapper: Self.legacyAskOmiShortcut
-        ) ?? Self.askOmiPresets[0]
+        ) ?? Self.defaultAskOmiShortcut
 
         self.askOmiEnabled = UserDefaults.standard.object(forKey: "shortcut_askOmiEnabled") as? Bool ?? true
         self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
@@ -589,13 +599,13 @@ class ShortcutSettings: ObservableObject {
     private static func legacyAskOmiShortcut(_ value: String) -> KeyboardShortcut? {
         switch value {
         case "⌘ Enter":
-            return askOmiPresets[0]
+            return askOmiCommandReturnShortcut
         case "⌘⇧ Enter":
-            return askOmiPresets[1]
+            return askOmiCommandShiftReturnShortcut
         case "⌘J":
-            return askOmiPresets[2]
+            return askOmiCommandJShortcut
         case "⌘O":
-            return askOmiPresets[3]
+            return askOmiCommandOShortcut
         default:
             return nil
         }

--- a/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Omi_Computer
+
+@MainActor
+final class ShortcutSettingsTests: XCTestCase {
+    func testAskOmiDefaultShortcutIsCommandO() {
+        XCTAssertEqual(ShortcutSettings.defaultAskOmiShortcut, ShortcutSettings.askOmiCommandOShortcut)
+        XCTAssertEqual(ShortcutSettings.defaultAskOmiShortcut.displayTokens, ["⌘", "O"])
+    }
+
+    func testAskOmiPresetsShowCommandOFirst() {
+        XCTAssertEqual(ShortcutSettings.askOmiPresets.first, ShortcutSettings.askOmiCommandOShortcut)
+        XCTAssertEqual(
+            ShortcutSettings.askOmiPresets,
+            [
+                ShortcutSettings.askOmiCommandOShortcut,
+                ShortcutSettings.askOmiCommandReturnShortcut,
+                ShortcutSettings.askOmiCommandShiftReturnShortcut,
+                ShortcutSettings.askOmiCommandJShortcut,
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Make Command-O the explicit default Ask Omi shortcut.
- Show Command-O as the first Ask Omi shortcut preset in settings and onboarding.
- Preserve legacy shortcut migration by mapping old values to named presets instead of array positions.

## Validation
- git diff --check
- xcrun swift test --package-path desktop/macos/Desktop --filter ShortcutSettingsTests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

