### PR TITLE
fix(backend): bound image chunk index to prevent IndexError on listen WS

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2431,7 +2431,7 @@ async def _stream_handler(
             image_chunks_cache[temp_id] = {'chunks': [None] * total, 'created_at': time.time()}
 
         chunks_data = image_chunks_cache[temp_id]['chunks']
-        if index < total and chunks_data[index] is None:
+        if 0 <= index < total and chunks_data[index] is None:
             chunks_data[index] = data
 
         if all(chunk is not None for chunk in chunks_data):

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2431,7 +2431,10 @@ async def _stream_handler(
             image_chunks_cache[temp_id] = {'chunks': [None] * total, 'created_at': time.time()}
 
         chunks_data = image_chunks_cache[temp_id]['chunks']
-        if 0 <= index < total and chunks_data[index] is None:
+        # Bound against the cached buffer length, not the per-chunk `total`: a
+        # malformed later chunk can report a larger `total` than the one that
+        # sized the buffer, so trusting it would index past the buffer.
+        if 0 <= index < len(chunks_data) and chunks_data[index] is None:
             chunks_data[index] = data
 
         if all(chunk is not None for chunk in chunks_data):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -43,6 +43,7 @@ pytest tests/unit/test_memories_validation.py -v
 pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_announcement_malformed_type.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
+pytest tests/unit/test_transcribe_image_chunk_bounds.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v
 pytest tests/unit/test_high_priority_usage_tracking.py -v

--- a/backend/tests/unit/test_transcribe_image_chunk_bounds.py
+++ b/backend/tests/unit/test_transcribe_image_chunk_bounds.py
@@ -1,0 +1,129 @@
+"""
+Bounds-check regression test for handle_image_chunk in routers/transcribe.py.
+
+handle_image_chunk indexes a pre-sized list with a client-controlled `index`
+(chunks_data[index]). On main the guard is `index < total` with NO lower bound,
+so a sufficiently-negative index raises IndexError (tearing down the listen
+WebSocket session) and an in-range-negative index silently writes the WRONG
+slot. The fix adds a lower bound: `0 <= index < total`.
+
+handle_image_chunk is a closure nested inside the ~2900-LOC `_stream_handler`,
+so it cannot be imported and called directly, and importing transcribe.py pulls
+in heavy top-level deps. Instead we extract the ACTUAL function node from the
+real source via AST, compile only that function, inject its free (non-parameter)
+names as harmless stubs, and call it. This exercises the real source lines in
+transcribe.py, so the test goes RED (IndexError / wrong-slot write) without the
+fix and GREEN with it -- without reproducing/forking the logic.
+"""
+
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+TRANSCRIBE_SOURCE = Path(__file__).resolve().parents[2] / 'routers' / 'transcribe.py'
+
+
+def _extract_handle_image_chunk_code():
+    """Compile only the real handle_image_chunk async def from transcribe.py."""
+    tree = ast.parse(TRANSCRIBE_SOURCE.read_text(encoding='utf-8'), filename=str(TRANSCRIBE_SOURCE))
+    target = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == 'handle_image_chunk':
+            target = node
+            break
+    assert target is not None, "handle_image_chunk not found in transcribe.py"
+    module = ast.Module(body=[target], type_ignores=[])
+    ast.fix_missing_locations(module)
+    return compile(module, filename=str(TRANSCRIBE_SOURCE), mode='exec')
+
+
+class _Logger:
+    def error(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+
+def _build_handle_image_chunk(spawn_calls):
+    """Return a callable bound to the real source with free names stubbed out."""
+    import time as _time
+
+    def _spawn(coro):
+        spawn_calls.append(1)
+        # The real spawn schedules process_photo(...) on the event loop; we just
+        # need to close the unawaited coroutine to avoid a warning.
+        if hasattr(coro, 'close'):
+            coro.close()
+
+    namespace = {
+        'logger': _Logger(),
+        'sanitize': lambda value: value,
+        'session_id': 'sess-test',
+        '_cleanup_expired_image_chunks': lambda: None,
+        'MAX_IMAGE_CHUNKS': 100,
+        'time': _time,
+        'spawn': _spawn,
+        'process_photo': lambda *args, **kwargs: None,
+        'all': all,
+    }
+    exec(_extract_handle_image_chunk_code(), namespace)
+    return namespace['handle_image_chunk']
+
+
+def _call(handler, chunk_data, cache):
+    async def _noop_send(*args, **kwargs):
+        return None
+
+    asyncio.run(handler('uid-1', chunk_data, cache, _noop_send, []))
+
+
+def test_negative_index_does_not_raise_index_error():
+    """A sufficiently-negative index must be ignored, not raise IndexError."""
+    spawn_calls = []
+    handler = _build_handle_image_chunk(spawn_calls)
+    cache = {}
+
+    # |index| far exceeds total -> chunks_data[index] would IndexError on main.
+    chunk = {'id': 'img-1', 'index': -1_000_000, 'total': 3, 'data': 'QUJDRA=='}
+
+    # Must not raise. (On unfixed source this raises IndexError.)
+    _call(handler, chunk, cache)
+
+    # The out-of-range chunk was ignored: the buffer stays empty and nothing
+    # was dispatched for assembly.
+    assert cache['img-1']['chunks'] == [None, None, None]
+    assert spawn_calls == []
+
+
+def test_in_range_negative_index_does_not_corrupt_wrong_slot():
+    """An in-range-negative index (e.g. -1) must not write the last slot."""
+    spawn_calls = []
+    handler = _build_handle_image_chunk(spawn_calls)
+    cache = {}
+
+    # -1 is "in range" for Python negative indexing and on main would overwrite
+    # chunks_data[-1] (the final slot) with the wrong chunk's data.
+    chunk = {'id': 'img-2', 'index': -1, 'total': 3, 'data': 'WRONG'}
+
+    _call(handler, chunk, cache)
+
+    # Fix ignores it: no slot (including the last) is written.
+    assert cache['img-2']['chunks'] == [None, None, None]
+    assert spawn_calls == []
+
+
+def test_valid_index_still_stored():
+    """Control: a valid in-bounds index is still accepted and stored."""
+    spawn_calls = []
+    handler = _build_handle_image_chunk(spawn_calls)
+    cache = {}
+
+    _call(handler, {'id': 'img-3', 'index': 0, 'total': 3, 'data': 'first'}, cache)
+    _call(handler, {'id': 'img-3', 'index': 2, 'total': 3, 'data': 'third'}, cache)
+
+    assert cache['img-3']['chunks'] == ['first', None, 'third']
+    # Not all chunks present yet -> not dispatched.
+    assert spawn_calls == []

--- a/backend/tests/unit/test_transcribe_image_chunk_bounds.py
+++ b/backend/tests/unit/test_transcribe_image_chunk_bounds.py
@@ -127,3 +127,28 @@ def test_valid_index_still_stored():
     assert cache['img-3']['chunks'] == ['first', None, 'third']
     # Not all chunks present yet -> not dispatched.
     assert spawn_calls == []
+
+
+def test_later_chunk_with_larger_total_does_not_raise_index_error():
+    """A later chunk reporting a larger `total` than the buffer must be ignored.
+
+    The buffer is sized once from the FIRST chunk's `total`. If the bounds
+    check trusts each chunk's reported `total` (instead of the cached buffer
+    length), a malformed later chunk with a larger `total` and an index past
+    the buffer raises IndexError -> tears down the listen WebSocket.
+    """
+    spawn_calls = []
+    handler = _build_handle_image_chunk(spawn_calls)
+    cache = {}
+
+    # First chunk sizes the buffer at length 2.
+    _call(handler, {'id': 'img-4', 'index': 0, 'total': 2, 'data': 'first'}, cache)
+
+    # Later chunk lies about `total` (9) and points past the real buffer.
+    # On code that trusts per-chunk `total`, `0 <= 5 < 9` passes and
+    # chunks_data[5] raises IndexError. Must not raise.
+    _call(handler, {'id': 'img-4', 'index': 5, 'total': 9, 'data': 'overflow'}, cache)
+
+    # Buffer is unchanged (still length 2) and the bogus slot was never written.
+    assert cache['img-4']['chunks'] == ['first', None]
+    assert spawn_calls == []


### PR DESCRIPTION
## Summary

The `/v4/listen` WebSocket accepts image uploads in chunks, and `handle_image_chunk` stores each chunk into a pre-sized list at a client-supplied `index`. The handler checks `index < total` but has no lower bound, so a negative `index` is accepted: a large negative value raises `IndexError` and tears down the whole listen session, and a small negative value like `-1` silently writes into the wrong slot via Python negative indexing. This adds the missing lower bound so out-of-range indices are dropped, the same way an out-of-range positive index is already dropped. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/transcribe.py`, `handle_image_chunk` (a closure inside `_stream_handler`) indexes the per-upload chunk buffer with the client value:

```python
chunks_data = image_chunks_cache[temp_id]['chunks']
if index < total and chunks_data[index] is None:
    chunks_data[index] = data
```

`index` is taken straight from the inbound chunk message (`chunk_data.get('index')`). The earlier validation only checks `isinstance(index, int)`, which passes for negatives. The guard `index < total` is true for every negative number, so the code falls through to `chunks_data[index]`. When `abs(index)` is greater than `total`, that subscript raises `IndexError`, which propagates out of the receive task and ends the listen WebSocket connection mid-session. When `index` is negative but within range (for example `-1` with `total` of 3), there is no exception, but Python negative indexing rewrites `chunks_data[-1]`, the final slot, with the wrong chunk's bytes. The reassembled image is then silently corrupt.

## Fix

Add the lower bound so only a real in-range index is stored:

```python
chunks_data = image_chunks_cache[temp_id]['chunks']
if 0 <= index < total and chunks_data[index] is None:
    chunks_data[index] = data
```

A negative or otherwise out-of-range index now falls through and is ignored, matching the existing behavior for an index past `total`. Valid in-bounds indices store exactly as before, so there is no change for well-formed uploads.

## Testing

Added `backend/tests/unit/test_transcribe_image_chunk_bounds.py` (registered in `backend/test.sh`). `handle_image_chunk` is a closure nested inside the ~2900 line `_stream_handler`, and importing `transcribe.py` pulls in heavy top-level dependencies, so the test loads it from source: it parses `transcribe.py` with `ast`, extracts the real `handle_image_chunk` function node, compiles just that node, injects its free names (`logger`, `time`, `spawn`, `MAX_IMAGE_CHUNKS`, and so on) as harmless stubs, and calls the function. This exercises the actual source lines rather than a reimplementation. The cases covered: a far-negative index (`-1_000_000`) is ignored instead of raising `IndexError` and dispatches nothing; an in-range negative index (`-1`) leaves the final slot untouched instead of corrupting it; and a control case where two valid in-bounds indices are still stored in the right slots. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The lower-bound guard added here does not appear anywhere in this file's history (`handle_image_chunk` was introduced with the omiglass upload support and has carried the unbounded check since), so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

