### PR TITLE
fix(backend): reject sync upload with missing filename as 400

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1637,6 +1637,8 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
     paths = []
     for file in files:
         filename = file.filename
+        if not filename:
+            raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
         if not filename.endswith('.bin'):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
         if '_' not in filename:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -134,6 +134,7 @@ pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_sync_v2.py -v
+pytest tests/unit/test_sync_file_paths_filename_none.py -v
 pytest tests/unit/test_sync_cloud_tasks.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_sync_record_usage.py -v

--- a/backend/tests/unit/test_sync_file_paths_filename_none.py
+++ b/backend/tests/unit/test_sync_file_paths_filename_none.py
@@ -1,0 +1,124 @@
+"""Regression test: _retrieve_file_paths_v2 must reject a None filename with 400.
+
+An UploadFile with filename=None used to crash _retrieve_file_paths_v2 with an
+AttributeError ('NoneType' object has no attribute 'endswith') -> 500. The guard
+returns a clean 400 (consistent with the endpoint's other 400s) instead.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+# routers/sync.py pulls in Firestore/Redis/GCS/opus/pydub/models and friends.
+# Stub every heavy package so importing the router stays light; fastapi, pydantic,
+# numpy and httpx are real (the function under test raises a real HTTPException).
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'models',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import sync as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException  # noqa: E402  (import after the finder block)
+
+
+class _StubUploadFile:
+    """Minimal UploadFile stand-in with a configurable filename."""
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.file = MagicMock()
+
+
+def test_retrieve_file_paths_v2_none_filename_raises_400(tmp_path, monkeypatch):
+    """A file with filename=None must raise HTTPException(400), not AttributeError -> 500."""
+    # Run inside a temp cwd so the 'syncing/<uid>/<job_id>/' makedirs is harmless.
+    monkeypatch.chdir(tmp_path)
+
+    upload = _StubUploadFile(filename=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        mod._retrieve_file_paths_v2([upload], 'u1', 'job-1')
+
+    assert exc_info.value.status_code == 400
+
+
+def test_retrieve_file_paths_v2_bad_extension_still_400(tmp_path, monkeypatch):
+    """Sanity: a present-but-wrong filename keeps the existing 400 behavior."""
+    monkeypatch.chdir(tmp_path)
+
+    upload = _StubUploadFile(filename='recording.mp3')
+
+    with pytest.raises(HTTPException) as exc_info:
+        mod._retrieve_file_paths_v2([upload], 'u1', 'job-1')
+
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary

The v2 async sync upload endpoint (`POST /v2/sync-local-files`) returns HTTP 500 when a multipart file part arrives without a filename. `_retrieve_file_paths_v2` reads `file.filename` and immediately calls `.endswith('.bin')` on it, but `UploadFile.filename` is `Optional[str]`, so a part with no filename is `None` and the call raises `AttributeError`. A client that sends a file part with an empty or missing `filename` therefore crashes the whole request instead of getting a clean rejection. This PR validates the filename up front and returns 400, matching the other 400s in the same loop. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/sync.py`, `_retrieve_file_paths_v2` pulls the filename off each `UploadFile` and uses it without a null check:

```python
for file in files:
    filename = file.filename
    if not filename.endswith('.bin'):
        raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
```

`UploadFile.filename` is `Optional[str]`. When a multipart part carries no `filename` (a `Content-Disposition` with no `filename=` parameter), Starlette sets it to `None`. `None.endswith('.bin')` raises `AttributeError: 'NoneType' object has no attribute 'endswith'`, which is unhandled and surfaces as a 500. The rest of this function already raises 400 for every other bad-input case (wrong extension, missing timestamp separator, bad timestamp), so the missing-filename case was the one gap that fell through to a crash.

## Fix

Check the filename before using it and raise the same 400 the loop already uses for bad input:

```python
for file in files:
    filename = file.filename
    if not filename:
        raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
    if not filename.endswith('.bin'):
        raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
```

A request whose file parts all have valid `.bin` filenames takes the exact same path as before, so there is no change to behavior for valid input.

## Testing

Added `backend/tests/unit/test_sync_file_paths_filename_none.py` (registered in `backend/test.sh`). `routers/sync.py` pulls in Firestore, Redis, GCS, opus, pydub and the models package, so the test installs a meta-path finder that stubs those heavy packages and imports the router under it, then calls `_retrieve_file_paths_v2` directly; fastapi and pydantic stay real so the function raises a real `HTTPException`. A stub `UploadFile` with `filename=None` is expected to raise `HTTPException` with status 400, and a sanity case with a present-but-wrong filename (`recording.mp3`) confirms the existing 400 path is unchanged. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth `Depends` on this router but does not touch this handler's body logic, so it does not address this bug. The filename guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

