### PR TITLE
fix(desktop): stop reporting batch-transcribe 401 INVALID_AUTH floods to Sentry

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -370,6 +370,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             // raw-message checks above miss it. Same root cause (server-side key needs rotation),
             // same flood (one bad key emits one event per task-extraction frame for every user).
             || lower.contains("ai service authentication error")
+            // Backend rejects the auth header on batch (PTT) transcription with a 401
+            // INVALID_AUTH / "Invalid credentials." body — a transient stale-token or BYOK
+            // misconfig, not a per-client app bug. The 30s refresh timer recovers it; left
+            // unfiltered it floods Sentry (one event per failed batch). Same class as the
+            // AuthError.notSignedIn filter below.
+            || lower.contains("invalid_auth")
           {
             return nil
           }


### PR DESCRIPTION
## What
Extends the existing `beforeSend` Sentry filter in `OmiApp.swift` to also drop batch (push-to-talk) transcription `401 INVALID_AUTH` / "Invalid credentials." events.

## Why
`TranscriptionService.batchTranscribe` logs every non-200 backend response via `logError`. A 401 INVALID_AUTH is a transient stale-token or BYOK misconfig that the 30s auth-refresh timer recovers from — not a per-client app bug. Unfiltered it floods Sentry: **OMI-COMPUTER-6SB = 377 events across 6 users (~63/user)**.

This is the same noise class the filter already drops for `AuthError.notSignedIn` (transient token refresh) and the backend Gemini auth-failure floods. Matching the distinctive `invalid_auth` err_code keeps it narrow — other status codes / 401 variants (real bugs) still report. Still logged locally and as a breadcrumb.

## Test
`xcrun swift build -c debug --package-path Desktop` — builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

