### PR TITLE
fix(backend): bound-check action item indices and validate parallel list lengths

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -481,11 +481,13 @@ def set_conversation_events_state(
 def set_action_item_status(
     data: SetConversationActionItemsStateRequest, conversation_id: str, uid=Depends(auth.get_current_user_uid)
 ):
+    if len(data.items_idx) != len(data.values):
+        raise HTTPException(status_code=422, detail="items_idx and values must have the same length")
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = deserialize_conversation(conversation)
     action_items = conversation.structured.action_items
     for i, action_item_idx in enumerate(data.items_idx):
-        if action_item_idx >= len(action_items):
+        if not (0 <= action_item_idx < len(action_items)):
             continue
 
         action_item = action_items[action_item_idx]
@@ -522,7 +524,7 @@ def set_action_item_status(
             description_to_ids.setdefault(desc, []).append(ai['id'])
 
         for i, action_item_idx in enumerate(data.items_idx):
-            if action_item_idx >= len(action_items):
+            if not (0 <= action_item_idx < len(action_items)):
                 continue
             action_item = action_items[action_item_idx]
             new_completed_status = data.values[i]

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -49,6 +49,7 @@ pytest tests/unit/test_high_priority_usage_tracking.py -v
 pytest tests/unit/test_new_usage_tracking_gaps.py -v
 pytest tests/unit/test_llm_usage_db.py -v
 pytest tests/unit/test_user_usage.py -v
+pytest tests/unit/test_conversation_action_item_bounds.py -v
 pytest tests/unit/test_llm_usage_endpoints.py -v
 pytest tests/unit/test_app_uid_keyerror.py -v
 pytest tests/unit/test_create_persona_user_none.py -v

--- a/backend/tests/unit/test_conversation_action_item_bounds.py
+++ b/backend/tests/unit/test_conversation_action_item_bounds.py
@@ -1,0 +1,247 @@
+"""Regression test for PATCH /v1/conversations/{id}/action-items index bounds.
+
+set_action_item_status takes parallel lists items_idx / values and originally only guarded the
+UPPER bound (action_item_idx >= len(action_items)). Two bugs followed:
+
+  1. A negative action_item_idx (e.g. -1) passed the guard and wrote to action_items[-1] -- silent
+     corruption of the wrong action item.
+  2. items_idx and values of mismatched length let data.values[i] raise IndexError -> HTTP 500.
+
+The fix rejects a length mismatch with 422 and bounds-checks both ends
+(0 <= action_item_idx < len(action_items)) so a negative or out-of-range index is skipped instead
+of corrupting data or 500ing, matching the already-shipped events endpoint behavior. This test
+mounts the conversations router (heavy deps stubbed, same pattern as the other router unit tests)
+and calls the handler directly.
+"""
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'database._client',
+    'database.conversations',
+    'database.action_items',
+    'database.memories',
+    'database.redis_db',
+    'database.users',
+    'database.vector_db',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.endpoints',
+    'utils.other.storage',
+    'utils.conversations.factory',
+    'utils.conversations.render',
+    'utils.conversations.process_conversation',
+    'utils.conversations.search',
+    'utils.conversations.calendar_linking',
+    'utils.conversations.calendar_utils',
+    'utils.conversations.location',
+    'utils.llm.conversation_processing',
+    'utils.speaker_identification',
+    'utils.app_integrations',
+    'utils.retrieval.tools.calendar_tools',
+    'utils.retrieval.tools.google_utils',
+]
+
+_MISSING = object()
+_saved_modules = {}
+_saved_parent_attrs = {}
+
+
+def _save_module_for_restore(name):
+    if name not in _saved_modules:
+        _saved_modules[name] = sys.modules.get(name, _MISSING)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        key = (parent_name, attr)
+        if key not in _saved_parent_attrs:
+            previous_attr = parent.__dict__.get(attr, _MISSING) if parent is not None else _MISSING
+            _saved_parent_attrs[key] = (parent, previous_attr)
+
+
+def _register_module(name, module):
+    _save_module_for_restore(name)
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, _AutoMockModule):
+            parent = _AutoMockModule(parent_name)
+            _register_module(parent_name, parent)
+        setattr(parent, attr, module)
+    return module
+
+
+def _remove_module_for_fresh_import(name):
+    _save_module_for_restore(name)
+    sys.modules.pop(name, None)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            parent.__dict__.pop(attr, None)
+
+
+def _restore_stubbed_modules():
+    for name in sorted(_saved_modules, key=lambda item: item.count('.'), reverse=True):
+        previous = _saved_modules[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (_parent_name, attr), (parent, previous_attr) in _saved_parent_attrs.items():
+        if parent is None:
+            continue
+        if previous_attr is _MISSING:
+            parent.__dict__.pop(attr, None)
+        else:
+            setattr(parent, attr, previous_attr)
+    _saved_modules.clear()
+    _saved_parent_attrs.clear()
+
+
+# Import the real, lightweight utils submodules the router actually needs at module level BEFORE
+# stubbing, so they stay cached as the real modules. The stub loop below replaces
+# sys.modules['utils'] with an AutoMock (a side effect of auto-stubbing utils.other.*); we re-pin
+# the real utils package afterward so `from utils.executors import ...` resolves the real module.
+import utils as _real_utils_pkg  # noqa: E402
+import utils.executors  # noqa: E402,F401
+import utils.conversations  # noqa: E402,F401
+import utils.conversations.factory  # noqa: E402,F401
+
+_save_module_for_restore('utils')
+
+for _mod_name in _stubs:
+    _register_module(_mod_name, _AutoMockModule(_mod_name))
+
+# Re-pin the real utils package so its real submodules (executors, conversations.factory) load.
+sys.modules['utils'] = _real_utils_pkg
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# utils.other.endpoints exposes the auth dependencies used in route signatures; FastAPI needs
+# real callables to build the dependants, so provide small stand-ins.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_endpoints.get_user = MagicMock()
+_register_module('utils.other.endpoints', _endpoints)
+
+from fastapi import HTTPException  # noqa: E402
+
+_remove_module_for_fresh_import('routers.conversations')
+_remove_module_for_fresh_import('routers')
+try:
+    from routers import conversations as conv  # noqa: E402
+    from models.conversation import SetConversationActionItemsStateRequest  # noqa: E402
+finally:
+    _restore_stubbed_modules()
+
+
+class _FakeActionItem:
+    """Minimal stand-in for a structured action item: tracks .completed and is .dict()-able."""
+
+    def __init__(self, description):
+        self.description = description
+        self.completed = False
+        self.created_at = None
+        self.completed_at = None
+
+    def dict(self):
+        return {
+            'description': self.description,
+            'completed': self.completed,
+            'created_at': self.created_at,
+            'completed_at': self.completed_at,
+        }
+
+
+def _fake_conversation_with_action_items(count):
+    items = [_FakeActionItem(f'item-{i}') for i in range(count)]
+    structured = SimpleNamespace(action_items=items)
+    convo = SimpleNamespace(structured=structured, created_at=None)
+    return convo, items
+
+
+def test_mismatched_lengths_returns_422():
+    """items_idx longer than values must 422, not IndexError -> 500."""
+    convo, _items = _fake_conversation_with_action_items(2)
+    with patch.object(conv, '_get_valid_conversation_by_id', return_value={'id': 'c1'}), patch.object(
+        conv, 'deserialize_conversation', return_value=convo
+    ):
+        data = SetConversationActionItemsStateRequest(items_idx=[0, 1], values=[True])
+        with pytest.raises(HTTPException) as exc:
+            conv.set_action_item_status(data, 'c1', uid='u1')
+        assert exc.value.status_code == 422
+
+
+def test_negative_index_is_skipped_not_corrupting():
+    """A negative action_item_idx (-1) must NOT write to the last action item."""
+    convo, items = _fake_conversation_with_action_items(2)
+    with patch.object(conv, '_get_valid_conversation_by_id', return_value={'id': 'c1'}), patch.object(
+        conv, 'deserialize_conversation', return_value=convo
+    ), patch.object(conv, 'conversations_db', MagicMock()), patch.object(conv, 'action_items_db', MagicMock()):
+        data = SetConversationActionItemsStateRequest(items_idx=[-1], values=[True])
+        result = conv.set_action_item_status(data, 'c1', uid='u1')
+
+    # No action item should have been mutated by the out-of-range negative index.
+    assert all(item.completed is False for item in items)
+    assert result == {"status": "Ok"}
+
+
+def test_valid_index_still_updates():
+    """Sanity: an in-range index still applies the value (fix must not break the happy path)."""
+    convo, items = _fake_conversation_with_action_items(2)
+    with patch.object(conv, '_get_valid_conversation_by_id', return_value={'id': 'c1'}), patch.object(
+        conv, 'deserialize_conversation', return_value=convo
+    ), patch.object(conv, 'conversations_db', MagicMock()), patch.object(conv, 'action_items_db', MagicMock()):
+        data = SetConversationActionItemsStateRequest(items_idx=[1], values=[True])
+        conv.set_action_item_status(data, 'c1', uid='u1')
+
+    assert items[1].completed is True
+    assert items[0].completed is False


### PR DESCRIPTION
## Summary

`PATCH /v1/conversations/{conversation_id}/action-items` (`set_action_item_status`) takes two parallel lists, `items_idx` and `values`, and toggles the completed state of the action items at those indices. It only guards the upper bound on the index, so a negative `action_item_idx` like `-1` passes the check and writes to `action_items[-1]`, flipping the wrong action item with no error. A separate problem: if the client sends `items_idx` and `values` of different lengths, `data.values[i]` runs off the end and raises `IndexError`, which FastAPI turns into a 500. This PR rejects a length mismatch with 422 and bounds-checks both ends of the index so an out-of-range value is skipped instead of corrupting data or 500ing.

## Root cause

In `backend/routers/conversations.py`, `set_action_item_status` loops over `data.items_idx` twice (once on `conversation.structured.action_items`, once when mirroring to the standalone collection). Both loops use the same one-sided guard:

```python
conversation = _get_valid_conversation_by_id(uid, conversation_id)
conversation = deserialize_conversation(conversation)
action_items = conversation.structured.action_items
for i, action_item_idx in enumerate(data.items_idx):
    if action_item_idx >= len(action_items):
        continue

    action_item = action_items[action_item_idx]
    new_completed_status = data.values[i]
```

`action_item_idx >= len(action_items)` only rejects indices that are too high. A negative index passes the check, and `action_items[action_item_idx]` then resolves it from the end of the list, so `-1` silently mutates the last action item rather than being skipped. The value read is `data.values[i]`, indexed by the position in `items_idx`, not by `action_item_idx`. There is no check that `items_idx` and `values` are the same length, so a request with more entries in `items_idx` than in `values` reaches `data.values[i]` with `i` past the end of `values` and raises `IndexError`, which surfaces as a 500. The sibling events endpoint in this same file pairs its indices and values up front; this handler did not.

## Fix

Validate the two lists are the same length before doing any work, and bounds-check both ends of the index in each loop:

```python
if len(data.items_idx) != len(data.values):
    raise HTTPException(status_code=422, detail="items_idx and values must have the same length")
```

```python
for i, action_item_idx in enumerate(data.items_idx):
    if not (0 <= action_item_idx < len(action_items)):
        continue
```

The `0 <= action_item_idx < len(action_items)` check is applied in both loops, so a negative or too-large index is skipped in both the structured update and the mirrored update. A request with matching lengths and in-range indices behaves exactly as before.

## Testing

Added `backend/tests/unit/test_conversation_action_item_bounds.py` (registered in `backend/test.sh`). The conversations router has a heavy import graph, so the test mounts it under a stub finder (heavy deps replaced with auto-mock modules, the real lightweight `utils` submodules re-pinned) and calls `set_action_item_status` directly, the same pattern the other router unit tests use. The cases: mismatched `items_idx`/`values` lengths returns 422 instead of raising `IndexError`; a negative index (`-1`) leaves every action item unmodified instead of writing to the last one; and a valid in-range index still flips that item's completed flag while leaving the others alone. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The bounds check and the length validation added here do not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

