### PR TITLE
fix(backend): skip malformed records in dev API goals list instead of 500ing the page

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1338,7 +1338,23 @@ def get_goals(
     else:
         goals = goals_db.get_user_goals(uid, limit=limit)
 
-    return [_serialize_goal_datetimes(g) for g in goals]
+    # Validate each record individually so a single malformed/legacy goal doc doesn't fail the whole
+    # page with a 500. Mirrors the hardening already applied to GET /v1/dev/user/memories.
+    valid_goals = []
+    for goal in goals:
+        if not isinstance(goal, dict) or not goal.get('id'):
+            logger.warning('Skipping malformed goal in Developer API goal list')
+            continue
+        try:
+            valid_goals.append(GoalResponse.model_validate(_serialize_goal_datetimes(goal)))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(
+                f"Skipping invalid goal doc {goal.get('id', 'unknown')} for uid {uid}: "
+                f"missing/invalid fields {invalid_fields}"
+            )
+            continue
+    return valid_goals
 
 
 @router.get("/v1/dev/user/goals/{goal_id}", tags=["developer"], response_model=GoalResponse)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -122,6 +122,7 @@ pytest tests/unit/test_kg_edge_id_sanitization.py -v
 pytest tests/unit/test_goal_extraction_batch.py -v
 pytest tests/unit/test_listen_pipeline.py -v
 pytest tests/unit/test_resample_pcm_divzero.py -v
+pytest tests/unit/test_dev_api_goals_poison.py -v
 pytest tests/unit/test_fair_use_models.py -v
 pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
 pytest tests/unit/test_fair_use_engine.py -v

--- a/backend/tests/unit/test_dev_api_goals_poison.py
+++ b/backend/tests/unit/test_dev_api_goals_poison.py
@@ -1,0 +1,183 @@
+"""GET /v1/dev/user/goals must skip a malformed record instead of 500ing the page.
+
+The endpoint declared response_model=List[GoalResponse] and returned raw Firestore dicts, so one malformed
+record made FastAPI raise ResponseValidationError -> HTTP 500 for the whole page.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if module is None or not hasattr(module, "__path__"):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _drop_stale_module(name, expected_file):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    module_file = getattr(module, "__file__", None)
+    try:
+        module_path = Path(module_file).resolve() if module_file else None
+    except TypeError:
+        module_path = None
+    if module_path == expected_file.resolve():
+        return
+    sys.modules.pop(name, None)
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, attr_name, None) is module:
+            delattr(parent, attr_name)
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.knowledge_graph',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.location',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.llm.knowledge_graph',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['database._client'].document_id_from_seed = MagicMock(return_value='memory-id')
+sys.modules['database.vector_db'].upsert_memory_vectors_batch = MagicMock()
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+
+_endpoints = sys.modules.get('utils.other.endpoints')
+if _endpoints is None:
+    _endpoints = ModuleType('utils.other.endpoints')
+    sys.modules['utils.other.endpoints'] = _endpoints
+if not hasattr(_endpoints, 'get_current_user_uid'):
+    _endpoints.get_current_user_uid = lambda: 'uid1'
+if not hasattr(_endpoints, 'with_rate_limit'):
+    _endpoints.with_rate_limit = lambda dependency, _policy: dependency
+if not hasattr(_endpoints, 'get_user'):
+    _endpoints.get_user = MagicMock()
+
+_ensure_package_path("models", BACKEND_DIR / "models")
+_ensure_package_path("routers", BACKEND_DIR / "routers")
+_ensure_package_path("utils", BACKEND_DIR / "utils")
+_ensure_package_path("utils.conversations", BACKEND_DIR / "utils" / "conversations")
+_drop_stale_module("models.conversation", BACKEND_DIR / "models" / "conversation.py")
+_drop_stale_module("models.conversation_enums", BACKEND_DIR / "models" / "conversation_enums.py")
+_drop_stale_module("models.dev_api_key", BACKEND_DIR / "models" / "dev_api_key.py")
+_drop_stale_module("models.folder", BACKEND_DIR / "models" / "folder.py")
+_drop_stale_module("models.geolocation", BACKEND_DIR / "models" / "geolocation.py")
+_drop_stale_module("models.memories", BACKEND_DIR / "models" / "memories.py")
+_drop_stale_module("models.transcript_segment", BACKEND_DIR / "models" / "transcript_segment.py")
+_drop_stale_module("routers.developer", BACKEND_DIR / "routers" / "developer.py")
+_drop_stale_module("utils.conversations.render", BACKEND_DIR / "utils" / "conversations" / "render.py")
+
+import database.goals as goals_db  # noqa: E402  (the stub)
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from routers.developer import router as developer_router  # noqa: E402
+from dependencies import get_uid_with_goals_read  # noqa: E402
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _valid(gid):
+    return {
+        'id': gid,
+        'title': 'A goal',
+        'goal_type': 'scale',
+        'target_value': 10.0,
+        'current_value': 0.0,
+        'min_value': 0.0,
+        'max_value': 10.0,
+        'unit': None,
+        'is_active': True,
+        'created_at': _NOW,
+        'updated_at': _NOW,
+    }
+
+
+def _build():
+    app = FastAPI()
+    app.include_router(developer_router)
+    app.dependency_overrides[get_uid_with_goals_read] = lambda: 'uid1'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_malformed_goal_skipped_not_500():
+    missing_target = _valid('bad')
+    del missing_target['target_value']
+    page = [_valid('g1'), missing_target, _valid('g2')]
+    with patch.object(goals_db, 'get_user_goals', return_value=page):
+        resp = _build().get('/v1/dev/user/goals')
+    assert resp.status_code == 200
+    assert [g['id'] for g in resp.json()] == ['g1', 'g2']


### PR DESCRIPTION
## Summary

The developer API goals list endpoint `GET /v1/dev/user/goals` declares `response_model=List[GoalResponse]` but returns raw Firestore dicts straight from the database. When one stored goal is malformed or is an older document missing a now-required field, FastAPI fails response validation and returns HTTP 500 for the entire page, so every other valid goal the developer owns disappears behind that one bad record. This validates each goal individually and skips the bad one, so a single legacy or partial-write document no longer takes down the whole list. This is a proactive hardening change; there is no filed GitHub issue for it. This PR is one of a group of small, independent backend reliability fixes that were prepared together and are being opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/developer.py`, `get_goals` ends with an unguarded comprehension that serializes datetimes and hands the raw dicts back:

```python
return [_serialize_goal_datetimes(g) for g in goals]
```

`_serialize_goal_datetimes` only converts `created_at` and `updated_at` to ISO strings, it does not validate anything. The list these dicts come from is read directly from Firestore with no validation, and the route is declared with `response_model=List[GoalResponse]`. `GoalResponse` requires fields like `target_value`, so a single goal doc missing a required field cannot be coerced into the model. FastAPI raises `pydantic.ValidationError` while building the response, which surfaces as a 500 for the whole page rather than a single dropped row. The sibling endpoint `GET /v1/dev/user/memories` in this same file already validates each record one at a time and skips bad ones, so the goals endpoint was the inconsistent one.

## Fix

Validate each goal after the datetime serialization step instead of trusting the whole list. Records that are not dicts or have no `id` are skipped, and each remaining record is run through `GoalResponse.model_validate`. Anything that fails validation is logged with the offending fields and dropped, so only the bad record is lost:

```python
valid_goals = []
for goal in goals:
    if not isinstance(goal, dict) or not goal.get('id'):
        logger.warning('Skipping malformed goal in Developer API goal list')
        continue
    try:
        valid_goals.append(GoalResponse.model_validate(_serialize_goal_datetimes(goal)))
    except ValidationError as e:
        invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
        logger.warning(
            f"Skipping invalid goal doc {goal.get('id', 'unknown')} for uid {uid}: "
            f"missing/invalid fields {invalid_fields}"
        )
        continue
return valid_goals
```

This matches the hardening already applied to `GET /v1/dev/user/memories`. There is no change to the response shape or contract for valid input, a well-formed page returns the same `List[GoalResponse]` it did before.

## Testing

Added `backend/tests/unit/test_dev_api_goals_poison.py`, registered in `backend/test.sh`. `routers/developer.py` has a heavy import graph, so the test stubs the heavy dependencies under a stub finder, imports the router, mounts it on a `FastAPI` app, and drives the real handler through a `TestClient` with `get_user_goals` patched to return a fixed page. The case covered builds a page of one valid goal, one goal with `target_value` deleted, and a second valid goal, then asserts the endpoint returns 200 and only the two valid ids rather than 500ing the page. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this fix touches. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `developer.py`, but it does not touch the body of `get_goals`, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

