### PR TITLE
fix(backend): fail open instead of 500 on a corrupt rate-limit cache entry

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -131,6 +131,7 @@ pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_rate_limiting.py -v
+pytest tests/unit/test_rate_limit_json_failopen.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_sync_v2.py -v

--- a/backend/tests/unit/test_rate_limit_json_failopen.py
+++ b/backend/tests/unit/test_rate_limit_json_failopen.py
@@ -1,0 +1,107 @@
+"""rate_limit_custom must fail open (not 500) when its cache entry is corrupt.
+
+It did current = json.loads(cached.get(key)) then current['remaining']/['timestamp'] with no guard, so a
+corrupt or partial cache entry raised JSONDecodeError/KeyError -> HTTP 500 on any rate-limited endpoint.
+utils/other/endpoints.py has a heavy import graph, so we import it under a stub finder.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils.other.auth',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'redis',
+    'sentry_sdk',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from utils.other import endpoints as ep_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+def _req():
+    r = MagicMock()
+    r.client.host = '1.2.3.4'
+    return r
+
+
+def test_corrupt_cache_fails_open_not_500():
+    with patch.object(ep_mod, 'cached', {'rate_limit:ep:1.2.3.4': 'not valid json{'}):
+        result = ep_mod.rate_limit_custom('ep', _req(), 60, 60)
+    assert result is True
+
+
+def test_partial_cache_entry_fails_open():
+    with patch.object(ep_mod, 'cached', {'rate_limit:ep:1.2.3.4': '{"foo": 1}'}):  # missing remaining/timestamp
+        result = ep_mod.rate_limit_custom('ep', _req(), 60, 60)
+    assert result is True

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -243,9 +243,15 @@ def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int,
     # Check if the IP is already rate-limited
     current = cached.get(key)
     if current:
-        current = json.loads(current)
-        remaining = current["remaining"]
-        timestamp = current["timestamp"]
+        try:
+            current = json.loads(current)
+            remaining = current["remaining"]
+            timestamp = current["timestamp"]
+        except (json.JSONDecodeError, TypeError, KeyError):
+            # Corrupt cache entry: fail open by starting a fresh window rather than 500ing the request.
+            current = None
+
+    if current:
         current_time = int(time.time())
 
         # Check if the time window has expired


### PR DESCRIPTION
## Summary

`rate_limit_custom` in `backend/utils/other/endpoints.py` is the custom per-IP rate limiter used by `rate_limit_dependency` to gate endpoints. It reads its cached counter back with `json.loads` and indexes `current["remaining"]` and `current["timestamp"]` with no guard, so a single corrupt or partial cache entry raises inside the limiter and turns into an HTTP 500 on the very request it was supposed to protect. This makes the limiter fail open on a corrupt entry by starting a fresh window instead, which matches the fail-open behavior already documented for Redis in this codebase. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/utils/other/endpoints.py`, `rate_limit_custom` reads the cached entry and uses it directly:

```python
current = cached.get(key)
if current:
    current = json.loads(current)
    remaining = current["remaining"]
    timestamp = current["timestamp"]
```

The cached value is a stored JSON string. If that entry is corrupt (truncated or partial write), `json.loads` raises `JSONDecodeError`; if it parsed but is missing a field, the `current["remaining"]` / `current["timestamp"]` subscripts raise `KeyError`; a non-string value raises `TypeError`. None of these are caught, so they bubble up out of the limiter and FastAPI returns a 500 for that request. A bad cache entry then keeps returning 500 for every request from that IP on that endpoint until the entry rolls over.

## Fix

Wrap the parse and the two subscripts in a `try/except`. On `JSONDecodeError`, `TypeError`, or `KeyError`, treat the entry as absent by setting `current = None`, which falls through to the existing new-window path:

```python
current = cached.get(key)
if current:
    try:
        current = json.loads(current)
        remaining = current["remaining"]
        timestamp = current["timestamp"]
    except (json.JSONDecodeError, TypeError, KeyError):
        # Corrupt cache entry: fail open by starting a fresh window rather than 500ing the request.
        current = None

if current:
    ...
```

A valid entry takes the same path as before, so there is no change to the response shape or the contract for valid input.

## Testing

Added `backend/tests/unit/test_rate_limit_json_failopen.py` (registered in `backend/test.sh`). `utils/other/endpoints.py` has a heavy import graph, so the test imports it under a stub finder and calls `rate_limit_custom` directly, patching the module-level `cached` dict via `patch.object`. Cases: a non-JSON cache entry and a parsed-but-incomplete entry (missing `remaining`/`timestamp`) both return `True` (fail open) instead of raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the parsing or validation logic this fix touches. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

