### PR TITLE
fix(backend): treat malformed pending phone verification as expired instead of 500ing

### DIFF
--- a/backend/database/phone_calls.py
+++ b/backend/database/phone_calls.py
@@ -154,7 +154,12 @@ def get_pending_verification_uid(phone_number: str) -> Optional[str]:
     if not doc.exists:
         return None
     data = doc.to_dict()
-    created_at = datetime.fromisoformat(data['created_at'])
+    try:
+        created_at = datetime.fromisoformat(data.get('created_at'))
+    except (TypeError, ValueError):
+        # Malformed/legacy pending verification (missing or non-ISO created_at); treat as expired.
+        db.collection('pending_verifications').document(doc_id).delete()
+        return None
     elapsed = (datetime.now(timezone.utc) - created_at).total_seconds()
     if elapsed > PENDING_VERIFICATION_TTL_SECONDS:
         db.collection('pending_verifications').document(doc_id).delete()

--- a/backend/database/phone_calls.py
+++ b/backend/database/phone_calls.py
@@ -160,6 +160,10 @@ def get_pending_verification_uid(phone_number: str) -> Optional[str]:
         # Malformed/legacy pending verification (missing or non-ISO created_at); treat as expired.
         db.collection('pending_verifications').document(doc_id).delete()
         return None
+    # A stored created_at without a timezone (legacy/naive value) would raise on the aware/naive
+    # subtraction below; normalize it to UTC so the elapsed-time check never 500s.
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
     elapsed = (datetime.now(timezone.utc) - created_at).total_seconds()
     if elapsed > PENDING_VERIFICATION_TTL_SECONDS:
         db.collection('pending_verifications').document(doc_id).delete()

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -173,6 +173,7 @@ pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_phone_calls.py -v
 pytest tests/unit/test_twilio_service.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
+pytest tests/unit/test_phone_verification_created_at.py -v
 pytest tests/unit/test_conversation_search_date_validation.py -v
 pytest tests/unit/test_conversation_hybrid_search.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v

--- a/backend/tests/unit/test_phone_verification_created_at.py
+++ b/backend/tests/unit/test_phone_verification_created_at.py
@@ -12,7 +12,7 @@ import importlib.util
 import os
 import sys
 import types
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -106,3 +106,18 @@ def test_valid_recent_created_at_returns_uid():
     with patch.object(phone_db, 'db', _db_returning(_doc({'created_at': now_iso, 'uid': 'u1'}))):
         result = phone_db.get_pending_verification_uid('+15551234567')
     assert result == 'u1'
+
+
+def test_naive_recent_created_at_returns_uid_not_500():
+    # A parseable but timezone-naive recent created_at must not crash the aware-minus-naive subtraction.
+    naive_recent = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+    with patch.object(phone_db, 'db', _db_returning(_doc({'created_at': naive_recent, 'uid': 'u1'}))):
+        result = phone_db.get_pending_verification_uid('+15551234567')
+    assert result == 'u1'
+
+
+def test_naive_old_created_at_treated_expired_not_500():
+    naive_old = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=365)).isoformat()
+    with patch.object(phone_db, 'db', _db_returning(_doc({'created_at': naive_old, 'uid': 'u1'}))):
+        result = phone_db.get_pending_verification_uid('+15551234567')
+    assert result is None

--- a/backend/tests/unit/test_phone_verification_created_at.py
+++ b/backend/tests/unit/test_phone_verification_created_at.py
@@ -1,0 +1,108 @@
+"""get_pending_verification_uid must not 500 on a malformed pending_verifications record.
+
+It read datetime.fromisoformat(data['created_at']) directly, so a record missing created_at (KeyError) or
+storing it as a non-string (TypeError) crashed POST /v1/phone/numbers/verify/check with a 500. It now
+treats a malformed record as expired. database/phone_calls.py has a heavy import graph, so we import it
+under a stub finder and patch the Firestore client.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = ('database._client', 'database.redis_db', 'database.helpers', 'utils', 'firebase_admin', 'google', 'sentry_sdk')
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    import database.phone_calls as phone_db
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+def _doc(data):
+    doc = MagicMock()
+    doc.exists = True
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _db_returning(doc):
+    fake = MagicMock()
+    fake.collection.return_value.document.return_value.get.return_value = doc
+    return fake
+
+
+def test_missing_created_at_returns_none_not_500():
+    with patch.object(phone_db, 'db', _db_returning(_doc({'uid': 'u1'}))):  # no created_at
+        result = phone_db.get_pending_verification_uid('+15551234567')
+    assert result is None
+
+
+def test_non_string_created_at_returns_none_not_500():
+    with patch.object(phone_db, 'db', _db_returning(_doc({'created_at': 12345, 'uid': 'u1'}))):
+        result = phone_db.get_pending_verification_uid('+15551234567')
+    assert result is None
+
+
+def test_valid_recent_created_at_returns_uid():
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with patch.object(phone_db, 'db', _db_returning(_doc({'created_at': now_iso, 'uid': 'u1'}))):
+        result = phone_db.get_pending_verification_uid('+15551234567')
+    assert result == 'u1'


### PR DESCRIPTION
## Summary

`get_pending_verification_uid` backs `POST /v1/phone/numbers/verify/check`. It reads the stored `created_at` off the pending verification record and parses it to decide whether the pending verification has expired. The parse had no guard, so a pending record with a missing or non-ISO `created_at` raised an exception that became an HTTP 500, blocking the user from completing phone verification at all until the stale record aged out or was removed by hand. This PR wraps the parse and treats a record it cannot parse as expired: it deletes the stale doc and returns None, so the verify check fails cleanly instead of crashing. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small, independent backend reliability fixes prepared together and opened at the same time, each self-contained and reviewable on its own.

## Root cause

In `backend/database/phone_calls.py`, `get_pending_verification_uid` parses the stored timestamp directly:

```python
data = doc.to_dict()
created_at = datetime.fromisoformat(data['created_at'])
elapsed = (datetime.now(timezone.utc) - created_at).total_seconds()
```

The record is a raw Firestore dict with no validation. A pending verification written by an older code path, a partial write, or any record where `created_at` is absent makes `data['created_at']` raise `KeyError`. A record where `created_at` is stored as something other than a string (for example a number) makes `datetime.fromisoformat(...)` raise `TypeError`, and a non-ISO string raises `ValueError`. Any of those propagates out of the handler as an unhandled 500. The TTL branch right below already deletes the doc once it is too old, so a record that simply cannot be parsed should be handled the same way rather than crashing.

## Fix

Wrap the parse. On `TypeError` or `ValueError`, treat the record as expired: delete the stale doc and return None, the same outcome the TTL branch produces. Switching to `data.get('created_at')` turns a missing key into `None`, which `fromisoformat` rejects with `TypeError`, so the missing and malformed cases take the same path.

```python
data = doc.to_dict()
try:
    created_at = datetime.fromisoformat(data.get('created_at'))
except (TypeError, ValueError):
    # Malformed/legacy pending verification (missing or non-ISO created_at); treat as expired.
    db.collection('pending_verifications').document(doc_id).delete()
    return None
elapsed = (datetime.now(timezone.utc) - created_at).total_seconds()
```

For a valid record the path is unchanged. The function still returns the uid for a live pending verification and None for an expired one, so there is no change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_phone_verification_created_at.py`, registered in `backend/test.sh`. `database/phone_calls.py` has a heavy import graph, so the test loads the module from source with its dependencies stubbed under a meta-path finder, then patches the Firestore client and calls `get_pending_verification_uid` directly. Cases: a record with no `created_at` returns None instead of 500, a record with a non-string `created_at` returns None instead of 500, and a record with a valid recent `created_at` still returns the uid. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this PR fixes. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

