### PR TITLE
fix(backend): return 400 instead of 500 on malformed JSON in POST /v1/personas

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -561,6 +561,8 @@ async def create_persona(
         data = json.loads(persona_data)
     except (json.JSONDecodeError, TypeError):
         raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail='Invalid persona_data: must be a JSON object')
     data['approved'] = False
     data['status'] = 'under-review'
     data['category'] = 'personality-emulation'

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -557,7 +557,10 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
 async def create_persona(
     persona_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)
 ):
-    data = json.loads(persona_data)
+    try:
+        data = json.loads(persona_data)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
     data['approved'] = False
     data['status'] = 'under-review'
     data['category'] = 'personality-emulation'

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -167,6 +167,7 @@ pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_staged_tasks_dedup.py -v
 pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
+pytest tests/unit/test_apps_create_persona_json.py -v
 pytest tests/unit/test_subscription_restructure.py -v
 pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_voice_message_filename_none.py -v

--- a/backend/tests/unit/test_apps_create_persona_json.py
+++ b/backend/tests/unit/test_apps_create_persona_json.py
@@ -116,3 +116,12 @@ def test_create_persona_invalid_json_returns_400_not_500():
     with pytest.raises(HTTPException) as e:
         asyncio.run(apps_mod.create_persona(persona_data='this is not json', file=MagicMock(), uid='uid1'))
     assert e.value.status_code == 400
+
+
+def test_create_persona_non_object_json_returns_400_not_500():
+    # Valid JSON that is not an object (array/scalar) must also be rejected with 400, not 500: the
+    # handler immediately does dict-style writes like data['approved'] = False.
+    for payload in ('[1, 2, 3]', '"a string"', '42'):
+        with pytest.raises(HTTPException) as e:
+            asyncio.run(apps_mod.create_persona(persona_data=payload, file=MagicMock(), uid='uid1'))
+        assert e.value.status_code == 400

--- a/backend/tests/unit/test_apps_create_persona_json.py
+++ b/backend/tests/unit/test_apps_create_persona_json.py
@@ -1,0 +1,118 @@
+"""POST /v1/personas (create_persona) must return 400, not 500, on malformed persona_data JSON.
+
+routers/apps.py has a very heavy import graph, so we import it under a stub finder, then call the handler.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+_rm = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+    if _rm:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_create_persona_invalid_json_returns_400_not_500():
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(apps_mod.create_persona(persona_data='this is not json', file=MagicMock(), uid='uid1'))
+    assert e.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /v1/personas` (`create_persona`) takes the persona payload as a multipart form field `persona_data` holding a JSON string. It parses that string with `json.loads` and no guard, so a `persona_data` field that is not valid JSON raises and the endpoint returns HTTP 500 instead of a 400 for bad input. This PR wraps the parse and returns a 400 when `persona_data` is not valid JSON. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/apps.py`, `create_persona` parses the form field directly:

```python
data = json.loads(persona_data)
```

`persona_data` comes straight off the multipart form as a string, so the client controls its contents. When that string is not valid JSON, `json.loads` raises `json.JSONDecodeError`, and a non-string value raises `TypeError`. Neither is caught, so FastAPI turns it into a 500. The sibling `create_app` handler in the same file takes its payload as a form string the same way, so this is the matching parse path.

## Fix

Wrap the parse and return a 400 when the field is not valid JSON:

```python
try:
    data = json.loads(persona_data)
except (json.JSONDecodeError, TypeError):
    raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
```

Valid JSON still parses and flows through exactly as before. No change to the response shape or contract for valid input.

## Testing

Added `backend/tests/unit/test_apps_create_persona_json.py`, registered in `backend/test.sh`. `routers/apps.py` has a heavy import graph, so the test imports it under a stub finder on `sys.meta_path` and then calls `create_persona` directly. The case passes a non-JSON `persona_data` string and asserts the handler raises `HTTPException` with status 400 rather than letting a decode error become a 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `routers/apps.py`, but it does not touch this handler's body, so it leaves the bare `json.loads(persona_data)` in place and does not address this. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

