### PR TITLE
fix(backend): clamp limit/offset in conversations list to prevent 500 on out-of-range pagination

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -181,6 +181,10 @@ def get_conversations(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     logger.info(f'get_conversations {uid} {limit} {offset} {statuses} {folder_id} {starred}')
+    # Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises
+    # on a negative argument and would otherwise return a 500 for the whole request.
+    limit = max(1, min(limit, 1000))
+    offset = max(0, offset)
     # force convos statuses to processing, completed on the empty filter
     if len(statuses) == 0:
         statuses = "processing,completed"

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -127,6 +127,7 @@ pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
 pytest tests/unit/test_fair_use_engine.py -v
 pytest tests/unit/test_fair_use_classifier.py -v
 pytest tests/unit/test_fair_use_async.py -v
+pytest tests/unit/test_conversations_pagination_clamp.py -v
 pytest tests/unit/test_dg_usage_batch.py -v
 pytest tests/unit/test_billable_transcription_seconds.py -v
 pytest tests/unit/test_sync_fair_use_gate.py -v

--- a/backend/tests/unit/test_conversations_pagination_clamp.py
+++ b/backend/tests/unit/test_conversations_pagination_clamp.py
@@ -1,0 +1,137 @@
+"""GET /v1/conversations must clamp limit/offset so an out-of-range value can't 500 the request.
+
+The endpoint passed limit/offset straight to Firestore .limit()/.offset(), which raise on a negative
+argument, so /v1/conversations?offset=-1 returned HTTP 500. routers/conversations.py has a heavy import
+graph, so we import it under a stub finder that auto-mocks those namespaces, then call get_conversations
+directly with its db call mocked.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import conversations as conv_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _call(limit, offset):
+    db = MagicMock(return_value=[])
+    with patch.object(conv_mod.conversations_db, 'get_conversations_without_photos', db), patch.object(
+        conv_mod, 'redact_conversations_for_list', lambda x: None
+    ):
+        conv_mod.get_conversations(limit=limit, offset=offset, uid='uid1')
+    # get_conversations_without_photos(uid, limit, offset, ...)
+    return db.call_args.args[1], db.call_args.args[2]
+
+
+def test_negative_pagination_is_clamped_not_500():
+    limit, offset = _call(-5, -1)
+    assert limit == 1
+    assert offset == 0
+
+
+def test_huge_limit_is_capped():
+    limit, _ = _call(99999, 0)
+    assert limit == 1000
+
+
+def test_valid_pagination_passes_through():
+    limit, offset = _call(50, 10)
+    assert limit == 50
+    assert offset == 10


### PR DESCRIPTION
## Summary

`GET /v1/conversations` passes the `limit` and `offset` query params straight into the Firestore query. A negative value (for example `?offset=-1` or `?limit=-5`) reaches Firestore `.limit()` / `.offset()`, which raise `ValueError` on a negative argument, so the whole request returns HTTP 500 instead of a page of conversations. This PR clamps `limit` and `offset` to a safe range before the database call so a malformed pagination param can no longer take down the request. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a group of small, independent backend reliability fixes prepared together and opened at the same time, and each one is self-contained and can be reviewed and merged on its own.

## Root cause

In `backend/routers/conversations.py`, `get_conversations` takes `limit` and `offset` as plain int query params and hands them to the DB query without any bounds check:

```python
def get_conversations(
    limit: int = 100,
    offset: int = 0,
    ...
):
    logger.info(f'get_conversations {uid} {limit} {offset} {statuses} {folder_id} {starred}')
    # force convos statuses to processing, completed on the empty filter
    if len(statuses) == 0:
        statuses = "processing,completed"

    conversations = conversations_db.get_conversations_without_photos(
        uid,
        limit,
        offset,
        ...
    )
```

FastAPI accepts any int for these, including negatives, so `limit=-5` or `offset=-1` flows through to `get_conversations_without_photos`, which calls the Firestore `.limit()` / `.offset()` builders. Those raise `ValueError` on a negative argument, and with no handler it surfaces as a 500. The sibling `get_conversations_count` in the same file does not take pagination params, so nothing else in this file already guarded this.

## Fix

Clamp both params right after the log line, before the DB call. `limit` is bounded to 1..1000 and `offset` to a floor of 0:

```python
    # Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises
    # on a negative argument and would otherwise return a 500 for the whole request.
    limit = max(1, min(limit, 1000))
    offset = max(0, offset)
```

Valid pagination passes through unchanged, so there is no change to the response shape or contract for valid input.

## Testing

Added `backend/tests/unit/test_conversations_pagination_clamp.py`, registered in `backend/test.sh`. `routers/conversations.py` has a heavy import graph, so the test imports it under a stub finder that auto-mocks those namespaces, then calls `get_conversations` directly with its DB call mocked and asserts on the args passed through. Cases: negative `limit` and `offset` are clamped to 1 and 0 instead of 500ing, a huge `limit` is capped to 1000, and valid values (limit 50, offset 10) pass through untouched. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the pagination handling this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it does not address this bug. The clamp added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

