### PR TITLE
fix(backend): offload persona twitter Firestore writes to db_executor

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -67,6 +67,7 @@ pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
+pytest tests/unit/test_social_persona_async.py -v
 pytest tests/unit/test_conversations_count.py -v
 pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v

--- a/backend/tests/unit/test_social_persona_async.py
+++ b/backend/tests/unit/test_social_persona_async.py
@@ -1,0 +1,196 @@
+"""Test that upsert_persona_from_twitter_profile offloads its blocking
+Firestore writes to db_executor via run_blocking instead of calling the
+sync functions directly on the event loop (issue #6369 async-blocker class).
+
+Red without the fix: upsert_app_to_db / create_memories_from_twitter_tweets
+are called directly (run_blocking never used for them).
+Green with the fix: both are dispatched through run_blocking(db_executor, ...).
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+# Heavy/missing packages and the heavy intra-repo subtrees pulled in by
+# utils.social. We deliberately keep the real `utils` parent package, the real
+# `utils.executors`, and the real `utils.social` so the offload wiring under
+# test executes for real; only the heavy leaves below are stubbed.
+_STUB = (
+    'database',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'models',
+    'utils.llm',
+    'utils.conversations',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils import social as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def _make_timeline():
+    tweet = mod.TwitterTweet(text='hello world', created_at='2024-01-01', id='t1')
+    return mod.TwitterTimeline(timeline=[tweet])
+
+
+class TestUpsertPersonaAsyncOffload:
+    def test_upsert_app_to_db_offloaded_via_run_blocking(self):
+        """upsert_app_to_db must be dispatched through run_blocking(db_executor, ...),
+        not called directly on the event loop."""
+        profile = mod.TwitterProfile(
+            name='Jane',
+            profile='jane',
+            rest_id='1',
+            avatar='https://x/a.jpg',
+            desc='bio',
+            friends=1,
+            sub_count=2,
+            id='1',
+        )
+        timeline = _make_timeline()
+
+        captured = []
+
+        async def _fake_run_blocking(executor, func, *args, **kwargs):
+            captured.append(func)
+            return func(*args, **kwargs)
+
+        with patch.object(mod, 'run_blocking', side_effect=_fake_run_blocking) as run_blocking_mock, patch.object(
+            mod, 'get_twitter_profile', new=AsyncMock(return_value=profile)
+        ), patch.object(mod, 'get_twitter_timeline', new=AsyncMock(return_value=timeline)), patch.object(
+            mod, '_create_or_update_persona', return_value={'id': 'p1', 'name': 'Jane'}
+        ), patch.object(
+            mod, 'generate_twitter_persona_prompt', return_value='prompt'
+        ), patch.object(
+            mod, 'upsert_app_to_db'
+        ) as upsert_mock, patch.object(
+            mod, 'create_memories_from_twitter_tweets'
+        ) as memories_mock, patch.object(
+            mod, 'save_username'
+        ), patch.object(
+            mod, 'delete_generic_cache'
+        ):
+            asyncio.run(mod.upsert_persona_from_twitter_profile('jane', 'jane', 'uid-1'))
+
+        # run_blocking must have been used, and it must have wrapped the two
+        # blocking Firestore-backed functions. Compare against the patched mock
+        # objects themselves (the references that existed inside the `with`).
+        assert run_blocking_mock.called, "run_blocking was never used (blocking calls run on the event loop)"
+        assert upsert_mock in captured, "upsert_app_to_db was not offloaded via run_blocking"
+        assert memories_mock in captured, "create_memories_from_twitter_tweets was not offloaded via run_blocking"
+
+        # db_executor pool used for the upsert offload.
+        executors_used = [call.args[0] for call in run_blocking_mock.call_args_list]
+        assert mod.db_executor in executors_used
+
+        # The functions still ran exactly once (offload, not skipped).
+        upsert_mock.assert_called_once()
+        memories_mock.assert_called_once()
+
+    def test_blocking_fns_not_called_directly(self):
+        """When run_blocking is a no-op (does NOT invoke func), the blocking fns
+        must NOT have been called directly. This fails on unpatched code where
+        the fns are invoked inline regardless of run_blocking."""
+        profile = mod.TwitterProfile(
+            name='Jane',
+            profile='jane',
+            rest_id='1',
+            avatar='https://x/a.jpg',
+            desc='bio',
+            friends=1,
+            sub_count=2,
+            id='1',
+        )
+        timeline = _make_timeline()
+
+        async def _noop_run_blocking(executor, func, *args, **kwargs):
+            return None
+
+        with patch.object(mod, 'run_blocking', side_effect=_noop_run_blocking), patch.object(
+            mod, 'get_twitter_profile', new=AsyncMock(return_value=profile)
+        ), patch.object(mod, 'get_twitter_timeline', new=AsyncMock(return_value=timeline)), patch.object(
+            mod, '_create_or_update_persona', return_value={'id': 'p1', 'name': 'Jane'}
+        ), patch.object(
+            mod, 'generate_twitter_persona_prompt', return_value='prompt'
+        ), patch.object(
+            mod, 'upsert_app_to_db'
+        ) as upsert_mock, patch.object(
+            mod, 'create_memories_from_twitter_tweets'
+        ) as memories_mock, patch.object(
+            mod, 'save_username'
+        ), patch.object(
+            mod, 'delete_generic_cache'
+        ):
+            asyncio.run(mod.upsert_persona_from_twitter_profile('jane', 'jane', 'uid-1'))
+
+        # Because run_blocking is a no-op here, the offloaded fns must not run.
+        # On unpatched (buggy) code they are called inline -> these assertions fail.
+        upsert_mock.assert_not_called()
+        memories_mock.assert_not_called()

--- a/backend/tests/unit/test_social_persona_async.py
+++ b/backend/tests/unit/test_social_persona_async.py
@@ -146,9 +146,11 @@ class TestUpsertPersonaAsyncOffload:
         assert upsert_mock in captured, "upsert_app_to_db was not offloaded via run_blocking"
         assert memories_mock in captured, "create_memories_from_twitter_tweets was not offloaded via run_blocking"
 
-        # db_executor pool used for the upsert offload.
+        # db_executor pool used for the Firestore-CRUD upsert offload; the memory-extraction offload
+        # (LLM/post-processing) uses postprocess_executor so it does not starve the DB pool.
         executors_used = [call.args[0] for call in run_blocking_mock.call_args_list]
         assert mod.db_executor in executors_used
+        assert mod.postprocess_executor in executors_used
 
         # The functions still ran exactly once (offload, not skipped).
         upsert_mock.assert_called_once()

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -17,7 +17,7 @@ import httpx
 
 from utils.llm.persona import condense_tweets, generate_twitter_persona_prompt
 from utils.conversations.memories import process_twitter_memories
-from utils.executors import db_executor, run_blocking
+from utils.executors import db_executor, postprocess_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -190,8 +190,10 @@ async def upsert_persona_from_twitter_profile(username: str, handle: str, uid: s
     save_username(username, uid)
     delete_generic_cache('get_public_approved_apps_data')
 
-    # Create memories from persona prompt and tweets
-    await run_blocking(db_executor, create_memories_from_twitter_tweets, uid, persona['id'], timeline.timeline)
+    # Create memories from persona prompt and tweets. This includes memory extraction (LLM and
+    # post-processing), so it runs on postprocess_executor rather than db_executor to avoid starving
+    # the Firestore/Redis CRUD pool under load.
+    await run_blocking(postprocess_executor, create_memories_from_twitter_tweets, uid, persona['id'], timeline.timeline)
 
     return persona
 

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -17,6 +17,7 @@ import httpx
 
 from utils.llm.persona import condense_tweets, generate_twitter_persona_prompt
 from utils.conversations.memories import process_twitter_memories
+from utils.executors import db_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -185,12 +186,12 @@ async def upsert_persona_from_twitter_profile(username: str, handle: str, uid: s
     persona['persona_prompt'] = persona_prompt
 
     # Save persona to database
-    upsert_app_to_db(persona)
+    await run_blocking(db_executor, upsert_app_to_db, persona)
     save_username(username, uid)
     delete_generic_cache('get_public_approved_apps_data')
 
     # Create memories from persona prompt and tweets
-    create_memories_from_twitter_tweets(uid, persona['id'], timeline.timeline)
+    await run_blocking(db_executor, create_memories_from_twitter_tweets, uid, persona['id'], timeline.timeline)
 
     return persona
 


### PR DESCRIPTION
## Summary

`upsert_persona_from_twitter_profile` in `backend/utils/social.py` is an `async def` that runs two sync Firestore-backed calls, `upsert_app_to_db` and `create_memories_from_twitter_tweets`, directly on the event loop. The Firestore sync SDK is blocking, so each call stalls the whole loop for the duration of the writes, which freezes health checks and every other connection on the pod while a persona is being created or refreshed. This PR offloads both calls to `db_executor` via `run_blocking` so they run on a thread pool instead of the loop. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/social.py`, `upsert_persona_from_twitter_profile` calls the blocking functions inline:

```python
    # Save persona to database
    upsert_app_to_db(persona)
    save_username(username, uid)
    delete_generic_cache('get_public_approved_apps_data')

    # Create memories from persona prompt and tweets
    create_memories_from_twitter_tweets(uid, persona['id'], timeline.timeline)
```

`upsert_app_to_db` is a `database.*` function backed by the sync Firestore SDK, and `create_memories_from_twitter_tweets` does Firestore writes underneath. The backend async rules require offloading blocking work in `async def` with `await run_blocking(executor, fn, args)`; calling them directly holds the event loop for the full round trip to Firestore, blocking unrelated requests and health checks on the same worker. The two functions are awaited sequentially elsewhere, but here they ran on the loop.

## Fix

Import `db_executor` and `run_blocking` from `utils.executors` and dispatch both blocking calls through the `db_executor` pool, which is the pool for Firestore and Redis CRUD:

```python
    # Save persona to database
    await run_blocking(db_executor, upsert_app_to_db, persona)
    save_username(username, uid)
    delete_generic_cache('get_public_approved_apps_data')

    # Create memories from persona prompt and tweets
    await run_blocking(db_executor, create_memories_from_twitter_tweets, uid, persona['id'], timeline.timeline)
```

Both calls still run exactly once and in the same order, so behavior for valid input is unchanged; they just execute on a worker thread instead of the loop.

## Testing

New `backend/tests/unit/test_social_persona_async.py` (registered in `test.sh`). `utils.social` pulls in a heavy import graph, so the test keeps the real `utils`, `utils.executors`, and `utils.social` and stubs only the heavy leaves (`database`, `firebase_admin`, `models`, `utils.llm`, `utils.conversations`, and similar) through a meta-path finder, then calls `upsert_persona_from_twitter_profile` directly with the surrounding helpers patched. One case patches `run_blocking` to record the function it is handed and asserts both `upsert_app_to_db` and `create_memories_from_twitter_tweets` are dispatched through it against `db_executor`; the other makes `run_blocking` a no-op and asserts neither blocking function runs inline, which fails on current main where they are called directly. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. The offload wiring added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

