### PR TITLE
fix(backend): derive calendar meeting doc id from natural key to prevent duplicate TOCTOU

### DIFF
--- a/backend/database/calendar_meetings.py
+++ b/backend/database/calendar_meetings.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from google.cloud import firestore
 
-from ._client import db
+from ._client import db, document_id_from_seed
 
 
 def _get_meetings_collection(uid: str):
@@ -19,13 +19,28 @@ def create_meeting(uid: str, meeting_data: Dict) -> str:
     NOTE: Times should already be in UTC before calling this function.
     """
     # Add timestamps (always in UTC for consistent querying)
-    from datetime import timezone
-
     now = datetime.now(timezone.utc)
-    meeting_data['created_at'] = now
     meeting_data['synced_at'] = now
 
-    # Create document
+    event_id = meeting_data.get('calendar_event_id')
+    source = meeting_data.get('calendar_source')
+    if event_id and source:
+        # Derive a deterministic document id from the natural key so concurrent
+        # creates for the same calendar event collide on one document (last write
+        # wins) instead of producing duplicate docs (TOCTOU on the router's
+        # get_meeting_id_by_calendar_event check-then-create).
+        doc_id = document_id_from_seed(f'{uid}:{source}:{event_id}')
+        doc_ref = _get_meetings_collection(uid).document(doc_id)
+        # Only set created_at when the doc doesn't already exist so a racing
+        # write doesn't reset it; merge=True makes concurrent creates idempotent.
+        snapshot = doc_ref.get()
+        if not snapshot.exists:
+            meeting_data['created_at'] = now
+        doc_ref.set(meeting_data, merge=True)
+        return doc_ref.id
+
+    # Fallback: no natural key -> preserve old random-id behavior.
+    meeting_data['created_at'] = now
     doc_ref = _get_meetings_collection(uid).document()
     doc_ref.set(meeting_data)
 

--- a/backend/database/calendar_meetings.py
+++ b/backend/database/calendar_meetings.py
@@ -22,9 +22,13 @@ def _create_meeting_transaction(transaction, doc_ref, meeting_data: Dict, now: d
     once and a racing write can never reset it.
     """
     snapshot = doc_ref.get(transaction=transaction)
+    # Build a fresh payload per attempt and never mutate the caller's dict: a Firestore transaction can
+    # retry, and a leaked created_at from a prior attempt would overwrite an existing doc's original
+    # timestamp. created_at is included only when the doc does not exist at read time.
+    payload = dict(meeting_data)
     if not snapshot.exists:
-        meeting_data['created_at'] = now
-    transaction.set(doc_ref, meeting_data, merge=True)
+        payload['created_at'] = now
+    transaction.set(doc_ref, payload, merge=True)
 
 
 def create_meeting(uid: str, meeting_data: Dict) -> str:

--- a/backend/database/calendar_meetings.py
+++ b/backend/database/calendar_meetings.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from google.cloud import firestore
+from google.cloud.firestore_v1 import transactional
 
 from ._client import db, document_id_from_seed
 
@@ -9,6 +10,21 @@ from ._client import db, document_id_from_seed
 def _get_meetings_collection(uid: str):
     """Get user's meetings collection reference"""
     return db.collection('users').document(uid).collection('meetings')
+
+
+@transactional
+def _create_meeting_transaction(transaction, doc_ref, meeting_data: Dict, now: datetime) -> None:
+    """Atomically upsert a meeting, stamping created_at only on first creation.
+
+    Running the existence check and the write inside one Firestore transaction
+    closes the TOCTOU window: concurrent creates for the same natural key are
+    serialized (Firestore retries on contention), so created_at is set exactly
+    once and a racing write can never reset it.
+    """
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        meeting_data['created_at'] = now
+    transaction.set(doc_ref, meeting_data, merge=True)
 
 
 def create_meeting(uid: str, meeting_data: Dict) -> str:
@@ -31,12 +47,10 @@ def create_meeting(uid: str, meeting_data: Dict) -> str:
         # get_meeting_id_by_calendar_event check-then-create).
         doc_id = document_id_from_seed(f'{uid}:{source}:{event_id}')
         doc_ref = _get_meetings_collection(uid).document(doc_id)
-        # Only set created_at when the doc doesn't already exist so a racing
-        # write doesn't reset it; merge=True makes concurrent creates idempotent.
-        snapshot = doc_ref.get()
-        if not snapshot.exists:
-            meeting_data['created_at'] = now
-        doc_ref.set(meeting_data, merge=True)
+        # Stamp created_at only when the doc doesn't already exist, and do the
+        # existence check + write atomically in a transaction so a racing create
+        # can't reset created_at; merge=True keeps concurrent creates idempotent.
+        _create_meeting_transaction(db.transaction(), doc_ref, meeting_data, now)
         return doc_ref.id
 
     # Fallback: no natural key -> preserve old random-id behavior.

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -109,6 +109,7 @@ pytest tests/unit/test_ws_auth_handshake.py -v
 pytest tests/unit/test_streaming_deepgram_backoff.py -v
 pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
+pytest tests/unit/test_calendar_meeting_duplicate_toctou.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
 pytest tests/unit/test_conversation_structure_timezone.py -v

--- a/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
+++ b/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
@@ -1,0 +1,187 @@
+"""calendar_meetings.create_meeting must be idempotent for the same calendar event.
+
+The router (routers/calendar_meetings.py::store_calendar_meeting) does a check-then-create:
+it calls get_meeting_id_by_calendar_event() and only create_meeting() if nothing was found.
+Under concurrency two same-event POSTs both pass that check and each called
+_get_meetings_collection(uid).document() -> a RANDOM Firestore id, producing duplicate
+meeting docs (TOCTOU).
+
+The fix derives the document id deterministically from the natural key
+(uid:calendar_source:calendar_event_id via document_id_from_seed), so concurrent creates
+converge on a single document. It also only sets created_at when the doc does not already
+exist, so a racing write does not reset it.
+
+database/calendar_meetings.py imports google.cloud.firestore + database._client at module top,
+so we import it under a meta-path stub finder and then inject a real deterministic
+document_id_from_seed plus a fake meetings collection.
+"""
+
+import hashlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+import uuid
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Stub only the heavy dependencies of database/calendar_meetings.py — NOT the
+# database package or calendar_meetings itself, so the real module loads from disk.
+_STUB = ('database._client', 'utils', 'firebase_admin', 'google', 'sentry_sdk')
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from database import calendar_meetings as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+def _real_document_id_from_seed(seed: str) -> str:
+    """The real implementation from database/_client.py: deterministic id from a seed."""
+    seed_hash = hashlib.sha256(seed.encode('utf-8')).digest()
+    return str(uuid.UUID(bytes=seed_hash[:16], version=4))
+
+
+class _FakeDoc:
+    """A fake Firestore document reference that records writes for a fixed id."""
+
+    def __init__(self, doc_id):
+        self.id = doc_id
+        self.set_calls = []  # list of (data_copy, merge)
+        self._exists = False  # first creator sees a non-existent doc
+
+    def get(self):
+        snap = MagicMock()
+        snap.exists = self._exists
+        return snap
+
+    def set(self, data, merge=False):
+        # Record a shallow copy so later mutations don't rewrite history.
+        self.set_calls.append((dict(data), merge))
+        self._exists = True  # after the first write, the doc exists
+
+
+class _FakeCollection:
+    """Returns the SAME _FakeDoc for the same id (mirrors Firestore document(id) semantics),
+    and a fresh random-id _FakeDoc when document() is called with no id."""
+
+    def __init__(self):
+        self.docs_by_id = {}
+        self.auto_docs = []
+
+    def document(self, doc_id=None):
+        if doc_id is None:
+            d = _FakeDoc(str(uuid.uuid4()))
+            self.auto_docs.append(d)
+            return d
+        if doc_id not in self.docs_by_id:
+            self.docs_by_id[doc_id] = _FakeDoc(doc_id)
+        return self.docs_by_id[doc_id]
+
+
+_MEETING = {
+    'calendar_event_id': 'evt-123',
+    'calendar_source': 'google_calendar',
+    'title': 'Standup',
+}
+
+
+# `create=True` so the patch also succeeds against the PRE-FIX module (which never
+# imports document_id_from_seed); then the RED comes from the actual duplicate-doc
+# BEHAVIOR (random ids -> two distinct docs), not merely from a missing attribute.
+_PATCH_SEED = dict(create=True, side_effect=_real_document_id_from_seed)
+
+
+def test_concurrent_same_event_creates_converge_to_one_doc():
+    """Two creates with identical calendar_event_id/source must land on ONE document
+    (deterministic id), not two distinct random-id docs (the TOCTOU duplicate)."""
+    coll = _FakeCollection()
+    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
+        mod, 'document_id_from_seed', **_PATCH_SEED
+    ):
+        id1 = mod.create_meeting('u1', dict(_MEETING))
+        id2 = mod.create_meeting('u1', dict(_MEETING))
+
+    # Same deterministic id both times.
+    assert id1 == id2
+    # Exactly one underlying document was ever materialized.
+    all_docs = list(coll.docs_by_id.values()) + coll.auto_docs
+    distinct_ids = {d.id for d in all_docs}
+    assert len(distinct_ids) == 1, f"expected one converged doc, got distinct ids {distinct_ids}"
+    # No random-id (auto) docs were created — the create path used a seeded id.
+    assert coll.auto_docs == [], "create path used a random .document() id instead of a deterministic one"
+
+
+def test_deterministic_id_matches_natural_key_seed():
+    """The id must be derived from uid:source:calendar_event_id (not random)."""
+    coll = _FakeCollection()
+    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
+        mod, 'document_id_from_seed', **_PATCH_SEED
+    ):
+        got = mod.create_meeting('u1', dict(_MEETING))
+
+    expected = _real_document_id_from_seed('u1:google_calendar:evt-123')
+    assert got == expected, f"id {got} is not derived from the natural-key seed (expected {expected})"
+
+
+def test_created_at_not_overwritten_on_second_create():
+    """The second (racing) create must NOT reset created_at, since the doc already exists."""
+    coll = _FakeCollection()
+    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
+        mod, 'document_id_from_seed', **_PATCH_SEED
+    ):
+        mod.create_meeting('u1', dict(_MEETING))
+        mod.create_meeting('u1', dict(_MEETING))
+
+    # Both creates must converge on the same single doc that was written twice.
+    all_docs = list(coll.docs_by_id.values()) + coll.auto_docs
+    converged = [d for d in all_docs if len(d.set_calls) == 2]
+    assert len(converged) == 1, "the two creates did not converge on a single document (duplicate created)"
+    doc = converged[0]
+    first_data, _ = doc.set_calls[0]
+    second_data, second_merge = doc.set_calls[1]
+    # First create stamps created_at; second (racing) create must not include created_at.
+    assert 'created_at' in first_data
+    assert 'created_at' not in second_data, "racing create overwrote created_at"
+    # And the racing write merges into the existing doc.
+    assert second_merge is True

--- a/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
+++ b/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
@@ -135,9 +135,10 @@ def _real_create_meeting_transaction(transaction, doc_ref, meeting_data, now):
     implementation to exercise the read-conditional-set logic.
     """
     snapshot = doc_ref.get(transaction=transaction)
+    payload = dict(meeting_data)
     if not snapshot.exists:
-        meeting_data['created_at'] = now
-    transaction.set(doc_ref, meeting_data, merge=True)
+        payload['created_at'] = now
+    transaction.set(doc_ref, payload, merge=True)
 
 
 class _FakeCollection:
@@ -230,6 +231,23 @@ def test_created_at_not_overwritten_on_second_create():
     assert 'created_at' not in second_data, "racing create overwrote created_at"
     # And the racing write merges into the existing doc.
     assert second_merge is True
+
+
+def test_created_at_not_leaked_across_transaction_retry():
+    """A Firestore transaction can retry, re-running the body with the SAME meeting_data. The helper
+    must build a fresh payload per attempt and never mutate the caller's dict, so a created_at stamped
+    on a first attempt cannot leak onto an existing doc on a retry."""
+    doc = _FakeDoc('m1')
+    txn = _FakeTransaction()
+    meeting_data = dict(_MEETING)
+    # Attempt 1: doc does not exist -> created_at is stamped. Attempt 2 (retry): doc now exists.
+    _real_create_meeting_transaction(txn, doc, meeting_data, 'TS')
+    _real_create_meeting_transaction(txn, doc, meeting_data, 'TS')
+    first_payload, _, _ = doc.set_calls[0]
+    second_payload, _, _ = doc.set_calls[1]
+    assert 'created_at' in first_payload
+    assert 'created_at' not in second_payload, "created_at leaked onto the existing doc on the retry"
+    assert 'created_at' not in meeting_data, "the caller's meeting_data dict was mutated across attempts"
 
 
 def test_created_at_check_and_write_are_transactional():

--- a/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
+++ b/backend/tests/unit/test_calendar_meeting_duplicate_toctou.py
@@ -8,14 +8,23 @@ meeting docs (TOCTOU).
 
 The fix derives the document id deterministically from the natural key
 (uid:calendar_source:calendar_event_id via document_id_from_seed), so concurrent creates
-converge on a single document. It also only sets created_at when the doc does not already
-exist, so a racing write does not reset it.
+converge on a single document. The existence check + write run inside a Firestore
+transaction (_create_meeting_transaction), so created_at is stamped only when the doc does
+not already exist and a racing write cannot reset it. Firestore serializes the transaction
+and retries on contention, which is what actually closes the check-then-set TOCTOU window
+(the bare get()+set() it replaced could not, since both racers could observe "not exists").
 
 database/calendar_meetings.py imports google.cloud.firestore + database._client at module top,
 so we import it under a meta-path stub finder and then inject a real deterministic
-document_id_from_seed plus a fake meetings collection.
+document_id_from_seed plus a fake meetings collection. Because google.cloud.firestore_v1
+is stubbed, the real @transactional decorator and db.transaction() are MagicMocks; we
+substitute a faithful pass-through transaction (_FakeTransaction) and re-bind a real
+implementation of _create_meeting_transaction so the read-conditional-set logic actually
+runs against the fake document. The atomic guarantee itself is provided by Firestore's
+transaction primitive and is not exercisable without a live emulator.
 """
 
+import contextlib
 import hashlib
 import importlib.abc
 import importlib.machinery
@@ -88,17 +97,47 @@ class _FakeDoc:
     def __init__(self, doc_id):
         self.id = doc_id
         self.set_calls = []  # list of (data_copy, merge)
+        self.get_in_transaction = []  # bool per get(): was a transaction passed?
         self._exists = False  # first creator sees a non-existent doc
 
-    def get(self):
+    def get(self, transaction=None):
+        # Real (fixed) code reads inside a transaction: doc_ref.get(transaction=...).
+        # The pre-fix bare check-then-set read with no transaction.
+        self.get_in_transaction.append(transaction is not None)
         snap = MagicMock()
         snap.exists = self._exists
         return snap
 
-    def set(self, data, merge=False):
+    def set(self, data, merge=False, _via_transaction=False):
         # Record a shallow copy so later mutations don't rewrite history.
-        self.set_calls.append((dict(data), merge))
+        self.set_calls.append((dict(data), merge, _via_transaction))
         self._exists = True  # after the first write, the doc exists
+
+
+class _FakeTransaction:
+    """A pass-through stand-in for a Firestore transaction.
+
+    A real transaction would serialize the get()+set() and retry on contention;
+    here we just forward set() to the document (flagged as transactional) so the
+    create_meeting orchestration (idempotent id, created_at-once, merge=True, write
+    routed through a transaction) can be asserted without a live Firestore emulator.
+    """
+
+    def set(self, doc_ref, data, merge=False):
+        doc_ref.set(data, merge=merge, _via_transaction=True)
+
+
+def _real_create_meeting_transaction(transaction, doc_ref, meeting_data, now):
+    """Faithful Python copy of the module's @transactional body.
+
+    The production function is wrapped by Firestore's @transactional, which is a
+    MagicMock here (google.cloud.firestore_v1 is stubbed), so we re-bind this real
+    implementation to exercise the read-conditional-set logic.
+    """
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        meeting_data['created_at'] = now
+    transaction.set(doc_ref, meeting_data, merge=True)
 
 
 class _FakeCollection:
@@ -132,13 +171,23 @@ _MEETING = {
 _PATCH_SEED = dict(create=True, side_effect=_real_document_id_from_seed)
 
 
+@contextlib.contextmanager
+def _patched(coll):
+    """Patch the meetings collection, the seed fn, the transaction factory, and the
+    transactional helper (the real ones are MagicMocks because firestore is stubbed)."""
+    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
+        mod, 'document_id_from_seed', **_PATCH_SEED
+    ), patch.object(mod.db, 'transaction', create=True, side_effect=_FakeTransaction), patch.object(
+        mod, '_create_meeting_transaction', create=True, side_effect=_real_create_meeting_transaction
+    ):
+        yield
+
+
 def test_concurrent_same_event_creates_converge_to_one_doc():
     """Two creates with identical calendar_event_id/source must land on ONE document
     (deterministic id), not two distinct random-id docs (the TOCTOU duplicate)."""
     coll = _FakeCollection()
-    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
-        mod, 'document_id_from_seed', **_PATCH_SEED
-    ):
+    with _patched(coll):
         id1 = mod.create_meeting('u1', dict(_MEETING))
         id2 = mod.create_meeting('u1', dict(_MEETING))
 
@@ -155,9 +204,7 @@ def test_concurrent_same_event_creates_converge_to_one_doc():
 def test_deterministic_id_matches_natural_key_seed():
     """The id must be derived from uid:source:calendar_event_id (not random)."""
     coll = _FakeCollection()
-    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
-        mod, 'document_id_from_seed', **_PATCH_SEED
-    ):
+    with _patched(coll):
         got = mod.create_meeting('u1', dict(_MEETING))
 
     expected = _real_document_id_from_seed('u1:google_calendar:evt-123')
@@ -167,9 +214,7 @@ def test_deterministic_id_matches_natural_key_seed():
 def test_created_at_not_overwritten_on_second_create():
     """The second (racing) create must NOT reset created_at, since the doc already exists."""
     coll = _FakeCollection()
-    with patch.object(mod, '_get_meetings_collection', return_value=coll), patch.object(
-        mod, 'document_id_from_seed', **_PATCH_SEED
-    ):
+    with _patched(coll):
         mod.create_meeting('u1', dict(_MEETING))
         mod.create_meeting('u1', dict(_MEETING))
 
@@ -178,10 +223,32 @@ def test_created_at_not_overwritten_on_second_create():
     converged = [d for d in all_docs if len(d.set_calls) == 2]
     assert len(converged) == 1, "the two creates did not converge on a single document (duplicate created)"
     doc = converged[0]
-    first_data, _ = doc.set_calls[0]
-    second_data, second_merge = doc.set_calls[1]
+    first_data, _, _ = doc.set_calls[0]
+    second_data, second_merge, _ = doc.set_calls[1]
     # First create stamps created_at; second (racing) create must not include created_at.
     assert 'created_at' in first_data
     assert 'created_at' not in second_data, "racing create overwrote created_at"
     # And the racing write merges into the existing doc.
     assert second_merge is True
+
+
+def test_created_at_check_and_write_are_transactional():
+    """The created_at existence-check and the write must run inside a Firestore
+    transaction. A bare get()+set() (the pre-fix code) can't close the TOCTOU window:
+    two racers can both see "not exists" and the second set() resets created_at.
+
+    Asserting the read carries a transaction and the write is routed through the
+    transaction is what distinguishes the atomic fix from the racy check-then-set."""
+    coll = _FakeCollection()
+    with _patched(coll):
+        mod.create_meeting('u1', dict(_MEETING))
+
+    all_docs = list(coll.docs_by_id.values()) + coll.auto_docs
+    written = [d for d in all_docs if d.set_calls]
+    assert len(written) == 1, "expected exactly one document write"
+    doc = written[0]
+    # The existence check read inside the transaction.
+    assert doc.get_in_transaction == [True], "created_at existence check was not read inside a transaction"
+    # The write was routed through the transaction (not a direct doc_ref.set()).
+    via_transaction = [flag for (_, _, flag) in doc.set_calls]
+    assert via_transaction == [True], "write did not go through a Firestore transaction (still a racy bare set)"


### PR DESCRIPTION
## Summary

`POST /v1/calendar/meetings` stores a meeting with a check-then-create pattern: the router calls `get_meeting_id_by_calendar_event` and only calls `create_meeting` when nothing was found. `create_meeting` writes to a fresh random Firestore document id every time, so two concurrent posts for the same calendar event both miss the existence check and each create a separate document. The result is duplicate meeting docs for one real calendar event, and later updates land on whichever copy the query happens to return. This change derives the document id deterministically from the natural key (uid, calendar_source, calendar_event_id) so concurrent creates converge on a single document instead of producing duplicates. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/database/calendar_meetings.py`, `create_meeting` always allocates a new auto-id document:

```python
def create_meeting(uid: str, meeting_data: Dict) -> str:
    # Add timestamps (always in UTC for consistent querying)
    from datetime import timezone

    now = datetime.now(timezone.utc)
    meeting_data['created_at'] = now
    meeting_data['synced_at'] = now

    # Create document
    doc_ref = _get_meetings_collection(uid).document()
    doc_ref.set(meeting_data)

    return doc_ref.id
```

`_get_meetings_collection(uid).document()` with no id returns a random Firestore id, so each call writes a brand new document regardless of whether one already exists for that calendar event. The caller in `backend/routers/calendar_meetings.py`, `store_calendar_meeting`, guards this with a read first:

```python
existing_meeting_id = calendar_db.get_meeting_id_by_calendar_event(
    uid, request.calendar_event_id, request.calendar_source
)

if existing_meeting_id:
    # Update existing meeting
    calendar_db.update_meeting(uid, existing_meeting_id, meeting_dict)
    meeting_id = existing_meeting_id
else:
    # Create new meeting
    meeting_id = calendar_db.create_meeting(uid, meeting_dict)
```

That read and the create are not atomic, so it is a time-of-check to time-of-use race. When the same event is posted twice close together (a client retry, or the macOS and mobile clients syncing the same event), both requests run `get_meeting_id_by_calendar_event` before either write commits, both see `None`, and both fall into the create branch. Two random-id documents are written for one event. From then on `get_meeting_id_by_calendar_event` uses `.limit(1)` and returns just one of them, so subsequent updates silently touch one copy while the duplicate stays stale.

## Fix

When the meeting carries a natural key (`calendar_event_id` and `calendar_source`), derive the document id from it with `document_id_from_seed` and write with `merge=True`, so concurrent creates for the same event collide on one document instead of producing duplicates. `created_at` is only stamped when the document does not already exist, so a racing write does not reset it. Meetings without a natural key keep the old random-id path.

```python
event_id = meeting_data.get('calendar_event_id')
source = meeting_data.get('calendar_source')
if event_id and source:
    doc_id = document_id_from_seed(f'{uid}:{source}:{event_id}')
    doc_ref = _get_meetings_collection(uid).document(doc_id)
    snapshot = doc_ref.get()
    if not snapshot.exists:
        meeting_data['created_at'] = now
    doc_ref.set(meeting_data, merge=True)
    return doc_ref.id

# Fallback: no natural key -> preserve old random-id behavior.
meeting_data['created_at'] = now
doc_ref = _get_meetings_collection(uid).document()
doc_ref.set(meeting_data)
```

`document_id_from_seed` already exists in `backend/database/_client.py` and is the same helper other domains use to make ids deterministic. A single first-time create behaves the same as before for the caller: it returns the document id and the stored fields are unchanged.

## Testing

Added `backend/tests/unit/test_calendar_meeting_duplicate_toctou.py`, registered in `backend/test.sh`. `database/calendar_meetings.py` imports `google.cloud.firestore` and `database._client` at module top, so the test imports the real module from source under a meta-path stub finder that stubs only those heavy dependencies, then injects a real deterministic `document_id_from_seed` and a fake meetings collection. The fake collection returns the same document object for a given id and a fresh random-id object for `document()` with no id, mirroring Firestore semantics, so the duplicate behavior is observable.

Cases covered: two creates with identical `calendar_event_id` and `calendar_source` converge on one document (same returned id, exactly one materialized doc, no random-id docs created); the returned id matches the `uid:source:calendar_event_id` seed; and the second racing create does not overwrite `created_at` and merges into the existing doc. The patch uses `create=True` so it also applies against the pre-fix module, which means the red comes from the actual duplicate-doc behavior (two random ids) rather than a missing attribute. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The deterministic-id write added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

