### PR TITLE
fix(backend): guard resample_pcm against non-positive sample rates

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -236,6 +236,8 @@ def resample_pcm(pcm_data: bytes, source_rate: int, target_rate: int) -> bytes:
     """Simple resampling by sample duplication/decimation."""
     if source_rate == target_rate:
         return pcm_data
+    if source_rate <= 0 or target_rate <= 0:
+        return pcm_data
     num_samples = len(pcm_data) // 2
     if num_samples == 0:
         return pcm_data

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -106,6 +106,7 @@ pytest tests/unit/test_kg_user_type_mismatch.py -v
 pytest tests/unit/test_kg_edge_id_sanitization.py -v
 pytest tests/unit/test_goal_extraction_batch.py -v
 pytest tests/unit/test_listen_pipeline.py -v
+pytest tests/unit/test_resample_pcm_divzero.py -v
 pytest tests/unit/test_fair_use_models.py -v
 pytest tests/unit/test_fair_use_engine.py -v
 pytest tests/unit/test_fair_use_classifier.py -v

--- a/backend/tests/unit/test_resample_pcm_divzero.py
+++ b/backend/tests/unit/test_resample_pcm_divzero.py
@@ -1,0 +1,116 @@
+"""Unit test for resample_pcm zero/invalid source_rate guard (routers/transcribe.py).
+
+resample_pcm computes `ratio = target_rate / source_rate`. With source_rate == 0
+(an attacker-controlled WS query param), this raised ZeroDivisionError -> the WS
+handler crashed. The guard makes resample_pcm a no-op for a non-positive rate,
+returning the input bytes unchanged.
+
+Red (without the fix): ZeroDivisionError.
+Green (with the fix): returns the input bytes unchanged.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# transcribe.py is VERY heavy: stub every heavy top-level import package it pulls.
+_STUB = (
+    'database',
+    'utils',
+    'models',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'lc3',
+    'av',
+    'numpy',
+    'audioop',  # removed from stdlib in py3.13; transcribe.py imports it at top level
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'httpx',
+    'typesense',
+    'pusher',
+    'fastapi',
+    'starlette',
+    'websockets',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import transcribe as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def test_resample_pcm_zero_source_rate_returns_input_unchanged():
+    """source_rate == 0 must be a no-op (no ZeroDivisionError)."""
+    pcm = b'\x00\x00\x00\x00'  # 4 zero bytes == 2 silent int16 samples
+    result = mod.resample_pcm(pcm, 0, 16000)
+    assert result == pcm
+
+
+def test_resample_pcm_negative_target_rate_returns_input_unchanged():
+    """target_rate <= 0 must also be a no-op."""
+    pcm = b'\x01\x00\x02\x00'
+    result = mod.resample_pcm(pcm, 16000, -1)
+    assert result == pcm
+
+
+def test_resample_pcm_equal_rates_still_passthrough():
+    """Sanity: the pre-existing equal-rate fast path is unaffected."""
+    pcm = b'\x05\x00\x06\x00'
+    assert mod.resample_pcm(pcm, 16000, 16000) == pcm


### PR DESCRIPTION
## Summary

`resample_pcm` in the listen pipeline does a simple sample-rate conversion by computing `ratio = target_rate / source_rate`. `source_rate` comes from the `sample_rate` query param on the `/v4/listen` WebSocket, which is never validated, so `sample_rate=0` makes the division raise `ZeroDivisionError`. This is a defensive guard in the resample helper: it returns the input bytes unchanged for a non-positive source or target rate. To be honest about scope, a zero rate on the live socket may also blow up earlier in decoder setup, but the division itself is genuinely unguarded and is the part that is cleanly unit-testable. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/transcribe.py`, `resample_pcm` only short-circuits when the rates are equal:

```python
def resample_pcm(pcm_data: bytes, source_rate: int, target_rate: int) -> bytes:
    """Simple resampling by sample duplication/decimation."""
    if source_rate == target_rate:
        return pcm_data
    num_samples = len(pcm_data) // 2
    if num_samples == 0:
        return pcm_data
    samples = struct.unpack(f'<{num_samples}h', pcm_data)
    ratio = target_rate / source_rate
    ...
```

The early return covers `source_rate == target_rate` and an empty buffer, but nothing covers a non-positive rate. With `source_rate == 0`, `ratio = target_rate / source_rate` raises `ZeroDivisionError`. A negative rate does not raise here but produces a nonsense ratio and a bad output length. The rate is taken straight from the unvalidated `sample_rate` WebSocket query param, so the input can be zero.

## Fix

Add a second early return for a non-positive source or target rate, right after the equal-rate check:

```python
    if source_rate == target_rate:
        return pcm_data
    if source_rate <= 0 or target_rate <= 0:
        return pcm_data
```

For a bad rate the function now returns the input bytes unchanged instead of dividing by zero. Valid rates take the same path as before, so there is no change to behavior for valid input.

## Testing

New `backend/tests/unit/test_resample_pcm_divzero.py` (registered in `backend/test.sh`). `transcribe.py` has a very heavy import graph, so the test installs a meta-path stub finder that fakes the heavy top-level packages (`database`, `utils`, `models`, `numpy`, `audioop`, `fastapi`, and the rest), imports the module under that finder, then restores `sys.modules`. It calls `resample_pcm` directly: `source_rate=0` returns the input unchanged, a negative `target_rate` returns the input unchanged, and the pre-existing equal-rate passthrough still works. Verified red to green: the test fails on current main and passes with this change.

## PR status check

PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug.

No open PR changes this logic. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

