### PR TITLE
fix(backend): offload notification memory read to db_executor

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -32,6 +32,7 @@ pytest tests/unit/test_parakeet_endpoints.py -v
 pytest tests/unit/test_audiobuffer_guard.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
+pytest tests/unit/test_notifications_memories_async.py -v
 pytest tests/unit/test_mcp_search_conversations_poison.py -v
 pytest tests/unit/test_mcp_memory_filters.py -v
 pytest tests/unit/test_mcp_client_tool_result.py -v

--- a/backend/tests/unit/test_notifications_memories_async.py
+++ b/backend/tests/unit/test_notifications_memories_async.py
@@ -1,0 +1,101 @@
+"""Tests that get_relevant_memories offloads the blocking Firestore read.
+
+utils/llm/notifications.py runs inside async notification flows. The
+get_memories() Firestore read must be offloaded to db_executor via
+run_blocking instead of being called directly on the event loop.
+Red (pre-fix): get_memories is called directly and run_blocking is never used.
+Green (post-fix): run_blocking(db_executor, get_memories, uid, limit) is used.
+"""
+
+import asyncio
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub the heavy LLM/Firestore siblings of the module under test before
+# importing it. utils.llm is kept a real package (so the real notifications.py
+# submodule resolves) and utils.executors is kept real (pure stdlib); only the
+# heavy leaf modules clients / usage_tracker / database.memories are stubbed.
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _ensure_real_package(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, types.ModuleType) or not hasattr(module, '__path__'):
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    return module
+
+
+_ensure_real_package('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_real_package('utils.llm', os.path.join(_BACKEND_DIR, 'utils', 'llm'))
+
+_clients_mod = types.ModuleType('utils.llm.clients')
+_clients_mod.get_llm = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _clients_mod)
+
+_usage_mod = types.ModuleType('utils.llm.usage_tracker')
+_usage_mod.track_usage = MagicMock()
+_usage_mod.Features = MagicMock()
+sys.modules.setdefault('utils.llm.usage_tracker', _usage_mod)
+
+_memories_db = types.ModuleType('database.memories')
+_memories_db.get_memories = MagicMock(return_value=[])
+sys.modules.setdefault('database.memories', _memories_db)
+
+import utils.llm.notifications as notifications_mod
+
+
+class TestGetRelevantMemoriesAsync:
+    """get_relevant_memories must not call the sync Firestore read on the loop."""
+
+    def test_offloads_get_memories_via_run_blocking(self):
+        sample = [{'content': 'a', 'is_locked': False}, {'content': 'b', 'is_locked': True}]
+
+        async def _fake_run_blocking(executor, fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        mock_run_blocking = MagicMock(side_effect=_fake_run_blocking)
+
+        # create=True so the patch applies whether or not the offload symbols
+        # already exist on the module (pre-fix they are absent), turning a
+        # missing offload into a clean assertion failure rather than a patch error.
+        with patch.object(notifications_mod, 'run_blocking', mock_run_blocking, create=True), patch.object(
+            notifications_mod, 'get_memories', return_value=sample
+        ) as mock_get_memories:
+            result = asyncio.run(notifications_mod.get_relevant_memories('u1'))
+
+        # The blocking read must be offloaded exactly once via run_blocking,
+        # rather than get_memories being awaited/called directly on the loop.
+        # Pre-fix, run_blocking is never called (call_count == 0) -> this fails.
+        assert mock_run_blocking.call_count == 1
+        call_args = mock_run_blocking.call_args
+        # The function handed to run_blocking must be get_memories itself.
+        assert call_args.args[1] is mock_get_memories
+        # db_executor is passed as the pool.
+        assert call_args.args[0] is notifications_mod.db_executor
+        # uid and limit are forwarded positionally.
+        assert call_args.args[2] == 'u1'
+        assert call_args.args[3] == 100
+        # Locked memories are filtered out.
+        assert result == [{'content': 'a', 'is_locked': False}]
+
+    def test_passes_explicit_limit_to_run_blocking(self):
+        async def _fake_run_blocking(executor, fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        mock_run_blocking = MagicMock(side_effect=_fake_run_blocking)
+
+        with patch.object(notifications_mod, 'run_blocking', mock_run_blocking, create=True), patch.object(
+            notifications_mod, 'get_memories', return_value=[]
+        ):
+            asyncio.run(notifications_mod.get_relevant_memories('u1', limit=50))
+
+        assert mock_run_blocking.call_count == 1
+        assert mock_run_blocking.call_args.args[3] == 50

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -3,6 +3,7 @@ from typing import Tuple, List
 from .clients import get_llm
 from .usage_tracker import track_usage, Features
 from database.memories import get_memories
+from utils.executors import db_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def get_relevant_memories(uid: str, limit: int = 100) -> List[dict]:
     """Get recent relevant memories to personalize notifications."""
-    memories = get_memories(uid, limit=limit)
+    memories = await run_blocking(db_executor, get_memories, uid, limit)
     return [m for m in memories if not m.get('is_locked')]
 
 


### PR DESCRIPTION
## Summary

`get_relevant_memories` in `backend/utils/llm/notifications.py` is an `async def` that calls the sync, Firestore-backed `get_memories` directly. Firestore's sync SDK is blocking, so every call stalls the whole event loop while the read runs, which freezes health checks, HPA scaling, and all other in-flight requests on that worker. This wraps the read in `await run_blocking(db_executor, get_memories, uid, limit)` so the blocking call runs on the `db_executor` pool instead of on the loop. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/llm/notifications.py`, `get_relevant_memories` is async but calls the sync read inline:

```python
async def get_relevant_memories(uid: str, limit: int = 100) -> List[dict]:
    """Get recent relevant memories to personalize notifications."""
    memories = get_memories(uid, limit=limit)
    return [m for m in memories if not m.get('is_locked')]
```

`get_memories` comes from `database.memories` and uses the synchronous Firestore client. Calling it directly inside `async def` blocks the event loop for the duration of the Firestore round trip. The repo's async rules require offloading blocking DB calls via `run_blocking` on the right pool (`db_executor` for Firestore/Redis CRUD), and this one was never offloaded. It runs inside the notification flows (`generate_notification_message`, `generate_credit_limit_notification`), so the stall lands in paths that also do LLM work.

## Fix

Offload the read to the `db_executor` pool with `run_blocking`, and import the two helpers from `utils.executors`:

```python
from utils.executors import db_executor, run_blocking
...
async def get_relevant_memories(uid: str, limit: int = 100) -> List[dict]:
    """Get recent relevant memories to personalize notifications."""
    memories = await run_blocking(db_executor, get_memories, uid, limit)
    return [m for m in memories if not m.get('is_locked')]
```

The return value is unchanged, locked memories are still filtered out, and the result is identical for valid input. The read just no longer runs on the event loop.

## Testing

New `backend/tests/unit/test_notifications_memories_async.py` (registered in `test.sh`). The module pulls in heavy LLM and Firestore siblings, so the test keeps `utils.llm` and `utils.executors` as real packages and stubs only the heavy leaf modules (`clients`, `usage_tracker`, `database.memories`), then imports `notifications` and calls `get_relevant_memories` directly. `run_blocking` is patched with `create=True` so the pre-fix absence of the offload surfaces as a clean assertion failure rather than a patch error. The cases check that `run_blocking` is called exactly once, that the function handed to it is `get_memories`, that `db_executor` is passed as the pool, that `uid` and `limit` are forwarded positionally (default 100 and an explicit 50), and that locked memories are filtered from the result. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The offload added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

