### PR TITLE
fix(backend): handle missing status in Google Maps geocoding response instead of 500ing

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -54,6 +54,7 @@ pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v
 pytest tests/unit/test_notification_token_cleanup.py -v
 pytest tests/unit/test_conversations_to_string.py -v
+pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v

--- a/backend/tests/unit/test_location_maps_status_guard.py
+++ b/backend/tests/unit/test_location_maps_status_guard.py
@@ -1,0 +1,110 @@
+"""get_google_maps_location must not 500 when the Google Maps response is missing the 'status' field.
+
+The geocoding helper (used by POST /v1/conversations when a geolocation is provided) read data['status']
+via direct subscript, so a malformed Maps response raised KeyError -> 500. It now uses .get(). The module
+has a heavy import graph, so we import it under a stub finder and patch the HTTP call.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils.http_client',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+sys.meta_path.insert(0, _finder)
+try:
+    from utils.conversations import location as loc_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_snap)
+
+
+def test_missing_status_returns_none_not_keyerror():
+    resp = MagicMock()
+    resp.json.return_value = {'results': [{'place_id': 'p1'}]}  # no 'status' key
+    with patch.object(loc_mod.r, 'get', return_value=None), patch.object(loc_mod.httpx, 'get', return_value=resp):
+        result = loc_mod.get_google_maps_location(1.0, 2.0)
+    assert result is None
+
+
+def test_error_status_returns_none():
+    resp = MagicMock()
+    resp.json.return_value = {'status': 'REQUEST_DENIED'}
+    with patch.object(loc_mod.r, 'get', return_value=None), patch.object(loc_mod.httpx, 'get', return_value=resp):
+        result = loc_mod.get_google_maps_location(1.0, 2.0)
+    assert result is None

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -32,7 +32,7 @@ def get_google_maps_location(latitude: float, longitude: float) -> Optional[Geol
     url = f"https://maps.googleapis.com/maps/api/geocode/json?latlng={latitude},{longitude}&key={key}"
     response = httpx.get(url)
     data = response.json()
-    if data['status'] != 'OK' or not data.get('results'):
+    if data.get('status') != 'OK' or not data.get('results'):
         return None
     place = data['results'][0]
     if not place.get('place_id'):
@@ -85,7 +85,7 @@ async def async_get_google_maps_location(latitude: float, longitude: float) -> O
         logger.error(f'async_get_google_maps_location error: {e}')
         return None
 
-    if data['status'] != 'OK' or not data.get('results'):
+    if data.get('status') != 'OK' or not data.get('results'):
         return None
     place = data['results'][0]
     if not place.get('place_id'):


### PR DESCRIPTION
## Summary

`get_google_maps_location` (and its async twin) is the geocoding helper used by `POST /v1/conversations` when a request includes a geolocation. It reads `data['status']` straight off the Google Maps response, so any reply that comes back without a `status` field, a partial body, an error page proxied as JSON, or a truncated 200, raises `KeyError` and turns into a 500. That fails the geocode step on a conversation create that would otherwise succeed, for an external response the caller does not control. This PR reads the field with `.get()` so a missing status returns `None` and the conversation still goes through. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes that were prepared together and are being opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/utils/conversations/location.py`, both `get_google_maps_location` and `async_get_google_maps_location` gate on the status with a direct subscript:

```python
data = response.json()
if data['status'] != 'OK' or not data.get('results'):
    return None
```

The Maps API normally returns a `status` field, but the code treats it as guaranteed. A response body without `status` (an error page, a malformed or truncated payload, a non-Maps response from a proxy in front of the API) makes `data['status']` raise `KeyError`. In the sync path there is no try/except around the call, so the `KeyError` propagates and FastAPI surfaces it as a 500. The same bare subscript was present in the async path. Note the very next clause already uses `data.get('results')`, so the missing-key case was handled for `results` but not for `status`.

## Fix

Read the status with `.get()` in both paths, so an absent field compares unequal to `'OK'` and the function returns `None` like any other non-OK result:

```python
if data.get('status') != 'OK' or not data.get('results'):
    return None
```

Valid responses are unaffected: an `OK` status with results still produces the same `Geolocation`, and the response shape and contract are unchanged.

## Testing

Added `backend/tests/unit/test_location_maps_status_guard.py` (registered in `backend/test.sh`). The module pulls in a heavy import graph (`database.redis_db`, `utils.http_client`, and the usual firebase/google/pinecone stack), so the test installs a meta-path finder that stubs those packages, imports `utils.conversations.location` under it, then patches the Redis client and `httpx.get` to feed canned Maps responses. Cases: a response with no `status` key returns `None` instead of raising `KeyError`, and a response with `status: 'REQUEST_DENIED'` returns `None`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation in this helper. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

