### PR TITLE
fix(backend): guard pending-sync action item serialization per record

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -138,9 +138,19 @@ def get_pending_sync_items(
     result = action_items_db.get_pending_apple_reminders_sync(uid)
     pending_export = [item for item in result["pending_export"] if not item.get('is_locked', False)]
     synced_items = [item for item in result["synced_items"] if not item.get('is_locked', False)]
+
+    def _safe(items):
+        out = []
+        for item in items:
+            try:
+                out.append(ActionItemResponse(**item))
+            except ValidationError:
+                logger.warning(f"Skipping malformed action item {item.get('id')} in pending-sync for uid {uid}")
+        return out
+
     return {
-        "pending_export": [ActionItemResponse(**item) for item in pending_export],
-        "synced_items": [ActionItemResponse(**item) for item in synced_items],
+        "pending_export": _safe(pending_export),
+        "synced_items": _safe(synced_items),
     }
 
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -163,6 +163,7 @@ pytest tests/unit/test_sync_record_usage.py -v
 pytest tests/unit/test_vision_stream_async.py -v
 pytest tests/unit/test_desktop_transcribe.py -v
 pytest tests/unit/test_desktop_migration.py -v
+pytest tests/unit/test_action_items_pending_sync_malformed.py -v
 pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_staged_tasks_dedup.py -v
 pytest tests/unit/test_dg_start_guard.py -v

--- a/backend/tests/unit/test_action_items_pending_sync_malformed.py
+++ b/backend/tests/unit/test_action_items_pending_sync_malformed.py
@@ -1,0 +1,137 @@
+"""GET /v1/action-items/pending-sync must skip a malformed action item instead of 500ing the whole page.
+
+get_pending_sync_items built ActionItemResponse(**item) directly in a list comprehension for both
+pending_export and synced_items. ActionItemResponse requires 'description' and 'completed' (no defaults),
+so one legacy/malformed doc raised ValidationError that 500'd the endpoint and dropped ALL of the user's
+sync items. The fix wraps each record in a per-item try/except (mirroring get_conversation_action_items).
+routers/action_items.py has a heavy import graph, so we import it under a stub finder, then call the
+handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import action_items as ai_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _valid(aid, completed=False):
+    return {'id': aid, 'description': 'do a thing', 'completed': completed}
+
+
+def test_pending_sync_skips_malformed_not_500():
+    # 'completed' is required on ActionItemResponse with no default -> a doc missing it raises
+    # ValidationError. Both lists contain one valid + one malformed record.
+    good_pending = _valid('p1')
+    bad_pending = {'id': 'p2', 'description': 'missing completed'}
+    good_synced = _valid('s1', completed=True)
+    bad_synced = {'id': 's2', 'description': 'missing completed'}
+
+    result = {
+        'pending_export': [good_pending, bad_pending],
+        'synced_items': [good_synced, bad_synced],
+    }
+
+    with patch.object(ai_mod.action_items_db, 'get_pending_apple_reminders_sync', return_value=result):
+        resp = ai_mod.get_pending_sync_items(platform='apple_reminders', uid='uid1')
+
+    # Only the valid records survive in each list; the malformed ones are skipped, not a 500.
+    assert [i.id for i in resp['pending_export']] == ['p1']
+    assert [i.id for i in resp['synced_items']] == ['s1']


### PR DESCRIPTION
## Summary

`GET /v1/action-items/pending-sync` returns the action items a client needs for Apple Reminders sync, split into `pending_export` and `synced_items`. Today one malformed stored record makes the whole endpoint return HTTP 500, which drops every sync item for that user, not just the bad one. This change builds each record under a per-item guard, so a single legacy or partial-write document is skipped and logged instead of failing the page. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/action_items.py`, `get_pending_sync_items` builds the response with two bare list comprehensions over raw Firestore dicts:

```python
    pending_export = [item for item in result["pending_export"] if not item.get('is_locked', False)]
    synced_items = [item for item in result["synced_items"] if not item.get('is_locked', False)]
    return {
        "pending_export": [ActionItemResponse(**item) for item in pending_export],
        "synced_items": [ActionItemResponse(**item) for item in synced_items],
    }
```

`ActionItemResponse` declares `description: str` and `completed: bool` with no defaults. The items come straight from Firestore, so a record missing either field raises `pydantic.ValidationError` while the comprehension is being built. That happens before the dict is returned, so the whole call fails and FastAPI surfaces it as a 500. Because the comprehension covers the entire list, one bad record takes out all of the user's pending and synced items. The sibling handler `get_conversation_action_items` in the same file already builds each `ActionItemResponse` inside a per-record `try/except ValidationError`.

## Fix

Build each record through a small helper that catches `ValidationError`, logs the offending id, and skips just that record. Both lists go through it:

```python
    def _safe(items):
        out = []
        for item in items:
            try:
                out.append(ActionItemResponse(**item))
            except ValidationError:
                logger.warning(f"Skipping malformed action item {item.get('id')} in pending-sync for uid {uid}")
        return out

    return {
        "pending_export": _safe(pending_export),
        "synced_items": _safe(synced_items),
    }
```

This mirrors the guard already used by `get_conversation_action_items`. Valid records serialize exactly as before, and the response shape is unchanged.

## Testing

Added `backend/tests/unit/test_action_items_pending_sync_malformed.py`, registered in `backend/test.sh`. `routers/action_items.py` has a heavy import graph, so the test installs a stub finder on `sys.meta_path` for the heavy packages (database, utils, firebase_admin, pinecone, and so on), imports the router under it, then removes the finder and calls `get_pending_sync_items` directly. The test patches `action_items_db.get_pending_apple_reminders_sync` with `patch.object` to return a result where both `pending_export` and `synced_items` contain one valid record plus one record missing the required `completed` field. It asserts the handler returns only the valid id from each list rather than raising. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. This guard does not appear anywhere in the history of `routers/action_items.py`, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

