### PR TITLE
fix(backend): guard None filename in transcribe_voice_message with 400

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -602,7 +602,10 @@ async def transcribe_voice_message(
             shutil.copyfileobj(file_obj, buffer)
 
     for file in upload_files:
-        if file.filename.lower().endswith('.wav'):
+        filename = file.filename
+        if not filename:
+            raise HTTPException(status_code=400, detail='Each uploaded file must have a filename')
+        if filename.lower().endswith('.wav'):
             # For WAV files, save directly to a temporary path
             temp_path = f"/tmp/{uid}_{uuid.uuid4()}.wav"
             await run_blocking(storage_executor, _save_wav, temp_path, file.file)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -146,6 +146,7 @@ pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
 pytest tests/unit/test_subscription_restructure.py -v
 pytest tests/unit/test_chat_quota.py -v
+pytest tests/unit/test_voice_message_filename_none.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
 pytest tests/unit/test_payment_promotion_codes.py -v

--- a/backend/tests/unit/test_voice_message_filename_none.py
+++ b/backend/tests/unit/test_voice_message_filename_none.py
@@ -1,0 +1,138 @@
+"""Regression test: transcribe_voice_message must reject a None filename with 400.
+
+A multipart upload whose UploadFile has filename=None previously hit
+`file.filename.lower()` and raised AttributeError -> 500. The endpoint now
+guards the missing filename and raises HTTPException(400), consistent with the
+other 400s on this endpoint.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'multipart',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import chat as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException
+
+
+class _StubUploadFile:
+    """Minimal UploadFile stand-in: has a .file attr and a None filename."""
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.file = MagicMock()
+
+
+class _StubForm:
+    def __init__(self, files):
+        self._files = files
+
+    def getlist(self, key):
+        return self._files if key == 'files' else []
+
+    def get(self, key, default=None):
+        return default
+
+
+class _StubRequest:
+    """Drive the multipart branch of transcribe_voice_message."""
+
+    def __init__(self, form):
+        self._form = form
+        self.headers = {'content-type': 'multipart/form-data; boundary=x'}
+        self.query_params = {}
+
+    async def form(self):
+        return self._form
+
+
+def _call(upload_file):
+    request = _StubRequest(_StubForm([upload_file]))
+    with patch.object(mod, 'is_trial_paywalled', return_value=False):
+        return asyncio.run(mod.transcribe_voice_message(request=request, uid='u1', x_app_platform='ios'))
+
+
+def test_none_filename_raises_400():
+    """A multipart upload with filename=None -> HTTPException(400), not AttributeError 500."""
+    with pytest.raises(HTTPException) as exc_info:
+        _call(_StubUploadFile(filename=None))
+    assert exc_info.value.status_code == 400
+
+
+def test_empty_filename_raises_400():
+    """An empty-string filename is also rejected with 400."""
+    with pytest.raises(HTTPException) as exc_info:
+        _call(_StubUploadFile(filename=''))
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /v2/voice-messages` (multipart mode) crashes with HTTP 500 when an uploaded file part has no filename. The handler calls `file.filename.lower()`, but `UploadFile.filename` is optional, so a multipart part sent without a filename has `filename=None` and the `.lower()` call raises `AttributeError`. Any client that posts a file part missing the `filename` field takes down the whole request instead of getting a clean error. This PR guards the missing filename and returns 400, matching the other 400s this endpoint already raises for bad input. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/chat.py`, `transcribe_voice_message` loops over the uploaded parts and branches on the file extension:

```python
for file in upload_files:
    if file.filename.lower().endswith('.wav'):
```

`upload_files` is filtered only by `hasattr(f, 'file')`, so a part can reach this loop with `filename=None`. Starlette's `UploadFile.filename` is `Optional[str]`, and a multipart file part with no `filename` in its Content-Disposition arrives as `None`. Calling `.lower()` on `None` raises `AttributeError`, which FastAPI surfaces as a 500. The octet-stream branch earlier in the same function already returns 400 for missing or empty input, so this path was inconsistent.

## Fix

Read the filename once and reject a missing one before using it:

```python
for file in upload_files:
    filename = file.filename
    if not filename:
        raise HTTPException(status_code=400, detail='Each uploaded file must have a filename')
    if filename.lower().endswith('.wav'):
```

The empty-string case is covered by the same `not filename` check. Files that arrive with a real filename behave exactly as before.

## Testing

New `backend/tests/unit/test_voice_message_filename_none.py` (registered in `test.sh`). `routers/chat.py` has a heavy import graph, so the test installs a stub meta-path finder, imports the router under it, and calls `transcribe_voice_message` directly with a stub request that drives the multipart branch. A part with `filename=None` and a part with `filename=''` both raise `HTTPException` with status 400 instead of `AttributeError`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) edits `routers/chat.py` to rewire the auth `Depends`, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

