### PR TITLE
Speed up desktop navigation and harness timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ The desktop app is a **Swift Package Manager** project (no Xcode project, no `.x
 - `cd desktop/macos && ./run.sh --yolo` — quick start against the prod backend, no local services.
 - `OMI_SKIP_BACKEND=1` — app only, use remote backend via `OMI_DESKTOP_API_URL`. `OMI_SKIP_TUNNEL=1` — no Cloudflare tunnel.
 - **Parallel worktrees auto-isolate.** `scripts/dev-instance.sh` derives a unique instance from each linked git worktree, so `run.sh` (and `backend/scripts/dev-serve.sh`) pick per-worktree ports (Rust 10201+, Python 8080+, automation 47777+) and bundle name (`omi-<worktree>`). Kills are pidfile-scoped (never the global `omi-desktop-backend` name), and a taken port fails loud instead of clobbering. The primary checkout is unchanged (`Omi Dev`, 10201/8080/47777). Override any of `OMI_INSTANCE` / `PORT` / `PYTHON_PORT` / `OMI_AUTOMATION_PORT` / `OMI_APP_NAME` to opt out.
+- `Omi Dev` is the canonical shared development profile: `/Applications/Omi Dev.app`, bundle id `com.omi.desktop-dev`, reusable permissions, and auth seed source. Do not pass `OMI_APP_NAME="Omi Dev"` from a linked worktree; that creates a named bundle displayed as Omi Dev with a different bundle id and breaks permission reuse.
 - Local Python backend (per-worktree port): `cd backend && ./scripts/dev-serve.sh`.
 - Compile-only check: `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` (the `xcrun` prefix is required to match the SDK).
 - **DO NOT** use bare `swift build`, `xcodebuild`, or launch from `build/` directly. Always launch via `cd desktop/macos && ./run.sh` (installs to `/Applications/` and registers with LaunchServices, required for permission "Quit & Reopen").
@@ -143,6 +144,7 @@ This installs `/Applications/omi-fix-rewind.app` with bundle id `com.omi.omi-fix
 
 Rules:
 - **ALWAYS prefix the name with `omi-`** (e.g. `omi-fix-rewind`, `omi-vision-test`) so bundles group together in `/Applications/`.
+- NEVER use `Omi Dev` as a named bundle. If you need the shared permission/profile grant, launch from the primary checkout with no `OMI_APP_NAME`; otherwise use an `omi-*` named bundle and expect separate macOS permissions.
 - NEVER use bare `./run.sh` when testing a specific change — it overwrites "Omi Dev".
 - NEVER kill or interfere with "Omi", "Omi Beta" — those are production installs.
 - Keep app name and bundle suffix identical (e.g. `omi-search.app` → `com.omi.omi-search`).

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -89,12 +89,14 @@ struct DesktopAutomationNavigationRequest: Codable {
   let settingsSection: String?
   let highlightedSettingId: String?
   let activateApp: Bool?
+  let settleMs: Int?
 }
 
 struct DesktopAutomationOpenConversationRequest: Codable {
   let conversationId: String
   let showTranscript: Bool?
   let activateApp: Bool?
+  let settleMs: Int?
 }
 
 struct DesktopAutomationVisualExportRequest: Codable {
@@ -164,8 +166,9 @@ private struct DesktopAutomationResponse<T: Codable>: Codable {
   let error: String?
 }
 
-actor DesktopAutomationStateStore {
+final class DesktopAutomationStateStore {
   static let shared = DesktopAutomationStateStore()
+  private let lock = NSLock()
 
   private var snapshot = DesktopAutomationSnapshot(
     bridgeEnabled: DesktopAutomationLaunchOptions.isEnabled,
@@ -192,16 +195,20 @@ actor DesktopAutomationStateStore {
   )
 
   func update(_ snapshot: DesktopAutomationSnapshot) {
+    lock.lock()
+    defer { lock.unlock() }
     self.snapshot = snapshot
   }
 
   func current() -> DesktopAutomationSnapshot {
-    snapshot
+    lock.lock()
+    defer { lock.unlock() }
+    return snapshot
   }
 }
 
 private func liveAutomationSnapshot() async -> DesktopAutomationSnapshot {
-  var snapshot = await DesktopAutomationStateStore.shared.current()
+  var snapshot = DesktopAutomationStateStore.shared.current()
   let floating = await MainActor.run {
     let floating = FloatingControlBarManager.shared.automationState
     return (
@@ -217,6 +224,13 @@ private func liveAutomationSnapshot() async -> DesktopAutomationSnapshot {
   snapshot.askOmiFocused = floating.isAskOmiFocused
   snapshot.floatingBarFrame = floating.frame
   snapshot.isAppActive = floating.isAppActive
+  snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
+  DesktopAutomationStateStore.shared.update(snapshot)
+  return snapshot
+}
+
+private func cachedAutomationSnapshot() async -> DesktopAutomationSnapshot {
+  var snapshot = DesktopAutomationStateStore.shared.current()
   snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
   return snapshot
 }
@@ -244,6 +258,10 @@ actor DesktopAutomationTraceStore {
 
   func recent(limit: Int = 50) -> [DesktopAutomationRouteTrace] {
     Array(traces.suffix(max(1, min(limit, 200))))
+  }
+
+  func clear() {
+    traces.removeAll(keepingCapacity: true)
   }
 }
 
@@ -391,6 +409,13 @@ private func boolParam(_ raw: String?, default fallback: Bool) -> Bool {
     return fallback
   }
   return ["1", "true", "yes", "on"].contains(raw)
+}
+
+private func intParam(_ raw: String?, default fallback: Int) -> Int {
+  guard let raw = raw?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else {
+    return fallback
+  }
+  return Int(raw) ?? fallback
 }
 
 final class DesktopAutomationBridge {
@@ -556,21 +581,24 @@ final class DesktopAutomationBridge {
   private func routeUntimed(request: HTTPRequest) async -> HTTPResponse {
     switch (request.method, request.path) {
     case ("GET", "/health"):
-      let snapshot = await liveAutomationSnapshot()
+      let snapshot = await cachedAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/state"):
-      let snapshot = await liveAutomationSnapshot()
+      let snapshot = await cachedAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/traces/recent"):
       let traces = await DesktopAutomationTraceStore.shared.recent()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: traces, error: nil))
+    case ("POST", "/traces/clear"):
+      await DesktopAutomationTraceStore.shared.clear()
+      return jsonResponse(DesktopAutomationResponse(ok: true, result: "cleared", error: nil))
     case ("POST", "/navigate"):
       do {
         let payload = try JSONDecoder().decode(
           DesktopAutomationNavigationRequest.self, from: request.body)
         try await dispatchNavigation(payload)
-        try await Task.sleep(for: .milliseconds(150))
-        let snapshot = await liveAutomationSnapshot()
+        try await sleepForAutomationSettle(payload.settleMs)
+        let snapshot = await cachedAutomationSnapshot()
         return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
       } catch {
         return jsonResponse(
@@ -587,8 +615,8 @@ final class DesktopAutomationBridge {
         let payload = try JSONDecoder().decode(
           DesktopAutomationOpenConversationRequest.self, from: request.body)
         try await dispatchOpenConversation(payload)
-        try await Task.sleep(for: .milliseconds(350))
-        let snapshot = await liveAutomationSnapshot()
+        try await sleepForAutomationSettle(payload.settleMs)
+        let snapshot = await cachedAutomationSnapshot()
         return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
       } catch {
         return jsonResponse(
@@ -634,6 +662,7 @@ final class DesktopAutomationBridge {
           "GET /capabilities",
           "GET /actions",
           "GET /traces/recent",
+          "POST /traces/clear",
           "POST /navigate",
           "POST /conversation/open",
           "POST /action",
@@ -657,9 +686,7 @@ final class DesktopAutomationBridge {
       do {
         let detail = try await DesktopAutomationActionRegistry.shared.perform(
           parsed.name, params: parsed.params)
-        if boolParam(parsed.params["wait"], default: true) {
-          try await Task.sleep(for: .milliseconds(150))
-        }
+        try await sleepForAutomationSettle(intParam(parsed.params["settleMs"], default: 0))
         let snapshot = await liveAutomationSnapshot()
         let result = DesktopAutomationActionResult(
           action: parsed.name, detail: detail, state: snapshot)
@@ -800,6 +827,12 @@ final class DesktopAutomationBridge {
         window.makeKeyAndOrderFront(nil)
       }
     }
+  }
+
+  private func sleepForAutomationSettle(_ milliseconds: Int?) async throws {
+    let clamped = max(0, min(milliseconds ?? 0, 5_000))
+    guard clamped > 0 else { return }
+    try await Task.sleep(for: .milliseconds(clamped))
   }
 
   private func exportWindow(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -200,6 +200,13 @@ final class DesktopAutomationStateStore {
     self.snapshot = snapshot
   }
 
+  func updateLiveFields(_ update: (inout DesktopAutomationSnapshot) -> Void) -> DesktopAutomationSnapshot {
+    lock.lock()
+    defer { lock.unlock() }
+    update(&snapshot)
+    return snapshot
+  }
+
   func current() -> DesktopAutomationSnapshot {
     lock.lock()
     defer { lock.unlock() }
@@ -208,7 +215,6 @@ final class DesktopAutomationStateStore {
 }
 
 private func liveAutomationSnapshot() async -> DesktopAutomationSnapshot {
-  var snapshot = DesktopAutomationStateStore.shared.current()
   let floating = await MainActor.run {
     let floating = FloatingControlBarManager.shared.automationState
     return (
@@ -219,14 +225,14 @@ private func liveAutomationSnapshot() async -> DesktopAutomationSnapshot {
       isAppActive: NSApp.isActive
     )
   }
-  snapshot.floatingBarVisible = floating.isVisible
-  snapshot.askOmiOpen = floating.isAskOmiOpen
-  snapshot.askOmiFocused = floating.isAskOmiFocused
-  snapshot.floatingBarFrame = floating.frame
-  snapshot.isAppActive = floating.isAppActive
-  snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
-  DesktopAutomationStateStore.shared.update(snapshot)
-  return snapshot
+  return DesktopAutomationStateStore.shared.updateLiveFields { snapshot in
+    snapshot.floatingBarVisible = floating.isVisible
+    snapshot.askOmiOpen = floating.isAskOmiOpen
+    snapshot.askOmiFocused = floating.isAskOmiFocused
+    snapshot.floatingBarFrame = floating.frame
+    snapshot.isAppActive = floating.isAppActive
+    snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
+  }
 }
 
 private func cachedAutomationSnapshot() async -> DesktopAutomationSnapshot {
@@ -584,7 +590,7 @@ final class DesktopAutomationBridge {
       let snapshot = await cachedAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/state"):
-      let snapshot = await cachedAutomationSnapshot()
+      let snapshot = await liveAutomationSnapshot()
       return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
     case ("GET", "/traces/recent"):
       let traces = await DesktopAutomationTraceStore.shared.recent()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -43,6 +43,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
   // Carries each chunk's source text alongside its synthesized audio so playback can fall
   // back to the system voice (speaking the text) if AVAudioPlayer can't play the audio.
   private var audioQueue: [(audio: Data, text: String)] = []
+  private var isFillerSynthesizing = false
   private var isSynthesizing = false
   private var hasStartedRealPlayback = false
   private var hasEmittedFirstChunk = false
@@ -61,7 +62,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
   var isSpeaking: Bool {
     if audioPlayer?.isPlaying == true { return true }
     if speechSynthesizer.isSpeaking { return true }
-    if fillerTask != nil || playbackTask != nil { return true }
+    if isFillerSynthesizing { return true }
     if isSynthesizing { return true }
     return !audioQueue.isEmpty || !synthesisQueue.isEmpty
   }
@@ -81,16 +82,31 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     case .systemVoice:
       enqueueSystemSpeech(phrase)
     case .openAI(let voiceID, let instructions):
+      isFillerSynthesizing = true
       fillerTask = Task { [weak self] in
         do {
           let audioData = try await Self.synthesizeOpenAISpeech(
             text: phrase, voiceID: voiceID, instructions: instructions)
           try Task.checkCancellation()
           await MainActor.run {
-            guard let self, !self.hasStartedRealPlayback else { return }
+            guard let self else { return }
+            self.isFillerSynthesizing = false
+            self.fillerTask = nil
+            guard !self.hasStartedRealPlayback else {
+              self.clearFloatingPillResponseGlowIfIdle()
+              return
+            }
             self.startPlayback(audioData)
+            self.clearFloatingPillResponseGlowIfIdle()
           }
-        } catch {}
+        } catch {
+          await MainActor.run {
+            guard let self else { return }
+            self.isFillerSynthesizing = false
+            self.fillerTask = nil
+            self.clearFloatingPillResponseGlowIfIdle()
+          }
+        }
       }
     }
   }
@@ -113,13 +129,14 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
 
     let text = Self.cleanedPlaybackText(from: message)
     guard !text.isEmpty, Self.shouldSpeak(text) else { return }
-    setFloatingPillResponseGlow(true)
 
     if interruptedResponseID == message.id {
       streamedText = text
       bufferedText = ""
+      clearFloatingPillResponseGlowIfIdle()
       return
     }
+    setFloatingPillResponseGlow(true)
 
     if currentMode == nil {
       currentMode = resolvePlaybackMode()
@@ -215,22 +232,28 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
+          self.playbackTask = nil
           self.audioQueue.append((audio: audioData, text: text))
           self.startPlaybackIfNeeded()
           self.startSynthesisIfNeeded(mode: mode)
+          self.clearFloatingPillResponseGlowIfIdle()
         }
       } catch is CancellationError {
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
+          self.playbackTask = nil
           self.startSynthesisIfNeeded(mode: mode)
+          self.clearFloatingPillResponseGlowIfIdle()
         }
       } catch {
         if Self.isCancellation(error) {
           await MainActor.run {
             guard let self else { return }
             self.isSynthesizing = false
+            self.playbackTask = nil
             self.startSynthesisIfNeeded(mode: mode)
+            self.clearFloatingPillResponseGlowIfIdle()
           }
           return
         }
@@ -238,11 +261,13 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
-        log(
-          "FloatingBarVoicePlaybackService: cloud TTS chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
-        )
+          self.playbackTask = nil
+          log(
+            "FloatingBarVoicePlaybackService: cloud TTS chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
+          )
           self.enqueueSystemSpeech(text)
           self.startSynthesisIfNeeded(mode: mode)
+          self.clearFloatingPillResponseGlowIfIdle()
         }
       }
     }
@@ -393,6 +418,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     playbackTask = nil
     fillerTask?.cancel()
     fillerTask = nil
+    isFillerSynthesizing = false
     if clearMode {
       currentMode = nil
       // Drop the tracer only on full teardown. interruptCurrentResponse uses

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import Foundation
 
 @MainActor
-final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
+final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AVSpeechSynthesizerDelegate {
   static let shared = FloatingBarVoicePlaybackService()
 
   // First chunk stays small so playback starts fast.
@@ -53,7 +53,10 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   var tracer: QueryTracer?
   private let speechSynthesizer = AVSpeechSynthesizer()
 
-  private override init() {}
+  private override init() {
+    super.init()
+    speechSynthesizer.delegate = self
+  }
 
   var isSpeaking: Bool {
     if audioPlayer?.isPlaying == true { return true }
@@ -65,6 +68,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   func playFillerIfEnabled() {
     guard ShortcutSettings.shared.hasAnyFloatingBarVoiceAnswersEnabled else { return }
+    setFloatingPillResponseGlow(true)
 
     if currentMode == nil {
       currentMode = resolvePlaybackMode()
@@ -109,6 +113,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
     let text = Self.cleanedPlaybackText(from: message)
     guard !text.isEmpty, Self.shouldSpeak(text) else { return }
+    setFloatingPillResponseGlow(true)
 
     if interruptedResponseID == message.id {
       streamedText = text
@@ -326,6 +331,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       shouldInterruptNextResponse = true
     }
     resetPlaybackPipeline(clearMode: false)
+    clearFloatingPillResponseGlowIfIdle()
   }
 
   private func startPlaybackIfNeeded() {
@@ -372,6 +378,13 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       guard let self else { return }
       self.audioPlayer = nil
       self.startPlaybackIfNeeded()
+      self.clearFloatingPillResponseGlowIfIdle()
+    }
+  }
+
+  nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+    Task { @MainActor [weak self] in
+      self?.clearFloatingPillResponseGlowIfIdle()
     }
   }
 
@@ -397,6 +410,17 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     audioPlayer?.stop()
     audioPlayer = nil
     speechSynthesizer.stopSpeaking(at: .immediate)
+    setFloatingPillResponseGlow(false)
+  }
+
+  private func setFloatingPillResponseGlow(_ active: Bool) {
+    FloatingControlBarManager.shared.barState?.isVoiceResponseActive = active
+  }
+
+  private func clearFloatingPillResponseGlowIfIdle() {
+    if !isSpeaking {
+      setFloatingPillResponseGlow(false)
+    }
   }
 
   private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -93,6 +93,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var isVoiceListening: Bool = false
     @Published var isVoiceLocked: Bool = false
     @Published var voiceTranscript: String = ""
+    @Published var isVoiceResponseActive: Bool = false
 
     // Voice follow-up state (PTT while AI conversation is active)
     @Published var isVoiceFollowUp: Bool = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -278,14 +278,15 @@ struct FloatingControlBarView: View {
     }
 
     private var controlBarView: some View {
-        Group {
+        let allowsHoverExpansion = isHovering && !state.isVoiceResponseActive
+        return Group {
             if state.isVoiceListening && !state.isVoiceFollowUp {
                 voiceListeningView
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
                     .frame(height: 42)
                     .transition(.opacity)
-            } else if isHovering || state.showingAIConversation {
+            } else if allowsHoverExpansion || state.showingAIConversation {
                 VStack(spacing: 1) {
                     compactButton(title: "Ask omi / Collapse", keys: shortcutSettings.askOmiShortcut.displayTokens) {
                         onAskAI()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -397,33 +397,13 @@ struct FloatingControlBarView: View {
                 .foregroundColor(.white)
 
             if state.isVoiceLocked {
-                Text("LOCKED")
+                Image(systemName: "lock.fill")
                     .scaledFont(size: 10, weight: .bold)
                     .foregroundColor(.orange)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .frame(width: 18, height: 18)
                     .background(Color.orange.opacity(0.2))
                     .cornerRadius(4)
             }
-
-            Text(voiceStatusText)
-                .scaledFont(size: 12, weight: .medium)
-                .foregroundColor(.white.opacity(0.78))
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    private var voiceStatusText: String {
-        if !state.voiceTranscript.isEmpty {
-            return state.voiceTranscript
-        }
-
-        if state.isVoiceLocked {
-            return "Tap \(shortcutSettings.pttShortcut.displayLabel) to send"
-        } else {
-            return "Release \(shortcutSettings.pttShortcut.displayLabel) to send"
         }
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -281,9 +281,9 @@ struct FloatingControlBarView: View {
         Group {
             if state.isVoiceListening && !state.isVoiceFollowUp {
                 voiceListeningView
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .frame(height: 50)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .frame(height: 42)
                     .transition(.opacity)
             } else if isHovering || state.showingAIConversation {
                 VStack(spacing: 1) {
@@ -309,8 +309,37 @@ struct FloatingControlBarView: View {
     /// Minimal thin bar shown when not hovering
     private var compactCircleView: some View {
         RoundedRectangle(cornerRadius: 3)
-            .fill(Color.white.opacity(0.5))
+            .fill(compactPillFill)
             .frame(width: 28, height: 6)
+            .shadow(
+                color: state.isVoiceResponseActive ? OmiColors.purpleAccent.opacity(0.75) : .clear,
+                radius: state.isVoiceResponseActive ? 10 : 0,
+                x: 0,
+                y: 0
+            )
+            .overlay {
+                if state.isVoiceResponseActive {
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(OmiColors.purplePrimary.opacity(0.65), lineWidth: 0.8)
+                        .blur(radius: 0.2)
+                }
+            }
+            .animation(.easeInOut(duration: 0.18), value: state.isVoiceResponseActive)
+    }
+
+    private var compactPillFill: LinearGradient {
+        if state.isVoiceResponseActive {
+            return LinearGradient(
+                colors: [OmiColors.purpleAccent, OmiColors.purplePrimary],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        }
+        return LinearGradient(
+            colors: [Color.white.opacity(0.5), Color.white.opacity(0.5)],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
     }
 
     private func compactToggle(_ title: String, isOn: Binding<Bool>) -> some View {
@@ -359,12 +388,12 @@ struct FloatingControlBarView: View {
     }
 
     private var voiceListeningView: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 7) {
             // Playful realtime mic waveform (replaces the old pulsing red dot)
             VoiceWaveformBars(isActive: state.isVoiceListening)
 
             Image(systemName: "mic.fill")
-                .scaledFont(size: 14, weight: .semibold)
+                .scaledFont(size: 12, weight: .semibold)
                 .foregroundColor(.white)
 
             if state.isVoiceLocked {
@@ -377,21 +406,24 @@ struct FloatingControlBarView: View {
                     .cornerRadius(4)
             }
 
-            if !state.voiceTranscript.isEmpty {
-                Text(state.voiceTranscript)
-                    .scaledFont(size: 13)
-                    .foregroundColor(.white.opacity(0.8))
-                    .lineLimit(1)
-                    .truncationMode(.head)
-            } else {
-                Text(
-                    state.isVoiceLocked
-                        ? "Tap \(shortcutSettings.pttShortcut.displayLabel) to send"
-                        : "Release \(shortcutSettings.pttShortcut.displayLabel) to send"
-                )
-                    .scaledFont(size: 13)
-                    .foregroundColor(.white.opacity(0.5))
-            }
+            Text(voiceStatusText)
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(.white.opacity(0.78))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var voiceStatusText: String {
+        if !state.voiceTranscript.isEmpty {
+            return state.voiceTranscript
+        }
+
+        if state.isVoiceLocked {
+            return "Tap \(shortcutSettings.pttShortcut.displayLabel) to send"
+        } else {
+            return "Release \(shortcutSettings.pttShortcut.displayLabel) to send"
         }
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -220,7 +220,7 @@ struct FloatingControlBarView: View {
                 if notification.assistantId == "task" {
                     Button {
                         let model = ShortcutSettings.shared.selectedModel.isEmpty
-                            ? "claude-sonnet-4-6"
+                            ? ModelQoS.Claude.defaultSelection
                             : ShortcutSettings.shared.selectedModel
                         let query = ProactiveTaskExecute.buildQuery(
                             title: notification.title,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -733,6 +733,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeAnchored(to: Self.minBarSize, makeResizable: false, animated: false, anchorTop: true)
     }
 
+    var hasSettledClosedForAutomation: Bool {
+        !state.showingAIConversation
+            && !suppressHoverResize
+            && pendingRestoreOrigin == nil
+            && NSEqualSizes(frame.size, Self.minBarSize)
+    }
+
     private func resizeToResponseHeight(animated: Bool = false) {
         // Determine the 2× cap from the user's saved (or default) preferred height.
         let savedSize = UserDefaults.standard.string(forKey: FloatingControlBarWindow.sizeKey)
@@ -1271,7 +1278,7 @@ class FloatingControlBarManager {
 
     private func waitForAskOmiClosed(in window: FloatingControlBarWindow) async -> String? {
         await waitForAutomationCondition {
-            !window.state.showingAIConversation
+            window.hasSettledClosedForAutomation
         }
     }
 
@@ -2171,6 +2178,8 @@ class FloatingControlBarManager {
         if provider.isUsingOmiAccountProvider {
             if limiter.isLimitReached {
                 currentTracer?.end("pre_llm", metadata: ["error": "usage_limit"])
+                barWindow.state.currentQueryFromVoice = false
+                barWindow.state.isVoiceResponseActive = false
                 FloatingBarVoicePlaybackService.shared.speakOneShot(
                     "You've reached \(limiter.limitDescription). Upgrade to keep chatting without restrictions."
                 )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -35,6 +35,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private static let notificationSpacing: CGFloat = 8
     private static let askOmiAnimationDuration: TimeInterval = 0.08
     private static let askOmiSettleDelay: TimeInterval = 0.10
+    private static let topInset: CGFloat = 40
     /// Minimum window height when AI response first appears.
     private static let minResponseHeight: CGFloat = 250
     /// Base height used as the reference for 2× cap (same as current default response height).
@@ -776,12 +777,15 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// Compute the default origin for the collapsed pill (top-center of the key screen).
     /// Used by closeAIConversation in non-draggable mode and centerOnMainScreen.
     private func defaultPillOrigin() -> NSPoint {
-        let size = FloatingControlBarWindow.minBarSize
+        defaultTopCenteredOrigin(for: FloatingControlBarWindow.minBarSize)
+    }
+
+    private func defaultTopCenteredOrigin(for size: NSSize) -> NSPoint {
         let targetScreen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
         guard let screen = targetScreen else { return .zero }
         let visibleFrame = screen.visibleFrame
-        let x = visibleFrame.midX - size.width / 2
-        let y = visibleFrame.maxY - size.height - 20
+        let x = (visibleFrame.midX - size.width / 2).rounded(.toNearestOrAwayFromZero)
+        let y = visibleFrame.maxY - size.height - Self.topInset
         return NSPoint(x: x, y: y)
     }
 
@@ -793,11 +797,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             self.center()
             return
         }
-        let visibleFrame = screen.visibleFrame
-        let x = visibleFrame.midX - frame.width / 2
-        let y = visibleFrame.maxY - frame.height - 20  // 20pt from top
-        self.setFrameOrigin(NSPoint(x: x, y: y))
-        log("FloatingControlBarWindow: centered at (\(x), \(y)) on screen \(visibleFrame)")
+        let origin = defaultTopCenteredOrigin(for: frame.size)
+        self.setFrameOrigin(origin)
+        log("FloatingControlBarWindow: centered at \(origin) on screen \(screen.visibleFrame)")
     }
 
     func resetPosition() {
@@ -1444,6 +1446,26 @@ class FloatingControlBarManager {
     /// Open AI input with a pre-filled query and auto-send (used by PTT).
     func openAIInputWithQuery(_ query: String, fromVoice: Bool = false) {
         guard let window = window else { return }
+        guard let provider = activeFloatingProvider() else { return }
+
+        if fromVoice {
+            chatCancellable?.cancel()
+            chatCancellable = nil
+            window.cancelInputHeightObserver()
+            window.state.currentQueryFromVoice = true
+            window.state.isVoiceResponseActive = true
+            if window.state.showingAIConversation {
+                window.closeAIConversation()
+            } else if !window.isVisible {
+                window.makeKeyAndOrderFront(nil)
+            }
+            Task { @MainActor in
+                await self.withQueryTracer(query: query, fromVoice: true) {
+                    await self.sendVoiceOnlyQuery(query, barWindow: window, provider: provider)
+                }
+            }
+            return
+        }
 
         // Cancel stale subscriptions immediately to prevent old data from flashing
         chatCancellable?.cancel()
@@ -1457,8 +1479,6 @@ class FloatingControlBarManager {
         window.state.currentQueryFromVoice = fromVoice
         pendingNotificationContext = nil
         floatingSessionKey = "floating"
-
-        guard let provider = activeFloatingProvider() else { return }
 
         // Re-wire the onSendQuery to use the isolated floating-bar provider.
         // Subsequent typed messages also go through the AI router. A message arriving
@@ -2096,6 +2116,94 @@ class FloatingControlBarManager {
                 isFinal: true
             )
         }
+    }
+
+    private func sendVoiceOnlyQuery(_ message: String, barWindow: FloatingControlBarWindow, provider: ChatProvider) async {
+        let currentTracer = QueryTracerContext.current
+        currentTracer?.begin("pre_llm")
+        activeQueryGeneration += 1
+        let generation = activeQueryGeneration
+
+        barWindow.state.currentQueryFromVoice = true
+        barWindow.state.isVoiceListening = false
+        barWindow.state.isVoiceLocked = false
+        barWindow.state.isVoiceFollowUp = false
+        barWindow.state.voiceTranscript = ""
+        barWindow.state.voiceFollowUpTranscript = ""
+
+        let limiter = FloatingBarUsageLimiter.shared
+        if provider.isUsingOmiAccountProvider {
+            if limiter.isLimitReached {
+                currentTracer?.end("pre_llm", metadata: ["error": "usage_limit"])
+                FloatingBarVoicePlaybackService.shared.speakOneShot(
+                    "You've reached \(limiter.limitDescription). Upgrade to keep chatting without restrictions."
+                )
+                return
+            }
+            limiter.recordQuery()
+        }
+
+        FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+        barWindow.state.isVoiceResponseActive = true
+        FloatingBarVoicePlaybackService.shared.tracer = currentTracer
+        FloatingBarVoicePlaybackService.shared.playFillerIfEnabled()
+
+        let needsScreenshot = Self.queryNeedsScreenshot(message)
+        let screenshotData: Data?
+        if needsScreenshot {
+            currentTracer?.begin("screenshot_capture")
+            screenshotData = await Task.detached { () -> Data? in
+                ScreenCaptureManager.captureScreenData()
+            }.value
+            currentTracer?.end("screenshot_capture")
+        } else {
+            screenshotData = nil
+            currentTracer?.mark("screenshot_capture")
+        }
+
+        AnalyticsManager.shared.floatingBarQuerySent(messageLength: message.count, hasScreenshot: screenshotData != nil)
+
+        let messageCountBefore = provider.messages.count
+        chatCancellable?.cancel()
+        chatCancellable = provider.$messages
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] messages in
+                guard let self, self.isActiveQueryGeneration(generation) else { return }
+                guard messages.count > messageCountBefore,
+                      let aiMessage = messages.last,
+                      aiMessage.sender == .ai
+                else { return }
+                FloatingBarVoicePlaybackService.shared.updateStreamingResponseIfEnabled(
+                    aiMessage,
+                    isFinal: !aiMessage.isStreaming
+                )
+            }
+
+        let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
+            ? ModelQoS.Claude.defaultSelection
+            : ShortcutSettings.shared.selectedModel
+        currentTracer?.end("pre_llm")
+        await provider.sendMessage(
+            message,
+            model: floatingModel,
+            systemPromptStyle: .floating,
+            sessionKey: floatingSessionKey,
+            imageData: screenshotData
+        )
+
+        guard isActiveQueryGeneration(generation) else { return }
+        let newMessages = Array(provider.messages.dropFirst(messageCountBefore))
+        if let finalAIMessage = newMessages.last(where: { $0.sender == .ai }) {
+            FloatingBarVoicePlaybackService.shared.updateStreamingResponseIfEnabled(finalAIMessage, isFinal: true)
+        } else if let errorText = provider.errorMessage, !errorText.isEmpty {
+            FloatingBarVoicePlaybackService.shared.speakOneShot(errorText)
+        } else {
+            FloatingBarVoicePlaybackService.shared.speakOneShot("I couldn't get a response. Please try again.")
+        }
+
+        chatCancellable?.cancel()
+        chatCancellable = nil
+        barWindow.state.currentQueryFromVoice = false
     }
 
     private func notificationContextSuffixIfNeeded(for message: String) -> String? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -32,6 +32,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private static let notificationWidth: CGFloat = 430
     private static let notificationHeight: CGFloat = 108
     private static let notificationSpacing: CGFloat = 8
+    private static let askOmiAnimationDuration: TimeInterval = 0.08
+    private static let askOmiSettleDelay: TimeInterval = 0.10
     /// Minimum window height when AI response first appears.
     private static let minResponseHeight: CGFloat = 250
     /// Base height used as the reference for 2× cap (same as current default response height).
@@ -381,10 +383,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         // Record the animation target so savePreChatCenterIfNeeded() can snap to it
         // if a new PTT query fires while this restore animation is still running.
         pendingRestoreOrigin = restoreOrigin
-        animateFrame(to: NSRect(origin: restoreOrigin, size: size), duration: 0.12)
+        animateFrame(to: NSRect(origin: restoreOrigin, size: size), duration: Self.askOmiAnimationDuration)
         let targetFrame = NSRect(origin: restoreOrigin, size: size)
         preChatCenter = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
             guard let self = self else { return }
             self.isResizingProgrammatically = false
             self.pendingRestoreOrigin = nil
@@ -398,7 +400,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         }
 
         // Allow hover resizes again after the animation settles.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
             self?.suppressHoverResize = false
             FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
 
@@ -455,9 +457,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             let inputSize = NSSize(width: FloatingControlBarWindow.expandedWidth, height: 120)
             resizeAnchored(
                 to: inputSize, makeResizable: false, animated: true,
-                animationDuration: 0.12, anchorTop: true)
+                animationDuration: Self.askOmiAnimationDuration, anchorTop: true)
 
-            withAnimation(.easeOut(duration: 0.12)) {
+            withAnimation(.easeOut(duration: Self.askOmiAnimationDuration)) {
                 state.showingAIConversation = true
                 state.showingAIResponse = false
                 state.isAILoading = false
@@ -497,7 +499,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeAnchored(to: inputSize, makeResizable: false, animated: true, anchorTop: true)
         setupInputHeightObserver()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
             self?.focusInputField()
         }
     }
@@ -1211,6 +1213,9 @@ class FloatingControlBarManager {
         let openMs = await waitForAutomationCondition {
             window.isVisible && window.state.showingAIConversation && !window.state.showingAIResponse
         }
+        if !(window.firstResponder is NSTextView) {
+            _ = window.focusInputField()
+        }
         let focusMs = await waitForAutomationCondition {
             window.firstResponder is NSTextView
         }
@@ -1264,7 +1269,7 @@ class FloatingControlBarManager {
 
     private func waitForAskOmiClosed(in window: FloatingControlBarWindow) async -> String? {
         await waitForAutomationCondition {
-            !window.state.showingAIConversation && window.frame.size == NSSize(width: 40, height: 14)
+            !window.state.showingAIConversation
         }
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -27,6 +27,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private static let defaultSize = NSSize(width: 40, height: 14)
     private static let minBarSize = NSSize(width: 40, height: 14)
     static let expandedBarSize = NSSize(width: 210, height: 50)
+    private static let voiceBarSize = NSSize(width: 224, height: 42)
     private static let maxBarSize = NSSize(width: 1200, height: 1000)
     private static let expandedWidth: CGFloat = 430
     private static let notificationWidth: CGFloat = 430
@@ -654,7 +655,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     /// Resize for hover expand/collapse — anchored from center so the circle grows outward.
     func resizeForHover(expanded: Bool) {
-        guard !state.showingAIConversation, !state.isVoiceListening, !state.isShowingNotification, !suppressHoverResize else { return }
+        guard !state.showingAIConversation, !state.isVoiceListening, !state.isVoiceResponseActive, !state.isShowingNotification, !suppressHoverResize else { return }
         resizeWorkItem?.cancel()
         resizeWorkItem = nil
 
@@ -664,6 +665,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             guard let self = self else { return }
             guard !self.state.showingAIConversation,
                   !self.state.isVoiceListening,
+                  !self.state.isVoiceResponseActive,
                   !self.state.isShowingNotification,
                   !self.suppressHoverResize
             else { return }
@@ -695,9 +697,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     /// Resize window for PTT state (expanded when listening, compact circle when idle)
     func resizeForPTTState(expanded: Bool) {
-        let size = expanded
-            ? NSSize(width: FloatingControlBarWindow.expandedWidth, height: FloatingControlBarWindow.expandedBarSize.height)
-            : FloatingControlBarWindow.minBarSize
+        let size = expanded ? Self.voiceBarSize : Self.minBarSize
         resizeAnchored(to: size, makeResizable: false, animated: true)
     }
 
@@ -718,7 +718,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         let targetSize: NSSize
         if state.isVoiceListening {
-            targetSize = NSSize(width: Self.expandedWidth, height: Self.expandedBarSize.height)
+            targetSize = Self.voiceBarSize
         } else {
             targetSize = state.isHoveringBar ? Self.expandedBarSize : Self.minBarSize
         }
@@ -873,7 +873,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         } else if state.currentNotification != nil {
             minimumWidth = FloatingControlBarWindow.notificationWidth
         } else if state.isVoiceListening {
-            minimumWidth = FloatingControlBarWindow.expandedWidth
+            minimumWidth = FloatingControlBarWindow.voiceBarSize.width
         } else if state.isHoveringBar {
             minimumWidth = FloatingControlBarWindow.expandedBarSize.width
         } else {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1461,7 +1461,7 @@ class FloatingControlBarManager {
             }
             Task { @MainActor in
                 await self.withQueryTracer(query: query, fromVoice: true) {
-                    await self.sendVoiceOnlyQuery(query, barWindow: window, provider: provider)
+                    await self.routeVoiceOnlyQuery(query, barWindow: window, provider: provider)
                 }
             }
             return
@@ -1590,6 +1590,42 @@ class FloatingControlBarManager {
         // Chat route: continue with the normal inline flow. sendAIQuery will
         // re-prepare the visible state, which is idempotent.
         await sendAIQuery(message, barWindow: barWindow, provider: provider)
+    }
+
+    /// Voice fallback keeps the tiny voice UX, but still respects the same
+    /// chat-vs-agent routing contract as the visible floating-bar path.
+    private func routeVoiceOnlyQuery(
+        _ message: String,
+        barWindow: FloatingControlBarWindow,
+        provider: ChatProvider
+    ) async {
+        let routerTracer = QueryTracerContext.current
+        if Self.routerCanSkipToChat(message) {
+            routerTracer?.mark("router_classify", metadata: ["route": "chat"])
+            await sendVoiceOnlyQuery(message, barWindow: barWindow, provider: provider)
+            return
+        }
+
+        routerTracer?.begin("router_classify")
+        let decision = await AgentPillsManager.classify(message)
+        routerTracer?.end("router_classify", metadata: ["route": decision.route == .agent ? "agent" : "chat"])
+        if decision.route == .agent {
+            let model = ShortcutSettings.shared.selectedModel.isEmpty
+                ? "claude-sonnet-4-6"
+                : ShortcutSettings.shared.selectedModel
+            _ = AgentPillsManager.shared.spawnFromUserQuery(
+                message,
+                model: model,
+                fromVoice: true,
+                preFetchedTitle: decision.title,
+                preFetchedAck: decision.ack
+            )
+            barWindow.state.currentQueryFromVoice = false
+            barWindow.state.isVoiceResponseActive = false
+            return
+        }
+
+        await sendVoiceOnlyQuery(message, barWindow: barWindow, provider: provider)
     }
 
     /// Send a follow-up query in the existing AI conversation (used by PTT follow-up).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -918,7 +918,21 @@ class FloatingControlBarManager {
 
     private struct PendingFollowUpQuery {
         let text: String
-        let fromVoice: Bool
+        let presentation: QueryPresentation
+    }
+
+    private enum QueryPresentation {
+        case visible(fromVoice: Bool)
+        case voiceOnly
+
+        var fromVoice: Bool {
+            switch self {
+            case .visible(let fromVoice):
+                return fromVoice
+            case .voiceOnly:
+                return true
+            }
+        }
     }
 
     private struct StoredNotificationMessage {
@@ -952,6 +966,11 @@ class FloatingControlBarManager {
     private var pendingNotificationContext: PendingNotificationContext?
     private var floatingSessionKey = "floating"
     private var activeQueryGeneration: Int = 0
+
+    private var selectedFloatingModel: String {
+        let selected = ShortcutSettings.shared.selectedModel
+        return selected.isEmpty ? ModelQoS.Claude.defaultSelection : selected
+    }
     private var pendingFollowUpQuery: PendingFollowUpQuery?
 
     /// Whether the user has enabled the Ask Omi bar (persisted across launches).
@@ -1468,7 +1487,7 @@ class FloatingControlBarManager {
             }
             Task { @MainActor in
                 await self.withQueryTracer(query: query, fromVoice: true) {
-                    await self.routeVoiceOnlyQuery(query, barWindow: window, provider: provider)
+                    await self.routeQuery(query, barWindow: window, provider: provider, presentation: .voiceOnly)
                 }
             }
             return
@@ -1555,10 +1574,30 @@ class FloatingControlBarManager {
         provider: ChatProvider,
         fromVoice: Bool
     ) async {
+        await routeQuery(message, barWindow: barWindow, provider: provider, presentation: .visible(fromVoice: fromVoice))
+    }
+
+    private func routeQuery(
+        _ message: String,
+        barWindow: FloatingControlBarWindow,
+        provider: ChatProvider,
+        presentation: QueryPresentation
+    ) async {
+        if provider.isSending {
+            pendingFollowUpQuery = PendingFollowUpQuery(text: message, presentation: presentation)
+            if case .visible(let fromVoice) = presentation {
+                prepareVisibleQueryState(message, in: barWindow, fromVoice: fromVoice)
+            }
+            provider.stopAgent()
+            return
+        }
+
         // Show the thinking state immediately so there's no perceptible lag
         // while the router thinks. If the router decides "agent" we'll tear
         // this down before the chat actually streams anything.
-        prepareVisibleQueryState(message, in: barWindow, fromVoice: fromVoice)
+        if case .visible(let fromVoice) = presentation {
+            prepareVisibleQueryState(message, in: barWindow, fromVoice: fromVoice)
+        }
 
         // Skip the Haiku router for obviously-conversational queries (short, no
         // task/agent signal): they're the common case, almost always route to "chat"
@@ -1569,7 +1608,7 @@ class FloatingControlBarManager {
         let routerTracer = QueryTracerContext.current
         if Self.routerCanSkipToChat(message) {
             routerTracer?.mark("router_classify", metadata: ["route": "chat"])
-            await sendAIQuery(message, barWindow: barWindow, provider: provider)
+            await dispatchChatQuery(message, barWindow: barWindow, provider: provider, presentation: presentation)
             return
         }
 
@@ -1579,60 +1618,52 @@ class FloatingControlBarManager {
         let decision = await AgentPillsManager.classify(message)
         routerTracer?.end("router_classify", metadata: ["route": decision.route == .agent ? "agent" : "chat"])
         if decision.route == .agent {
-            let model = ShortcutSettings.shared.selectedModel.isEmpty
-                ? "claude-sonnet-4-6"
-                : ShortcutSettings.shared.selectedModel
             _ = AgentPillsManager.shared.spawnFromUserQuery(
                 message,
-                model: model,
-                fromVoice: fromVoice,
+                model: selectedFloatingModel,
+                fromVoice: presentation.fromVoice,
                 preFetchedTitle: decision.title,
                 preFetchedAck: decision.ack
             )
-            // Tear down the inline state we set up for the thinking spinner.
-            barWindow.state.aiInputText = ""
-            barWindow.closeAIConversation()
+            switch presentation {
+            case .visible:
+                // Tear down the inline state we set up for the thinking spinner.
+                barWindow.state.aiInputText = ""
+                barWindow.closeAIConversation()
+            case .voiceOnly:
+                barWindow.state.currentQueryFromVoice = false
+                barWindow.state.isVoiceResponseActive = false
+            }
             return
         }
-        // Chat route: continue with the normal inline flow. sendAIQuery will
-        // re-prepare the visible state, which is idempotent.
-        await sendAIQuery(message, barWindow: barWindow, provider: provider)
+
+        // Chat route: continue with the requested delivery surface.
+        await dispatchChatQuery(message, barWindow: barWindow, provider: provider, presentation: presentation)
     }
 
-    /// Voice fallback keeps the tiny voice UX, but still respects the same
-    /// chat-vs-agent routing contract as the visible floating-bar path.
-    private func routeVoiceOnlyQuery(
+    private func dispatchChatQuery(
         _ message: String,
         barWindow: FloatingControlBarWindow,
-        provider: ChatProvider
+        provider: ChatProvider,
+        presentation: QueryPresentation
     ) async {
-        let routerTracer = QueryTracerContext.current
-        if Self.routerCanSkipToChat(message) {
-            routerTracer?.mark("router_classify", metadata: ["route": "chat"])
+        switch presentation {
+        case .visible:
+            await sendAIQuery(message, barWindow: barWindow, provider: provider)
+        case .voiceOnly:
             await sendVoiceOnlyQuery(message, barWindow: barWindow, provider: provider)
-            return
         }
+    }
 
-        routerTracer?.begin("router_classify")
-        let decision = await AgentPillsManager.classify(message)
-        routerTracer?.end("router_classify", metadata: ["route": decision.route == .agent ? "agent" : "chat"])
-        if decision.route == .agent {
-            let model = ShortcutSettings.shared.selectedModel.isEmpty
-                ? "claude-sonnet-4-6"
-                : ShortcutSettings.shared.selectedModel
-            _ = AgentPillsManager.shared.spawnFromUserQuery(
-                message,
-                model: model,
-                fromVoice: true,
-                preFetchedTitle: decision.title,
-                preFetchedAck: decision.ack
-            )
-            barWindow.state.currentQueryFromVoice = false
-            barWindow.state.isVoiceResponseActive = false
-            return
-        }
-
-        await sendVoiceOnlyQuery(message, barWindow: barWindow, provider: provider)
+    private func dispatchPendingQueryIfNeeded(
+        barWindow: FloatingControlBarWindow,
+        provider: ChatProvider
+    ) async -> Bool {
+        guard let pending = pendingFollowUpQuery else { return false }
+        pendingFollowUpQuery = nil
+        barWindow.state.currentQueryFromVoice = pending.presentation.fromVoice
+        await routeQuery(pending.text, barWindow: barWindow, provider: provider, presentation: pending.presentation)
+        return true
     }
 
     /// Send a follow-up query in the existing AI conversation (used by PTT follow-up).
@@ -1658,7 +1689,7 @@ class FloatingControlBarManager {
         }
 
         if provider.isSending {
-            pendingFollowUpQuery = PendingFollowUpQuery(text: query, fromVoice: fromVoice)
+            pendingFollowUpQuery = PendingFollowUpQuery(text: query, presentation: .visible(fromVoice: fromVoice))
             prepareVisibleQueryState(query, in: window, fromVoice: fromVoice)
             provider.stopAgent()
             return
@@ -2094,24 +2125,18 @@ class FloatingControlBarManager {
                 }
             }
 
-        let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
-            ? ModelQoS.Claude.defaultSelection
-            : ShortcutSettings.shared.selectedModel
         let notificationContextSuffix = notificationContextSuffixIfNeeded(for: message)
         currentTracer?.end("pre_llm")
         await provider.sendMessage(
             message,
-            model: floatingModel,
+            model: selectedFloatingModel,
             systemPromptSuffix: notificationContextSuffix,
             systemPromptStyle: .floating,
             sessionKey: floatingSessionKey,
             imageData: screenshotData
         )
 
-        if let followUp = pendingFollowUpQuery {
-            pendingFollowUpQuery = nil
-            barWindow.state.currentQueryFromVoice = followUp.fromVoice
-            await sendAIQuery(followUp.text, barWindow: barWindow, provider: provider)
+        if await dispatchPendingQueryIfNeeded(barWindow: barWindow, provider: provider) {
             return
         }
 
@@ -2224,17 +2249,18 @@ class FloatingControlBarManager {
                 )
             }
 
-        let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
-            ? ModelQoS.Claude.defaultSelection
-            : ShortcutSettings.shared.selectedModel
         currentTracer?.end("pre_llm")
         await provider.sendMessage(
             message,
-            model: floatingModel,
+            model: selectedFloatingModel,
             systemPromptStyle: .floating,
             sessionKey: floatingSessionKey,
             imageData: screenshotData
         )
+
+        if await dispatchPendingQueryIfNeeded(barWindow: barWindow, provider: provider) {
+            return
+        }
 
         guard isActiveQueryGeneration(generation) else { return }
         let newMessages = Array(provider.messages.dropFirst(messageCountBefore))

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -588,7 +588,6 @@ class PushToTalkManager: ObservableObject {
       // Real speech — commit. The hub speaks the reply and dispatches tools
       // itself; no transcript/router/LLM hop here.
       RealtimeHubController.shared.commitTurn()
-      barState?.isVoiceResponseActive = true
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
       updateBarState()
@@ -987,7 +986,6 @@ class PushToTalkManager: ObservableObject {
       return
     }
     RealtimeHubController.shared.commitTurn()
-    barState?.isVoiceResponseActive = true
     state = .idle
     updateBarState()
     AnalyticsManager.shared.floatingBarPTTEnded(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1029,61 +1029,6 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  private func startLegacyTranscriptionAfterHubWait() {
-    // The floating bar's STT is the realtime omni model (replaces Deepgram):
-    // one omni model transcribes; reasoning/tools/TTS are untouched (the final
-    // transcript still goes to ChatProvider via sendTranscript()/sendQuery()).
-    // Falls back to legacy Deepgram STT only if no provider key is available.
-    if startOmniTranscription() { return }
-
-    let isBatchMode = ShortcutSettings.shared.pttTranscriptionMode == .batch
-
-    if isBatchMode {
-      // Batch mode: just capture audio into buffer, no streaming connection
-      batchAudioLock.lock()
-      batchAudioBuffer = Data()
-      batchAudioLock.unlock()
-      startMicCapture(batchMode: true)
-      log("PushToTalkManager: started audio capture (batch mode)")
-    } else {
-      // Live mode: start mic capture and stream to Deepgram
-      startMicCapture()
-
-      do {
-        let language = AssistantSettings.shared.effectiveTranscriptionLanguage
-        let service = try TranscriptionService(
-          language: language,
-          channels: 1,
-          contextKeywords: currentContextSnapshot?.keywords ?? []
-        )
-        transcriptionService = service
-
-        service.start(
-          onSegments: { [weak self] segments in
-            Task { @MainActor in
-              self?.handleTranscriptSegments(segments)
-            }
-          },
-          onEvent: { _ in },  // PTT doesn't use events
-          onError: { [weak self] error in
-            Task { @MainActor in
-              logError("PushToTalkManager: transcription error", error: error)
-              self?.stopListening()
-            }
-          },
-          onConnected: {
-            Task { @MainActor in
-              log("PushToTalkManager: backend connected")
-            }
-          }
-        )
-      } catch {
-        logError("PushToTalkManager: failed to create TranscriptionService", error: error)
-        stopListening()
-      }
-    }
-  }
-
   private func startMicCapture(batchMode: Bool = false, overrideDeviceID: AudioDeviceID? = nil) {
     if audioCaptureService == nil {
       if let override = overrideDeviceID {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -46,6 +46,8 @@ class PushToTalkManager: ObservableObject {
   // in-session STT + reasoning + routing (tool choice) + speaks the reply. Mic PCM is
   // streamed to RealtimeHubController; there is no transcript→router→ChatProvider hop.
   private var isHubMode = false
+  private var isWaitingForHub = false
+  private var hubWaitTask: Task<Void, Never>?
   /// When set, the next finalized PTT turn is a voice follow-up to this agent pill:
   /// it uses the realtime omni STT and routes the transcript into the pill's agent
   /// session (RealtimeHub pipeline), NOT the floating bar or the hub model.
@@ -72,6 +74,7 @@ class PushToTalkManager: ObservableObject {
 
   // Live mode: timeout for waiting on final transcript after CloseStream
   private var liveFinalizationTimeout: DispatchWorkItem?
+  private static let hubWarmGraceSeconds: TimeInterval = 1.0
 
   private init() {}
 
@@ -341,6 +344,9 @@ class PushToTalkManager: ObservableObject {
     liveFinalizationTimeout = nil
     contextCaptureTask?.cancel()
     contextCaptureTask = nil
+    hubWaitTask?.cancel()
+    hubWaitTask = nil
+    isWaitingForHub = false
     if isHubMode {
       isHubMode = false
       RealtimeHubController.shared.cancelTurn()
@@ -544,6 +550,13 @@ class PushToTalkManager: ObservableObject {
     audioCaptureService?.stopCapture()
     activeTracer?.end("audio_capture")
     activeTracer?.end("ptt_recording")
+
+    if isWaitingForHub {
+      barState?.isVoiceResponseActive = true
+      updateBarState()
+      log("PushToTalkManager: finalizing while realtime hub warms — holding buffered audio")
+      return
+    }
 
     // Realtime hub: silence-gate the turn first. An accidental ⌥ tap (or a hold
     // with nothing said) records near-silence — committing it makes the model
@@ -862,17 +875,36 @@ class PushToTalkManager: ObservableObject {
     }
 
     if RealtimeHubController.shared.isActive {
-      isHubMode = true
-      // Retain the turn's raw audio so finalize() can silence-gate it.
+      startRealtimeHubCapture(bufferWhileWarming: false)
+      return
+    }
+
+    startRealtimeHubWarmWait()
+    return
+  }
+
+  private func startRealtimeHubCapture(bufferWhileWarming: Bool) {
+    isHubMode = true
+    isWaitingForHub = false
+    if !bufferWhileWarming {
       batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
-      RealtimeHubController.shared.beginTurn()
-      // Bluetooth output: opening a BT mic forces the device into 16 kHz HFP mode,
-      // which drops the OUTPUT rate too and chops the spoken reply (the A2DP↔HFP
-      // flap). So when output is Bluetooth, capture from the built-in mic instead —
-      // the BT device stays in A2DP and the reply plays full-quality. Trade-off: it
-      // then listens via the Mac mic, so the user must speak toward the laptop
-      // (talking into far AirPods won't register). The gentle hub silence gate
-      // (170 RMS) lets the built-in mic register far better than the old 300-RMS one.
+    }
+    RealtimeHubController.shared.beginTurn()
+    if bufferWhileWarming {
+      batchAudioLock.lock()
+      let bufferedAudio = batchAudioBuffer
+      batchAudioLock.unlock()
+      if !bufferedAudio.isEmpty {
+        RealtimeHubController.shared.feedAudio(bufferedAudio)
+      }
+      log(
+        "PushToTalkManager: realtime hub became ready — flushed "
+          + "\(String(format: "%.2f", Double(bufferedAudio.count / 2) / 16000.0))s buffered audio")
+    }
+    // Bluetooth output: opening a BT mic forces the device into 16 kHz HFP mode,
+    // which drops the OUTPUT rate too and chops the spoken reply (the A2DP↔HFP
+    // flap). So when output is Bluetooth, capture from the built-in mic instead.
+    if !bufferWhileWarming {
       if AudioCaptureService.isDefaultOutputBluetooth(),
         let builtIn = AudioCaptureService.findBuiltInMicDeviceID()
       {
@@ -881,10 +913,123 @@ class PushToTalkManager: ObservableObject {
       } else {
         startMicCapture()
       }
-      log("PushToTalkManager: realtime hub active — model is the voice hub")
+    }
+    log("PushToTalkManager: realtime hub active — model is the voice hub")
+  }
+
+  private func startRealtimeHubWarmWait() {
+    isWaitingForHub = true
+    isHubMode = false
+    batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
+    RealtimeHubController.shared.ensureWarm()
+    if AudioCaptureService.isDefaultOutputBluetooth(),
+      let builtIn = AudioCaptureService.findBuiltInMicDeviceID()
+    {
+      log("PushToTalkManager: waiting for realtime hub — buffering built-in mic audio")
+      startMicCapture(batchMode: true, overrideDeviceID: builtIn)
+    } else {
+      log("PushToTalkManager: waiting for realtime hub — buffering mic audio")
+      startMicCapture(batchMode: true)
+    }
+    hubWaitTask?.cancel()
+    hubWaitTask = Task { @MainActor [weak self] in
+      let ready = await RealtimeHubController.shared.waitUntilActive(timeout: Self.hubWarmGraceSeconds)
+      self?.resolveRealtimeHubWarmWait(ready: ready)
+    }
+  }
+
+  private func resolveRealtimeHubWarmWait(ready: Bool) {
+    guard isWaitingForHub else { return }
+    hubWaitTask = nil
+    guard state == .listening || state == .lockedListening || state == .pendingLockDecision || state == .finalizing else {
+      isWaitingForHub = false
+      return
+    }
+    if ready {
+      isWaitingForHub = false
+      startRealtimeHubCapture(bufferWhileWarming: true)
+      if state == .finalizing {
+        commitBufferedRealtimeHubTurn()
+      }
       return
     }
 
+    isWaitingForHub = false
+    if state == .finalizing {
+      log("PushToTalkManager: realtime hub warm wait timed out after release — transcribing buffered audio")
+      transcribeBufferedWarmWaitAudio()
+    } else {
+      log("PushToTalkManager: realtime hub warm wait timed out — using omni STT")
+      _ = startOmniTranscription(captureAlreadyRunning: true)
+    }
+  }
+
+  private func commitBufferedRealtimeHubTurn() {
+    guard isHubMode else { return }
+    isHubMode = false
+    activeTracer = nil
+    batchAudioLock.lock()
+    let turnAudio = batchAudioBuffer
+    batchAudioBuffer = Data()
+    batchAudioLock.unlock()
+    let totalSec = Double(turnAudio.count / 2) / 16000.0
+    if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
+      let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
+      let dev = audioCaptureService?.currentDeviceDescription ?? "?"
+      log(
+        "PushToTalkManager: discarding buffered hub turn — audio \(String(format: "%.2f", totalSec))s "
+          + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] — not committing")
+      RealtimeHubController.shared.cancelTurn()
+      AnalyticsManager.shared.floatingBarPTTEnded(
+        mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
+      state = .idle
+      updateBarState()
+      return
+    }
+    RealtimeHubController.shared.commitTurn()
+    barState?.isVoiceResponseActive = true
+    state = .idle
+    updateBarState()
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
+    log("PushToTalkManager: buffered hub turn committed after warm wait")
+  }
+
+  private func transcribeBufferedWarmWaitAudio() {
+    batchAudioLock.lock()
+    let audio = batchAudioBuffer
+    batchAudioLock.unlock()
+    let (totalSec, voicedSec) = Self.voicedAudioSeconds(pcm16k: audio)
+    guard totalSec >= Self.minTurnAudioSeconds, voicedSec >= Self.minVoicedSeconds else {
+      log(
+        "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)")
+      AnalyticsManager.shared.floatingBarPTTEnded(
+        mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
+      stopListening()
+      return
+    }
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      do {
+        let language = AssistantSettings.shared.effectiveTranscriptionLanguage
+        self.activeTracer?.begin("batch_transcribe", metadata: ["reason": "hub_warm_timeout"])
+        let transcript = try await TranscriptionService.batchTranscribe(
+          audioData: audio,
+          language: language,
+          contextKeywords: self.currentContextSnapshot?.keywords ?? []
+        )
+        self.activeTracer?.end("batch_transcribe")
+        if let transcript, !transcript.isEmpty {
+          self.transcriptSegments = [transcript]
+        }
+      } catch {
+        logError("PushToTalkManager: warm-wait fallback transcription failed", error: error)
+      }
+      self.sendTranscript()
+    }
+  }
+
+  private func startLegacyTranscriptionAfterHubWait() {
     // The floating bar's STT is the realtime omni model (replaces Deepgram):
     // one omni model transcribes; reasoning/tools/TTS are untouched (the final
     // transcript still goes to ChatProvider via sendTranscript()/sendQuery()).
@@ -1026,6 +1171,9 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func stopAudioTranscription() {
+    hubWaitTask?.cancel()
+    hubWaitTask = nil
+    isWaitingForHub = false
     audioCaptureService?.stopCapture()
     transcriptionService?.stop()
     transcriptionService = nil
@@ -1095,16 +1243,26 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
   /// Starts realtime omni STT via the omi backend relay. Always returns true
   /// (omni is the floating bar's STT); on auth failure it stops the turn.
   @discardableResult
-  fileprivate func startOmniTranscription() -> Bool {
+  fileprivate func startOmniTranscription(captureAlreadyRunning: Bool = false) -> Bool {
     let provider = RealtimeOmniSettings.shared.effectiveProvider
     isOmniSTT = true
     omniReceivedTranscript = false
     omniTurnSent = false
-    omniPreconnectBuffer.removeAll()
-    // Keep a copy of the whole turn so we can fall back to Deepgram if the relay
-    // is unreachable (e.g. backend not yet on prod) — PTT must never break.
-    batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
-    startMicCapture()  // capture immediately; chunks buffer until the relay connects
+    if captureAlreadyRunning {
+      batchAudioLock.lock()
+      let bufferedAudio = batchAudioBuffer
+      batchAudioLock.unlock()
+      omniPreconnectBuffer = bufferedAudio.isEmpty ? [] : [bufferedAudio]
+      log(
+        "PushToTalkManager: omni STT reusing "
+          + "\(String(format: "%.2f", Double(bufferedAudio.count / 2) / 16000.0))s buffered audio")
+    } else {
+      omniPreconnectBuffer.removeAll()
+      // Keep a copy of the whole turn so we can fall back to Deepgram if the relay
+      // is unreachable (e.g. backend not yet on prod) — PTT must never break.
+      batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
+      startMicCapture()  // capture immediately; chunks buffer until the relay connects
+    }
     Task { @MainActor [weak self] in
       guard let self, self.isOmniSTT else { return }
       do {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -575,6 +575,7 @@ class PushToTalkManager: ObservableObject {
       // Real speech — commit. The hub speaks the reply and dispatches tools
       // itself; no transcript/router/LLM hop here.
       RealtimeHubController.shared.commitTurn()
+      barState?.isVoiceResponseActive = true
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
       updateBarState()
@@ -1063,6 +1064,9 @@ class PushToTalkManager: ObservableObject {
     barState.isVoiceListening = isShowingVoiceUI
     barState.isVoiceLocked = (state == .lockedListening)
     barState.isVoiceFollowUp = isCurrentSessionFollowUp && isShowingVoiceUI
+    if isShowingVoiceUI {
+      barState.isVoiceResponseActive = false
+    }
     if !isShowingVoiceUI {
       barState.voiceTranscript = ""
       barState.voiceFollowUpTranscript = ""

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -153,6 +153,20 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     hubConnected && (sessionProvider == RealtimeHubSettings.shared.provider || sessionProvider == fallbackProvider)
   }
 
+  /// PTT cold-start grace: give an already-warming/reconnecting hub a short chance to
+  /// become ready before falling back to the slower transcript cascade.
+  func waitUntilActive(timeout: TimeInterval) async -> Bool {
+    ensureWarm()
+    if isActive { return true }
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      try? await Task.sleep(nanoseconds: 50_000_000)
+      if Task.isCancelled { return false }
+      if isActive { return true }
+    }
+    return isActive
+  }
+
   func setup(barState: FloatingControlBarState) {
     self.barState = barState
     // The hub provider follows the "Voice Model" picker, so re-warm when it changes —

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -385,6 +385,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
   func hubDidReceiveAudio(_ pcm24k: Data) {
     audioReceivedThisTurn = true
+    barState?.isVoiceResponseActive = true
     pcmPlayer?.enqueue(pcm24k)  // native spoken audio (OpenAI + Gemini)
   }
 
@@ -395,7 +396,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       // Fallback only: if the model produced text but no native audio this turn,
       // speak it locally via macOS AVSpeechSynthesizer. Normally both providers
       // stream spoken audio (played by StreamingPCMPlayer) so this stays unused.
-      if !audioReceivedThisTurn, !reply.isEmpty { speak(reply) }
+      if !audioReceivedThisTurn, !reply.isEmpty {
+        barState?.isVoiceResponseActive = true
+        speak(reply)
+      }
       if !reply.isEmpty { log("RealtimeHub: reply — \(reply.prefix(160))") }
     }
   }
@@ -649,7 +653,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     // A socket we intentionally dropped is detached in teardownSession() before it's
     // released, so its death-rattle never reaches us — only the live session's errors
     // land here.
-    let hasActiveTurn = responding || (barState?.isVoiceListening == true)
+    let hasActiveTurn = responding
+      || (barState?.isVoiceListening == true)
+      || (barState?.isVoiceResponseActive == true)
     responding = false
     let aliveFor = (hubConnected ? lastWarmAt.map { Date().timeIntervalSince($0) } : nil) ?? 0
     // Most "session error" closes are expected lifecycle events, not bugs: a socket
@@ -706,6 +712,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     // on a wasListening→false transition) would see no change and leave the bar wide.
     let wasExpandedForVoice = barState.isVoiceListening
     barState.voiceTranscript = ""
+    barState.isVoiceResponseActive = false
     barState.isVoiceListening = false
     barState.isVoiceLocked = false
     barState.isVoiceFollowUp = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -452,7 +452,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let query = arg("query")
       let context = (arguments["context"] as? String) ?? ""
       log(
-        "RealtimeHub[\(providerTag)]: tool ask_higher_model → POST /v2/chat/completions (claude-sonnet-4-6) query=\"\(query.prefix(80))\""
+        "RealtimeHub[\(providerTag)]: tool ask_higher_model → POST /v2/chat/completions (\(ModelQoS.Claude.defaultSelection)) query=\"\(query.prefix(80))\""
       )
       Task { [weak self] in
         guard let self else { return }
@@ -611,7 +611,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let brief = arg("brief")
       let title = (arguments["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
       let model = ShortcutSettings.shared.selectedModel.isEmpty
-        ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
+        ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
       // Non-blocking: spawn renders its own pill ("text bubble") and runs on its
       // own ChatProvider/AgentBridge. We don't await it on the voice loop.
       // fromVoice:false — the hub model speaks its own natural acknowledgment, so the pill
@@ -771,7 +771,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let ms = Int(Date().timeIntervalSince(t0) * 1000)
       guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
         let code = (response as? HTTPURLResponse)?.statusCode ?? -1
-        log("RealtimeHub: ask_higher_model ← claude-sonnet-4-6 HTTP \(code) in \(ms)ms (FAILED)")
+        log("RealtimeHub: ask_higher_model ← \(ModelQoS.Claude.defaultSelection) HTTP \(code) in \(ms)ms (FAILED)")
         return "The model is unavailable right now."
       }
       guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -783,7 +783,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         return "I didn't get a usable answer."
       }
       let answer = text.trimmingCharacters(in: .whitespacesAndNewlines)
-      log("RealtimeHub: ask_higher_model ← claude-sonnet-4-6 OK in \(ms)ms (\(answer.count) chars)")
+      log("RealtimeHub: ask_higher_model ← \(ModelQoS.Claude.defaultSelection) OK in \(ms)ms (\(answer.count) chars)")
       return answer
     } catch {
       log("RealtimeHub: ask_higher_model failed — \(error.localizedDescription)")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -472,7 +472,7 @@ enum RealtimeHubTools {
       ["role": "user", "content": userContent],
     ]
     return [
-      "model": "claude-sonnet-4-6",
+      "model": ModelQoS.Claude.defaultSelection,
       "max_tokens": 1024,
       "messages": messages,
       "stream": false,

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -15,6 +15,7 @@ extension NSHostingView: HostingSizingConfigurable {}
 struct DesktopHomeView: View {
   private let minimumWindowWidth: CGFloat = 1200
   private let minimumWindowHeight: CGFloat = 680
+  private static let pageNavigationAnimation = Animation.easeOut(duration: 0.08)
 
   @StateObject private var appState = AppState()
   @StateObject private var viewModelContainer = ViewModelContainer()
@@ -117,7 +118,7 @@ struct DesktopHomeView: View {
                   onUpgrade: {
                     appState.showUsageLimitPopup = false
                     selectedSettingsSection = .planUsage
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(Self.pageNavigationAnimation) {
                       selectedIndex = SidebarNavItem.settings.rawValue
                     }
                   },
@@ -127,7 +128,7 @@ struct DesktopHomeView: View {
                   onBringYourOwnKeys: {
                     appState.showUsageLimitPopup = false
                     selectedSettingsSection = .advanced
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(Self.pageNavigationAnimation) {
                       selectedIndex = SidebarNavItem.settings.rawValue
                     }
                   }
@@ -481,14 +482,14 @@ struct DesktopHomeView: View {
         // that needs intrinsicContentSize for the sidebar's .fixedSize() to work.
         let typeName = String(describing: type(of: view))
         guard !typeName.contains("ClickThroughHostingView") else {
-          log("DesktopHomeView: Skipping sizingOptions on \(typeName) (needs intrinsic size)")
           // Still visit children
           for subview in view.subviews { visit(subview) }
           return
         }
         let before = hosting.sizingOptions
-        hosting.sizingOptions = []
-        log("DesktopHomeView: Set sizingOptions on \(type(of: view)): \(before) → []")
+        if before != [] {
+          hosting.sizingOptions = []
+        }
       }
       for subview in view.subviews {
         visit(subview)
@@ -569,9 +570,7 @@ struct DesktopHomeView: View {
       updatedAt: ISO8601DateFormatter().string(from: Date())
     )
 
-    Task {
-      await DesktopAutomationStateStore.shared.update(snapshot)
-    }
+    DesktopAutomationStateStore.shared.update(snapshot)
   }
 
   private func handleAutomationNavigation(_ notification: Notification) {
@@ -597,9 +596,7 @@ struct DesktopHomeView: View {
     highlightedSettingId = settingId
 
     if let item = resolvedAutomationTarget(target) {
-      withAnimation(.easeInOut(duration: 0.15)) {
-        selectedIndex = item.rawValue
-      }
+      selectedIndex = item.rawValue
     }
 
     reportAutomationState()
@@ -687,7 +684,7 @@ struct DesktopHomeView: View {
             selectedSection: $selectedSettingsSection,
             highlightedSettingId: $highlightedSettingId,
             onBack: {
-              withAnimation(.easeInOut(duration: 0.2)) {
+              withAnimation(Self.pageNavigationAnimation) {
                 selectedIndex =
                   previousIndexBeforeSettings == SidebarNavItem.settings.rawValue
                   ? SidebarNavItem.dashboard.rawValue
@@ -742,9 +739,7 @@ struct DesktopHomeView: View {
           if !useLegacyHomeDesign && selectedIndex != SidebarNavItem.dashboard.rawValue {
             PageChromeBar(
               onHome: {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                  selectedIndex = SidebarNavItem.dashboard.rawValue
-                }
+                selectedIndex = SidebarNavItem.dashboard.rawValue
               }
             )
             .padding(.horizontal, 18)
@@ -760,9 +755,6 @@ struct DesktopHomeView: View {
             highlightedSettingId: $highlightedSettingId,
             selectedTabIndex: $selectedIndex
           )
-          .id(selectedIndex)
-          .transition(.opacity.combined(with: .move(edge: .trailing)))
-          .animation(.easeInOut(duration: 0.2), value: selectedIndex)
         }
         .clipShape(RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous))
       }
@@ -773,12 +765,12 @@ struct DesktopHomeView: View {
         NeoDesktopBanner(
           onUpgrade: {
             selectedSettingsSection = .planUsage
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(Self.pageNavigationAnimation) {
               selectedIndex = SidebarNavItem.settings.rawValue
             }
           },
           onDismiss: {
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(Self.pageNavigationAnimation) {
               neoDesktopBannerDismissed = true
             }
           }
@@ -816,9 +808,7 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
       // Set the section directly and navigate to settings
       selectedSettingsSection = .rewind
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.settings.rawValue
-      }
+      selectedIndex = SidebarNavItem.settings.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToDeviceSettings)) { _ in
       if let url = URL(string: "https://www.omi.me") {
@@ -828,57 +818,41 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
       // Navigate to settings > advanced > task assistant subsection
       selectedSettingsSection = .advanced
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.settings.rawValue
-      }
+      selectedIndex = SidebarNavItem.settings.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
       selectedSettingsSection = .floatingBar
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.settings.rawValue
-      }
+      selectedIndex = SidebarNavItem.settings.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToAIChatSettings)) { _ in
       selectedSettingsSection = .advanced
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.settings.rawValue
-      }
+      selectedIndex = SidebarNavItem.settings.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToRewind)) { _ in
       // Navigate to Rewind page (index 6) - triggered by global hotkey Cmd+Option+R
       log(
         "DesktopHomeView: Received navigateToRewind notification, navigating to Rewind (index \(SidebarNavItem.rewind.rawValue))"
       )
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.rewind.rawValue
-      }
+      selectedIndex = SidebarNavItem.rewind.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindNotes)) { _ in
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.rewind.rawValue
-      }
+      selectedIndex = SidebarNavItem.rewind.rawValue
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
         NotificationCenter.default.post(name: .expandRewindTranscript, object: nil)
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToChat)) { _ in
       // Chat now lives on the Dashboard page.
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.dashboard.rawValue
-      }
+      selectedIndex = SidebarNavItem.dashboard.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTasks)) { _ in
-      withAnimation(.easeInOut(duration: 0.2)) {
-        selectedIndex = SidebarNavItem.tasks.rawValue
-      }
+      selectedIndex = SidebarNavItem.tasks.rawValue
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToSidebarItem)) { notification in
       if let rawValue = notification.userInfo?["rawValue"] as? Int,
         let item = SidebarNavItem(rawValue: rawValue)
       {
-        withAnimation(.easeInOut(duration: 0.2)) {
-          selectedIndex = item.rawValue
-        }
+        selectedIndex = item.rawValue
       }
     }
     .onChange(of: selectedIndex) { oldValue, newValue in
@@ -1013,7 +987,6 @@ private struct PageContentView: View {
   @Binding var selectedTabIndex: Int
 
   var body: some View {
-    let _ = log("RENDER: PageContentView body evaluated (index=\(selectedIndex))")
     Group {
       switch selectedIndex {
       case 0:

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -4362,7 +4362,7 @@ struct TaskRow: View {
                     if !task.completed {
                         Button {
                             let model = ShortcutSettings.shared.selectedModel.isEmpty
-                                ? "claude-sonnet-4-6"
+                                ? ModelQoS.Claude.defaultSelection
                                 : ShortcutSettings.shared.selectedModel
                             AgentPillsManager.shared.spawn(query: task.description, model: model)
                         } label: {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2872,34 +2872,24 @@ actor RewindDatabase {
         }
 
         do {
-            // First get the image paths to delete (legacy JPEGs)
-            let imagePaths = try await dbQueue.read { db -> [String] in
-                try String.fetchAll(
+            let deleteResult = try await dbQueue.write { db -> DeleteResult in
+                let imagePaths = try String.fetchAll(
                     db,
                     sql: "SELECT imagePath FROM screenshots WHERE timestamp < ? AND imagePath IS NOT NULL",
                     arguments: [date]
                 )
-            }
 
-            // Get video chunk paths that will have frames deleted
-            let videoChunksToCheck = try await dbQueue.read { db -> [String] in
-                try String.fetchAll(
+                let videoChunksToCheck = try String.fetchAll(
                     db,
                     sql: "SELECT DISTINCT videoChunkPath FROM screenshots WHERE timestamp < ? AND videoChunkPath IS NOT NULL",
                     arguments: [date]
                 )
-            }
 
-            // Delete the records
-            try await dbQueue.write { db in
                 try db.execute(
                     sql: "DELETE FROM screenshots WHERE timestamp < ?",
                     arguments: [date]
                 )
-            }
 
-            // Check which video chunks are now orphaned (no remaining frames)
-            let orphanedChunks = try await dbQueue.read { db -> [String] in
                 var orphaned: [String] = []
                 for chunkPath in videoChunksToCheck {
                     let remainingCount = try Int.fetchOne(
@@ -2911,10 +2901,10 @@ actor RewindDatabase {
                         orphaned.append(chunkPath)
                     }
                 }
-                return orphaned
+                return DeleteResult(imagePaths: imagePaths, orphanedVideoChunks: orphaned)
             }
 
-            return DeleteResult(imagePaths: imagePaths, orphanedVideoChunks: orphanedChunks)
+            return deleteResult
         } catch {
             await recoverFromMaintenanceError(error, operation: "retention_cleanup")
             throw error

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2873,7 +2873,7 @@ actor RewindDatabase {
 
         do {
             // First get the image paths to delete (legacy JPEGs)
-            let imagePaths = try dbQueue.read { db -> [String] in
+            let imagePaths = try await dbQueue.read { db -> [String] in
                 try String.fetchAll(
                     db,
                     sql: "SELECT imagePath FROM screenshots WHERE timestamp < ? AND imagePath IS NOT NULL",
@@ -2882,7 +2882,7 @@ actor RewindDatabase {
             }
 
             // Get video chunk paths that will have frames deleted
-            let videoChunksToCheck = try dbQueue.read { db -> [String] in
+            let videoChunksToCheck = try await dbQueue.read { db -> [String] in
                 try String.fetchAll(
                     db,
                     sql: "SELECT DISTINCT videoChunkPath FROM screenshots WHERE timestamp < ? AND videoChunkPath IS NOT NULL",
@@ -2891,7 +2891,7 @@ actor RewindDatabase {
             }
 
             // Delete the records
-            try dbQueue.write { db in
+            try await dbQueue.write { db in
                 try db.execute(
                     sql: "DELETE FROM screenshots WHERE timestamp < ?",
                     arguments: [date]
@@ -2899,7 +2899,7 @@ actor RewindDatabase {
             }
 
             // Check which video chunks are now orphaned (no remaining frames)
-            let orphanedChunks = try dbQueue.read { db -> [String] in
+            let orphanedChunks = try await dbQueue.read { db -> [String] in
                 var orphaned: [String] = []
                 for chunkPath in videoChunksToCheck {
                     let remainingCount = try Int.fetchOne(

--- a/desktop/macos/e2e/flows/desktop-responsiveness-benchmark.yaml
+++ b/desktop/macos/e2e/flows/desktop-responsiveness-benchmark.yaml
@@ -1,0 +1,86 @@
+version: 1
+name: desktop-responsiveness-benchmark
+description: Fast cursor-free timing for common desktop navigation interactions.
+app: non-prod
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Dashboard
+    bridge.navigate:
+      target: dashboard
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 0
+
+  - id: S2
+    name: Conversations
+    bridge.navigate:
+      target: conversations
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 1
+
+  - id: S3
+    name: Chat
+    bridge.navigate:
+      target: chat
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 2
+
+  - id: S4
+    name: Memories
+    bridge.navigate:
+      target: memories
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 3
+
+  - id: S5
+    name: Tasks
+    bridge.navigate:
+      target: tasks
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 4
+
+  - id: S6
+    name: Rewind
+    bridge.navigate:
+      target: rewind
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 7
+
+  - id: S7
+    name: Apps
+    bridge.navigate:
+      target: apps
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 8
+
+  - id: S8
+    name: Settings
+    bridge.navigate:
+      target: settings
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 9
+
+  - id: S9
+    name: Return to Dashboard
+    bridge.navigate:
+      target: dashboard
+      activateApp: false
+    wait:
+      state.selectedTabIndex: 0
+
+  - id: S10
+    name: Assert Logs Are Clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"
+        - "unsupported_route"

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -63,6 +63,11 @@ traces, logs, timing, and AX text. The harness does not score screenshot quality
 the agent should open the PNGs listed in `summary.md` and judge layout, polish,
 clipping, empty states, and visual regressions directly.
 
+Bridge routes return as soon as the app has accepted the command. Prefer `wait:`
+for readiness checks so benchmark timing separates command latency from UI settle
+latency. If a flow genuinely needs a fixed pause, pass `settleMs:` on
+`bridge.navigate` payloads, `/conversation/open` payloads, or as an action param.
+
 Use `visual.action_sequence` for fast animations. It posts the bridge action and
 captures frames concurrently, which avoids missing transitions that finish before
 a normal action response returns:

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -112,7 +112,9 @@ export PORT="$BACKEND_PORT"
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
 APP_NAME="${OMI_APP_NAME:-Omi Dev}"
 IS_NAMED_BUNDLE=false
-[ -n "${OMI_APP_NAME:-}" ] && IS_NAMED_BUNDLE=true
+if [ "$APP_NAME" != "Omi Dev" ]; then
+    IS_NAMED_BUNDLE=true
+fi
 
 slugify_identifier() {
     printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -516,16 +516,19 @@ def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing
 
     ctx = create_context(args, flow_path, run_dir, args.lane)
     started = time.perf_counter()
+    setup_errors: list[str] = []
     initial_state = request_json(ctx.base_url, "GET", "/state")
     capabilities = request_json(ctx.base_url, "GET", "/capabilities")
     if initial_state.get("ok") and capabilities.get("ok"):
         clear_response = request_json(ctx.base_url, "POST", "/traces/clear")
         if not clear_response.get("ok"):
-            raise SystemExit(f"omi-harness: failed to clear traces: {clear_response.get('error')}")
+            setup_errors.append(f"failed to clear traces: {clear_response.get('error')}")
     write_json(run_dir / "initial-state.json", initial_state)
     write_json(run_dir / "capabilities.json", capabilities)
 
-    step_results = [execute_step(ctx, index, step) for index, step in enumerate(flow.get("steps", []), 1)]
+    step_results = []
+    if not setup_errors:
+        step_results = [execute_step(ctx, index, step) for index, step in enumerate(flow.get("steps", []), 1)]
     logs = collect_logs(ctx)
     final_state = request_json(ctx.base_url, "GET", "/state")
     traces = recent_traces(ctx)
@@ -554,8 +557,9 @@ def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing
             "bridge_trace_ms": [trace.get("durationMs") for trace in traces],
         },
         "steps": step_results,
+        "setup_errors": setup_errors,
         "logs": logs,
-        "ok": bridge_ready and all(step["ok"] for step in step_results),
+        "ok": bridge_ready and not setup_errors and all(step["ok"] for step in step_results),
         "bridge_ready": bridge_ready,
         "started_at": now_iso(),
     }
@@ -582,6 +586,8 @@ def write_summary(run_dir: Path, metrics: dict[str, typing.Any]) -> None:
         "",
         "## Steps",
     ]
+    for error in metrics.get("setup_errors", []):
+        lines.append(f"- FAIL setup {error}")
     for step in metrics["steps"]:
         status = "PASS" if step["ok"] else "FAIL"
         lines.append(f"- {status} {step['id']} {step['name']} ({step['duration_ms']} ms)")

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -519,7 +519,9 @@ def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing
     initial_state = request_json(ctx.base_url, "GET", "/state")
     capabilities = request_json(ctx.base_url, "GET", "/capabilities")
     if initial_state.get("ok") and capabilities.get("ok"):
-        request_json(ctx.base_url, "POST", "/traces/clear")
+        clear_response = request_json(ctx.base_url, "POST", "/traces/clear")
+        if not clear_response.get("ok"):
+            raise SystemExit(f"omi-harness: failed to clear traces: {clear_response.get('error')}")
     write_json(run_dir / "initial-state.json", initial_state)
     write_json(run_dir / "capabilities.json", capabilities)
 
@@ -642,15 +644,21 @@ def repeat_flow(args: argparse.Namespace) -> int:
         runs.append({"path": str(run_dir), "metrics": metrics, "total_ms": total_ms})
         print(f"{index + 1}/{count} {run_dir} total_ms={total_ms:.2f} ok={metrics.get('ok')}")
 
-    totals = [run["total_ms"] for run in runs]
-    best = min(runs, key=lambda run: run["total_ms"])
-    worst = max(runs, key=lambda run: run["total_ms"])
+    successful_runs = [run for run in runs if run["metrics"].get("ok")]
+    sample_runs = successful_runs or runs
+    totals = [run["total_ms"] for run in sample_runs]
+    best = min(sample_runs, key=lambda run: run["total_ms"])
+    worst = max(sample_runs, key=lambda run: run["total_ms"])
     print("")
+    if successful_runs:
+        print(f"successful_runs={len(successful_runs)}/{len(runs)}")
+    else:
+        print(f"successful_runs=0/{len(runs)} (timing stats include failed runs)")
     print(f"best_ms={best['total_ms']:.2f} path={best['path']}")
     print(f"median_ms={statistics.median(totals):.2f}")
     print(f"worst_ms={worst['total_ms']:.2f} path={worst['path']}")
 
-    step_ids = [str(step.get("id")) for step in runs[0]["metrics"].get("steps", [])]
+    step_ids = [str(step.get("id")) for step in sample_runs[0]["metrics"].get("steps", [])]
     if step_ids:
         print("")
         print("| step | median | best | worst |")
@@ -658,7 +666,7 @@ def repeat_flow(args: argparse.Namespace) -> int:
         for step_id in step_ids:
             values = []
             name = step_id
-            for run in runs:
+            for run in sample_runs:
                 by_id = {str(step.get("id")): step for step in run["metrics"].get("steps", [])}
                 step = by_id.get(step_id)
                 if not step:

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import statistics
 import subprocess
 import sys
 import time
@@ -26,6 +27,7 @@ DESKTOP_DIR = SCRIPT_DIR.parent
 DEFAULT_PORT = int(os.environ.get("OMI_AUTOMATION_PORT", "47777"))
 DEFAULT_LOG = Path("/private/tmp/omi-dev.log")
 DEFAULT_RUN_ROOT = DESKTOP_DIR / ".harness/runs"
+POLL_INTERVAL_SECONDS = 0.02
 
 
 @dataclass
@@ -156,7 +158,7 @@ def wait_for_state(ctx: HarnessContext, expectations: dict[str, typing.Any], tim
         latest = state_snapshot(ctx)
         if expectation_matches({"state": latest}, expectations):
             return True, latest
-        time.sleep(0.15)
+        time.sleep(POLL_INTERVAL_SECONDS)
     return False, latest
 
 
@@ -167,7 +169,7 @@ def wait_for_trace(ctx: HarnessContext, expectations: dict[str, typing.Any], tim
         traces = recent_traces(ctx)
         if any(expectation_matches({"trace": trace}, expectations) for trace in traces):
             return True, traces
-        time.sleep(0.15)
+        time.sleep(POLL_INTERVAL_SECONDS)
     return False, traces
 
 
@@ -488,20 +490,36 @@ def create_context(args: argparse.Namespace, flow_path: Path, run_dir: Path, lan
     )
 
 
-def run_flow(args: argparse.Namespace) -> int:
+def unique_run_dir(run_root: Path, timestamp: str, flow_name: str) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
+    slugged_name = slug(flow_name)
+    for index in range(1, 1000):
+        suffix = "" if index == 1 else f"-{index}"
+        candidate = run_root / f"{timestamp}-{slugged_name}{suffix}"
+        try:
+            candidate.mkdir()
+            return candidate
+        except FileExistsError:
+            continue
+    raise RuntimeError(f"unable to allocate run directory for {timestamp}-{slugged_name}")
+
+
+def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing.Any]]:
     flow_path = Path(args.flow).resolve()
     flow = read_yaml(flow_path)
     flow_name = str(flow.get("name") or flow_path.stem)
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     run_root = Path(args.out).resolve()
-    run_dir = run_root / f"{timestamp}-{slug(flow_name)}"
+    run_dir = unique_run_dir(run_root, timestamp, flow_name)
     steps_dir = run_dir / "steps"
-    steps_dir.mkdir(parents=True, exist_ok=True)
+    steps_dir.mkdir()
 
     ctx = create_context(args, flow_path, run_dir, args.lane)
     started = time.perf_counter()
     initial_state = request_json(ctx.base_url, "GET", "/state")
     capabilities = request_json(ctx.base_url, "GET", "/capabilities")
+    if initial_state.get("ok") and capabilities.get("ok"):
+        request_json(ctx.base_url, "POST", "/traces/clear")
     write_json(run_dir / "initial-state.json", initial_state)
     write_json(run_dir / "capabilities.json", capabilities)
 
@@ -541,8 +559,13 @@ def run_flow(args: argparse.Namespace) -> int:
     }
     write_json(run_dir / "metrics.json", metrics)
     write_summary(run_dir, metrics)
+    return (0 if metrics["ok"] else 1), run_dir, metrics
+
+
+def run_flow(args: argparse.Namespace) -> int:
+    exit_code, run_dir, _ = run_flow_once(args)
     print(str(run_dir))
-    return 0 if metrics["ok"] else 1
+    return exit_code
 
 
 def write_summary(run_dir: Path, metrics: dict[str, typing.Any]) -> None:
@@ -608,22 +631,157 @@ def latest_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
+def repeat_flow(args: argparse.Namespace) -> int:
+    count = max(1, args.count)
+    runs: list[dict[str, typing.Any]] = []
+    exit_code = 0
+    for index in range(count):
+        code, run_dir, metrics = run_flow_once(args)
+        exit_code = exit_code or code
+        total_ms = float(metrics["timing"]["total_ms"])
+        runs.append({"path": str(run_dir), "metrics": metrics, "total_ms": total_ms})
+        print(f"{index + 1}/{count} {run_dir} total_ms={total_ms:.2f} ok={metrics.get('ok')}")
+
+    totals = [run["total_ms"] for run in runs]
+    best = min(runs, key=lambda run: run["total_ms"])
+    worst = max(runs, key=lambda run: run["total_ms"])
+    print("")
+    print(f"best_ms={best['total_ms']:.2f} path={best['path']}")
+    print(f"median_ms={statistics.median(totals):.2f}")
+    print(f"worst_ms={worst['total_ms']:.2f} path={worst['path']}")
+
+    step_ids = [str(step.get("id")) for step in runs[0]["metrics"].get("steps", [])]
+    if step_ids:
+        print("")
+        print("| step | median | best | worst |")
+        print("| --- | ---: | ---: | ---: |")
+        for step_id in step_ids:
+            values = []
+            name = step_id
+            for run in runs:
+                by_id = {str(step.get("id")): step for step in run["metrics"].get("steps", [])}
+                step = by_id.get(step_id)
+                if not step:
+                    continue
+                name = f"{step_id} {step.get('name', '')}".strip()
+                values.append(float(step.get("duration_ms") or 0))
+            if values:
+                print(
+                    f"| {name} | {statistics.median(values):.2f} ms | "
+                    f"{min(values):.2f} ms | {max(values):.2f} ms |"
+                )
+    return exit_code
+
+
+def percent_delta(before: float, after: float) -> float | None:
+    if before == 0:
+        return None
+    return (after - before) / before * 100
+
+
+def speedup(before: float, after: float) -> float | None:
+    if before <= 0 or after <= 0:
+        return None
+    return before / after
+
+
+def format_percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:+.1f}%"
+
+
+def format_speedup(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
+def comparable_steps(left: dict[str, typing.Any], right: dict[str, typing.Any]) -> list[dict[str, typing.Any]]:
+    left_steps = {str(step.get("id")): step for step in left.get("steps", [])}
+    right_steps = {str(step.get("id")): step for step in right.get("steps", [])}
+    ordered_ids = [str(step.get("id")) for step in left.get("steps", [])]
+    ordered_ids.extend(step_id for step_id in right_steps if step_id not in left_steps)
+    rows = []
+    for step_id in ordered_ids:
+        before_step = left_steps.get(step_id)
+        after_step = right_steps.get(step_id)
+        if not before_step or not after_step:
+            rows.append(
+                {
+                    "id": step_id,
+                    "name": (before_step or after_step or {}).get("name", ""),
+                    "operation": (before_step or after_step or {}).get("operation", ""),
+                    "before_ms": None if not before_step else before_step.get("duration_ms"),
+                    "after_ms": None if not after_step else after_step.get("duration_ms"),
+                    "delta_ms": None,
+                    "delta_percent": None,
+                    "speedup": None,
+                    "ok": [before_step.get("ok") if before_step else None, after_step.get("ok") if after_step else None],
+                }
+            )
+            continue
+        before_ms = float(before_step.get("duration_ms") or 0)
+        after_ms = float(after_step.get("duration_ms") or 0)
+        rows.append(
+            {
+                "id": step_id,
+                "name": after_step.get("name") or before_step.get("name") or "",
+                "operation": after_step.get("operation") or before_step.get("operation") or "",
+                "before_ms": before_ms,
+                "after_ms": after_ms,
+                "delta_ms": round(after_ms - before_ms, 2),
+                "delta_percent": percent_delta(before_ms, after_ms),
+                "speedup": speedup(before_ms, after_ms),
+                "ok": [before_step.get("ok"), after_step.get("ok")],
+            }
+        )
+    return rows
+
+
 def compare_runs(args: argparse.Namespace) -> int:
     left = json.loads((Path(args.left) / "metrics.json").read_text(encoding="utf-8"))
     right = json.loads((Path(args.right) / "metrics.json").read_text(encoding="utf-8"))
+    total_before = float(left["timing"]["total_ms"])
+    total_after = float(right["timing"]["total_ms"])
     comparison = {
         "left": str(Path(args.left).resolve()),
         "right": str(Path(args.right).resolve()),
         "ok_changed": [left.get("ok"), right.get("ok")],
-        "total_ms_delta": round(right["timing"]["total_ms"] - left["timing"]["total_ms"], 2),
+        "total_before_ms": total_before,
+        "total_after_ms": total_after,
+        "total_ms_delta": round(total_after - total_before, 2),
+        "total_delta_percent": percent_delta(total_before, total_after),
+        "total_speedup": speedup(total_before, total_after),
         "log_error_count_delta": right["logs"].get("error_count", 0) - left["logs"].get("error_count", 0),
         "step_count_delta": len(right.get("steps", [])) - len(left.get("steps", [])),
+        "steps": comparable_steps(left, right),
     }
     if args.markdown:
         print("| metric | value |")
         print("| --- | --- |")
         for key, value in comparison.items():
+            if key == "steps":
+                continue
+            if key.endswith("_percent"):
+                value = format_percent(value)
+            elif key.endswith("_speedup"):
+                value = format_speedup(value)
             print(f"| {key} | `{value}` |")
+        print("")
+        print("| step | operation | before | after | delta | change | speedup | ok |")
+        print("| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |")
+        for row in comparison["steps"]:
+            before = "n/a" if row["before_ms"] is None else f"{row['before_ms']:.2f} ms"
+            after = "n/a" if row["after_ms"] is None else f"{row['after_ms']:.2f} ms"
+            delta = "n/a" if row["delta_ms"] is None else f"{row['delta_ms']:+.2f} ms"
+            print(
+                "| "
+                f"{row['id']} {row['name']} | "
+                f"{row['operation']} | "
+                f"{before} | "
+                f"{after} | "
+                f"{delta} | "
+                f"{format_percent(row['delta_percent'])} | "
+                f"{format_speedup(row['speedup'])} | "
+                f"{row['ok']} |"
+            )
     else:
         print(json.dumps(comparison, indent=2, sort_keys=True))
     return 0
@@ -666,6 +824,11 @@ def main() -> int:
     baseline = subparsers.add_parser("baseline", help="alias for run, intended for before/after comparisons")
     add_run_args(baseline)
     baseline.set_defaults(func=run_flow)
+
+    repeat = subparsers.add_parser("repeat", help="run a flow sequentially and summarize timing spread")
+    add_run_args(repeat)
+    repeat.add_argument("--count", type=int, default=3)
+    repeat.set_defaults(func=repeat_flow)
 
     compare = subparsers.add_parser("compare", help="compare two harness run directories")
     compare.add_argument("left")


### PR DESCRIPTION
## Summary
- speed up desktop automation bridge responses by replacing fixed sleeps with explicit settleMs, cached state reads, and trace clearing
- speed up common desktop navigation by removing heavyweight page replacement transitions and synchronous render logging from the main content switch
- speed up Ask Omi open/close readiness by shortening panel animation timing and waiting on perceptual open/focus/close state
- add a desktop responsiveness benchmark flow covering dashboard, conversations, chat, memories, tasks, rewind, apps, and settings
- improve the harness with repeat runs, faster polling, collision-safe run dirs, and richer compare output
- fix async Rewind cleanup database calls found during clean desktop builds

## Speedups measured
- Desktop responsiveness loop: 3350.11 ms -> 250.70 ms, 13.36x faster
- Ask Omi open benchmark: 1618.84 ms -> 45.85 ms, 35.31x faster

## Validation
- xcrun swift build -c debug --package-path Desktop
- python3 -m py_compile desktop/macos/scripts/omi-harness
- python3 desktop/macos/scripts/omi-harness repeat desktop/macos/e2e/flows/desktop-responsiveness-benchmark.yaml --port 47888 --count 5
- python3 desktop/macos/scripts/omi-harness repeat desktop/macos/e2e/flows/ask-omi-open-benchmark.yaml --port 47888 --count 3

## Harness artifacts
- desktop/macos/.harness/runs/20260624-034544-desktop-responsiveness-benchmark-2
- desktop/macos/.harness/runs/20260624-034659-ask-omi-open-benchmark-3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

