### PR TITLE
fix(backend): bounds-check segment_idx in set_assignee_conversation_segment

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -629,6 +629,9 @@ def set_assignee_conversation_segment(
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = deserialize_conversation(conversation)
 
+    if not (0 <= segment_idx < len(conversation.transcript_segments)):
+        raise HTTPException(status_code=404, detail="Segment index out of range")
+
     if value == 'null':
         value = None
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -42,6 +42,7 @@ pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v
 pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_announcement_malformed_type.py -v
+pytest tests/unit/test_conversation_segment_assign_bounds.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/tests/unit/test_conversation_segment_assign_bounds.py
+++ b/backend/tests/unit/test_conversation_segment_assign_bounds.py
@@ -1,0 +1,192 @@
+"""Regression test for PATCH /v1/conversations/{id}/segments/{segment_idx}/assign bounds.
+
+`set_assignee_conversation_segment` subscripts `conversation.transcript_segments[segment_idx]`
+directly. Before the fix an out-of-range segment_idx raised an unhandled IndexError -> HTTP 500
+(and a negative index silently corrupted a different segment). The handler now bounds-checks
+segment_idx and returns HTTP 404 when it is out of range. This test mounts the conversations
+router (heavy deps stubbed, same pattern as the other router unit tests) and exercises the HTTP
+layer for the out-of-range case.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'database._client',
+    'database.conversations',
+    'database.action_items',
+    'database.memories',
+    'database.redis_db',
+    'database.users',
+    'database.vector_db',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.endpoints',
+    'utils.other.storage',
+    'utils.conversations.factory',
+    'utils.conversations.render',
+    'utils.conversations.process_conversation',
+    'utils.executors',
+    'utils.conversations.search',
+    'utils.conversations.calendar_linking',
+    'utils.conversations.calendar_utils',
+    'utils.conversations.location',
+    'utils.llm.conversation_processing',
+    'utils.speaker_identification',
+    'utils.app_integrations',
+    'utils.retrieval.tools.calendar_tools',
+    'utils.retrieval.tools.google_utils',
+]
+
+_MISSING = object()
+_saved_modules = {}
+_saved_parent_attrs = {}
+
+
+def _save_module_for_restore(name):
+    if name not in _saved_modules:
+        _saved_modules[name] = sys.modules.get(name, _MISSING)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        key = (parent_name, attr)
+        if key not in _saved_parent_attrs:
+            previous_attr = parent.__dict__.get(attr, _MISSING) if parent is not None else _MISSING
+            _saved_parent_attrs[key] = (parent, previous_attr)
+
+
+def _register_module(name, module):
+    _save_module_for_restore(name)
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, _AutoMockModule):
+            parent = _AutoMockModule(parent_name)
+            _register_module(parent_name, parent)
+        setattr(parent, attr, module)
+    return module
+
+
+def _remove_module_for_fresh_import(name):
+    _save_module_for_restore(name)
+    sys.modules.pop(name, None)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            parent.__dict__.pop(attr, None)
+
+
+def _restore_stubbed_modules():
+    for name in sorted(_saved_modules, key=lambda item: item.count('.'), reverse=True):
+        previous = _saved_modules[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (_parent_name, attr), (parent, previous_attr) in _saved_parent_attrs.items():
+        if parent is None:
+            continue
+        if previous_attr is _MISSING:
+            parent.__dict__.pop(attr, None)
+        else:
+            setattr(parent, attr, previous_attr)
+    _saved_modules.clear()
+    _saved_parent_attrs.clear()
+
+
+for _mod_name in _stubs:
+    _register_module(_mod_name, _AutoMockModule(_mod_name))
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# utils.other.endpoints exposes the auth dependencies used in route signatures; FastAPI needs
+# real callables to build the dependants, so provide small stand-ins.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_endpoints.get_user = MagicMock()
+_register_module('utils.other.endpoints', _endpoints)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_remove_module_for_fresh_import('routers.conversations')
+_remove_module_for_fresh_import('routers')
+try:
+    from routers import conversations as conv  # noqa: E402
+finally:
+    _restore_stubbed_modules()
+
+
+class _FakeConversation:
+    """Minimal stand-in: only transcript_segments (length 1) is exercised on the bug path."""
+
+    def __init__(self, n_segments):
+        self.transcript_segments = [MagicMock() for _ in range(n_segments)]
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(conv.router)
+    app.dependency_overrides[conv.auth.get_current_user_uid] = lambda: 'test-uid'
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_out_of_range_segment_idx_returns_404_not_500():
+    # transcript_segments has length 1; segment_idx=5 is out of range.
+    with patch.object(conv, '_get_valid_conversation_by_id', return_value={'id': 'c1'}), patch.object(
+        conv, 'deserialize_conversation', return_value=_FakeConversation(1)
+    ):
+        client = _client()
+        resp = client.patch(
+            '/v1/conversations/c1/segments/5/assign',
+            params={'assign_type': 'is_user', 'value': 'true'},
+        )
+        assert resp.status_code == 404
+        assert 'out of range' in resp.json().get('detail', '').lower()
+        # The out-of-range request must never reach the Firestore write.
+        assert not conv.conversations_db.update_conversation_segments.called


### PR DESCRIPTION
## Summary

`PATCH /v1/conversations/{conversation_id}/segments/{segment_idx}/assign` indexes the transcript segment list with `segment_idx` straight from the path with no bounds check. A `segment_idx` past the end of the list raises an unhandled `IndexError` and returns HTTP 500, and a negative `segment_idx` (for example `-1`) silently assigns the wrong segment via Python's negative indexing, then persists that corrupted state to Firestore. This adds a bounds check that returns 404 when `segment_idx` is out of range. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/conversations.py`, `set_assignee_conversation_segment` uses `segment_idx` to subscript the segment list directly, in several places, with nothing validating it first:

```python
if assign_type == 'is_user':
    conversation.transcript_segments[segment_idx].is_user = bool(value) if value is not None else False
    conversation.transcript_segments[segment_idx].person_id = None
elif assign_type == 'person_id':
    conversation.transcript_segments[segment_idx].is_user = False
    conversation.transcript_segments[segment_idx].person_id = value
```

`segment_idx: int` comes from the path, so any integer reaches this code. An index at or past `len(conversation.transcript_segments)` raises `IndexError`, which FastAPI surfaces as a 500. A negative index does not raise; it resolves to a real element from the end of the list, so the handler edits and saves a different segment than the caller asked for.

## Fix

Bounds-check `segment_idx` right after the conversation is loaded and deserialized, before any write:

```python
if not (0 <= segment_idx < len(conversation.transcript_segments)):
    raise HTTPException(status_code=404, detail="Segment index out of range")
```

This rejects both the out-of-range and the negative cases with a clean 404 and stops before the Firestore write. Valid in-range indices behave exactly as before.

## Testing

New `backend/tests/unit/test_conversation_segment_assign_bounds.py` (registered in `test.sh`). The conversations router has a heavy import graph, so the test mounts it under a stub finder that returns `MagicMock` for the heavy deps, then drives the real HTTP layer with FastAPI's `TestClient`. With a conversation whose `transcript_segments` has length 1, a request to `segment_idx=5` returns 404 with an "out of range" detail and never reaches `conversations_db.update_conversation_segments`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) edits this router to rewire the auth `Depends`, but it does not touch this handler's body logic, so it does not address this bug. The bounds check added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

