### PR TITLE
fix(backend): guard None persona in add_twitter_to_persona

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -193,6 +193,7 @@ pytest tests/unit/test_trial_metadata.py -v
 pytest tests/unit/test_neo_desktop_grandfather.py -v
 pytest tests/unit/test_vertex_ai_system_role.py -v
 pytest tests/unit/test_tts.py -v
+pytest tests/unit/test_add_twitter_to_persona_none.py -v
 pytest tests/unit/test_webhook_auto_disable.py -v
 pytest tests/unit/test_merge_validation.py -v
 pytest tests/unit/test_phone_calls.py -v

--- a/backend/tests/unit/test_add_twitter_to_persona_none.py
+++ b/backend/tests/unit/test_add_twitter_to_persona_none.py
@@ -1,0 +1,153 @@
+"""add_twitter_to_persona must not 500 with TypeError when the persona lookup returns None.
+
+utils/social.py has a heavy import graph (utils.llm.persona, utils.conversations.memories,
+database.apps, database.redis_db, ulid, ...), so we import it under a meta-path stub finder
+that auto-mocks those namespaces (keeping fastapi/pydantic/httpx real). utils.social itself is
+explicitly NOT stubbed so the real function under test loads, while its collaborators are mocked.
+
+Without the fix, `persona = get_persona_by_id_db(persona_id)` is None and the line
+`if 'twitter' not in persona['connected_accounts']:` raises
+`TypeError: 'NoneType' object is not subscriptable` (-> unhandled 500). With the guard the
+function raises a clean HTTPException(404) before subscripting.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# The module under test is utils.social itself, so the real `utils` package (empty __init__)
+# and utils.social must load. Only the heavy utils submodules that social.py imports
+# (utils.llm.persona, utils.conversations.memories) and the external/database deps get stubbed.
+_STUB = (
+    'database',
+    'utils.llm',
+    'utils.conversations',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+sys.meta_path.insert(0, _finder)
+try:
+    from utils import social as social_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+
+
+def _run_add_twitter(persona_value):
+    """Drive add_twitter_to_persona with get_persona_by_id_db returning ``persona_value``.
+
+    get_twitter_profile is stubbed (AsyncMock) so the unfixed code path reaches the
+    persona['connected_accounts'] subscript (and raises TypeError on None) instead of making a
+    real network call; the rest of the collaborators are mocked so only the None-guard is tested.
+    """
+    fake_profile = MagicMock()
+    fake_profile.profile = 'somehandle'
+    fake_profile.avatar = 'http://img/avatar.png'
+
+    fake_timeline = MagicMock()
+    fake_timeline.timeline = []
+
+    with patch.object(social_mod, 'get_persona_by_id_db', MagicMock(return_value=persona_value)), patch.object(
+        social_mod, 'get_twitter_profile', AsyncMock(return_value=fake_profile)
+    ), patch.object(social_mod, 'get_twitter_timeline', AsyncMock(return_value=fake_timeline)), patch.object(
+        social_mod, 'update_app_in_db', MagicMock()
+    ), patch.object(
+        social_mod, 'delete_generic_cache', MagicMock()
+    ), patch.object(
+        social_mod, 'create_memories_from_twitter_tweets', MagicMock()
+    ):
+        return asyncio.run(social_mod.add_twitter_to_persona('somehandle', 'persona-id'))
+
+
+def test_add_twitter_to_persona_missing_raises_404():
+    """Persona lookup returning None must raise HTTPException(404), not TypeError (the bug)."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        _run_add_twitter(None)
+    assert exc.value.status_code == 404
+
+
+def test_add_twitter_to_persona_existing_succeeds():
+    """When the persona exists, it is updated and returned (no regression)."""
+    persona = {'id': 'persona-id', 'uid': 'uid1', 'connected_accounts': ['omi']}
+    result = _run_add_twitter(persona)
+    assert isinstance(result, dict)
+    assert result['id'] == 'persona-id'
+    assert 'twitter' in result['connected_accounts']
+    assert result['twitter']['username'] == 'somehandle'

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime, timezone
 from typing import Dict, Any, Callable, TypeVar, List, Optional, Tuple
 
+from fastapi import HTTPException
 from pydantic import BaseModel
 from ulid import ULID
 
@@ -236,6 +237,9 @@ def _create_or_update_persona(profile: TwitterProfile, username: str, uid: str, 
 async def add_twitter_to_persona(handle: str, persona_id) -> Dict[str, Any]:
     """Add Twitter account to an existing persona"""
     persona = get_persona_by_id_db(persona_id)
+    if not persona:
+        raise HTTPException(status_code=404, detail='Persona not found')
+
     profile = await get_twitter_profile(handle)
 
     if 'twitter' not in persona['connected_accounts']:


### PR DESCRIPTION
## Summary

`add_twitter_to_persona` in `backend/utils/social.py` looks up a persona by id and then immediately reads `persona['connected_accounts']`. When the id does not resolve to a persona, the lookup returns `None` and the subscript raises `TypeError: 'NoneType' object is not subscriptable`, which surfaces as an unhandled HTTP 500. This adds a None check that raises a clean 404 before the function touches the persona, so a bad or stale persona id returns "Persona not found" instead of crashing the request. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/social.py`, `add_twitter_to_persona` uses the lookup result without checking it:

```python
async def add_twitter_to_persona(handle: str, persona_id) -> Dict[str, Any]:
    """Add Twitter account to an existing persona"""
    persona = get_persona_by_id_db(persona_id)
    profile = await get_twitter_profile(handle)

    if 'twitter' not in persona['connected_accounts']:
        persona['connected_accounts'].append('twitter')
```

`get_persona_by_id_db` returns `None` when no document matches the id (deleted persona, wrong id, or a caller passing an id that was never valid). The next use of `persona` is `persona['connected_accounts']`, and indexing `None` raises `TypeError`. Nothing in the call path catches it, so the request returns a 500.

## Fix

Guard the lookup result right after the call and raise a 404 when it is empty:

```python
    persona = get_persona_by_id_db(persona_id)
    if not persona:
        raise HTTPException(status_code=404, detail='Persona not found')

    profile = await get_twitter_profile(handle)
```

This also adds `from fastapi import HTTPException` at the top of the module. For a valid persona id the lookup returns a dict, `not persona` is False, and the function proceeds exactly as before, so there is no change to behavior for valid input.

## Testing

Added `backend/tests/unit/test_add_twitter_to_persona_none.py`, registered in `backend/test.sh`. `utils/social.py` has a heavy import graph (`utils.llm.persona`, `utils.conversations.memories`, `database.apps`, `database.redis_db`, `ulid`, and others), so the test imports it under a meta-path stub finder that auto-mocks those namespaces while keeping `fastapi`, `pydantic`, and `httpx` real, and it leaves `utils.social` itself unstubbed so the real function loads. It then patches `get_persona_by_id_db` and the Twitter collaborators on the module and calls `add_twitter_to_persona` directly. Two cases are covered: a persona lookup returning `None` raises `HTTPException(404)` (the bug, which would otherwise raise `TypeError`), and an existing persona is updated and returned with `twitter` added to `connected_accounts` (no regression). Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The None guard added here does not appear anywhere in the history of `backend/utils/social.py`, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

