### PR TITLE
fix(backend): return 400 for calendrically-invalid daily-score date

### DIFF
--- a/backend/routers/scores.py
+++ b/backend/routers/scores.py
@@ -1,6 +1,6 @@
 """Scores — daily, weekly, and overall productivity scores computed from action items."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 import database.action_items as action_items_db
 from utils.other import endpoints as auth
@@ -13,7 +13,10 @@ def get_daily_score(
     date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
-    return action_items_db.get_daily_score(uid, date=date)
+    try:
+        return action_items_db.get_daily_score(uid, date=date)
+    except ValueError:
+        raise HTTPException(status_code=400, detail='Invalid date. Use a real calendar date in YYYY-MM-DD format.')
 
 
 @router.get('/v1/scores', tags=['scores'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -77,6 +77,7 @@ pytest tests/unit/test_action_items_conversation_list_malformed.py -v
 pytest tests/unit/test_firmware_pagination.py -v
 pytest tests/unit/test_vad_gate.py -v
 pytest tests/unit/test_vad_onnx.py -v
+pytest tests/unit/test_scores_daily_date_validation.py -v
 pytest tests/unit/test_log_sanitizer.py -v
 pytest tests/unit/test_hume_callback_malformed.py -v
 pytest tests/unit/test_file_upload_security.py -v

--- a/backend/tests/unit/test_scores_daily_date_validation.py
+++ b/backend/tests/unit/test_scores_daily_date_validation.py
@@ -1,0 +1,119 @@
+"""Regression test for GET /v1/daily-score calendar date validation.
+
+The `date` query param is regex-constrained to YYYY-MM-DD, but a calendrically-invalid value
+that still matches the shape (e.g. 2026-02-30) reaches database.action_items.get_daily_score,
+whose `datetime.strptime(date, '%Y-%m-%d')` raises ValueError. Before the fix that surfaced as an
+unhandled HTTP 500. The endpoint now catches ValueError and returns HTTP 400.
+
+The real database.action_items.get_daily_score runs here (only the Firestore client is stubbed),
+so the actual strptime is exercised: an invalid date raises before any Firestore access, while a
+valid date proceeds into the (mocked) Firestore call.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+# Stub only the heavy leaf deps that database.action_items / the router pull in. We deliberately
+# keep the REAL database.action_items so the real strptime parses the date.
+_stubs = [
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'database._client',
+]
+
+_MISSING = object()
+_saved_modules = {}
+
+
+def _register_stub(name):
+    _saved_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    sys.modules[name] = _AutoMockModule(name)
+
+
+for _mod_name in _stubs:
+    _register_stub(_mod_name)
+
+# google.cloud.firestore_v1.FieldFilter must be a real callable for the `from ... import FieldFilter`.
+sys.modules['google.cloud.firestore_v1'].FieldFilter = MagicMock()
+
+# utils.other.endpoints exposes the auth dependencies used in the route signatures; FastAPI needs
+# real callables to build the dependants, so provide small stand-ins.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_saved_modules.setdefault('utils.other.endpoints', sys.modules.get('utils.other.endpoints', _MISSING))
+sys.modules['utils.other.endpoints'] = _endpoints
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_saved_modules.setdefault('routers.scores', sys.modules.get('routers.scores', _MISSING))
+sys.modules.pop('routers.scores', None)
+try:
+    from routers import scores as scores_mod  # noqa: E402
+finally:
+    for _name, _prev in _saved_modules.items():
+        if _prev is _MISSING:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _prev
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(scores_mod.router)
+    app.dependency_overrides[scores_mod.auth.get_current_user_uid] = lambda: 'test-uid'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_invalid_calendar_date_returns_400_not_500():
+    client = _client()
+    resp = client.get('/v1/daily-score', params={'date': '2026-02-30'})
+    assert resp.status_code == 400
+    assert 'date' in resp.json().get('detail', '').lower()
+
+
+def test_valid_date_is_accepted():
+    client = _client()
+    resp = client.get('/v1/daily-score', params={'date': '2026-01-15'})
+    # A real calendar date must not 400; the (mocked) Firestore read returns a score payload.
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

`GET /v1/daily-score` accepts an optional `date` query param and passes it to `database.action_items.get_daily_score`, which parses it with `datetime.strptime(date, '%Y-%m-%d')`. The param is regex-constrained to the `YYYY-MM-DD` shape, but a value that matches the shape yet is not a real calendar date (for example `2026-02-30`) passes the regex and then makes `strptime` raise `ValueError`, which surfaces as an unhandled HTTP 500. This wraps the call at the endpoint and returns a 400 for those inputs instead. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/scores.py`, `get_daily_score` calls the database function directly with no guard:

```python
@router.get('/v1/daily-score', tags=['scores'])
def get_daily_score(
    date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
    uid: str = Depends(auth.get_current_user_uid),
):
    return action_items_db.get_daily_score(uid, date=date)
```

The `pattern` only checks the digit layout, so `2026-02-30` is accepted as well-formed. In `database/action_items.py`, `get_daily_score` then does:

```python
if date:
    day = datetime.strptime(date, '%Y-%m-%d').replace(tzinfo=timezone.utc)
```

`strptime` rejects February 30 (and similar non-dates like month 13 or day 32) by raising `ValueError`. Nothing catches it, so FastAPI turns it into a 500. The blast radius is small but real: any client that sends a shape-valid but impossible date gets a server error instead of a clean client error.

## Fix

Catch `ValueError` at the endpoint and return a 400:

```python
try:
    return action_items_db.get_daily_score(uid, date=date)
except ValueError:
    raise HTTPException(status_code=400, detail='Invalid date. Use a real calendar date in YYYY-MM-DD format.')
```

`HTTPException` is added to the existing `fastapi` import. Valid dates and the no-date default behave exactly as before; only the bad-date path changes from 500 to 400.

## Testing

New `backend/tests/unit/test_scores_daily_date_validation.py` (registered in `test.sh`). The router pulls in a heavy import graph, so the test stubs only the leaf deps (Firebase, the Firestore client, the auth dependencies) and keeps the real `database.action_items` so the actual `strptime` runs. It imports `routers.scores` under those stubs, mounts the router on a `FastAPI` app, and calls the endpoint through `TestClient`. A calendrically-invalid date (`2026-02-30`) returns 400 with `date` in the detail; a valid date (`2026-01-15`) returns 200 from the mocked Firestore read. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) edits this file to rewire the auth `Depends`, but it does not touch this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

