### PR TITLE
fix(backend): skip malformed action item in GET /v1/conversations/{id}/action-items instead of 500

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import logging
 import uuid
 
 from utils.executors import db_executor
@@ -29,9 +30,11 @@ from utils.notifications import (
     sync_action_item_reminder,
 )
 from utils.task_sync import auto_sync_action_item
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 
 # Request models specific to action items
@@ -496,7 +499,15 @@ def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.
     if conversation.get('is_locked', False):
         raise HTTPException(status_code=402, detail="A paid plan is required to access this conversation.")
     action_items = action_items_db.get_action_items_by_conversation(uid, conversation_id)
-    response_items = [ActionItemResponse(**item) for item in action_items]
+    response_items = []
+    for item in action_items:
+        try:
+            response_items.append(ActionItemResponse(**item))
+        except ValidationError:
+            logger.warning(
+                f"Skipping malformed action item {item.get('id')} for conversation {conversation_id}, uid {uid}"
+            )
+            continue
 
     return {"action_items": response_items, "conversation_id": conversation_id}
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -62,6 +62,7 @@ pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v
 pytest tests/unit/test_firestore_cache.py -v
 pytest tests/unit/test_task_sharing.py -v
+pytest tests/unit/test_action_items_conversation_list_malformed.py -v
 pytest tests/unit/test_firmware_pagination.py -v
 pytest tests/unit/test_vad_gate.py -v
 pytest tests/unit/test_vad_onnx.py -v

--- a/backend/tests/unit/test_action_items_conversation_list_malformed.py
+++ b/backend/tests/unit/test_action_items_conversation_list_malformed.py
@@ -1,0 +1,123 @@
+"""GET /v1/conversations/{id}/action-items must skip a malformed action item instead of 500ing the page.
+
+The endpoint built ActionItemResponse(**item) per item, so one malformed/legacy item (missing a required
+field like 'completed') raised ValidationError and failed the whole page. routers/action_items.py has a
+heavy import graph, so we import it under a stub finder, then call the endpoint directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import action_items as ai_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _valid(aid, completed=False):
+    return {'id': aid, 'description': 'do a thing', 'completed': completed}
+
+
+def test_conversation_list_skips_malformed_not_500():
+    bad = {'id': 'a2', 'description': 'missing completed'}  # missing required field -> ValidationError
+    page = [_valid('a1'), bad]
+    with patch.object(
+        ai_mod.conversations_db, 'get_conversation', return_value={'id': 'c1', 'is_locked': False}
+    ), patch.object(ai_mod.action_items_db, 'get_action_items_by_conversation', return_value=page):
+        resp = ai_mod.get_conversation_action_items(conversation_id='c1', uid='uid1')
+    assert [i.id for i in resp['action_items']] == ['a1']


### PR DESCRIPTION
## Summary

`GET /v1/conversations/{conversation_id}/action-items` returns HTTP 500 for the whole page when a single stored action item is malformed. One legacy or partial-write item that is missing a required field takes down the entire list, so the user sees an error instead of the other valid action items on that conversation. This PR builds each `ActionItemResponse` on its own and skips the bad one with a logged warning, so the rest of the page still loads. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes that were prepared together and are being opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/action_items.py`, `get_conversation_action_items` builds the response list in a single unguarded comprehension:

```python
action_items = action_items_db.get_action_items_by_conversation(uid, conversation_id)
response_items = [ActionItemResponse(**item) for item in action_items]
```

`ActionItemResponse` requires `id`, `description`, and `completed`. The items come straight from Firestore with no validation, so one record missing a required field (for example an older item written before `completed` existed) raises `pydantic.ValidationError`. Because the comprehension has no guard, that one failure propagates out of the handler and FastAPI turns it into a 500 for the whole conversation, hiding every other action item that parsed fine.

## Fix

Build the list item by item and wrap each model construction in a `try/except ValidationError`. On a bad item, log a warning with the item id and continue, so only that record is dropped:

```python
response_items = []
for item in action_items:
    try:
        response_items.append(ActionItemResponse(**item))
    except ValidationError:
        logger.warning(
            f"Skipping malformed action item {item.get('id')} for conversation {conversation_id}, uid {uid}"
        )
        continue

return {"action_items": response_items, "conversation_id": conversation_id}
```

Valid items behave exactly as before. The response shape and contract are unchanged for valid input.

## Testing

New `backend/tests/unit/test_action_items_conversation_list_malformed.py` (registered in `backend/test.sh`). `routers/action_items.py` has a heavy import graph, so the test imports it under a stub meta-path finder and calls `get_conversation_action_items` directly with `get_conversation` and `get_action_items_by_conversation` patched. The case feeds a page of one valid item plus one item missing `completed` and asserts the response contains only the valid item instead of raising a 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation in this endpoint. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it keeps the unguarded comprehension and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

