### PR TITLE
Fix plan usage refresh after checkout

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -65,6 +65,10 @@ final class FloatingBarUsageLimiter: ObservableObject {
     /// Update cached plan directly from an already-fetched subscription (no extra API call).
     func applyPlan(plan: SubscriptionPlanType, status: SubscriptionStatusType) {
         hasPaidPlan = plan != .basic && status == .active
+        if hasPaidPlan, serverQuota?.planType == SubscriptionPlanType.basic.rawValue {
+            serverQuota = nil
+            optimisticDelta = 0
+        }
         UserDefaults.standard.set(plan.rawValue, forKey: Self.cachedPlanKey)
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -7217,6 +7217,7 @@ struct SettingsContentView: View {
     guard !isLoadingSubscription else { return }
     isLoadingSubscription = true
     subscriptionError = nil
+    refreshPlanUsageDetails()
 
     Task {
       do {
@@ -7243,7 +7244,6 @@ struct SettingsContentView: View {
             log("Paywall: cleared sticky flag — subscription \(subscription.subscription.plan.rawValue) is active")
           }
           isLoadingSubscription = false
-          refreshPlanUsageDetails()
         }
       } catch {
         logError("Failed to load subscription", error: error)
@@ -7300,14 +7300,6 @@ struct SettingsContentView: View {
     isLoadingOverage = false
   }
 
-  private func loadChatUsageQuota() {
-    refreshPlanUsageDetails()
-  }
-
-  private func loadOverageInfo() {
-    refreshPlanUsageDetails()
-  }
-
   private func applySuccessfulSubscriptionRefresh(_ subscription: UserSubscriptionResponse) {
     userSubscription = subscription
     subscriptionError = nil
@@ -7328,12 +7320,6 @@ struct SettingsContentView: View {
     }
 
     refreshPlanUsageDetails()
-  }
-
-  private func syncSharedPlanStateAfterSubscriptionMutation() {
-    Task {
-      await FloatingBarUsageLimiter.shared.fetchPlan()
-    }
   }
 
   private func startCheckout(for priceId: String) {
@@ -7498,7 +7484,6 @@ struct SettingsContentView: View {
             await MainActor.run {
               applySuccessfulSubscriptionRefresh(subscription)
             }
-            syncSharedPlanStateAfterSubscriptionMutation()
             return
           }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -231,6 +231,7 @@ struct SettingsContentView: View {
   @State private var isLoadingChatUsage: Bool = false
   @State private var overageInfo: OverageInfoResponse?
   @State private var isLoadingOverage: Bool = false
+  @State private var planUsageDetailsRequestID: Int = 0
   @State private var showOverageExplainer: Bool = false
   @State private var fallbackPlanCatalog: [SubscriptionPlanOption] = []
   @State private var activeCheckoutPriceId: String?
@@ -7242,6 +7243,7 @@ struct SettingsContentView: View {
             log("Paywall: cleared sticky flag — subscription \(subscription.subscription.plan.rawValue) is active")
           }
           isLoadingSubscription = false
+          refreshPlanUsageDetails()
         }
       } catch {
         logError("Failed to load subscription", error: error)
@@ -7251,38 +7253,86 @@ struct SettingsContentView: View {
         }
       }
     }
-    loadChatUsageQuota()
-    loadOverageInfo()
   }
 
-  private func loadChatUsageQuota() {
-    guard !isLoadingChatUsage else { return }
+  private func refreshPlanUsageDetails() {
+    planUsageDetailsRequestID += 1
+    let requestID = planUsageDetailsRequestID
     isLoadingChatUsage = true
+    isLoadingOverage = true
+    chatUsageQuota = nil
+    overageInfo = nil
+
     Task {
-      let quota = await APIClient.shared.fetchChatUsageQuota()
-      await MainActor.run {
-        chatUsageQuota = quota
-        isLoadingChatUsage = false
-      }
+      async let quota = APIClient.shared.fetchChatUsageQuota()
+      async let overageInfo = fetchOverageInfoForPlanUsage()
+      let (quotaValue, overageInfoValue) = await (quota, overageInfo)
+      applyPlanUsageDetails(
+        requestID: requestID,
+        quota: quotaValue,
+        overageInfo: overageInfoValue
+      )
     }
   }
 
+  private func fetchOverageInfoForPlanUsage() async -> OverageInfoResponse? {
+    do {
+      return try await APIClient.shared.getOverageInfo()
+    } catch {
+      logError("Failed to load overage info", error: error)
+      return nil
+    }
+  }
+
+  @MainActor
+  private func applyPlanUsageDetails(
+    requestID: Int,
+    quota: APIClient.ChatUsageQuota?,
+    overageInfo: OverageInfoResponse?
+  ) {
+    guard requestID == planUsageDetailsRequestID else { return }
+    chatUsageQuota = quota
+    if let quota {
+      FloatingBarUsageLimiter.shared.applyQuota(quota)
+    }
+    self.overageInfo = overageInfo
+    isLoadingChatUsage = false
+    isLoadingOverage = false
+  }
+
+  private func loadChatUsageQuota() {
+    refreshPlanUsageDetails()
+  }
+
   private func loadOverageInfo() {
-    guard !isLoadingOverage else { return }
-    isLoadingOverage = true
+    refreshPlanUsageDetails()
+  }
+
+  private func applySuccessfulSubscriptionRefresh(_ subscription: UserSubscriptionResponse) {
+    userSubscription = subscription
+    subscriptionError = nil
+    pendingSubscriptionPriceId = nil
+    pendingCheckoutSessionId = nil
+    selectedPlanIdForCheckout = nil
+
+    FloatingBarUsageLimiter.shared.applyPlan(
+      plan: subscription.subscription.plan,
+      status: subscription.subscription.status
+    )
+
+    if subscription.subscription.plan != .basic,
+       subscription.subscription.status == .active,
+       AppState.current?.isPaywalled == true {
+      AppState.current?.isPaywalled = false
+      log("Paywall: cleared sticky flag — subscription \(subscription.subscription.plan.rawValue) is active")
+    }
+
+    refreshPlanUsageDetails()
+  }
+
+  private func syncSharedPlanStateAfterSubscriptionMutation() {
     Task {
-      do {
-        let info = try await APIClient.shared.getOverageInfo()
-        await MainActor.run {
-          overageInfo = info
-          isLoadingOverage = false
-        }
-      } catch {
-        logError("Failed to load overage info", error: error)
-        await MainActor.run {
-          isLoadingOverage = false
-        }
-      }
+      await FloatingBarUsageLimiter.shared.fetchPlan()
     }
   }
 
@@ -7445,13 +7495,10 @@ struct SettingsContentView: View {
             subscription.subscription.plan != .basic && subscription.subscription.status == .active
 
           if matchedPrice && hasPaidPlan {
-            await FloatingBarUsageLimiter.shared.fetchPlan()
             await MainActor.run {
-              userSubscription = subscription
-              subscriptionError = nil
-              pendingSubscriptionPriceId = nil
-              pendingCheckoutSessionId = nil
+              applySuccessfulSubscriptionRefresh(subscription)
             }
+            syncSharedPlanStateAfterSubscriptionMutation()
             return
           }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarUsageLimiterTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarUsageLimiterTests.swift
@@ -162,6 +162,20 @@ final class FloatingBarUsageLimiterTests: XCTestCase {
     XCTAssertTrue(limiter.hasPaidPlan)
   }
 
+  func testApplyPaidPlanClearsStaleFreeQuota() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: false)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+
+    limiter.applyPlan(plan: .operator, status: .active)
+
+    XCTAssertTrue(limiter.hasPaidPlan)
+    XCTAssertNil(limiter.serverQuota)
+    XCTAssertEqual(limiter.optimisticDelta, 0)
+    XCTAssertFalse(limiter.isLimitReached)
+  }
+
   func testApplyPlanInactiveIsNotPaid() {
     let limiter = FloatingBarUsageLimiter()
     limiter.applyPlan(plan: .operator, status: .inactive)


### PR DESCRIPTION
## Summary
- Refresh Settings > Plan and Usage quota and overage state after checkout poll observes the paid subscription
- Supersede older quota/overage requests so stale Free-plan responses cannot repaint the bottom usage card
- Clear stale Free quota from the shared usage limiter immediately when a paid plan becomes active

## Root cause
Checkout completion updated the page's subscription state and shared limiter, but the bottom Usage this month card reads a separate chatUsageQuota @State value. That state was not refreshed on the checkout success path, so it stayed on the old Free quota until navigating away and back triggered a full reload. Overage state used the same split refresh path.

## Verification
- git diff --check
- xcrun swift test --package-path Desktop --filter FloatingBarUsageLimiterTests (blocked by unrelated existing Desktop compile errors in RewindDatabase.swift: dbQueue.read/write calls require await)

A read-only sub-agent also inspected the billing/settings state flow and found the same stale quota and stale overage paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

