### PR TITLE
fix(desktop): key conversation-count cache by query params (#8195)

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -29,8 +29,9 @@ actor APIClient {
   // Short-lived caches to deduplicate simultaneous calls from multiple services
   private var goalsCacheTime: Date?
   private var goalsCache: [Goal]?
-  private var conversationsCountCacheTime: Date?
-  private var conversationsCountCache: Int?
+  // Keyed by the query parameters so a cached total for one filter set is never
+  // returned for a different one (e.g. includeDiscarded / statuses).
+  private var conversationsCountCache: [String: (count: Int, time: Date)] = [:]
 
   init() {
     let config = URLSessionConfiguration.default
@@ -512,12 +513,6 @@ extension APIClient {
     includeDiscarded: Bool = false,
     statuses: [ConversationStatus] = [.completed, .processing]
   ) async throws -> Int {
-    if let cache = conversationsCountCache, let time = conversationsCountCacheTime,
-      Date().timeIntervalSince(time) < 5
-    {
-      return cache
-    }
-
     var queryItems: [String] = [
       "include_discarded=\(includeDiscarded)"
     ]
@@ -529,13 +524,16 @@ extension APIClient {
 
     let endpoint = "v1/conversations/count?\(queryItems.joined(separator: "&"))"
 
+    if let cache = conversationsCountCache[endpoint], Date().timeIntervalSince(cache.time) < 5 {
+      return cache.count
+    }
+
     struct CountResponse: Decodable {
       let count: Int
     }
 
     let response: CountResponse = try await get(endpoint)
-    conversationsCountCache = response.count
-    conversationsCountCacheTime = Date()
+    conversationsCountCache[endpoint] = (count: response.count, time: Date())
     return response.count
   }
 


### PR DESCRIPTION
## Bug
`APIClient.getConversationsCount(includeDiscarded:statuses:)` (desktop) memoized the total in a single `conversationsCountCache` slot that was **not keyed by the request parameters**. Within the 5s dedup window, a count fetched for one filter set (e.g. `includeDiscarded: false`, default statuses) could be returned for a call with different `includeDiscarded`/`statuses` — a misleading total. Called out as one bullet of #8195.

## Root cause
The cache stored only `(count, time)` with no parameter key, so any two calls within 5s collided regardless of their query.

## Fix
Build the request endpoint string (which already encodes `include_discarded` + `statuses`) first and use it as the cache key: `[String: (count, time)]`. Same-param calls still dedup; different-param calls no longer cross-contaminate. Behavior for the current callers (all default params) is unchanged; this hardens the path before any new caller passes different filters.

Scope intentionally limited to the cache-key correctness bullet. The other parts of #8195 (count endpoint lacking folder/date/starred filters; filtered list vs unfiltered total) require backend + product changes and are out of scope here.

## Verification
`xcrun swift build -c debug` succeeds (only pre-existing unrelated warnings). Latent path — no live runtime repro, so **UNVERIFIED** at runtime.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

