### PR TITLE
fix(mind-map) clear stale error state on successful background reload

### DIFF
--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -327,6 +327,12 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
       final newNodes = data['nodes'] as List<dynamic>? ?? [];
       final newEdges = data['edges'] as List<dynamic>? ?? [];
 
+      if (_error != null && mounted) {
+        setState(() {
+          _error = null;
+        });
+      }
+
       if (_isSameGraph(newNodes, newEdges)) {
         if (!silent) {
           setState(() {
@@ -338,11 +344,6 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
 
       _populateGraph(data);
       _runLayoutSync();
-      if (_error != null && mounted) {
-        setState(() {
-          _error = null;
-        });
-      }
     } catch (e) {
       if (!mounted) return;
       if (!silent) {

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -265,7 +265,7 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
   final _repaintNotifier = ValueNotifier<int>(0);
 
   String? _selectedNodeId;
-  Set<String> _highlightedNodeIds = {};
+  final Set<String> _highlightedNodeIds = {};
   int _autoRebuildAttempts = 0;
 
   @override

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -547,16 +547,16 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
       canvas.drawImage(image, Offset.zero, paint);
 
       // Draw minimal branding "omi.me" at top center
-      final textSpan = TextSpan(
+      const textSpan = TextSpan(
         text: 'omi.me',
-        style: const TextStyle(color: Colors.white, fontSize: 72, fontWeight: FontWeight.bold, letterSpacing: -1.0),
+        style: TextStyle(color: Colors.white, fontSize: 72, fontWeight: FontWeight.bold, letterSpacing: -1.0),
       );
       final textPainter = TextPainter(text: textSpan, textDirection: TextDirection.ltr);
       textPainter.layout();
 
       // Center horizontally, near top
       final xPos = (image.width - textPainter.width) / 2;
-      final yPos = 140.0; // Margin from top (increased to avoid notch/edge feeling)
+      const yPos = 140.0; // Margin from top (increased to avoid notch/edge feeling)
 
       textPainter.paint(canvas, Offset(xPos, yPos));
 

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -822,7 +822,7 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
       _highlightedNodeIds.clear();
 
       if (hitNodeId != null) {
-        _highlightedNodeIds.add(hitNodeId!);
+        _highlightedNodeIds.add(hitNodeId);
 
         final node = simulation.nodeMap[hitNodeId];
         if (node != null) {

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -338,6 +338,11 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
 
       _populateGraph(data);
       _runLayoutSync();
+      if (_error != null && mounted) {
+        setState(() {
+          _error = null;
+        });
+      }
     } catch (e) {
       if (!mounted) return;
       if (!silent) {


### PR DESCRIPTION
## Summary

- **Bug fix**: When the Mind Map failed to load on initial open (e.g. momentary network issue), the error state persisted permanently — even after the app resumed and a background reload succeeded. Root cause: the `silent: true` reload path never called `setState`, so `_error` was never cleared after a successful load.
- **Lint cleanups**: Three follow-up refactors in the same file — remove unnecessary `!` null assertion, add `final` to a never-reassigned field, and use `const` for compile-time constants in the share-graph path.

## Commits

1. `fix(mind-map)`: clear `_error` when silent reload succeeds
2. `refactor(mind-map)`: remove unnecessary `!` on `hitNodeId`
3. `refactor(mind-map)`: make `_highlightedNodeIds` final
4. `refactor(mind-map)`: prefer `const` for `textSpan` and `yPos`

## Test plan

- Open the app with no network → Mind Map shows error
- Restore network, background + foreground the app → Mind Map should now show the graph (no more stuck error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

