### PR TITLE
fix(backend): offload get_available_apps off the event loop in trigger_external_integrations

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -52,6 +52,7 @@ pytest tests/unit/test_user_usage.py -v
 pytest tests/unit/test_llm_usage_endpoints.py -v
 pytest tests/unit/test_app_uid_keyerror.py -v
 pytest tests/unit/test_create_persona_user_none.py -v
+pytest tests/unit/test_app_integrations_trigger_async.py -v
 pytest tests/unit/test_daily_summary_race_condition.py -v
 pytest tests/unit/test_daily_summary_regenerate.py -v
 pytest tests/unit/test_chat_tools_messages.py -v

--- a/backend/tests/unit/test_app_integrations_trigger_async.py
+++ b/backend/tests/unit/test_app_integrations_trigger_async.py
@@ -1,0 +1,141 @@
+"""Regression test for issue: trigger_external_integrations blocks the event loop.
+
+`trigger_external_integrations` is an `async def` that historically called the
+sync, Firestore-backed `get_available_apps(uid)` directly on the event loop. Per
+the backend async rules, every blocking DB call inside an `async def` must be
+offloaded via `await run_blocking(db_executor, fn, args)`.
+
+This test drives the handler with an `AsyncMock` standing in for `run_blocking`
+(returning [] so the function short-circuits before any webhook fan-out) and
+asserts that the apps lookup went through `run_blocking(get_available_apps, ...)`
+rather than calling `get_available_apps` directly.
+
+Red (before fix): `get_available_apps` is called directly; `run_blocking` is
+never invoked for it. Green (after fix): `run_blocking` is called with
+`get_available_apps`.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, AsyncMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+_STUB = (
+    'database',
+    'utils.apps',
+    'utils.notifications',
+    'utils.conversations',
+    'utils.llm',
+    'utils.llms',
+    'utils.mentor_notifications',
+    'utils.subscription',
+    'utils.log_sanitizer',
+    'utils.http_client',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'httpx',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils import app_integrations as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def _make_conversation():
+    """A conversation that passes the early discarded/locked guards."""
+    conversation = MagicMock()
+    conversation.discarded = False
+    conversation.is_locked = False
+    conversation.id = 'conv-1'
+    return conversation
+
+
+def test_trigger_external_integrations_offloads_get_available_apps():
+    """The Firestore-backed apps lookup must go through run_blocking, not a bare call."""
+    conversation = _make_conversation()
+
+    # run_blocking is awaited; AsyncMock returns an awaitable. Returning [] means
+    # filtered_apps is empty and the function short-circuits before any fan-out,
+    # so run_blocking is invoked exactly once: for the apps lookup.
+    fake_run_blocking = AsyncMock(return_value=[])
+    # Sentinel standing in for get_available_apps. Held in a local so it survives
+    # after patch.object reverts mod.get_available_apps, letting us assert exactly
+    # which callable was handed to run_blocking.
+    sentinel_get_available_apps = MagicMock(return_value=[], name='get_available_apps')
+
+    with patch.object(mod, 'run_blocking', fake_run_blocking), patch.object(
+        mod, 'get_available_apps', sentinel_get_available_apps
+    ):
+        result = asyncio.run(mod.trigger_external_integrations('uid-1', conversation))
+
+    assert result == []
+    # The fix routes the apps lookup through run_blocking(db_executor, get_available_apps, uid).
+    assert fake_run_blocking.await_count >= 1
+    offloaded_fns = [call.args[1] for call in fake_run_blocking.await_args_list if len(call.args) >= 2]
+    assert (
+        sentinel_get_available_apps in offloaded_fns
+    ), 'get_available_apps must be offloaded via run_blocking, not called directly on the event loop'
+    # And it must NOT be called directly (bare sync call on the event loop).
+    sentinel_get_available_apps.assert_not_called()

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -166,7 +166,7 @@ async def trigger_external_integrations(uid: str, conversation: Conversation) ->
     if conversation.is_locked:
         return []
 
-    apps: List[App] = get_available_apps(uid)
+    apps: List[App] = await run_blocking(db_executor, get_available_apps, uid)
     filtered_apps = [app for app in apps if app.triggers_on_conversation_creation() and app.enabled]
     if not filtered_apps:
         return []


### PR DESCRIPTION
## Summary

`trigger_external_integrations` in `backend/utils/app_integrations.py` is an `async def`, but it called the sync, Firestore-backed `get_available_apps(uid)` directly. That call runs on the event loop and blocks it for the duration of the Firestore read, so under load every other coroutine on that worker (health checks, other requests, webhook fan-out) stalls until the lookup returns. This PR offloads the lookup to a thread pool via `run_blocking`, matching how the rest of the function already handles its blocking DB calls. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/app_integrations.py`, `trigger_external_integrations` fetched the user's apps with a bare synchronous call:

```python
apps: List[App] = get_available_apps(uid)
```

`get_available_apps` is a sync function backed by the Firestore sync SDK, so awaiting nothing, it runs inline on the event loop and blocks it while Firestore responds. The backend async rules require every blocking DB call inside an `async def` to be offloaded with `await run_blocking(executor, fn, args)`. The rest of this same function already follows that rule, for example the webhook health checks use `await run_blocking(db_executor, is_app_webhook_disabled, app.id)` and the mentor path uses `await run_blocking(db_executor, process_mentor_notification, uid, segments)`. This one apps lookup was the outlier still running on the loop.

## Fix

Wrap the lookup in `run_blocking` so the Firestore read happens on `db_executor` instead of the event loop:

```python
apps: List[App] = await run_blocking(db_executor, get_available_apps, uid)
```

`db_executor` and `run_blocking` are already imported in this file. The result is the same list of apps, so behavior for valid input is unchanged; only the thread it runs on changes.

## Testing

Added `backend/tests/unit/test_app_integrations_trigger_async.py` (registered in `backend/test.sh`). This module has a heavy import graph, so the test installs a stub meta path finder, imports `utils.app_integrations` under it, then removes the finder. It patches `run_blocking` with an `AsyncMock` returning `[]` (so `filtered_apps` is empty and the function short-circuits before any webhook fan-out) and patches `get_available_apps` with a sentinel via `patch.object`. It then calls `trigger_external_integrations` directly and asserts the sentinel was handed to `run_blocking` and never called directly on the loop. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. The offload added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

