### PR TITLE
fix(backend): skip malformed records in dev API conversations list instead of 500ing the page

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -909,7 +909,23 @@ def get_conversations(
 
     populate_folder_names(uid, unlocked_conversations)
 
-    return unlocked_conversations
+    # Validate each record individually so a single malformed/legacy doc doesn't fail the whole page
+    # with a 500. Mirrors the hardening already applied to GET /v1/dev/user/memories.
+    valid_conversations = []
+    for conv in unlocked_conversations:
+        if not isinstance(conv, dict) or not conv.get('id'):
+            logger.warning('Skipping malformed conversation in Developer API conversation list')
+            continue
+        try:
+            valid_conversations.append(Conversation.model_validate(conv))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(
+                f"Skipping invalid conversation doc {conv.get('id', 'unknown')} for uid {uid}: "
+                f"missing/invalid fields {invalid_fields}"
+            )
+            continue
+    return valid_conversations
 
 
 @router.post("/v1/dev/user/conversations", response_model=ConversationResponse, tags=["developer"])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -129,6 +129,7 @@ pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
+pytest tests/unit/test_dev_api_conversations_poison.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -1,0 +1,182 @@
+"""GET /v1/dev/user/conversations must skip a malformed record instead of 500ing the page.
+
+The endpoint declared response_model=List[Conversation] and returned raw Firestore dicts, so one malformed
+record made FastAPI raise ResponseValidationError -> HTTP 500 for the whole page.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if module is None or not hasattr(module, "__path__"):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _drop_stale_module(name, expected_file):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    module_file = getattr(module, "__file__", None)
+    try:
+        module_path = Path(module_file).resolve() if module_file else None
+    except TypeError:
+        module_path = None
+    if module_path == expected_file.resolve():
+        return
+    sys.modules.pop(name, None)
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, attr_name, None) is module:
+            delattr(parent, attr_name)
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.knowledge_graph',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.location',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.llm.knowledge_graph',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['database._client'].document_id_from_seed = MagicMock(return_value='memory-id')
+sys.modules['database.vector_db'].upsert_memory_vectors_batch = MagicMock()
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+
+_endpoints = sys.modules.get('utils.other.endpoints')
+if _endpoints is None:
+    _endpoints = ModuleType('utils.other.endpoints')
+    sys.modules['utils.other.endpoints'] = _endpoints
+if not hasattr(_endpoints, 'get_current_user_uid'):
+    _endpoints.get_current_user_uid = lambda: 'uid1'
+if not hasattr(_endpoints, 'with_rate_limit'):
+    _endpoints.with_rate_limit = lambda dependency, _policy: dependency
+if not hasattr(_endpoints, 'get_user'):
+    _endpoints.get_user = MagicMock()
+
+_ensure_package_path("models", BACKEND_DIR / "models")
+_ensure_package_path("routers", BACKEND_DIR / "routers")
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.conversations", BACKEND_DIR / "utils" / "conversations")
+_drop_stale_module("models.conversation", BACKEND_DIR / "models" / "conversation.py")
+_drop_stale_module("models.conversation_enums", BACKEND_DIR / "models" / "conversation_enums.py")
+_drop_stale_module("models.dev_api_key", BACKEND_DIR / "models" / "dev_api_key.py")
+_drop_stale_module("models.folder", BACKEND_DIR / "models" / "folder.py")
+_drop_stale_module("models.geolocation", BACKEND_DIR / "models" / "geolocation.py")
+_drop_stale_module("models.memories", BACKEND_DIR / "models" / "memories.py")
+_drop_stale_module("models.transcript_segment", BACKEND_DIR / "models" / "transcript_segment.py")
+_drop_stale_module("routers.developer", BACKEND_DIR / "routers" / "developer.py")
+_drop_stale_module("utils.conversations.render", BACKEND_DIR / "utils" / "conversations" / "render.py")
+
+import database.conversations as conversations_db  # noqa: E402  (the stub)
+from models.conversation_enums import CategoryEnum  # noqa: E402  (real enum)
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+import routers.developer as developer_module  # noqa: E402
+from routers.developer import router as developer_router  # noqa: E402
+from dependencies import get_uid_with_conversations_read  # noqa: E402
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_VALID_CATEGORY = next(iter(CategoryEnum)).value
+
+
+def _valid(cid):
+    return {
+        'id': cid,
+        'created_at': _NOW,
+        'started_at': _NOW,
+        'finished_at': _NOW,
+        'structured': {'title': 'A Title', 'overview': 'An overview', 'category': _VALID_CATEGORY},
+    }
+
+
+def _build():
+    app = FastAPI()
+    app.include_router(developer_router)
+    app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_malformed_conversation_skipped_not_500():
+    missing_structured = _valid('bad')
+    del missing_structured['structured']
+    page = [_valid('c1'), missing_structured, _valid('c2')]
+    with patch.object(conversations_db, 'get_conversations', return_value=page), patch.object(
+        developer_module, 'populate_folder_names', lambda *a, **k: None
+    ), patch.object(developer_module, 'populate_speaker_names', lambda *a, **k: None):
+        resp = _build().get('/v1/dev/user/conversations')
+    assert resp.status_code == 200
+    assert [c['id'] for c in resp.json()] == ['c1', 'c2']


### PR DESCRIPTION
## Summary

`GET /v1/dev/user/conversations` in the Developer API returns HTTP 500 for the entire page when a single stored conversation is malformed. The handler declared `response_model=List[Conversation]` but returned raw Firestore dicts, so one legacy or partial-write document that fails Conversation validation makes FastAPI raise `ResponseValidationError`, which becomes a 500 that hides every other conversation on the page. This PR validates each record up front and skips a bad one instead, so a single poison document no longer takes down the whole list. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes that were prepared together and are being opened at the same time, and each one is self-contained and can be reviewed and merged on its own.

## Root cause

In `backend/routers/developer.py`, `get_conversations` ended like this:

```python
populate_folder_names(uid, unlocked_conversations)

return unlocked_conversations
```

`unlocked_conversations` is a list of raw dicts straight out of `conversations_db.get_conversations`, with no per-record validation. The route is declared with `response_model=List[Conversation]`, so FastAPI runs each dict through `Conversation` on the way out. `Conversation` requires fields like `structured` (title, overview, category). A document missing or mistyping one of those raises `pydantic.ValidationError` during response serialization, which FastAPI reports as `ResponseValidationError` and surfaces as a 500 for the whole page rather than a single dropped row. The sibling `GET /v1/dev/user/memories` in this same file already guards each record this way (the merged dev-memories fix), so this endpoint was the inconsistent one.

## Fix

Build and validate each `Conversation` inside the handler, skipping records that are not a dict, are missing an `id`, or fail validation. On a validation failure, log the id and the offending fields and `continue`:

```python
# Validate each record individually so a single malformed/legacy doc doesn't fail the whole page
# with a 500. Mirrors the hardening already applied to GET /v1/dev/user/memories.
valid_conversations = []
for conv in unlocked_conversations:
    if not isinstance(conv, dict) or not conv.get('id'):
        logger.warning('Skipping malformed conversation in Developer API conversation list')
        continue
    try:
        valid_conversations.append(Conversation.model_validate(conv))
    except ValidationError as e:
        invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
        logger.warning(
            f"Skipping invalid conversation doc {conv.get('id', 'unknown')} for uid {uid}: "
            f"missing/invalid fields {invalid_fields}"
        )
        continue
return valid_conversations
```

Validation now happens in the handler instead of in FastAPI's response step, so valid input produces the exact same `List[Conversation]` payload as before. There is no change to the response shape or contract for valid records.

## Testing

Added `backend/tests/unit/test_dev_api_conversations_poison.py` (registered in `backend/test.sh`). `routers/developer.py` has a heavy import graph, so the test imports the router under a stub finder and drives `get_conversations` through a FastAPI `TestClient` with the data layer and the folder/speaker population helpers patched out. A page of one valid record, one record with `structured` deleted, and a second valid record returns HTTP 200 with only the two valid ids, instead of the 500 the raw-dict path produced on current main. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including `developer.py`, but it does not touch this handler's body, so it keeps the unguarded `return unlocked_conversations` and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

