### PR TITLE
fix(backend): normalize naive last_checked_at in get_general_announcements

### DIFF
--- a/backend/database/announcements.py
+++ b/backend/database/announcements.py
@@ -126,6 +126,11 @@ def get_general_announcements(last_checked_at: Optional[datetime] = None) -> Lis
     If last_checked_at is provided, only returns announcements created after that time.
     """
     now = datetime.now(timezone.utc)
+    # A client-supplied last_checked_at may be tz-naive (ISO string without an
+    # offset); Firestore created_at is always tz-aware. Coerce to UTC so the
+    # comparison below cannot raise TypeError.
+    if last_checked_at is not None and last_checked_at.tzinfo is None:
+        last_checked_at = last_checked_at.replace(tzinfo=timezone.utc)
     announcements_ref = db.collection("announcements")
     query = announcements_ref.where(filter=FieldFilter("type", "==", AnnouncementType.ANNOUNCEMENT.value)).where(
         filter=FieldFilter("active", "==", True)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -181,6 +181,7 @@ pytest tests/unit/test_async_app_integrations.py -v
 pytest tests/unit/test_async_realtime_integrations_offload.py -v
 pytest tests/unit/test_async_geocoding.py -v
 pytest tests/unit/test_geocoding_cache.py -v
+pytest tests/unit/test_announcements_naive_datetime.py -v
 pytest tests/unit/test_realtime_integrations_usage_tracking.py -v
 pytest tests/unit/test_async_auth.py -v
 pytest tests/unit/test_thread_join_elimination.py -v

--- a/backend/tests/unit/test_announcements_naive_datetime.py
+++ b/backend/tests/unit/test_announcements_naive_datetime.py
@@ -1,0 +1,144 @@
+"""get_general_announcements must not 500 on a tz-naive last_checked_at.
+
+GET /v1/announcements/general parses last_checked_at via
+datetime.fromisoformat(last_checked_at.replace("Z", "+00:00")). When the client
+sends an ISO string with no offset (e.g. "2026-01-01T00:00:00"), fromisoformat
+returns a tz-NAIVE datetime. database.announcements.get_general_announcements
+then compares it against the tz-AWARE Firestore created_at
+(`announcement.created_at <= last_checked_at`), raising
+"TypeError: can't compare offset-naive and offset-aware datetimes" -> 500.
+
+The fix normalizes a naive last_checked_at to UTC before the comparison.
+
+Red (without the fix): TypeError. Green (with the fix): the older announcement
+is filtered out, the newer one is returned, no exception.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Stub only the heavy externals. Keep `database`, `models`, `pydantic` REAL so we
+# exercise the real get_general_announcements and build a real Announcement.
+_STUB = ('google', 'firebase_admin', 'redis')
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from database import announcements as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+class _Doc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+def _wire_docs(docs):
+    """Make mod.db.collection(...).where(...).where(...).stream() return docs."""
+    stream_obj = MagicMock()
+    stream_obj.stream.return_value = list(docs)
+    # query chain: collection().where().where() -> stream_obj
+    chain = MagicMock()
+    chain.where.return_value = stream_obj
+    collection = MagicMock()
+    collection.where.return_value = chain
+    mod.db.collection.return_value = collection
+
+
+def test_naive_last_checked_at_does_not_raise():
+    # Firestore created_at is tz-AWARE.
+    newer = _Doc(
+        {
+            'id': 'new',
+            'type': 'announcement',
+            'created_at': datetime(2026, 6, 1, tzinfo=timezone.utc),
+            'active': True,
+        }
+    )
+    older = _Doc(
+        {
+            'id': 'old',
+            'type': 'announcement',
+            'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
+            'active': True,
+        }
+    )
+    _wire_docs([newer, older])
+
+    # Client-supplied last_checked_at with NO offset -> tz-NAIVE (this is what
+    # datetime.fromisoformat("2026-03-01T00:00:00") returns in the router).
+    naive_last_checked = datetime(2026, 3, 1)
+    assert naive_last_checked.tzinfo is None
+
+    # Without the fix this raises TypeError (naive vs aware comparison).
+    result = mod.get_general_announcements(naive_last_checked)
+
+    # With the fix: only the announcement created AFTER last_checked_at is returned.
+    ids = [a.id for a in result]
+    assert ids == ['new']
+
+
+def test_naive_returns_all_when_before_everything():
+    older = _Doc(
+        {
+            'id': 'a',
+            'type': 'announcement',
+            'created_at': datetime(2026, 6, 1, tzinfo=timezone.utc),
+            'active': True,
+        }
+    )
+    _wire_docs([older])
+
+    naive_last_checked = datetime(2025, 1, 1)  # naive, before everything
+    assert naive_last_checked.tzinfo is None
+
+    result = mod.get_general_announcements(naive_last_checked)
+    assert [a.id for a in result] == ['a']


### PR DESCRIPTION
## Summary

`GET /v1/announcements/general` accepts a `last_checked_at` query value and returns only announcements created after it. The router parses that value with `datetime.fromisoformat(...)`, which yields a tz-naive datetime when the client sends an ISO string with no UTC offset (for example `2026-01-01T00:00:00`). `get_general_announcements` then compares that naive value against the tz-aware Firestore `created_at`, which raises `TypeError: can't compare offset-naive and offset-aware datetimes` and turns the whole endpoint into a 500. This PR normalizes a naive `last_checked_at` to UTC before the comparison so the filter works instead of crashing. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/database/announcements.py`, `get_general_announcements` compares the caller-supplied `last_checked_at` directly against each record's `created_at`:

```python
now = datetime.now(timezone.utc)
announcements_ref = db.collection("announcements")
query = announcements_ref.where(filter=FieldFilter("type", "==", AnnouncementType.ANNOUNCEMENT.value)).where(
    filter=FieldFilter("active", "==", True)
)

docs = query.stream()
announcements = []

for doc in docs:
    data = doc.to_dict()
    announcement = Announcement.from_dict(data)

    # Skip if created before last check
    if last_checked_at and announcement.created_at <= last_checked_at:
        continue
```

`announcement.created_at` comes from Firestore and is always tz-aware (UTC). `last_checked_at` comes from the client through `datetime.fromisoformat(...)`, which returns a tz-naive datetime whenever the string has no offset. Comparing a naive datetime to an aware one with `<=` raises `TypeError`, which is unhandled and surfaces as a 500 for the request. The caller controls whether the input is naive, so any client sending an offsetless timestamp takes the endpoint down.

## Fix

Coerce a naive `last_checked_at` to UTC once, before the loop, so the comparison always runs between two aware datetimes:

```python
now = datetime.now(timezone.utc)
# A client-supplied last_checked_at may be tz-naive (ISO string without an
# offset); Firestore created_at is always tz-aware. Coerce to UTC so the
# comparison below cannot raise TypeError.
if last_checked_at is not None and last_checked_at.tzinfo is None:
    last_checked_at = last_checked_at.replace(tzinfo=timezone.utc)
```

An already-aware `last_checked_at` is left untouched, so valid input behaves exactly as before. The treatment of a naive value as UTC matches what the rest of the codebase assumes for these timestamps.

## Testing

Added `backend/tests/unit/test_announcements_naive_datetime.py`, registered in `backend/test.sh`. The module keeps `database`, `models`, and `pydantic` real and stubs only the heavy externals (`google`, `firebase_admin`, `redis`) under a meta-path finder, then imports `database.announcements` and calls `get_general_announcements` directly. The Firestore query chain is wired through a mock so `collection(...).where(...).where(...).stream()` returns hand-built docs with tz-aware `created_at`. One case passes a naive `last_checked_at` between the two records and asserts only the newer one comes back, with no exception; a second passes a naive timestamp earlier than every record and asserts all of them are returned. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The normalization added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

