### PR TITLE
fix(backend): skip malformed records in dev API action-items list instead of 500ing the page

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -547,10 +547,26 @@ def get_action_items(
         offset=offset,
     )
 
-    # Filter out locked action items
-    unlocked_action_items = [item for item in action_items if not item.get('is_locked', False)]
-
-    return unlocked_action_items
+    # Validate each record individually so a single malformed/legacy doc (e.g. missing a required
+    # field like description/completed) doesn't fail the whole page with a 500. Mirrors the hardening
+    # already applied to GET /v1/dev/user/memories.
+    valid_action_items = []
+    for item in action_items:
+        if not isinstance(item, dict) or not item.get('id'):
+            logger.warning('Skipping malformed action item in Developer API action-item list')
+            continue
+        if item.get('is_locked', False):
+            continue
+        try:
+            valid_action_items.append(ActionItemResponse.model_validate(item))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(
+                f"Skipping invalid action item doc {item.get('id', 'unknown')} for uid {uid}: "
+                f"missing/invalid fields {invalid_fields}"
+            )
+            continue
+    return valid_action_items
 
 
 @router.post("/v1/dev/user/action-items", response_model=ActionItemResponse, tags=["developer"])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -130,6 +130,7 @@ pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v
+pytest tests/unit/test_dev_api_action_items_poison.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v

--- a/backend/tests/unit/test_dev_api_action_items_poison.py
+++ b/backend/tests/unit/test_dev_api_action_items_poison.py
@@ -1,0 +1,166 @@
+"""GET /v1/dev/user/action-items must skip a malformed record instead of 500ing the page.
+
+The endpoint declared response_model=List[ActionItemResponse] and returned raw Firestore dicts, so one
+malformed record made FastAPI raise ResponseValidationError -> HTTP 500 for the whole page.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if module is None or not hasattr(module, "__path__"):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _drop_stale_module(name, expected_file):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    module_file = getattr(module, "__file__", None)
+    try:
+        module_path = Path(module_file).resolve() if module_file else None
+    except TypeError:
+        module_path = None
+    if module_path == expected_file.resolve():
+        return
+    sys.modules.pop(name, None)
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, attr_name, None) is module:
+            delattr(parent, attr_name)
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.knowledge_graph',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.location',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.llm.knowledge_graph',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['database._client'].document_id_from_seed = MagicMock(return_value='memory-id')
+sys.modules['database.vector_db'].upsert_memory_vectors_batch = MagicMock()
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+
+_endpoints = sys.modules.get('utils.other.endpoints')
+if _endpoints is None:
+    _endpoints = ModuleType('utils.other.endpoints')
+    sys.modules['utils.other.endpoints'] = _endpoints
+if not hasattr(_endpoints, 'get_current_user_uid'):
+    _endpoints.get_current_user_uid = lambda: 'uid1'
+if not hasattr(_endpoints, 'with_rate_limit'):
+    _endpoints.with_rate_limit = lambda dependency, _policy: dependency
+if not hasattr(_endpoints, 'get_user'):
+    _endpoints.get_user = MagicMock()
+
+_ensure_package_path("models", BACKEND_DIR / "models")
+_ensure_package_path("routers", BACKEND_DIR / "routers")
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.conversations", BACKEND_DIR / "utils" / "conversations")
+_drop_stale_module("models.conversation", BACKEND_DIR / "models" / "conversation.py")
+_drop_stale_module("models.conversation_enums", BACKEND_DIR / "models" / "conversation_enums.py")
+_drop_stale_module("models.dev_api_key", BACKEND_DIR / "models" / "dev_api_key.py")
+_drop_stale_module("models.folder", BACKEND_DIR / "models" / "folder.py")
+_drop_stale_module("models.geolocation", BACKEND_DIR / "models" / "geolocation.py")
+_drop_stale_module("models.memories", BACKEND_DIR / "models" / "memories.py")
+_drop_stale_module("models.transcript_segment", BACKEND_DIR / "models" / "transcript_segment.py")
+_drop_stale_module("routers.developer", BACKEND_DIR / "routers" / "developer.py")
+_drop_stale_module("utils.conversations.render", BACKEND_DIR / "utils" / "conversations" / "render.py")
+
+import database.action_items as action_items_db  # noqa: E402  (the stub)
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from routers.developer import router as developer_router  # noqa: E402
+from dependencies import get_uid_with_action_items_read  # noqa: E402
+
+
+def _build():
+    app = FastAPI()
+    app.include_router(developer_router)
+    app.dependency_overrides[get_uid_with_action_items_read] = lambda: 'uid1'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _valid(aid):
+    return {'id': aid, 'description': 'do a thing', 'completed': False}
+
+
+def test_malformed_action_item_skipped_not_500():
+    page = [_valid('a1'), {'id': 'bad', 'description': 'missing completed'}, _valid('a2')]
+    with patch.object(action_items_db, 'get_action_items', return_value=page):
+        resp = _build().get('/v1/dev/user/action-items')
+    assert resp.status_code == 200
+    assert [i['id'] for i in resp.json()] == ['a1', 'a2']


### PR DESCRIPTION
## Summary

The developer API endpoint `GET /v1/dev/user/action-items` is declared with `response_model=List[ActionItemResponse]` but returns the raw Firestore dicts straight from the database. When one stored record is missing a required field (`id`, `description`, or `completed`), FastAPI fails serializing the response and raises `ResponseValidationError`, which comes back as HTTP 500 for the whole page. A single malformed or legacy document hides every other action item the call would have returned. This PR validates each record on its own, drops and logs the bad one, and returns the rest. This is a proactive hardening change; there is no filed GitHub issue for it. This is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/developer.py`, `get_action_items` filters out locked items and then returns the raw list:

```python
# Filter out locked action items
unlocked_action_items = [item for item in action_items if not item.get('is_locked', False)]

return unlocked_action_items
```

The items here are plain dicts read from Firestore with no per-record validation. The route response model is `List[ActionItemResponse]`, and `ActionItemResponse` requires `id`, `description`, and `completed`. FastAPI validates the return value against that model when building the response, so one dict missing any of those fields raises `pydantic.ValidationError` during response serialization. FastAPI turns that into a 500 for the entire page instead of skipping the offending row. The sibling endpoint in the same file, `get_memories` (`GET /v1/dev/user/memories`), already guards each record this way, so this endpoint was the odd one out.

## Fix

Validate each record individually before returning. Skip records that are not a dict or have no `id`, keep the existing lock filter, and build the `ActionItemResponse` per item inside a `try/except ValidationError`. On a validation failure, log the doc id and the offending fields and continue, so only the bad record is dropped.

```python
valid_action_items = []
for item in action_items:
    if not isinstance(item, dict) or not item.get('id'):
        logger.warning('Skipping malformed action item in Developer API action-item list')
        continue
    if item.get('is_locked', False):
        continue
    try:
        valid_action_items.append(ActionItemResponse.model_validate(item))
    except ValidationError as e:
        invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
        logger.warning(
            f"Skipping invalid action item doc {item.get('id', 'unknown')} for uid {uid}: "
            f"missing/invalid fields {invalid_fields}"
        )
        continue
return valid_action_items
```

For valid input the response shape and contract are unchanged. The handler now returns validated `ActionItemResponse` objects rather than raw dicts, which serialize to the same JSON the route already promised.

## Testing

New `backend/tests/unit/test_dev_api_action_items_poison.py`, registered in `backend/test.sh`. `routers/developer.py` has a heavy import graph, so the test stubs the heavy deps under a stub finder, imports the router, mounts it on a bare `FastAPI` app with the read dependency overridden, and patches `database.action_items.get_action_items` to return a fixed page. Case covered: a page of one valid record, one malformed record missing `completed`, and a second valid record returns HTTP 200 with only the two valid ids, instead of a 500. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation of action-item records in this endpoint. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `developer.py`, but it does not touch the body of `get_action_items`, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

