### PR TITLE
fix(backend): skip photos with no base64 during data-protection-level migration

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -664,6 +664,12 @@ def migrate_conversations_level_batch(uid: str, conversation_ids: List[str], tar
             # Decrypt first to get a clean state
             plain_photo_data = _prepare_photo_for_read(photo_data, uid)
 
+            # A photo doc with no base64 payload (legacy or partial write) has nothing to re-encrypt; skip
+            # it so one bad photo doesn't abort the whole multi-conversation migration batch.
+            if not plain_photo_data or plain_photo_data.get('base64') is None:
+                logger.warning(f"Skipping photo with no base64 data during level migration for uid {uid}")
+                continue
+
             # Prepare the specific fields for update
             photo_update_payload = {'data_protection_level': target_level}
             if target_level == 'enhanced':

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -137,6 +137,7 @@ pytest tests/unit/test_sync_silent_failure.py -v
 pytest tests/unit/test_sync_ordered_assignment.py -v
 pytest tests/unit/test_fair_use_free_tier.py -v
 pytest tests/unit/test_fair_use_upgrade.py -v
+pytest tests/unit/test_conversation_photo_migration_missing_base64.py -v
 pytest tests/unit/test_skip_classifier_restrict.py -v
 pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v

--- a/backend/tests/unit/test_conversation_photo_migration_missing_base64.py
+++ b/backend/tests/unit/test_conversation_photo_migration_missing_base64.py
@@ -1,0 +1,135 @@
+"""migrate_conversations_level_batch must not abort when a photo doc has no base64 payload.
+
+The photo migration loop decrypted each photo with _prepare_photo_for_read and then read
+plain_photo_data['base64'] unconditionally. A photo doc missing the base64 field (legacy or a partial
+write) makes _prepare_photo_for_read return None (empty doc) or a dict without 'base64', so the bracket
+access raised KeyError/TypeError and aborted the whole multi-conversation migration batch partway through
+(after some batches had already been committed).
+
+database/conversations.py initializes the Firestore client at import time, so we load it from source with
+its heavy dependencies stubbed, then patch the conversation-prep helpers (not under test) and drive the
+real photo loop with a mocked Firestore.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+# Stub every heavy dependency database/conversations.py pulls in at import time. We load the module from
+# source (it inits Firestore at import), so a meta-path finder satisfies its imports with auto-mocks while
+# the module's own functions stay real.
+_STUB = ('database', 'utils', 'models', 'google', 'firebase_admin', 'pinecone', 'opuslib', 'pydub', 'redis')
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_saved = {name: mod for name, mod in sys.modules.items() if _is_stubbed_name(name)}
+for name in list(sys.modules):
+    if _is_stubbed_name(name):
+        sys.modules.pop(name, None)
+sys.meta_path.insert(0, _finder)
+try:
+    _spec = importlib.util.spec_from_file_location(
+        'database.conversations', str(_BACKEND_DIR / 'database' / 'conversations.py')
+    )
+    conv_db = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(conv_db)
+finally:
+    sys.meta_path.remove(_finder)
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in _saved:
+            sys.modules.pop(name, None)
+    sys.modules.update(_saved)
+
+
+def _make_snapshot(doc_id, data, reference):
+    snap = MagicMock()
+    snap.exists = True
+    snap.id = doc_id
+    snap.to_dict.return_value = data
+    snap.reference = reference
+    return snap
+
+
+def _make_photo_doc(data):
+    doc = MagicMock()
+    doc.to_dict.return_value = data
+    doc.reference = MagicMock()
+    return doc
+
+
+def _run_migration(photo_docs, target_level='enhanced'):
+    """Drive migrate_conversations_level_batch for one standard conversation with the given photo docs."""
+    batch = MagicMock()
+    db = MagicMock()
+    db.batch.return_value = batch
+
+    conv_ref = MagicMock()
+    conv_ref.collection.return_value.select.return_value.stream.return_value = iter(photo_docs)
+    conv_snapshot = _make_snapshot('c1', {'data_protection_level': 'standard'}, conv_ref)
+    db.get_all.return_value = [conv_snapshot]
+
+    with patch.object(conv_db, 'db', db), patch.object(
+        conv_db, '_prepare_conversation_for_read', lambda data, uid: data
+    ), patch.object(conv_db, '_prepare_conversation_for_write', lambda payload, uid, level: {}):
+        conv_db.migrate_conversations_level_batch('uid1', ['c1'], target_level)
+    return batch
+
+
+def test_photo_missing_base64_does_not_abort_migration():
+    # A photo doc with no base64 field (and an empty one) must be skipped, not crash the whole batch.
+    photos = [_make_photo_doc({'data_protection_level': 'standard'}), _make_photo_doc({})]
+    batch = _run_migration(photos)  # must not raise
+    photo_payloads = [
+        c.args[1] for c in batch.update.call_args_list if isinstance(c.args[1], dict) and 'base64' in c.args[1]
+    ]
+    assert photo_payloads == []  # neither bad photo produced a base64 update
+
+
+def test_valid_photo_still_migrated():
+    # A photo that does have base64 must still be migrated (regression guard for over-skipping).
+    photos = [_make_photo_doc({'data_protection_level': 'standard', 'base64': 'abc'})]
+    batch = _run_migration(photos)
+    photo_payloads = [
+        c.args[1] for c in batch.update.call_args_list if isinstance(c.args[1], dict) and 'base64' in c.args[1]
+    ]
+    assert len(photo_payloads) == 1


### PR DESCRIPTION
## Summary

`migrate_conversations_level_batch` in `backend/database/conversations.py` re-encrypts a user's conversation photos when they switch their data protection level. For each photo it decrypted the doc and then read `plain_photo_data['base64']` with no guard. A photo doc that has no base64 field (a legacy doc or a partial write) makes the decrypt helper return None or a dict without that key, so the subscript raises and the loop dies. Since this runs across many conversations in one pass and commits in chunks of 100, one bad photo aborts the migration after earlier chunks already committed, leaving that user partially migrated with some docs on the new level and some still on the old one. This PR skips any photo that has no base64 payload (there is nothing to re-encrypt) and logs a warning, so the rest of the run finishes. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small, independent backend reliability fixes prepared together and opened at the same time, each self-contained and reviewable on its own.

## Root cause

In `backend/database/conversations.py`, `migrate_conversations_level_batch` loops over each photo and does:

```python
# Decrypt first to get a clean state
plain_photo_data = _prepare_photo_for_read(photo_data, uid)

# Prepare the specific fields for update
photo_update_payload = {'data_protection_level': target_level}
if target_level == 'enhanced':
    photo_update_payload['base64'] = encryption.encrypt(plain_photo_data['base64'], uid)
else:  # Moving from enhanced to standard
    photo_update_payload['base64'] = plain_photo_data['base64']
```

`_prepare_photo_for_read` returns None for an empty doc and a dict without `base64` when the field was never stored. `plain_photo_data['base64']` then raises `TypeError` on the None case and `KeyError` on the missing-key case. The exception propagates out of the photo loop and out of the whole function, so the migration stops mid-run. The conversation segments above this block already tolerate missing data by reading through `.get('transcript_segments')`, but the photo path used a hard subscript.

## Fix

Before building the update payload, check the decrypted photo for a base64 value. If it is missing there is nothing to re-encrypt, so log a warning and `continue` to the next photo instead of crashing the run:

```python
# A photo doc with no base64 payload (legacy or partial write) has nothing to re-encrypt; skip
# it so one bad photo doesn't abort the whole multi-conversation migration batch.
if not plain_photo_data or plain_photo_data.get('base64') is None:
    logger.warning(f"Skipping photo with no base64 data during level migration for uid {uid}")
    continue
```

Photos that do have base64 are migrated exactly as before; there is no change to what gets written or to the function's return.

## Testing

Added `backend/tests/unit/test_conversation_photo_migration_missing_base64.py` (registered in `backend/test.sh`). `database/conversations.py` initializes the Firestore client at import time, so the test loads it from source with its heavy dependencies stubbed through a meta-path finder, patches the conversation-prep helpers that are not under test, and drives the real photo loop with a mocked Firestore batch. Cases: a doc with no base64 field and an empty doc are both skipped without raising and produce no base64 update, and a doc that does carry base64 is still migrated (regression guard so the skip is not too broad). Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the photo migration logic this PR fixes. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

