### PR TITLE
Clamp desktop goal progress

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -2734,7 +2734,8 @@ struct Goal: Codable, Identifiable {
   /// Progress as a percentage (0-100), based on targetValue
   var progress: Double {
     guard targetValue != minValue else { return 0 }
-    return ((currentValue - minValue) / (targetValue - minValue)) * 100.0
+    let pct = ((currentValue - minValue) / (targetValue - minValue)) * 100.0
+    return min(max(pct, 0), 100)
   }
 
   /// Whether the goal is completed

--- a/desktop/macos/Desktop/Tests/GoalProgressTests.swift
+++ b/desktop/macos/Desktop/Tests/GoalProgressTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class GoalProgressTests: XCTestCase {
+  private func makeGoal(min: Double, target: Double, current: Double) throws -> Goal {
+    let json = """
+      {
+        "id": "goal-1",
+        "goal_type": "numeric",
+        "min_value": \(min),
+        "target_value": \(target),
+        "current_value": \(current)
+      }
+      """
+    return try JSONDecoder().decode(Goal.self, from: Data(json.utf8))
+  }
+
+  func testProgressMidRange() throws {
+    let goal = try makeGoal(min: 0, target: 10, current: 5)
+    XCTAssertEqual(goal.progress, 50, accuracy: 0.0001)
+  }
+
+  func testProgressClampsBelowMinToZero() throws {
+    let goal = try makeGoal(min: 5, target: 15, current: 2)
+    XCTAssertEqual(goal.progress, 0, accuracy: 0.0001)
+  }
+
+  func testProgressClampsAboveTargetToHundred() throws {
+    let goal = try makeGoal(min: 0, target: 10, current: 20)
+    XCTAssertEqual(goal.progress, 100, accuracy: 0.0001)
+  }
+
+  func testProgressIsZeroWhenTargetEqualsMin() throws {
+    let goal = try makeGoal(min: 5, target: 5, current: 5)
+    XCTAssertEqual(goal.progress, 0, accuracy: 0.0001)
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: desktop goal progress can calculate below `0` or above `100` even though `Goal.progress` is documented as a percentage in the `0...100` range.
- What changed: clamp the computed desktop `Goal.progress` percentage to `0...100` at the model boundary.
- What did NOT change (scope boundary): no API contract changes, no backend changes, no UI redesign, and no docs.

## Linked Issue / Bounty

- N/A — independent contribution.
- Related context: this supersedes the older draft PR #8003 on top of current `main`.

## Root Cause (bug fixes only)

- Root cause: `Goal.progress` computed a raw percentage from `currentValue`, `minValue`, and `targetValue` but did not clamp the result, so out-of-range backend/local values could leak into desktop progress UI.
- Why it wasn't caught before: callers handled some display cases, but the model property itself did not enforce its documented range.

## How It Works

`Goal.progress` still uses the existing percentage calculation and `targetValue == minValue` guard. The result is now clamped with `min(max(pct, 0), 100)` before being returned.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore / infra

## Scope

- [ ] Mobile app (Flutter)
- [x] Desktop app (Swift/macOS)
- [ ] Backend (Python API)
- [ ] Firmware / hardware
- [ ] Plugins / integrations
- [ ] SDKs (Expo / React Native / Python / Swift)
- [ ] MCP server
- [ ] Web frontend
- [ ] Docs
- [ ] CI / build / infra

## Security Impact

- New permissions or capabilities introduced? No
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No
- New or changed network calls? No
- Plugin or tool execution surface changed? No
- If any `Yes` — risk and mitigation: N/A

## Testing

- [ ] Built locally
- [ ] Manual verification:
  - N/A — model calculation clamp; no new UI surface or route.
- [ ] Existing tests pass
- [x] New tests added (if applicable)
  - `GoalProgressTests` covers mid-range progress, below-min clamping, above-target clamping, and the `targetValue == minValue` guard.

Commands run:

- `git diff --check` — passed
- `xcrun swiftc -parse Desktop/Sources/APIClient.swift Desktop/Tests/GoalProgressTests.swift` — passed
- `xcrun swift test --package-path Desktop --filter GoalProgressTests` — attempted, blocked by existing upstream compile errors in unchanged `Desktop/Sources/Rewind/Core/RewindDatabase.swift` (`expression is 'async' but is not marked with 'await'` at lines 2876, 2885, 2894, and 2902). This PR does not touch that file.
- `xcrun swift build -c debug --package-path Desktop` — attempted earlier with the same unrelated `RewindDatabase.swift` blocker.

## Human Verification

- Verified scenarios:
  - Confirmed current `main` still returned raw unclamped `Goal.progress` before this PR.
  - Confirmed this branch changes only `desktop/macos/Desktop/Sources/APIClient.swift` and `desktop/macos/Desktop/Tests/GoalProgressTests.swift`.
  - Confirmed the changed source and test file parse successfully.
- Edge cases checked:
  - Mid-range progress returns `50`.
  - Values below range clamp to `0`.
  - Values above range clamp to `100`.
  - `targetValue == minValue` remains guarded as `0`.
- What you did **not** verify (and why):
  - Full desktop build/runtime QA, because current upstream package build is blocked by unrelated `RewindDatabase.swift` async/await compile errors in unchanged code.

## Evidence

- [ ] Screenshot or recording
- [ ] Log output (before/after)
- [x] Test output
- [ ] N/A — change is not user-visible

Evidence is the command output listed above; this change has no new visual surface.

## Docs

- [ ] Updated docs in [`docs/`](https://github.com/BasedHardware/omi/tree/main/docs) (if user-facing change)
- [x] N/A — no docs impact

## Performance, Privacy, and Reliability

Reliability improves by enforcing the documented progress range at the model boundary. No performance or privacy impact.

## Migration / Backward Compatibility

- Backward compatible? Yes
- Migration needed? No
- If yes, upgrade steps: N/A

## Risks and Mitigations

- Risk: If a future caller intentionally wants overachievement above 100%, that value will no longer come from `Goal.progress`.
  - Mitigation: The property is documented as `0-100`, and raw values remain available through `currentValue`, `minValue`, and `targetValue`.

## AI Disclosure

- Tools used: OpenAI Codex.
- AI-assisted portions: branch preparation, code edit, focused test addition, verification commands, and PR body drafting.
- How you verified correctness: inspected current upstream implementation, kept the diff scoped to the desktop model and focused XCTest coverage, ran `git diff --check`, parsed the changed source and test file, and attempted focused/full package verification with the unrelated upstream blocker documented above.
