### PR TITLE
fix(backend): clamp days in GET /v1/goals/{id}/history to a safe range

### DIFF
--- a/backend/routers/goals.py
+++ b/backend/routers/goals.py
@@ -186,6 +186,8 @@ def get_goal_history(
     goal_id: str, days: int = Query(default=30, le=365), uid: str = Depends(auth.get_current_user_uid)
 ) -> List[dict]:
     """Get progress history for a goal."""
+    # Clamp days to a safe range so a negative value cannot reach the Firestore .limit() call and 500.
+    days = max(1, min(days, 365))
     history = goals_db.get_goal_history(uid, goal_id, days)
 
     # Convert datetime objects

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
 pytest tests/unit/test_transcript_segment.py -v
+pytest tests/unit/test_goals_history_days_clamp.py -v
 pytest tests/unit/test_import_job_status_detail_enum.py -v
 pytest tests/unit/test_text_similarity.py -v
 pytest tests/unit/test_text_containment.py -v

--- a/backend/tests/unit/test_goals_history_days_clamp.py
+++ b/backend/tests/unit/test_goals_history_days_clamp.py
@@ -1,0 +1,78 @@
+"""GET /v1/goals/{goal_id}/history must clamp days so a negative value cannot reach Firestore.
+
+get_goal_history declared days as Query(default=30, le=365) with no lower bound, then passed it straight
+into goals_db.get_goal_history, which uses it as a Firestore .limit(). A negative days reached .limit(-1)
+and raised, surfacing as a 500. routers/goals.py has a heavy import graph, so we import it under a stub
+finder and call the handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = ('database', 'utils', 'firebase_admin', 'google', 'pinecone', 'opuslib', 'pydub', 'redis', 'langchain')
+
+
+def _is_stubbed(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import goals as goals_mod
+finally:
+    sys.meta_path.remove(_finder)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+
+def test_negative_days_clamped_to_one():
+    db = MagicMock(return_value=[])
+    with patch.object(goals_mod.goals_db, 'get_goal_history', db):
+        goals_mod.get_goal_history(goal_id='g1', days=-5, uid='u1')
+    assert db.call_args.args[2] == 1
+
+
+def test_oversized_days_clamped_to_365():
+    db = MagicMock(return_value=[])
+    with patch.object(goals_mod.goals_db, 'get_goal_history', db):
+        goals_mod.get_goal_history(goal_id='g1', days=100000, uid='u1')
+    assert db.call_args.args[2] == 365


### PR DESCRIPTION
## Summary

`GET /v1/goals/{goal_id}/history` declares `days` as `Query(default=30, le=365)` with an upper bound but no lower bound, then passes it straight into the Firestore-backed `goals_db.get_goal_history`, which uses it as a `.limit()`. A request with a negative `days` (for example `?days=-1`) reaches `.limit(-1)`, which Firestore rejects, and the whole endpoint returns HTTP 500. This PR clamps `days` to `[1, 365]` in the handler before the DB call. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/goals.py`, `get_goal_history` takes `days` with only an upper bound and forwards it without a floor:

```python
@router.get('/v1/goals/{goal_id}/history', tags=['goals'])
def get_goal_history(
    goal_id: str, days: int = Query(default=30, le=365), uid: str = Depends(auth.get_current_user_uid)
) -> List[dict]:
    """Get progress history for a goal."""
    history = goals_db.get_goal_history(uid, goal_id, days)
```

`le=365` blocks oversized values but nothing blocks zero or a negative. `goals_db.get_goal_history(uid, goal_id, days)` passes `days` through to a Firestore query `.limit(days)`. Firestore raises `ValueError` on a negative limit, which is unhandled, so FastAPI surfaces it as a 500 instead of a clean rejection.

## Fix

Clamp `days` to the valid range at the top of the handler, before the DB call:

```python
    """Get progress history for a goal."""
    # Clamp days to a safe range so a negative value cannot reach the Firestore .limit() call and 500.
    days = max(1, min(days, 365))
    history = goals_db.get_goal_history(uid, goal_id, days)
```

Any value in `[1, 365]` is unchanged, so valid requests behave exactly as before. Only out-of-range input is pulled back to the nearest bound.

## Testing

New `backend/tests/unit/test_goals_history_days_clamp.py` (registered in `backend/test.sh`). `routers/goals.py` has a heavy import graph, so the test imports it under a stub finder that auto-mocks `database`, `utils`, and the other heavy deps, then calls `get_goal_history` directly. With `goals_db.get_goal_history` patched, `days=-5` reaches the DB call as `1` and `days=100000` reaches it as `365`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug.

No open PR changes the logic this PR fixes. The clamp added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

