### PR TITLE
fix(backend): return 400 instead of 500 on missing url in set developer webhook

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -306,7 +306,9 @@ def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_c
 
 @router.post('/v1/users/developer/webhook/{wtype}', tags=['v1'])
 def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends(auth.get_current_user_uid)):
-    url = data['url']
+    url = data.get('url')
+    if url is None:
+        raise HTTPException(status_code=400, detail='url is required')
     if url == '' or url == ',':
         disable_user_webhook_db(uid, wtype)
     set_user_webhook_db(uid, wtype, url)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -13,6 +13,7 @@ pytest tests/unit/test_speaker_sample.py -v
 pytest tests/unit/test_speaker_sample_migration.py -v
 pytest tests/unit/test_short_audio_embedding.py -v
 pytest tests/unit/test_users_add_sample_transaction.py -v
+pytest tests/unit/test_users_webhook_url_validation.py -v
 pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v

--- a/backend/tests/unit/test_users_webhook_url_validation.py
+++ b/backend/tests/unit/test_users_webhook_url_validation.py
@@ -1,0 +1,125 @@
+"""POST /v1/users/developer/webhook/{wtype} must return 400 (not 500) when 'url' is missing.
+
+set_user_webhook_endpoint read data['url'] via direct subscript, so a body without url raised KeyError ->
+500. routers/users.py has a heavy import graph, so we import it under a stub finder and call the handler.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_rm_mp = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import users as users_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_snap)
+    if _rm_mp:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def test_missing_url_returns_400():
+    with pytest.raises(HTTPException) as e:
+        users_mod.set_user_webhook_endpoint(wtype='audio_bytes', data={}, uid='u1')
+    assert e.value.status_code == 400
+
+
+def test_valid_url_sets():
+    with patch.object(users_mod, 'set_user_webhook_db') as setdb, patch.object(users_mod, 'disable_user_webhook_db'):
+        result = users_mod.set_user_webhook_endpoint(wtype='audio_bytes', data={'url': 'http://x'}, uid='u1')
+    assert result['status'] == 'ok'
+    setdb.assert_called_once()


### PR DESCRIPTION
## Summary

`POST /v1/users/developer/webhook/{wtype}` registers a developer webhook URL for the calling user. The handler read `url` straight out of the request body, so any request whose JSON body leaves out `url` raised a `KeyError` and came back as an HTTP 500 instead of a clean client error. This validates `url` up front and returns 400 when it is missing, so a malformed request gets a proper status code rather than a server error. This is a proactive hardening change; there is no filed GitHub issue for it. This PR is one of a set of small, independent backend reliability fixes prepared together and opened at the same time, and each one stands on its own and can be reviewed and merged separately.

## Root cause

In `backend/routers/users.py`, `set_user_webhook_endpoint` pulled the field with a direct subscript:

```python
@router.post('/v1/users/developer/webhook/{wtype}', tags=['v1'])
def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends(auth.get_current_user_uid)):
    url = data['url']
    if url == '' or url == ',':
        disable_user_webhook_db(uid, wtype)
    set_user_webhook_db(uid, wtype, url)
    return {'status': 'ok'}
```

`data` is an unvalidated `dict` taken from the request body. When a caller posts a body that does not include `url`, `data['url']` raises `KeyError`, which FastAPI surfaces as an unhandled 500. Other handlers in this same file already read optional body fields defensively (for example `set_user_language` uses `language = data.get('language')`), so this endpoint was the inconsistent one.

## Fix

Read the field with `data.get('url')` and reject a missing value with a 400 before touching the database:

```python
url = data.get('url')
if url is None:
    raise HTTPException(status_code=400, detail='url is required')
if url == '' or url == ',':
    disable_user_webhook_db(uid, wtype)
set_user_webhook_db(uid, wtype, url)
return {'status': 'ok'}
```

A request that includes a valid `url` behaves exactly as before, including the empty-string and comma cases that disable the webhook. There is no change to the response shape or contract for valid input.

## Testing

Added `backend/tests/unit/test_users_webhook_url_validation.py` (registered in `backend/test.sh`). `routers/users.py` has a heavy import graph, so the test imports it under a stub finder and calls `set_user_webhook_endpoint` directly. Cases: a body with no `url` raises `HTTPException` with status 400, and a body carrying a valid `url` returns `status` `ok` and calls `set_user_webhook_db`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR touches the parsing or validation logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` across many routers including this file, but it does not change this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

