### PR TITLE
fix(backend): skip malformed conversations in folder listing instead of 500ing

### DIFF
--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -1,5 +1,8 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Optional
+from pydantic import ValidationError
 
 import database.folders as folders_db
 import database.conversations as conversations_db
@@ -14,6 +17,8 @@ from models.folder import (
 from models.conversation import Conversation
 from utils.conversations.render import redact_conversations_for_list
 from utils.other import endpoints as auth
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -113,7 +118,17 @@ def get_folder_conversations(
         uid, folder_id, limit=limit, offset=offset, include_discarded=include_discarded
     )
     redact_conversations_for_list(conversations)
-    return conversations
+    # Validate each record individually so one malformed/legacy conversation doesn't fail the whole list
+    # with a 500.
+    valid_conversations = []
+    for conv in conversations:
+        try:
+            valid_conversations.append(Conversation.model_validate(conv))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(f"Skipping invalid conversation in folder {folder_id} for uid {uid}: {invalid_fields}")
+            continue
+    return valid_conversations
 
 
 @router.patch('/v1/conversations/{conversation_id}/folder', tags=['folders'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -57,6 +57,7 @@ pytest tests/unit/test_conversations_to_string.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
+pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v

--- a/backend/tests/unit/test_folder_conversations_malformed.py
+++ b/backend/tests/unit/test_folder_conversations_malformed.py
@@ -1,0 +1,114 @@
+"""GET /v1/folders/{id}/conversations must skip a malformed conversation instead of 500ing the list.
+
+The endpoint returned raw dicts under response_model=List[Conversation], so one malformed/legacy record
+500'd the whole list. We patch the Conversation model with a simple stand-in to exercise the skip loop.
+routers/folders.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import folders as folders_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+class _FakeConv(BaseModel):
+    id: str
+
+
+def test_malformed_conversation_skipped_not_500():
+    page = [{'id': 'c1'}, {}, {'id': 'c2'}]  # middle one missing required id
+    with patch.object(folders_mod, 'Conversation', _FakeConv), patch.object(
+        folders_mod.folders_db, 'get_folder', return_value={'id': 'f1'}
+    ), patch.object(folders_mod.folders_db, 'get_conversations_in_folder', return_value=page), patch.object(
+        folders_mod, 'redact_conversations_for_list', lambda x: None
+    ):
+        result = folders_mod.get_folder_conversations(
+            folder_id='f1', limit=100, offset=0, include_discarded=False, uid='u1'
+        )
+    assert [c.id for c in result] == ['c1', 'c2']


### PR DESCRIPTION
## Summary

`GET /v1/folders/{folder_id}/conversations` lists the conversations in a folder under `response_model=List[Conversation]`. The handler returns the raw Firestore dicts straight through, so if one stored conversation is malformed or predates a schema change, FastAPI fails to serialize the whole page and returns HTTP 500. The user sees no conversations at all for that folder, even though every other record is fine. This PR validates each record on its own and skips the bad one, so a single legacy document no longer takes down the entire listing. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small, independent backend reliability fixes that were prepared together and are being opened at the same time, and each one stands alone and can be reviewed and merged on its own.

## Root cause

In `backend/routers/folders.py`, `get_folder_conversations` fetches the page and returns it directly:

```python
    conversations = folders_db.get_conversations_in_folder(
        uid, folder_id, limit=limit, offset=offset, include_discarded=include_discarded
    )
    redact_conversations_for_list(conversations)
    return conversations
```

The route is declared with `response_model=List[Conversation]`, so FastAPI coerces every item in `conversations` into a `Conversation` during response serialization. These are raw dicts read from Firestore with no per-record validation. One record missing a required field (or holding a value the model rejects) raises `pydantic.ValidationError` while the response is being built, and FastAPI turns that into a 500 for the full page instead of dropping the single offending row. There is no sibling listing endpoint in this file that already guards the conversation records this way.

## Fix

Validate each record individually before returning. Build the `Conversation` for each item inside a `try/except`; on `ValidationError`, log the offending field names with the folder and uid and `continue`, so only that record is skipped:

```python
    redact_conversations_for_list(conversations)
    # Validate each record individually so one malformed/legacy conversation doesn't fail the whole list
    # with a 500.
    valid_conversations = []
    for conv in conversations:
        try:
            valid_conversations.append(Conversation.model_validate(conv))
        except ValidationError as e:
            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
            logger.warning(f"Skipping invalid conversation in folder {folder_id} for uid {uid}: {invalid_fields}")
            continue
    return valid_conversations
```

The function now returns validated `Conversation` objects, which is exactly what `response_model=List[Conversation]` already produced for valid input, so there is no change to the response shape or contract for valid records.

## Testing

Added `backend/tests/unit/test_folder_conversations_malformed.py` (registered in `backend/test.sh`). `routers/folders.py` has a heavy import graph, so the test imports it under a stub finder and calls `get_folder_conversations` directly, patching `Conversation` with a small stand-in model that requires `id` and patching the database and redaction calls. A page of three records where the middle one is missing the required field returns only the two valid records (`['c1', 'c2']`) instead of raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the validation or serialization logic this fixes. PR #6946, the unified auth and BYOK middleware refactor, rewires the auth `Depends` across many routers including `folders.py`, but it does not touch this handler's body, so it leaves the unguarded `return conversations` in place and does not address this bug. The per-record guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

