### PR TITLE
fix(backend): skip malformed person docs in /v1/users/people list

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -474,7 +474,13 @@ def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.
         for i, person in enumerate(people):
             stored_paths = person.get('speech_samples', [])
             people[i]['speech_samples'] = get_speech_sample_signed_urls(stored_paths)
-    return people
+    valid_people = []
+    for person in people:
+        try:
+            valid_people.append(Person.model_validate(person))
+        except Exception as e:  # noqa: BLE001 - one malformed person must not 500 the whole list
+            logger.warning(f"Skipping malformed person doc {person.get('id', 'unknown')}: {e}")
+    return valid_people
 
 
 @router.patch('/v1/users/people/{person_id}/name', tags=['v1'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -72,6 +72,7 @@ pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v
 pytest tests/unit/test_firestore_cache.py -v
+pytest tests/unit/test_people_list_name_poison.py -v
 pytest tests/unit/test_task_sharing.py -v
 pytest tests/unit/test_action_items_conversation_list_malformed.py -v
 pytest tests/unit/test_firmware_pagination.py -v

--- a/backend/tests/unit/test_people_list_name_poison.py
+++ b/backend/tests/unit/test_people_list_name_poison.py
@@ -1,0 +1,135 @@
+"""Regression test for the /v1/users/people poison-page bug.
+
+get_all_people returned raw Firestore dicts for FastAPI to coerce against
+response_model=List[Person]. A single legacy/malformed person doc (e.g. one
+missing the required 'name' field) made response_model validation 500 the
+ENTIRE list, hiding every other valid person from the user.
+
+The fix validates each doc into a Person inside the handler with a per-record
+try/except, skipping malformed docs and returning only the valid ones.
+
+Red (pre-fix): get_all_people returns the raw list including the name-less dict.
+Green (post-fix): only the one valid Person is returned; the malformed doc is
+dropped instead of poisoning the page.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Heavy / unavailable packages that routers.users pulls in transitively. Stub
+# them so importing the router is cheap. models.* and pydantic/fastapi are NOT
+# stubbed: we want real Pydantic validation of Person to exercise the guard.
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'langchain_openai',
+    'langchain_google_genai',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'twilio',
+    'scipy',
+    'tiktoken',
+    'pycountry',
+    'PIL',
+    'websockets',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import users as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+from models.other import Person
+
+
+def test_get_all_people_skips_name_less_doc():
+    """One name-less (malformed) person doc must not poison the whole list."""
+    valid = {'id': 'p-valid', 'name': 'Alice'}
+    malformed = {'id': 'p-bad'}  # missing required 'name'
+
+    # get_people enters routers.users via `from database.users import *`; under
+    # the stub-finder database.* is mocked, so create=True binds it for the call.
+    with patch.object(mod, 'get_people', return_value=[valid, malformed], create=True):
+        result = mod.get_all_people(include_speech_samples=False, uid='u1')
+
+    # Only the valid person survives, returned as a validated Person model.
+    assert len(result) == 1
+    assert all(isinstance(p, Person) for p in result)
+    assert result[0].id == 'p-valid'
+    assert result[0].name == 'Alice'
+    assert all(getattr(p, 'id', None) != 'p-bad' for p in result)
+
+
+def test_get_all_people_returns_all_valid():
+    """All well-formed docs are returned as Person models."""
+    people = [
+        {'id': 'p1', 'name': 'Alice'},
+        {'id': 'p2', 'name': 'Bob'},
+    ]
+    with patch.object(mod, 'get_people', return_value=people, create=True):
+        result = mod.get_all_people(include_speech_samples=False, uid='u1')
+
+    assert len(result) == 2
+    assert all(isinstance(p, Person) for p in result)
+    assert {p.id for p in result} == {'p1', 'p2'}


### PR DESCRIPTION
## Summary

`GET /v1/users/people` returns the user's whole contacts list, declared with `response_model=List[Person]`. The handler returns raw Firestore dicts and lets FastAPI coerce them against that model. `Person.name` is a required field with no default, so a single legacy or partial-write person doc that is missing `name` fails response validation and 500s the entire list, hiding every other valid person from the user. This PR builds each `Person` inside the handler and skips the malformed docs, so one bad record no longer takes down the whole response. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/users.py`, `get_all_people` ends by returning the raw list:

```python
@router.get('/v1/users/people', tags=['v1'], response_model=List[Person])
def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.get_current_user_uid)):
    logger.info(f'get_all_people {include_speech_samples}')
    people = get_people(uid)
    if include_speech_samples:
        # Convert GCS paths to signed URLs for each person
        for i, person in enumerate(people):
            stored_paths = person.get('speech_samples', [])
            people[i]['speech_samples'] = get_speech_sample_signed_urls(stored_paths)
    return people
```

`people` is a list of raw Firestore dicts. Because the route sets `response_model=List[Person]`, FastAPI validates each dict against `Person` when serializing the response. `Person` requires `name` (and `id`) with no default:

```python
class Person(BaseModel):
    id: str
    name: str
```

So one doc missing `name` raises `pydantic.ValidationError` during response serialization, which FastAPI surfaces as a 500 for the whole page. The sibling `get_single_person` works on one record at a time, so it never hit this, but the list endpoint fails for all records on the first malformed one.

## Fix

Validate each doc into a `Person` in the handler, inside a per-record try/except, and return only the ones that pass:

```python
valid_people = []
for person in people:
    try:
        valid_people.append(Person.model_validate(person))
    except Exception as e:  # noqa: BLE001 - one malformed person must not 500 the whole list
        logger.warning(f"Skipping malformed person doc {person.get('id', 'unknown')}: {e}")
return valid_people
```

A malformed doc is logged and dropped instead of poisoning the page. For valid input nothing changes: the same people come back in the same order, now as already-validated `Person` models rather than dicts handed to FastAPI to coerce.

## Testing

New `backend/tests/unit/test_people_list_name_poison.py` (registered in `test.sh`). `routers.users` has a heavy import graph, so the test imports it under a stub finder (database, utils, firebase, and other heavy packages are mocked) and calls `get_all_people` directly. `models.*` and pydantic are left real so the test exercises actual `Person` validation. `get_people` is patched to return a mix of records. Cases: a valid plus a name-less doc returns only the valid one as a `Person`, and an all-valid list returns every record. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 edits `routers/users.py` for the unified auth and BYOK middleware rewiring, but it only changes the `Depends` on this handler, not the body that returns the raw list, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

