### PR TITLE
[codex] Add desktop harness and speed up Ask Omi pill

### DIFF
--- a/desktop/macos/.gitignore
+++ b/desktop/macos/.gitignore
@@ -86,6 +86,7 @@ linkedin-*.md
 
 # Runtime log files
 *.log
+.harness/
 
 # Agent configs (user-local)
 .agents/

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -806,14 +806,30 @@ final class DesktopAutomationBridge {
     _ payload: DesktopAutomationVisualExportRequest
   ) async throws -> DesktopAutomationVisualExportResult {
     try await MainActor.run {
+      let fileManager = FileManager.default
       let url = URL(fileURLWithPath: payload.path).standardizedFileURL
-      let captureRoot = DesktopAutomationLaunchOptions.captureRoot
-      guard url.path == captureRoot.path || url.path.hasPrefix(captureRoot.path + "/") else {
+      let captureRoot = DesktopAutomationLaunchOptions.captureRoot.resolvingSymlinksInPath()
+      try fileManager.createDirectory(at: captureRoot, withIntermediateDirectories: true)
+      let parent = url.deletingLastPathComponent()
+      let resolvedParent = parent.resolvingSymlinksInPath()
+      let resolvedURL = resolvedParent.appendingPathComponent(url.lastPathComponent)
+      guard resolvedURL.path == captureRoot.path || resolvedURL.path.hasPrefix(captureRoot.path + "/") else {
         throw DesktopAutomationActionError.invalidParams(
           "visual export path must be under \(captureRoot.path)")
       }
-      try FileManager.default.createDirectory(
-        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      if let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey]),
+        values.isSymbolicLink == true
+      {
+        throw DesktopAutomationActionError.invalidParams("visual export path must not be a symlink")
+      }
+      try fileManager.createDirectory(
+        at: parent, withIntermediateDirectories: true)
+      let postCreateParent = parent.resolvingSymlinksInPath()
+      let writeURL = postCreateParent.appendingPathComponent(url.lastPathComponent)
+      guard writeURL.path == captureRoot.path || writeURL.path.hasPrefix(captureRoot.path + "/") else {
+        throw DesktopAutomationActionError.invalidParams(
+          "visual export path must be under \(captureRoot.path)")
+      }
 
       let window: NSWindow?
       if payload.target == "floating" {
@@ -846,9 +862,9 @@ final class DesktopAutomationBridge {
         throw DesktopAutomationActionError.invalidParams("failed to encode png")
       }
 
-      try pngData.write(to: url, options: [.atomic])
+      try pngData.write(to: writeURL, options: [.atomic])
       return DesktopAutomationVisualExportResult(
-        path: payload.path,
+        path: writeURL.path,
         width: bitmap.pixelsWide,
         height: bitmap.pixelsHigh
       )

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -72,6 +72,16 @@ struct DesktopAutomationOpenConversationRequest: Codable {
   let activateApp: Bool?
 }
 
+struct DesktopAutomationVisualExportRequest: Codable {
+  let path: String
+}
+
+struct DesktopAutomationVisualExportResult: Codable {
+  let path: String
+  let width: Int
+  let height: Int
+}
+
 struct DesktopAutomationExecuteExportRequest: Codable {
   let destination: String
 }
@@ -90,6 +100,24 @@ struct DesktopAutomationActionResult: Codable {
   let action: String
   let detail: [String: String]?
   let state: DesktopAutomationSnapshot
+}
+
+struct DesktopAutomationCapabilities: Codable {
+  let schemaVersion: Int
+  let routes: [String]
+  let lanes: [String]
+  let waits: [String]
+  let assertions: [String]
+  let artifactTypes: [String]
+  let actions: [DesktopAutomationActionDescriptor]
+}
+
+struct DesktopAutomationRouteTrace: Codable {
+  let method: String
+  let path: String
+  let statusCode: Int
+  let durationMs: Double
+  let finishedAt: String
 }
 
 enum DesktopAutomationActionError: LocalizedError {
@@ -139,6 +167,32 @@ actor DesktopAutomationStateStore {
 
   func current() -> DesktopAutomationSnapshot {
     snapshot
+  }
+}
+
+actor DesktopAutomationTraceStore {
+  static let shared = DesktopAutomationTraceStore()
+
+  private var traces: [DesktopAutomationRouteTrace] = []
+  private let formatter = ISO8601DateFormatter()
+
+  func record(method: String, path: String, statusCode: Int, durationMs: Double) {
+    traces.append(
+      DesktopAutomationRouteTrace(
+        method: method,
+        path: path,
+        statusCode: statusCode,
+        durationMs: durationMs,
+        finishedAt: formatter.string(from: Date())
+      )
+    )
+    if traces.count > 200 {
+      traces.removeFirst(traces.count - 200)
+    }
+  }
+
+  func recent(limit: Int = 50) -> [DesktopAutomationRouteTrace] {
+    Array(traces.suffix(max(1, min(limit, 200))))
   }
 }
 
@@ -410,6 +464,19 @@ final class DesktopAutomationBridge {
   }
 
   private func route(request: HTTPRequest) async -> HTTPResponse {
+    let started = DispatchTime.now().uptimeNanoseconds
+    let response = await routeUntimed(request: request)
+    let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+    await DesktopAutomationTraceStore.shared.record(
+      method: request.method,
+      path: request.path,
+      statusCode: response.statusCode,
+      durationMs: (elapsedMs * 100).rounded() / 100
+    )
+    return response
+  }
+
+  private func routeUntimed(request: HTTPRequest) async -> HTTPResponse {
     switch (request.method, request.path) {
     case ("GET", "/health"):
       let snapshot = await DesktopAutomationStateStore.shared.current()
@@ -417,6 +484,9 @@ final class DesktopAutomationBridge {
     case ("GET", "/state"):
       let snapshot = await DesktopAutomationStateStore.shared.current()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
+    case ("GET", "/traces/recent"):
+      let traces = await DesktopAutomationTraceStore.shared.recent()
+      return jsonResponse(DesktopAutomationResponse(ok: true, result: traces, error: nil))
     case ("POST", "/navigate"):
       do {
         let payload = try JSONDecoder().decode(
@@ -477,6 +547,28 @@ final class DesktopAutomationBridge {
     case ("GET", "/actions"):
       let descriptors = await DesktopAutomationActionRegistry.shared.descriptors()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: descriptors, error: nil))
+    case ("GET", "/capabilities"):
+      let descriptors = await DesktopAutomationActionRegistry.shared.descriptors()
+      let capabilities = DesktopAutomationCapabilities(
+        schemaVersion: 1,
+        routes: [
+          "GET /health",
+          "GET /state",
+          "GET /capabilities",
+          "GET /actions",
+          "GET /traces/recent",
+          "POST /navigate",
+          "POST /conversation/open",
+          "POST /action",
+          "POST /visual/export",
+        ],
+        lanes: ["bridge", "visual", "ui"],
+        waits: ["state", "log", "trace"],
+        assertions: ["state", "log", "trace", "ax"],
+        artifactTypes: ["state", "bridge_response", "visual_png", "logs", "traces", "summary"],
+        actions: descriptors
+      )
+      return jsonResponse(DesktopAutomationResponse(ok: true, result: capabilities, error: nil))
     case ("POST", "/action"):
       guard let parsed = parseActionRequest(from: request.body) else {
         return jsonResponse(
@@ -498,6 +590,19 @@ final class DesktopAutomationBridge {
           DesktopAutomationResponse<DesktopAutomationActionResult>(
             ok: false, result: nil, error: error.localizedDescription),
           statusCode: 400
+        )
+      }
+    case ("POST", "/visual/export"):
+      do {
+        let payload = try JSONDecoder().decode(
+          DesktopAutomationVisualExportRequest.self, from: request.body)
+        let result = try await exportMainWindow(payload)
+        return jsonResponse(DesktopAutomationResponse(ok: true, result: result, error: nil))
+      } catch {
+        return jsonResponse(
+          DesktopAutomationResponse<DesktopAutomationVisualExportResult>(
+            ok: false, result: nil, error: error.localizedDescription),
+          statusCode: 500
         )
       }
     case ("POST", "/open-export"):
@@ -615,6 +720,47 @@ final class DesktopAutomationBridge {
       if let window = NSApp.windows.first(where: { $0.title.lowercased().hasPrefix("omi") }) {
         window.makeKeyAndOrderFront(nil)
       }
+    }
+  }
+
+  private func exportMainWindow(
+    _ payload: DesktopAutomationVisualExportRequest
+  ) async throws -> DesktopAutomationVisualExportResult {
+    try await MainActor.run {
+      let url = URL(fileURLWithPath: payload.path)
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+      guard
+        let window = NSApp.windows.first(where: { window in
+          window.title.lowercased().hasPrefix("omi") || window.isMainWindow || window.isKeyWindow
+        }),
+        let contentView = window.contentView
+      else {
+        throw DesktopAutomationActionError.invalidParams("main window not available")
+      }
+
+      contentView.needsLayout = true
+      contentView.layoutSubtreeIfNeeded()
+
+      let bounds = contentView.bounds
+      guard !bounds.isEmpty,
+        let bitmap = contentView.bitmapImageRepForCachingDisplay(in: bounds)
+      else {
+        throw DesktopAutomationActionError.invalidParams("main window has no renderable content")
+      }
+
+      contentView.cacheDisplay(in: bounds, to: bitmap)
+      guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
+        throw DesktopAutomationActionError.invalidParams("failed to encode png")
+      }
+
+      try pngData.write(to: url, options: [.atomic])
+      return DesktopAutomationVisualExportResult(
+        path: payload.path,
+        width: bitmap.pixelsWide,
+        height: bitmap.pixelsHigh
+      )
     }
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -5,6 +5,7 @@ import Network
 enum DesktopAutomationLaunchOptions {
   static let enableFlag = "--automation-bridge"
   static let portPrefix = "--automation-port="
+  static let captureRootPrefix = "--automation-capture-root="
   static let defaultPort: UInt16 = 47777
 
   static var isEnabled: Bool {
@@ -36,6 +37,26 @@ enum DesktopAutomationLaunchOptions {
     }
 
     return defaultPort
+  }
+
+  static var captureRoot: URL {
+    for argument in CommandLine.arguments {
+      guard argument.hasPrefix(captureRootPrefix) else { continue }
+      let rawValue = String(argument.dropFirst(captureRootPrefix.count))
+      if !rawValue.isEmpty {
+        return URL(fileURLWithPath: rawValue).standardizedFileURL
+      }
+    }
+
+    if let rawValue = ProcessInfo.processInfo.environment["OMI_AUTOMATION_CAPTURE_ROOT"],
+      !rawValue.isEmpty
+    {
+      return URL(fileURLWithPath: rawValue).standardizedFileURL
+    }
+
+    return URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("omi-harness", isDirectory: true)
+      .standardizedFileURL
   }
 }
 
@@ -391,7 +412,13 @@ final class DesktopAutomationBridge {
         log("DesktopAutomationBridge: invalid port \(DesktopAutomationLaunchOptions.port)")
         return
       }
-      let listener = try NWListener(using: parameters, on: port)
+      guard let loopback = IPv4Address("127.0.0.1") else {
+        log("DesktopAutomationBridge: failed to resolve loopback address")
+        return
+      }
+      parameters.requiredLocalEndpoint = .hostPort(host: .ipv4(loopback), port: port)
+
+      let listener = try NWListener(using: parameters)
       listener.newConnectionHandler = { [weak self] connection in
         self?.handleConnection(connection)
       }
@@ -779,7 +806,12 @@ final class DesktopAutomationBridge {
     _ payload: DesktopAutomationVisualExportRequest
   ) async throws -> DesktopAutomationVisualExportResult {
     try await MainActor.run {
-      let url = URL(fileURLWithPath: payload.path)
+      let url = URL(fileURLWithPath: payload.path).standardizedFileURL
+      let captureRoot = DesktopAutomationLaunchOptions.captureRoot
+      guard url.path == captureRoot.path || url.path.hasPrefix(captureRoot.path + "/") else {
+        throw DesktopAutomationActionError.invalidParams(
+          "visual export path must be under \(captureRoot.path)")
+      }
       try FileManager.default.createDirectory(
         at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -341,7 +341,7 @@ final class DesktopAutomationActionRegistry {
       name: "close_ask_omi",
       summary: "Close the Ask Omi input panel if it is open"
     ) { _ in
-      return FloatingControlBarManager.shared.closeAskOmiForAutomation()
+      return await FloatingControlBarManager.shared.closeAskOmiForAutomation()
     }
 
     register(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -56,6 +56,10 @@ struct DesktopAutomationSnapshot: Codable {
   var isRestoringAuth: Bool
   var isAppActive: Bool
   var mainWindowTitle: String?
+  var floatingBarVisible: Bool
+  var askOmiOpen: Bool
+  var askOmiFocused: Bool
+  var floatingBarFrame: String?
   var updatedAt: String
 }
 
@@ -74,6 +78,7 @@ struct DesktopAutomationOpenConversationRequest: Codable {
 
 struct DesktopAutomationVisualExportRequest: Codable {
   let path: String
+  let target: String?
 }
 
 struct DesktopAutomationVisualExportResult: Codable {
@@ -158,6 +163,10 @@ actor DesktopAutomationStateStore {
     isRestoringAuth: true,
     isAppActive: false,
     mainWindowTitle: nil,
+    floatingBarVisible: false,
+    askOmiOpen: false,
+    askOmiFocused: false,
+    floatingBarFrame: nil,
     updatedAt: ISO8601DateFormatter().string(from: Date())
   )
 
@@ -168,6 +177,27 @@ actor DesktopAutomationStateStore {
   func current() -> DesktopAutomationSnapshot {
     snapshot
   }
+}
+
+private func liveAutomationSnapshot() async -> DesktopAutomationSnapshot {
+  var snapshot = await DesktopAutomationStateStore.shared.current()
+  let floating = await MainActor.run {
+    let floating = FloatingControlBarManager.shared.automationState
+    return (
+      isVisible: floating.isVisible,
+      isAskOmiOpen: floating.isAskOmiOpen,
+      isAskOmiFocused: floating.isAskOmiFocused,
+      frame: floating.frame,
+      isAppActive: NSApp.isActive
+    )
+  }
+  snapshot.floatingBarVisible = floating.isVisible
+  snapshot.askOmiOpen = floating.isAskOmiOpen
+  snapshot.askOmiFocused = floating.isAskOmiFocused
+  snapshot.floatingBarFrame = floating.frame
+  snapshot.isAppActive = floating.isAppActive
+  snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
+  return snapshot
 }
 
 actor DesktopAutomationTraceStore {
@@ -298,6 +328,22 @@ final class DesktopAutomationActionRegistry {
     // Send a typed query through the real floating-bar AI path
     // (openAIInputWithQuery → routeQuery → sendAIQuery → ChatProvider → bridge).
     // Used to drive cache/latency benchmarks without a mic or the cursor.
+    register(
+      name: "open_ask_omi",
+      summary: "Open the Ask Omi input panel and return app-side open/focus timing",
+      params: ["reset"]
+    ) { params in
+      let reset = boolParam(params["reset"], default: false)
+      return await FloatingControlBarManager.shared.openAskOmiForAutomation(reset: reset)
+    }
+
+    register(
+      name: "close_ask_omi",
+      summary: "Close the Ask Omi input panel if it is open"
+    ) { _ in
+      return FloatingControlBarManager.shared.closeAskOmiForAutomation()
+    }
+
     register(
       name: "ask",
       summary: "Send a query to the floating-bar AI (typed path); exercises the full chat pipeline",
@@ -479,10 +525,10 @@ final class DesktopAutomationBridge {
   private func routeUntimed(request: HTTPRequest) async -> HTTPResponse {
     switch (request.method, request.path) {
     case ("GET", "/health"):
-      let snapshot = await DesktopAutomationStateStore.shared.current()
+      let snapshot = await liveAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/state"):
-      let snapshot = await DesktopAutomationStateStore.shared.current()
+      let snapshot = await liveAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/traces/recent"):
       let traces = await DesktopAutomationTraceStore.shared.recent()
@@ -493,7 +539,7 @@ final class DesktopAutomationBridge {
           DesktopAutomationNavigationRequest.self, from: request.body)
         try await dispatchNavigation(payload)
         try await Task.sleep(for: .milliseconds(150))
-        let snapshot = await DesktopAutomationStateStore.shared.current()
+        let snapshot = await liveAutomationSnapshot()
         return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
       } catch {
         return jsonResponse(
@@ -511,7 +557,7 @@ final class DesktopAutomationBridge {
           DesktopAutomationOpenConversationRequest.self, from: request.body)
         try await dispatchOpenConversation(payload)
         try await Task.sleep(for: .milliseconds(350))
-        let snapshot = await DesktopAutomationStateStore.shared.current()
+        let snapshot = await liveAutomationSnapshot()
         return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
       } catch {
         return jsonResponse(
@@ -581,7 +627,7 @@ final class DesktopAutomationBridge {
         let detail = try await DesktopAutomationActionRegistry.shared.perform(
           parsed.name, params: parsed.params)
         try await Task.sleep(for: .milliseconds(150))
-        let snapshot = await DesktopAutomationStateStore.shared.current()
+        let snapshot = await liveAutomationSnapshot()
         let result = DesktopAutomationActionResult(
           action: parsed.name, detail: detail, state: snapshot)
         return jsonResponse(DesktopAutomationResponse(ok: true, result: result, error: nil))
@@ -596,7 +642,7 @@ final class DesktopAutomationBridge {
       do {
         let payload = try JSONDecoder().decode(
           DesktopAutomationVisualExportRequest.self, from: request.body)
-        let result = try await exportMainWindow(payload)
+        let result = try await exportWindow(payload)
         return jsonResponse(DesktopAutomationResponse(ok: true, result: result, error: nil))
       } catch {
         return jsonResponse(
@@ -723,7 +769,7 @@ final class DesktopAutomationBridge {
     }
   }
 
-  private func exportMainWindow(
+  private func exportWindow(
     _ payload: DesktopAutomationVisualExportRequest
   ) async throws -> DesktopAutomationVisualExportResult {
     try await MainActor.run {
@@ -731,13 +777,20 @@ final class DesktopAutomationBridge {
       try FileManager.default.createDirectory(
         at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-      guard
-        let window = NSApp.windows.first(where: { window in
+      let window: NSWindow?
+      if payload.target == "floating" {
+        window = NSApp.windows.first(where: { $0 is FloatingControlBarWindow && $0.isVisible })
+      } else {
+        window = NSApp.windows.first(where: { window in
           window.title.lowercased().hasPrefix("omi") || window.isMainWindow || window.isKeyWindow
-        }),
+        })
+      }
+
+      guard
+        let window,
         let contentView = window.contentView
       else {
-        throw DesktopAutomationActionError.invalidParams("main window not available")
+        throw DesktopAutomationActionError.invalidParams("\(payload.target ?? "main") window not available")
       }
 
       contentView.needsLayout = true
@@ -747,7 +800,7 @@ final class DesktopAutomationBridge {
       guard !bounds.isEmpty,
         let bitmap = contentView.bitmapImageRepForCachingDisplay(in: bounds)
       else {
-        throw DesktopAutomationActionError.invalidParams("main window has no renderable content")
+        throw DesktopAutomationActionError.invalidParams("\(payload.target ?? "main") window has no renderable content")
       }
 
       contentView.cacheDisplay(in: bounds, to: bitmap)

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -331,17 +331,21 @@ final class DesktopAutomationActionRegistry {
     register(
       name: "open_ask_omi",
       summary: "Open the Ask Omi input panel and return app-side open/focus timing",
-      params: ["reset"]
+      params: ["reset", "wait"]
     ) { params in
       let reset = boolParam(params["reset"], default: false)
-      return await FloatingControlBarManager.shared.openAskOmiForAutomation(reset: reset)
+      let wait = boolParam(params["wait"], default: true)
+      return await FloatingControlBarManager.shared.openAskOmiForAutomation(
+        reset: reset, wait: wait)
     }
 
     register(
       name: "close_ask_omi",
-      summary: "Close the Ask Omi input panel if it is open"
-    ) { _ in
-      return await FloatingControlBarManager.shared.closeAskOmiForAutomation()
+      summary: "Close the Ask Omi input panel if it is open",
+      params: ["wait"]
+    ) { params in
+      let wait = boolParam(params["wait"], default: true)
+      return await FloatingControlBarManager.shared.closeAskOmiForAutomation(wait: wait)
     }
 
     register(
@@ -626,7 +630,9 @@ final class DesktopAutomationBridge {
       do {
         let detail = try await DesktopAutomationActionRegistry.shared.perform(
           parsed.name, params: parsed.params)
-        try await Task.sleep(for: .milliseconds(150))
+        if boolParam(parsed.params["wait"], default: true) {
+          try await Task.sleep(for: .milliseconds(150))
+        }
         let snapshot = await liveAutomationSnapshot()
         let result = DesktopAutomationActionResult(
           action: parsed.name, detail: detail, state: snapshot)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -61,6 +61,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// Used by savePreChatCenterIfNeeded() to snap to the correct pill position
     /// if a new PTT query fires while the restore animation is still running.
     private var pendingRestoreOrigin: NSPoint?
+    private var frameAnimationToken: Int = 0
 
     var onPlayPause: (() -> Void)?
     var onAskAI: (() -> Void)?
@@ -380,10 +381,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // Record the animation target so savePreChatCenterIfNeeded() can snap to it
         // if a new PTT query fires while this restore animation is still running.
         pendingRestoreOrigin = restoreOrigin
-        self.setFrame(NSRect(origin: restoreOrigin, size: size), display: true, animate: false)
+        animateFrame(to: NSRect(origin: restoreOrigin, size: size), duration: 0.12)
         let targetFrame = NSRect(origin: restoreOrigin, size: size)
         preChatCenter = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) { [weak self] in
             guard let self = self else { return }
             self.isResizingProgrammatically = false
             self.pendingRestoreOrigin = nil
@@ -391,13 +392,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             // Without this guard, a rapid PTT query that fires while close settles gets collapsed
             // back to the pill position by this stale completion block.
             guard !self.state.showingAIConversation else { return }
-            if self.frame != targetFrame {
+            if !NSEqualRects(self.frame, targetFrame) {
                 self.setFrame(targetFrame, display: true, animate: false)
             }
         }
 
         // Allow hover resizes again after the animation settles.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) { [weak self] in
             self?.suppressHoverResize = false
             FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
 
@@ -452,7 +453,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         } else {
             // Anchor from top so the control bar stays visually in place, input grows downward.
             let inputSize = NSSize(width: FloatingControlBarWindow.expandedWidth, height: 120)
-            resizeAnchored(to: inputSize, makeResizable: false, animated: false, anchorTop: true)
+            resizeAnchored(
+                to: inputSize, makeResizable: false, animated: true,
+                animationDuration: 0.12, anchorTop: true)
 
             withAnimation(.easeOut(duration: 0.12)) {
                 state.showingAIConversation = true
@@ -567,7 +570,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         )
     }
 
-    private func resizeAnchored(to size: NSSize, makeResizable: Bool, animated: Bool = false, anchorTop: Bool = false) {
+    private func resizeAnchored(
+        to size: NSSize,
+        makeResizable: Bool,
+        animated: Bool = false,
+        animationDuration: TimeInterval = 0.3,
+        anchorTop: Bool = false
+    ) {
         // Cancel any pending resizeToFixedHeight work item to prevent stale resizes
         resizeWorkItem?.cancel()
         resizeWorkItem = nil
@@ -590,18 +599,39 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         isResizingProgrammatically = true
 
-        // On macOS 26+ (Tahoe), animated setFrame triggers NSHostingView.updateAnimatedWindowSize
-        // which invalidates safe area insets -> view graph -> requestUpdate -> setNeedsUpdateConstraints,
-        // causing an infinite constraint update loop (OMI-COMPUTER-1J). Disable implicit animations
-        // during the resize to prevent the updateAnimatedWindowSize code path.
-        NSAnimationContext.beginGrouping()
-        NSAnimationContext.current.duration = animated ? 0.3 : 0
-        NSAnimationContext.current.allowsImplicitAnimation = false
-        NSAnimationContext.current.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        self.setFrame(NSRect(origin: newOrigin, size: constrainedSize), display: true, animate: animated)
-        NSAnimationContext.endGrouping()
+        let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
+        if animated {
+            animateFrame(to: targetFrame, duration: animationDuration)
+        } else {
+            self.setFrame(targetFrame, display: true, animate: false)
+        }
 
         self.isResizingProgrammatically = false
+    }
+
+    private func animateFrame(to frame: NSRect, duration: TimeInterval) {
+        frameAnimationToken += 1
+        let token = frameAnimationToken
+        let startFrame = self.frame
+        let steps = max(1, Int((duration * 120).rounded()))
+        for step in 1...steps {
+            let delay = duration * Double(step) / Double(steps)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self, self.frameAnimationToken == token else { return }
+                let rawProgress = CGFloat(step) / CGFloat(steps)
+                let progress = 1 - pow(1 - rawProgress, 2)
+                let interpolated = NSRect(
+                    x: startFrame.origin.x + (frame.origin.x - startFrame.origin.x) * progress,
+                    y: startFrame.origin.y + (frame.origin.y - startFrame.origin.y) * progress,
+                    width: startFrame.width + (frame.width - startFrame.width) * progress,
+                    height: startFrame.height + (frame.height - startFrame.height) * progress
+                )
+                self.setFrame(interpolated, display: true, animate: false)
+                if step == steps {
+                    self.setFrame(frame, display: true, animate: false)
+                }
+            }
+        }
     }
 
     private func resizeToFixedHeight(_ height: CGFloat, animated: Bool = false) {
@@ -1156,7 +1186,7 @@ class FloatingControlBarManager {
         )
     }
 
-    func openAskOmiForAutomation(reset: Bool) async -> [String: String] {
+    func openAskOmiForAutomation(reset: Bool, wait: Bool = true) async -> [String: String] {
         guard let window else {
             return ["error": "floating_bar_window_unavailable"]
         }
@@ -1167,6 +1197,13 @@ class FloatingControlBarManager {
 
         let start = ContinuousClock.now
         openAIInput()
+        guard wait else {
+            return [
+                "triggered": "true",
+                "frame": NSStringFromRect(window.frame),
+                "focused": (window.firstResponder is NSTextView) ? "true" : "false",
+            ]
+        }
         let openMs = await waitForAutomationCondition {
             window.isVisible && window.state.showingAIConversation && !window.state.showingAIResponse
         }
@@ -1183,13 +1220,21 @@ class FloatingControlBarManager {
         ]
     }
 
-    func closeAskOmiForAutomation() async -> [String: String] {
+    func closeAskOmiForAutomation(wait: Bool = true) async -> [String: String] {
         guard let window else {
             return ["error": "floating_bar_window_unavailable"]
         }
         let start = ContinuousClock.now
         if window.state.showingAIConversation {
             window.closeAIConversation()
+        }
+        guard wait else {
+            return [
+                "triggered": "true",
+                "visible": window.isVisible ? "true" : "false",
+                "askOmiOpen": window.state.showingAIConversation ? "true" : "false",
+                "frame": NSStringFromRect(window.frame),
+            ]
         }
         let closeMs = await waitForAskOmiClosed(in: window)
         let elapsedMs = start.duration(to: .now).millisecondsString

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -601,15 +601,16 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
         if animated {
-            animateFrame(to: targetFrame, duration: animationDuration)
+            animateFrame(to: targetFrame, duration: animationDuration) { [weak self] in
+                self?.isResizingProgrammatically = false
+            }
         } else {
             self.setFrame(targetFrame, display: true, animate: false)
+            self.isResizingProgrammatically = false
         }
-
-        self.isResizingProgrammatically = false
     }
 
-    private func animateFrame(to frame: NSRect, duration: TimeInterval) {
+    private func animateFrame(to frame: NSRect, duration: TimeInterval, completion: (() -> Void)? = nil) {
         frameAnimationToken += 1
         let token = frameAnimationToken
         let startFrame = self.frame
@@ -629,6 +630,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                 self.setFrame(interpolated, display: true, animate: false)
                 if step == steps {
                     self.setFrame(frame, display: true, animate: false)
+                    completion?()
                 }
             }
         }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -343,7 +343,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             PushToTalkManager.shared.cancelListening()
         }
 
-        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+        withAnimation(.easeOut(duration: 0.08)) {
             state.showingAIConversation = false
             state.showingAIResponse = false
             state.aiInputText = ""
@@ -380,20 +380,15 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // Record the animation target so savePreChatCenterIfNeeded() can snap to it
         // if a new PTT query fires while this restore animation is still running.
         pendingRestoreOrigin = restoreOrigin
-        NSAnimationContext.beginGrouping()
-        NSAnimationContext.current.duration = 0.3
-        NSAnimationContext.current.allowsImplicitAnimation = false
-        NSAnimationContext.current.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        self.setFrame(NSRect(origin: restoreOrigin, size: size), display: true, animate: true)
-        NSAnimationContext.endGrouping()
+        self.setFrame(NSRect(origin: restoreOrigin, size: size), display: true, animate: false)
         let targetFrame = NSRect(origin: restoreOrigin, size: size)
         preChatCenter = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
             guard let self = self else { return }
             self.isResizingProgrammatically = false
             self.pendingRestoreOrigin = nil
-            // Safety net: only snap if no new AI session was opened while the animation ran.
-            // Without this guard, a rapid PTT query that fires within 0.35s gets collapsed
+            // Safety net: only snap if no new AI session was opened while the close settled.
+            // Without this guard, a rapid PTT query that fires while close settles gets collapsed
             // back to the pill position by this stale completion block.
             guard !self.state.showingAIConversation else { return }
             if self.frame != targetFrame {
@@ -402,7 +397,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         }
 
         // Allow hover resizes again after the animation settles.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
             self?.suppressHoverResize = false
             FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
 
@@ -1167,7 +1162,7 @@ class FloatingControlBarManager {
         }
         if reset, window.state.showingAIConversation {
             window.closeAIConversation()
-            try? await Task.sleep(for: .milliseconds(360))
+            _ = await waitForAskOmiClosed(in: window)
         }
 
         let start = ContinuousClock.now
@@ -1188,16 +1183,22 @@ class FloatingControlBarManager {
         ]
     }
 
-    func closeAskOmiForAutomation() -> [String: String] {
+    func closeAskOmiForAutomation() async -> [String: String] {
         guard let window else {
             return ["error": "floating_bar_window_unavailable"]
         }
+        let start = ContinuousClock.now
         if window.state.showingAIConversation {
             window.closeAIConversation()
         }
+        let closeMs = await waitForAskOmiClosed(in: window)
+        let elapsedMs = start.duration(to: .now).millisecondsString
         return [
+            "closeMs": closeMs ?? "timeout",
+            "elapsedMs": elapsedMs,
             "visible": window.isVisible ? "true" : "false",
             "askOmiOpen": window.state.showingAIConversation ? "true" : "false",
+            "frame": NSStringFromRect(window.frame),
         ]
     }
 
@@ -1210,6 +1211,12 @@ class FloatingControlBarManager {
             try? await Task.sleep(for: .milliseconds(5))
         }
         return nil
+    }
+
+    private func waitForAskOmiClosed(in window: FloatingControlBarWindow) async -> String? {
+        await waitForAutomationCondition {
+            !window.state.showingAIConversation && window.frame.size == NSSize(width: 40, height: 14)
+        }
     }
 
     /// Show the floating bar and persist the preference.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -8,6 +8,15 @@ private final class FloatingBarHostingView<Content: View>: NSHostingView<Content
     }
 }
 
+private extension Duration {
+    var millisecondsString: String {
+        let components = self.components
+        let milliseconds = Double(components.seconds) * 1000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+        return String(format: "%.1f", milliseconds)
+    }
+}
+
 /// NSPanel subclass for the floating control bar.
 ///
 /// Using a non-activating panel lets the Ask Omi shortcut focus the floating bar
@@ -424,6 +433,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     func showAIConversation() {
         resizeWorkItem?.cancel()
         resizeWorkItem = nil
+        makeKeyAndOrderFront(nil)
 
         let shouldRestoreVisibleConversation = state.canRestoreVisibleConversation
         if !shouldRestoreVisibleConversation && state.hasVisibleConversation {
@@ -437,7 +447,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         if shouldRestoreVisibleConversation {
             cancelInputHeightObserver()
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            withAnimation(.easeOut(duration: 0.12)) {
                 state.showingAIConversation = true
                 state.showingAIResponse = true
                 state.isAILoading = false
@@ -447,9 +457,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         } else {
             // Anchor from top so the control bar stays visually in place, input grows downward.
             let inputSize = NSSize(width: FloatingControlBarWindow.expandedWidth, height: 120)
-            resizeAnchored(to: inputSize, makeResizable: false, animated: true, anchorTop: true)
+            resizeAnchored(to: inputSize, makeResizable: false, animated: false, anchorTop: true)
 
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            withAnimation(.easeOut(duration: 0.12)) {
                 state.showingAIConversation = true
                 state.showingAIResponse = false
                 state.isAILoading = false
@@ -461,16 +471,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             setupInputHeightObserver()
         }
 
-        // Make the window key so the OmiTextEditor's focusOnAppear can take effect.
-        // The text editor itself handles focusing via updateNSView once it's in the window.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-            self?.makeKeyAndOrderFront(nil)
-        }
-
         // Fallback: explicitly focus the input after SwiftUI layout settles.
         // The AutoFocusScrollView.viewDidMoveToWindow() fires once and can miss
         // if the window isn't yet key at that moment.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             self?.focusInputField()
         }
 
@@ -1135,6 +1139,77 @@ class FloatingControlBarManager {
     /// Whether the floating bar window is currently visible.
     var isVisible: Bool {
         window?.isVisible ?? false
+    }
+
+    struct AutomationState {
+        let isVisible: Bool
+        let isAskOmiOpen: Bool
+        let isAskOmiFocused: Bool
+        let frame: String?
+    }
+
+    var automationState: AutomationState {
+        guard let window else {
+            return AutomationState(isVisible: false, isAskOmiOpen: false, isAskOmiFocused: false, frame: nil)
+        }
+        let focused = window.firstResponder is NSTextView
+        return AutomationState(
+            isVisible: window.isVisible,
+            isAskOmiOpen: window.state.showingAIConversation && !window.state.showingAIResponse,
+            isAskOmiFocused: focused,
+            frame: NSStringFromRect(window.frame)
+        )
+    }
+
+    func openAskOmiForAutomation(reset: Bool) async -> [String: String] {
+        guard let window else {
+            return ["error": "floating_bar_window_unavailable"]
+        }
+        if reset, window.state.showingAIConversation {
+            window.closeAIConversation()
+            try? await Task.sleep(for: .milliseconds(360))
+        }
+
+        let start = ContinuousClock.now
+        openAIInput()
+        let openMs = await waitForAutomationCondition {
+            window.isVisible && window.state.showingAIConversation && !window.state.showingAIResponse
+        }
+        let focusMs = await waitForAutomationCondition {
+            window.firstResponder is NSTextView
+        }
+        let elapsedMs = start.duration(to: .now).millisecondsString
+        return [
+            "openMs": openMs ?? "timeout",
+            "focusMs": focusMs ?? "timeout",
+            "elapsedMs": elapsedMs,
+            "frame": NSStringFromRect(window.frame),
+            "focused": (window.firstResponder is NSTextView) ? "true" : "false",
+        ]
+    }
+
+    func closeAskOmiForAutomation() -> [String: String] {
+        guard let window else {
+            return ["error": "floating_bar_window_unavailable"]
+        }
+        if window.state.showingAIConversation {
+            window.closeAIConversation()
+        }
+        return [
+            "visible": window.isVisible ? "true" : "false",
+            "askOmiOpen": window.state.showingAIConversation ? "true" : "false",
+        ]
+    }
+
+    private func waitForAutomationCondition(_ condition: @MainActor @escaping () -> Bool) async -> String? {
+        let start = ContinuousClock.now
+        while start.duration(to: .now) < .milliseconds(500) {
+            if condition() {
+                return start.duration(to: .now).millisecondsString
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return nil
     }
 
     /// Show the floating bar and persist the preference.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -601,6 +601,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
         if animated {
+            // Keep windowDidResize from persisting transient animation frames as
+            // the user's saved response size until the final frame lands.
             animateFrame(to: targetFrame, duration: animationDuration) { [weak self] in
                 self?.isResizingProgrammatically = false
             }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -562,6 +562,10 @@ struct DesktopHomeView: View {
       isRestoringAuth: authState.isRestoringAuth,
       isAppActive: NSApp.isActive,
       mainWindowTitle: currentWindow?.title,
+      floatingBarVisible: FloatingControlBarManager.shared.automationState.isVisible,
+      askOmiOpen: FloatingControlBarManager.shared.automationState.isAskOmiOpen,
+      askOmiFocused: FloatingControlBarManager.shared.automationState.isAskOmiFocused,
+      floatingBarFrame: FloatingControlBarManager.shared.automationState.frame,
       updatedAt: ISO8601DateFormatter().string(from: Date())
     )
 

--- a/desktop/macos/e2e/flows/ask-omi-animation-benchmark.yaml
+++ b/desktop/macos/e2e/flows/ask-omi-animation-benchmark.yaml
@@ -1,0 +1,51 @@
+version: 1
+name: ask-omi-animation-benchmark
+description: Capture short frame sequences for Ask Omi open and close transitions.
+app: non-prod
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Reset Ask Omi
+    bridge.action:
+      name: close_ask_omi
+
+  - id: S2
+    name: Capture Open Animation
+    visual.action_sequence:
+      action: open_ask_omi
+      params:
+        reset: false
+        wait: false
+      target: floating
+      frames: 8
+      interval_ms: 16
+
+  - id: S3
+    name: Assert Open State
+    state.expect:
+      state.askOmiOpen: true
+      state.askOmiFocused: true
+
+  - id: S4
+    name: Capture Close Animation
+    visual.action_sequence:
+      action: close_ask_omi
+      params:
+        wait: false
+      target: floating
+      frames: 8
+      interval_ms: 16
+
+  - id: S5
+    name: Assert Closed State
+    state.expect:
+      state.askOmiOpen: false
+
+  - id: S6
+    name: Assert Logs Are Clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"
+        - "unsupported_route"

--- a/desktop/macos/e2e/flows/ask-omi-open-benchmark.yaml
+++ b/desktop/macos/e2e/flows/ask-omi-open-benchmark.yaml
@@ -1,0 +1,64 @@
+version: 1
+name: ask-omi-open-benchmark
+description: Repeated cursor-free Ask Omi open timing for the floating pill.
+app: non-prod
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Reset Ask Omi
+    bridge.action:
+      name: close_ask_omi
+
+  - id: S2
+    name: Open Ask Omi 1
+    bridge.action:
+      name: open_ask_omi
+      reset: true
+    wait:
+      state.askOmiOpen: true
+
+  - id: S3
+    name: Close Ask Omi 1
+    bridge.action:
+      name: close_ask_omi
+
+  - id: S4
+    name: Open Ask Omi 2
+    bridge.action:
+      name: open_ask_omi
+      reset: true
+    wait:
+      state.askOmiOpen: true
+
+  - id: S5
+    name: Close Ask Omi 2
+    bridge.action:
+      name: close_ask_omi
+
+  - id: S6
+    name: Open Ask Omi 3
+    bridge.action:
+      name: open_ask_omi
+      reset: true
+    wait:
+      state.askOmiOpen: true
+
+  - id: S7
+    name: Capture Ask Omi Visual
+    visual.export:
+      name: ask-omi-open
+      target: floating
+
+  - id: S8
+    name: Assert Ask Omi State
+    state.expect:
+      state.askOmiOpen: true
+
+  - id: S9
+    name: Assert Logs Are Clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"
+        - "unsupported_route"

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -1,0 +1,62 @@
+version: 1
+name: harness-smoke
+description: Cursor-free smoke flow for the Omi desktop experience harness.
+app: non-prod
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Navigate to Dashboard
+    bridge.navigate:
+      target: dashboard
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 0
+
+  - id: S2
+    name: Capture Dashboard Visual
+    visual.export:
+      name: dashboard
+
+  - id: S3
+    name: Assert Dashboard State
+    state.expect:
+      state.selectedTabIndex: 0
+
+  - id: S4
+    name: Navigate to Memories
+    bridge.navigate:
+      target: memories
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 3
+
+  - id: S5
+    name: Refresh Data
+    bridge.action:
+      name: refresh_all_data
+
+  - id: S6
+    name: Assert Refresh Trace
+    trace.expect:
+      trace.path: /action
+      trace.statusCode: 200
+
+  - id: S7
+    name: Assert Logs Are Clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"
+        - "unsupported_route"
+
+  - id: S8
+    name: Capture Memories Visual
+    visual.export:
+      name: memories
+
+  - id: S9
+    name: Optional AX Smoke
+    ax.expect:
+      text_visible:
+        - Memories

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -24,7 +24,7 @@ chat content. Do not attach or publish a run directory unless you have reviewed 
 
 ```bash
 cd desktop/macos
-OMI_APP_NAME=omi-harness-test OMI_AUTOMATION_PORT=47888 ./run.sh --yolo
+OMI_SKIP_STALE_BUNDLE_SCAN=1 OMI_APP_NAME=omi-harness-test OMI_AUTOMATION_PORT=47888 ./run.sh --yolo
 ```
 
 In another shell:
@@ -51,6 +51,7 @@ Supported step types:
 - `bridge.navigate`
 - `bridge.action`
 - `visual.export`
+- `visual.action_sequence`
 - `state.expect`
 - `trace.expect`
 - `log.expect`
@@ -61,3 +62,18 @@ step. Keep automated checks to facts the harness can measure directly: state,
 traces, logs, timing, and AX text. The harness does not score screenshot quality;
 the agent should open the PNGs listed in `summary.md` and judge layout, polish,
 clipping, empty states, and visual regressions directly.
+
+Use `visual.action_sequence` for fast animations. It posts the bridge action and
+captures frames concurrently, which avoids missing transitions that finish before
+a normal action response returns:
+
+```yaml
+- name: Capture Ask Omi Open Animation
+  visual.action_sequence:
+    action: open_ask_omi
+    params:
+      wait: false
+    target: floating
+    frames: 8
+    interval_ms: 16
+```

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -1,0 +1,63 @@
+# Omi Desktop Experience Harness
+
+`scripts/omi-harness` runs cursor-free desktop experience checks against the local
+automation bridge. Use it to collect behavior, latency, logs, traces, and screenshots
+while iterating on the macOS app.
+
+## Lanes
+
+- `bridge` — drives semantic navigation/actions and state assertions. This is the
+  default lane and should stay cursor-free.
+- `visual` — includes `bridge` behavior plus app-side PNG export from the running
+  window. It does not use `screencapture` and does not move the cursor.
+- `ui` — reserved for final Accessibility checks via `agent-swift`. Use sparingly
+  for real user-facing affordances, menus, sheets, permissions, onboarding, and OS
+  integration.
+
+## Artifacts
+
+Runs are written under `desktop/macos/.harness/runs/`, which is gitignored. Artifacts
+can contain real user data from logs, state, screenshots, AX trees, memories, and
+chat content. Do not attach or publish a run directory unless you have reviewed it.
+
+## Usage
+
+```bash
+cd desktop/macos
+OMI_APP_NAME=omi-harness-test OMI_AUTOMATION_PORT=47888 ./run.sh --yolo
+```
+
+In another shell:
+
+```bash
+python3 scripts/omi-harness run e2e/flows/harness-smoke.yaml --lane visual --port 47888
+python3 scripts/omi-harness summarize latest
+python3 scripts/omi-harness latest
+python3 scripts/omi-harness compare <before-run> <after-run> --markdown
+python3 scripts/omi-harness cleanup --keep 10
+```
+
+For `ui` lane AX assertions, pass the named bundle id:
+
+```bash
+python3 scripts/omi-harness run e2e/flows/harness-smoke.yaml \
+  --lane ui --port 47888 --bundle-id com.omi.omi-harness-test
+```
+
+## Typed Steps
+
+Supported step types:
+
+- `bridge.navigate`
+- `bridge.action`
+- `visual.export`
+- `state.expect`
+- `trace.expect`
+- `log.expect`
+- `ax.expect`
+
+Use `wait:` after bridge steps when a state or trace must settle before the next
+step. Keep automated checks to facts the harness can measure directly: state,
+traces, logs, timing, and AX text. The harness does not score screenshot quality;
+the agent should open the PNGs listed in `summary.md` and judge layout, polish,
+clipping, empty states, and visual regressions directly.

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -151,10 +151,11 @@ if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
     echo "ERROR: APP_NAME '$APP_NAME' must use URL scheme '$EXPECTED_URL_SCHEME' (got '$URL_SCHEME')"
     exit 1
 fi
-AUTOMATION_ARGS=()
+AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-${AUTOMATION_PORT:-47777}}"
+AUTOMATION_CAPTURE_ROOT="${OMI_AUTOMATION_CAPTURE_ROOT:-$(pwd)/.harness/runs}"
+AUTOMATION_ARGS=("--automation-port=$AUTOMATION_PORT" "--automation-capture-root=$AUTOMATION_CAPTURE_ROOT")
 if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
-    AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-${AUTOMATION_PORT:-47777}}"
-    AUTOMATION_ARGS+=(--automation-bridge "--automation-port=$AUTOMATION_PORT")
+    AUTOMATION_ARGS=(--automation-bridge "${AUTOMATION_ARGS[@]}")
 fi
 
 # Backend configuration (Rust)

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -78,6 +78,8 @@ unset OPENAI_API_KEY
 # Use Xcode's default toolchain to match the SDK version
 unset TOOLCHAINS
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Timing utilities
 SCRIPT_START_TIME=$(date +%s.%N)
 STEP_START_TIME=$SCRIPT_START_TIME
@@ -102,7 +104,7 @@ substep() {
 # Per-worktree isolation: derive unique ports + bundle name so parallel worktrees don't
 # collide. Sets OMI_INSTANCE / RUST_PORT / PYTHON_PORT / AUTOMATION_PORT / OMI_APP_NAME /
 # OMI_DEV_DIR (explicit overrides always win; the primary checkout keeps "Omi Dev" + 10201).
-source "$(dirname "$0")/../../scripts/dev-instance.sh"
+source "$SCRIPT_DIR/../../scripts/dev-instance.sh"
 BACKEND_PORT="${PORT:-$RUST_PORT}"
 export PORT="$BACKEND_PORT"
 
@@ -136,7 +138,7 @@ APP_PATH="/Applications/$APP_NAME.app"
 # Agent runtime source (staged into the app bundle at Resources/agent below).
 # Without this, `[ -d "$AGENT_DIR/dist" ]` tests an empty path and the agent
 # copy is silently skipped → app shows "AI components missing".
-AGENT_DIR="$(dirname "$0")/agent"
+AGENT_DIR="$SCRIPT_DIR/agent"
 APP_DESKTOP_PATH="$HOME/Desktop/$APP_NAME.app"
 APP_DOWNLOADS_PATH="$HOME/Downloads/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
@@ -152,7 +154,7 @@ if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
     exit 1
 fi
 AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-${AUTOMATION_PORT:-47777}}"
-AUTOMATION_CAPTURE_ROOT="${OMI_AUTOMATION_CAPTURE_ROOT:-$(pwd)/.harness/runs}"
+AUTOMATION_CAPTURE_ROOT="${OMI_AUTOMATION_CAPTURE_ROOT:-$SCRIPT_DIR/.harness/runs}"
 AUTOMATION_ARGS=("--automation-port=$AUTOMATION_PORT" "--automation-capture-root=$AUTOMATION_CAPTURE_ROOT")
 if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
     AUTOMATION_ARGS=(--automation-bridge "${AUTOMATION_ARGS[@]}")

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -229,10 +229,14 @@ done
 find "$(dirname "$0")/../../app/build" -name "$APP_NAME.app" -type d -exec rm -rf {} + 2>/dev/null || true
 # Kill stale app bundles from other repo clones (e.g. ~/omi-desktop/)
 # These confuse LaunchServices and get launched instead of the /Applications copy.
-find "$HOME" -maxdepth 4 -name "$APP_NAME.app" -type d -not -path "$APP_BUNDLE" -not -path "$APP_PATH" 2>/dev/null | while read stale; do
-    substep "Removing stale clone: $stale"
-    rm -rf "$stale"
-done
+if [ "${OMI_SKIP_STALE_BUNDLE_SCAN:-0}" = "1" ]; then
+    substep "Skipping stale clone scan (OMI_SKIP_STALE_BUNDLE_SCAN=1)"
+else
+    find "$HOME" -maxdepth 4 -name "$APP_NAME.app" -type d -not -path "$APP_BUNDLE" -not -path "$APP_PATH" 2>/dev/null | while read stale; do
+        substep "Removing stale clone: $stale"
+        rm -rf "$stale"
+    done
+fi
 
 if [ "${OMI_SKIP_TUNNEL:-0}" != "1" ]; then
     step "Starting Cloudflare quick tunnel..."

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -635,6 +635,9 @@ def cleanup_runs(args: argparse.Namespace) -> int:
     keep = max(0, args.keep)
     remove = runs[:-keep] if keep else runs
     for path in remove:
+        resolved = path.resolve()
+        if path.is_symlink() or path.parent.resolve() != root or root not in resolved.parents:
+            raise SystemExit(f"omi-harness: refusing unsafe cleanup path: {path}")
         shutil.rmtree(path)
         print(f"removed {path}")
     return 0

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -27,9 +27,11 @@ except ImportError as exc:
 
 
 SCHEMA_VERSION = 2
+SCRIPT_DIR = Path(__file__).resolve().parent
+DESKTOP_DIR = SCRIPT_DIR.parent
 DEFAULT_PORT = int(os.environ.get("OMI_AUTOMATION_PORT", "47777"))
 DEFAULT_LOG = Path("/private/tmp/omi-dev.log")
-DEFAULT_RUN_ROOT = Path("desktop/macos/.harness/runs")
+DEFAULT_RUN_ROOT = DESKTOP_DIR / ".harness/runs"
 
 
 @dataclass
@@ -197,8 +199,28 @@ def step_prefix(index: int, step: dict[str, Any]) -> str:
 def run_agent_swift(ctx: HarnessContext, args: list[str]) -> subprocess.CompletedProcess[str]:
     if not ctx.bundle_id:
         raise RuntimeError("ax.expect requires --bundle-id")
-    subprocess.run(["agent-swift", "connect", "--bundle-id", ctx.bundle_id], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
+    connect = subprocess.run(
+        ["agent-swift", "connect", "--bundle-id", ctx.bundle_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=10,
+    )
+    if connect.returncode != 0:
+        return connect
     return subprocess.run(["agent-swift", *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=20)
+
+
+def action_payload(spec: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(spec)
+    params = dict(payload.get("params") or {})
+    for key in list(payload.keys()):
+        if key not in {"name", "params"}:
+            params[key] = payload.pop(key)
+    if params:
+        payload["params"] = params
+    return payload
 
 
 def assert_state(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
@@ -312,7 +334,7 @@ def execute_step(ctx: HarnessContext, index: int, step: dict[str, Any]) -> dict[
                 result["error"] = response.get("error")
 
         elif "bridge.action" in step:
-            payload = dict(step["bridge.action"] or {})
+            payload = action_payload(dict(step["bridge.action"] or {}))
             response = request_json(ctx.base_url, "POST", "/action", payload)
             response_path = ctx.steps_dir / f"{prefix}-action.json"
             write_json(response_path, response)
@@ -605,7 +627,10 @@ def compare_runs(args: argparse.Namespace) -> int:
 
 
 def cleanup_runs(args: argparse.Namespace) -> int:
-    root = run_root(args.out)
+    root = run_root(args.out).resolve()
+    default_root = DEFAULT_RUN_ROOT.resolve()
+    if root != default_root and default_root not in root.parents:
+        raise SystemExit(f"omi-harness: refusing cleanup outside harness run storage: {root}")
     runs = sorted([path for path in root.glob("*") if path.is_dir()])
     keep = max(0, args.keep)
     remove = runs[:-keep] if keep else runs

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -17,7 +17,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+import typing
 
 
 SCHEMA_VERSION = 2
@@ -49,7 +49,7 @@ def slug(value: str) -> str:
     return cleaned or "flow"
 
 
-def read_yaml(path: Path) -> dict[str, Any]:
+def read_yaml(path: Path) -> dict[str, typing.Any]:
     try:
         import yaml
     except ImportError as exc:
@@ -63,11 +63,11 @@ def read_yaml(path: Path) -> dict[str, Any]:
         return yaml.safe_load(handle) or {}
 
 
-def write_json(path: Path, data: Any) -> None:
+def write_json(path: Path, data: typing.Any) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def request_json(base_url: str, method: str, route: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+def request_json(base_url: str, method: str, route: str, body: dict[str, typing.Any] | None = None) -> dict[str, typing.Any]:
     data = None
     headers = {"Accept": "application/json"}
     if body is not None:
@@ -120,8 +120,8 @@ def tool_version(command: list[str]) -> str | None:
     return result.stdout.strip().splitlines()[0] if result.stdout.strip() else None
 
 
-def nested_get(data: dict[str, Any], dotted: str) -> Any:
-    current: Any = data
+def nested_get(data: dict[str, typing.Any], dotted: str) -> typing.Any:
+    current: typing.Any = data
     for part in dotted.split("."):
         if isinstance(current, dict):
             current = current.get(part)
@@ -130,28 +130,28 @@ def nested_get(data: dict[str, Any], dotted: str) -> Any:
     return current
 
 
-def normalize_state_response(response: dict[str, Any]) -> dict[str, Any]:
+def normalize_state_response(response: dict[str, typing.Any]) -> dict[str, typing.Any]:
     result = response.get("result")
     return result if isinstance(result, dict) else {}
 
 
-def state_snapshot(ctx: HarnessContext) -> dict[str, Any]:
+def state_snapshot(ctx: HarnessContext) -> dict[str, typing.Any]:
     return normalize_state_response(request_json(ctx.base_url, "GET", "/state"))
 
 
-def recent_traces(ctx: HarnessContext) -> list[dict[str, Any]]:
+def recent_traces(ctx: HarnessContext) -> list[dict[str, typing.Any]]:
     response = request_json(ctx.base_url, "GET", "/traces/recent")
     result = response.get("result")
     return result if isinstance(result, list) else []
 
 
-def expectation_matches(data: dict[str, Any], expectations: dict[str, Any]) -> bool:
+def expectation_matches(data: dict[str, typing.Any], expectations: dict[str, typing.Any]) -> bool:
     return all(nested_get(data, key) == value for key, value in expectations.items())
 
 
-def wait_for_state(ctx: HarnessContext, expectations: dict[str, Any], timeout: float = 5.0) -> tuple[bool, dict[str, Any]]:
+def wait_for_state(ctx: HarnessContext, expectations: dict[str, typing.Any], timeout: float = 5.0) -> tuple[bool, dict[str, typing.Any]]:
     deadline = time.monotonic() + timeout
-    latest: dict[str, Any] = {}
+    latest: dict[str, typing.Any] = {}
     while time.monotonic() < deadline:
         latest = state_snapshot(ctx)
         if expectation_matches({"state": latest}, expectations):
@@ -160,9 +160,9 @@ def wait_for_state(ctx: HarnessContext, expectations: dict[str, Any], timeout: f
     return False, latest
 
 
-def wait_for_trace(ctx: HarnessContext, expectations: dict[str, Any], timeout: float = 5.0) -> tuple[bool, list[dict[str, Any]]]:
+def wait_for_trace(ctx: HarnessContext, expectations: dict[str, typing.Any], timeout: float = 5.0) -> tuple[bool, list[dict[str, typing.Any]]]:
     deadline = time.monotonic() + timeout
-    traces: list[dict[str, Any]] = []
+    traces: list[dict[str, typing.Any]] = []
     while time.monotonic() < deadline:
         traces = recent_traces(ctx)
         if any(expectation_matches({"trace": trace}, expectations) for trace in traces):
@@ -187,7 +187,7 @@ def read_log_tail(ctx: HarnessContext) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
-def collect_logs(ctx: HarnessContext) -> dict[str, Any]:
+def collect_logs(ctx: HarnessContext) -> dict[str, typing.Any]:
     text = read_log_tail(ctx)
     out = ctx.run_dir / "logs.txt"
     out.write_text(text, encoding="utf-8")
@@ -195,7 +195,7 @@ def collect_logs(ctx: HarnessContext) -> dict[str, Any]:
     return {"path": str(out), "available": ctx.log_path.exists(), "bytes": len(text.encode("utf-8")), "error_count": error_count}
 
 
-def step_prefix(index: int, step: dict[str, Any]) -> str:
+def step_prefix(index: int, step: dict[str, typing.Any]) -> str:
     return f"{index:03d}-{slug(str(step.get('id') or step.get('name') or 'step'))}"
 
 
@@ -215,7 +215,7 @@ def run_agent_swift(ctx: HarnessContext, args: list[str]) -> subprocess.Complete
     return subprocess.run(["agent-swift", *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=20)
 
 
-def action_payload(spec: dict[str, Any]) -> dict[str, Any]:
+def action_payload(spec: dict[str, typing.Any]) -> dict[str, typing.Any]:
     payload = dict(spec)
     params = dict(payload.get("params") or {})
     for key in list(payload.keys()):
@@ -226,7 +226,7 @@ def action_payload(spec: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def assert_state(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+def assert_state(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> tuple[bool, str | None]:
     state = state_snapshot(ctx)
     write_json(path, state)
     expectations = spec.get("equals") or spec
@@ -237,7 +237,7 @@ def assert_state(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple
     return False, f"state assertions failed: {expectations}"
 
 
-def assert_log(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+def assert_log(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> tuple[bool, str | None]:
     text = read_log_tail(ctx)
     path.write_text(text, encoding="utf-8")
     contains = spec.get("contains", [])
@@ -255,7 +255,7 @@ def assert_log(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[b
     return True, None
 
 
-def assert_trace(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+def assert_trace(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> tuple[bool, str | None]:
     traces = recent_traces(ctx)
     write_json(path, traces)
     expectations = spec.get("equals") or spec
@@ -266,7 +266,7 @@ def assert_trace(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple
     return False, f"no trace matched: {expectations}"
 
 
-def assert_ax(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+def assert_ax(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> tuple[bool, str | None]:
     if ctx.lane != "ui":
         return True, "skipped outside ui lane"
     result = run_agent_swift(ctx, ["snapshot", "-i", "--json"])
@@ -283,14 +283,14 @@ def assert_ax(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bo
     return True, None
 
 
-def export_visual(ctx: HarnessContext, path: Path, target: str | None = None) -> dict[str, Any]:
+def export_visual(ctx: HarnessContext, path: Path, target: str | None = None) -> dict[str, typing.Any]:
     payload = {"path": str(path)}
     if target:
         payload["target"] = target
     return request_json(ctx.base_url, "POST", "/visual/export", payload)
 
 
-def apply_wait(ctx: HarnessContext, step: dict[str, Any], prefix: str, result: dict[str, Any]) -> None:
+def apply_wait(ctx: HarnessContext, step: dict[str, typing.Any], prefix: str, result: dict[str, typing.Any]) -> None:
     wait_spec = step.get("wait") or {}
     if not result["ok"] or not isinstance(wait_spec, dict) or not wait_spec:
         return
@@ -313,10 +313,10 @@ def apply_wait(ctx: HarnessContext, step: dict[str, Any], prefix: str, result: d
             result["error"] = f"state wait timed out after {timeout}s"
 
 
-def execute_step(ctx: HarnessContext, index: int, step: dict[str, Any]) -> dict[str, Any]:
+def execute_step(ctx: HarnessContext, index: int, step: dict[str, typing.Any]) -> dict[str, typing.Any]:
     prefix = step_prefix(index, step)
     started = time.perf_counter()
-    result: dict[str, Any] = {
+    result: dict[str, typing.Any] = {
         "id": step.get("id", f"S{index}"),
         "name": step.get("name", f"Step {index}"),
         "started_at": now_iso(),
@@ -545,7 +545,7 @@ def run_flow(args: argparse.Namespace) -> int:
     return 0 if metrics["ok"] else 1
 
 
-def write_summary(run_dir: Path, metrics: dict[str, Any]) -> None:
+def write_summary(run_dir: Path, metrics: dict[str, typing.Any]) -> None:
     lines = [
         f"# {metrics['flow']['name']}",
         "",

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -320,7 +320,10 @@ def execute_step(ctx: HarnessContext, index: int, step: dict[str, Any]) -> dict[
                 options = dict(step["visual.export"] or {})
                 name = slug(str(options.get("name") or step.get("id") or f"step-{index}"))
                 png_path = ctx.steps_dir / f"{prefix}-{name}.png"
-                response = request_json(ctx.base_url, "POST", "/visual/export", {"path": str(png_path)})
+                payload = {"path": str(png_path)}
+                if "target" in options:
+                    payload["target"] = str(options["target"])
+                response = request_json(ctx.base_url, "POST", "/visual/export", payload)
                 response_path = ctx.steps_dir / f"{prefix}-visual.json"
                 write_json(response_path, response)
                 result.update(operation="visual.export", response_path=str(response_path), ok=bool(response.get("ok")))

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Run Omi desktop experience flows through the local automation bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:
+    print("omi-harness: PyYAML is required to read flow files", file=sys.stderr)
+    raise SystemExit(2) from exc
+
+
+SCHEMA_VERSION = 2
+DEFAULT_PORT = int(os.environ.get("OMI_AUTOMATION_PORT", "47777"))
+DEFAULT_LOG = Path("/private/tmp/omi-dev.log")
+DEFAULT_RUN_ROOT = Path("desktop/macos/.harness/runs")
+
+
+@dataclass
+class HarnessContext:
+    base_url: str
+    flow_path: Path
+    run_dir: Path
+    steps_dir: Path
+    lane: str
+    log_path: Path
+    log_start: int
+    bundle_id: str | None
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def slug(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip().lower()).strip("-")
+    return cleaned or "flow"
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def request_json(base_url: str, method: str, route: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(f"{base_url}{route}", data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        payload = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            parsed = {"ok": False, "error": payload}
+        parsed["http_status"] = exc.code
+        return parsed
+    except urllib.error.URLError as exc:
+        return {"ok": False, "error": f"connection_failed: {exc.reason}"}
+    except TimeoutError as exc:
+        return {"ok": False, "error": f"connection_timeout: {exc}"}
+
+
+def git_sha() -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def tool_version(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    return result.stdout.strip().splitlines()[0] if result.stdout.strip() else None
+
+
+def nested_get(data: dict[str, Any], dotted: str) -> Any:
+    current: Any = data
+    for part in dotted.split("."):
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def normalize_state_response(response: dict[str, Any]) -> dict[str, Any]:
+    result = response.get("result")
+    return result if isinstance(result, dict) else {}
+
+
+def state_snapshot(ctx: HarnessContext) -> dict[str, Any]:
+    return normalize_state_response(request_json(ctx.base_url, "GET", "/state"))
+
+
+def recent_traces(ctx: HarnessContext) -> list[dict[str, Any]]:
+    response = request_json(ctx.base_url, "GET", "/traces/recent")
+    result = response.get("result")
+    return result if isinstance(result, list) else []
+
+
+def expectation_matches(data: dict[str, Any], expectations: dict[str, Any]) -> bool:
+    return all(nested_get(data, key) == value for key, value in expectations.items())
+
+
+def wait_for_state(ctx: HarnessContext, expectations: dict[str, Any], timeout: float = 5.0) -> tuple[bool, dict[str, Any]]:
+    deadline = time.monotonic() + timeout
+    latest: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        latest = state_snapshot(ctx)
+        if expectation_matches({"state": latest}, expectations):
+            return True, latest
+        time.sleep(0.15)
+    return False, latest
+
+
+def wait_for_trace(ctx: HarnessContext, expectations: dict[str, Any], timeout: float = 5.0) -> tuple[bool, list[dict[str, Any]]]:
+    deadline = time.monotonic() + timeout
+    traces: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        traces = recent_traces(ctx)
+        if any(expectation_matches({"trace": trace}, expectations) for trace in traces):
+            return True, traces
+        time.sleep(0.15)
+    return False, traces
+
+
+def log_cursor(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def read_log_tail(ctx: HarnessContext) -> str:
+    if not ctx.log_path.exists():
+        return ""
+    with ctx.log_path.open("rb") as handle:
+        handle.seek(ctx.log_start)
+        raw = handle.read(256_000)
+    return raw.decode("utf-8", errors="replace")
+
+
+def collect_logs(ctx: HarnessContext) -> dict[str, Any]:
+    text = read_log_tail(ctx)
+    out = ctx.run_dir / "logs.txt"
+    out.write_text(text, encoding="utf-8")
+    error_count = len(re.findall(r"\b(error|failed|exception|crash)\b", text, flags=re.IGNORECASE))
+    return {"path": str(out), "available": ctx.log_path.exists(), "bytes": len(text.encode("utf-8")), "error_count": error_count}
+
+
+def step_prefix(index: int, step: dict[str, Any]) -> str:
+    return f"{index:03d}-{slug(str(step.get('id') or step.get('name') or 'step'))}"
+
+
+def run_agent_swift(ctx: HarnessContext, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if not ctx.bundle_id:
+        raise RuntimeError("ax.expect requires --bundle-id")
+    subprocess.run(["agent-swift", "connect", "--bundle-id", ctx.bundle_id], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
+    return subprocess.run(["agent-swift", *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=20)
+
+
+def assert_state(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+    state = state_snapshot(ctx)
+    write_json(path, state)
+    expectations = spec.get("equals") or spec
+    if not isinstance(expectations, dict):
+        return False, "state.expect requires a mapping"
+    if expectation_matches({"state": state}, expectations):
+        return True, None
+    return False, f"state assertions failed: {expectations}"
+
+
+def assert_log(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+    text = read_log_tail(ctx)
+    path.write_text(text, encoding="utf-8")
+    contains = spec.get("contains", [])
+    absent = spec.get("absent", [])
+    if isinstance(contains, str):
+        contains = [contains]
+    if isinstance(absent, str):
+        absent = [absent]
+    missing = [item for item in contains if item not in text]
+    present = [item for item in absent if item in text]
+    if missing:
+        return False, f"log missing expected text: {missing}"
+    if present:
+        return False, f"log contained forbidden text: {present}"
+    return True, None
+
+
+def assert_trace(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+    traces = recent_traces(ctx)
+    write_json(path, traces)
+    expectations = spec.get("equals") or spec
+    if not isinstance(expectations, dict):
+        return False, "trace.expect requires a mapping"
+    if any(expectation_matches({"trace": trace}, expectations) for trace in traces):
+        return True, None
+    return False, f"no trace matched: {expectations}"
+
+
+def assert_ax(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bool, str | None]:
+    if ctx.lane != "ui":
+        return True, "skipped outside ui lane"
+    result = run_agent_swift(ctx, ["snapshot", "-i", "--json"])
+    path.write_text(result.stdout, encoding="utf-8")
+    if result.returncode != 0:
+        return False, "agent-swift snapshot failed"
+    text = result.stdout
+    visible = spec.get("text_visible", [])
+    if isinstance(visible, str):
+        visible = [visible]
+    missing = [item for item in visible if item not in text]
+    if missing:
+        return False, f"AX snapshot missing text: {missing}"
+    return True, None
+
+
+def apply_wait(ctx: HarnessContext, step: dict[str, Any], prefix: str, result: dict[str, Any]) -> None:
+    wait_spec = step.get("wait") or {}
+    if not result["ok"] or not isinstance(wait_spec, dict) or not wait_spec:
+        return
+    timeout = float(step.get("timeout_seconds", 5))
+    if "trace" in wait_spec:
+        waited_ok, traces = wait_for_trace(ctx, wait_spec["trace"], timeout)
+        trace_path = ctx.steps_dir / f"{prefix}-traces.json"
+        write_json(trace_path, traces)
+        result["artifacts"]["traces"] = str(trace_path)
+        if not waited_ok:
+            result["ok"] = False
+            result["error"] = f"trace wait timed out after {timeout}s"
+    else:
+        waited_ok, state = wait_for_state(ctx, wait_spec, timeout)
+        state_path = ctx.steps_dir / f"{prefix}-state.json"
+        write_json(state_path, state)
+        result["artifacts"]["state"] = str(state_path)
+        if not waited_ok:
+            result["ok"] = False
+            result["error"] = f"state wait timed out after {timeout}s"
+
+
+def execute_step(ctx: HarnessContext, index: int, step: dict[str, Any]) -> dict[str, Any]:
+    prefix = step_prefix(index, step)
+    started = time.perf_counter()
+    result: dict[str, Any] = {
+        "id": step.get("id", f"S{index}"),
+        "name": step.get("name", f"Step {index}"),
+        "started_at": now_iso(),
+        "ok": True,
+        "warnings": [],
+        "artifacts": {},
+    }
+
+    try:
+        if "bridge.navigate" in step:
+            payload = dict(step["bridge.navigate"] or {})
+            payload.setdefault("activateApp", False)
+            response = request_json(ctx.base_url, "POST", "/navigate", payload)
+            response_path = ctx.steps_dir / f"{prefix}-navigate.json"
+            write_json(response_path, response)
+            result.update(operation="bridge.navigate", response_path=str(response_path), ok=bool(response.get("ok")))
+            if not result["ok"]:
+                result["error"] = response.get("error")
+
+        elif "bridge.action" in step:
+            payload = dict(step["bridge.action"] or {})
+            response = request_json(ctx.base_url, "POST", "/action", payload)
+            response_path = ctx.steps_dir / f"{prefix}-action.json"
+            write_json(response_path, response)
+            result.update(operation="bridge.action", response_path=str(response_path), ok=bool(response.get("ok")))
+            if not result["ok"]:
+                result["error"] = response.get("error")
+
+        elif "visual.export" in step:
+            if ctx.lane not in {"visual", "ui"}:
+                result["operation"] = "visual.export"
+                result["warnings"].append(f"skipped in {ctx.lane} lane")
+            else:
+                options = dict(step["visual.export"] or {})
+                name = slug(str(options.get("name") or step.get("id") or f"step-{index}"))
+                png_path = ctx.steps_dir / f"{prefix}-{name}.png"
+                response = request_json(ctx.base_url, "POST", "/visual/export", {"path": str(png_path)})
+                response_path = ctx.steps_dir / f"{prefix}-visual.json"
+                write_json(response_path, response)
+                result.update(operation="visual.export", response_path=str(response_path), ok=bool(response.get("ok")))
+                result["artifacts"]["screenshot"] = str(png_path)
+                if not result["ok"]:
+                    result["error"] = response.get("error")
+
+        elif "state.expect" in step:
+            path = ctx.steps_dir / f"{prefix}-state.json"
+            ok, error = assert_state(ctx, dict(step["state.expect"] or {}), path)
+            result.update(operation="state.expect", ok=ok)
+            result["artifacts"]["state"] = str(path)
+            if error:
+                result["error"] = error
+
+        elif "log.expect" in step:
+            path = ctx.steps_dir / f"{prefix}-logs.txt"
+            ok, error = assert_log(ctx, dict(step["log.expect"] or {}), path)
+            result.update(operation="log.expect", ok=ok)
+            result["artifacts"]["logs"] = str(path)
+            if error:
+                result["error"] = error
+
+        elif "trace.expect" in step:
+            path = ctx.steps_dir / f"{prefix}-traces.json"
+            ok, error = assert_trace(ctx, dict(step["trace.expect"] or {}), path)
+            result.update(operation="trace.expect", ok=ok)
+            result["artifacts"]["traces"] = str(path)
+            if error:
+                result["error"] = error
+
+        elif "ax.expect" in step:
+            path = ctx.steps_dir / f"{prefix}-ax.json"
+            ok, error = assert_ax(ctx, dict(step["ax.expect"] or {}), path)
+            result.update(operation="ax.expect", ok=ok)
+            result["artifacts"]["ax"] = str(path)
+            if error and ok:
+                result["warnings"].append(error)
+            elif error:
+                result["error"] = error
+
+        else:
+            result.update(operation="unsupported", ok=False, error="step has no typed harness operation")
+
+        apply_wait(ctx, step, prefix, result)
+
+    except Exception as exc:  # noqa: BLE001 - runner records failures as artifacts.
+        result["ok"] = False
+        result["error"] = f"{type(exc).__name__}: {exc}"
+
+    result["duration_ms"] = round((time.perf_counter() - started) * 1000, 2)
+    result["finished_at"] = now_iso()
+    return result
+
+
+def create_context(args: argparse.Namespace, flow_path: Path, run_dir: Path, lane: str) -> HarnessContext:
+    return HarnessContext(
+        base_url=f"http://127.0.0.1:{args.port}",
+        flow_path=flow_path,
+        run_dir=run_dir,
+        steps_dir=run_dir / "steps",
+        lane=lane,
+        log_path=Path(args.log),
+        log_start=log_cursor(Path(args.log)),
+        bundle_id=getattr(args, "bundle_id", None),
+    )
+
+
+def run_flow(args: argparse.Namespace) -> int:
+    flow_path = Path(args.flow).resolve()
+    flow = read_yaml(flow_path)
+    flow_name = str(flow.get("name") or flow_path.stem)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_root = Path(args.out).resolve()
+    run_dir = run_root / f"{timestamp}-{slug(flow_name)}"
+    steps_dir = run_dir / "steps"
+    steps_dir.mkdir(parents=True, exist_ok=True)
+
+    ctx = create_context(args, flow_path, run_dir, args.lane)
+    started = time.perf_counter()
+    initial_state = request_json(ctx.base_url, "GET", "/state")
+    capabilities = request_json(ctx.base_url, "GET", "/capabilities")
+    write_json(run_dir / "initial-state.json", initial_state)
+    write_json(run_dir / "capabilities.json", capabilities)
+
+    step_results = [execute_step(ctx, index, step) for index, step in enumerate(flow.get("steps", []), 1)]
+    logs = collect_logs(ctx)
+    final_state = request_json(ctx.base_url, "GET", "/state")
+    traces = recent_traces(ctx)
+    write_json(run_dir / "final-state.json", final_state)
+    write_json(run_dir / "traces.json", traces)
+
+    bridge_ready = bool(initial_state.get("ok")) and bool(capabilities.get("ok"))
+    metrics = {
+        "schema_version": SCHEMA_VERSION,
+        "runner": "omi-harness",
+        "runner_version": 2,
+        "flow": {"name": flow_name, "path": str(flow_path), "version": flow.get("version")},
+        "environment": {
+            "git_sha": git_sha(),
+            "lane": args.lane,
+            "port": args.port,
+            "base_url": ctx.base_url,
+            "bundle_id": args.bundle_id,
+            "agent_swift_version": tool_version(["agent-swift", "--version"]),
+        },
+        "cursor_safety": {"coordinate_clicks": 0, "external_screenshot_tool": False},
+        "artifacts": {"captures_gitignored": True},
+        "timing": {
+            "total_ms": round((time.perf_counter() - started) * 1000, 2),
+            "step_ms": [step["duration_ms"] for step in step_results],
+            "bridge_trace_ms": [trace.get("durationMs") for trace in traces],
+        },
+        "steps": step_results,
+        "logs": logs,
+        "ok": bridge_ready and all(step["ok"] for step in step_results),
+        "bridge_ready": bridge_ready,
+        "started_at": now_iso(),
+    }
+    write_json(run_dir / "metrics.json", metrics)
+    write_summary(run_dir, metrics)
+    print(str(run_dir))
+    return 0 if metrics["ok"] else 1
+
+
+def write_summary(run_dir: Path, metrics: dict[str, Any]) -> None:
+    lines = [
+        f"# {metrics['flow']['name']}",
+        "",
+        f"- status: {'PASS' if metrics['ok'] else 'FAIL'}",
+        f"- lane: {metrics['environment']['lane']}",
+        f"- total_ms: {metrics['timing']['total_ms']}",
+        f"- coordinate_clicks: {metrics['cursor_safety']['coordinate_clicks']}",
+        f"- log_error_count: {metrics['logs'].get('error_count', 0)}",
+        "",
+        "## Steps",
+    ]
+    for step in metrics["steps"]:
+        status = "PASS" if step["ok"] else "FAIL"
+        lines.append(f"- {status} {step['id']} {step['name']} ({step['duration_ms']} ms)")
+        if step.get("error"):
+            lines.append(f"  error: {step['error']}")
+        for warning in step.get("warnings", []):
+            lines.append(f"  warning: {warning}")
+    screenshots = [
+        step["artifacts"]["screenshot"]
+        for step in metrics["steps"]
+        if isinstance(step.get("artifacts"), dict) and step["artifacts"].get("screenshot")
+    ]
+    if screenshots:
+        lines.extend(["", "## Visual Evidence"])
+        lines.extend(f"- {path}" for path in screenshots)
+    (run_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_root(path: str | None) -> Path:
+    return Path(path or DEFAULT_RUN_ROOT)
+
+
+def latest_run(root: Path) -> Path:
+    runs = sorted([path for path in root.glob("*") if path.is_dir()])
+    if not runs:
+        raise SystemExit(f"omi-harness: no runs under {root}")
+    return runs[-1]
+
+
+def summarize_run(args: argparse.Namespace) -> int:
+    run_dir = latest_run(run_root(args.out)).resolve() if args.run == "latest" else Path(args.run).resolve()
+    summary = run_dir / "summary.md"
+    if not summary.exists():
+        raise SystemExit(f"omi-harness: missing summary: {summary}")
+    print(summary.read_text(encoding="utf-8"), end="")
+    return 0
+
+
+def latest_cmd(args: argparse.Namespace) -> int:
+    print(str(latest_run(run_root(args.out)).resolve()))
+    return 0
+
+
+def compare_runs(args: argparse.Namespace) -> int:
+    left = json.loads((Path(args.left) / "metrics.json").read_text(encoding="utf-8"))
+    right = json.loads((Path(args.right) / "metrics.json").read_text(encoding="utf-8"))
+    comparison = {
+        "left": str(Path(args.left).resolve()),
+        "right": str(Path(args.right).resolve()),
+        "ok_changed": [left.get("ok"), right.get("ok")],
+        "total_ms_delta": round(right["timing"]["total_ms"] - left["timing"]["total_ms"], 2),
+        "log_error_count_delta": right["logs"].get("error_count", 0) - left["logs"].get("error_count", 0),
+        "step_count_delta": len(right.get("steps", [])) - len(left.get("steps", [])),
+    }
+    if args.markdown:
+        print("| metric | value |")
+        print("| --- | --- |")
+        for key, value in comparison.items():
+            print(f"| {key} | `{value}` |")
+    else:
+        print(json.dumps(comparison, indent=2, sort_keys=True))
+    return 0
+
+
+def cleanup_runs(args: argparse.Namespace) -> int:
+    root = run_root(args.out)
+    runs = sorted([path for path in root.glob("*") if path.is_dir()])
+    keep = max(0, args.keep)
+    remove = runs[:-keep] if keep else runs
+    for path in remove:
+        shutil.rmtree(path)
+        print(f"removed {path}")
+    return 0
+
+
+def add_run_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("flow")
+    parser.add_argument("--lane", choices=["bridge", "visual", "ui"], default="bridge")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--out", default=str(DEFAULT_RUN_ROOT))
+    parser.add_argument("--log", default=str(DEFAULT_LOG))
+    parser.add_argument("--bundle-id")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run", help="run a typed harness flow")
+    add_run_args(run)
+    run.set_defaults(func=run_flow)
+
+    baseline = subparsers.add_parser("baseline", help="alias for run, intended for before/after comparisons")
+    add_run_args(baseline)
+    baseline.set_defaults(func=run_flow)
+
+    compare = subparsers.add_parser("compare", help="compare two harness run directories")
+    compare.add_argument("left")
+    compare.add_argument("right")
+    compare.add_argument("--markdown", action="store_true")
+    compare.set_defaults(func=compare_runs)
+
+    summarize = subparsers.add_parser("summarize", help="print a run summary")
+    summarize.add_argument("run", nargs="?", default="latest")
+    summarize.add_argument("--out", default=str(DEFAULT_RUN_ROOT))
+    summarize.set_defaults(func=summarize_run)
+
+    latest = subparsers.add_parser("latest", help="print the latest run directory")
+    latest.add_argument("--out", default=str(DEFAULT_RUN_ROOT))
+    latest.set_defaults(func=latest_cmd)
+
+    cleanup = subparsers.add_parser("cleanup", help="delete old local run artifacts")
+    cleanup.add_argument("--out", default=str(DEFAULT_RUN_ROOT))
+    cleanup.add_argument("--keep", type=int, default=10)
+    cleanup.set_defaults(func=cleanup_runs)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 import json
 import os
 import re
@@ -257,6 +258,13 @@ def assert_ax(ctx: HarnessContext, spec: dict[str, Any], path: Path) -> tuple[bo
     return True, None
 
 
+def export_visual(ctx: HarnessContext, path: Path, target: str | None = None) -> dict[str, Any]:
+    payload = {"path": str(path)}
+    if target:
+        payload["target"] = target
+    return request_json(ctx.base_url, "POST", "/visual/export", payload)
+
+
 def apply_wait(ctx: HarnessContext, step: dict[str, Any], prefix: str, result: dict[str, Any]) -> None:
     wait_spec = step.get("wait") or {}
     if not result["ok"] or not isinstance(wait_spec, dict) or not wait_spec:
@@ -320,16 +328,79 @@ def execute_step(ctx: HarnessContext, index: int, step: dict[str, Any]) -> dict[
                 options = dict(step["visual.export"] or {})
                 name = slug(str(options.get("name") or step.get("id") or f"step-{index}"))
                 png_path = ctx.steps_dir / f"{prefix}-{name}.png"
-                payload = {"path": str(png_path)}
-                if "target" in options:
-                    payload["target"] = str(options["target"])
-                response = request_json(ctx.base_url, "POST", "/visual/export", payload)
+                response = export_visual(ctx, png_path, str(options["target"]) if "target" in options else None)
                 response_path = ctx.steps_dir / f"{prefix}-visual.json"
                 write_json(response_path, response)
                 result.update(operation="visual.export", response_path=str(response_path), ok=bool(response.get("ok")))
                 result["artifacts"]["screenshot"] = str(png_path)
                 if not result["ok"]:
                     result["error"] = response.get("error")
+
+        elif "visual.action_sequence" in step:
+            if ctx.lane not in {"visual", "ui"}:
+                result["operation"] = "visual.action_sequence"
+                result["warnings"].append(f"skipped in {ctx.lane} lane")
+            else:
+                options = dict(step["visual.action_sequence"] or {})
+                action_name = str(options.get("action") or "")
+                if not action_name:
+                    result.update(operation="visual.action_sequence", ok=False, error="visual.action_sequence requires action")
+                else:
+                    frames = max(1, int(options.get("frames", 8)))
+                    interval_ms = max(1, int(options.get("interval_ms", 16)))
+                    target = str(options.get("target") or "floating")
+                    params = dict(options.get("params") or {})
+                    action_path = ctx.steps_dir / f"{prefix}-action.json"
+                    frame_records = []
+                    with ThreadPoolExecutor(max_workers=1) as executor:
+                        action_future = executor.submit(
+                            request_json,
+                            ctx.base_url,
+                            "POST",
+                            "/action",
+                            {"name": action_name, "params": params},
+                        )
+                        ok = True
+                        for frame_index in range(frames):
+                            frame_path = ctx.steps_dir / f"{prefix}-frame-{frame_index:02d}.png"
+                            captured_at = now_iso()
+                            response = export_visual(ctx, frame_path, target)
+                            frame_records.append(
+                                {
+                                    "index": frame_index,
+                                    "captured_at": captured_at,
+                                    "path": str(frame_path),
+                                    "ok": bool(response.get("ok")),
+                                    "response": response,
+                                }
+                            )
+                            ok = ok and bool(response.get("ok"))
+                            if frame_index < frames - 1:
+                                time.sleep(interval_ms / 1000)
+                        try:
+                            action_response = action_future.result(timeout=25)
+                        except FutureTimeoutError:
+                            action_response = {"ok": False, "error": "action request timed out after capture"}
+                    write_json(action_path, action_response)
+                    ok = ok and bool(action_response.get("ok"))
+                    manifest_path = ctx.steps_dir / f"{prefix}-sequence.json"
+                    write_json(
+                        manifest_path,
+                        {
+                            "action": action_name,
+                            "capture_mode": "concurrent",
+                            "params": params,
+                            "target": target,
+                            "frames": frame_records,
+                            "interval_ms": interval_ms,
+                            "action_response": str(action_path),
+                        },
+                    )
+                    result.update(operation="visual.action_sequence", ok=ok, response_path=str(action_path))
+                    result["artifacts"]["sequence"] = str(manifest_path)
+                    result["artifacts"]["frames"] = [record["path"] for record in frame_records]
+                    if not ok:
+                        result["error"] = "action sequence capture failed"
 
         elif "state.expect" in step:
             path = ctx.steps_dir / f"{prefix}-state.json"
@@ -476,6 +547,14 @@ def write_summary(run_dir: Path, metrics: dict[str, Any]) -> None:
     if screenshots:
         lines.extend(["", "## Visual Evidence"])
         lines.extend(f"- {path}" for path in screenshots)
+    sequences = [
+        step["artifacts"]["sequence"]
+        for step in metrics["steps"]
+        if isinstance(step.get("artifacts"), dict) and step["artifacts"].get("sequence")
+    ]
+    if sequences:
+        lines.extend(["", "## Animation Evidence"])
+        lines.extend(f"- {path}" for path in sequences)
     (run_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -19,12 +19,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import yaml
-except ImportError as exc:
-    print("omi-harness: PyYAML is required to read flow files", file=sys.stderr)
-    raise SystemExit(2) from exc
-
 
 SCHEMA_VERSION = 2
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -56,6 +50,15 @@ def slug(value: str) -> str:
 
 
 def read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+    except ImportError as exc:
+        print(
+            "omi-harness: PyYAML is required to run flow files; install it with `python3 -m pip install PyYAML`",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
+
     with path.open("r", encoding="utf-8") as handle:
         return yaml.safe_load(handle) or {}
 


### PR DESCRIPTION
## Summary

- Add a lightweight local desktop experience harness for cursor-free bridge, visual, timing, log, and animation capture flows.
- Add Ask Omi pill benchmarks for open/close latency and animation frame sequences.
- Make Ask Omi open/focus feel instant by ordering the panel and focusing earlier.
- Make close much faster while preserving a smoother explicit frame transition.
- Harden the dev automation bridge by binding to loopback only, constraining visual exports to the configured capture root, and passing per-worktree automation ports on non-prod launches.

## Results

Before optimization:
- Open app-side elapsed median: ~442.6 ms.
- Close app-side elapsed median: ~371.3 ms.

After optimization and smoothness pass:
- Warm open elapsed: ~0.4 ms with focus ~0.0 ms in the final benchmark run.
- Smooth close: ~126 ms, down from ~371 ms, with multiple captured intermediate frame sizes instead of a start/end jump.

## Validation

- Built and launched named non-production macOS bundle: `omi-pr-harness` / `com.omi.omi-pr-harness`.
- Ran `ask-omi-animation-benchmark` through the hardened bridge on port `47892`: PASS.
- Ran `ask-omi-open-benchmark`: PASS.
- Ran `python3 -m py_compile desktop/macos/scripts/omi-harness`.
- Parsed the Ask Omi harness YAML flows with PyYAML.
- Ran `git diff --check`.
- Subagent review found two P1 automation hardening issues; fixed both and follow-up review approved the fixes.

## Notes

Harness capture artifacts are written under `desktop/macos/.harness/runs/` and are gitignored. The harness records screenshots and frame manifests for agents to inspect directly; it does not try to score screenshot quality automatically.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

