### PR TITLE
fix(backend): clamp limit/offset in /v3/memories to prevent 500 on out-of-range pagination

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -148,10 +148,14 @@ async def create_memories_batch(
 
 @router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])
 def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
+    # Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises
+    # on a negative argument and would otherwise 500 the request.
+    offset = max(0, offset)
     # Use high limits for the first page
     # Warn: should remove
     if offset == 0:
         limit = 5000
+    limit = max(1, min(limit, 5000))
     memories = memories_db.get_memories(uid, limit, offset)
 
     valid_memories = []

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -133,6 +133,7 @@ pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
+pytest tests/unit/test_memories_pagination_clamp.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_cloud_tasks.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -1,0 +1,133 @@
+"""GET /v3/memories must clamp limit/offset so an out-of-range value can't 500 the request.
+
+The endpoint passed limit/offset straight to Firestore .limit()/.offset(), which raise on a negative
+argument, so /v3/memories?offset=-1 returned HTTP 500. routers/memories.py has a heavy import graph, so
+we import it under a stub finder, then call get_memories directly with its db call mocked.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import memories as mem_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _call(limit, offset):
+    db = MagicMock(return_value=[])
+    with patch.object(mem_mod.memories_db, 'get_memories', db):
+        mem_mod.get_memories(limit=limit, offset=offset, uid='uid1')
+    # get_memories(uid, limit, offset)
+    return db.call_args.args[1], db.call_args.args[2]
+
+
+def test_negative_offset_is_clamped_not_500():
+    _, offset = _call(50, -1)
+    assert offset == 0
+
+
+def test_huge_limit_is_capped():
+    # offset != 0 so the first-page override does not apply; limit must be capped at 5000.
+    limit, _ = _call(99999, 10)
+    assert limit == 5000
+
+
+def test_negative_limit_is_floored():
+    limit, _ = _call(-5, 10)
+    assert limit == 1


### PR DESCRIPTION
## Summary

`GET /v3/memories` passes the `limit` and `offset` query params straight into the Firestore query. A negative `offset` (or negative `limit` on a non-first page) reaches Firestore `.limit()` / `.offset()`, which raises on a negative argument, so a request like `/v3/memories?offset=-1` returns HTTP 500 instead of a page of memories. This PR clamps both values to a safe range before the database call so a bad query param returns a normal page instead of a server error. This is a proactive hardening change; there is no filed GitHub issue for it. This is one of a set of small independent backend reliability fixes prepared together and opened at the same time, each self-contained and reviewable and mergeable on its own.

## Root cause

In `backend/routers/memories.py`, `get_memories` takes `limit` and `offset` from the query string and hands them to the db call without bounds:

```python
@router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])
def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
    # Use high limits for the first page
    # Warn: should remove
    if offset == 0:
        limit = 5000
    memories = memories_db.get_memories(uid, limit, offset)
```

`memories_db.get_memories` builds a Firestore query and applies `.offset(offset)` and `.limit(limit)`. The Firestore client rejects a negative argument to either with `ValueError`, and since nothing catches it, FastAPI turns it into a 500. The first-page override sets `limit = 5000` only when `offset == 0`, so a negative `offset` skips that branch and a negative `limit` passes through untouched. There is also no upper bound on `limit` for non-first pages, so a caller can ask for an arbitrarily large page.

## Fix

Clamp `offset` to be non-negative and `limit` to between 1 and 5000 before the query runs:

```python
@router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])
def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
    # Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises
    # on a negative argument and would otherwise 500 the request.
    offset = max(0, offset)
    # Use high limits for the first page
    # Warn: should remove
    if offset == 0:
        limit = 5000
    limit = max(1, min(limit, 5000))
    memories = memories_db.get_memories(uid, limit, offset)
```

Valid pagination is unaffected: in-range `limit` and `offset` pass through unchanged, and the response shape and contract are the same.

## Testing

Added `backend/tests/unit/test_memories_pagination_clamp.py`, registered in `backend/test.sh`. `routers/memories.py` has a heavy import graph, so the test imports it under a stub meta-path finder, then calls `get_memories` directly with `memories_db.get_memories` mocked and reads back the `limit` and `offset` the handler actually passed. Cases: a negative `offset` is clamped to 0, an oversized `limit` on a non-first page is capped at 5000, and a negative `limit` is floored to 1. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the pagination or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch the body of `get_memories`, so it does not address this bug. The clamp added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

