### PR TITLE
fix(backend): return 422 for missing app name/description in generate-description

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1136,9 +1136,9 @@ def get_payment_plans(uid: str = Depends(auth.get_current_user_uid)):
 
 @router.post('/v1/app/generate-description', tags=['v1'])
 def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
-    if data['name'] == '':
+    if not data.get('name'):
         raise HTTPException(status_code=422, detail='App Name is required')
-    if data['description'] == '':
+    if not data.get('description'):
         raise HTTPException(status_code=422, detail='App Description is required')
     with track_usage(uid, Features.APP_GENERATOR):
         desc = generate_description(data['name'], data['description'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -92,6 +92,7 @@ pytest tests/unit/test_translation_dedup_edge_cases.py -v
 pytest tests/unit/test_conversation_source_unknown.py -v
 pytest tests/unit/test_conversation_model_split.py -v
 pytest tests/unit/test_transcribe_conversation_cache.py -v
+pytest tests/unit/test_app_generate_description_keyerror.py -v
 pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
 pytest tests/unit/test_pusher_batch_upload.py -v
 pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v

--- a/backend/tests/unit/test_app_generate_description_keyerror.py
+++ b/backend/tests/unit/test_app_generate_description_keyerror.py
@@ -1,0 +1,157 @@
+"""generate_description_endpoint must return 422 (not 500) when 'name'/'description' is missing.
+
+Previously the handler read data['name'] / data['description'] directly, so a payload that
+omits a key raised KeyError -> 500 instead of the intended 422 (the sibling
+generate_description_and_emoji_endpoint already uses data.get(...)).
+
+routers/apps.py has a very heavy import graph (langchain, utils.llm, stripe, ...), so we import it
+under a stub finder that auto-mocks those namespaces (keeping models/fastapi/pydantic real), then
+call generate_description_endpoint directly with track_usage patched.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+@contextmanager
+def _no_op_track_usage():
+    """track_usage is a context manager used to wrap the LLM call; make it a no-op."""
+    yield
+
+
+def _call(data):
+    # generate_description must never be reached for a missing-field payload; if the guard is
+    # broken and we fall through, the MagicMock keeps the test from doing real work.
+    with patch.object(apps_mod, 'track_usage', return_value=_no_op_track_usage()), patch.object(
+        apps_mod, 'generate_description', return_value='desc'
+    ):
+        return apps_mod.generate_description_endpoint(data=data, uid='u1')
+
+
+def test_missing_both_fields_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({})
+    assert e.value.status_code == 422
+
+
+def test_missing_description_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'name': 'x'})
+    assert e.value.status_code == 422
+
+
+def test_empty_name_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'name': '', 'description': 'd'})
+    assert e.value.status_code == 422
+
+
+def test_valid_payload_succeeds():
+    result = _call({'name': 'x', 'description': 'd'})
+    assert result == {'description': 'desc'}


### PR DESCRIPTION
## Summary

`POST /v1/app/generate-description` returns HTTP 500 when the request body omits either the `name` or `description` field, instead of a clean 422. The handler meant to validate both fields and reject missing input, but it reads them by subscript, so an absent key crashes before the guard can fire. This validates both fields with `.get(...)`, matching the sibling `generate_description_and_emoji_endpoint` in the same file. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/apps.py`, `generate_description_endpoint` reads both fields directly off the request dict:

```python
if data['name'] == '':
    raise HTTPException(status_code=422, detail='App Name is required')
if data['description'] == '':
    raise HTTPException(status_code=422, detail='App Description is required')
```

`data` is the raw request body. A payload that omits `name` (or `description`) never reaches the equality check, because `data['name']` raises `KeyError` first, and an unhandled `KeyError` surfaces as a 500. The intended 422 only happens when the key is present and equal to the empty string. The sibling `generate_description_and_emoji_endpoint` in the same file already reads these with `data.get('name')` and returns 422 for missing input, so this handler was the inconsistent one.

## Fix

Read each field with `.get(...)` so a missing key is treated the same as an empty value:

```python
if not data.get('name'):
    raise HTTPException(status_code=422, detail='App Name is required')
if not data.get('description'):
    raise HTTPException(status_code=422, detail='App Description is required')
```

A present-but-empty string was already rejected and still is. Valid payloads behave exactly as before.

## Testing

New `backend/tests/unit/test_app_generate_description_keyerror.py` (registered in `test.sh`). `routers/apps.py` has a heavy import graph (langchain, utils.llm, stripe, and so on), so the test imports it under a stub finder that auto-mocks those namespaces while keeping fastapi and pydantic real, then calls `generate_description_endpoint` directly with `track_usage` and `generate_description` patched. Cases: missing both fields, missing `description`, and an empty `name` all return 422; a valid payload returns the description dict. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) edits `routers/apps.py` to rewire the auth `Depends`, but it does not touch this handler's body, so it does not address this bug. The change here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

