### PR TITLE
fix(backend): skip malformed import jobs in list instead of 500ing the whole page

### DIFF
--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -3,6 +3,7 @@ Import endpoints for importing data from external sources.
 """
 
 import asyncio
+import logging
 import os
 import uuid
 from typing import List, Optional
@@ -18,6 +19,8 @@ from utils.other import endpoints as auth
 from utils.imports.limitless import create_import_job, process_limitless_import
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 # Temp directory for uploaded files
 TEMP_DIR = '_temp'
@@ -100,18 +103,26 @@ def get_import_jobs(
     """
     jobs = import_jobs_db.get_import_jobs(uid, limit=limit)
 
-    return [
-        ImportJobResponse(
-            job_id=job['id'],
-            status=ImportJobStatus(job['status']),
-            total_files=job.get('total_files'),
-            processed_files=job.get('processed_files'),
-            conversations_created=job.get('conversations_created'),
-            created_at=job.get('created_at'),
-            error=job.get('error'),
-        )
-        for job in jobs
-    ]
+    # Build each response individually so one malformed/legacy job (missing id, or a status value not in
+    # the ImportJobStatus enum) doesn't fail the whole list with a 500.
+    result = []
+    for job in jobs:
+        try:
+            result.append(
+                ImportJobResponse(
+                    job_id=job['id'],
+                    status=ImportJobStatus(job['status']),
+                    total_files=job.get('total_files'),
+                    processed_files=job.get('processed_files'),
+                    conversations_created=job.get('conversations_created'),
+                    created_at=job.get('created_at'),
+                    error=job.get('error'),
+                )
+            )
+        except (KeyError, ValueError) as e:
+            logger.warning(f"Skipping malformed import job for uid {uid}: {e}")
+            continue
+    return result
 
 
 @router.get(

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -89,6 +89,7 @@ pytest tests/unit/test_storage_fanout_limits.py -v
 pytest tests/unit/test_deferred_blob_janitor.py -v
 pytest tests/unit/test_audio_merge_tasks.py -v
 pytest tests/unit/test_people_conversations_500s.py -v
+pytest tests/unit/test_import_jobs_malformed.py -v
 pytest tests/unit/test_firestore_read_ops_cache.py -v
 pytest tests/unit/test_ws_auth_handshake.py -v
 pytest tests/unit/test_streaming_deepgram_backoff.py -v

--- a/backend/tests/unit/test_import_jobs_malformed.py
+++ b/backend/tests/unit/test_import_jobs_malformed.py
@@ -1,0 +1,134 @@
+"""GET /v1/import/jobs must skip a malformed/legacy job instead of 500ing the whole list.
+
+get_import_jobs built ImportJobResponse(job_id=job['id'], status=ImportJobStatus(job['status']), ...) per
+job, so a job missing 'id' (KeyError) or holding a status value not in the enum (ValueError) failed the
+whole page. routers/imports.py has a heavy import graph, so we import it under a stub finder that
+auto-mocks those namespaces (keeping models real), then call get_import_jobs directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import imports as imports_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+_PENDING = imports_mod.ImportJobStatus.pending.value
+
+
+def _get(page):
+    with patch.object(imports_mod.import_jobs_db, 'get_import_jobs', return_value=page):
+        return imports_mod.get_import_jobs(uid='uid1', limit=50)
+
+
+def test_malformed_import_job_skipped_not_500():
+    page = [
+        {'id': 'j1', 'status': _PENDING},
+        {'id': 'j2', 'status': 'not_a_real_status'},  # ValueError on enum
+        {'status': _PENDING},  # KeyError on missing id
+        {'id': 'j4', 'status': _PENDING},
+    ]
+    result = _get(page)
+    assert [r.job_id for r in result] == ['j1', 'j4']
+
+
+def test_all_valid_jobs_returned():
+    page = [{'id': 'a', 'status': _PENDING}, {'id': 'b', 'status': _PENDING}]
+    result = _get(page)
+    assert [r.job_id for r in result] == ['a', 'b']


### PR DESCRIPTION
## Summary

`GET /v1/import/jobs` lists a user's import jobs and builds an `ImportJobResponse` for each stored job. If one job document is malformed or legacy (missing `id`, or a `status` value that is not in the `ImportJobStatus` enum), the whole list raises HTTP 500, so the user sees no jobs at all even though every other record is fine. This PR builds each response on its own and skips a bad record instead of failing the page. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes that were prepared together and are being opened at the same time, each self-contained and reviewable and mergeable on its own.

## Root cause

In `backend/routers/imports.py`, `get_import_jobs` builds the whole list in one comprehension with no guard:

```python
return [
    ImportJobResponse(
        job_id=job['id'],
        status=ImportJobStatus(job['status']),
        total_files=job.get('total_files'),
        processed_files=job.get('processed_files'),
        conversations_created=job.get('conversations_created'),
        created_at=job.get('created_at'),
        error=job.get('error'),
    )
    for job in jobs
]
```

`jobs` comes straight from Firestore with no per-record validation. `job['id']` raises `KeyError` if a document is missing that field, and `ImportJobStatus(job['status'])` raises `ValueError` if the stored status string is not a member of the enum (an older or partial-write document). Either one propagates out of the comprehension, and FastAPI surfaces it as a 500 for the entire response rather than dropping the single bad row.

## Fix

Build the responses in a loop and wrap each one in `try/except (KeyError, ValueError)`. On failure, log the uid and the error and `continue`, so only the offending record is dropped:

```python
result = []
for job in jobs:
    try:
        result.append(
            ImportJobResponse(
                job_id=job['id'],
                status=ImportJobStatus(job['status']),
                total_files=job.get('total_files'),
                processed_files=job.get('processed_files'),
                conversations_created=job.get('conversations_created'),
                created_at=job.get('created_at'),
                error=job.get('error'),
            )
        )
    except (KeyError, ValueError) as e:
        logger.warning(f"Skipping malformed import job for uid {uid}: {e}")
        continue
return result
```

Valid jobs come back exactly as before. The response shape and contract are unchanged.

## Testing

Added `backend/tests/unit/test_import_jobs_malformed.py`, registered in `backend/test.sh`. `routers/imports.py` has a heavy import graph, so the test imports it under a stub finder that auto-mocks the heavy namespaces (database, utils, firebase, etc.) while keeping the models real, then patches `import_jobs_db.get_import_jobs` and calls `get_import_jobs` directly. Cases: a page with one missing-`id` record (KeyError) and one bad-status record (ValueError) mixed with valid jobs returns only the valid ones, and an all-valid page returns every record unchanged. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch the body of `get_import_jobs`, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

