### PR TITLE
fix(backend): skip malformed meeting in GET /v1/calendar/meetings instead of 500

### DIFF
--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -1,14 +1,17 @@
+import logging
 from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 import database.calendar_meetings as calendar_db
 from models.calendar_context import CalendarMeetingContext, MeetingParticipant
 from utils.other import endpoints as auth
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 
 class StoreMeetingRequest(BaseModel):
@@ -100,4 +103,13 @@ def list_calendar_meetings(
 ):
     """List calendar meetings within a date range"""
     meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
-    return [CalendarMeetingContext(**m) for m in meetings]
+    # Build each response individually so one malformed/legacy meeting doc doesn't fail the whole list
+    # with a 500.
+    result = []
+    for m in meetings:
+        try:
+            result.append(CalendarMeetingContext(**m))
+        except (TypeError, ValidationError) as e:
+            logger.warning(f"Skipping malformed calendar meeting for uid {uid}: {e}")
+            continue
+    return result

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -147,6 +147,7 @@ pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_oauth_callback_uid_guard.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
+pytest tests/unit/test_calendar_meetings_poison_skip.py -v
 pytest tests/unit/test_dev_api_conversations_poison.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_dev_api_action_items_poison.py -v

--- a/backend/tests/unit/test_calendar_meetings_poison_skip.py
+++ b/backend/tests/unit/test_calendar_meetings_poison_skip.py
@@ -1,0 +1,125 @@
+"""GET /v1/calendar/meetings must skip a malformed meeting instead of 500ing the whole list.
+
+list_calendar_meetings built CalendarMeetingContext(**m) per meeting, so one malformed/legacy meeting doc
+(missing a required field) raised ValidationError and failed the whole page. routers/calendar_meetings.py
+has a heavy import graph, so we import it under a stub finder, then call the endpoint directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import calendar_meetings as cm_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _valid(eid):
+    return {'calendar_event_id': eid, 'title': 'Standup', 'start_time': _NOW, 'duration_minutes': 30}
+
+
+def test_malformed_meeting_skipped_not_500():
+    bad = _valid('e2')
+    del bad['duration_minutes']  # missing required field -> ValidationError
+    page = [_valid('e1'), bad, _valid('e3')]
+    with patch.object(cm_mod.calendar_db, 'list_meetings', return_value=page):
+        result = cm_mod.list_calendar_meetings(uid='uid1', start_date=None, end_date=None, limit=50)
+    assert [r.calendar_event_id for r in result] == ['e1', 'e3']


### PR DESCRIPTION
## Summary

`GET /v1/calendar/meetings` returns HTTP 500 for the whole page when a single stored meeting document is malformed. One legacy or partial-write meeting that is missing a required field takes down the entire list, so the client gets nothing back and every other valid meeting is hidden behind the error. This PR builds each `CalendarMeetingContext` individually and skips the bad record, logging it, so one bad document no longer fails the whole response. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/calendar_meetings.py`, `list_calendar_meetings` builds the whole page in one unguarded comprehension:

```python
meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)
return [CalendarMeetingContext(**m) for m in meetings]
```

`meetings` is a list of raw Firestore dicts with no validation. `CalendarMeetingContext` requires fields like `start_time` and `duration_minutes`, so a single document missing one of those raises `pydantic.ValidationError` while the comprehension is being built. A bad dict shape (for example a stored value of the wrong type) raises `TypeError`. Either one propagates out of the handler and FastAPI surfaces it as a 500 for the whole page instead of dropping the one offending row. The list endpoint is the only place this matters; the single-record `get_calendar_meeting` either returns one meeting or 404s, so it does not have the same all-or-nothing failure.

## Fix

Loop over the meetings and build each response one at a time. On `TypeError` or `ValidationError`, log a warning with the uid and the error, and skip just that record:

```python
# Build each response individually so one malformed/legacy meeting doc doesn't fail the whole list
# with a 500.
result = []
for m in meetings:
    try:
        result.append(CalendarMeetingContext(**m))
    except (TypeError, ValidationError) as e:
        logger.warning(f"Skipping malformed calendar meeting for uid {uid}: {e}")
        continue
return result
```

A page where every document is well formed returns exactly the same list as before. No signature, response-shape, or contract change.

## Testing

Added `backend/tests/unit/test_calendar_meetings_poison_skip.py`, registered in `backend/test.sh`. `routers/calendar_meetings.py` has a heavy import graph, so the test imports it under a stub meta-path finder and then calls `list_calendar_meetings` directly with `calendar_db.list_meetings` patched to return a fixed page. The page has three meetings where the middle one is missing the required `duration_minutes` field, which is what triggers the `ValidationError`. The result contains only the two valid meetings (`e1` and `e3`), in order, with no 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it leaves the unguarded comprehension in place and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

