### PR TITLE
fix(backend): guard add_mcp_server against a null user lookup

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1478,7 +1478,7 @@ async def add_mcp_server(data: McpServerRequest, uid: str = Depends(auth.get_cur
     logo_url = await fetch_brandfetch_logo(domain) or ''
 
     app_id = str(ULID())
-    user = await run_blocking(db_executor, get_user_from_uid, uid)
+    user = await run_blocking(db_executor, get_user_from_uid, uid) or {}
 
     # Check for OAuth metadata
     oauth_meta = await discover_oauth_metadata(server_url)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -82,6 +82,7 @@ pytest tests/unit/test_hume_callback_malformed.py -v
 pytest tests/unit/test_file_upload_security.py -v
 pytest tests/unit/test_file_upload_endpoint_security.py -v
 pytest tests/unit/test_auth_redirect_uri.py -v
+pytest tests/unit/test_apps_add_mcp_server_user_none.py -v
 pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_pusher_conversation_retry.py -v
 pytest tests/unit/test_listen_fallback_removal.py -v

--- a/backend/tests/unit/test_apps_add_mcp_server_user_none.py
+++ b/backend/tests/unit/test_apps_add_mcp_server_user_none.py
@@ -1,0 +1,155 @@
+"""add_mcp_server must not 500 when the user lookup returns None.
+
+routers/apps.py has a very heavy import graph (langchain, utils.llm, stripe, ...), so we import it
+under a stub finder that auto-mocks those namespaces (keeping models/fastapi/pydantic real), then
+call add_mcp_server directly with its collaborators patched so get_user_from_uid yields None.
+
+Without the `or {}` guard, `user.get('display_name', '')` raises AttributeError -> 500.
+With the guard, `user` becomes {} and the endpoint returns its normal dict.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _run_blocking_side_effect(executor, func, *args, **kwargs):
+    """Mimic run_blocking: actually invoke the offloaded sync fn (here, the patched mocks)."""
+    return func(*args, **kwargs)
+
+
+def _call(user_value):
+    """Drive add_mcp_server through the no-OAuth branch with the user lookup returning user_value."""
+    data = apps_mod.McpServerRequest(name='Test MCP', mcp_server_url='https://mcp.example.com')
+
+    tool = MagicMock()
+    tool.endpoint = 'https://mcp.example.com/http'
+    tool.name = 'do_thing'
+    tool.model_dump.return_value = {'name': 'do_thing', 'parameters': None, 'endpoint': 'https://mcp.example.com/http'}
+
+    with patch.object(apps_mod, 'get_user_from_uid', return_value=user_value), patch.object(
+        apps_mod, 'run_blocking', new=AsyncMock(side_effect=_run_blocking_side_effect)
+    ), patch.object(apps_mod, 'fetch_brandfetch_logo', new=AsyncMock(return_value='')), patch.object(
+        apps_mod, 'discover_oauth_metadata', new=AsyncMock(return_value=None)
+    ), patch.object(
+        apps_mod, 'discover_mcp_tools', new=AsyncMock(return_value=[tool])
+    ), patch.object(
+        apps_mod, 'add_app_to_db'
+    ):
+        return asyncio.run(apps_mod.add_mcp_server(data, uid='u1'))
+
+
+def test_user_none_does_not_500():
+    # Red on current code: get_user_from_uid -> None -> user.get(...) AttributeError -> 500.
+    result = _call(None)
+    assert result['app_id']
+    assert result['requires_oauth'] is False
+
+
+def test_user_present_still_works():
+    result = _call({'display_name': 'Jane', 'email': 'jane@example.com'})
+    assert result['app_id']
+    assert result['requires_oauth'] is False


### PR DESCRIPTION
## Summary

`POST /v1/apps/mcp` (`add_mcp_server`) creates a private app from a remote MCP server. It looks up the caller's user record and reads `display_name` and `email` off it to set the new app's author and email fields. The lookup can return `None`, and the handler dereferences it unconditionally, so the whole request crashes with `AttributeError` and the client gets a 500 instead of a created app. This PR guards the lookup so a missing user record falls back to empty author/email instead of crashing. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/apps.py`, `add_mcp_server` fetches the user and then reads fields off it directly:

```python
app_id = str(ULID())
user = await run_blocking(db_executor, get_user_from_uid, uid)
```

`get_user_from_uid` returns `None` when there is no matching user document. Both code paths in the handler then call `user.get(...)` on it, for example in the no-OAuth branch:

```python
'author': user.get('display_name', ''),
'email': user.get('email', ''),
```

When `user` is `None`, `user.get(...)` raises `AttributeError: 'NoneType' object has no attribute 'get'`, which FastAPI surfaces as a 500. The OAuth branch above it (lines 1526-1527) reads the same fields the same way, so it fails identically.

## Fix

Default the lookup result to an empty dict, so a missing record yields empty strings instead of a crash:

```python
user = await run_blocking(db_executor, get_user_from_uid, uid) or {}
```

`{}.get('display_name', '')` returns `''`, matching the existing fallback already passed to `.get`. When the user record exists, `user` is unchanged and behavior is identical to before.

## Testing

New `backend/tests/unit/test_apps_add_mcp_server_user_none.py` (registered in `test.sh`). `routers/apps.py` has a heavy import graph (langchain, utils.llm, stripe, and more), so the test imports it under a stub finder that auto-mocks those namespaces while keeping models, fastapi, and pydantic real, then calls `add_mcp_server` directly with its collaborators patched. `get_user_from_uid` is patched to return `None`, the OAuth discovery is patched to take the no-OAuth path, and tool discovery and the DB write are stubbed. One case drives the lookup returning `None` and asserts the handler returns its normal dict, a second drives a present user dict and asserts the same. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) edits `routers/apps.py` to rewire the auth `Depends`, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

