### PR TITLE
fix(backend): guard None user in get_or_create_user_persona

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -676,7 +676,7 @@ async def get_or_create_user_persona(uid: str = Depends(auth.get_current_user_ui
         return persona
 
     # Create a new persona for the user
-    user = await run_blocking(db_executor, get_user_from_uid, uid)
+    user = await run_blocking(db_executor, get_user_from_uid, uid) or {}
 
     # Generate a unique ID for the persona
     persona_id = str(ULID())

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -57,6 +57,7 @@ pytest tests/unit/test_daily_summary_regenerate.py -v
 pytest tests/unit/test_chat_tools_messages.py -v
 pytest tests/unit/test_chat_tool_parameters_json.py -v
 pytest tests/unit/test_prompt_caching.py -v
+pytest tests/unit/test_get_or_create_user_persona_user_none.py -v
 pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v
 pytest tests/unit/test_notification_token_cleanup.py -v

--- a/backend/tests/unit/test_get_or_create_user_persona_user_none.py
+++ b/backend/tests/unit/test_get_or_create_user_persona_user_none.py
@@ -1,0 +1,149 @@
+"""get_or_create_user_persona must not 500 when the user lookup returns None.
+
+routers/apps.py has a very heavy import graph (langchain, utils.llm, stripe, ...), so we import it
+under a stub finder that auto-mocks those namespaces (keeping models/fastapi/pydantic real), then
+call get_or_create_user_persona directly with its collaborators patched.
+
+On current (unfixed) code, get_user_from_uid returning None makes the subsequent user.get(...)
+dereference raise AttributeError -> HTTP 500. The fix (`... or {}`) lets the handler complete.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+async def _run_blocking_sync(executor, fn, *args):
+    """Stand-in for utils.executors.run_blocking that runs the callable inline."""
+    return fn(*args)
+
+
+def _drive_no_existing_persona():
+    """Drive get_or_create_user_persona with no pre-existing persona and get_user_from_uid -> None."""
+    with patch.object(apps_mod, 'run_blocking', side_effect=_run_blocking_sync), patch.object(
+        apps_mod, 'get_user_persona_by_uid', return_value=None
+    ), patch.object(apps_mod, 'get_user_from_uid', return_value=None), patch.object(
+        apps_mod, 'increment_username', return_value='mypersona'
+    ), patch.object(
+        apps_mod, 'save_username'
+    ), patch.object(
+        apps_mod, 'add_app_to_db'
+    ), patch.object(
+        apps_mod, 'generate_persona_prompt', new=AsyncMock(return_value='prompt')
+    ), patch.object(
+        apps_mod.AppCreate, 'model_validate', return_value=MagicMock(model_dump=MagicMock(return_value={}))
+    ):
+        return asyncio.run(apps_mod.get_or_create_user_persona(uid='u1'))
+
+
+def test_user_lookup_none_does_not_500():
+    # Must not raise AttributeError/TypeError when the user lookup returns None.
+    result = _drive_no_existing_persona()
+    assert isinstance(result, dict)
+    # The persona dict is still well-formed despite the missing user.
+    assert result['uid'] == 'u1'
+    assert result['email'] == ''
+    assert result['author'] == ''


### PR DESCRIPTION
## Summary

`POST /v1/user/persona` (`get_or_create_user_persona`) returns HTTP 500 the first time a user creates a persona if their user record lookup comes back empty. The handler reads the user record and then calls `.get(...)` on it to fill in the persona fields, so a `None` result crashes the request and the user cannot create a persona at all. This guards the lookup the same way the sibling `create_app` handler in this file already does. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/apps.py`, `get_or_create_user_persona` reads the user record and uses it directly:

```python
user = await run_blocking(db_executor, get_user_from_uid, uid)

# ...
persona_data = {
    'id': persona_id,
    'name': user.get('display_name', 'My Persona'),
    ...
    'author': user.get('display_name', ''),
    'email': user.get('email', ''),
    ...
}
```

`get_user_from_uid` can return `None` (no user document, or a 404 / empty result for that uid). When it does, the first `user.get('display_name', 'My Persona')` dereferences `None`, which raises `AttributeError` ('NoneType' object has no attribute 'get'). That is unhandled, so FastAPI surfaces it as a 500. The `create_app` handler in the same file already reads this with `get_user_from_uid(uid) or {}`, so this path was inconsistent.

## Fix

Default the lookup to an empty dict, matching `create_app`:

```python
user = await run_blocking(db_executor, get_user_from_uid, uid) or {}
```

With a missing user the persona is still created with the existing defaults (`'My Persona'`, empty author and email). Valid users with a real record behave exactly as before.

## Testing

New `backend/tests/unit/test_get_or_create_user_persona_user_none.py` (registered in `backend/test.sh`). `routers/apps.py` has a heavy import graph (langchain, utils.llm, stripe), so the test imports it under a stub finder that auto-mocks those namespaces while keeping models, fastapi, and pydantic real, then calls `get_or_create_user_persona` directly with its collaborators patched. With `get_user_persona_by_uid` returning `None` and `get_user_from_uid` returning `None`, the handler returns a well-formed persona dict (`uid` set, empty `email` and `author`) instead of raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) edits `routers/apps.py`, but it rewires the auth `Depends` and does not touch this handler's body logic, so it does not address this bug. The change here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

