### PR TITLE
fix(backend): return 400 instead of 500 on malformed JSON in PATCH /v1/personas/{id}

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -603,7 +603,10 @@ async def update_persona(
     file: UploadFile = File(None),
     uid=Depends(auth.get_current_user_uid),
 ):
-    data = json.loads(persona_data)
+    try:
+        data = json.loads(persona_data)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
     persona = await run_blocking(db_executor, get_available_app_by_id, persona_id, uid)
     if not persona:
         raise HTTPException(status_code=404, detail='Persona not found')

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -607,6 +607,8 @@ async def update_persona(
         data = json.loads(persona_data)
     except (json.JSONDecodeError, TypeError):
         raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail='Invalid persona_data: must be a JSON object')
     persona = await run_blocking(db_executor, get_available_app_by_id, persona_id, uid)
     if not persona:
         raise HTTPException(status_code=404, detail='Persona not found')

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -157,6 +157,7 @@ pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_memories_pagination_clamp.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_file_paths_filename_none.py -v
+pytest tests/unit/test_apps_update_persona_json.py -v
 pytest tests/unit/test_sync_cloud_tasks.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_sync_record_usage.py -v

--- a/backend/tests/unit/test_apps_update_persona_json.py
+++ b/backend/tests/unit/test_apps_update_persona_json.py
@@ -118,3 +118,12 @@ def test_update_persona_invalid_json_returns_400_not_500():
             apps_mod.update_persona(persona_id='p1', persona_data='this is not json', file=MagicMock(), uid='uid1')
         )
     assert e.value.status_code == 400
+
+
+def test_update_persona_non_object_json_returns_400_not_500():
+    # Valid JSON that is not an object (array/scalar) must also be rejected with 400, not 500: the
+    # handler later does dict-style access like data['image'] and data['username'].
+    for payload in ('[1, 2, 3]', '"a string"', '42'):
+        with pytest.raises(HTTPException) as e:
+            asyncio.run(apps_mod.update_persona(persona_id='p1', persona_data=payload, file=MagicMock(), uid='uid1'))
+        assert e.value.status_code == 400

--- a/backend/tests/unit/test_apps_update_persona_json.py
+++ b/backend/tests/unit/test_apps_update_persona_json.py
@@ -1,0 +1,120 @@
+"""PATCH /v1/personas/{id} (update_persona) must return 400, not 500, on malformed persona_data JSON.
+
+routers/apps.py has a very heavy import graph, so we import it under a stub finder, then call the handler.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+_rm = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+    if _rm:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_update_persona_invalid_json_returns_400_not_500():
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(
+            apps_mod.update_persona(persona_id='p1', persona_data='this is not json', file=MagicMock(), uid='uid1')
+        )
+    assert e.value.status_code == 400


### PR DESCRIPTION
## Summary

`PATCH /v1/personas/{persona_id}` takes the persona payload as a multipart form field `persona_data` holding a JSON string, and `update_persona` parses it with `json.loads` before any validation. A request whose `persona_data` is not valid JSON returns HTTP 500 instead of a clean 400, so a malformed client payload looks like a server fault. This validates the field up front and returns 400 on bad input. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/apps.py`, `update_persona` parses the form field directly with no guard:

```python
async def update_persona(
    persona_id: str,
    persona_data: str = Form(...),
    file: UploadFile = File(None),
    uid=Depends(auth.get_current_user_uid),
):
    data = json.loads(persona_data)
```

`persona_data` is a plain string form field, so the client controls its contents. When it is not valid JSON, `json.loads` raises `json.JSONDecodeError` (and `TypeError` if it is not a string at all). Nothing catches it, so FastAPI turns it into an unhandled 500. The earlier `create_persona` path in the same file parses its body through `AppCreate.model_validate` inside a `try/except ValidationError` that returns 422, so the persona update path was the inconsistent one here.

## Fix

Wrap the parse in a guard and return 400 when the field is not valid JSON:

```python
try:
    data = json.loads(persona_data)
except (json.JSONDecodeError, TypeError):
    raise HTTPException(status_code=400, detail='Invalid persona_data: must be valid JSON')
```

Everything after the parse is unchanged. A valid `persona_data` payload produces the same `data` dict and the same response as before, so there is no change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_apps_update_persona_json.py`, registered in `backend/test.sh`. `routers/apps.py` has a very heavy import graph, so the test imports it under a stub finder (a meta path finder that returns auto-mock modules for the heavy dependencies) and then calls `update_persona` directly. The case covered is a non-JSON `persona_data` string, which must raise an `HTTPException` with status 400 rather than a `JSONDecodeError`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `routers/apps.py`, but it does not touch this handler's body, so it keeps the bare `json.loads(persona_data)` and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

