### PR TITLE
[codex] Add Claude connector copy fields

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -433,6 +433,9 @@ struct MemoryExportDestinationSheet: View {
     .background(OmiColors.backgroundPrimary)
     .task {
       await model.loadConfiguration()
+      if destination == .claude && model.mcpKey == nil {
+        await model.generateMCPKey()
+      }
     }
   }
 
@@ -641,10 +644,14 @@ struct MemoryExportDestinationSheet: View {
   private var mcpSection: some View {
     let setup = destination.mcpSetup(key: model.mcpKey ?? "YOUR_OMI_KEY")
     VStack(alignment: .leading, spacing: 12) {
-      mcpCodeRow(
-        label: "Server URL", value: MemoryExportDestination.mcpServerURL, copyLabel: "Server URL")
+      if destination == .claude {
+        claudeConnectorFields
+      } else {
+        mcpCodeRow(
+          label: "Server URL", value: MemoryExportDestination.mcpServerURL, copyLabel: "Server URL")
 
-      mcpKeyRow
+        mcpKeyRow
+      }
 
       if let setup, let copyText = setup.copyText, let copyTitle = setup.copyTitle {
         mcpSnippet(copyText, title: copyTitle, enabled: model.mcpKey != nil)
@@ -673,6 +680,73 @@ struct MemoryExportDestinationSheet: View {
             .foregroundColor(OmiColors.textSecondary)
         }
       }
+    }
+  }
+
+  @ViewBuilder
+  private var claudeConnectorFields: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Copy these fields into Claude's Add custom connector form.")
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.textTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      mcpCodeRow(label: "Name", value: "Omi Memory", copyLabel: "Name")
+
+      mcpCodeRow(
+        label: "Remote MCP server URL",
+        value: MemoryExportDestination.mcpServerURL,
+        copyLabel: "Remote MCP server URL"
+      )
+
+      Text("Advanced settings")
+        .scaledFont(size: 12, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+        .padding(.top, 2)
+
+      mcpCodeRow(label: "OAuth Client ID", value: "omi", copyLabel: "OAuth Client ID")
+
+      if let key = model.mcpKey {
+        mcpCodeRow(
+          label: "OAuth Client Secret",
+          value: key,
+          copyLabel: "OAuth Client Secret",
+          secure: true
+        )
+      } else {
+        claudeConnectorPendingSecretRow
+      }
+    }
+  }
+
+  private var claudeConnectorPendingSecretRow: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("OAuth Client Secret")
+        .scaledFont(size: 12, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+      HStack(spacing: 8) {
+        Text(model.isLoadingMCPKey ? "Generating connection key..." : "Connection key unavailable")
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+          .lineLimit(1)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        Button("Retry") {
+          Task { await model.generateMCPKey() }
+        }
+        .buttonStyle(.plain)
+        .scaledFont(size: 11, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+        .disabled(model.isLoadingMCPKey)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 10)
+      .background(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(OmiColors.backgroundSecondary)
+          .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+              .stroke(Color.white.opacity(0.08), lineWidth: 1))
+      )
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -191,8 +191,8 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
         copyText: nil,
         steps: [
           "Open claude.ai → Settings → Connectors → Add custom connector",
-          "Name it “Omi Memory” and paste the server URL below",
-          "Under Advanced settings set OAuth Client ID to “omi” and Client Secret to your key below",
+          "Copy Name and Remote MCP server URL into the first two Claude fields",
+          "Open Advanced settings and copy OAuth Client ID and OAuth Client Secret into the matching fields",
           "Click Add, then Connect. Syncs to Claude desktop + mobile automatically.",
         ],
         openURL: URL(string: "https://claude.ai/settings/connectors"),
@@ -256,11 +256,24 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     var lines = [
       "Set up the Omi memory MCP connector in \(clientName) end-to-end for me so it can read my Omi memories. Use the browser/terminal as needed and confirm when it's connected.",
       "",
-      "MCP server URL: \(setup.serverURL)",
-      "My Omi MCP key: \(key)",
-      "",
-      "Steps:",
     ]
+    if self == .claude {
+      lines.append(contentsOf: [
+        "Claude custom connector fields:",
+        "Name: Omi Memory",
+        "Remote MCP server URL: \(setup.serverURL)",
+        "OAuth Client ID: omi",
+        "OAuth Client Secret: \(key)",
+        "",
+      ])
+    } else {
+      lines.append(contentsOf: [
+        "MCP server URL: \(setup.serverURL)",
+        "My Omi MCP key: \(key)",
+        "",
+      ])
+    }
+    lines.append("Steps:")
     for (index, step) in setup.steps.enumerated() {
       lines.append("\(index + 1). \(step)")
     }

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -2437,6 +2437,72 @@ function DeveloperSection({
           </button>
         </Card>
 
+        {/* Generic MCP Server Info */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-bg-tertiary">
+              <Server className="w-5 h-5 text-text-tertiary" />
+            </div>
+            <div>
+              <p className="text-text-primary font-medium">MCP Server</p>
+              <p className="text-xs text-text-tertiary">
+                Connect ChatGPT, Codex, Claude, or any MCP client to your data
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+                Server URL
+              </p>
+              <button
+                onClick={copyUrl}
+                className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors"
+              >
+                <code className="text-sm text-text-primary font-mono truncate mr-2">
+                  {mcpServerUrl}
+                </code>
+                {copiedUrl ? (
+                  <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+                ) : (
+                  <Copy className="w-4 h-4 text-text-quaternary flex-shrink-0" />
+                )}
+              </button>
+            </div>
+
+            <div className="border-t border-white/[0.06] pt-4">
+              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+                API Key Auth
+              </p>
+              <div className="flex items-center gap-4 text-sm">
+                <span className="text-text-tertiary">Header</span>
+                <code className="text-text-quaternary font-mono text-xs">
+                  Authorization: Bearer &lt;key&gt;
+                </code>
+              </div>
+            </div>
+
+            <div className="border-t border-white/[0.06] pt-4">
+              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+                OAuth
+              </p>
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center gap-4">
+                  <span className="text-text-tertiary w-24">Client ID</span>
+                  <code className="text-text-primary font-mono">omi</code>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="text-text-tertiary w-24">Client Secret</span>
+                  <span className="text-text-quaternary italic text-xs">
+                    Use your MCP API key
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Card>
+
         {/* Claude Connector — 4 copy fields mirroring Claude's "Add custom connector" form */}
         <Card>
           <div className="flex items-center gap-3 mb-4">

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -92,7 +92,18 @@ import {
   getCustomerPortal,
 } from '@/lib/api';
 import { SUPPORTED_LANGUAGES, API_KEY_SCOPES } from '@/types/user';
-import type { DailySummarySettings, UserUsage, UserSubscription, AllUsageData, DeveloperWebhooks, DeveloperApiKey, McpApiKey, Integration, UsageHistoryPoint, PricingOption } from '@/types/user';
+import type {
+  DailySummarySettings,
+  UserUsage,
+  UserSubscription,
+  AllUsageData,
+  DeveloperWebhooks,
+  DeveloperApiKey,
+  McpApiKey,
+  Integration,
+  UsageHistoryPoint,
+  PricingOption,
+} from '@/types/user';
 
 // ============================================================================
 // Types
@@ -123,20 +134,26 @@ function Toggle({
         enabled
           ? 'bg-purple-500 shadow-[0_0_12px_rgba(139,92,246,0.4)]'
           : 'bg-white/[0.08]',
-        disabled && 'opacity-50 cursor-not-allowed'
+        disabled && 'opacity-50 cursor-not-allowed',
       )}
     >
       <div
         className={cn(
           'absolute top-0.5 w-5 h-5 rounded-full bg-white transition-all duration-200 shadow-sm',
-          enabled ? 'left-[22px]' : 'left-0.5'
+          enabled ? 'left-[22px]' : 'left-0.5',
         )}
       />
     </button>
   );
 }
 
-function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+function Card({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
     <div
       className={cn(
@@ -145,7 +162,7 @@ function Card({ children, className }: { children: React.ReactNode; className?: 
         'bg-gradient-to-b from-white/[0.03] to-white/[0.01]',
         // Soft shadow stack
         'shadow-[0_0_0_1px_rgba(255,255,255,0.04),0_2px_4px_rgba(0,0,0,0.1),0_8px_16px_rgba(0,0,0,0.1)]',
-        className
+        className,
       )}
     >
       {children}
@@ -167,7 +184,9 @@ function SettingRow({
       <div className="flex-1 min-w-0 mr-4">
         <p className="text-[15px] text-white/85 font-medium">{label}</p>
         {description && (
-          <p className="text-[13px] text-white/40 mt-0.5 leading-relaxed">{description}</p>
+          <p className="text-[13px] text-white/40 mt-0.5 leading-relaxed">
+            {description}
+          </p>
         )}
       </div>
       {children}
@@ -210,24 +229,26 @@ function Dropdown({
           'flex items-center justify-between gap-2 px-4 py-2.5 rounded-xl',
           'bg-white/[0.04] ring-1 ring-white/[0.06]',
           'text-white/80 min-w-[160px]',
-          'hover:bg-white/[0.06] transition-colors'
+          'hover:bg-white/[0.06] transition-colors',
         )}
       >
         <span className="truncate text-sm">{selectedOption?.label || placeholder}</span>
         <ChevronDown
           className={cn(
             'w-4 h-4 text-white/40 transition-transform',
-            isOpen && 'rotate-180'
+            isOpen && 'rotate-180',
           )}
         />
       </button>
 
       {isOpen && (
-        <div className={cn(
-          'absolute z-50 w-full mt-2 py-1.5 rounded-xl max-h-64 overflow-y-auto',
-          'bg-[#1a1a1f]/95 backdrop-blur-xl',
-          'shadow-[0_0_0_1px_rgba(255,255,255,0.06),0_10px_30px_-5px_rgba(0,0,0,0.5)]'
-        )}>
+        <div
+          className={cn(
+            'absolute z-50 w-full mt-2 py-1.5 rounded-xl max-h-64 overflow-y-auto',
+            'bg-[#1a1a1f]/95 backdrop-blur-xl',
+            'shadow-[0_0_0_1px_rgba(255,255,255,0.06),0_10px_30px_-5px_rgba(0,0,0,0.5)]',
+          )}
+        >
           {options.map((option) => (
             <button
               key={option.value}
@@ -240,13 +261,11 @@ function Dropdown({
                 'w-full px-4 py-2.5 text-left transition-colors flex items-center justify-between text-sm',
                 option.value === value
                   ? 'bg-purple-500/15 text-white'
-                  : 'text-white/70 hover:bg-white/[0.04] hover:text-white/90'
+                  : 'text-white/70 hover:bg-white/[0.04] hover:text-white/90',
               )}
             >
               <span>{option.label}</span>
-              {option.value === value && (
-                <Check className="w-4 h-4 text-purple-400" />
-              )}
+              {option.value === value && <Check className="w-4 h-4 text-purple-400" />}
             </button>
           ))}
         </div>
@@ -311,13 +330,13 @@ function ConfirmDialog({
           <div
             className={cn(
               'p-2 rounded-full',
-              isDestructive ? 'bg-red-500/10' : 'bg-purple-500/10'
+              isDestructive ? 'bg-red-500/10' : 'bg-purple-500/10',
             )}
           >
             <AlertTriangle
               className={cn(
                 'w-6 h-6',
-                isDestructive ? 'text-red-400' : 'text-purple-400'
+                isDestructive ? 'text-red-400' : 'text-purple-400',
               )}
             />
           </div>
@@ -334,7 +353,7 @@ function ConfirmDialog({
               'px-4 py-2 rounded-xl font-medium',
               'bg-bg-tertiary text-text-primary',
               'hover:bg-bg-quaternary transition-colors',
-              'disabled:opacity-50'
+              'disabled:opacity-50',
             )}
           >
             Cancel
@@ -347,7 +366,7 @@ function ConfirmDialog({
               isDestructive
                 ? 'bg-red-500 text-white hover:bg-red-600'
                 : 'bg-purple-500 text-white hover:bg-purple-600',
-              'transition-colors disabled:opacity-50'
+              'transition-colors disabled:opacity-50',
             )}
           >
             {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
@@ -411,7 +430,9 @@ function ProfileSection({
     <div className="space-y-8">
       {/* Account Info */}
       <div id="account-info" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Account</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Account
+        </h3>
         <Card>
           <div className="flex items-center gap-5">
             <div className="w-20 h-20 rounded-full overflow-hidden bg-bg-tertiary ring-2 ring-purple-500/30 flex-shrink-0">
@@ -450,10 +471,14 @@ function ProfileSection({
                   'p-2 rounded-lg transition-colors',
                   copiedUserId
                     ? 'bg-green-500/10 text-green-400'
-                    : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary'
+                    : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary',
                 )}
               >
-                {copiedUserId ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                {copiedUserId ? (
+                  <Check className="w-4 h-4" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
               </button>
             </div>
           </SettingRow>
@@ -462,7 +487,9 @@ function ProfileSection({
 
       {/* Language & Transcription */}
       <div id="language" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Language & Transcription</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Language & Transcription
+        </h3>
         <Card>
           <SettingRow
             label="Primary Language"
@@ -479,7 +506,9 @@ function ProfileSection({
 
       {/* Custom Vocabulary */}
       <div id="vocabulary" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Custom Vocabulary</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Custom Vocabulary
+        </h3>
         <Card>
           <div className="space-y-4">
             <p className="text-sm text-text-tertiary">
@@ -497,7 +526,7 @@ function ProfileSection({
                   'flex-1 px-4 py-2.5 rounded-xl',
                   'bg-bg-tertiary border border-white/[0.06]',
                   'text-text-primary placeholder:text-text-quaternary',
-                  'focus:outline-none focus:border-purple-500'
+                  'focus:outline-none focus:border-purple-500',
                 )}
               />
               <button
@@ -507,7 +536,7 @@ function ProfileSection({
                   'px-4 py-2.5 rounded-xl font-medium',
                   'bg-purple-500 text-white',
                   'hover:bg-purple-600 transition-colors',
-                  'disabled:opacity-50 disabled:cursor-not-allowed'
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
                 )}
               >
                 <Plus className="w-5 h-5" />
@@ -544,7 +573,9 @@ function ProfileSection({
 
       {/* Notifications */}
       <div id="notifications" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Notifications</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Notifications
+        </h3>
         <Card>
           <SettingRow
             label="Daily Summary"
@@ -608,7 +639,8 @@ function PrivacySection({
           <div>
             <h3 className="text-text-primary font-medium">Your Privacy Matters</h3>
             <p className="text-sm text-text-tertiary mt-1">
-              Your data is encrypted and never shared with third parties. You have full control over what data is collected and stored.
+              Your data is encrypted and never shared with third parties. You have full
+              control over what data is collected and stored.
             </p>
             <a
               href="https://omi.me/privacy"
@@ -639,8 +671,16 @@ const PERIOD_LABELS: Record<UsagePeriod, string> = {
   all_time: 'All Time',
 };
 
-function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period: UsagePeriod }) {
-  const [selectedMetric, setSelectedMetric] = useState<'listening' | 'words' | 'insights' | 'memories'>('listening');
+function UsageChart({
+  history,
+  period,
+}: {
+  history?: UsageHistoryPoint[];
+  period: UsagePeriod;
+}) {
+  const [selectedMetric, setSelectedMetric] = useState<
+    'listening' | 'words' | 'insights' | 'memories'
+  >('listening');
 
   if (!history || history.length === 0) {
     return (
@@ -655,14 +695,15 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
   if (period === 'all_time' && history.length > 12) {
     // Group by year and aggregate
     const yearlyData = new Map<string, UsageHistoryPoint>();
-    history.forEach(point => {
+    history.forEach((point) => {
       const date = new Date(point.date);
       const key = String(date.getFullYear());
       const existing = yearlyData.get(key);
       if (existing) {
         yearlyData.set(key, {
           date: `${key}-01-01`,
-          transcription_seconds: existing.transcription_seconds + point.transcription_seconds,
+          transcription_seconds:
+            existing.transcription_seconds + point.transcription_seconds,
           words_transcribed: existing.words_transcribed + point.words_transcribed,
           insights_gained: existing.insights_gained + point.insights_gained,
           memories_created: existing.memories_created + point.memories_created,
@@ -671,7 +712,9 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
         yearlyData.set(key, { ...point, date: `${key}-01-01` });
       }
     });
-    dataToProcess = Array.from(yearlyData.values()).sort((a, b) => a.date.localeCompare(b.date));
+    dataToProcess = Array.from(yearlyData.values()).sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
   }
 
   // Process history data for display
@@ -692,7 +735,20 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
       if (period === 'monthly') {
         label = `${day}`;
       } else if (period === 'yearly') {
-        label = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][month - 1];
+        label = [
+          'Jan',
+          'Feb',
+          'Mar',
+          'Apr',
+          'May',
+          'Jun',
+          'Jul',
+          'Aug',
+          'Sep',
+          'Oct',
+          'Nov',
+          'Dec',
+        ][month - 1];
       } else {
         // For all_time, show year
         label = String(year);
@@ -704,10 +760,14 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
   // Get value based on selected metric
   const getValue = (d: UsageHistoryPoint) => {
     switch (selectedMetric) {
-      case 'listening': return d.transcription_seconds / 60; // Convert to minutes
-      case 'words': return d.words_transcribed;
-      case 'insights': return d.insights_gained;
-      case 'memories': return d.memories_created;
+      case 'listening':
+        return d.transcription_seconds / 60; // Convert to minutes
+      case 'words':
+        return d.words_transcribed;
+      case 'insights':
+        return d.insights_gained;
+      case 'memories':
+        return d.memories_created;
     }
   };
 
@@ -722,15 +782,19 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
   const formatValueWithUnit = (value: number) => {
     const formatted = formatValue(value);
     switch (selectedMetric) {
-      case 'listening': return `${formatted} min`;
-      case 'words': return formatted;
-      case 'insights': return formatted;
-      case 'memories': return formatted;
+      case 'listening':
+        return `${formatted} min`;
+      case 'words':
+        return formatted;
+      case 'insights':
+        return formatted;
+      case 'memories':
+        return formatted;
     }
   };
 
   // Find max value for scaling
-  const maxValue = Math.max(...processedData.map(d => getValue(d)), 1);
+  const maxValue = Math.max(...processedData.map((d) => getValue(d)), 1);
 
   const metricConfig = [
     { key: 'listening' as const, color: 'rgb(96, 165, 250)', label: 'Listening' },
@@ -739,7 +803,7 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
     { key: 'memories' as const, color: 'rgb(192, 132, 252)', label: 'Memories' },
   ];
 
-  const currentMetric = metricConfig.find(m => m.key === selectedMetric)!;
+  const currentMetric = metricConfig.find((m) => m.key === selectedMetric)!;
 
   return (
     <Card>
@@ -747,7 +811,7 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
       <div className="flex items-center justify-between mb-4">
         <h4 className="text-sm font-semibold text-text-secondary">Activity Over Time</h4>
         <div className="flex gap-1">
-          {metricConfig.map(metric => (
+          {metricConfig.map((metric) => (
             <button
               key={metric.key}
               onClick={() => setSelectedMetric(metric.key)}
@@ -755,10 +819,11 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
                 'px-2.5 py-1 rounded-md text-xs font-medium transition-all',
                 selectedMetric === metric.key
                   ? 'opacity-100'
-                  : 'opacity-40 hover:opacity-60'
+                  : 'opacity-40 hover:opacity-60',
               )}
               style={{
-                backgroundColor: selectedMetric === metric.key ? `${metric.color}20` : 'transparent',
+                backgroundColor:
+                  selectedMetric === metric.key ? `${metric.color}20` : 'transparent',
                 color: metric.color,
               }}
             >
@@ -798,7 +863,9 @@ function UsageChart({ history, period }: { history?: UsageHistoryPoint[]; period
                 }}
               />
               {/* Label */}
-              <span className="text-xs text-text-quaternary mt-2 font-medium">{d.label}</span>
+              <span className="text-xs text-text-quaternary mt-2 font-medium">
+                {d.label}
+              </span>
             </div>
           );
         })}
@@ -894,11 +961,15 @@ function UsageSectionContent({
   };
 
   // Sort pricing options: monthly first, then annual
-  const sortedOptions = cachedPlans ? [...cachedPlans].sort((a, b) => {
-    const aIsAnnual = a.interval === 'year' || a.title?.toLowerCase().includes('annual');
-    const bIsAnnual = b.interval === 'year' || b.title?.toLowerCase().includes('annual');
-    return (aIsAnnual ? 1 : 0) - (bIsAnnual ? 1 : 0);
-  }) : [];
+  const sortedOptions = cachedPlans
+    ? [...cachedPlans].sort((a, b) => {
+        const aIsAnnual =
+          a.interval === 'year' || a.title?.toLowerCase().includes('annual');
+        const bIsAnnual =
+          b.interval === 'year' || b.title?.toLowerCase().includes('annual');
+        return (aIsAnnual ? 1 : 0) - (bIsAnnual ? 1 : 0);
+      })
+    : [];
 
   const selectedOption = cachedPlans?.find((p) => p.id === selectedPriceId);
 
@@ -991,7 +1062,7 @@ function UsageSectionContent({
             'px-4 py-2 rounded-lg text-sm font-medium transition-all',
             activeTab === 'plan'
               ? 'bg-purple-500 text-white shadow-md'
-              : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary',
           )}
         >
           Plan
@@ -1002,7 +1073,7 @@ function UsageSectionContent({
             'px-4 py-2 rounded-lg text-sm font-medium transition-all',
             activeTab === 'usage'
               ? 'bg-purple-500 text-white shadow-md'
-              : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary',
           )}
         >
           Usage
@@ -1025,7 +1096,9 @@ function UsageSectionContent({
                       <Zap className="w-6 h-6 text-purple-400" />
                     </div>
                     <div>
-                      <h3 className="text-xl font-semibold text-text-primary">Basic Plan</h3>
+                      <h3 className="text-xl font-semibold text-text-primary">
+                        Basic Plan
+                      </h3>
                       <p className="text-sm text-text-tertiary">Free tier</p>
                     </div>
                   </div>
@@ -1041,35 +1114,51 @@ function UsageSectionContent({
                 <div className="p-4 bg-amber-500/5 border border-amber-500/20 rounded-xl mb-6">
                   <div className="flex items-center gap-2 mb-3">
                     <Clock className="w-4 h-4 text-amber-400" />
-                    <span className="text-sm font-semibold text-amber-400">Monthly Listening Limit</span>
+                    <span className="text-sm font-semibold text-amber-400">
+                      Monthly Listening Limit
+                    </span>
                   </div>
                   <div className="flex items-baseline justify-between mb-2">
                     <span className="text-2xl font-bold text-text-primary">
-                      {monthlyUsage ? Math.round(monthlyUsage.transcription_seconds / 60) : 0}
-                      <span className="text-sm font-normal text-text-tertiary ml-1">/ 1,200 min</span>
+                      {monthlyUsage
+                        ? Math.round(monthlyUsage.transcription_seconds / 60)
+                        : 0}
+                      <span className="text-sm font-normal text-text-tertiary ml-1">
+                        / 1,200 min
+                      </span>
                     </span>
                     <span className="text-sm text-text-tertiary">
-                      {monthlyUsage ? (1200 - Math.round(monthlyUsage.transcription_seconds / 60)) : 1200} min left
+                      {monthlyUsage
+                        ? 1200 - Math.round(monthlyUsage.transcription_seconds / 60)
+                        : 1200}{' '}
+                      min left
                     </span>
                   </div>
                   <div className="h-2.5 bg-bg-quaternary rounded-full overflow-hidden">
                     <div
                       className="h-full bg-gradient-to-r from-amber-500 to-amber-400 rounded-full transition-all duration-500"
-                      style={{ width: `${monthlyUsage ? getUsagePercent(monthlyUsage.transcription_seconds, limits.transcription_seconds) : 0}%` }}
+                      style={{
+                        width: `${monthlyUsage ? getUsagePercent(monthlyUsage.transcription_seconds, limits.transcription_seconds) : 0}%`,
+                      }}
                     />
                   </div>
                 </div>
 
                 {/* What's Included - Checklist */}
                 <div>
-                  <h4 className="text-sm font-semibold text-text-secondary mb-3">What&apos;s included</h4>
+                  <h4 className="text-sm font-semibold text-text-secondary mb-3">
+                    What&apos;s included
+                  </h4>
                   <div className="space-y-3">
                     <div className="flex items-center gap-3">
                       <div className="w-5 h-5 rounded bg-amber-500/20 flex items-center justify-center flex-shrink-0">
                         <Clock className="w-3 h-3 text-amber-400" />
                       </div>
                       <span className="text-sm text-text-secondary">
-                        <span className="font-medium text-text-primary">1,200 minutes</span> of listening per month
+                        <span className="font-medium text-text-primary">
+                          1,200 minutes
+                        </span>{' '}
+                        of listening per month
                         <span className="text-amber-400 text-xs ml-1">(limited)</span>
                       </span>
                     </div>
@@ -1078,7 +1167,8 @@ function UsageSectionContent({
                         <Check className="w-3 h-3 text-green-400" />
                       </div>
                       <span className="text-sm text-text-secondary">
-                        <span className="font-medium text-text-primary">Unlimited</span> words transcribed
+                        <span className="font-medium text-text-primary">Unlimited</span>{' '}
+                        words transcribed
                       </span>
                     </div>
                     <div className="flex items-center gap-3">
@@ -1086,7 +1176,8 @@ function UsageSectionContent({
                         <Check className="w-3 h-3 text-green-400" />
                       </div>
                       <span className="text-sm text-text-secondary">
-                        <span className="font-medium text-text-primary">Unlimited</span> insights
+                        <span className="font-medium text-text-primary">Unlimited</span>{' '}
+                        insights
                       </span>
                     </div>
                     <div className="flex items-center gap-3">
@@ -1094,7 +1185,8 @@ function UsageSectionContent({
                         <Check className="w-3 h-3 text-green-400" />
                       </div>
                       <span className="text-sm text-text-secondary">
-                        <span className="font-medium text-text-primary">Unlimited</span> memories
+                        <span className="font-medium text-text-primary">Unlimited</span>{' '}
+                        memories
                       </span>
                     </div>
                   </div>
@@ -1106,8 +1198,12 @@ function UsageSectionContent({
                 <Card className="border-purple-500/20">
                   <div className="flex items-center justify-between mb-5">
                     <div>
-                      <h4 className="text-lg font-semibold text-text-primary">Choose a Plan</h4>
-                      <p className="text-sm text-text-tertiary">Unlock unlimited listening time</p>
+                      <h4 className="text-lg font-semibold text-text-primary">
+                        Choose a Plan
+                      </h4>
+                      <p className="text-sm text-text-tertiary">
+                        Unlock unlimited listening time
+                      </p>
                     </div>
                     <button
                       onClick={() => setShowUpgradeOptions(false)}
@@ -1122,7 +1218,9 @@ function UsageSectionContent({
                     <div className="grid grid-cols-2 gap-4 mb-5">
                       {sortedOptions.map((option) => {
                         const isSelected = selectedPriceId === option.id;
-                        const isAnnual = option.interval === 'year' || option.title?.toLowerCase().includes('annual');
+                        const isAnnual =
+                          option.interval === 'year' ||
+                          option.title?.toLowerCase().includes('annual');
 
                         return (
                           <button
@@ -1132,7 +1230,7 @@ function UsageSectionContent({
                               'relative p-5 rounded-2xl border-2 text-left transition-all',
                               isSelected
                                 ? 'border-purple-500 bg-purple-500/5 shadow-lg shadow-purple-500/10'
-                                : 'border-bg-tertiary hover:border-purple-500/30 bg-bg-tertiary/30'
+                                : 'border-bg-tertiary hover:border-purple-500/30 bg-bg-tertiary/30',
                             )}
                           >
                             {isAnnual && (
@@ -1140,10 +1238,16 @@ function UsageSectionContent({
                                 Best Value
                               </span>
                             )}
-                            <h4 className="font-semibold text-text-primary mb-1">{option.title}</h4>
-                            <p className="text-2xl font-bold text-text-primary">{option.price_string}</p>
+                            <h4 className="font-semibold text-text-primary mb-1">
+                              {option.title}
+                            </h4>
+                            <p className="text-2xl font-bold text-text-primary">
+                              {option.price_string}
+                            </p>
                             {option.description && (
-                              <p className="text-xs text-purple-400 mt-2 font-medium">{option.description}</p>
+                              <p className="text-xs text-purple-400 mt-2 font-medium">
+                                {option.description}
+                              </p>
                             )}
                           </button>
                         );
@@ -1171,7 +1275,7 @@ function UsageSectionContent({
                       'bg-gradient-to-r from-purple-500 to-purple-600 text-white',
                       'hover:from-purple-600 hover:to-purple-700',
                       'shadow-lg shadow-purple-500/20',
-                      'disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none'
+                      'disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none',
                     )}
                   >
                     {isLoading ? (
@@ -1188,14 +1292,18 @@ function UsageSectionContent({
 
               {/* This Month Stats - Compact Single Row */}
               <Card>
-                <h4 className="text-sm font-semibold text-text-secondary mb-4">This month</h4>
+                <h4 className="text-sm font-semibold text-text-secondary mb-4">
+                  This month
+                </h4>
                 <div className="grid grid-cols-4 gap-3">
                   <div className="text-center">
                     <div className="w-10 h-10 mx-auto rounded-xl bg-blue-500/10 flex items-center justify-center mb-2">
                       <Mic className="w-5 h-5 text-blue-400" />
                     </div>
                     <p className="text-xl font-bold text-blue-400">
-                      {monthlyUsage ? formatDuration(monthlyUsage.transcription_seconds) : '0m'}
+                      {monthlyUsage
+                        ? formatDuration(monthlyUsage.transcription_seconds)
+                        : '0m'}
                     </p>
                     <p className="text-xs text-text-quaternary">Listening</p>
                   </div>
@@ -1245,8 +1353,7 @@ function UsageSectionContent({
                     <p className="text-xs text-text-quaternary">
                       {isCancelingSubscription
                         ? `Cancels on ${formatDate(subscription.current_period_end)}`
-                        : `Renews ${formatDate(subscription.current_period_end)}`
-                      }
+                        : `Renews ${formatDate(subscription.current_period_end)}`}
                     </p>
                   )}
                 </div>
@@ -1258,7 +1365,9 @@ function UsageSectionContent({
                   {sortedOptions.map((option) => {
                     const isSelected = selectedPriceId === option.id;
                     const isCurrent = option.is_active;
-                    const isAnnual = option.interval === 'year' || option.title?.toLowerCase().includes('annual');
+                    const isAnnual =
+                      option.interval === 'year' ||
+                      option.title?.toLowerCase().includes('annual');
 
                     return (
                       <button
@@ -1268,7 +1377,7 @@ function UsageSectionContent({
                           'relative p-4 rounded-xl border-2 text-left transition-all',
                           isSelected
                             ? 'border-purple-500 bg-purple-500/5'
-                            : 'border-bg-tertiary hover:border-bg-quaternary bg-bg-tertiary/50'
+                            : 'border-bg-tertiary hover:border-bg-quaternary bg-bg-tertiary/50',
                         )}
                       >
                         {isAnnual && (
@@ -1329,12 +1438,16 @@ function UsageSectionContent({
               {/* Primary Action Button */}
               <button
                 onClick={handleSubscribe}
-                disabled={isLoading || !selectedPriceId || (!isCancelingSubscription && selectedOption?.is_active)}
+                disabled={
+                  isLoading ||
+                  !selectedPriceId ||
+                  (!isCancelingSubscription && selectedOption?.is_active)
+                }
                 className={cn(
                   'w-full py-3 rounded-xl font-medium transition-colors',
                   'bg-purple-500 text-white',
                   'hover:bg-purple-600',
-                  'disabled:opacity-50 disabled:cursor-not-allowed'
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
                 )}
               >
                 {isLoading ? (
@@ -1388,7 +1501,7 @@ function UsageSectionContent({
                   'flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all',
                   selectedPeriod === period
                     ? 'bg-purple-500 text-white shadow-md'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary'
+                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-quaternary',
                 )}
               >
                 {PERIOD_LABELS[period]}
@@ -1468,7 +1581,7 @@ function UsageSectionContent({
 
 function IntegrationsSection({
   integrations,
-  onRefresh
+  onRefresh,
 }: {
   integrations: Integration[];
   onRefresh: () => Promise<void>;
@@ -1527,7 +1640,10 @@ function IntegrationsSection({
     <div className="space-y-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {integrations.map((integration) => (
-          <Card key={integration.id} className={cn(integration.coming_soon && 'opacity-60')}>
+          <Card
+            key={integration.id}
+            className={cn(integration.coming_soon && 'opacity-60')}
+          >
             <div className="flex items-center gap-4">
               <div className="w-12 h-12 rounded-xl overflow-hidden bg-bg-tertiary flex items-center justify-center">
                 {integration.icon.startsWith('/') ? (
@@ -1554,18 +1670,19 @@ function IntegrationsSection({
                     </span>
                   )}
                 </div>
-                <p className="text-sm text-text-tertiary truncate">{integration.description}</p>
+                <p className="text-sm text-text-tertiary truncate">
+                  {integration.description}
+                </p>
               </div>
-              {!integration.coming_soon && (
-                loadingId === integration.id ? (
+              {!integration.coming_soon &&
+                (loadingId === integration.id ? (
                   <Loader2 className="w-5 h-5 animate-spin text-text-tertiary" />
                 ) : (
                   <Toggle
                     enabled={integration.connected}
                     onChange={() => handleToggle(integration)}
                   />
-                )
-              )}
+                ))}
             </div>
           </Card>
         ))}
@@ -1576,7 +1693,7 @@ function IntegrationsSection({
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-bg-secondary rounded-2xl p-6 max-w-md mx-4 shadow-xl">
             <h3 className="text-lg font-semibold text-text-primary mb-2">
-              Disconnect {integrations.find(i => i.id === showDisconnectConfirm)?.name}?
+              Disconnect {integrations.find((i) => i.id === showDisconnectConfirm)?.name}?
             </h3>
             <p className="text-text-secondary mb-6">
               This will remove the connection. You can reconnect anytime.
@@ -1590,7 +1707,9 @@ function IntegrationsSection({
               </button>
               <button
                 onClick={() => {
-                  const integration = integrations.find(i => i.id === showDisconnectConfirm);
+                  const integration = integrations.find(
+                    (i) => i.id === showDisconnectConfirm,
+                  );
                   if (integration) handleDisconnect(integration);
                 }}
                 className="px-4 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors"
@@ -1632,27 +1751,40 @@ function CreateApiKeyDialog({
   const [createdKey, setCreatedKey] = useState<DeveloperApiKey | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const selectedScopes = Object.entries(scopes).filter(([, v]) => v).map(([k]) => k);
-  const isReadOnly = scopes['conversations:read'] && scopes['memories:read'] && scopes['action_items:read'] &&
-    !scopes['conversations:write'] && !scopes['memories:write'] && !scopes['action_items:write'];
-  const isFullAccess = Object.values(scopes).every(v => v);
+  const selectedScopes = Object.entries(scopes)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+  const isReadOnly =
+    scopes['conversations:read'] &&
+    scopes['memories:read'] &&
+    scopes['action_items:read'] &&
+    !scopes['conversations:write'] &&
+    !scopes['memories:write'] &&
+    !scopes['action_items:write'];
+  const isFullAccess = Object.values(scopes).every((v) => v);
 
   const selectReadOnly = () => {
     setScopes({
-      'conversations:read': true, 'conversations:write': false,
-      'memories:read': true, 'memories:write': false,
-      'action_items:read': true, 'action_items:write': false,
+      'conversations:read': true,
+      'conversations:write': false,
+      'memories:read': true,
+      'memories:write': false,
+      'action_items:read': true,
+      'action_items:write': false,
     });
   };
 
   const selectFullAccess = () => {
-    setScopes(Object.fromEntries(Object.keys(scopes).map(k => [k, true])));
+    setScopes(Object.fromEntries(Object.keys(scopes).map((k) => [k, true])));
   };
 
   const handleCreate = async () => {
     if (!keyName.trim()) return;
     setIsCreating(true);
-    const key = await onCreateKey(keyName.trim(), selectedScopes.length > 0 ? selectedScopes : undefined as unknown as string[]);
+    const key = await onCreateKey(
+      keyName.trim(),
+      selectedScopes.length > 0 ? selectedScopes : (undefined as unknown as string[]),
+    );
     if (key) {
       setCreatedKey(key);
     }
@@ -1669,7 +1801,7 @@ function CreateApiKeyDialog({
 
   const handleClose = () => {
     setKeyName('');
-    setScopes(Object.fromEntries(Object.keys(scopes).map(k => [k, false])));
+    setScopes(Object.fromEntries(Object.keys(scopes).map((k) => [k, false])));
     setCreatedKey(null);
     setCopied(false);
     onClose();
@@ -1678,8 +1810,14 @@ function CreateApiKeyDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={handleClose}>
-      <div className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 overflow-hidden" onClick={e => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
         {createdKey ? (
           <div className="p-6">
             <div className="flex items-center gap-3 mb-4">
@@ -1687,23 +1825,37 @@ function CreateApiKeyDialog({
                 <Check className="w-6 h-6 text-green-400" />
               </div>
               <div>
-                <h3 className="text-lg font-semibold text-text-primary">API Key Created</h3>
-                <p className="text-sm text-text-tertiary">Save this key now - you won&apos;t see it again!</p>
+                <h3 className="text-lg font-semibold text-text-primary">
+                  API Key Created
+                </h3>
+                <p className="text-sm text-text-tertiary">
+                  Save this key now - you won&apos;t see it again!
+                </p>
               </div>
             </div>
             <div className="p-4 rounded-xl bg-bg-tertiary mb-4">
               <p className="text-xs text-text-tertiary mb-2">Your API Key</p>
-              <code className="text-sm text-text-primary font-mono break-all">{createdKey.key}</code>
+              <code className="text-sm text-text-primary font-mono break-all">
+                {createdKey.key}
+              </code>
             </div>
             <div className="flex gap-3">
-              <button onClick={handleCopy} className={cn(
-                'flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-colors',
-                copied ? 'bg-green-500/20 text-green-400' : 'bg-purple-500 text-white hover:bg-purple-600'
-              )}>
+              <button
+                onClick={handleCopy}
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-colors',
+                  copied
+                    ? 'bg-green-500/20 text-green-400'
+                    : 'bg-purple-500 text-white hover:bg-purple-600',
+                )}
+              >
                 {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
                 {copied ? 'Copied!' : 'Copy Key'}
               </button>
-              <button onClick={handleClose} className="px-4 py-3 rounded-xl bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary transition-colors">
+              <button
+                onClick={handleClose}
+                className="px-4 py-3 rounded-xl bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary transition-colors"
+              >
                 Done
               </button>
             </div>
@@ -1712,18 +1864,23 @@ function CreateApiKeyDialog({
           <div className="p-6">
             <div className="flex items-center justify-between mb-6">
               <h3 className="text-lg font-semibold text-text-primary">Create API Key</h3>
-              <button onClick={handleClose} className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors">
+              <button
+                onClick={handleClose}
+                className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors"
+              >
                 <X className="w-5 h-5 text-text-tertiary" />
               </button>
             </div>
 
             <div className="space-y-6">
               <div>
-                <label className="block text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">Key Name</label>
+                <label className="block text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+                  Key Name
+                </label>
                 <input
                   type="text"
                   value={keyName}
-                  onChange={e => setKeyName(e.target.value)}
+                  onChange={(e) => setKeyName(e.target.value)}
                   placeholder="e.g., My App Integration"
                   className="w-full px-4 py-3 rounded-xl bg-bg-tertiary border border-white/[0.06] text-text-primary placeholder:text-text-quaternary focus:outline-none focus:border-purple-500"
                 />
@@ -1731,47 +1888,80 @@ function CreateApiKeyDialog({
 
               <div>
                 <div className="flex items-center justify-between mb-3">
-                  <label className="text-xs font-semibold text-text-tertiary uppercase tracking-wider">Permissions</label>
+                  <label className="text-xs font-semibold text-text-tertiary uppercase tracking-wider">
+                    Permissions
+                  </label>
                   <div className="flex gap-2">
-                    <button onClick={selectReadOnly} className={cn(
-                      'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
-                      isReadOnly ? 'bg-purple-500 text-white' : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary'
-                    )}>Read Only</button>
-                    <button onClick={selectFullAccess} className={cn(
-                      'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
-                      isFullAccess ? 'bg-purple-500 text-white' : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary'
-                    )}>Full Access</button>
+                    <button
+                      onClick={selectReadOnly}
+                      className={cn(
+                        'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+                        isReadOnly
+                          ? 'bg-purple-500 text-white'
+                          : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary',
+                      )}
+                    >
+                      Read Only
+                    </button>
+                    <button
+                      onClick={selectFullAccess}
+                      className={cn(
+                        'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+                        isFullAccess
+                          ? 'bg-purple-500 text-white'
+                          : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary',
+                      )}
+                    >
+                      Full Access
+                    </button>
                   </div>
                 </div>
 
                 <div className="space-y-2">
-                  {['Conversations', 'Memories', 'Action Items'].map(resource => {
+                  {['Conversations', 'Memories', 'Action Items'].map((resource) => {
                     const readKey = `${resource.toLowerCase().replace(' ', '_')}:read`;
                     const writeKey = `${resource.toLowerCase().replace(' ', '_')}:write`;
                     return (
-                      <div key={resource} className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary">
+                      <div
+                        key={resource}
+                        className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary"
+                      >
                         <span className="text-sm text-text-primary">{resource}</span>
                         <div className="flex bg-bg-quaternary rounded-lg overflow-hidden">
                           <button
-                            onClick={() => setScopes({ ...scopes, [readKey]: !scopes[readKey] })}
+                            onClick={() =>
+                              setScopes({ ...scopes, [readKey]: !scopes[readKey] })
+                            }
                             className={cn(
                               'px-3 py-1.5 text-xs font-semibold transition-colors',
-                              scopes[readKey] ? 'bg-blue-500 text-white' : 'text-text-quaternary hover:text-text-secondary'
+                              scopes[readKey]
+                                ? 'bg-blue-500 text-white'
+                                : 'text-text-quaternary hover:text-text-secondary',
                             )}
-                          >R</button>
+                          >
+                            R
+                          </button>
                           <button
-                            onClick={() => setScopes({ ...scopes, [writeKey]: !scopes[writeKey] })}
+                            onClick={() =>
+                              setScopes({ ...scopes, [writeKey]: !scopes[writeKey] })
+                            }
                             className={cn(
                               'px-3 py-1.5 text-xs font-semibold transition-colors',
-                              scopes[writeKey] ? 'bg-purple-500 text-white' : 'text-text-quaternary hover:text-text-secondary'
+                              scopes[writeKey]
+                                ? 'bg-purple-500 text-white'
+                                : 'text-text-quaternary hover:text-text-secondary',
                             )}
-                          >W</button>
+                          >
+                            W
+                          </button>
                         </div>
                       </div>
                     );
                   })}
                 </div>
-                <p className="text-xs text-text-quaternary mt-2">R = Read, W = Write. Defaults to read-only if nothing selected.</p>
+                <p className="text-xs text-text-quaternary mt-2">
+                  R = Read, W = Write. Defaults to read-only if nothing selected.
+                </p>
               </div>
 
               <button
@@ -1781,7 +1971,7 @@ function CreateApiKeyDialog({
                   'w-full py-3 rounded-xl font-medium transition-colors',
                   keyName.trim() && !isCreating
                     ? 'bg-purple-500 text-white hover:bg-purple-600'
-                    : 'bg-bg-tertiary text-text-quaternary cursor-not-allowed'
+                    : 'bg-bg-tertiary text-text-quaternary cursor-not-allowed',
                 )}
               >
                 {isCreating ? 'Creating...' : 'Create Key'}
@@ -1837,8 +2027,14 @@ function CreateMcpKeyDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={handleClose}>
-      <div className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 overflow-hidden" onClick={e => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
         {createdKey ? (
           <div className="p-6">
             <div className="flex items-center gap-3 mb-4">
@@ -1846,23 +2042,37 @@ function CreateMcpKeyDialog({
                 <Check className="w-6 h-6 text-green-400" />
               </div>
               <div>
-                <h3 className="text-lg font-semibold text-text-primary">MCP Key Created</h3>
-                <p className="text-sm text-text-tertiary">Save this key now - you won&apos;t see it again!</p>
+                <h3 className="text-lg font-semibold text-text-primary">
+                  MCP Key Created
+                </h3>
+                <p className="text-sm text-text-tertiary">
+                  Save this key now - you won&apos;t see it again!
+                </p>
               </div>
             </div>
             <div className="p-4 rounded-xl bg-bg-tertiary mb-4">
               <p className="text-xs text-text-tertiary mb-2">Your MCP Key</p>
-              <code className="text-sm text-text-primary font-mono break-all">{createdKey.key}</code>
+              <code className="text-sm text-text-primary font-mono break-all">
+                {createdKey.key}
+              </code>
             </div>
             <div className="flex gap-3">
-              <button onClick={handleCopy} className={cn(
-                'flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-colors',
-                copied ? 'bg-green-500/20 text-green-400' : 'bg-purple-500 text-white hover:bg-purple-600'
-              )}>
+              <button
+                onClick={handleCopy}
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-colors',
+                  copied
+                    ? 'bg-green-500/20 text-green-400'
+                    : 'bg-purple-500 text-white hover:bg-purple-600',
+                )}
+              >
                 {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
                 {copied ? 'Copied!' : 'Copy Key'}
               </button>
-              <button onClick={handleClose} className="px-4 py-3 rounded-xl bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary transition-colors">
+              <button
+                onClick={handleClose}
+                className="px-4 py-3 rounded-xl bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary transition-colors"
+              >
                 Done
               </button>
             </div>
@@ -1871,17 +2081,22 @@ function CreateMcpKeyDialog({
           <div className="p-6">
             <div className="flex items-center justify-between mb-6">
               <h3 className="text-lg font-semibold text-text-primary">Create MCP Key</h3>
-              <button onClick={handleClose} className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors">
+              <button
+                onClick={handleClose}
+                className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors"
+              >
                 <X className="w-5 h-5 text-text-tertiary" />
               </button>
             </div>
             <div className="space-y-4">
               <div>
-                <label className="block text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">Key Name</label>
+                <label className="block text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+                  Key Name
+                </label>
                 <input
                   type="text"
                   value={keyName}
-                  onChange={e => setKeyName(e.target.value)}
+                  onChange={(e) => setKeyName(e.target.value)}
                   placeholder="e.g., Claude Desktop"
                   className="w-full px-4 py-3 rounded-xl bg-bg-tertiary border border-white/[0.06] text-text-primary placeholder:text-text-quaternary focus:outline-none focus:border-purple-500"
                 />
@@ -1893,7 +2108,7 @@ function CreateMcpKeyDialog({
                   'w-full py-3 rounded-xl font-medium transition-colors',
                   keyName.trim() && !isCreating
                     ? 'bg-purple-500 text-white hover:bg-purple-600'
-                    : 'bg-bg-tertiary text-text-quaternary cursor-not-allowed'
+                    : 'bg-bg-tertiary text-text-quaternary cursor-not-allowed',
                 )}
               >
                 {isCreating ? 'Creating...' : 'Create Key'}
@@ -1936,6 +2151,17 @@ function DeveloperSection({
   const [showDeleteGraphDialog, setShowDeleteGraphDialog] = useState(false);
   const [copiedConfig, setCopiedConfig] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState(false);
+  const [copiedClaudeName, setCopiedClaudeName] = useState(false);
+  const [copiedClaudeUrl, setCopiedClaudeUrl] = useState(false);
+  const [copiedClaudeClientId, setCopiedClaudeClientId] = useState(false);
+  const [copiedClaudeSecret, setCopiedClaudeSecret] = useState(false);
+
+  // Claude connector values — mirror the 4 fields in Claude's "Add custom connector" form
+  const claudeConnectorName = 'Omi Memory';
+  const claudeConnectorUrl = mcpServerUrl;
+  const claudeConnectorClientId = 'omi';
+  // Use the first MCP key as the client secret; fall back to placeholder
+  const claudeConnectorSecret = mcpKeys.length > 0 ? mcpKeys[0].key : '';
 
   // Experimental features (stored in localStorage)
   const [experimentalFeatures, setExperimentalFeatures] = useState({
@@ -1960,7 +2186,10 @@ function DeveloperSection({
   }, []);
 
   // Save experimental features to localStorage when they change
-  const updateExperimentalFeature = (key: keyof typeof experimentalFeatures, value: boolean) => {
+  const updateExperimentalFeature = (
+    key: keyof typeof experimentalFeatures,
+    value: boolean,
+  ) => {
     const updated = { ...experimentalFeatures, [key]: value };
     setExperimentalFeatures(updated);
     if (typeof window !== 'undefined') {
@@ -2001,10 +2230,31 @@ function DeveloperSection({
   }, [webhooks]);
 
   const webhookTypes = [
-    { id: 'memory_created', label: 'Conversation Events', description: 'New conversation created', icon: MessageSquare },
-    { id: 'transcript_received', label: 'Real-time Transcript', description: 'Transcript received', icon: FileText },
-    { id: 'audio_bytes', label: 'Audio Bytes', description: 'Audio data received', icon: Radio, hasDelay: true },
-    { id: 'day_summary', label: 'Day Summary', description: 'Summary generated', icon: Calendar },
+    {
+      id: 'memory_created',
+      label: 'Conversation Events',
+      description: 'New conversation created',
+      icon: MessageSquare,
+    },
+    {
+      id: 'transcript_received',
+      label: 'Real-time Transcript',
+      description: 'Transcript received',
+      icon: FileText,
+    },
+    {
+      id: 'audio_bytes',
+      label: 'Audio Bytes',
+      description: 'Audio data received',
+      icon: Radio,
+      hasDelay: true,
+    },
+    {
+      id: 'day_summary',
+      label: 'Day Summary',
+      description: 'Summary generated',
+      icon: Calendar,
+    },
   ];
 
   const mcpServerUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.omi.me'}/v1/mcp/sse`;
@@ -2035,7 +2285,9 @@ function DeveloperSection({
       {/* Developer API Keys */}
       <div id="api-keys" className="space-y-3 scroll-mt-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">Developer API Keys</h3>
+          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">
+            Developer API Keys
+          </h3>
           <button
             onClick={() => setShowApiKeyDialog(true)}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-purple-500/10 text-purple-400 text-xs font-medium hover:bg-purple-500/20 transition-colors"
@@ -2048,10 +2300,15 @@ function DeveloperSection({
           {apiKeys.length > 0 ? (
             <div className="space-y-3">
               {apiKeys.map((apiKey) => (
-                <div key={apiKey.id} className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary">
+                <div
+                  key={apiKey.id}
+                  className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary"
+                >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm text-text-primary font-medium">{apiKey.name}</span>
+                      <span className="text-sm text-text-primary font-medium">
+                        {apiKey.name}
+                      </span>
                       <code className="text-xs text-text-tertiary font-mono bg-bg-quaternary px-2 py-0.5 rounded">
                         {apiKey.key_prefix}...
                       </code>
@@ -2063,7 +2320,8 @@ function DeveloperSection({
                     </div>
                     <p className="text-xs text-text-quaternary mt-1">
                       Created {new Date(apiKey.created_at).toLocaleDateString()}
-                      {apiKey.last_used_at && ` • Last used ${new Date(apiKey.last_used_at).toLocaleDateString()}`}
+                      {apiKey.last_used_at &&
+                        ` • Last used ${new Date(apiKey.last_used_at).toLocaleDateString()}`}
                     </p>
                   </div>
                   <button
@@ -2076,7 +2334,9 @@ function DeveloperSection({
               ))}
             </div>
           ) : (
-            <p className="text-sm text-text-quaternary text-center py-6">No API keys created yet</p>
+            <p className="text-sm text-text-quaternary text-center py-6">
+              No API keys created yet
+            </p>
           )}
         </Card>
       </div>
@@ -2085,9 +2345,15 @@ function DeveloperSection({
       <div id="mcp" className="space-y-3 scroll-mt-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">MCP</h3>
-            <a href="https://docs.omi.me/doc/developer/MCP" target="_blank" rel="noopener noreferrer"
-              className="text-xs text-purple-400 hover:text-purple-300 transition-colors">
+            <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">
+              MCP
+            </h3>
+            <a
+              href="https://docs.omi.me/doc/developer/MCP"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-purple-400 hover:text-purple-300 transition-colors"
+            >
               Docs ↗
             </a>
           </div>
@@ -2105,17 +2371,23 @@ function DeveloperSection({
           {mcpKeys.length > 0 ? (
             <div className="space-y-3">
               {mcpKeys.map((key) => (
-                <div key={key.id} className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary">
+                <div
+                  key={key.id}
+                  className="flex items-center justify-between p-3 rounded-xl bg-bg-tertiary"
+                >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-text-primary font-medium">{key.name}</span>
+                      <span className="text-sm text-text-primary font-medium">
+                        {key.name}
+                      </span>
                       <code className="text-xs text-text-tertiary font-mono bg-bg-quaternary px-2 py-0.5 rounded">
                         {key.key_prefix}...
                       </code>
                     </div>
                     <p className="text-xs text-text-quaternary mt-1">
                       Created {new Date(key.created_at).toLocaleDateString()}
-                      {key.last_used_at && ` • Last used ${new Date(key.last_used_at).toLocaleDateString()}`}
+                      {key.last_used_at &&
+                        ` • Last used ${new Date(key.last_used_at).toLocaleDateString()}`}
                     </p>
                   </div>
                   <button
@@ -2128,7 +2400,9 @@ function DeveloperSection({
               ))}
             </div>
           ) : (
-            <p className="text-sm text-text-quaternary text-center py-6">No MCP keys created yet</p>
+            <p className="text-sm text-text-quaternary text-center py-6">
+              No MCP keys created yet
+            </p>
           )}
         </Card>
 
@@ -2140,17 +2414,23 @@ function DeveloperSection({
             </div>
             <div>
               <p className="text-text-primary font-medium">Claude Desktop</p>
-              <p className="text-xs text-text-tertiary">Add to claude_desktop_config.json</p>
+              <p className="text-xs text-text-tertiary">
+                Add to claude_desktop_config.json
+              </p>
             </div>
           </div>
           <div className="p-4 rounded-xl bg-[#0d0d0d] border border-white/[0.06] font-mono text-xs overflow-x-auto">
-            <pre className="text-text-secondary whitespace-pre">{claudeDesktopConfig}</pre>
+            <pre className="text-text-secondary whitespace-pre">
+              {claudeDesktopConfig}
+            </pre>
           </div>
           <button
             onClick={copyConfig}
             className={cn(
               'w-full mt-3 flex items-center justify-center gap-2 py-2.5 rounded-xl transition-colors',
-              copiedConfig ? 'bg-green-500/20 text-green-400' : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary'
+              copiedConfig
+                ? 'bg-green-500/20 text-green-400'
+                : 'bg-bg-tertiary text-text-secondary hover:bg-bg-quaternary',
             )}
           >
             {copiedConfig ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
@@ -2158,51 +2438,164 @@ function DeveloperSection({
           </button>
         </Card>
 
-        {/* MCP Server Info */}
+        {/* Claude Connector — 4 copy fields mirroring Claude's "Add custom connector" form */}
         <Card>
           <div className="flex items-center gap-3 mb-4">
-            <div className="p-2 rounded-lg bg-bg-tertiary">
-              <Server className="w-5 h-5 text-text-tertiary" />
+            <div className="w-12 h-12 rounded-xl overflow-hidden bg-gradient-to-br from-orange-500/20 to-orange-600/10 border border-orange-500/20 flex items-center justify-center flex-shrink-0">
+              <span className="text-lg font-semibold text-orange-400">C</span>
             </div>
             <div>
-              <p className="text-text-primary font-medium">MCP Server</p>
-              <p className="text-xs text-text-tertiary">Connect AI assistants to your data</p>
+              <p className="text-text-primary font-medium">Claude</p>
+              <p className="text-xs text-text-tertiary">Live MCP or memory pack</p>
             </div>
           </div>
 
-          <div className="space-y-4">
+          <p className="text-sm text-text-secondary mb-4">
+            Connect over MCP so Claude reads your memories live, or copy a memory pack.
+            Each field below maps to Claude's{' '}
+            <span className="text-text-tertiary">
+              Settings → Connectors → Add custom connector
+            </span>{' '}
+            form.
+          </p>
+
+          <div className="space-y-3">
+            {/* Field 1: Name → pastes into Claude's "Name" input */}
             <div>
-              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">Server URL</p>
+              <p className="text-xs font-medium text-text-tertiary mb-1.5">
+                1. Name{' '}
+                <span className="text-purple-400/60 font-normal">→ Claude "Name"</span>
+              </p>
               <button
-                onClick={copyUrl}
-                className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors"
+                onClick={() => {
+                  navigator.clipboard.writeText(claudeConnectorName);
+                  setCopiedClaudeName(true);
+                  setTimeout(() => setCopiedClaudeName(false), 2000);
+                }}
+                className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors group"
               >
-                <code className="text-sm text-text-primary font-mono">{mcpServerUrl}</code>
-                {copiedUrl ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4 text-text-quaternary" />}
+                <code className="text-sm text-text-primary font-mono">
+                  {claudeConnectorName}
+                </code>
+                {copiedClaudeName ? (
+                  <Check className="w-4 h-4 text-green-400" />
+                ) : (
+                  <Copy className="w-4 h-4 text-text-quaternary group-hover:text-text-secondary transition-colors" />
+                )}
               </button>
             </div>
 
-            <div className="border-t border-white/[0.06] pt-4">
-              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">API Key Auth</p>
-              <div className="flex items-center gap-4 text-sm">
-                <span className="text-text-tertiary">Header</span>
-                <code className="text-text-quaternary font-mono text-xs">Authorization: Bearer &lt;key&gt;</code>
-              </div>
+            {/* Field 2: Server URL → pastes into Claude's "Remote MCP server URL" input */}
+            <div>
+              <p className="text-xs font-medium text-text-tertiary mb-1.5">
+                2. Remote MCP server URL{' '}
+                <span className="text-purple-400/60 font-normal">
+                  → Claude "Remote MCP server URL"
+                </span>
+              </p>
+              <button
+                onClick={() => {
+                  navigator.clipboard.writeText(claudeConnectorUrl);
+                  setCopiedClaudeUrl(true);
+                  setTimeout(() => setCopiedClaudeUrl(false), 2000);
+                }}
+                className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors group"
+              >
+                <code className="text-sm text-text-primary font-mono truncate mr-2">
+                  {claudeConnectorUrl}
+                </code>
+                {copiedClaudeUrl ? (
+                  <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+                ) : (
+                  <Copy className="w-4 h-4 text-text-quaternary group-hover:text-text-secondary transition-colors flex-shrink-0" />
+                )}
+              </button>
             </div>
 
-            <div className="border-t border-white/[0.06] pt-4">
-              <p className="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">OAuth</p>
-              <div className="space-y-2 text-sm">
-                <div className="flex items-center gap-4">
-                  <span className="text-text-tertiary w-24">Client ID</span>
-                  <code className="text-text-primary font-mono">omi</code>
-                </div>
-                <div className="flex items-center gap-4">
-                  <span className="text-text-tertiary w-24">Client Secret</span>
-                  <span className="text-text-quaternary italic text-xs">Use your MCP API key</span>
-                </div>
-              </div>
+            {/* Field 3: OAuth Client ID → pastes into Claude's Advanced "OAuth Client ID" */}
+            <div>
+              <p className="text-xs font-medium text-text-tertiary mb-1.5">
+                3. OAuth Client ID{' '}
+                <span className="text-purple-400/60 font-normal">
+                  → Claude Advanced "OAuth Client ID"
+                </span>
+              </p>
+              <button
+                onClick={() => {
+                  navigator.clipboard.writeText(claudeConnectorClientId);
+                  setCopiedClaudeClientId(true);
+                  setTimeout(() => setCopiedClaudeClientId(false), 2000);
+                }}
+                className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors group"
+              >
+                <code className="text-sm text-text-primary font-mono">
+                  {claudeConnectorClientId}
+                </code>
+                {copiedClaudeClientId ? (
+                  <Check className="w-4 h-4 text-green-400" />
+                ) : (
+                  <Copy className="w-4 h-4 text-text-quaternary group-hover:text-text-secondary transition-colors" />
+                )}
+              </button>
             </div>
+
+            {/* Field 4: OAuth Client Secret → pastes into Claude's Advanced "OAuth Client Secret" */}
+            <div>
+              <p className="text-xs font-medium text-text-tertiary mb-1.5">
+                4. OAuth Client Secret{' '}
+                <span className="text-purple-400/60 font-normal">
+                  → Claude Advanced "OAuth Client Secret"
+                </span>
+              </p>
+              {claudeConnectorSecret ? (
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(claudeConnectorSecret);
+                    setCopiedClaudeSecret(true);
+                    setTimeout(() => setCopiedClaudeSecret(false), 2000);
+                  }}
+                  className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] hover:border-purple-500/50 transition-colors group"
+                >
+                  <code className="text-sm text-text-primary font-mono truncate mr-2">
+                    {claudeConnectorSecret.slice(0, 8)}…{claudeConnectorSecret.slice(-4)}
+                  </code>
+                  {copiedClaudeSecret ? (
+                    <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+                  ) : (
+                    <Copy className="w-4 h-4 text-text-quaternary group-hover:text-text-secondary transition-colors flex-shrink-0" />
+                  )}
+                </button>
+              ) : (
+                <div className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] opacity-60">
+                  <span className="text-sm text-text-quaternary italic">
+                    Create an MCP key first (above)
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-4 pt-4 border-t border-white/[0.06]">
+            <ol className="text-xs text-text-tertiary space-y-1.5 list-decimal list-inside">
+              <li>
+                Open{' '}
+                <span className="text-text-secondary">
+                  claude.ai → Settings → Connectors → Add custom connector
+                </span>
+              </li>
+              <li>
+                Click each <span className="text-text-secondary">Copy</span> button above
+                and paste into the matching field
+              </li>
+              <li>
+                Under <span className="text-text-secondary">Advanced settings</span>,
+                paste OAuth Client ID + Secret
+              </li>
+              <li>
+                Click <span className="text-text-secondary">Add</span>, then{' '}
+                <span className="text-text-secondary">Connect</span>
+              </li>
+            </ol>
           </div>
         </Card>
       </div>
@@ -2210,9 +2603,15 @@ function DeveloperSection({
       {/* Webhooks */}
       <div id="webhooks" className="space-y-3 scroll-mt-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">Webhooks</h3>
-          <a href="https://docs.omi.me/doc/developer/apps/Introduction" target="_blank" rel="noopener noreferrer"
-            className="text-xs text-purple-400 hover:text-purple-300 transition-colors">
+          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">
+            Webhooks
+          </h3>
+          <a
+            href="https://docs.omi.me/doc/developer/apps/Introduction"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-purple-400 hover:text-purple-300 transition-colors"
+          >
             Docs ↗
           </a>
         </div>
@@ -2233,18 +2632,24 @@ function DeveloperSection({
                           <Icon className="w-4 h-4 text-text-tertiary" />
                         </div>
                         <div>
-                          <p className="text-text-primary font-medium text-sm">{webhook.label}</p>
-                          <p className="text-xs text-text-tertiary">{webhook.description}</p>
+                          <p className="text-text-primary font-medium text-sm">
+                            {webhook.label}
+                          </p>
+                          <p className="text-xs text-text-tertiary">
+                            {webhook.description}
+                          </p>
                         </div>
                       </div>
                       <Toggle
                         enabled={isEnabled}
-                        onChange={(enabled) => onWebhookChange(
-                          webhook.id,
-                          enabled,
-                          webhookUrls[webhook.id],
-                          webhook.hasDelay ? audioBytesDelay : undefined
-                        )}
+                        onChange={(enabled) =>
+                          onWebhookChange(
+                            webhook.id,
+                            enabled,
+                            webhookUrls[webhook.id],
+                            webhook.hasDelay ? audioBytesDelay : undefined,
+                          )
+                        }
                       />
                     </div>
                     {isEnabled && (
@@ -2252,13 +2657,20 @@ function DeveloperSection({
                         <input
                           type="url"
                           value={webhookUrls[webhook.id] || ''}
-                          onChange={(e) => setWebhookUrls({ ...webhookUrls, [webhook.id]: e.target.value })}
-                          onBlur={() => onWebhookChange(
-                            webhook.id,
-                            true,
-                            webhookUrls[webhook.id],
-                            webhook.hasDelay ? audioBytesDelay : undefined
-                          )}
+                          onChange={(e) =>
+                            setWebhookUrls({
+                              ...webhookUrls,
+                              [webhook.id]: e.target.value,
+                            })
+                          }
+                          onBlur={() =>
+                            onWebhookChange(
+                              webhook.id,
+                              true,
+                              webhookUrls[webhook.id],
+                              webhook.hasDelay ? audioBytesDelay : undefined,
+                            )
+                          }
                           placeholder="https://your-server.com/webhook"
                           className="w-full px-3 py-2 rounded-lg bg-bg-tertiary border border-white/[0.06] text-text-primary text-sm placeholder:text-text-quaternary focus:outline-none focus:border-purple-500"
                         />
@@ -2267,7 +2679,14 @@ function DeveloperSection({
                             type="number"
                             value={audioBytesDelay}
                             onChange={(e) => setAudioBytesDelay(e.target.value)}
-                            onBlur={() => onWebhookChange(webhook.id, true, webhookUrls[webhook.id], audioBytesDelay)}
+                            onBlur={() =>
+                              onWebhookChange(
+                                webhook.id,
+                                true,
+                                webhookUrls[webhook.id],
+                                audioBytesDelay,
+                              )
+                            }
                             placeholder="Interval (seconds)"
                             className="w-full px-3 py-2 rounded-lg bg-bg-tertiary border border-white/[0.06] text-text-primary text-sm placeholder:text-text-quaternary focus:outline-none focus:border-purple-500"
                           />
@@ -2284,14 +2703,18 @@ function DeveloperSection({
 
       {/* Data Management */}
       <div id="data-management" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">Data Management</h3>
+        <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">
+          Data Management
+        </h3>
         <Card>
           <button
             onClick={onExportData}
             disabled={isExporting}
             className={cn(
-              "w-full flex items-center gap-4 py-3 transition-colors",
-              isExporting ? "text-text-tertiary cursor-not-allowed" : "text-text-primary hover:text-purple-400"
+              'w-full flex items-center gap-4 py-3 transition-colors',
+              isExporting
+                ? 'text-text-tertiary cursor-not-allowed'
+                : 'text-text-primary hover:text-purple-400',
             )}
           >
             <div className="p-2 rounded-lg bg-bg-tertiary">
@@ -2302,9 +2725,13 @@ function DeveloperSection({
               )}
             </div>
             <div className="flex-1 text-left">
-              <p className="font-medium">{isExporting ? 'Exporting...' : 'Export All Data'}</p>
+              <p className="font-medium">
+                {isExporting ? 'Exporting...' : 'Export All Data'}
+              </p>
               <p className="text-xs text-text-tertiary">
-                {isExporting ? 'This may take a moment' : 'Export conversations to a JSON file'}
+                {isExporting
+                  ? 'This may take a moment'
+                  : 'Export conversations to a JSON file'}
               </p>
             </div>
             {!isExporting && <ExternalLink className="w-4 h-4 text-text-quaternary" />}
@@ -2320,7 +2747,9 @@ function DeveloperSection({
             </div>
             <div className="flex-1 text-left">
               <p className="font-medium">Delete Knowledge Graph</p>
-              <p className="text-xs text-text-tertiary">Clear all nodes and connections</p>
+              <p className="text-xs text-text-tertiary">
+                Clear all nodes and connections
+              </p>
             </div>
             <Trash2 className="w-4 h-4 text-text-quaternary" />
           </button>
@@ -2330,7 +2759,9 @@ function DeveloperSection({
       {/* Experimental Features */}
       <div id="experimental" className="space-y-3 scroll-mt-4">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">Experimental</h3>
+          <h3 className="text-sm font-semibold text-text-tertiary uppercase tracking-wider">
+            Experimental
+          </h3>
           <FlaskConical className="w-4 h-4 text-purple-400" />
         </div>
         <Card>
@@ -2342,8 +2773,12 @@ function DeveloperSection({
                   <Activity className="w-4 h-4 text-text-tertiary" />
                 </div>
                 <div>
-                  <p className="text-text-primary font-medium text-sm">Transcription Diagnostics</p>
-                  <p className="text-xs text-text-tertiary">Detailed diagnostic messages</p>
+                  <p className="text-text-primary font-medium text-sm">
+                    Transcription Diagnostics
+                  </p>
+                  <p className="text-xs text-text-tertiary">
+                    Detailed diagnostic messages
+                  </p>
                 </div>
               </div>
               <Toggle
@@ -2359,8 +2794,12 @@ function DeveloperSection({
                   <UserPlus className="w-4 h-4 text-text-tertiary" />
                 </div>
                 <div>
-                  <p className="text-text-primary font-medium text-sm">Auto-create Speakers</p>
-                  <p className="text-xs text-text-tertiary">Auto-create when name detected</p>
+                  <p className="text-text-primary font-medium text-sm">
+                    Auto-create Speakers
+                  </p>
+                  <p className="text-xs text-text-tertiary">
+                    Auto-create when name detected
+                  </p>
                 </div>
               </div>
               <Toggle
@@ -2376,8 +2815,12 @@ function DeveloperSection({
                   <Lightbulb className="w-4 h-4 text-text-tertiary" />
                 </div>
                 <div>
-                  <p className="text-text-primary font-medium text-sm">Follow-up Questions</p>
-                  <p className="text-xs text-text-tertiary">Suggest questions after conversations</p>
+                  <p className="text-text-primary font-medium text-sm">
+                    Follow-up Questions
+                  </p>
+                  <p className="text-xs text-text-tertiary">
+                    Suggest questions after conversations
+                  </p>
                 </div>
               </div>
               <Toggle
@@ -2394,7 +2837,9 @@ function DeveloperSection({
                 </div>
                 <div>
                   <p className="text-text-primary font-medium text-sm">Goal Tracker</p>
-                  <p className="text-xs text-text-tertiary">Track your personal goals on homepage</p>
+                  <p className="text-xs text-text-tertiary">
+                    Track your personal goals on homepage
+                  </p>
                 </div>
               </div>
               <Toggle
@@ -2436,16 +2881,26 @@ function DeveloperSection({
 
       {/* Delete Knowledge Graph Dialog */}
       {showDeleteGraphDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setShowDeleteGraphDialog(false)}>
-          <div className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 p-6" onClick={e => e.stopPropagation()}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => setShowDeleteGraphDialog(false)}
+        >
+          <div
+            className="bg-bg-secondary rounded-2xl w-full max-w-md mx-4 p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center gap-3 mb-4">
               <div className="p-3 rounded-xl bg-red-500/20">
                 <AlertTriangle className="w-6 h-6 text-red-400" />
               </div>
-              <h3 className="text-lg font-semibold text-text-primary">Delete Knowledge Graph?</h3>
+              <h3 className="text-lg font-semibold text-text-primary">
+                Delete Knowledge Graph?
+              </h3>
             </div>
             <p className="text-text-secondary text-sm mb-6">
-              This will delete all derived knowledge graph data (nodes and connections). Your original memories will remain safe. The graph will be rebuilt over time.
+              This will delete all derived knowledge graph data (nodes and connections).
+              Your original memories will remain safe. The graph will be rebuilt over
+              time.
             </p>
             <div className="flex gap-3">
               <button
@@ -2513,7 +2968,9 @@ function AccountSection({
               <Scale className="w-5 h-5 text-text-tertiary" />
               <div>
                 <span className="font-medium">Fair Use</span>
-                <p className="text-sm text-text-quaternary">View speech usage and policy status</p>
+                <p className="text-sm text-text-quaternary">
+                  View speech usage and policy status
+                </p>
               </div>
             </div>
             <ChevronRight className="w-4 h-4 text-text-quaternary" />
@@ -2523,7 +2980,9 @@ function AccountSection({
 
       {/* Account Actions */}
       <div id="actions" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Account Actions</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Account Actions
+        </h3>
         <Card>
           <button
             onClick={onSignOut}
@@ -2542,7 +3001,9 @@ function AccountSection({
             <Trash2 className="w-5 h-5" />
             <div className="text-left">
               <span className="font-medium block">Delete Account</span>
-              <span className="text-sm text-red-400/70">Permanently delete your account and all data</span>
+              <span className="text-sm text-red-400/70">
+                Permanently delete your account and all data
+              </span>
             </div>
           </button>
         </Card>
@@ -2550,7 +3011,9 @@ function AccountSection({
 
       {/* Support */}
       <div id="support" className="space-y-3 scroll-mt-4">
-        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">Support</h3>
+        <h3 className="text-sm font-medium text-text-tertiary uppercase tracking-wider">
+          Support
+        </h3>
         <Card>
           <a
             href="https://feedback.omi.me"
@@ -2582,7 +3045,10 @@ function AccountSection({
 
 // Section titles and descriptions for the header
 const SECTION_INFO: Record<SettingsSection, { title: string; description: string }> = {
-  profile: { title: 'Profile', description: 'Account details, language, and notifications' },
+  profile: {
+    title: 'Profile',
+    description: 'Account details, language, and notifications',
+  },
   privacy: { title: 'Privacy', description: 'Data permissions and training settings' },
   integrations: { title: 'Integrations', description: 'Connected services and apps' },
   developer: { title: 'Developer', description: 'API keys, webhooks, and data export' },
@@ -2598,9 +3064,10 @@ export function SettingsPage() {
 
   // Get section from URL, default to 'profile'
   const sectionParam = searchParams.get('section');
-  const activeSection: SettingsSection = (sectionParam && sectionParam in SECTION_INFO)
-    ? (sectionParam as SettingsSection)
-    : 'profile';
+  const activeSection: SettingsSection =
+    sectionParam && sectionParam in SECTION_INFO
+      ? (sectionParam as SettingsSection)
+      : 'profile';
 
   // Track which sections have been loaded (using ref to avoid dependency issues)
   const loadedSectionsRef = useRef<Set<SettingsSection>>(new Set());
@@ -2609,7 +3076,10 @@ export function SettingsPage() {
   // Settings state - each section's data
   const [language, setLanguage] = useState('en');
   const [vocabulary, setVocabulary] = useState<string[]>([]);
-  const [dailySummary, setDailySummary] = useState<DailySummarySettings>({ enabled: true, hour: 22 });
+  const [dailySummary, setDailySummary] = useState<DailySummarySettings>({
+    enabled: true,
+    hour: 22,
+  });
   const [recordingPermission, setRecordingPermissionState] = useState(false);
   const [trainingDataOptIn, setTrainingDataOptInState] = useState(false);
   const [allUsage, setAllUsage] = useState<AllUsageData | null>(null);
@@ -2671,7 +3141,15 @@ export function SettingsPage() {
           case 'developer':
             // Fetch API keys, MCP keys, webhook status, and individual webhook URLs in parallel
             // Note: Status API returns boolean fields, URL API returns {url: string}
-            const [keys, mKeys, webhookStatus, memoryUrl, transcriptUrl, audioBytesUrl, daySummaryUrl] = await Promise.all([
+            const [
+              keys,
+              mKeys,
+              webhookStatus,
+              memoryUrl,
+              transcriptUrl,
+              audioBytesUrl,
+              daySummaryUrl,
+            ] = await Promise.all([
               getDeveloperApiKeys().catch(() => []),
               getMcpApiKeys().catch(() => []),
               getDeveloperWebhooksStatus().catch(() => ({})),
@@ -2687,19 +3165,19 @@ export function SettingsPage() {
             setWebhooks({
               memory_created: {
                 url: memoryUrl?.url || '',
-                enabled: statusMap['memory_created'] ?? false
+                enabled: statusMap['memory_created'] ?? false,
               },
               transcript_received: {
                 url: transcriptUrl?.url || '',
-                enabled: statusMap['realtime_transcript'] ?? false
+                enabled: statusMap['realtime_transcript'] ?? false,
               },
               audio_bytes: {
                 url: audioBytesUrl?.url || '',
-                enabled: statusMap['audio_bytes'] ?? false
+                enabled: statusMap['audio_bytes'] ?? false,
               },
               day_summary: {
                 url: daySummaryUrl?.url || '',
-                enabled: statusMap['day_summary'] ?? false
+                enabled: statusMap['day_summary'] ?? false,
               },
             });
             break;
@@ -2806,7 +3284,10 @@ export function SettingsPage() {
     }
   };
 
-  const handleCreateApiKey = async (name: string, scopes: string[]): Promise<DeveloperApiKey | null> => {
+  const handleCreateApiKey = async (
+    name: string,
+    scopes: string[],
+  ): Promise<DeveloperApiKey | null> => {
     try {
       const newKey = await createDeveloperApiKey(name, scopes);
       setApiKeys([...apiKeys, newKey]);
@@ -2876,11 +3357,20 @@ export function SettingsPage() {
     }
   };
 
-  const handleWebhookChange = async (type: string, enabled: boolean, url?: string, delay?: string) => {
+  const handleWebhookChange = async (
+    type: string,
+    enabled: boolean,
+    url?: string,
+    delay?: string,
+  ) => {
     // Convert internal type names to API type names
     // UI uses 'transcript_received' but API expects 'realtime_transcript'
     const apiType = type === 'transcript_received' ? 'realtime_transcript' : type;
-    const webhookType = apiType as 'memory_created' | 'realtime_transcript' | 'audio_bytes' | 'day_summary';
+    const webhookType = apiType as
+      | 'memory_created'
+      | 'realtime_transcript'
+      | 'audio_bytes'
+      | 'day_summary';
     try {
       // For audio_bytes, combine URL and delay if both are provided
       const webhookUrl = type === 'audio_bytes' && url && delay ? `${url},${delay}` : url;
@@ -2894,7 +3384,10 @@ export function SettingsPage() {
       }
       setWebhooks({
         ...webhooks,
-        [type]: { enabled, url: url || webhooks[type as keyof DeveloperWebhooks]?.url || '' },
+        [type]: {
+          enabled,
+          url: url || webhooks[type as keyof DeveloperWebhooks]?.url || '',
+        },
       });
     } catch (error) {
       console.error('Failed to update webhook:', error);
@@ -3040,14 +3533,18 @@ export function SettingsPage() {
                 <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
               </div>
               <div>
-                <h3 className="text-lg font-semibold text-text-primary">Exporting Your Data</h3>
+                <h3 className="text-lg font-semibold text-text-primary">
+                  Exporting Your Data
+                </h3>
                 <p className="text-text-secondary mt-2 text-sm">
                   This may take a moment depending on the amount of data in your account.
                 </p>
               </div>
               <div className="flex items-center gap-2 bg-yellow-500/10 rounded-xl px-4 py-2">
                 <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0" />
-                <span className="text-xs text-yellow-400">Please don&apos;t close this tab</span>
+                <span className="text-xs text-yellow-400">
+                  Please don&apos;t close this tab
+                </span>
               </div>
             </div>
           </div>
@@ -3062,15 +3559,15 @@ export function SettingsPage() {
         <div className="max-w-4xl mx-auto px-6 lg:px-8 pt-6">
           <div className="flex gap-6">
             {/* Main content */}
-            <div className="flex-1 min-w-0">
-              {renderSection()}
-            </div>
+            <div className="flex-1 min-w-0">{renderSection()}</div>
 
             {/* Quick Nav Sidebar - only show on desktop when there are sections */}
             {quickNavSections.length > 0 && (
               <div className="hidden lg:block w-32 flex-shrink-0">
                 <div className="sticky top-4">
-                  <p className="text-xs font-medium text-text-quaternary uppercase tracking-wider mb-3">On this page</p>
+                  <p className="text-xs font-medium text-text-quaternary uppercase tracking-wider mb-3">
+                    On this page
+                  </p>
                   <nav className="space-y-1">
                     {quickNavSections.map((section) => (
                       <a

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -111,6 +111,35 @@ import type {
 
 type SettingsSection = 'profile' | 'privacy' | 'integrations' | 'developer' | 'account';
 
+const MCP_KEYS_STORAGE_KEY = 'omi_mcp_api_key_secrets';
+
+function getStoredMcpKeySecrets(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  try {
+    return JSON.parse(localStorage.getItem(MCP_KEYS_STORAGE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function storeMcpKeySecret(keyId: string, key: string): void {
+  if (typeof window === 'undefined') return;
+  const secrets = getStoredMcpKeySecrets();
+  secrets[keyId] = key;
+  localStorage.setItem(MCP_KEYS_STORAGE_KEY, JSON.stringify(secrets));
+}
+
+function removeMcpKeySecret(keyId: string): void {
+  if (typeof window === 'undefined') return;
+  const secrets = getStoredMcpKeySecrets();
+  delete secrets[keyId];
+  localStorage.setItem(MCP_KEYS_STORAGE_KEY, JSON.stringify(secrets));
+}
+
+function withStoredMcpKey(key: McpApiKey): McpApiKey {
+  return { ...key, key: key.key ?? getStoredMcpKeySecrets()[key.id] };
+}
+
 // ============================================================================
 // Reusable Components
 // ============================================================================
@@ -2156,12 +2185,13 @@ function DeveloperSection({
   const [copiedClaudeClientId, setCopiedClaudeClientId] = useState(false);
   const [copiedClaudeSecret, setCopiedClaudeSecret] = useState(false);
 
+  const mcpServerUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.omi.me'}/v1/mcp/sse`;
+
   // Claude connector values — mirror the 4 fields in Claude's "Add custom connector" form
   const claudeConnectorName = 'Omi Memory';
   const claudeConnectorUrl = mcpServerUrl;
   const claudeConnectorClientId = 'omi';
-  // Use the first MCP key as the client secret; fall back to placeholder
-  const claudeConnectorSecret = mcpKeys.length > 0 ? mcpKeys[0].key : '';
+  const claudeConnectorSecret = mcpKeys.find((k) => k.key)?.key ?? '';
 
   // Experimental features (stored in localStorage)
   const [experimentalFeatures, setExperimentalFeatures] = useState({
@@ -2256,8 +2286,6 @@ function DeveloperSection({
       icon: Calendar,
     },
   ];
-
-  const mcpServerUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.omi.me'}/v1/mcp/sse`;
 
   const claudeDesktopConfig = `{
   "mcpServers": {
@@ -2568,7 +2596,9 @@ function DeveloperSection({
               ) : (
                 <div className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] opacity-60">
                   <span className="text-sm text-text-quaternary italic">
-                    Create an MCP key first (above)
+                    {mcpKeys.length > 0
+                      ? 'Create a new MCP key above to copy the secret'
+                      : 'Create an MCP key first (above)'}
                   </span>
                 </div>
               )}
@@ -3159,7 +3189,7 @@ export function SettingsPage() {
               getDeveloperWebhook('day_summary').catch(() => ({ url: '' })),
             ]);
             setApiKeys(keys);
-            setMcpKeys(mKeys);
+            setMcpKeys(mKeys.map(withStoredMcpKey));
             // Combine status (booleans) with URLs
             const statusMap = webhookStatus as Record<string, boolean>;
             setWebhooks({
@@ -3310,6 +3340,9 @@ export function SettingsPage() {
   const handleCreateMcpKey = async (name: string): Promise<McpApiKey | null> => {
     try {
       const newKey = await createMcpApiKey(name);
+      if (newKey.key) {
+        storeMcpKeySecret(newKey.id, newKey.key);
+      }
       setMcpKeys([...mcpKeys, newKey]);
       return newKey;
     } catch (error) {
@@ -3321,6 +3354,7 @@ export function SettingsPage() {
   const handleDeleteMcpKey = async (keyId: string) => {
     try {
       await deleteMcpApiKey(keyId);
+      removeMcpKeySecret(keyId);
       setMcpKeys(mcpKeys.filter((k) => k.id !== keyId));
     } catch (error) {
       console.error('Failed to delete MCP key:', error);

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -111,35 +111,6 @@ import type {
 
 type SettingsSection = 'profile' | 'privacy' | 'integrations' | 'developer' | 'account';
 
-const MCP_KEYS_STORAGE_KEY = 'omi_mcp_api_key_secrets';
-
-function getStoredMcpKeySecrets(): Record<string, string> {
-  if (typeof window === 'undefined') return {};
-  try {
-    return JSON.parse(localStorage.getItem(MCP_KEYS_STORAGE_KEY) || '{}');
-  } catch {
-    return {};
-  }
-}
-
-function storeMcpKeySecret(keyId: string, key: string): void {
-  if (typeof window === 'undefined') return;
-  const secrets = getStoredMcpKeySecrets();
-  secrets[keyId] = key;
-  localStorage.setItem(MCP_KEYS_STORAGE_KEY, JSON.stringify(secrets));
-}
-
-function removeMcpKeySecret(keyId: string): void {
-  if (typeof window === 'undefined') return;
-  const secrets = getStoredMcpKeySecrets();
-  delete secrets[keyId];
-  localStorage.setItem(MCP_KEYS_STORAGE_KEY, JSON.stringify(secrets));
-}
-
-function withStoredMcpKey(key: McpApiKey): McpApiKey {
-  return { ...key, key: key.key ?? getStoredMcpKeySecrets()[key.id] };
-}
-
 // ============================================================================
 // Reusable Components
 // ============================================================================
@@ -2597,7 +2568,7 @@ function DeveloperSection({
                 <div className="w-full flex items-center justify-between p-3 rounded-xl bg-[#0d0d0d] border border-white/[0.06] opacity-60">
                   <span className="text-sm text-text-quaternary italic">
                     {mcpKeys.length > 0
-                      ? 'Create a new MCP key above to copy the secret'
+                      ? 'Create a new MCP key above — existing keys cannot be retrieved'
                       : 'Create an MCP key first (above)'}
                   </span>
                 </div>
@@ -3189,7 +3160,11 @@ export function SettingsPage() {
               getDeveloperWebhook('day_summary').catch(() => ({ url: '' })),
             ]);
             setApiKeys(keys);
-            setMcpKeys(mKeys.map(withStoredMcpKey));
+            // Full MCP key is only returned at creation time; keep secrets in memory for this session only.
+            if (typeof window !== 'undefined') {
+              localStorage.removeItem('omi_mcp_api_key_secrets');
+            }
+            setMcpKeys(mKeys);
             // Combine status (booleans) with URLs
             const statusMap = webhookStatus as Record<string, boolean>;
             setWebhooks({
@@ -3340,9 +3315,6 @@ export function SettingsPage() {
   const handleCreateMcpKey = async (name: string): Promise<McpApiKey | null> => {
     try {
       const newKey = await createMcpApiKey(name);
-      if (newKey.key) {
-        storeMcpKeySecret(newKey.id, newKey.key);
-      }
       setMcpKeys([...mcpKeys, newKey]);
       return newKey;
     } catch (error) {
@@ -3354,7 +3326,6 @@ export function SettingsPage() {
   const handleDeleteMcpKey = async (keyId: string) => {
     try {
       await deleteMcpApiKey(keyId);
-      removeMcpKeySecret(keyId);
       setMcpKeys(mcpKeys.filter((k) => k.id !== keyId));
     } catch (error) {
       console.error('Failed to delete MCP key:', error);


### PR DESCRIPTION
## Summary
- add Claude-specific connector copy fields to web Developer Settings
- add matching Claude connector fields and setup instructions to the macOS memory export sheet
- keep newly-created MCP secrets in session memory only instead of persisting them to localStorage

## Source
Ported from Git-on-my-level/omi#32 after confirming the five fork PR commits were not present on current BasedHardware/omi main.

## Validation
- git diff --check origin/main...HEAD
- npm ci
- node_modules/.bin/tsc --noEmit
- xcrun swift build -c debug --package-path Desktop

## Notes
- npm audit reports existing dependency vulnerabilities after npm ci: 1 low, 1 moderate, 2 high.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

