### PR TITLE
fix(backend): skip malformed conversations in the conversations list instead of 500ing

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -34,7 +34,7 @@ from utils.conversations.render import conversation_to_dict
 from models.conversation_enums import ConversationStatus, ConversationVisibility
 from models.conversation_photo import ConversationPhoto
 from models.geolocation import Geolocation
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from models.transcript_segment import TranscriptSegment
 from models.other import Person
 
@@ -198,7 +198,17 @@ def get_conversations(
     )
 
     redact_conversations_for_list(conversations)
-    return conversations
+    # Validate each record individually so one malformed/legacy conversation doesn't fail the whole list
+    # with a 500.
+    valid_conversations = []
+    for conv in conversations:
+        try:
+            valid_conversations.append(Conversation.model_validate(conv))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(f"Skipping invalid conversation for uid {uid}: {invalid_fields}")
+            continue
+    return valid_conversations
 
 
 @router.get('/v1/conversations/count', tags=['conversations'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -132,6 +132,7 @@ pytest tests/unit/test_billable_transcription_seconds.py -v
 pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_sync_pcm_decode.py -v
 pytest tests/unit/test_sync_opus_decode.py -v
+pytest tests/unit/test_conversations_list_malformed.py -v
 pytest tests/unit/test_transcribe_lc3_optional.py -v
 pytest tests/unit/test_sync_silent_failure.py -v
 pytest tests/unit/test_sync_ordered_assignment.py -v

--- a/backend/tests/unit/test_conversations_list_malformed.py
+++ b/backend/tests/unit/test_conversations_list_malformed.py
@@ -1,0 +1,120 @@
+"""GET /v1/conversations must skip a malformed conversation instead of 500ing the whole list.
+
+The endpoint returned raw dicts under response_model=List[Conversation], so one malformed/legacy record
+500'd the whole page. We patch the Conversation model with a simple stand-in to exercise the skip loop.
+routers/conversations.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import conversations as conv_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+class _FakeConv(BaseModel):
+    id: str
+
+
+def test_malformed_conversation_skipped_not_500():
+    page = [{'id': 'c1'}, {}, {'id': 'c2'}]
+    with patch.object(conv_mod, 'Conversation', _FakeConv), patch.object(
+        conv_mod.conversations_db, 'get_conversations_without_photos', return_value=page
+    ), patch.object(conv_mod, 'redact_conversations_for_list', lambda x: None):
+        result = conv_mod.get_conversations(
+            limit=100,
+            offset=0,
+            statuses='processing,completed',
+            include_discarded=True,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='u1',
+        )
+    assert [c.id for c in result] == ['c1', 'c2']


### PR DESCRIPTION
## Summary

`GET /v1/conversations` is the main conversations list endpoint. It is declared with `response_model=List[Conversation]`, so when one stored conversation document is malformed or predates a schema change, FastAPI fails to serialize the response and the whole page returns HTTP 500. That one bad record hides every other valid conversation in the same page, so the list looks broken to the user. This PR validates each record on its own and skips the bad ones, so a single legacy or partial-write document no longer takes down the list. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own so it can be reviewed and merged separately.

## Root cause

In `backend/routers/conversations.py`, `get_conversations` reads raw Firestore dicts from `conversations_db.get_conversations_without_photos`, redacts them in place, and returns the list directly:

```python
    redact_conversations_for_list(conversations)
    return conversations
```

These are unvalidated dicts. FastAPI then coerces the returned list against `response_model=List[Conversation]` during serialization. If any record is missing a required field or has a value of the wrong type (a legacy document, a partial write), the coercion raises `pydantic.ValidationError`, and FastAPI turns that into a 500 for the entire page instead of dropping the one bad row. The function had no per-record guard, so there was no way for the good records to come through.

## Fix

Validate each record individually inside the handler with `Conversation.model_validate`, wrapped in a try/except. On a `ValidationError`, log the offending field names with the uid and skip just that record. The handler then returns the list of validated models:

```python
    redact_conversations_for_list(conversations)
    # Validate each record individually so one malformed/legacy conversation doesn't fail the whole list
    # with a 500.
    valid_conversations = []
    for conv in conversations:
        try:
            valid_conversations.append(Conversation.model_validate(conv))
        except ValidationError as e:
            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
            logger.warning(f"Skipping invalid conversation for uid {uid}: {invalid_fields}")
            continue
    return valid_conversations
```

For valid input the result is the same list of `Conversation` objects the endpoint already returned, so there is no change to the response shape or contract.

## Testing

Added `backend/tests/unit/test_conversations_list_malformed.py`, registered in `backend/test.sh`. `routers/conversations.py` has a heavy import graph, so the test imports it under a stub finder (a custom meta path finder that auto-mocks `database`, `utils`, and the other heavy packages) and then calls `get_conversations` directly. The test patches the `Conversation` model with a simple stand-in that requires `id`, patches `get_conversations_without_photos` to return a page of `[{'id': 'c1'}, {}, {'id': 'c2'}]`, and stubs the redact step. The middle record is invalid, and the assertion is that the call returns only `c1` and `c2` rather than raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including this file, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

