### PR TITLE
docs(agents): add Cursor Cloud backend dev setup instructions

### DIFF
--- a/.cursor/cloud-agent-environment.md
+++ b/.cursor/cloud-agent-environment.md
@@ -1,0 +1,38 @@
+# Cursor Cloud agent environment (Linux x86 VM)
+
+Guidance for AI agents running in a Cursor Cloud VM. Linked from `AGENTS.md`.
+
+## What runs here
+
+Only the **Python backend** (`backend/`) is exercised on this VM. The macOS desktop app, iOS/Android builds, and firmware **cannot** be built or run here (they need macOS/Xcode, the Android SDK, or embedded hardware).
+
+Preinstalled in the snapshot: `uv` (global), `redis-server`, `firebase-tools` (Firestore emulator), Java 21, FFmpeg, Node. The startup update script refreshes `backend/.venv` from `backend/pylock.toml` (idempotent `uv pip sync`). To use the venv: `cd backend && source .venv/bin/activate`.
+
+## Preferred: hermetic E2E harness (no credentials)
+
+The backend constructs Firestore, GCS, OpenAI, Pinecone, and Typesense clients **at import time**, so it normally won't even import without those services/keys. The repo ships a fully hermetic harness that imports the **real** FastAPI app with in-process fakes (`fake_firestore`, `fakeredis`, fake GCS), `LOCAL_DEVELOPMENT=true` auth, and an outbound-network guard — no credentials, no emulator, nothing to start:
+
+```bash
+cd backend && source .venv/bin/activate
+bash testing/e2e/run.sh -q --tb=short
+```
+
+This is the best way to validate backend changes end-to-end on this VM (real routers, auth, encryption, middleware against the fakes). It is the same harness CI runs (`.github/workflows/backend-hermetic-e2e.yml`). Verified here: **72 passed, 6 skipped**. Add new hermetic scenarios under `backend/testing/e2e/`; fixtures and the `client`/`auth_headers` fixtures live in `backend/testing/e2e/conftest.py` (dev auth is `Authorization: Bearer dev-token` → uid `123`).
+
+## Unit tests (known pre-existing failures on `main`)
+
+`bash test.sh` runs each file in its own pytest process under `set -e`, so it **halts at the first failing file**. On current `main` that is `tests/unit/test_speaker_sample.py` (pre-existing: it patches `deepgram_prerecorded_from_bytes`, renamed to `prerecorded_from_bytes`). Async-heavy files also fail because `pytest-asyncio` is **not** in the lock and no `asyncio_mode` is configured. Run files individually (`pytest tests/unit/test_x.py`) to validate; ~129/172 unit-test files pass in isolation. Do **not** run the whole `tests/unit` dir in one pytest process — cross-file mock contamination causes mass false failures (the per-file isolation in `test.sh` is intentional).
+
+## Running the backend live (manual API calls)
+
+Only needed when the hermetic harness isn't enough (e.g. poking endpoints with `curl`). Unlike the harness, a live `uvicorn` process has no fakes injected, so it needs the import-time clients satisfied. `backend/.env` is pre-seeded for this (gitignored, persists via snapshot): Firestore emulator (`FIRESTORE_EMULATOR_HOST=127.0.0.1:8081`, `GOOGLE_CLOUD_PROJECT=demo-omi`), a dummy `GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json` so the GCS client constructs, placeholder `OPENAI_API_KEY`/`TYPESENSE_*`, `ENCRYPTION_SECRET`, `ADMIN_KEY=local_dev_admin_key`, and **Pinecone left unset** so `database/vector_db.py` takes its `index = None` no-op path. If `backend/.env` is missing, recreate it from `.env.template` plus those values, and regenerate `google-credentials.json` as any syntactically valid service-account JSON (a generated RSA key — Firestore I/O goes to the emulator, not real GCP).
+
+```bash
+redis-server --daemonize yes
+firebase emulators:start --only firestore --project demo-omi   # needs a firebase.json pinning firestore to :8081
+cd backend && source .venv/bin/activate && python -m uvicorn main:app --host 0.0.0.0 --port 8080
+```
+
+Auth: `Authorization: Bearer local_dev_admin_key<uid>` (the `<uid>` is taken verbatim), or set `LOCAL_DEVELOPMENT=true` and use `Bearer dev-token` → uid `123`. Verified hello-world: `POST /v3/memories` then `GET /v3/memories` round-trips through the emulator.
+
+Features needing real external services (Deepgram STT, LLM chat, GCS audio, Pinecone/Typesense search) fail at **call time** with placeholders — that's expected, not an env bug. Supply real keys / `SERVICE_ACCOUNT_JSON` to exercise them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,3 +254,18 @@ Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f bran
 - If a PR changes setup, test commands, safety rules, service boundaries, or env vars — update this file in the same PR.
 - For architecture / core flow / API changes — update Mintlify docs (`docs/doc/developer/`) in the same PR.
 - If a PR changes audio streaming, transcription, conversation lifecycle, or listen/pusher WebSocket — update `docs/doc/developer/backend/listen_pusher_pipeline.mdx`.
+
+## Cursor Cloud specific instructions
+
+This is a **Linux x86 VM**: only the Python services run here. The macOS desktop app, iOS/Android builds, and firmware **cannot** be built/run on this VM. The runnable target is the **Python backend** (`backend/`). `uv` (global), `redis-server`, `firebase-tools`, Java 21, and FFmpeg are preinstalled in the snapshot; the startup update script refreshes `backend/.venv` from `backend/pylock.toml`.
+
+### Running the backend (no real cloud creds)
+The backend constructs Firestore, GCS, OpenAI, Pinecone, and Typesense clients **at import time**, so it won't even import without satisfying them. For local dev without real credentials, `backend/.env` is pre-seeded (gitignored, persists in snapshot) with: `FIRESTORE_EMULATOR_HOST=127.0.0.1:8081`, `GOOGLE_CLOUD_PROJECT=demo-omi`, a dummy `GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json` (lets the GCS client construct), placeholder `OPENAI_API_KEY` + `TYPESENSE_*`, `ENCRYPTION_SECRET`, `ADMIN_KEY=local_dev_admin_key`, and **Pinecone left unset** (so `database/vector_db.py` takes its `index = None` no-op path). If `backend/.env` is missing, recreate it from `.env.template` plus these values, and regenerate `google-credentials.json` as a syntactically valid service-account JSON (any generated RSA key — Firestore reads/writes go to the emulator, not real GCP).
+- Start Firestore emulator: `firebase emulators:start --only firestore --project demo-omi` from a dir with a `firebase.json` pinning firestore to port 8081 (a demo project id forces emulator-only mode, no creds).
+- Start Redis: `redis-server --daemonize yes`.
+- Start API: `cd backend && source .venv/bin/activate && python -m uvicorn main:app --host 0.0.0.0 --port 8080` (or `./scripts/dev-serve.sh`).
+- Auth bypass for local API calls: `Authorization: Bearer local_dev_admin_key<uid>` (the `<uid>` is taken verbatim as the user id). Verified hello-world: `POST /v3/memories` then `GET /v3/memories` round-trips through the Firestore emulator.
+- Features needing real external services (Deepgram STT, LLM chat, GCS audio, Pinecone/Typesense search) fail at **call time** with placeholders — that's expected, not an env bug. Supply real keys/`SERVICE_ACCOUNT_JSON` to exercise them.
+
+### Backend tests (known pre-existing failures on `main`)
+`bash test.sh` runs each file in its own pytest process and uses `set -e`, so it **halts at the first failing file**. On current `main` that is `tests/unit/test_speaker_sample.py` (pre-existing: it patches `deepgram_prerecorded_from_bytes`, renamed to `prerecorded_from_bytes`). Async-heavy files also fail because `pytest-asyncio` is **not** in the lock and no `asyncio_mode` is configured. Run files individually (`pytest tests/unit/test_x.py`) to validate; ~129/172 unit-test files pass in isolation. Do not run the whole `tests/unit` dir in one pytest process — cross-file mock contamination causes mass false failures (the per-file isolation in `test.sh` is intentional).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,15 +257,4 @@ Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f bran
 
 ## Cursor Cloud specific instructions
 
-This is a **Linux x86 VM**: only the Python services run here. The macOS desktop app, iOS/Android builds, and firmware **cannot** be built/run on this VM. The runnable target is the **Python backend** (`backend/`). `uv` (global), `redis-server`, `firebase-tools`, Java 21, and FFmpeg are preinstalled in the snapshot; the startup update script refreshes `backend/.venv` from `backend/pylock.toml`.
-
-### Running the backend (no real cloud creds)
-The backend constructs Firestore, GCS, OpenAI, Pinecone, and Typesense clients **at import time**, so it won't even import without satisfying them. For local dev without real credentials, `backend/.env` is pre-seeded (gitignored, persists in snapshot) with: `FIRESTORE_EMULATOR_HOST=127.0.0.1:8081`, `GOOGLE_CLOUD_PROJECT=demo-omi`, a dummy `GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json` (lets the GCS client construct), placeholder `OPENAI_API_KEY` + `TYPESENSE_*`, `ENCRYPTION_SECRET`, `ADMIN_KEY=local_dev_admin_key`, and **Pinecone left unset** (so `database/vector_db.py` takes its `index = None` no-op path). If `backend/.env` is missing, recreate it from `.env.template` plus these values, and regenerate `google-credentials.json` as a syntactically valid service-account JSON (any generated RSA key — Firestore reads/writes go to the emulator, not real GCP).
-- Start Firestore emulator: `firebase emulators:start --only firestore --project demo-omi` from a dir with a `firebase.json` pinning firestore to port 8081 (a demo project id forces emulator-only mode, no creds).
-- Start Redis: `redis-server --daemonize yes`.
-- Start API: `cd backend && source .venv/bin/activate && python -m uvicorn main:app --host 0.0.0.0 --port 8080` (or `./scripts/dev-serve.sh`).
-- Auth bypass for local API calls: `Authorization: Bearer local_dev_admin_key<uid>` (the `<uid>` is taken verbatim as the user id). Verified hello-world: `POST /v3/memories` then `GET /v3/memories` round-trips through the Firestore emulator.
-- Features needing real external services (Deepgram STT, LLM chat, GCS audio, Pinecone/Typesense search) fail at **call time** with placeholders — that's expected, not an env bug. Supply real keys/`SERVICE_ACCOUNT_JSON` to exercise them.
-
-### Backend tests (known pre-existing failures on `main`)
-`bash test.sh` runs each file in its own pytest process and uses `set -e`, so it **halts at the first failing file**. On current `main` that is `tests/unit/test_speaker_sample.py` (pre-existing: it patches `deepgram_prerecorded_from_bytes`, renamed to `prerecorded_from_bytes`). Async-heavy files also fail because `pytest-asyncio` is **not** in the lock and no `asyncio_mode` is configured. Run files individually (`pytest tests/unit/test_x.py`) to validate; ~129/172 unit-test files pass in isolation. Do not run the whole `tests/unit` dir in one pytest process — cross-file mock contamination causes mass false failures (the per-file isolation in `test.sh` is intentional).
+Running in a Cursor Cloud VM (Linux x86)? See **[.cursor/cloud-agent-environment.md](.cursor/cloud-agent-environment.md)** — what runs here, the credential-free **hermetic E2E harness** (preferred), running the backend live, and known pre-existing test failures.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for running the **Omi Python backend** on a Cursor Cloud Linux VM. This VM is Linux x86, so only the Python services run here (the macOS desktop app, iOS/Android builds, and firmware cannot).

### Docs layout
- `AGENTS.md` keeps only a short `## Cursor Cloud specific instructions` pointer.
- Full detail lives in **`.cursor/cloud-agent-environment.md`**: what runs here, the credential-free hermetic E2E harness (preferred), running the backend live for manual calls, and known pre-existing test failures.
- `backend/.env` and `backend/google-credentials.json` are intentionally gitignored (local-dev only; persisted via VM snapshot).

### Environment (snapshot + update script)
- Installed `uv` (global), `redis-server`, `firebase-tools` (Firestore emulator) alongside preinstalled Java 21 / FFmpeg / Node; synced `backend/.venv` (Python 3.11.15) from `backend/pylock.toml`.
- Registered a minimal, idempotent startup update script that refreshes the venv from the lock.

### Preferred validation: hermetic E2E harness (no credentials)
The repo's `backend/testing/e2e/run.sh` imports the **real** FastAPI app with in-process fakes (`fake_firestore`, `fakeredis`, fake GCS), `LOCAL_DEVELOPMENT=true` auth, and an outbound-network guard — no creds, no emulator. This is the clean way around the VM's credential limits and is what CI runs.

[backend_hermetic_e2e.log](https://cursor.com/agents/bc-94b76dad-1638-4f94-8b57-a87315a1ca87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_hermetic_e2e.log)

### Live backend (manual API) hello-world
For `curl`-style poking, the backend also boots live against the Firestore emulator + placeholder env; verified a real `POST` + `GET /v3/memories` round-trip:

[backend_hello_world.log](https://cursor.com/agents/bc-94b76dad-1638-4f94-8b57-a87315a1ca87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_hello_world.log)

### Notes for reviewers
- `backend/test.sh` halts at the first failing file; on current `main` that is the pre-existing `tests/unit/test_speaker_sample.py` breakage (patches the renamed `deepgram_prerecorded_from_bytes`). Many async test files also fail because `pytest-asyncio` is absent from the lock. ~129/172 unit-test files pass in isolation. None of these are caused by this change — prefer the hermetic harness for backend validation.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94b76dad-1638-4f94-8b57-a87315a1ca87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94b76dad-1638-4f94-8b57-a87315a1ca87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

