### PR TITLE
fix(backend): return 404 instead of 500 on a malformed shared-chat record

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1206,8 +1206,10 @@ def get_shared_chat_messages(token: str):
     if not share_data:
         raise HTTPException(status_code=404, detail='Share link expired or not found')
 
-    sender_uid = share_data['uid']
-    message_ids = share_data['message_ids']
+    sender_uid = share_data.get('uid')
+    message_ids = share_data.get('message_ids')
+    if not sender_uid or message_ids is None:
+        raise HTTPException(status_code=404, detail='Share link expired or not found')
 
     messages = []
     for mid in message_ids:
@@ -1224,7 +1226,7 @@ def get_shared_chat_messages(token: str):
             )
 
     return {
-        "sender_name": share_data['display_name'],
+        "sender_name": share_data.get('display_name', ''),
         "messages": messages,
         "count": len(messages),
     }

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -142,6 +142,7 @@ pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_async_tasks.py -v
+pytest tests/unit/test_chat_share_malformed.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_oauth_callback_uid_guard.py -v

--- a/backend/tests/unit/test_chat_share_malformed.py
+++ b/backend/tests/unit/test_chat_share_malformed.py
@@ -1,0 +1,136 @@
+"""GET /v2/messages/shared/{token} must return 404 (not 500) when the stored share record is malformed.
+
+The public handler read share_data['uid'] / ['message_ids'] / ['display_name'] via direct subscript, so a
+corrupted/legacy share record missing a key raised KeyError -> 500. routers/chat.py has a heavy import
+graph, so we import it under a stub finder, then call the handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import chat as chat_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_share_missing_uid_returns_404():
+    with patch.object(chat_mod, 'get_chat_share', return_value={'message_ids': ['m1'], 'display_name': 'X'}):
+        with pytest.raises(HTTPException) as e:
+            chat_mod.get_shared_chat_messages(token='t')
+    assert e.value.status_code == 404
+
+
+def test_share_missing_message_ids_returns_404():
+    with patch.object(chat_mod, 'get_chat_share', return_value={'uid': 'u1', 'display_name': 'X'}):
+        with pytest.raises(HTTPException) as e:
+            chat_mod.get_shared_chat_messages(token='t')
+    assert e.value.status_code == 404
+
+
+def test_valid_share_returns_response():
+    with patch.object(
+        chat_mod, 'get_chat_share', return_value={'uid': 'u1', 'message_ids': ['m1'], 'display_name': 'X'}
+    ), patch.object(chat_mod.chat_db, 'get_message', return_value=None):
+        result = chat_mod.get_shared_chat_messages(token='t')
+    assert result['sender_name'] == 'X'
+    assert result['count'] == 0


### PR DESCRIPTION
## Summary

`GET /v2/messages/shared/{token}` is the public, no-auth endpoint that renders a shared chat. It pulls the sender uid and the message id list straight out of the stored share record, so a share record that is missing either field returns HTTP 500 instead of a clean not found. The whole shared page is dead for that link until the record is fixed, even though the right answer is just "this share is gone." This PR reads those fields defensively and returns 404 (share expired or not found) when they are absent. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands alone and can be reviewed and merged on its own.

## Root cause

In `backend/routers/chat.py`, `get_shared_chat_messages` already handles a missing record, but then reads the record contents with direct subscripts:

```python
sender_uid = share_data['uid']
message_ids = share_data['message_ids']
```

and later:

```python
"sender_name": share_data['display_name'],
```

`get_chat_share` returns a raw stored dict, so it can come back present but incomplete (a legacy record, a partial write, a corrupted entry). Any of those keys missing raises `KeyError`, which FastAPI turns into a 500 for the whole request. The not found branch above it is the behavior we actually want here, but it only fires when the record is entirely absent, not when it is present and malformed.

## Fix

Read the fields with `.get` and treat a missing uid or message id list the same as a missing record, returning 404. `display_name` falls back to an empty string since it is only a label.

```python
sender_uid = share_data.get('uid')
message_ids = share_data.get('message_ids')
if not sender_uid or message_ids is None:
    raise HTTPException(status_code=404, detail='Share link expired or not found')
```

```python
"sender_name": share_data.get('display_name', ''),
```

For a valid share record the response shape and contract are unchanged.

## Testing

Added `backend/tests/unit/test_chat_share_malformed.py`, registered in `backend/test.sh`. `routers/chat.py` has a heavy import graph, so the test imports it under a stub finder and calls `get_shared_chat_messages` directly. Cases: a record missing `uid` returns 404, a record missing `message_ids` returns 404, and a complete record returns the normal response with the right `sender_name` and `count`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation in this handler. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including this file, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

