### PR TITLE
fix(backend): import asyncio at top of agent_tools router

### DIFF
--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -9,6 +9,7 @@ Endpoints:
 - POST /v1/agent/keepalive     — pings the VM to reset its idle auto-stop timer
 """
 
+import asyncio
 import logging
 
 from utils.executors import db_executor, run_blocking

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -157,6 +157,7 @@ pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_memories_pagination_clamp.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_file_paths_filename_none.py -v
+pytest tests/unit/test_agent_tools_asyncio_import.py -v
 pytest tests/unit/test_sync_cloud_tasks.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_sync_record_usage.py -v

--- a/backend/tests/unit/test_agent_tools_asyncio_import.py
+++ b/backend/tests/unit/test_agent_tools_asyncio_import.py
@@ -1,0 +1,155 @@
+"""Regression test for routers/agent_tools.py missing `import asyncio`.
+
+`_start_vm_and_wait` calls `await asyncio.sleep(...)` on its VM-restart path, but
+`asyncio` was never imported at module level (only `from datetime import ...`). The
+reachable path therefore raised `NameError: name 'asyncio' is not defined`.
+
+Two complementary checks, both red-before / green-after:
+  1. Source-assert: the module text contains a top-level `import asyncio`.
+  2. Functional: drive `_start_vm_and_wait` to the first `await asyncio.sleep(...)`
+     call site. With the import missing this raises NameError; with the import
+     present it resolves `asyncio` and hits our patched sleep sentinel instead.
+"""
+
+import asyncio as _real_asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import inspect
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'httpx',
+)
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import agent_tools as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+def test_module_imports_asyncio_at_top_level():
+    """Source-assert: the fix adds a module-level `import asyncio`."""
+    src = inspect.getsource(mod)
+    assert 'import asyncio' in src, "agent_tools.py must import asyncio at module top"
+    # asyncio must be resolvable as a module attribute (the actual stdlib module).
+    assert getattr(mod, 'asyncio', None) is _real_asyncio
+
+
+class _ReachedSleep(Exception):
+    """Sentinel: raised from the patched asyncio.sleep to prove the path resolved."""
+
+
+class _FakeResp:
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {"name": "op-123"}
+
+
+class _FakeAsyncClient:
+    """Minimal async context manager standing in for httpx.AsyncClient."""
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, *a, **k):
+        return _FakeResp()
+
+    async def get(self, *a, **k):
+        return _FakeResp()
+
+
+def test_start_vm_and_wait_reaches_sleep_without_nameerror():
+    """The VM-restart path must reach `await asyncio.sleep(...)` without NameError.
+
+    Pre-fix: line `await asyncio.sleep(5)` raises NameError (asyncio undefined) ->
+    our _ReachedSleep is never raised -> test fails.
+    Post-fix: asyncio resolves; the patched sleep raises _ReachedSleep -> test passes.
+    """
+
+    async def _boom(*a, **k):
+        raise _ReachedSleep()
+
+    async def _await_value(*a, **k):
+        # Stand-in for run_blocking: returns the token coroutine-style.
+        return "fake-token"
+
+    # Patch the real asyncio.sleep so reaching it raises our sentinel instead of
+    # actually sleeping. Once `import asyncio` exists, mod.asyncio IS this module.
+    with patch.object(_real_asyncio, 'sleep', _boom), patch.object(mod, 'run_blocking', _await_value), patch.object(
+        mod, 'httpx', MagicMock(AsyncClient=_FakeAsyncClient)
+    ):
+        with pytest.raises(_ReachedSleep):
+            _real_asyncio.run(mod._start_vm_and_wait("vm-1", "us-central1-a"))


### PR DESCRIPTION
## Summary

`backend/routers/agent_tools.py` backs the agent VM endpoints, including `POST /v1/agent/vm-ensure`, which restarts a stopped GCE VM in a background task. The restart helper `_start_vm_and_wait` calls `await asyncio.sleep(...)` while polling for the start operation and the new IP, but the module never imports `asyncio`. The first time that path runs it raises `NameError: name 'asyncio' is not defined`, so the background restart dies, the VM never reaches `ready`, and the user's agent stays unreachable. This PR adds the missing top-level `import asyncio`. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/agent_tools.py`, the module imports are:

```python
import logging

from utils.executors import db_executor, run_blocking
from datetime import datetime, timezone

import google.auth
import google.auth.transport.requests
import httpx
```

There is no `import asyncio`, but `_start_vm_and_wait` uses it on every restart:

```python
op_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
for i in range(24):
    await asyncio.sleep(5)
    token = await run_blocking(db_executor, _get_gce_access_token)
```

and again while waiting for the external IP:

```python
if attempt < 5:
    logger.info(f"[vm-start] {vm_name} no IP yet, retrying ({attempt + 1}/6)...")
    await asyncio.sleep(3)
```

The first `await asyncio.sleep(5)` references the bare name `asyncio`, which is unbound at module scope, so it raises `NameError`. The call site is reachable: `ensure_vm` schedules `_restart_vm_background` as a background task whenever GCE reports the VM as `TERMINATED` or `STOPPED`, and that task awaits `_start_vm_and_wait`. The `NameError` propagates out of the helper, gets caught in `_restart_vm_background`, and the VM is marked `error` instead of restarted. Module import itself succeeds, so this is not caught at startup; it only fails when the restart path actually executes.

## Fix

Add `asyncio` to the module-level imports:

```python
import asyncio
import logging

from utils.executors import db_executor, run_blocking
from datetime import datetime, timezone
```

The `asyncio.sleep(...)` calls now resolve to the stdlib module. No behavior changes for any other path; the only thing that changes is that the VM-restart polling loop runs instead of raising.

## Testing

Added `backend/tests/unit/test_agent_tools_asyncio_import.py`, registered in `backend/test.sh`. The router has a heavy import graph, so the test installs a stub meta-path finder for the heavy dependency packages (`database`, `utils`, `httpx`, `google`, and friends), imports `routers.agent_tools` under it, then restores `sys.modules`. Two checks cover the bug. The first is a source assert that the module text contains `import asyncio` and that `mod.asyncio` resolves to the real stdlib module. The second drives `_start_vm_and_wait` to its first `await asyncio.sleep(...)` call site with `run_blocking` and `httpx.AsyncClient` patched to fakes, and `asyncio.sleep` patched to raise a sentinel. On main the `await asyncio.sleep(5)` line raises `NameError` before the sentinel can fire, so the test fails; with the import present the name resolves and the sentinel is raised as expected. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The missing import does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

