### PR TITLE
fix(backend): clamp days in GET /v1/dev/user/goals/{id}/history to a safe range

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1459,6 +1459,8 @@ def get_goal_history(
     - **goal_id**: The ID of the goal
     - **days**: Number of days of history to return (max 365, default 30)
     """
+    # Clamp days to a safe range so a negative value cannot reach the Firestore .limit() call and 500.
+    days = max(1, min(days, 365))
     history = goals_db.get_goal_history(uid, goal_id, days)
 
     for entry in history:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -27,6 +27,7 @@ pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_parakeet_gpu_worker.py -v
 pytest tests/unit/test_parakeet_batch_engine.py -v
 pytest tests/unit/test_parakeet_batch_routing.py -v
+pytest tests/unit/test_developer_goal_history_days_clamp.py -v
 pytest tests/unit/test_parakeet_builtin_embedding.py -v
 pytest tests/unit/test_parakeet_endpoints.py -v
 pytest tests/unit/test_audiobuffer_guard.py -v

--- a/backend/tests/unit/test_developer_goal_history_days_clamp.py
+++ b/backend/tests/unit/test_developer_goal_history_days_clamp.py
@@ -1,0 +1,78 @@
+"""GET /v1/dev/user/goals/{goal_id}/history must clamp days so a negative value cannot reach Firestore.
+
+get_goal_history declared days as Query(default=30, le=365) with no lower bound, then passed it straight
+into goals_db.get_goal_history, which uses it as a Firestore .limit(). A negative days reached .limit(-1)
+and raised, surfacing as a 500. routers/goals.py has a heavy import graph, so we import it under a stub
+finder and call the handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = ('database', 'utils', 'firebase_admin', 'google', 'pinecone', 'opuslib', 'pydub', 'redis', 'langchain')
+
+
+def _is_stubbed(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import developer as dev_mod
+finally:
+    sys.meta_path.remove(_finder)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def test_negative_days_clamped_to_one():
+    db = MagicMock(return_value=[])
+    with patch.object(dev_mod.goals_db, 'get_goal_history', db):
+        dev_mod.get_goal_history(goal_id='g1', days=-5, uid='u1')
+    assert db.call_args.args[2] == 1
+
+
+def test_oversized_days_clamped_to_365():
+    db = MagicMock(return_value=[])
+    with patch.object(dev_mod.goals_db, 'get_goal_history', db):
+        dev_mod.get_goal_history(goal_id='g1', days=100000, uid='u1')
+    assert db.call_args.args[2] == 365


### PR DESCRIPTION
## Summary

The developer API `GET /v1/dev/user/goals/{goal_id}/history` returns HTTP 500 when `days` is negative. The value is used downstream as a Firestore `.limit()`, and a negative limit raises before any history comes back, so the whole request fails. This clamps `days` into the documented 1 to 365 range in the handler before it reaches the query. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/developer.py`, `get_goal_history` declares `days` with an upper bound but no lower bound, then passes it straight through:

```python
@router.get("/v1/dev/user/goals/{goal_id}/history", tags=["developer"])
def get_goal_history(
    goal_id: str,
    days: int = Query(default=30, le=365),
    uid: str = Depends(get_uid_with_goals_read),
) -> List[dict]:
    ...
    history = goals_db.get_goal_history(uid, goal_id, days)
```

`Query(default=30, le=365)` caps the high end but accepts any value at or below 365, including negatives. `goals_db.get_goal_history` feeds `days` into a Firestore `.limit()`, and `.limit()` rejects a negative count with `ValueError`, which FastAPI surfaces as a 500. The docstring already says the valid range is 1 to 365, so the missing lower bound was the gap.

## Fix

Clamp `days` to the documented range at the top of the handler, before the query:

```python
# Clamp days to a safe range so a negative value cannot reach the Firestore .limit() call and 500.
days = max(1, min(days, 365))
history = goals_db.get_goal_history(uid, goal_id, days)
```

Any value already in 1 to 365 is unchanged, so valid requests behave exactly as before.

## Testing

Added `backend/tests/unit/test_developer_goal_history_days_clamp.py` (registered in `backend/test.sh`). `routers/developer.py` has a heavy import graph, so the test imports it under a stub finder and calls `get_goal_history` directly, patching `goals_db.get_goal_history` to capture the args. A negative `days` is clamped to 1 and an oversized `days` is clamped to 365. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 edits `routers/developer.py` for the unified auth and BYOK middleware rewiring, but it only swaps the auth `Depends` and does not touch this handler's body, so it leaves the unclamped `days` in place and does not address this bug. The clamp added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

