### PR TITLE
fix(backend): build chat metadata entities from result.entities

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -13,6 +13,7 @@ pytest tests/unit/test_text_containment.py -v
 pytest tests/unit/test_speaker_sample.py -v
 pytest tests/unit/test_speaker_sample_migration.py -v
 pytest tests/unit/test_short_audio_embedding.py -v
+pytest tests/unit/test_chat_metadata_entities_source.py -v
 pytest tests/unit/test_users_add_sample_transaction.py -v
 pytest tests/unit/test_users_webhook_url_validation.py -v
 pytest tests/unit/test_voice_message_language.py -v

--- a/backend/tests/unit/test_chat_metadata_entities_source.py
+++ b/backend/tests/unit/test_chat_metadata_entities_source.py
@@ -1,0 +1,138 @@
+"""
+Regression test for retrieve_metadata_fields_from_transcript in utils/llm/chat.py.
+
+Bug: the 'entities' list was built from result.topics instead of result.entities,
+so the returned entities mirrored the topics and the real entities were dropped.
+This drives the function with a fake LLM result whose .topics and .entities are
+distinct and asserts the returned 'entities' come from result.entities.
+
+Red (without the fix): metadata['entities'] equals the topics.
+Green (with the fix): metadata['entities'] equals the entities.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Stub heavy packages so importing utils.llm.chat does not require external services.
+# pydantic / fastapi are intentionally NOT stubbed (chat.py defines a real pydantic model).
+_STUB = (
+    'database',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'langchain_openai',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'httpx',
+    'cachetools',
+    'tiktoken',
+    'utils.llms',
+    'utils.llm.clients',
+    'utils.llm.usage_tracker',
+)
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils.llm import chat as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+class _FakeResult:
+    """Stand-in for the ExtractedInformation returned by the structured LLM call."""
+
+    def __init__(self):
+        self.people = ['Alice']
+        self.topics = ['machinelearning']  # already normalized-friendly, no special chars
+        self.entities = ['openai']  # distinct from topics on purpose
+        self.dates = []
+
+
+def _drive():
+    fake_result = _FakeResult()
+
+    fake_llm = MagicMock()
+    fake_llm.with_structured_output.return_value.invoke.return_value = fake_result
+
+    @contextmanager
+    def _noop_ctx(*args, **kwargs):
+        yield MagicMock()
+
+    with patch.object(mod, 'get_llm', return_value=fake_llm), patch.object(mod, 'track_usage', _noop_ctx), patch.object(
+        mod, 'add_filter_category_item'
+    ):
+        metadata = mod.retrieve_metadata_fields_from_transcript(
+            uid='test_uid',
+            created_at=__import__('datetime').datetime(2025, 6, 1, tzinfo=__import__('datetime').timezone.utc),
+            transcript_segment=[{'text': 'hello world'}],
+            tz='UTC',
+        )
+    return metadata
+
+
+def test_entities_come_from_result_entities_not_topics():
+    metadata = _drive()
+    # With the bug, entities mirror topics -> ['machinelearning'].
+    # With the fix, entities come from result.entities -> ['openai'].
+    assert metadata['entities'] == ['openai'], f"entities should come from result.entities, got {metadata['entities']}"
+    # And entities must NOT equal the topics list (the symptom of the bug).
+    assert metadata['entities'] != metadata['topics'], "entities should not mirror topics"
+    # Sanity: topics still come from result.topics.
+    assert metadata['topics'] == ['machinelearning']

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1111,7 +1111,7 @@ def retrieve_metadata_fields_from_transcript(
     metadata = {
         'people': [normalize_filter(p) for p in result.people],
         'topics': [normalize_filter(t) for t in result.topics],
-        'entities': [normalize_filter(e) for e in result.topics],
+        'entities': [normalize_filter(e) for e in result.entities],
         'dates': [],
     }
     # 'dates': [date.strftime('%Y-%m-%d') for date in result.dates],


### PR DESCRIPTION
## Summary

`retrieve_metadata_fields_from_transcript` in `backend/utils/llm/chat.py` extracts people, topics, entities, and dates from a conversation transcript and stores them as Firestore filter categories used for later search and retrieval. The entities list is built by iterating `result.topics` instead of `result.entities`, so the returned `entities` are just a copy of the topics and the real extracted entities (products, technologies, places) are dropped on the floor. The handler does not crash; it returns and persists wrong data. This PR builds the entities list from `result.entities`.

## Root cause

In `retrieve_metadata_fields_from_transcript`, the structured LLM call returns an `ExtractedInformation` model with separate `topics` and `entities` fields. The model defines them as distinct things:

```python
topics: List[str] = Field(
    default=[],
    examples=[['Artificial Intelligence', 'Machine Learning']],
    description='List all the main topics and subtopics that were discussed.',
)
entities: List[str] = Field(
    default=[],
    examples=[['OpenAI', 'GPT-4']],
    description='List any products, technologies, places, or other entities that are relevant to the conversation.',
)
```

The metadata dict is then built like this on `main`:

```python
metadata = {
    'people': [normalize_filter(p) for p in result.people],
    'topics': [normalize_filter(t) for t in result.topics],
    'entities': [normalize_filter(e) for e in result.topics],
    'dates': [],
}
```

The `entities` value iterates `result.topics`, a copy-paste of the line above it, so `result.entities` is never read. Both `topics` and `entities` end up holding the topics, and the model's actual entities are discarded. The function then calls `add_filter_category_item(uid, 'entities', e)` for each of those values, so the per-user `entities` filter category gets populated with topic strings. There is no exception; the data is just wrong, and any entity-based filtering or retrieval downstream is built on duplicated topics.

## Fix

Read the entities list from `result.entities`:

```python
metadata = {
    'people': [normalize_filter(p) for p in result.people],
    'topics': [normalize_filter(t) for t in result.topics],
    'entities': [normalize_filter(e) for e in result.entities],
    'dates': [],
}
```

This is a one-line change. People, topics, and dates are untouched, and the normalization, date parsing, and `add_filter_category_item` calls all behave the same as before for any case where topics and entities happen to match.

## Testing

Added `backend/tests/unit/test_chat_metadata_entities_source.py`, registered in `backend/test.sh`. `chat.py` has a heavy import graph, so the test imports `utils.llm.chat` under a stub meta-path finder that fakes the external packages (database, firebase, pinecone, redis, langchain, openai, and so on) while leaving pydantic and fastapi real, since the module defines a real pydantic model. It then patches `get_llm`, `track_usage`, and `add_filter_category_item` and calls `retrieve_metadata_fields_from_transcript` directly with a fake LLM result whose `.topics` (`['machinelearning']`) and `.entities` (`['openai']`) are deliberately different. The test asserts the returned `entities` come from `result.entities`, that `entities` does not mirror `topics`, and that `topics` still come from `result.topics`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The entities line has only ever existed in its buggy `result.topics` form since the file was created (it predates the split of `llm.py` into separate modules), so the `result.entities` form does not appear anywhere in this file's history and this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

