### PR TITLE
fix(backend): return 422 instead of 500 on invalid due_date in task-integration create

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -690,10 +690,17 @@ async def create_task_via_integration(
     if not integration.get('access_token'):
         raise HTTPException(status_code=401, detail=f"No access token for {app_key}")
 
-    # Parse due date if provided
+    # Parse due date if provided. due_date is a free-form Optional[str] from the request body, so an
+    # invalid value must return 422 rather than raising an unhandled ValueError that surfaces as a 500.
     due_date = None
     if request.due_date:
-        due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
+        try:
+            due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid due_date format. Use ISO 8601, e.g. 2026-06-09 or 2026-06-09T15:00:00Z.",
+            )
 
     result = await _create_task_internal(
         uid=uid,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -97,6 +97,7 @@ pytest tests/unit/test_pusher_batch_upload.py -v
 pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
 pytest tests/unit/test_optional_audio_codecs.py -v
 pytest tests/unit/test_storage_opus_encoding.py -v
+pytest tests/unit/test_task_integration_due_date_validation.py -v
 pytest tests/unit/test_speech_profile_existence.py -v
 pytest tests/unit/test_speech_profile_wav_decode.py -v
 pytest tests/unit/test_storage_fanout_limits.py -v

--- a/backend/tests/unit/test_task_integration_due_date_validation.py
+++ b/backend/tests/unit/test_task_integration_due_date_validation.py
@@ -1,0 +1,101 @@
+"""Regression test for POST /v1/task-integrations/{app_key}/tasks input validation.
+
+create_task_via_integration parsed a free-form Optional[str] due_date with datetime.fromisoformat and no
+guard, so an invalid value (e.g. "tomorrow") raised an unhandled ValueError that surfaced as HTTP 500.
+It now returns 422 for a malformed due_date.
+"""
+
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+for _n in [
+    'database._client',
+    'database.users',
+    'database.redis_db',
+    'firebase_admin',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+]:
+    if _n not in sys.modules:
+        sys.modules[_n] = _AutoMockModule(_n)
+
+# Provide a real callable for the auth dependency so FastAPI can resolve it.
+_endpoints = sys.modules.get('utils.other.endpoints')
+if _endpoints is None:
+    _endpoints = ModuleType('utils.other.endpoints')
+    sys.modules['utils.other.endpoints'] = _endpoints
+
+
+def _fake_uid():  # pragma: no cover - dependency stand-in
+    return 'uid1'
+
+
+if not hasattr(_endpoints, 'get_current_user_uid'):
+    _endpoints.get_current_user_uid = _fake_uid
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+import routers.task_integrations as ti  # noqa: E402
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(ti.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _connected_integration():
+    ti.users_db.get_task_integration = MagicMock(return_value={'connected': True, 'access_token': 'tok'})
+
+
+def test_invalid_due_date_returns_422_not_500():
+    _connected_integration()
+    with patch.object(ti, '_create_task_internal', new=AsyncMock(return_value={'success': True})) as internal:
+        resp = _client().post('/v1/task-integrations/todoist/tasks', json={'title': 'x', 'due_date': 'tomorrow'})
+    assert resp.status_code == 422
+    internal.assert_not_called()
+
+
+def test_valid_due_date_is_parsed_and_passed_through():
+    _connected_integration()
+    with patch.object(
+        ti, '_create_task_internal', new=AsyncMock(return_value={'success': True, 'external_task_id': 'ext-1'})
+    ) as internal:
+        resp = _client().post(
+            '/v1/task-integrations/todoist/tasks', json={'title': 'x', 'due_date': '2026-06-09T15:00:00Z'}
+        )
+    assert resp.status_code == 200
+    internal.assert_called_once()
+    assert isinstance(internal.call_args.kwargs['due_date'], datetime)
+
+
+def test_no_due_date_passes_through():
+    _connected_integration()
+    with patch.object(
+        ti, '_create_task_internal', new=AsyncMock(return_value={'success': True, 'external_task_id': 'ext-2'})
+    ) as internal:
+        resp = _client().post('/v1/task-integrations/todoist/tasks', json={'title': 'x'})
+    assert resp.status_code == 200
+    internal.assert_called_once()
+    assert internal.call_args.kwargs['due_date'] is None


### PR DESCRIPTION
## Summary

`POST /v1/task-integrations/{app_key}/tasks` creates a task in a connected integration (Todoist, ClickUp, and so on) using stored credentials. The handler parses an optional `due_date` from the request body with `datetime.fromisoformat` and no guard, so any value that is not a valid ISO timestamp (for example "tomorrow" or "next friday") raises `ValueError` and the caller gets an HTTP 500 instead of a clean 422 telling them the input was bad. This PR catches that parse failure and returns 422 with a usable message. This is a proactive hardening change; there is no filed GitHub issue for it. It is one of a set of small independent backend reliability fixes prepared together and opened at the same time, and each one is self-contained so it can be reviewed and merged on its own.

## Root cause

In `backend/routers/task_integrations.py`, `create_task_via_integration` parses the due date inline with no error handling:

```python
# Parse due date if provided
due_date = None
if request.due_date:
    due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
```

`due_date` comes off `CreateTaskRequest` as `Optional[str]` with no format validation, so it is whatever the client sent. `datetime.fromisoformat` raises `ValueError` on anything it can't parse, and since nothing catches it, FastAPI turns it into a 500. A malformed `due_date` is a client input problem, so it should be a 422, not a server error.

## Fix

Wrap the parse in a try/except and convert the `ValueError` into a 422 with a message that says what format is expected:

```python
due_date = None
if request.due_date:
    try:
        due_date = datetime.fromisoformat(request.due_date.replace('Z', '+00:00'))
    except ValueError:
        raise HTTPException(
            status_code=422,
            detail="Invalid due_date format. Use ISO 8601, e.g. 2026-06-09 or 2026-06-09T15:00:00Z.",
        )
```

A valid `due_date`, or no `due_date` at all, behaves exactly as before. No change to the response shape or contract for valid input.

## Testing

New `backend/tests/unit/test_task_integration_due_date_validation.py` (registered in `test.sh`). `routers/task_integrations.py` pulls in a heavy import graph, so the test stubs the database and firebase modules under a custom finder, mounts the router on a bare FastAPI app, and drives it through `TestClient` with `_create_task_internal` patched out. Cases: an invalid `due_date` ("tomorrow") returns 422 and never reaches `_create_task_internal`; a valid `due_date` ("2026-06-09T15:00:00Z") returns 200 and a parsed `datetime` is passed through; and a request with no `due_date` returns 200 with `due_date` of `None`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the due_date parsing or validation in this handler. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not touch this handler's body, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

