### PR TITLE
fix(backend): tolerate invalid announcement type so one bad record cannot 500 the public list

### DIFF
--- a/backend/models/announcement.py
+++ b/backend/models/announcement.py
@@ -159,9 +159,17 @@ class Announcement(BaseModel):
         targeting_data = data.get("targeting")
         display_data = data.get("display")
 
+        # Tolerate a missing or out-of-enum type so one malformed/legacy announcement document cannot
+        # 500 the whole (public) announcements list. Fall back to the generic ANNOUNCEMENT type.
+        raw_type = data.get("type")
+        try:
+            announcement_type = AnnouncementType(raw_type)
+        except ValueError:
+            announcement_type = AnnouncementType.ANNOUNCEMENT
+
         return Announcement(
             id=data.get("id"),
-            type=AnnouncementType(data.get("type")),
+            type=announcement_type,
             created_at=data.get("created_at"),
             active=data.get("active", True),
             app_version=data.get("app_version"),

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -37,6 +37,7 @@ pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v
 pytest tests/unit/test_memories_user_review.py -v
+pytest tests/unit/test_announcement_malformed_type.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/tests/unit/test_announcement_malformed_type.py
+++ b/backend/tests/unit/test_announcement_malformed_type.py
@@ -1,0 +1,36 @@
+"""Announcement.from_dict must tolerate a missing/invalid type instead of raising.
+
+The public announcement list endpoints (/v1/announcements/changelogs, /features, /general) build
+Announcement.from_dict(doc) per record in database/announcements.py. from_dict did
+AnnouncementType(data.get("type")), so one malformed/legacy announcement with a null or out-of-enum
+type raised ValueError and 500'd the whole public list. It now falls back to the generic type.
+"""
+
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from models.announcement import Announcement, AnnouncementType  # noqa: E402
+
+_BASE = {'id': 'a1', 'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc)}
+
+
+def test_bad_type_falls_back_not_raises():
+    a = Announcement.from_dict({**_BASE, 'type': 'bogus_type'})
+    assert a.type == AnnouncementType.ANNOUNCEMENT
+
+
+def test_none_type_falls_back():
+    a = Announcement.from_dict({**_BASE, 'type': None})
+    assert a.type == AnnouncementType.ANNOUNCEMENT
+
+
+def test_valid_types_preserved():
+    for raw, expected in [
+        ('changelog', AnnouncementType.CHANGELOG),
+        ('feature', AnnouncementType.FEATURE),
+        ('announcement', AnnouncementType.ANNOUNCEMENT),
+    ]:
+        a = Announcement.from_dict({**_BASE, 'type': raw})
+        assert a.type == expected


### PR DESCRIPTION
## Summary

`Announcement.from_dict` is the per-record parser behind the public announcement list endpoints (`/v1/announcements/changelogs`, `/features`, `/general`), which build it once per Firestore document in `database/announcements.py`. It coerced the stored `type` field straight through the `AnnouncementType` enum, so a single announcement document with a null or out-of-enum `type` raised and returned HTTP 500 for the whole page, hiding every other valid announcement. This PR makes the parser fall back to the generic `ANNOUNCEMENT` type when the stored value is not a recognized enum member, so one bad or legacy record no longer takes down the list. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small, independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own so it can be reviewed and merged separately.

## Root cause

In `backend/models/announcement.py`, `Announcement.from_dict` passed the raw stored value directly into the enum:

```python
return Announcement(
    id=data.get("id"),
    type=AnnouncementType(data.get("type")),
    created_at=data.get("created_at"),
    ...
)
```

`data` is a raw Firestore dict with no validation. `AnnouncementType(value)` raises `ValueError` when `value` is `None` or any string that is not a defined member (for example a renamed or removed type left behind in an old document). That `ValueError` propagates out of the list handler that loops over documents and surfaces as a 500 for the entire response, even though every other record parses fine.

## Fix

Read the stored value once, try to resolve it through the enum, and fall back to `AnnouncementType.ANNOUNCEMENT` on `ValueError`:

```python
raw_type = data.get("type")
try:
    announcement_type = AnnouncementType(raw_type)
except ValueError:
    announcement_type = AnnouncementType.ANNOUNCEMENT
```

The resolved `announcement_type` is then passed to the constructor in place of the inline call. A document with a valid `type` resolves to the same member as before, so there is no change to the response shape or contract for valid input.

## Testing

Added `backend/tests/unit/test_announcement_malformed_type.py`, registered in `backend/test.sh`. `models/announcement.py` is a plain models module, so the test sets `ENCRYPTION_SECRET` and imports `Announcement` and `AnnouncementType` directly, then calls `from_dict` on built dicts. Cases: a `bogus_type` string and a `None` type both fall back to `AnnouncementType.ANNOUNCEMENT`, and the valid values `changelog`, `feature`, and `announcement` still map to their correct members. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

