### PR TITLE
fix(backend): skip malformed conversations in MCP list endpoint

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -309,7 +309,15 @@ def get_conversations(
     )
 
     redact_conversations_for_list(conversations)
-    return conversations
+    # Validate each record individually so one malformed conversation (e.g. a category
+    # no longer in CategoryEnum) cannot 500 the whole page via response_model coercion.
+    valid_conversations = []
+    for conv in conversations:
+        try:
+            valid_conversations.append(SimpleConversation.model_validate(conv))
+        except Exception as e:  # noqa: BLE001 - one bad record must not 500 the page
+            logger.warning(f"Skipping malformed conversation {conv.get('id', 'unknown')} in MCP list: {e}")
+    return valid_conversations
 
 
 @router.get("/v1/mcp/conversations/search", response_model=List[SimpleConversation], tags=["mcp"])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -33,6 +33,7 @@ pytest tests/unit/test_mcp_search_memories.py -v
 pytest tests/unit/test_mcp_memory_filters.py -v
 pytest tests/unit/test_mcp_client_tool_result.py -v
 pytest tests/unit/test_mcp_data_endpoints.py -v
+pytest tests/unit/test_mcp_conversations_poison.py -v
 pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v

--- a/backend/tests/unit/test_mcp_conversations_poison.py
+++ b/backend/tests/unit/test_mcp_conversations_poison.py
@@ -1,0 +1,186 @@
+"""Unit test for the MCP get_conversations poison-page guard (routers/mcp.py).
+
+A single malformed conversation record (e.g. a structured.category no longer in
+CategoryEnum) must not 500 the whole /v1/mcp/conversations page. The handler now
+validates each record into SimpleConversation individually and skips the bad ones.
+
+Heavy deps are stubbed following the proven pattern in test_mcp_data_endpoints.py.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+import os
+import sys
+from types import ModuleType
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module(
+    'utils.retrieval.hybrid',
+    os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'),
+)
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+_drop_stale_module('models.conversation_enums', os.path.join(_BACKEND_DIR, 'models', 'conversation_enums.py'))
+_drop_stale_module('models.mcp_api_key', os.path.join(_BACKEND_DIR, 'models', 'mcp_api_key.py'))
+
+_stubs = [
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.screen_activity',
+    'database.x_posts',
+    'database.fair_use',
+    'database.auth',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.FieldFilter',
+    'google',
+    'google.cloud',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'utils.other.storage',
+    'utils.other.endpoints',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.render',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.log_sanitizer',
+    'utils.executors',
+    'dependencies',
+]
+for mod_name in _stubs:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = _AutoMockModule(mod_name)
+
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+sys.modules['utils.executors'].db_executor = MagicMock()
+sys.modules['utils.executors'].postprocess_executor = MagicMock()
+sys.modules['utils.llm.memories'].identify_category_for_memory = MagicMock(return_value='other')
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
+sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
+
+from routers import mcp as rest  # noqa: E402
+
+NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
+UID = "user-1"
+
+
+def _conversation(conv_id='conv-good', category='technology'):
+    return {
+        'id': conv_id,
+        'started_at': NOW,
+        'finished_at': NOW,
+        'structured': {
+            'title': 'Standup',
+            'overview': 'Daily sync',
+            'category': category,
+        },
+        'language': 'en',
+    }
+
+
+class TestGetConversationsPoisonPage:
+    """One malformed conversation record must not 500 the whole MCP list page."""
+
+    @patch('routers.mcp.redact_conversations_for_list', side_effect=lambda convs: convs)
+    @patch('routers.mcp.conversations_db')
+    def test_skips_malformed_returns_only_valid(self, mock_db, _mock_redact):
+        # First record is valid; second has a category that is NOT in CategoryEnum.
+        mock_db.get_conversations.return_value = [
+            _conversation('conv-good', category='technology'),
+            _conversation('conv-poison', category='not_a_real_category'),
+        ]
+        result = rest.get_conversations(uid=UID)
+        # Without the per-record guard, response_model coercion would 500 the page.
+        assert len(result) == 1
+        assert result[0].id == 'conv-good'
+        assert result[0].structured.category.value == 'technology'
+
+    @patch('routers.mcp.redact_conversations_for_list', side_effect=lambda convs: convs)
+    @patch('routers.mcp.conversations_db')
+    def test_all_valid_returned(self, mock_db, _mock_redact):
+        mock_db.get_conversations.return_value = [
+            _conversation('conv-1', category='technology'),
+            _conversation('conv-2', category='work'),
+        ]
+        result = rest.get_conversations(uid=UID)
+        assert [c.id for c in result] == ['conv-1', 'conv-2']


### PR DESCRIPTION
## Summary

`GET /v1/mcp/conversations` returns the user's conversation list, declared `response_model=List[SimpleConversation]`. The handler hands FastAPI the raw Firestore records and lets the response_model coerce them. `SimpleConversation.structured.category` is a required `CategoryEnum` with no fallback, so a single stored conversation whose category is no longer in the enum fails coercion and 500s the entire page, hiding every other conversation. This validates each record in the handler and skips the bad ones, so one stale record no longer takes down the whole list. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/mcp.py`, `get_conversations` returns the raw list straight to the response_model:

```python
redact_conversations_for_list(conversations)
return conversations
```

`conversations` are raw dicts from `conversations_db.get_conversations`. FastAPI then coerces the whole list into `List[SimpleConversation]`. `SimpleStructured.category` is typed `CategoryEnum`, which is a plain `str` Enum with no `_missing_` handler (unlike `ConversationSource` in the same module, which maps unknown values to `unknown`). So a record carrying a `structured.category` value that has since been dropped or renamed raises `pydantic.ValidationError` during response serialization, and FastAPI surfaces that as a 500 for the entire page. One outdated record poisons the list for everyone.

## Fix

Validate each record into `SimpleConversation` inside the handler, and skip the ones that fail:

```python
redact_conversations_for_list(conversations)
# Validate each record individually so one malformed conversation (e.g. a category
# no longer in CategoryEnum) cannot 500 the whole page via response_model coercion.
valid_conversations = []
for conv in conversations:
    try:
        valid_conversations.append(SimpleConversation.model_validate(conv))
    except Exception as e:  # noqa: BLE001 - one bad record must not 500 the page
        logger.warning(f"Skipping malformed conversation {conv.get('id', 'unknown')} in MCP list: {e}")
return valid_conversations
```

Valid records validate and serialize exactly as before, so the response shape is unchanged for good input.

## Testing

Added `backend/tests/unit/test_mcp_conversations_poison.py` (registered in `test.sh`). The router has a heavy import graph, so the test stubs the database and util deps, imports `routers.mcp` under the stub finder, and calls `get_conversations` directly with `conversations_db` and `redact_conversations_for_list` patched. A page of one valid record plus one whose `structured.category` is not in `CategoryEnum` returns only the valid record; an all-valid page returns both records in order. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 edits `routers/mcp.py` for auth rewiring but keeps this handler returning the unvalidated list. The per-record validation added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

