### PR TITLE
fix(backend): skip malformed action item in GET /v1/action-items instead of 500

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -287,7 +287,13 @@ def get_action_items(
             description = item.get('description', '')
             item['description'] = (description[:70] + '...') if len(description) > 70 else description
 
-    response_items = [ActionItemResponse(**item) for item in action_items]
+    response_items = []
+    for item in action_items:
+        try:
+            response_items.append(ActionItemResponse(**item))
+        except ValidationError:
+            logger.warning(f"Skipping malformed action item {item.get('id')} in action items list for uid {uid}")
+            continue
 
     has_more = len(action_items) == limit
     if has_more:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -172,6 +172,7 @@ pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_voice_message_filename_none.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
+pytest tests/unit/test_action_items_main_list_malformed.py -v
 pytest tests/unit/test_payment_promotion_codes.py -v
 pytest tests/unit/test_stripe_webhook_none_guard.py -v
 pytest tests/unit/test_stripe_webhook_behavioral.py -v

--- a/backend/tests/unit/test_action_items_main_list_malformed.py
+++ b/backend/tests/unit/test_action_items_main_list_malformed.py
@@ -1,0 +1,131 @@
+"""GET /v1/action-items must skip a malformed action item instead of 500ing the whole list.
+
+The endpoint built ActionItemResponse(**item) per item, so one malformed/legacy item (missing a required
+field like 'completed') raised ValidationError and failed the whole page. routers/action_items.py has a
+heavy import graph, so we import it under a stub finder, then call the endpoint directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import action_items as ai_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _valid(aid, completed=False):
+    return {'id': aid, 'description': 'do a thing', 'completed': completed}
+
+
+def test_main_list_skips_malformed_not_500():
+    bad = {'id': 'a2', 'description': 'missing completed'}  # missing required field -> ValidationError
+    page = [_valid('a1'), bad, _valid('a3', completed=True)]
+    with patch.object(ai_mod.action_items_db, 'get_action_items', return_value=page):
+        resp = ai_mod.get_action_items(
+            limit=50,
+            offset=0,
+            completed=None,
+            conversation_id=None,
+            start_date=None,
+            end_date=None,
+            due_start_date=None,
+            due_end_date=None,
+            uid='uid1',
+        )
+    assert [i.id for i in resp['action_items']] == ['a1', 'a3']


### PR DESCRIPTION
## Summary

`GET /v1/action-items` returns the current user's task list. It builds one `ActionItemResponse` per stored item, so a single malformed or legacy item (for example one missing the required `completed` field) raises during validation and the endpoint returns HTTP 500 for the whole page. That hides every other valid task the user has, not just the bad one. This PR builds each response object individually and skips the items that fail, so one bad record no longer takes down the list. This is a proactive hardening change; there is no filed GitHub issue for it. It is part of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands alone and can be reviewed and merged on its own.

## Root cause

In `backend/routers/action_items.py`, `get_action_items` builds the response in one unguarded list comprehension:

```python
response_items = [ActionItemResponse(**item) for item in action_items]
```

`action_items` is a list of raw Firestore dicts. `ActionItemResponse` requires `id`, `description`, and `completed`, and these dicts are not validated before this point. An item that is missing `completed` (or has a wrong type for any required field) raises `pydantic.ValidationError`, and because the comprehension is not wrapped, that propagates up and FastAPI turns it into a 500 for the entire page. One bad row fails the whole request instead of being dropped.

## Fix

Build the list one item at a time and skip the ones that do not validate, logging the id so the bad record is traceable:

```python
response_items = []
for item in action_items:
    try:
        response_items.append(ActionItemResponse(**item))
    except ValidationError:
        logger.warning(f"Skipping malformed action item {item.get('id')} in action items list for uid {uid}")
        continue
```

Valid items serialize exactly as before. There is no change to the response shape or the contract for valid input; the only difference is that a malformed item is left out of the list rather than 500ing the whole page. The per-conversation action-items endpoint has the same pattern and is covered in a separate PR.

## Testing

Added `backend/tests/unit/test_action_items_main_list_malformed.py`, registered in `backend/test.sh`. `routers/action_items.py` has a heavy import graph, so the test installs a stub finder on `sys.meta_path`, imports the router under it, then calls `get_action_items` directly with `action_items_db.get_action_items` patched to return a fixed page. The page mixes valid items with one that is missing `completed`, and the test asserts the handler returns only the valid ids instead of raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch the body of `get_action_items`, so it leaves the unguarded comprehension in place and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

