### PR TITLE
fix(backend): tolerate malformed ChatTool parameters JSON

### DIFF
--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from datetime import datetime
 from enum import Enum
 from typing import List, Literal, Optional, Set
 
 from pydantic import BaseModel, field_validator
+
+logger = logging.getLogger(__name__)
 
 # Fields to exclude when reducing App data for list views and cache
 APP_REDUCE_EXCLUDE_FIELDS = {
@@ -106,7 +109,11 @@ class ChatTool(BaseModel):
     def deserialize_parameters(cls, v):
         """Deserialize parameters from JSON string (stored that way in Firestore to avoid nesting limits)."""
         if isinstance(v, str):
-            return json.loads(v)
+            try:
+                return json.loads(v)
+            except (json.JSONDecodeError, ValueError):
+                logger.warning('ChatTool.parameters is not valid JSON; dropping malformed parameters')
+                return None
         return v
 
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -49,6 +49,7 @@ pytest tests/unit/test_app_uid_keyerror.py -v
 pytest tests/unit/test_daily_summary_race_condition.py -v
 pytest tests/unit/test_daily_summary_regenerate.py -v
 pytest tests/unit/test_chat_tools_messages.py -v
+pytest tests/unit/test_chat_tool_parameters_json.py -v
 pytest tests/unit/test_prompt_caching.py -v
 pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v

--- a/backend/tests/unit/test_chat_tool_parameters_json.py
+++ b/backend/tests/unit/test_chat_tool_parameters_json.py
@@ -1,0 +1,59 @@
+"""
+Tests for ChatTool.deserialize_parameters tolerance of malformed stored JSON.
+
+A ChatTool's `parameters` is stored as a JSON string in Firestore (to avoid
+Firestore nesting limits) and parsed by a pre-validator. A single malformed
+stored string must not 500 an app read/list: the validator should drop the
+malformed value (parameters -> None) instead of raising JSONDecodeError.
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+from models.app import App, ChatTool
+
+
+def test_malformed_parameters_json_does_not_raise():
+    """A non-JSON parameters string is tolerated and yields parameters=None."""
+    tool = ChatTool(name='t', description='d', endpoint='e', parameters='{not json')
+    assert tool.parameters is None
+
+
+def test_valid_parameters_json_still_parsed():
+    """A valid JSON parameters string is still deserialized to a dict."""
+    tool = ChatTool(
+        name='t',
+        description='d',
+        endpoint='e',
+        parameters='{"type": "object", "properties": {}}',
+    )
+    assert tool.parameters == {"type": "object", "properties": {}}
+
+
+def test_app_with_malformed_chat_tool_parameters_succeeds():
+    """Building an App whose chat_tool has malformed parameters does not 500."""
+    app_dict = {
+        'id': 'app-1',
+        'name': 'My App',
+        'category': 'productivity',
+        'author': 'tester',
+        'description': 'an app',
+        'image': '/image.png',
+        'capabilities': ['chat'],
+        'chat_tools': [
+            {
+                'name': 't',
+                'description': 'd',
+                'endpoint': 'e',
+                'parameters': '{not json',
+            }
+        ],
+    }
+    app = App(**app_dict)
+    assert app.chat_tools[0].parameters is None


### PR DESCRIPTION
## Summary

`ChatTool` stores its `parameters` as a JSON string in Firestore (to dodge Firestore nesting limits) and parses it back with a pre-validator. The validator calls `json.loads` with no guard, so a single app whose stored parameters string is not valid JSON raises `JSONDecodeError` while the `ChatTool` is being built. That turns into an HTTP 500 on the app read, and since the parse happens during model construction it takes down the whole read for that app, not just the one tool. This PR catches the parse error and drops the malformed value to `None`, matching the field's `Optional` default. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/models/app.py`, the `parameters` pre-validator `ChatTool.deserialize_parameters` does the conversion with no error handling:

```python
@field_validator('parameters', mode='before')
@classmethod
def deserialize_parameters(cls, v):
    """Deserialize parameters from JSON string (stored that way in Firestore to avoid nesting limits)."""
    if isinstance(v, str):
        return json.loads(v)
    return v
```

The value comes straight from Firestore, so if a stored record holds a parameters string that is not valid JSON (a truncated or partial write, a legacy value), `json.loads` raises `json.JSONDecodeError`. That propagates out of validation as a 500 when the app is loaded, and because it fires during `ChatTool` construction the entire app read fails, not just the affected tool.

## Fix

Wrap the parse in a try/except that catches the decode error, logs a warning, and returns `None`:

```python
if isinstance(v, str):
    try:
        return json.loads(v)
    except (json.JSONDecodeError, ValueError):
        logger.warning('ChatTool.parameters is not valid JSON; dropping malformed parameters')
        return None
return v
```

`None` is the declared default for `parameters`, so the bad tool loads with no parameters instead of crashing the read. Valid JSON strings parse exactly as before.

## Testing

Added `backend/tests/unit/test_chat_tool_parameters_json.py` (registered in `backend/test.sh`). `models.app` is a light import, so the test sets `ENCRYPTION_SECRET` and imports `App` and `ChatTool` from source directly, then calls the validator through normal model construction. Cases covered: a non-JSON parameters string yields `parameters=None`, a valid JSON string still deserializes to the expected dict, and building a full `App` whose `chat_tools` entry has malformed parameters succeeds with that tool's parameters set to `None`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes the logic this PR fixes. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

