### PR TITLE
fix(backend): return 400 instead of 500 on invalid stored timestamp in calendar auto-link

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -347,11 +347,16 @@ async def auto_link_calendar_event(conversation_id: str, uid: str = Depends(auth
     if not started_at:
         raise HTTPException(status_code=400, detail="Conversation has no timestamp information")
 
-    # Parse datetimes if they're strings
-    if isinstance(started_at, str):
-        started_at = datetime.fromisoformat(started_at.replace('Z', '+00:00'))
-    if isinstance(finished_at, str):
-        finished_at = datetime.fromisoformat(finished_at.replace('Z', '+00:00'))
+    # Parse datetimes if they're strings. A stored timestamp that is not valid ISO (legacy or imported
+    # data) would otherwise raise ValueError and surface as a 500; return a clear 400 instead, matching the
+    # missing-timestamp case handled just above.
+    try:
+        if isinstance(started_at, str):
+            started_at = datetime.fromisoformat(started_at.replace('Z', '+00:00'))
+        if isinstance(finished_at, str):
+            finished_at = datetime.fromisoformat(finished_at.replace('Z', '+00:00'))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Conversation has invalid timestamp information")
 
     # Ensure timezone-aware
     if started_at.tzinfo is None:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -58,6 +58,7 @@ pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_conversations_count.py -v
+pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v
 pytest tests/unit/test_firestore_cache.py -v

--- a/backend/tests/unit/test_calendar_autolink_invalid_timestamp.py
+++ b/backend/tests/unit/test_calendar_autolink_invalid_timestamp.py
@@ -1,0 +1,112 @@
+"""POST /v1/conversations/{id}/calendar-event/auto-link must return 400, not 500, on a bad timestamp.
+
+The handler parses the conversation's stored started_at/finished_at with datetime.fromisoformat when they
+are strings. A legacy or imported conversation whose timestamp string is not valid ISO raised ValueError
+and surfaced as a 500. The same handler already returns 400 when the timestamp is missing, so a malformed
+timestamp should be a 400 too. routers/conversations.py has a heavy import graph, so we import it under a
+stub finder, then call the handler directly.
+"""
+
+import asyncio
+import pytest
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import conversations as conv_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_invalid_stored_timestamp_returns_400_not_500():
+    convo = {'id': 'c1', 'started_at': 'not-a-real-timestamp', 'finished_at': 'not-a-real-timestamp'}
+    with patch.object(conv_mod, '_get_valid_conversation_by_id', return_value=convo):
+        with pytest.raises(HTTPException) as e:
+            asyncio.run(conv_mod.auto_link_calendar_event(conversation_id='c1', uid='uid1'))
+    assert e.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /v1/conversations/{id}/calendar-event/auto-link` reads the conversation's stored `started_at` and `finished_at` and parses them with `datetime.fromisoformat` when they are strings. A conversation with a non-ISO timestamp (legacy or imported data) makes that parse raise `ValueError`, which becomes an HTTP 500, so the user cannot auto-link that conversation at all. This catches the parse failure and returns a 400 instead, matching the missing-timestamp case the same handler already returns a few lines above. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/conversations.py`, `auto_link_calendar_event` parses the stored strings with no guard:

```python
# Parse datetimes if they're strings
if isinstance(started_at, str):
    started_at = datetime.fromisoformat(started_at.replace('Z', '+00:00'))
if isinstance(finished_at, str):
    finished_at = datetime.fromisoformat(finished_at.replace('Z', '+00:00'))
```

These values come straight from the Firestore document. `datetime.fromisoformat` raises `ValueError` on anything that is not a valid ISO string, and nothing catches it, so a single bad stored timestamp surfaces as a 500. The handler already treats a bad timestamp as a client-data problem a few lines up, where a missing `started_at` returns a 400, so the malformed case was the inconsistent one.

## Fix

Wrap both `fromisoformat` calls in a `try/except ValueError` and raise a 400 on failure:

```python
try:
    if isinstance(started_at, str):
        started_at = datetime.fromisoformat(started_at.replace('Z', '+00:00'))
    if isinstance(finished_at, str):
        finished_at = datetime.fromisoformat(finished_at.replace('Z', '+00:00'))
except ValueError:
    raise HTTPException(status_code=400, detail="Conversation has invalid timestamp information")
```

A valid ISO timestamp parses exactly as before. There is no change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_calendar_autolink_invalid_timestamp.py`, registered in `backend/test.sh`. `routers/conversations.py` has a heavy import graph, so the test imports it under a stub finder and calls `auto_link_calendar_event` directly, patching `_get_valid_conversation_by_id` to return a conversation whose stored `started_at`/`finished_at` are not valid ISO. The case asserts the handler raises `HTTPException` with status 400 rather than letting the `ValueError` become a 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

