### PR TITLE
fix(backend): guard invalid timezone in chat metadata extraction

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -19,6 +19,7 @@ pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v
 pytest tests/unit/test_user_speaker_embedding.py -v
+pytest tests/unit/test_chat_metadata_tz_guard.py -v
 pytest tests/unit/test_parakeet_diarization.py -v
 pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
 pytest tests/unit/test_parakeet_prerecorded.py -v

--- a/backend/tests/unit/test_chat_metadata_tz_guard.py
+++ b/backend/tests/unit/test_chat_metadata_tz_guard.py
@@ -1,0 +1,119 @@
+"""
+Regression test for the timezone guard in chat metadata extraction
+(utils/llm/chat.py :: retrieve_metadata_fields_from_transcript).
+
+The prompt was built with `created_at.astimezone(ZoneInfo(tz))` directly inside
+the f-string, OUTSIDE the try/except that wraps the LLM call. An invalid (or
+None) timezone made `ZoneInfo(tz)` raise BEFORE the LLM call, so the function
+blew up with an unhandled exception instead of degrading to empty metadata.
+
+Fix: resolve the timezone defensively (mirroring _local_started_at_iso /
+extract_action_items), falling back to UTC, before building the prompt.
+
+This test drives the function with an invalid / None timezone and asserts it
+does NOT raise and returns the empty-metadata shape.
+
+Red (without fix): ZoneInfoNotFoundError / TypeError escapes the function.
+Green (with fix): returns {'people': [], 'topics': [], 'entities': [], 'dates': []}.
+"""
+
+import contextlib
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# ---------------------------------------------------------------------------
+# Stub the heavy dependencies that utils/llm/chat.py imports, BEFORE importing
+# the module under test. We deliberately do NOT stub the `utils` / `utils.llm`
+# packages themselves, so the real chat.py loads as real code.
+# (Mirrors tests/unit/test_fair_use_classifier.py, a sibling in utils/llm/.)
+# ---------------------------------------------------------------------------
+
+
+def _stub(name):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    return sys.modules[name]
+
+
+_db_client = _stub('database._client')
+_db_client.db = MagicMock()
+
+_redis_db = _stub('database.redis_db')
+_redis_db.r = MagicMock()
+_redis_db.add_filter_category_item = MagicMock()
+
+_users_db = _stub('database.users')
+_notifications_db = _stub('database.notifications')
+_goals_db = _stub('database.goals')
+
+_auth_db = _stub('database.auth')
+_auth_db.get_user_name = MagicMock(return_value='TestUser')
+
+_llm_clients = _stub('utils.llm.clients')
+_llm_clients.get_llm = MagicMock()
+
+_usage_tracker = _stub('utils.llm.usage_tracker')
+_usage_tracker.track_usage = MagicMock()
+_usage_tracker.Features = MagicMock()
+
+_memory_mod = _stub('utils.llms.memory')
+_memory_mod.get_prompt_memories = MagicMock(return_value=('TestUser', 'some memories'))
+
+from utils.llm import chat as mod  # noqa: E402
+
+_EMPTY = {'people': [], 'topics': [], 'entities': [], 'dates': []}
+
+
+def _make_segments():
+    # Non-empty so the function reaches the prompt-building / timezone code
+    # instead of short-circuiting on empty context.
+    return [{'text': 'we should meet tomorrow about the budget'}]
+
+
+def _noop_usage(*args, **kwargs):
+    # Real no-op context manager. `track_usage` is mocked; a bare MagicMock
+    # used as a context manager would have its __exit__ return a truthy
+    # MagicMock and SILENTLY SUPPRESS the exception raised inside the `with`
+    # block, hiding the LLM failure we rely on to reach the degrade path.
+    return contextlib.nullcontext()
+
+
+def test_invalid_timezone_does_not_raise_and_returns_empty_metadata():
+    created_at = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Force the LLM call (which sits AFTER the tz line) to fail, so the function
+    # exercises its existing degrade-to-empty path. Before the fix, the tz line
+    # raises BEFORE we ever reach the LLM call.
+    bad_llm = MagicMock(side_effect=RuntimeError('llm offline'))
+    with patch.object(mod, 'track_usage', _noop_usage), patch.object(mod, 'get_llm', bad_llm):
+        result = mod.retrieve_metadata_fields_from_transcript(
+            uid='user-123',
+            created_at=created_at,
+            transcript_segment=_make_segments(),
+            tz='Not/AZone',  # invalid IANA name -> ZoneInfo(tz) raises without the guard
+        )
+
+    assert result == _EMPTY
+
+
+def test_none_timezone_does_not_raise():
+    created_at = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    bad_llm = MagicMock(side_effect=RuntimeError('llm offline'))
+    with patch.object(mod, 'track_usage', _noop_usage), patch.object(mod, 'get_llm', bad_llm):
+        result = mod.retrieve_metadata_fields_from_transcript(
+            uid='user-123',
+            created_at=created_at,
+            transcript_segment=_make_segments(),
+            tz=None,  # None -> ZoneInfo(None) raises TypeError without the guard
+        )
+
+    assert result == _EMPTY

--- a/backend/tests/unit/test_chat_metadata_tz_guard.py
+++ b/backend/tests/unit/test_chat_metadata_tz_guard.py
@@ -117,3 +117,47 @@ def test_none_timezone_does_not_raise():
         )
 
     assert result == _EMPTY
+
+
+def _capturing_llm(captured_prompts):
+    """A get_llm replacement whose .with_structured_output(...).invoke(prompt) records the
+    prompt and returns an empty-but-valid ExtractedInformation-shaped result."""
+    structured = MagicMock()
+    structured.people = []
+    structured.topics = []
+    structured.dates = []
+
+    def _invoke(prompt):
+        captured_prompts.append(prompt)
+        return structured
+
+    chain = MagicMock()
+    chain.invoke.side_effect = _invoke
+
+    llm = MagicMock()
+    llm.with_structured_output.return_value = chain
+
+    return MagicMock(return_value=llm)
+
+
+def test_invalid_timezone_prompt_uses_utc_not_the_bad_string():
+    # Cubic edge case: when tz parsing fails, the date context is computed in UTC,
+    # so the prompt label must say UTC too -- not the original invalid timezone string,
+    # otherwise the LLM is told the date is local to a bogus zone (inconsistent date context).
+    created_at = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    captured = []
+
+    with patch.object(mod, 'track_usage', _noop_usage), patch.object(mod, 'get_llm', _capturing_llm(captured)):
+        mod.retrieve_metadata_fields_from_transcript(
+            uid='user-123',
+            created_at=created_at,
+            transcript_segment=_make_segments(),
+            tz='Not/AZone',  # invalid IANA name -> falls back to UTC
+        )
+
+    assert len(captured) == 1
+    prompt = captured[0]
+    # The invalid timezone must NOT leak into the prompt's date context.
+    assert 'Not/AZone' not in prompt
+    # The prompt must name UTC as the timezone, matching the UTC-computed date.
+    assert 'in UTC (user' in prompt

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1060,6 +1060,14 @@ def retrieve_metadata_fields_from_transcript(
 
     full_context = "\n\n".join(context_parts)
 
+    try:
+        user_tz = ZoneInfo(tz) if tz else timezone.utc
+    except Exception:
+        logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
+        user_tz = timezone.utc
+    tz = tz or 'UTC'
+    today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
+
     # TODO: ask it to use max 2 words? to have more standardization possibilities
     prompt = f'''
     You will be given content which could be a raw transcript of a conversation, a series of photo descriptions from a wearable camera, or both. The transcript has about 20% word error rate, and diarization is also made very poorly.
@@ -1068,7 +1076,7 @@ def retrieve_metadata_fields_from_transcript(
 
     Make sure as a first step, you infer and fix any raw transcript errors and then proceed to extract the information from the entire content.
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
+    For context when extracting dates, today is {today_local} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
     If one says "today", it means the current day.
     If one says "tomorrow", it means the next day after today.
     If one says "yesterday", it means the day before today.
@@ -1142,6 +1150,14 @@ def retrieve_metadata_from_message(
     """Extract metadata from messaging app content"""
     source_context = f"from {source_spec}" if source_spec else "from a messaging application"
 
+    try:
+        user_tz = ZoneInfo(tz) if tz else timezone.utc
+    except Exception:
+        logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
+        user_tz = timezone.utc
+    tz = tz or 'UTC'
+    today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
+
     prompt = f'''
     You will be given the content of a message or conversation {source_context}.
 
@@ -1153,7 +1169,7 @@ def retrieve_metadata_from_message(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {today_local} in {tz} (user's local timezone).
     {tz} is the user's timezone, respond in user local timezone.
     If the message mentions "today", it means the current day.
     If the message mentions "tomorrow", it means the next day after today.
@@ -1176,6 +1192,14 @@ def retrieve_metadata_from_text(
     """Extract metadata from generic text content"""
     source_context = f"from {source_spec}" if source_spec else "from a text document"
 
+    try:
+        user_tz = ZoneInfo(tz) if tz else timezone.utc
+    except Exception:
+        logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
+        user_tz = timezone.utc
+    tz = tz or 'UTC'
+    today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
+
     prompt = f'''
     You will be given the content of a text {source_context}.
 
@@ -1187,7 +1211,7 @@ def retrieve_metadata_from_text(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {today_local} in {tz} (user's local timezone).
     {tz} is the user's timezone, respond in user local timezone.
     If the text mentions "today", it means the current day.
     If the text mentions "tomorrow", it means the next day after today.

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1065,6 +1065,7 @@ def retrieve_metadata_fields_from_transcript(
     except Exception:
         logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
         user_tz = timezone.utc
+        tz = 'UTC'
     tz = tz or 'UTC'
     today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
 
@@ -1155,6 +1156,7 @@ def retrieve_metadata_from_message(
     except Exception:
         logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
         user_tz = timezone.utc
+        tz = 'UTC'
     tz = tz or 'UTC'
     today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
 
@@ -1197,6 +1199,7 @@ def retrieve_metadata_from_text(
     except Exception:
         logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
         user_tz = timezone.utc
+        tz = 'UTC'
     tz = tz or 'UTC'
     today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
 


### PR DESCRIPTION
## Summary

`retrieve_metadata_fields_from_transcript` in `backend/utils/llm/chat.py` extracts people, topics, entities, and dates from a conversation transcript during post-processing. It already wraps the LLM call in a try/except so a model failure degrades to empty metadata, but the prompt string interpolates the user's timezone with `ZoneInfo(tz)` before that try/except runs. When the stored timezone is invalid or missing, `ZoneInfo(tz)` raises and the exception escapes the function, crashing the conversation post-processing step that calls it instead of degrading cleanly. This PR resolves the timezone defensively with a UTC fallback before the prompt is built. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/llm/chat.py`, `retrieve_metadata_fields_from_transcript` builds the prompt like this:

```python
    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
```

`tz` comes from the stored user record (`notification_db.get_user_time_zone(uid)`), so it can be a stale or malformed IANA name, an empty string, or `None`. An unknown name makes `ZoneInfo(tz)` raise `zoneinfo.ZoneInfoNotFoundError`, and `None` makes it raise `TypeError`. This line sits in the f-string outside the `try` block that guards the `get_llm(...).invoke(prompt)` call, so the exception is not caught here. It propagates up to `save_structured_vector` in `process_conversation.py` and takes down the post-processing run, even though the function was written to fall back to empty metadata on failure.

## Fix

Resolve the timezone once, with a UTC fallback, before the prompt is assembled, and reuse the precomputed date string in the f-string:

```python
    try:
        user_tz = ZoneInfo(tz) if tz else timezone.utc
    except Exception:
        logger.warning(f'Invalid timezone {tz!r} for metadata extraction; falling back to UTC')
        user_tz = timezone.utc
    tz = tz or 'UTC'
    today_local = created_at.astimezone(user_tz).strftime('%Y-%m-%d')
```

The f-string then reads `today is {today_local} in {tz}`. This mirrors the timezone handling already used by `_local_started_at_iso` and `extract_action_items`. A valid timezone produces the same date string as before, so there is no behavior change for valid input. The two sibling extractors in the same file, `retrieve_metadata_from_message` and `retrieve_metadata_from_text`, had the identical unguarded pattern and get the same fallback.

## Testing

Added `backend/tests/unit/test_chat_metadata_tz_guard.py`, registered in `backend/test.sh`. `utils/llm/chat.py` pulls in a heavy dependency graph, so the test stubs the database and LLM client modules under `sys.modules` before importing, then loads the real `chat.py` as source and calls `retrieve_metadata_fields_from_transcript` directly (the same approach as the sibling `tests/unit/test_fair_use_classifier.py`). The LLM call that follows the timezone line is patched to raise, so the test confirms the function reaches its existing degrade-to-empty path rather than dying earlier on the timezone line. Cases covered: an invalid IANA name (`'Not/AZone'`) and a `None` timezone both return `{'people': [], 'topics': [], 'entities': [], 'dates': []}` without raising. The test also uses a real no-op context manager for `track_usage` so a MagicMock `__exit__` cannot silently swallow the raised exception. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The timezone guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted; the version on `main` still interpolates `ZoneInfo(tz)` directly inside the prompt f-string. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

