### PR TITLE
fix(backend): return 400 on invalid speech-profile WAV upload

### DIFF
--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -52,7 +52,10 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
     with open(file_path, 'wb') as f:
         f.write(file.file.read())
 
-    aseg = AudioSegment.from_wav(file_path)
+    try:
+        aseg = AudioSegment.from_wav(file_path)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid audio file: must be a valid 16kHz WAV.")
     if aseg.frame_rate != 16000:
         raise HTTPException(status_code=400, detail="Invalid codec, must be opus 16khz.")
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -85,6 +85,7 @@ pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
 pytest tests/unit/test_optional_audio_codecs.py -v
 pytest tests/unit/test_storage_opus_encoding.py -v
 pytest tests/unit/test_speech_profile_existence.py -v
+pytest tests/unit/test_speech_profile_wav_decode.py -v
 pytest tests/unit/test_storage_fanout_limits.py -v
 pytest tests/unit/test_deferred_blob_janitor.py -v
 pytest tests/unit/test_audio_merge_tasks.py -v

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -1,0 +1,134 @@
+"""Unit test for the speech-profile upload WAV-decode guard.
+
+POST /v3/upload-audio decodes the uploaded file with AudioSegment.from_wav.
+A malformed / non-WAV upload makes pydub raise (e.g. CouldntDecodeError),
+which previously escaped the handler and surfaced as a 500. A bad client
+upload should be reported as a 400 client error instead.
+
+This test patches AudioSegment.from_wav to raise and asserts upload_profile
+raises HTTPException(400). It is red on the unguarded code (raw exception -> 500)
+and green once the decode is wrapped in a try/except that returns 400.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import io
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+
+# Heavy / native packages pulled in (directly or transitively) by routers.speech_profile.
+_STUB = (
+    "database",
+    "utils.other.storage",
+    "utils.stt.speaker_embedding",
+    "utils.stt.vad",
+    "av",
+    "pydub",
+    "firebase_admin",
+    "google",
+    "pinecone",
+    "opuslib",
+    "redis",
+    "scipy",
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + ".") for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for _n in list(sys.modules):
+    if _is_stubbed(_n):
+        sys.modules.pop(_n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import speech_profile as mod
+finally:
+    sys.meta_path.remove(_f)
+    for _n in list(sys.modules):
+        if _is_stubbed(_n) and _n not in _saved:
+            sys.modules.pop(_n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException  # noqa: E402  (import after the finder block)
+
+
+class _FakeDecodeError(Exception):
+    """Stand-in for pydub.exceptions.CouldntDecodeError (pydub is stubbed here)."""
+
+
+def _fake_upload_file(content: bytes, filename: str = "speech_profile.wav"):
+    f = MagicMock()
+    f.filename = filename
+    f.file = MagicMock()
+    f.file.read.return_value = content
+    return f
+
+
+class TestUploadProfileWavDecodeGuard:
+    def test_invalid_wav_returns_400_not_500(self):
+        """A failing AudioSegment.from_wav must surface as HTTPException(400), not escape as 500."""
+        fake_file = _fake_upload_file(b"not a wav")
+
+        with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+            mod, "AudioSegment"
+        ) as mock_aseg:
+            # makedirs is a no-op; everything else on os.* stays usable via the mock.
+            mock_os.makedirs.return_value = None
+            mock_aseg.from_wav.side_effect = _FakeDecodeError("Decoding failed")
+
+            with pytest.raises(HTTPException) as exc_info:
+                mod.upload_profile(fake_file, uid="test-uid")
+
+        assert exc_info.value.status_code == 400
+
+    def test_invalid_wav_does_not_run_vad_or_upload(self):
+        """On a decode failure the handler must bail before VAD / storage side effects."""
+        fake_file = _fake_upload_file(b"garbage bytes")
+
+        with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+            mod, "AudioSegment"
+        ) as mock_aseg, patch.object(mod, "apply_vad_for_speech_profile") as mock_vad, patch.object(
+            mod, "upload_profile_audio"
+        ) as mock_upload:
+            mock_os.makedirs.return_value = None
+            mock_aseg.from_wav.side_effect = _FakeDecodeError("Decoding failed")
+
+            with pytest.raises(HTTPException) as exc_info:
+                mod.upload_profile(fake_file, uid="test-uid")
+
+        assert exc_info.value.status_code == 400
+        mock_vad.assert_not_called()
+        mock_upload.assert_not_called()


### PR DESCRIPTION
## Summary

`POST /v3/upload-audio` in the speech-profile router decodes the uploaded file with `AudioSegment.from_wav` and never guards that call. A client that uploads a non-WAV or corrupt file makes pydub raise, and the exception escapes the handler as an HTTP 500. The handler already returns 400 for a wrong frame rate or a bad duration, so an undecodable upload should be a 400 too. This PR wraps the decode and returns 400, which lines up with the rest of the validation in the same function. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/speech_profile.py`, `upload_profile` writes the request body to a temp file and then decodes it with no try/except:

```python
aseg = AudioSegment.from_wav(file_path)
if aseg.frame_rate != 16000:
    raise HTTPException(status_code=400, detail="Invalid codec, must be opus 16khz.")
```

`AudioSegment.from_wav` shells out to ffmpeg and raises `pydub.exceptions.CouldntDecodeError` (a subclass of `Exception`) when the bytes are not a WAV it can read. Nothing catches it, so FastAPI turns it into a 500. The two checks right after it already reject bad input with a 400, so a malformed upload was the one bad-input path that fell through as a server error instead of a client error.

## Fix

Wrap the decode and convert any failure into a 400:

```python
try:
    aseg = AudioSegment.from_wav(file_path)
except Exception:
    raise HTTPException(status_code=400, detail="Invalid audio file: must be a valid 16kHz WAV.")
```

A valid 16kHz WAV decodes exactly as before and the rest of the handler is unchanged.

## Testing

Added `backend/tests/unit/test_speech_profile_wav_decode.py` (registered in `test.sh`). This router has a heavy import graph (av, pydub, firebase, pinecone, and the storage and stt helpers), so the test installs a meta path finder that stubs those modules, imports `routers.speech_profile` under it, and calls `upload_profile` directly. It patches `AudioSegment.from_wav` to raise a decode error and asserts the call raises `HTTPException` with status 400, and a second case asserts the handler bails before running VAD or uploading on that failure. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946, the unified auth and BYOK middleware refactor, edits this router to rewire the auth `Depends`, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

