### PR TITLE
fix(backend): return invalid-state response instead of 500 when OAuth state has no uid

### DIFF
--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -422,7 +422,9 @@ async def handle_oauth_callback(
     if not state_data or state_data.get('app_key') != app_key:
         return render_oauth_response(request, app_key, success=False, error_type='invalid_state')
 
-    uid = state_data['uid']
+    uid = state_data.get('uid')
+    if not uid:
+        return render_oauth_response(request, app_key, success=False, error_type='invalid_state')
 
     try:
         client = get_http_client()

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -127,6 +127,7 @@ pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_async_tasks.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
+pytest tests/unit/test_oauth_callback_uid_guard.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v

--- a/backend/tests/unit/test_oauth_callback_uid_guard.py
+++ b/backend/tests/unit/test_oauth_callback_uid_guard.py
@@ -1,0 +1,124 @@
+"""The OAuth callback must not 500 when the consumed state record has no uid.
+
+handle_oauth_callback read uid = state_data['uid'] via direct subscript, so a state record that passed the
+app_key check but lacked uid raised KeyError -> 500. It now returns the normal invalid-state response.
+routers/integrations.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+_rm = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import integrations as int_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+    if _rm:
+        sys.modules.pop('python_multipart', None)
+
+
+def test_state_without_uid_returns_invalid_state_not_500():
+    sentinel = object()
+    with patch.object(
+        int_mod, 'validate_and_consume_oauth_state', return_value={'app_key': 'google_calendar'}
+    ), patch.object(int_mod, 'render_oauth_response', return_value=sentinel) as render:
+        result = asyncio.run(
+            int_mod.handle_oauth_callback(
+                request=MagicMock(), app_key='google_calendar', code='abc', state='xyz', provider_config=MagicMock()
+            )
+        )
+    assert result is sentinel
+    assert render.call_args.kwargs.get('error_type') == 'invalid_state'


### PR DESCRIPTION
## Summary

`handle_oauth_callback` in `backend/routers/integrations.py` is the shared OAuth callback handler for the integration providers (google_calendar, whoop). It read the user id straight off the consumed state record with `state_data['uid']`, so a state record that passed the app_key check but had no `uid` raised a KeyError and the callback returned HTTP 500 instead of the normal invalid-state page. The user just sees a server error at the end of the OAuth redirect with no way to recover. This PR reads `uid` defensively and returns the same invalid-state response the handler already returns for a bad state token. This is a proactive hardening change; there is no filed GitHub issue for it. This is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own so it can be reviewed and merged separately.

## Root cause

In `backend/routers/integrations.py`, `handle_oauth_callback` validates the state token, then pulls the uid by direct subscript:

```python
state_data = validate_and_consume_oauth_state(state)
if not state_data or state_data.get('app_key') != app_key:
    return render_oauth_response(request, app_key, success=False, error_type='invalid_state')

uid = state_data['uid']
```

The line right above already reads `app_key` with `state_data.get('app_key')` and bails out cleanly, but the uid read does not. The state record comes back from `validate_and_consume_oauth_state`, and if that record is missing `uid` (a partial write, an older record from before the field was stored, or a state shaped by a different flow), `state_data['uid']` raises `KeyError`. The callback has no handler for that, so FastAPI turns it into a 500 on the redirect instead of the invalid-state page the function is already set up to render.

## Fix

Read `uid` with `.get()` and treat a missing or empty uid the same as a bad state token, returning the existing invalid-state response:

```python
uid = state_data.get('uid')
if not uid:
    return render_oauth_response(request, app_key, success=False, error_type='invalid_state')
```

This matches the `app_key` check two lines up. There is no change to the response shape or contract for a valid state record. A callback with a normal state that has a uid runs exactly as before.

## Testing

Added `backend/tests/unit/test_oauth_callback_uid_guard.py`, registered in `backend/test.sh`. `routers/integrations.py` has a heavy import graph, so the test imports it under a stub finder (database, utils, firebase_admin, the LLM and vector clients, and so on are stubbed) and then calls `handle_oauth_callback` directly. The case patches `validate_and_consume_oauth_state` to return a record that has `app_key` but no `uid`, patches `render_oauth_response` to a sentinel, and asserts the handler returns that sentinel and calls `render_oauth_response` with `error_type='invalid_state'` rather than raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the state parsing or uid validation in this handler. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends across many routers including this file, but it does not touch the body of `handle_oauth_callback`, so it leaves the bare `state_data['uid']` subscript in place and does not fix this. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

