### PR TITLE
fix(backend): coerce unknown import job status to failed in list endpoint

### DIFF
--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -100,18 +100,24 @@ def get_import_jobs(
     """
     jobs = import_jobs_db.get_import_jobs(uid, limit=limit)
 
-    return [
-        ImportJobResponse(
-            job_id=job['id'],
-            status=ImportJobStatus(job['status']),
-            total_files=job.get('total_files'),
-            processed_files=job.get('processed_files'),
-            conversations_created=job.get('conversations_created'),
-            created_at=job.get('created_at'),
-            error=job.get('error'),
+    responses = []
+    for job in jobs:
+        try:
+            status_val = ImportJobStatus(job.get('status'))
+        except (ValueError, TypeError):
+            status_val = ImportJobStatus.failed
+        responses.append(
+            ImportJobResponse(
+                job_id=job['id'],
+                status=status_val,
+                total_files=job.get('total_files'),
+                processed_files=job.get('processed_files'),
+                conversations_created=job.get('conversations_created'),
+                created_at=job.get('created_at'),
+                error=job.get('error'),
+            )
         )
-        for job in jobs
-    ]
+    return responses
 
 
 @router.get(

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
 pytest tests/unit/test_transcript_segment.py -v
+pytest tests/unit/test_import_jobs_status_enum.py -v
 pytest tests/unit/test_text_similarity.py -v
 pytest tests/unit/test_text_containment.py -v
 pytest tests/unit/test_speaker_sample.py -v

--- a/backend/tests/unit/test_import_jobs_status_enum.py
+++ b/backend/tests/unit/test_import_jobs_status_enum.py
@@ -1,0 +1,137 @@
+"""get_import_jobs must not 500 when a stored job has an out-of-enum status.
+
+routers/imports.py constructs ImportJobStatus(job['status']) for every job in the list. A job whose
+persisted status is not one of {pending, processing, completed, failed} (or is missing) raises
+ValueError and 500s the whole list endpoint. The fix coerces an unknown/missing status to
+ImportJobStatus.failed inline at the call site, so the list still returns.
+
+routers/imports.py pulls in heavy namespaces (database, utils, ...), so we import it under a stub
+finder that auto-mocks those, keeping models/fastapi/pydantic real (we need the real ImportJobStatus
+enum and ImportJobResponse validation), then call get_import_jobs directly with the jobs getter
+patched.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+)
+
+
+def _is_stubbed(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+_remove_multipart = _install_python_multipart_stub()
+sys.meta_path.insert(0, _f)
+try:
+    from routers import imports as imports_mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+    if _remove_multipart:
+        sys.modules.pop('python_multipart', None)
+
+from models.import_job import ImportJobStatus  # noqa: E402
+
+
+def _job(job_id, status):
+    return {
+        'id': job_id,
+        'uid': 'u1',
+        'status': status,
+        'total_files': 1,
+        'processed_files': 1,
+        'conversations_created': 0,
+        'created_at': None,
+        'error': None,
+    }
+
+
+def test_bogus_status_is_coerced_not_500():
+    """A job with an out-of-enum status is returned (coerced to failed), not raised as ValueError."""
+    jobs = [_job('good', 'completed'), _job('bad', 'bogus_status_value')]
+    with patch.object(imports_mod.import_jobs_db, 'get_import_jobs', return_value=jobs):
+        result = imports_mod.get_import_jobs(uid='u1', limit=50)
+
+    assert len(result) == 2
+    by_id = {r.job_id: r for r in result}
+    assert by_id['good'].status == ImportJobStatus.completed
+    assert by_id['bad'].status == ImportJobStatus.failed
+
+
+def test_missing_status_is_coerced_not_500():
+    """A job whose status is missing/None degrades to failed instead of raising."""
+    job = {'id': 'nostat', 'uid': 'u1'}  # no 'status' key at all
+    with patch.object(imports_mod.import_jobs_db, 'get_import_jobs', return_value=[job]):
+        result = imports_mod.get_import_jobs(uid='u1', limit=50)
+
+    assert len(result) == 1
+    assert result[0].status == ImportJobStatus.failed


### PR DESCRIPTION
## Summary

`GET /v1/import/jobs` returns HTTP 500 for the whole list when any one stored job has a status that is not a valid `ImportJobStatus`. The handler builds `ImportJobStatus(job['status'])` per job, so a single record with an out-of-enum or missing status raises and takes down the entire response, hiding every other job the user has. This coerces an unknown or missing status to `ImportJobStatus.failed` at the call site so the list still returns. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/imports.py`, `get_import_jobs` constructs the status enum directly inside a list comprehension over the raw job dicts:

```python
return [
    ImportJobResponse(
        job_id=job['id'],
        status=ImportJobStatus(job['status']),
        total_files=job.get('total_files'),
        processed_files=job.get('processed_files'),
        conversations_created=job.get('conversations_created'),
        created_at=job.get('created_at'),
        error=job.get('error'),
    )
    for job in jobs
]
```

These are raw stored dicts. `ImportJobStatus(value)` only accepts the enum members `pending`, `processing`, `completed`, `failed`. Any other persisted value (a legacy status, a typo, a status from an older or newer writer) raises `ValueError`, and a missing/`None` status raises `TypeError`. Either one is unhandled, so FastAPI surfaces it as a 500 for the full page instead of returning the jobs that are fine.

## Fix

Build the status per job and fall back to `ImportJobStatus.failed` when the value is not in the enum:

```python
responses = []
for job in jobs:
    try:
        status_val = ImportJobStatus(job.get('status'))
    except (ValueError, TypeError):
        status_val = ImportJobStatus.failed
    responses.append(
        ImportJobResponse(
            job_id=job['id'],
            status=status_val,
            total_files=job.get('total_files'),
            processed_files=job.get('processed_files'),
            conversations_created=job.get('conversations_created'),
            created_at=job.get('created_at'),
            error=job.get('error'),
        )
    )
return responses
```

A job with a valid status produces the same response it did before; only previously-fatal values change behavior, and they now degrade to `failed` instead of 500ing the list.

## Testing

New `backend/tests/unit/test_import_jobs_status_enum.py` (registered in `backend/test.sh`). `routers/imports.py` pulls in heavy namespaces (`database`, `utils`, and friends), so the test imports it under a stub finder that auto-mocks those while keeping `models`, `fastapi`, and `pydantic` real, since the test needs the actual `ImportJobStatus` enum and `ImportJobResponse` validation. It then calls `get_import_jobs` directly with `import_jobs_db.get_import_jobs` patched. One case feeds a valid job plus a job with a bogus status and asserts both come back, the bad one coerced to `failed`; the other feeds a job with no `status` key and asserts it degrades to `failed`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. PR #6946 (the unified auth and BYOK middleware refactor) touches `routers/imports.py`, but it only rewires the auth `Depends` and does not touch this handler's body logic, so it does not address this bug. The coercion added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

