### PR TITLE
fix(backend): clamp flagged-users limit to [1, 200] in handler

### DIFF
--- a/backend/routers/fair_use_admin.py
+++ b/backend/routers/fair_use_admin.py
@@ -50,6 +50,9 @@ def get_flagged_users(
     limit: int = Query(default=50, le=200),
 ):
     """Get users with active fair-use enforcement."""
+    # Clamp in-function (not only via Query) so direct/non-HTTP callers can't pass a
+    # negative or huge limit straight through to the Firestore query.
+    limit = max(1, min(limit, 200))
     users = fair_use_db.get_flagged_users(stage_filter=stage, limit=limit)
     return {'users': users, 'fair_use_enabled': FAIR_USE_ENABLED}
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -107,6 +107,7 @@ pytest tests/unit/test_kg_edge_id_sanitization.py -v
 pytest tests/unit/test_goal_extraction_batch.py -v
 pytest tests/unit/test_listen_pipeline.py -v
 pytest tests/unit/test_fair_use_models.py -v
+pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
 pytest tests/unit/test_fair_use_engine.py -v
 pytest tests/unit/test_fair_use_classifier.py -v
 pytest tests/unit/test_fair_use_async.py -v

--- a/backend/tests/unit/test_fair_use_flagged_limit_clamp.py
+++ b/backend/tests/unit/test_fair_use_flagged_limit_clamp.py
@@ -1,0 +1,113 @@
+"""Regression test for GET /v1/admin/fair-use/flagged limit clamping.
+
+`get_flagged_users` exposes `limit: int = Query(default=50, le=200)`. The Query bound only
+constrains the HTTP layer; a direct/non-HTTP caller (or any path that bypasses FastAPI's
+validation) could pass a negative or huge limit straight through to the Firestore-backed
+`fair_use_db.get_flagged_users(...)`. The handler now clamps in-function to [1, 200]. These
+tests call the handler directly and assert the clamped value reaches the DB call.
+
+The fair_use_admin router pulls heavy deps (database.*, firebase_admin, redis, models/utils
+chains) at import time, so we import it under a meta-path stub-finder that fakes those packages.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+_STUB = (
+    'database',
+    'utils',
+    'models',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import fair_use_admin as fu_mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def test_negative_limit_is_clamped_to_one():
+    mock_get = MagicMock(return_value=[])
+    with patch.object(fu_mod.fair_use_db, 'get_flagged_users', mock_get):
+        fu_mod.get_flagged_users(admin_id='a', stage=None, limit=-5)
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs['limit'] == 1
+
+
+def test_huge_limit_is_clamped_to_two_hundred():
+    mock_get = MagicMock(return_value=[])
+    with patch.object(fu_mod.fair_use_db, 'get_flagged_users', mock_get):
+        fu_mod.get_flagged_users(admin_id='a', stage=None, limit=100000)
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs['limit'] == 200
+
+
+def test_in_range_limit_is_passed_through():
+    mock_get = MagicMock(return_value=[])
+    with patch.object(fu_mod.fair_use_db, 'get_flagged_users', mock_get):
+        fu_mod.get_flagged_users(admin_id='a', stage=None, limit=75)
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs['limit'] == 75


### PR DESCRIPTION
## Summary

The admin endpoint `GET /v1/admin/fair-use/flagged` lists users under active fair-use enforcement. Its `limit` parameter is declared `Query(default=50, le=200)`, which caps the upper bound but sets no lower bound, and the value is handed straight to the Firestore-backed `fair_use_db.get_flagged_users(...)`. A negative `limit` reaches Firestore's `.limit()` and raises, so the endpoint returns HTTP 500 instead of a result page. This PR clamps `limit` to `[1, 200]` inside the handler before the query runs. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/fair_use_admin.py`, `get_flagged_users` passes the parameter through without any in-function guard:

```python
@router.get('/v1/admin/fair-use/flagged', tags=['admin'])
def get_flagged_users(
    admin_id: str = Depends(_verify_admin_key),
    stage: Optional[str] = None,
    limit: int = Query(default=50, le=200),
):
    """Get users with active fair-use enforcement."""
    users = fair_use_db.get_flagged_users(stage_filter=stage, limit=limit)
    return {'users': users, 'fair_use_enabled': FAIR_USE_ENABLED}
```

The `Query(le=200)` bound only applies at FastAPI's HTTP validation layer, and only on the upper side. There is no `ge=` floor, so a negative value passes validation, and any caller that reaches the function without going through that validation (a direct call, a test, or an internal caller) can pass any integer. A negative `limit` flows into Firestore's `.limit()`, which rejects it and raises `ValueError`, surfaced by FastAPI as a 500.

## Fix

Clamp `limit` to `[1, 200]` in the handler, before the query:

```python
# Clamp in-function (not only via Query) so direct/non-HTTP callers can't pass a
# negative or huge limit straight through to the Firestore query.
limit = max(1, min(limit, 200))
users = fair_use_db.get_flagged_users(stage_filter=stage, limit=limit)
```

Valid input in the existing range behaves exactly as before, since `max(1, min(limit, 200))` is the identity for any value already in `[1, 200]`.

## Testing

New `backend/tests/unit/test_fair_use_flagged_limit_clamp.py` (registered in `backend/test.sh`). The fair_use_admin router pulls heavy deps (database.*, firebase_admin, redis, models/utils chains) at import time, so the test imports it under a meta-path stub finder that fakes those packages, then calls `get_flagged_users` directly with `fair_use_db.get_flagged_users` patched. The cases covered are a negative limit clamped up to 1, a huge limit clamped down to 200, and an in-range limit (75) passed through unchanged, each asserting the value that reaches the DB call. Verified red to green: the test fails on current main and passes with this change.

## PR status check

PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug.

No open PR changes the logic this PR fixes. The clamp added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

