### PR TITLE
fix(backend): clamp limit in MCP SSE x-posts and search tool branches

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -719,7 +719,10 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         if not query:
             raise ToolExecutionError("query is required")
 
-        limit = arguments.get("limit", 10)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=10, minimum=1, maximum=500)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         start_date = arguments.get("start_date")
         end_date = arguments.get("end_date")
 
@@ -769,7 +772,10 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         query = arguments.get("query")
         if not query:
             raise ToolExecutionError("query is required")
-        limit = arguments.get("limit", 10)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=10, minimum=1, maximum=500)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
 
         matches = vector_db.find_similar_x_posts(user_id, query, limit=limit)
         if not matches:
@@ -792,7 +798,10 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         return {"posts": results}
 
     elif tool_name == "get_x_posts":
-        limit = arguments.get("limit", 50)
+        try:
+            limit = parse_mcp_int(arguments.get("limit"), "limit", default=50, minimum=1, maximum=500)
+        except ValueError as e:
+            raise ToolExecutionError(str(e), code=-32602)
         kind = arguments.get("kind")
         posts = x_posts_db.get_x_posts(user_id, limit=limit, kind=kind)
         results = [

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -62,6 +62,7 @@ pytest tests/unit/test_proactive_notification_language.py -v
 pytest tests/unit/test_notification_token_cleanup.py -v
 pytest tests/unit/test_integration_notification_validation.py -v
 pytest tests/unit/test_conversations_to_string.py -v
+pytest tests/unit/test_mcp_sse_posts_clamp.py -v
 pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v

--- a/backend/tests/unit/test_mcp_sse_posts_clamp.py
+++ b/backend/tests/unit/test_mcp_sse_posts_clamp.py
@@ -1,0 +1,202 @@
+"""Unit tests for limit clamping in the MCP SSE x-posts/search tool branches.
+
+The get_x_posts / search_x_posts / search_conversations branches of
+routers/mcp_sse.py:execute_tool previously read `limit` straight from the
+client arguments and passed it unguarded to Firestore / the vector DB. A
+negative, huge, or non-integer limit therefore reached the data layer
+(500-ing the request or hammering the backing store). These tests assert the
+value is now clamped via parse_mcp_int (or rejected as a clean -32602
+ToolExecutionError) before it reaches the DB.
+
+Reuses the heavy-dependency stubbing harness from test_mcp_data_endpoints.py.
+"""
+
+from unittest.mock import patch, MagicMock
+import os
+import sys
+from types import ModuleType
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module(
+    'utils.retrieval.hybrid',
+    os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'),
+)
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+_drop_stale_module('models.conversation_enums', os.path.join(_BACKEND_DIR, 'models', 'conversation_enums.py'))
+_drop_stale_module('models.mcp_api_key', os.path.join(_BACKEND_DIR, 'models', 'mcp_api_key.py'))
+
+_stubs = [
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.screen_activity',
+    'database.x_posts',
+    'database.fair_use',
+    'database.auth',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.FieldFilter',
+    'google',
+    'google.cloud',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'utils.other.storage',
+    'utils.other.endpoints',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.render',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.log_sanitizer',
+    'utils.executors',
+    'dependencies',
+]
+for mod_name in _stubs:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = _AutoMockModule(mod_name)
+
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+sys.modules['utils.executors'].db_executor = MagicMock()
+sys.modules['utils.executors'].postprocess_executor = MagicMock()
+sys.modules['utils.llm.memories'].identify_category_for_memory = MagicMock(return_value='other')
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
+sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
+
+from routers import mcp_sse as sse  # noqa: E402
+
+UID = "user-1"
+
+
+class TestGetXPostsLimitClamp:
+    @patch('routers.mcp_sse.x_posts_db')
+    def test_negative_limit_clamped_to_minimum(self, mock_db):
+        mock_db.get_x_posts.return_value = []
+        sse.execute_tool(UID, 'get_x_posts', {'limit': -5})
+        _, kwargs = mock_db.get_x_posts.call_args
+        # Without the fix, raw -5 reaches Firestore.
+        assert kwargs['limit'] == 1
+
+    @patch('routers.mcp_sse.x_posts_db')
+    def test_huge_limit_clamped_to_maximum(self, mock_db):
+        mock_db.get_x_posts.return_value = []
+        sse.execute_tool(UID, 'get_x_posts', {'limit': 100000})
+        _, kwargs = mock_db.get_x_posts.call_args
+        assert kwargs['limit'] == 500
+
+    @patch('routers.mcp_sse.x_posts_db')
+    def test_non_integer_limit_rejected(self, mock_db):
+        mock_db.get_x_posts.return_value = []
+        with pytest.raises(sse.ToolExecutionError) as e:
+            sse.execute_tool(UID, 'get_x_posts', {'limit': 'not-an-int'})
+        assert e.value.code == -32602
+        mock_db.get_x_posts.assert_not_called()
+
+    @patch('routers.mcp_sse.x_posts_db')
+    def test_default_limit_when_absent(self, mock_db):
+        mock_db.get_x_posts.return_value = []
+        sse.execute_tool(UID, 'get_x_posts', {})
+        _, kwargs = mock_db.get_x_posts.call_args
+        assert kwargs['limit'] == 50
+
+
+class TestSearchXPostsLimitClamp:
+    @patch('routers.mcp_sse.x_posts_db')
+    @patch('routers.mcp_sse.vector_db')
+    def test_negative_limit_clamped_to_minimum(self, mock_vector_db, mock_x_posts_db):
+        mock_vector_db.find_similar_x_posts.return_value = []
+        sse.execute_tool(UID, 'search_x_posts', {'query': 'hi', 'limit': -5})
+        _, kwargs = mock_vector_db.find_similar_x_posts.call_args
+        # Without the fix, raw -5 reaches the vector DB.
+        assert kwargs['limit'] == 1
+
+
+class TestSearchConversationsLimitClamp:
+    @patch('routers.mcp_sse.conversations_db')
+    @patch('routers.mcp_sse.vector_db')
+    def test_negative_limit_clamped_to_minimum(self, mock_vector_db, mock_conversations_db):
+        mock_vector_db.query_vectors.return_value = []
+        sse.execute_tool(UID, 'search_conversations', {'query': 'hi', 'limit': -5})
+        _, kwargs = mock_vector_db.query_vectors.call_args
+        # query_vectors is called with k=limit; without the fix raw -5 reaches it.
+        assert kwargs['k'] == 1


### PR DESCRIPTION
## Summary

The MCP SSE server in `backend/routers/mcp_sse.py` exposes `get_x_posts`, `search_x_posts`, and `search_conversations` tools that take a client-supplied `limit`. These branches read `limit` straight off the arguments dict and pass it into the backing query unchanged, so a negative, zero, or huge value goes all the way to Firestore and the vector DB. A negative or zero limit produces a wrong or empty result, and a value like 100000 turns one tool call into an unbounded fetch against the data layer. This PR routes those branches through `parse_mcp_int` with the same min/max clamp the sibling tool branches already use. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `execute_tool` in `backend/routers/mcp_sse.py`, the `search_x_posts` and `get_x_posts` branches build `limit` with a bare `arguments.get`:

```python
elif tool_name == "search_x_posts":
    query = arguments.get("query")
    if not query:
        raise ToolExecutionError("query is required")
    limit = arguments.get("limit", 10)

    matches = vector_db.find_similar_x_posts(user_id, query, limit=limit)
```

```python
elif tool_name == "get_x_posts":
    limit = arguments.get("limit", 50)
    kind = arguments.get("kind")
    posts = x_posts_db.get_x_posts(user_id, limit=limit, kind=kind)
```

`limit` is whatever the client sent. A non-integer reaches the query and raises a `TypeError`/`ValueError` from the data layer, which the tool surfaces as a generic execution error rather than a clean invalid-params response. A negative limit gives a wrong slice, and an oversized one fetches far more than intended. The `get_action_items`, `search_memories`, and other tool branches in the same function already wrap their `limit` in `parse_mcp_int(..., minimum=1, maximum=...)`, so these branches were the inconsistent ones.

## Fix

Parse `limit` through `parse_mcp_int` with explicit bounds, matching the sibling branches, and turn a bad value into a clean invalid-params error (`-32602`):

```python
try:
    limit = parse_mcp_int(arguments.get("limit"), "limit", default=10, minimum=1, maximum=500)
except ValueError as e:
    raise ToolExecutionError(str(e), code=-32602)
```

`get_x_posts` uses `default=50`. `parse_mcp_int` clamps with `max(minimum, min(parsed, maximum))`, so a valid limit inside the range is passed through unchanged and behaves exactly as before. Out-of-range values are clamped to 1..500 and a non-integer is rejected with `-32602` before it reaches the DB.

## Testing

New `backend/tests/unit/test_mcp_sse_posts_clamp.py`, registered in `backend/test.sh`. `routers/mcp_sse.py` has a heavy import graph, so the test reuses the stub-finder harness from `test_mcp_data_endpoints.py`: database and firebase modules are stubbed, then the router is imported and `execute_tool` is called directly with `x_posts_db`, `vector_db`, and `conversations_db` patched. Cases: a negative `limit` is clamped to the minimum of 1 (asserted on the `limit` kwarg passed to `get_x_posts` / `find_similar_x_posts`, and on `k` for `search_conversations`), a huge `limit` is clamped to 500, a non-integer raises `ToolExecutionError` with code `-32602` and never calls the DB, and an absent `limit` falls back to the per-tool default of 50. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends on this router but does not touch the body of `execute_tool`, so it does not address this bug. The clamp added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

