### PR TITLE
fix(backend): return 400 instead of 500 on missing title/body in POST /v1/notification

### DIFF
--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -87,6 +87,8 @@ def send_notification_to_user(data: dict, secret_key: str = Header(...)):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
     if not data.get('uid'):
         raise HTTPException(status_code=400, detail='uid is required')
+    if not data.get('title') or not data.get('body'):
+        raise HTTPException(status_code=400, detail='title and body are required')
     uid = data['uid']
     send_notification(uid, data['title'], data['body'], data.get('data', {}))
     return {'status': 'Ok'}

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -102,6 +102,7 @@ pytest tests/unit/test_speech_profile_wav_decode.py -v
 pytest tests/unit/test_storage_fanout_limits.py -v
 pytest tests/unit/test_deferred_blob_janitor.py -v
 pytest tests/unit/test_audio_merge_tasks.py -v
+pytest tests/unit/test_notification_send_validation.py -v
 pytest tests/unit/test_people_conversations_500s.py -v
 pytest tests/unit/test_import_jobs_malformed.py -v
 pytest tests/unit/test_firestore_read_ops_cache.py -v

--- a/backend/tests/unit/test_notification_send_validation.py
+++ b/backend/tests/unit/test_notification_send_validation.py
@@ -1,0 +1,123 @@
+"""POST /v1/notification must return 400 (not 500) when title or body is missing.
+
+It read data['title']/data['body'] via direct subscript, so a body missing those raised KeyError -> 500.
+routers/notifications.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ['ADMIN_KEY'] = 'testkey'
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import notifications as notif_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_missing_title_returns_400():
+    with patch.object(notif_mod, 'send_notification') as send:
+        with pytest.raises(HTTPException) as e:
+            notif_mod.send_notification_to_user(data={'uid': 'u1', 'body': 'b'}, secret_key='testkey')
+    assert e.value.status_code == 400
+    send.assert_not_called()
+
+
+def test_missing_body_returns_400():
+    with patch.object(notif_mod, 'send_notification'):
+        with pytest.raises(HTTPException) as e:
+            notif_mod.send_notification_to_user(data={'uid': 'u1', 'title': 't'}, secret_key='testkey')
+    assert e.value.status_code == 400
+
+
+def test_valid_sends():
+    with patch.object(notif_mod, 'send_notification') as send:
+        result = notif_mod.send_notification_to_user(
+            data={'uid': 'u1', 'title': 't', 'body': 'b'}, secret_key='testkey'
+        )
+    assert result['status'] == 'Ok'
+    send.assert_called_once()


### PR DESCRIPTION
## Summary

`POST /v1/notification`, the admin send-notification endpoint, returns HTTP 500 when the request body omits `title` or `body`, instead of a clean 400. The handler reads both fields by direct subscript and hands them straight to `send_notification`, so a payload missing either one fails downstream and the caller gets an opaque server error instead of a clear "you sent a bad request" response. This PR validates both fields up front and returns 400 when either is missing. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/notifications.py`, `send_notification_to_user` checks `uid` but then passes `title` and `body` through with no presence check:

```python
if not data.get('uid'):
    raise HTTPException(status_code=400, detail='uid is required')
uid = data['uid']
send_notification(uid, data['title'], data['body'], data.get('data', {}))
return {'status': 'Ok'}
```

`data` is a raw dict from the request body. A body without `title` or `body` makes `data['title']` or `data['body']` raise `KeyError`, which FastAPI surfaces as an unhandled 500. The endpoint already does a `data.get('uid')` presence check and returns 400 for the missing uid case, so the two required fields right next to it were inconsistent with that.

## Fix

Add a presence check for both fields next to the existing `uid` check, before the call to `send_notification`:

```python
if not data.get('title') or not data.get('body'):
    raise HTTPException(status_code=400, detail='title and body are required')
```

A valid request with all three fields behaves exactly as before. No change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_notification_send_validation.py`, registered in `backend/test.sh`. `routers/notifications.py` has a heavy import graph, so the test imports it under a stub finder that mocks the heavy dependencies, then calls `send_notification_to_user` directly with `send_notification` patched out. Cases: a body missing `title` returns 400 and never calls `send_notification`, a body missing `body` returns 400, and a body with `uid`, `title`, and `body` returns `{'status': 'Ok'}` and calls `send_notification` once. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including this file, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

