### PR TITLE
fix(backend): reject missing webhook_url in create_app with 422

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -500,7 +500,10 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
             raise HTTPException(status_code=422, detail='Triggers on or actions is required')
         # Trigger on
         if external_integration.get('triggers_on'):
-            external_integration['webhook_url'] = external_integration['webhook_url'].strip()
+            webhook_url = external_integration.get('webhook_url')
+            if not webhook_url:
+                raise HTTPException(status_code=422, detail='webhook_url is required when triggers_on is set')
+            external_integration['webhook_url'] = webhook_url.strip()
             if external_integration.get('setup_instructions_file_path'):
                 external_integration['setup_instructions_file_path'] = external_integration[
                     'setup_instructions_file_path'

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -501,7 +501,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
         # Trigger on
         if external_integration.get('triggers_on'):
             webhook_url = external_integration.get('webhook_url')
-            if not webhook_url:
+            if not isinstance(webhook_url, str) or not webhook_url.strip():
                 raise HTTPException(status_code=422, detail='webhook_url is required when triggers_on is set')
             external_integration['webhook_url'] = webhook_url.strip()
             if external_integration.get('setup_instructions_file_path'):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -22,6 +22,7 @@ pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_parakeet_diarization.py -v
 pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
 pytest tests/unit/test_parakeet_prerecorded.py -v
+pytest tests/unit/test_apps_create_app_webhook_url_validation.py -v
 pytest tests/unit/test_parakeet_nim.py -v
 pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_parakeet_gpu_worker.py -v

--- a/backend/tests/unit/test_apps_create_app_webhook_url_validation.py
+++ b/backend/tests/unit/test_apps_create_app_webhook_url_validation.py
@@ -142,3 +142,16 @@ def test_triggers_on_empty_webhook_url_returns_422():
     with pytest.raises(HTTPException) as e:
         _call({'triggers_on': 'memory_creation', 'webhook_url': ''})
     assert e.value.status_code == 422
+
+
+def test_triggers_on_whitespace_webhook_url_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'triggers_on': 'memory_creation', 'webhook_url': '   '})
+    assert e.value.status_code == 422
+
+
+def test_triggers_on_non_string_webhook_url_returns_422():
+    for bad in (123, ['http://x'], {'u': 'http://x'}, True):
+        with pytest.raises(HTTPException) as e:
+            _call({'triggers_on': 'memory_creation', 'webhook_url': bad})
+        assert e.value.status_code == 422

--- a/backend/tests/unit/test_apps_create_app_webhook_url_validation.py
+++ b/backend/tests/unit/test_apps_create_app_webhook_url_validation.py
@@ -1,0 +1,144 @@
+"""create_app must return 422 (not 500) when external_integration sets triggers_on but omits webhook_url.
+
+routers/apps.py has a very heavy import graph (langchain, utils.llm, stripe, ...), so we import it
+under a stub finder that auto-mocks those namespaces (keeping models/fastapi/pydantic real), then
+call create_app directly. The triggers_on branch used to subscript external_integration['webhook_url']
+directly, which raises KeyError -> 500 when the key is missing; it now raises a clean HTTPException 422.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import apps as apps_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def _call(external_integration):
+    """Call create_app with an app payload carrying the given external_integration block."""
+    app_data = json.dumps(
+        {
+            'name': 'Test App',
+            'author': 'someone',
+            'email': 'someone@example.com',
+            'external_integration': external_integration,
+        }
+    )
+    # get_user_from_uid is patched defensively; the triggers_on/webhook_url check runs before
+    # any DB/file work, so a missing webhook_url must raise before we ever reach the lookup/upload.
+    with patch.object(apps_mod, 'get_user_from_uid', return_value={'email': 'someone@example.com'}):
+        return apps_mod.create_app(app_data=app_data, file=MagicMock(), uid='u1')
+
+
+def test_triggers_on_missing_webhook_url_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'triggers_on': 'memory_creation'})
+    assert e.value.status_code == 422
+
+
+def test_triggers_on_empty_webhook_url_returns_422():
+    with pytest.raises(HTTPException) as e:
+        _call({'triggers_on': 'memory_creation', 'webhook_url': ''})
+    assert e.value.status_code == 422


### PR DESCRIPTION
## Summary

`POST /v1/apps` returns HTTP 500 when an app's `external_integration` sets `triggers_on` but leaves out `webhook_url`. The handler reads the webhook URL with a bare subscript, so a missing key crashes the request instead of telling the caller their payload is wrong. This validates the field up front and returns a clean 422, matching how the surrounding code already rejects bad integration input. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/apps.py`, `create_app` handles the trigger branch of `external_integration` like this:

```python
if external_integration.get('triggers_on'):
    external_integration['webhook_url'] = external_integration['webhook_url'].strip()
```

The `triggers_on` check uses `.get()`, but `webhook_url` is then read with a direct `external_integration['webhook_url']`. A payload that sets `triggers_on` without a `webhook_url` raises `KeyError`, which FastAPI surfaces as a 500. The actions branch in the same block already raises 422 for missing or unsupported fields, so the webhook path was the odd one out.

## Fix

Read `webhook_url` with `.get()` and reject a missing or empty value before stripping it:

```python
if external_integration.get('triggers_on'):
    webhook_url = external_integration.get('webhook_url')
    if not webhook_url:
        raise HTTPException(status_code=422, detail='webhook_url is required when triggers_on is set')
    external_integration['webhook_url'] = webhook_url.strip()
```

A valid payload with both `triggers_on` and `webhook_url` behaves exactly as before.

## Testing

New `backend/tests/unit/test_apps_create_app_webhook_url_validation.py` (registered in `backend/test.sh`). `routers/apps.py` has a heavy import graph (langchain, utils.llm, stripe, and more), so the test installs a stub finder that auto-mocks those namespaces, imports the router under it, and calls `create_app` directly with `get_user_from_uid` patched. The triggers_on check runs before any DB or file work, so the missing-webhook case raises before the lookup. A `triggers_on` payload with no `webhook_url` and one with an empty `webhook_url` both return 422. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth Depends on this router but does not touch this handler's body, so it does not address this bug. The validation added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

