### PR TITLE
fix(backend): coerce out-of-enum import job status to failed in status endpoint

### DIFF
--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -141,9 +141,15 @@ def get_import_job_status(
     if job['uid'] != uid:
         raise HTTPException(status_code=403, detail="Not authorized to view this import job")
 
+    # Coerce an out-of-enum/missing stored status to failed instead of 500ing the request
+    try:
+        status_val = ImportJobStatus(job.get('status'))
+    except (ValueError, TypeError):
+        status_val = ImportJobStatus.failed
+
     return ImportJobResponse(
         job_id=job['id'],
-        status=ImportJobStatus(job['status']),
+        status=status_val,
         total_files=job.get('total_files'),
         processed_files=job.get('processed_files'),
         conversations_created=job.get('conversations_created'),

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
 pytest tests/unit/test_transcript_segment.py -v
+pytest tests/unit/test_import_job_status_detail_enum.py -v
 pytest tests/unit/test_text_similarity.py -v
 pytest tests/unit/test_text_containment.py -v
 pytest tests/unit/test_speaker_sample.py -v

--- a/backend/tests/unit/test_import_job_status_detail_enum.py
+++ b/backend/tests/unit/test_import_job_status_detail_enum.py
@@ -1,0 +1,124 @@
+"""get_import_job_status must not 500 when a stored job has an out-of-enum status.
+
+routers/imports.py pulls in database.* and utils.* (Firestore SDK, executors, ...), so we import it
+under a meta-path stub finder that auto-mocks those namespaces while keeping models/fastapi/pydantic
+real (we need the genuine ImportJobStatus enum + ImportJobResponse). Then we patch the single-job
+getter to return a job whose stored status is bogus and call get_import_job_status directly.
+
+Without the fix, ImportJobStatus(job['status']) raises ValueError -> 500. With the fix the status is
+coerced to ImportJobStatus.failed and a normal ImportJobResponse is returned.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import imports as imports_mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from models.import_job import ImportJobStatus  # noqa: E402
+
+
+def _job_with_status(status):
+    return {
+        'id': 'job-1',
+        'uid': 'u1',
+        'status': status,
+        'total_files': 3,
+        'processed_files': 1,
+        'conversations_created': 0,
+        'created_at': None,
+        'error': None,
+    }
+
+
+def _call(status):
+    job = _job_with_status(status)
+    with patch.object(imports_mod.import_jobs_db, 'get_import_job', return_value=job):
+        return imports_mod.get_import_job_status('job-1', uid='u1')
+
+
+def test_bogus_status_is_coerced_to_failed():
+    # Out-of-enum stored status must degrade to failed, not 500 the request.
+    resp = _call('bogus')
+    assert resp.status == ImportJobStatus.failed
+    assert resp.job_id == 'job-1'
+
+
+def test_missing_status_is_coerced_to_failed():
+    resp = _call(None)
+    assert resp.status == ImportJobStatus.failed
+
+
+def test_valid_status_is_preserved():
+    resp = _call('completed')
+    assert resp.status == ImportJobStatus.completed


### PR DESCRIPTION
## Summary

`GET /v1/import/jobs/{job_id}` returns HTTP 500 when the stored job has a status string that is not a member of the `ImportJobStatus` enum. The handler converts the raw Firestore value with `ImportJobStatus(job['status'])`, so any value written by an older code path, a partial write, or a missing field takes down the status check for that job and the client can no longer poll its progress. This PR coerces an unknown or missing status to `ImportJobStatus.failed` at the call site so the endpoint returns a normal response instead of crashing. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/imports.py`, `get_import_job_status` builds the response status straight from the raw dict:

```python
return ImportJobResponse(
    job_id=job['id'],
    status=ImportJobStatus(job['status']),
    total_files=job.get('total_files'),
    processed_files=job.get('processed_files'),
    conversations_created=job.get('conversations_created'),
    created_at=job.get('created_at'),
    error=job.get('error'),
)
```

`job` is a raw Firestore document. Calling `ImportJobStatus(...)` with a value that is not in the enum raises `ValueError`, and a missing `status` key passes `None` in, which also fails to construct. There is no guard, so the exception surfaces as a 500 for the whole request.

## Fix

Build the status once, ahead of the response, and fall back to `failed` when the stored value cannot be mapped:

```python
# Coerce an out-of-enum/missing stored status to failed instead of 500ing the request
try:
    status_val = ImportJobStatus(job.get('status'))
except (ValueError, TypeError):
    status_val = ImportJobStatus.failed

return ImportJobResponse(
    job_id=job['id'],
    status=status_val,
    ...
)
```

A valid stored status constructs the same enum member it did before, so there is no change in behavior for valid input.

## Testing

New `backend/tests/unit/test_import_job_status_detail_enum.py` (registered in `backend/test.sh`). `routers/imports.py` pulls in `database.*` and `utils.*` (Firestore SDK, executors, and so on), so the test imports the router under a meta-path stub finder that auto-mocks those namespaces while keeping `models`, `fastapi`, and `pydantic` real, since it needs the genuine `ImportJobStatus` enum and `ImportJobResponse`. It then patches `import_jobs_db.get_import_job` to return a job with a chosen stored status and calls `get_import_job_status` directly. Cases covered: a bogus out-of-enum status coerces to `failed`, a missing (`None`) status coerces to `failed`, and a valid status (`completed`) is preserved. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) touches `routers/imports.py`, but it only rewires the auth `Depends` and does not touch this handler's body logic, so it does not address this bug. The coercion added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

