### PR TITLE
fix(backend): clamp limit in GET /v1/calendar/meetings to a safe range

### DIFF
--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -99,5 +99,6 @@ def list_calendar_meetings(
     limit: int = 50,
 ):
     """List calendar meetings within a date range"""
+    limit = max(1, min(limit, 1000))
     meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
     return [CalendarMeetingContext(**m) for m in meetings]

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -152,6 +152,7 @@ pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_dev_api_action_items_poison.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_rate_limit_json_failopen.py -v
+pytest tests/unit/test_calendar_meetings_limit_clamp.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_memories_pagination_clamp.py -v

--- a/backend/tests/unit/test_calendar_meetings_limit_clamp.py
+++ b/backend/tests/unit/test_calendar_meetings_limit_clamp.py
@@ -1,0 +1,131 @@
+"""GET /v1/calendar/meetings must clamp the limit so a negative/oversized value can't reach Firestore.
+
+list_calendar_meetings passed the raw limit straight into the Firestore .limit() call, so ?limit=-5 hit
+calendar_db.list_meetings with a negative limit (Firestore raises ValueError -> 500). routers/
+calendar_meetings.py has a heavy import graph, so we import it under a stub finder, then call the endpoint
+directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import calendar_meetings as cm_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _valid(eid):
+    return {'calendar_event_id': eid, 'title': 'Standup', 'start_time': _NOW, 'duration_minutes': 30}
+
+
+def test_negative_limit_is_clamped():
+    db = MagicMock(return_value=[])
+    with patch.object(cm_mod.calendar_db, 'list_meetings', db):
+        cm_mod.list_calendar_meetings(uid='uid1', start_date=None, end_date=None, limit=-5)
+    assert db.call_args.kwargs['limit'] == 1
+
+
+def test_oversized_limit_is_clamped():
+    db = MagicMock(return_value=[])
+    with patch.object(cm_mod.calendar_db, 'list_meetings', db):
+        cm_mod.list_calendar_meetings(uid='uid1', start_date=None, end_date=None, limit=10_000)
+    assert db.call_args.kwargs['limit'] == 1000


### PR DESCRIPTION
## Summary

`GET /v1/calendar/meetings` passes the raw `limit` query param straight into the Firestore query. A negative limit like `?limit=-5` reaches Firestore's `.limit()` and raises `ValueError`, so the whole list call returns HTTP 500 instead of any meetings, and an oversized limit lets a single request pull an unbounded number of documents. This clamps `limit` to a safe range (at least 1, at most 1000) before it reaches the database. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of several small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/calendar_meetings.py`, `list_calendar_meetings` forwards the request `limit` with no bounds check:

```python
def list_calendar_meetings(
    uid: str = Depends(auth.get_current_user_uid),
    start_date: Optional[datetime] = None,
    end_date: Optional[datetime] = None,
    limit: int = 50,
):
    """List calendar meetings within a date range"""
    meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
    return [CalendarMeetingContext(**m) for m in meetings]
```

`limit` is a plain int with a default of 50 and no minimum or maximum. `calendar_db.list_meetings` hands it to the Firestore query's `.limit()`, which rejects a negative value with `ValueError`, and that surfaces as an unhandled 500. A large positive value is accepted and turns one request into an unbounded read. The other GET in this file, `get_calendar_meeting`, fetches a single document by id and takes no limit, so nothing here already guarded this path.

## Fix

Clamp `limit` to `[1, 1000]` before calling the database:

```python
limit = max(1, min(limit, 1000))
meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
```

A negative or zero limit becomes 1, anything over 1000 becomes 1000, and any value already in range is unchanged. There is no change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_calendar_meetings_limit_clamp.py`, registered in `backend/test.sh`. `routers/calendar_meetings.py` has a heavy import graph, so the test imports it under a stub finder and then calls `list_calendar_meetings` directly, patching `calendar_db.list_meetings` to record what it received. Cases: `limit=-5` reaches the database as 1, and `limit=10000` reaches it as 1000. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the limit handling in this endpoint. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it does not address this bug. The clamp added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

