### PR TITLE
fix(backend): skip missing ids in batch_sync_update_action_items to avoid NotFound 500

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -653,7 +653,20 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
     batch = db.batch()
     count = 0
 
+    # batch.update() on a missing doc raises google NotFound, which would
+    # 500 the whole sync batch on one stale/deleted reminder id. Pre-filter
+    # to existing docs (same pattern as folders.bulk_move_conversations_to_folder)
+    # and skip past missing ids.
+    requested_ids = [entry['id'] for entry in updates]
+    existing_ids = {
+        doc.id
+        for doc in db.get_all([action_items_ref.document(i) for i in requested_ids])
+        if doc is not None and doc.exists
+    }
+
     for entry in updates:
+        if entry['id'] not in existing_ids:
+            continue
         update_data = _prepare_action_item_for_write(entry['data'])
         update_data['updated_at'] = now
         # Clear sync_requested when item is successfully exported

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone, timedelta
-from typing import Optional, List
+from typing import Optional, List, Set
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -635,16 +635,22 @@ def get_pending_apple_reminders_sync(uid: str) -> dict:
     return {"pending_export": pending_export, "synced_items": synced_items}
 
 
-def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
+def batch_sync_update_action_items(uid: str, updates: List[dict]) -> Set[str]:
     """
     Batch update action items during reminders sync. Single Firestore batch commit.
 
     Args:
         uid: User ID
         updates: List of {'id': str, 'data': dict} entries
+
+    Returns:
+        The set of ids that were actually written. Missing/stale ids are skipped
+        (see below), so callers must use this to compute updated counts and to
+        gate downstream side effects (e.g. vector upserts) on confirmed updates
+        rather than assuming every requested id was updated.
     """
     if not updates:
-        return
+        return set()
 
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
@@ -652,6 +658,7 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
 
     batch = db.batch()
     count = 0
+    updated_ids: Set[str] = set()
 
     # batch.update() on a missing doc raises google NotFound, which would
     # 500 the whole sync batch on one stale/deleted reminder id. Pre-filter
@@ -674,6 +681,7 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
             update_data['sync_requested'] = False
         doc_ref = action_items_ref.document(entry['id'])
         batch.update(doc_ref, update_data)
+        updated_ids.add(entry['id'])
         count += 1
 
         if count >= 499:
@@ -683,6 +691,8 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
 
     if count > 0:
         batch.commit()
+
+    return updated_ids
 
 
 def unlock_all_action_items(uid: str):

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -181,16 +181,21 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
         if update_data:
             updates.append({'id': item.id, 'data': update_data})
 
-    action_items_db.batch_sync_update_action_items(uid, updates)
+    # Missing/stale ids are skipped inside the batch (a deleted reminder id must
+    # not 500 the whole sync), so only the returned ids were actually written.
+    # Count and upsert vectors against those, never the full requested set —
+    # otherwise updated_count is inflated and we upsert vectors for action items
+    # that no longer exist.
+    updated_ids = action_items_db.batch_sync_update_action_items(uid, updates)
 
-    desc_updates = [u for u in updates if 'description' in u['data']]
+    desc_updates = [u for u in updates if 'description' in u['data'] and u['id'] in updated_ids]
     if desc_updates:
         upsert_action_item_vectors_batch(
             uid,
             [{'action_item_id': u['id'], 'description': u['data']['description']} for u in desc_updates],
         )
 
-    return {"status": "ok", "updated_count": len(updates)}
+    return {"status": "ok", "updated_count": len(updated_ids)}
 
 
 # *****************************

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -103,6 +103,7 @@ pytest tests/unit/test_storage_fanout_limits.py -v
 pytest tests/unit/test_deferred_blob_janitor.py -v
 pytest tests/unit/test_audio_merge_tasks.py -v
 pytest tests/unit/test_people_conversations_500s.py -v
+pytest tests/unit/test_action_items_batch_sync_missing_id.py -v
 pytest tests/unit/test_import_jobs_malformed.py -v
 pytest tests/unit/test_firestore_read_ops_cache.py -v
 pytest tests/unit/test_ws_auth_handshake.py -v

--- a/backend/tests/unit/test_action_items_batch_sync_missing_id.py
+++ b/backend/tests/unit/test_action_items_batch_sync_missing_id.py
@@ -1,0 +1,200 @@
+"""Regression test for database.action_items.batch_sync_update_action_items.
+
+PATCH /v1/action-items/sync-batch funnels reminder-sync updates into
+``batch_sync_update_action_items``. Firestore's ``batch.update()`` raises a
+``NotFound`` for a document that does not exist, and the failure surfaces at
+``batch.commit()`` — so a single stale/deleted reminder id supplied by the
+client would 500 the entire sync batch (dropping every other update in it).
+
+The router pre-fetch only flags *locked* items; genuinely MISSING ids still
+flowed straight into ``batch.update``. The fix pre-filters the entries to
+documents that actually exist (via ``db.get_all``) and skips the rest.
+
+This test drives the db helper directly with a mix of existing and missing ids
+and asserts:
+  * no NotFound escapes (no 500), and
+  * ``batch.update`` is invoked only for the ids that exist.
+
+Red (pre-fix): ``batch.update`` is called for the missing id, the fake batch
+raises NotFound exactly like Firestore, and the call blows up.
+
+Import bootstrap mirrors test_action_item_idempotency.py: stub the heavy
+``database._client`` singleton and the ``google.cloud.firestore*`` modules,
+then import the real ``database.action_items``.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _ensure_module(name):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    return sys.modules[name]
+
+
+for _mod_name in [
+    'firebase_admin',
+    'firebase_admin.auth',
+    'google',
+    'google.cloud',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.base_query',
+]:
+    _ensure_module(_mod_name)
+
+
+class _FakeFirestoreClient:
+    def collection(self, *a, **kw):
+        return MagicMock()
+
+    def batch(self):
+        return MagicMock()
+
+
+sys.modules['google.cloud.firestore'].Client = _FakeFirestoreClient
+sys.modules['google.cloud.firestore'].SERVER_TIMESTAMP = object()
+sys.modules['google.cloud.firestore'].Query = MagicMock()
+
+
+class _FieldFilter:
+    def __init__(self, field, op, value):
+        self.field = field
+        self.op = op
+        self.value = value
+
+
+sys.modules['google.cloud.firestore'].FieldFilter = _FieldFilter
+sys.modules['google.cloud.firestore_v1'].FieldFilter = _FieldFilter
+sys.modules['google.cloud.firestore_v1.base_query'].FieldFilter = _FieldFilter
+
+# Stub the firestore client singleton so importing the module does not init
+# real credentials.
+_client_stub = types.ModuleType('database._client')
+_client_stub.db = MagicMock()
+sys.modules['database._client'] = _client_stub
+
+
+from database import action_items as mod  # noqa: E402
+
+
+class _NotFound(Exception):
+    """Stand-in for google.api_core.exceptions.NotFound (raised by Firestore
+    when batch.update targets a document that does not exist)."""
+
+
+class _DocRef:
+    def __init__(self, doc_id):
+        self.id = doc_id
+
+
+class _Snapshot:
+    def __init__(self, doc_id, exists):
+        self.id = doc_id
+        self.exists = exists
+        self.reference = _DocRef(doc_id)
+
+
+class _Collection:
+    def document(self, doc_id):
+        return _DocRef(doc_id)
+
+
+class _FakeBatch:
+    """A batch that mirrors Firestore: update() on a missing doc raises NotFound."""
+
+    def __init__(self, existing_ids):
+        self._existing = existing_ids
+        self.updated_ids = []
+
+    def update(self, doc_ref, data):
+        if doc_ref.id not in self._existing:
+            # Firestore reports the missing doc as a NotFound; raise it eagerly
+            # at update() time so the test fails loudly without the existence
+            # pre-filter (real Firestore surfaces it at commit()).
+            raise _NotFound(f"No document to update: {doc_ref.id}")
+        self.updated_ids.append(doc_ref.id)
+
+    def commit(self):
+        pass
+
+
+class _PatchDb:
+    """Context manager: swap module.db for a fake and restore it afterwards."""
+
+    def __init__(self, module, fake_db):
+        self._module = module
+        self._fake = fake_db
+        self._orig = None
+
+    def __enter__(self):
+        self._orig = self._module.db
+        self._module.db = self._fake
+        return self._fake
+
+    def __exit__(self, *exc):
+        self._module.db = self._orig
+        return False
+
+
+def _make_db(existing_ids):
+    existing_ids = set(existing_ids)
+    db = MagicMock()
+    db.collection.return_value.document.return_value.collection.return_value = _Collection()
+
+    batch = _FakeBatch(existing_ids)
+    db.batch.return_value = batch
+
+    def _get_all(refs):
+        return [_Snapshot(ref.id, ref.id in existing_ids) for ref in refs]
+
+    db.get_all.side_effect = _get_all
+    return db, batch
+
+
+def test_missing_id_does_not_blow_up_the_sync_batch():
+    """A deleted/stale id mixed with valid ids must not raise NotFound and must
+    not be sent to batch.update; the valid ids still get updated."""
+    existing = {'alive-1', 'alive-2'}
+    updates = [
+        {'id': 'alive-1', 'data': {'exported': True}},
+        {'id': 'ghost', 'data': {'exported': True}},  # does not exist anymore
+        {'id': 'alive-2', 'data': {'sort_order': 3}},
+    ]
+
+    db, batch = _make_db(existing)
+    with _PatchDb(mod, db):
+        # Must not raise NotFound on the missing 'ghost' id.
+        mod.batch_sync_update_action_items('uid-xyz', updates)
+
+    # Only the existing ids were written.
+    assert set(batch.updated_ids) == existing
+    assert 'ghost' not in batch.updated_ids
+
+
+def test_all_missing_ids_commit_nothing():
+    """If every id is missing, nothing is updated and no error is raised."""
+    db, batch = _make_db(set())
+    updates = [
+        {'id': 'gone-1', 'data': {'exported': True}},
+        {'id': 'gone-2', 'data': {'exported': True}},
+    ]
+
+    with _PatchDb(mod, db):
+        mod.batch_sync_update_action_items('uid-xyz', updates)
+
+    assert batch.updated_ids == []
+
+
+def test_all_existing_ids_all_updated():
+    """Sanity: when every id exists, every entry is written (no over-filtering)."""
+    existing = {'a', 'b', 'c'}
+    updates = [{'id': i, 'data': {'exported': True}} for i in ['a', 'b', 'c']]
+
+    db, batch = _make_db(existing)
+    with _PatchDb(mod, db):
+        mod.batch_sync_update_action_items('uid-xyz', updates)
+
+    assert set(batch.updated_ids) == existing

--- a/backend/tests/unit/test_action_items_batch_sync_missing_id.py
+++ b/backend/tests/unit/test_action_items_batch_sync_missing_id.py
@@ -198,3 +198,37 @@ def test_all_existing_ids_all_updated():
         mod.batch_sync_update_action_items('uid-xyz', updates)
 
     assert set(batch.updated_ids) == existing
+
+
+def test_returns_only_actually_updated_ids():
+    """The helper must report exactly the ids it wrote, not the requested set.
+
+    Callers use the return value to compute ``updated_count`` and to gate vector
+    upserts. If skipped (missing) ids leaked into the return, the router would
+    over-report updates and upsert vectors for action items that no longer exist
+    (cross-system data-consistency drift). Pre-fix the helper returned ``None``,
+    so the router fell back to ``len(updates)`` and upserted every description.
+    """
+    existing = {'alive-1', 'alive-2'}
+    updates = [
+        {'id': 'alive-1', 'data': {'description': 'one'}},
+        {'id': 'ghost', 'data': {'description': 'gone'}},  # does not exist anymore
+        {'id': 'alive-2', 'data': {'description': 'two'}},
+    ]
+
+    db, batch = _make_db(existing)
+    with _PatchDb(mod, db):
+        updated_ids = mod.batch_sync_update_action_items('uid-xyz', updates)
+
+    # Exactly the existing ids are reported back — the missing id is excluded.
+    assert updated_ids == existing
+    assert 'ghost' not in updated_ids
+    # And it stays consistent with what was actually written.
+    assert updated_ids == set(batch.updated_ids)
+
+
+def test_empty_updates_returns_empty_set():
+    """No updates means an empty set (not None) so callers can len() it safely."""
+    db, _ = _make_db(set())
+    with _PatchDb(mod, db):
+        assert mod.batch_sync_update_action_items('uid-xyz', []) == set()

--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -669,7 +669,9 @@ class TestSyncBatchSkipsLocked:
                 {"id": "t1", "description": "OK", "is_locked": False},
                 {"id": "t2", "description": "Secret", "is_locked": True},
             ]
-            mock_db.batch_sync_update_action_items = MagicMock()
+            # The helper returns the set of ids actually written; the router
+            # uses that for updated_count and to gate vector upserts.
+            mock_db.batch_sync_update_action_items = MagicMock(return_value={"t1"})
 
             request = SyncBatchRequest(
                 items=[


### PR DESCRIPTION
## Summary

`PATCH /v1/action-items/sync-batch` funnels reminder-sync updates into `batch_sync_update_action_items` in `backend/database/action_items.py`. The function builds one Firestore batch of `batch.update()` calls, one per supplied id, with no check that the target document still exists. If the client sends an id that has since been deleted, `batch.commit()` raises `NotFound` and the whole batch fails, so every other update in that batch is dropped too and the request returns HTTP 500. This change pre-filters the entries to ids that actually exist and skips the rest, so one stale id no longer takes down the whole sync. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/database/action_items.py`, `batch_sync_update_action_items` loops over the caller-supplied `updates` and adds each one to the batch unconditionally:

```python
for entry in updates:
    update_data = _prepare_action_item_for_write(entry['data'])
    update_data['updated_at'] = now
    # Clear sync_requested when item is successfully exported
    if update_data.get('exported') is True:
        update_data['sync_requested'] = False
    doc_ref = action_items_ref.document(entry['id'])
    batch.update(doc_ref, update_data)
    count += 1
```

`batch.update()` targets a specific document and requires it to exist. Firestore does not validate that at enqueue time, it validates at commit, so a single id for a deleted or stale reminder raises `google.api_core.exceptions.NotFound` out of `batch.commit()`. Because all the updates share one batch, the entire commit is rejected and the handler surfaces a 500. The router's pre-fetch only catches items flagged as locked, not ids that are genuinely gone, so those flowed straight through.

## Fix

Before the loop, fetch the requested docs with `db.get_all` and keep only the ids that exist, then skip any entry whose id is not in that set. This matches the pattern in `folders.bulk_move_conversations_to_folder`.

```python
requested_ids = [entry['id'] for entry in updates]
existing_ids = {
    doc.id
    for doc in db.get_all([action_items_ref.document(i) for i in requested_ids])
    if doc is not None and doc.exists
}

for entry in updates:
    if entry['id'] not in existing_ids:
        continue
    update_data = _prepare_action_item_for_write(entry['data'])
    ...
```

When every id exists the behavior is identical to before: every entry is still written in the same batch.

## Testing

Added `backend/tests/unit/test_action_items_batch_sync_missing_id.py`, registered in `backend/test.sh`. The module loads heavy deps under stubs (the `database._client` singleton and the `google.cloud.firestore*` modules are stubbed) so the real `database.action_items` can be imported and `batch_sync_update_action_items` is called directly. The fake batch mirrors Firestore by raising `NotFound` when `update()` targets a missing id. Cases covered: a mix of existing and missing ids does not raise and writes only the existing ids; an all-missing batch writes nothing and raises nothing; an all-existing batch writes every entry, confirming no over-filtering. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The existence pre-filter added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

