### PR TITLE
fix(backend): skip malformed messages in the chat messages list instead of 500ing

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -38,6 +38,7 @@ from models.chat import (
     MessageConversation,
     FileChat,
 )
+from pydantic import ValidationError
 from routers.sync import retrieve_file_paths, decode_files_to_wav
 from utils.apps import get_available_app_by_id
 from utils.conversation_helpers import extract_memory_ids
@@ -467,7 +468,17 @@ def get_messages(
 
     if not messages:
         return [initial_message_util(uid, compat_app_id)]
-    return messages
+    # Validate each record individually so one malformed/legacy message doesn't fail the whole list
+    # with a 500.
+    valid_messages = []
+    for m in messages:
+        try:
+            valid_messages.append(Message.model_validate(m))
+        except ValidationError as e:
+            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
+            logger.warning(f"Skipping invalid message for uid {uid}: {invalid_fields}")
+            continue
+    return valid_messages
 
 
 @router.post("/v2/voice-messages")

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -107,6 +107,7 @@ pytest tests/unit/test_import_jobs_malformed.py -v
 pytest tests/unit/test_firestore_read_ops_cache.py -v
 pytest tests/unit/test_ws_auth_handshake.py -v
 pytest tests/unit/test_streaming_deepgram_backoff.py -v
+pytest tests/unit/test_messages_list_malformed.py -v
 pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v

--- a/backend/tests/unit/test_messages_list_malformed.py
+++ b/backend/tests/unit/test_messages_list_malformed.py
@@ -1,0 +1,124 @@
+"""GET /v2/messages must skip a malformed message instead of 500ing the whole list.
+
+The endpoint returned raw dicts under response_model=List[Message], so one malformed/legacy record 500'd
+the whole page. We patch the Message model with a simple stand-in to exercise the skip loop. routers/
+chat.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+_rm = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import chat as chat_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+    if _rm:
+        sys.modules.pop('python_multipart', None)
+
+
+class _FakeMsg(BaseModel):
+    id: str
+
+
+def test_malformed_message_skipped_not_500():
+    page = [{'id': 'm1'}, {}, {'id': 'm2'}]
+    with patch.object(chat_mod, 'Message', _FakeMsg), patch.object(
+        chat_mod.chat_db, 'get_chat_session', return_value=None
+    ), patch.object(chat_mod.chat_db, 'get_messages', return_value=page):
+        result = chat_mod.get_messages(plugin_id=None, app_id=None, uid='u1')
+    assert [m.id for m in result] == ['m1', 'm2']


### PR DESCRIPTION
## Summary

`GET /v2/messages` returns the chat message list for a user and app. The handler is declared with `response_model=List[Message]` but returns the raw Firestore dicts straight from the database, so FastAPI validates each dict against `Message` on the way out. One malformed or legacy message document raises during that serialization and turns into an HTTP 500 for the entire page, which hides every other valid message in the chat. This PR validates each record individually and skips the bad ones, so a single broken document no longer takes down the whole list. This is a proactive hardening change; there is no filed GitHub issue for it. This change is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/chat.py`, `get_messages` fetches messages from Firestore and returns them with no per-record validation:

```python
    if not messages:
        return [initial_message_util(uid, compat_app_id)]
    return messages
```

`messages` is a list of raw dicts from `chat_db.get_messages`. The route is declared `@router.get('/v2/messages', response_model=List[Message], ...)`, so FastAPI coerces each dict into a `Message` during response serialization. A record that is missing a required field or has the wrong type for one raises `pydantic.ValidationError`, and because that happens inside response handling it surfaces as a 500 for the full page rather than a single dropped row. There is no sibling endpoint in this file that already guards the list this way.

## Fix

Validate each record with `Message.model_validate` inside the loop, collect the ones that pass, and skip the ones that fail after logging which fields were invalid:

```python
    # Validate each record individually so one malformed/legacy message doesn't fail the whole list
    # with a 500.
    valid_messages = []
    for m in messages:
        try:
            valid_messages.append(Message.model_validate(m))
        except ValidationError as e:
            invalid_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
            logger.warning(f"Skipping invalid message for uid {uid}: {invalid_fields}")
            continue
    return valid_messages
```

`ValidationError` is imported from `pydantic`. For valid input the response is the same list of `Message` objects as before, so there is no change to the response shape or contract.

## Testing

New `backend/tests/unit/test_messages_list_malformed.py`, registered in `backend/test.sh`. `routers/chat.py` has a heavy import graph, so the test imports it under a stub finder and calls `get_messages` directly with `chat_db.get_chat_session` and `chat_db.get_messages` patched. It patches `Message` with a small `BaseModel` stand-in that requires `id`, feeds a page of `[{'id': 'm1'}, {}, {'id': 'm2'}]`, and asserts the result keeps only `m1` and `m2` instead of raising on the empty middle record. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including `chat.py`, but it does not touch the body of `get_messages`, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

