### PR TITLE
fix(backend): return 400 instead of 500 on malformed JSON in POST /v1/apps

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -467,7 +467,10 @@ def get_popular_apps_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 @router.post('/v1/apps', tags=['v1'])
 def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)):
-    data = json.loads(app_data)
+    try:
+        data = json.loads(app_data)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=400, detail='Invalid app_data: must be valid JSON')
     data['approved'] = False
     data['status'] = 'under-review'
     data['name'] = (data.get('name') or '').strip()

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -471,6 +471,8 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
         data = json.loads(app_data)
     except (json.JSONDecodeError, TypeError):
         raise HTTPException(status_code=400, detail='Invalid app_data: must be valid JSON')
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail='Invalid app_data: must be a JSON object')
     data['approved'] = False
     data['status'] = 'under-review'
     data['name'] = (data.get('name') or '').strip()

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -178,6 +178,7 @@ pytest tests/unit/test_conversation_hybrid_search.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v
 pytest tests/unit/test_delete_account_purge_storage.py -v
 pytest tests/unit/test_apps_review_reply_validation.py -v
+pytest tests/unit/test_apps_create_app_json.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_apps_create_app_json.py
+++ b/backend/tests/unit/test_apps_create_app_json.py
@@ -1,0 +1,118 @@
+"""POST /v1/apps (create_app) must return 400, not 500, on a malformed app_data JSON form field.
+
+routers/apps.py has a very heavy import graph, so we import it under a stub finder that auto-mocks those
+namespaces (keeping models/fastapi/pydantic real), then call the handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+_rm = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+    if _rm:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_create_app_invalid_json_returns_400_not_500():
+    with pytest.raises(HTTPException) as e:
+        apps_mod.create_app(app_data='this is not json', file=MagicMock(), uid='uid1')
+    assert e.value.status_code == 400

--- a/backend/tests/unit/test_apps_create_app_json.py
+++ b/backend/tests/unit/test_apps_create_app_json.py
@@ -116,3 +116,12 @@ def test_create_app_invalid_json_returns_400_not_500():
     with pytest.raises(HTTPException) as e:
         apps_mod.create_app(app_data='this is not json', file=MagicMock(), uid='uid1')
     assert e.value.status_code == 400
+
+
+def test_create_app_non_object_json_returns_400_not_500():
+    # Valid JSON that is not an object (array/scalar) must also be rejected with 400, not 500: the
+    # handler immediately does dict-style writes like data['approved'] = False.
+    for payload in ('[1, 2, 3]', '"a string"', '42'):
+        with pytest.raises(HTTPException) as e:
+            apps_mod.create_app(app_data=payload, file=MagicMock(), uid='uid1')
+        assert e.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /v1/apps` (`create_app`) takes the app payload as a multipart form field `app_data` that holds a JSON string, and parses it with `json.loads` with no guard. A client that sends a non-JSON value in `app_data` makes the parse raise, and that turns into an HTTP 500 instead of a clean 400, so a malformed request the server should reject up front looks like a server fault and tells the client nothing about what was wrong. This PR wraps the parse in a guard that returns 400 with a clear message. This is a proactive hardening change; there is no filed GitHub issue for it. It is part of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/apps.py`, `create_app` parses the form field on the first line of the handler with nothing around it:

```python
def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)):
    data = json.loads(app_data)
```

`app_data` arrives as a raw string from the multipart form, so its contents are whatever the client sent. If it is not valid JSON, `json.loads` raises `json.JSONDecodeError`, and if a non-string somehow reaches it, it raises `TypeError`. Neither is caught, so FastAPI surfaces it as a 500 for a request that is really a client input error and should be a 400.

## Fix

Wrap the `json.loads` call in a try/except at the top of the handler. On a parse failure, raise `HTTPException(status_code=400, ...)` with a message that names the bad field:

```python
try:
    data = json.loads(app_data)
except (json.JSONDecodeError, TypeError):
    raise HTTPException(status_code=400, detail='Invalid app_data: must be valid JSON')
```

Valid JSON flows through exactly as before. There is no change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_apps_create_app_json.py` (registered in `test.sh`). `routers/apps.py` has a very heavy import graph, so the test imports it under a stub finder that auto-mocks those namespaces while keeping models, fastapi, and pydantic real, then calls `create_app` directly. The case covered: a non-JSON `app_data` value raises `HTTPException` with status 400 rather than an uncaught 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including this file, but it does not touch this handler's body, so it leaves the bare `json.loads(app_data)` in place and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

