### PR TITLE
fix(onboarding): freemium CTAs — 'Skip for now' on keys, 'Take me to Omi', dev 'Skip onboarding'

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [
-    "Onboarding: \"Use Omi for free\" is now the primary action on the keys step (bring-your-own-keys is optional/secondary), and the tasks step button now says \"Take me to Omi\""
+    "Onboarding: the keys step is now optional with a primary \"Skip for now\" action (bring-your-own-keys demoted to a secondary \"Save keys\"); tasks step button now says \"Take me to Omi\"; dev builds get a \"Skip onboarding\" shortcut on the first screen"
   ],
   "releases": [
     {

--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Onboarding: \"Use Omi for free\" is now the primary action on the keys step (bring-your-own-keys is optional/secondary), and the tasks step button now says \"Take me to Omi\""
+  ],
   "releases": [
     {
       "version": "0.11.507",

--- a/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -25,11 +25,11 @@ struct OnboardingBYOKStepView: View {
       graphViewModel: graphViewModel,
       stepIndex: stepIndex,
       totalSteps: totalSteps,
-      eyebrow: "Free forever",
+      eyebrow: "Optional",
       title: "Bring your own keys.",
       description:
-        "Paste your own API keys for OpenAI, Anthropic, Gemini, and Deepgram and Omi is free forever. Keys stay on this Mac — we never store them on our servers.",
-      showsSkip: true,
+        "Omi is free to use — just continue. Prefer to run on your own API usage? Paste your OpenAI, Anthropic, Gemini, and Deepgram keys and hit Save. Keys stay on this Mac — we never store them on our servers.",
+      showsSkip: false,
       onSkip: {
         AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Skipped")
         onSkip()
@@ -49,18 +49,23 @@ struct OnboardingBYOKStepView: View {
         }
 
         HStack(spacing: 12) {
-          Button(isActivating ? "Activating…" : "Activate free plan") {
-            Task { await activate() }
+          Button("Use Omi for free") {
+            AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_UseFree")
+            onSkip()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
-          .disabled(!allKeysProvided || isActivating)
+          .disabled(isActivating)
 
-          if !allKeysProvided {
-            Text("Fill all four to activate.")
-              .font(.system(size: 12))
-              .foregroundColor(OmiColors.textTertiary)
+          Button(isActivating ? "Saving…" : "Save keys") {
+            Task { await activate() }
           }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: false))
+          .disabled(!allKeysProvided || isActivating)
         }
+
+        Text("Adding keys is optional — fill all four to run on your own API usage.")
+          .font(.system(size: 12))
+          .foregroundColor(OmiColors.textTertiary)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -49,8 +49,8 @@ struct OnboardingBYOKStepView: View {
         }
 
         HStack(spacing: 12) {
-          Button("Use Omi for free") {
-            AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_UseFree")
+          Button("Skip for now") {
+            AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Skipped")
             onSkip()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))

--- a/desktop/macos/Desktop/Sources/OnboardingTasksStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingTasksStepView.swift
@@ -84,7 +84,7 @@ struct OnboardingTasksStepView: View {
 
             VStack(spacing: 12) {
                 Button(action: onComplete) {
-                    Text("Take me to my tasks")
+                    Text("Take me to Omi")
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundColor(.black)
                         .frame(maxWidth: 280)

--- a/desktop/macos/Desktop/Sources/OnboardingWelcomeStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingWelcomeStepView.swift
@@ -51,6 +51,17 @@ struct OnboardingWelcomeStepView: View {
           }
         }
         .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+
+        // Dev-only shortcut to skip the whole onboarding flow — same as the
+        // hidden logo long-press. Never shown on production builds.
+        if AnalyticsManager.isDevBuild {
+          Button("Skip onboarding") {
+            onForceComplete?()
+          }
+          .buttonStyle(.plain)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundColor(OmiColors.textTertiary)
+        }
       }
       .frame(maxWidth: .infinity, alignment: .center)
       .onAppear {


### PR DESCRIPTION
Onboarding tweaks for freemium:
- **Keys step**: primary CTA is now **'Skip for now'** (BYOK is optional/secondary 'Save keys'); reframed Optional.
- **Tasks step**: button now **'Take me to Omi'** (was 'Take me to my tasks').
- **First screen (dev builds only)**: **'Skip onboarding'** shortcut that mirrors the hidden logo long-press (onForceComplete). Gated on AppBuild.isNonProduction → never on prod/beta.

Verified live in a named bundle: drove each screen, clicked through, confirmed Skip-onboarding flips hasCompletedOnboarding→true and lands in the main UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

