### PR TITLE
fix(backend): skip malformed folders in list instead of 500ing the whole page

### DIFF
--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+logger = logging.getLogger(__name__)
+
 
 @router.get('/v1/folders', response_model=List[Folder], tags=['folders'])
 def get_folders(uid: str = Depends(auth.get_current_user_uid)):
@@ -32,7 +34,17 @@ def get_folders(uid: str = Depends(auth.get_current_user_uid)):
     folders = folders_db.get_folders(uid)
     if not folders:
         folders = folders_db.initialize_system_folders(uid)
-    return folders
+    # Validate each folder individually so one malformed/legacy record doesn't fail the whole list
+    # with a 500.
+    valid_folders = []
+    for folder in folders:
+        try:
+            valid_folders.append(Folder.model_validate(folder))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(f"Skipping invalid folder for uid {uid}: missing/invalid fields {invalid_fields}")
+            continue
+    return valid_folders
 
 
 @router.post('/v1/folders', response_model=Folder, tags=['folders'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -112,6 +112,7 @@ pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
 pytest tests/unit/test_conversation_structure_timezone.py -v
+pytest tests/unit/test_folders_list_malformed.py -v
 pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
 pytest tests/unit/test_action_item_idempotency.py -v

--- a/backend/tests/unit/test_folders_list_malformed.py
+++ b/backend/tests/unit/test_folders_list_malformed.py
@@ -1,0 +1,131 @@
+"""GET /v1/folders must skip a malformed folder instead of 500ing the whole list.
+
+The endpoint returned raw dicts under response_model=List[Folder], so a folder missing a required field
+(name/id/created_at/updated_at) 500'd the whole list. routers/folders.py has a heavy import graph, so we
+import it under a stub finder, then call get_folders directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import folders as folders_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _valid(fid, name):
+    return {'id': fid, 'name': name, 'created_at': _NOW, 'updated_at': _NOW}
+
+
+def test_malformed_folder_skipped_not_500():
+    bad = {'id': 'f2', 'created_at': _NOW, 'updated_at': _NOW}  # missing required name
+    page = [_valid('f1', 'Work'), bad, _valid('f3', 'Home')]
+    with patch.object(folders_mod.folders_db, 'get_folders', return_value=page):
+        result = folders_mod.get_folders(uid='u1')
+    assert [f.id for f in result] == ['f1', 'f3']
+
+
+def test_all_valid_folders_returned():
+    page = [_valid('a', 'A'), _valid('b', 'B')]
+    with patch.object(folders_mod.folders_db, 'get_folders', return_value=page):
+        result = folders_mod.get_folders(uid='u1')
+    assert [f.id for f in result] == ['a', 'b']


### PR DESCRIPTION
## Summary

`GET /v1/folders` returns the full list of folders for the current user. The handler returned the raw Firestore dicts straight through `response_model=List[Folder]`, so one malformed or legacy folder document (for example one written before `name`, `created_at`, or `updated_at` existed) makes FastAPI fail validation on the whole response and return HTTP 500. The user then sees no folders at all, even though all of their other folders are fine. This PR validates each folder on its own and skips only the bad ones, so a single broken record no longer hides the entire list. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small, independent backend reliability fixes that were prepared together and are being opened at the same time, and each one stands alone and can be reviewed and merged by itself.

## Root cause

In `backend/routers/folders.py`, `get_folders` reads the folders and returns them with no per-record guard:

```python
@router.get('/v1/folders', response_model=List[Folder], tags=['folders'])
def get_folders(uid: str = Depends(auth.get_current_user_uid)):
    """
    Get all folders for the current user.
    Initializes system folders if this is the first access.
    """
    folders = folders_db.get_folders(uid)
    if not folders:
        folders = folders_db.initialize_system_folders(uid)
    return folders
```

`folders` is a list of raw Firestore dicts. `Folder` requires `id`, `name` (with `min_length=1`), `created_at`, and `updated_at`, none of which have defaults. Because the route declares `response_model=List[Folder]`, FastAPI validates the returned list against that model when serializing the response. If any single dict is missing a required field, or has an empty `name`, that validation raises `pydantic.ValidationError`, and FastAPI surfaces it as a 500 for the whole page instead of dropping the one bad row. The list endpoint had no equivalent of the per-item guard used elsewhere when building models from stored dicts.

## Fix

Validate each folder one at a time with `Folder.model_validate`. On `ValidationError`, log which fields were missing or invalid and skip that record, then return the folders that did validate:

```python
# Validate each folder individually so one malformed/legacy record doesn't fail the whole list
# with a 500.
valid_folders = []
for folder in folders:
    try:
        valid_folders.append(Folder.model_validate(folder))
    except ValidationError as e:
        invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
        logger.warning(f"Skipping invalid folder for uid {uid}: missing/invalid fields {invalid_fields}")
        continue
return valid_folders
```

For valid input the response is the same as before. The route still returns `List[Folder]` in the same shape, since FastAPI was already serializing those same dicts through `response_model=List[Folder]`; the only behavior change is that a record that would have 500'd the page is now dropped and logged.

## Testing

New `backend/tests/unit/test_folders_list_malformed.py`, registered in `backend/test.sh`. `routers/folders.py` has a heavy import graph, so the test imports it under a stub finder (a meta-path finder that resolves `database`, `utils`, and the other heavy deps to auto-mock modules) and then calls `get_folders` directly with `folders_db.get_folders` patched to return a fixed page. Cases: a page of one valid folder, one folder missing the required `name`, and a second valid folder returns only the two valid ids and no 500; a page of all-valid folders returns every one in order. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `routers/folders.py`, but it does not touch the body of `get_folders`, so it leaves the unguarded `return folders` in place and does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

