### PR TITLE
fix(backend): skip missing ids in batch_update_action_items to avoid NotFound 500

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -446,7 +446,18 @@ def batch_update_action_items(uid: str, items: list) -> None:
     batch = db.batch()
     count = 0
 
+    # Pre-filter to existing docs: batch.update() on a missing doc raises
+    # google NotFound, which would 500 the whole batch on one stale id.
+    requested_ids = [item.id for item in items]
+    existing_ids = {
+        doc.id
+        for doc in db.get_all([action_items_ref.document(i) for i in requested_ids])
+        if doc is not None and doc.exists
+    }
+
     for item in items:
+        if item.id not in existing_ids:
+            continue
         update_data = {'updated_at': now}
         if item.sort_order is not None:
             update_data['sort_order'] = item.sort_order

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -428,34 +428,46 @@ def update_action_item(uid: str, action_item_id: str, update_data: dict) -> bool
     return True
 
 
-def batch_update_action_items(uid: str, items: list) -> None:
+def batch_update_action_items(uid: str, items: list) -> int:
     """
     Batch update sort_order and/or indent_level for multiple action items.
 
     Args:
         uid: User ID
         items: List of objects with id, sort_order (optional), indent_level (optional)
+
+    Returns:
+        Number of action items actually updated (missing ids and no-op entries
+        are skipped, so this can be lower than ``len(items)``).
     """
     if not items:
-        return
+        return 0
 
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
     now = datetime.now(timezone.utc)
 
-    batch = db.batch()
-    count = 0
+    # Only items that carry a sort_order/indent_level change can produce a write;
+    # entries with neither are no-ops, so skip them before the existence read to
+    # avoid wasted Firestore get_all reads.
+    actionable_items = [item for item in items if item.sort_order is not None or item.indent_level is not None]
+    if not actionable_items:
+        return 0
 
     # Pre-filter to existing docs: batch.update() on a missing doc raises
     # google NotFound, which would 500 the whole batch on one stale id.
-    requested_ids = [item.id for item in items]
+    requested_ids = [item.id for item in actionable_items]
     existing_ids = {
         doc.id
         for doc in db.get_all([action_items_ref.document(i) for i in requested_ids])
         if doc is not None and doc.exists
     }
 
-    for item in items:
+    batch = db.batch()
+    count = 0
+    updated_count = 0
+
+    for item in actionable_items:
         if item.id not in existing_ids:
             continue
         update_data = {'updated_at': now}
@@ -464,10 +476,10 @@ def batch_update_action_items(uid: str, items: list) -> None:
         if item.indent_level is not None:
             update_data['indent_level'] = item.indent_level
 
-        if len(update_data) > 1:  # More than just updated_at
-            doc_ref = action_items_ref.document(item.id)
-            batch.update(doc_ref, update_data)
-            count += 1
+        doc_ref = action_items_ref.document(item.id)
+        batch.update(doc_ref, update_data)
+        count += 1
+        updated_count += 1
 
         if count >= 499:  # Firestore batch limit is 500
             batch.commit()
@@ -476,6 +488,8 @@ def batch_update_action_items(uid: str, items: list) -> None:
 
     if count > 0:
         batch.commit()
+
+    return updated_count
 
 
 def mark_action_item_completed(uid: str, action_item_id: str, completed: bool = True) -> bool:

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -106,8 +106,8 @@ class BatchUpdateActionItemsRequest(BaseModel):
 @router.patch("/v1/action-items/batch", tags=['action-items'])
 def batch_update_action_items(request: BatchUpdateActionItemsRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Batch update sort_order and indent_level for multiple action items."""
-    action_items_db.batch_update_action_items(uid, request.items)
-    return {"status": "ok", "updated_count": len(request.items)}
+    updated_count = action_items_db.batch_update_action_items(uid, request.items)
+    return {"status": "ok", "updated_count": updated_count}
 
 
 # *****************************

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -97,6 +97,7 @@ pytest tests/unit/test_pusher_batch_upload.py -v
 pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
 pytest tests/unit/test_optional_audio_codecs.py -v
 pytest tests/unit/test_storage_opus_encoding.py -v
+pytest tests/unit/test_action_items_batch_update_missing_id.py -v
 pytest tests/unit/test_speech_profile_existence.py -v
 pytest tests/unit/test_speech_profile_wav_decode.py -v
 pytest tests/unit/test_storage_fanout_limits.py -v

--- a/backend/tests/unit/test_action_items_batch_update_missing_id.py
+++ b/backend/tests/unit/test_action_items_batch_update_missing_id.py
@@ -1,0 +1,196 @@
+"""Regression test for database.action_items.batch_update_action_items.
+
+PATCH /v1/action-items/batch (router batch_update_action_items) forwards the
+client-supplied list of {id, sort_order, indent_level} straight into the db
+helper, which issued ``batch.update(doc_ref, ...)`` for every id with no
+existence check. In Firestore, ``batch.update()`` on a document that does not
+exist raises ``google.api_core.exceptions.NotFound`` when the batch commits —
+so a single stale/deleted id supplied by a client 500s the whole batch and
+drops every other (valid) reorder in the request.
+
+The fix pre-filters the requested ids to those that actually exist via
+``db.get_all`` (the same existence-batch pattern used by
+``folders.bulk_move_conversations_to_folder``) and skips missing ids, so one
+stale id no longer poisons the batch.
+
+This test models a faithful Firestore: ``batch.update`` records its target
+doc refs and ``batch.commit`` raises NotFound if any update targeted a doc the
+backing store does not contain (matching real commit-time behavior). It also
+asserts ``batch.update`` is invoked only for the existing id.
+
+Red (pre-fix): missing id flows to batch.update -> commit raises NotFound.
+Green (post-fix): missing id is filtered out -> no NotFound, only valid id updated.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Pre-stub the heavy deps that database.action_items imports at module top
+# (google.cloud.firestore + the Firestore client singleton in database._client)
+# so the real module loads without touching Firestore. Same pattern as
+# tests/unit/test_action_item_idempotency.py.
+for _mod_name in [
+    'firebase_admin',
+    'firebase_admin.auth',
+    'google',
+    'google.cloud',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = types.ModuleType(_mod_name)
+
+sys.modules['google.cloud.firestore'].Client = MagicMock
+sys.modules['google.cloud.firestore'].SERVER_TIMESTAMP = object()
+sys.modules['google.cloud.firestore'].Query = MagicMock()
+sys.modules['google.cloud.firestore'].FieldFilter = MagicMock
+sys.modules['google.cloud.firestore_v1'].FieldFilter = MagicMock
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# Stub the Firestore client singleton; the real module does `from ._client import db`.
+_client_stub = types.ModuleType('database._client')
+_client_stub.db = MagicMock()
+sys.modules['database._client'] = _client_stub
+
+# Ensure the real `database` package (with its on-disk __path__) is importable so
+# `database.action_items` resolves to the real source, not a stub. Drop any cached
+# stub of the submodule so the real one loads.
+_database_pkg = sys.modules.get('database')
+if _database_pkg is None or not getattr(_database_pkg, '__path__', None):
+    _database_pkg = types.ModuleType('database')
+    _database_pkg.__path__ = [os.path.join(_BACKEND_DIR, 'database')]
+    sys.modules['database'] = _database_pkg
+sys.modules.pop('database.action_items', None)
+
+# Import the real module under test. Importing as `database.action_items` (rather
+# than from a file with a bare name) keeps its `from ._client import db` relative
+# import resolvable against the stubbed database._client above.
+from database import action_items as mod  # noqa: E402
+
+
+class _FakeNotFound(Exception):
+    """Stand-in for google.api_core.exceptions.NotFound (commit-time error)."""
+
+
+class _Item:
+    """Minimal stand-in for BatchUpdateActionItemEntry."""
+
+    def __init__(self, id, sort_order=None, indent_level=None):
+        self.id = id
+        self.sort_order = sort_order
+        self.indent_level = indent_level
+
+
+class _FakeBatch:
+    def __init__(self, existing_ids):
+        self._existing_ids = existing_ids
+        self.updated_ids = []
+        self.commits = 0
+
+    def update(self, doc_ref, data):
+        # Record which document id this update targeted.
+        self.updated_ids.append(doc_ref._doc_id)
+
+    def commit(self):
+        self.commits += 1
+        # Real Firestore raises NotFound at commit if any update targeted a
+        # document that does not exist.
+        for doc_id in self.updated_ids:
+            if doc_id not in self._existing_ids:
+                raise _FakeNotFound(f"No document to update: {doc_id}")
+
+
+class _FakeDocRef:
+    def __init__(self, doc_id):
+        self._doc_id = doc_id
+
+
+class _FakeDocSnapshot:
+    def __init__(self, doc_id, exists):
+        self.id = doc_id
+        self.exists = exists
+
+
+class _FakeCollection:
+    def document(self, doc_id):
+        return _FakeDocRef(doc_id)
+
+
+def _build_db(existing_ids):
+    """Build a fake `db` whose collection('action_items') resolves doc refs and
+    whose get_all reports only `existing_ids` as existing."""
+    collection = _FakeCollection()
+
+    user_doc = MagicMock()
+    user_doc.collection.return_value = collection
+
+    users = MagicMock()
+    users.document.return_value = user_doc
+
+    fake_batch = _FakeBatch(existing_ids)
+
+    db = MagicMock()
+    db.collection.return_value = users
+    db.batch.return_value = fake_batch
+
+    def _get_all(doc_refs):
+        return [_FakeDocSnapshot(ref._doc_id, ref._doc_id in existing_ids) for ref in doc_refs]
+
+    db.get_all.side_effect = _get_all
+    return db, fake_batch
+
+
+def test_missing_id_does_not_raise_not_found(monkeypatch):
+    """A client-supplied id that does not exist must not 500 the batch."""
+    existing_ids = {'exists-1'}
+    db, fake_batch = _build_db(existing_ids)
+    monkeypatch.setattr(mod, 'db', db)
+
+    items = [
+        _Item('exists-1', sort_order=1, indent_level=0),
+        _Item('missing-1', sort_order=2, indent_level=0),  # stale / deleted id
+    ]
+
+    # Pre-fix: 'missing-1' reaches batch.update -> commit raises _FakeNotFound.
+    # Post-fix: 'missing-1' is filtered out via db.get_all and skipped.
+    mod.batch_update_action_items('uid', items)
+
+    # Only the existing id should have been written.
+    assert fake_batch.updated_ids == [
+        'exists-1'
+    ], f"batch.update must run only for existing ids, got {fake_batch.updated_ids}"
+
+
+def test_all_missing_ids_commits_nothing(monkeypatch):
+    """If every requested id is missing, the helper must be a clean no-op."""
+    db, fake_batch = _build_db(existing_ids=set())
+    monkeypatch.setattr(mod, 'db', db)
+
+    items = [_Item('gone-1', sort_order=1), _Item('gone-2', indent_level=2)]
+
+    mod.batch_update_action_items('uid', items)
+
+    assert fake_batch.updated_ids == []
+
+
+def test_valid_ids_still_updated(monkeypatch):
+    """Regression guard: the happy path (all ids exist) still updates each."""
+    existing_ids = {'a', 'b'}
+    db, fake_batch = _build_db(existing_ids)
+    monkeypatch.setattr(mod, 'db', db)
+
+    items = [_Item('a', sort_order=1), _Item('b', indent_level=3)]
+
+    mod.batch_update_action_items('uid', items)
+
+    assert sorted(fake_batch.updated_ids) == ['a', 'b']
+    assert fake_batch.commits >= 1

--- a/backend/tests/unit/test_action_items_batch_update_missing_id.py
+++ b/backend/tests/unit/test_action_items_batch_update_missing_id.py
@@ -20,6 +20,13 @@ asserts ``batch.update`` is invoked only for the existing id.
 
 Red (pre-fix): missing id flows to batch.update -> commit raises NotFound.
 Green (post-fix): missing id is filtered out -> no NotFound, only valid id updated.
+
+Additionally guards the cubic review follow-ups:
+- The helper returns the count of items *actually* updated, so the router does
+  not over-report ``updated_count`` to the client when ids are missing (a
+  skipped missing id must not inflate the count).
+- No-op entries (neither sort_order nor indent_level set) are filtered out
+  before the ``db.get_all`` existence read, so they add no Firestore reads.
 """
 
 import os
@@ -162,12 +169,17 @@ def test_missing_id_does_not_raise_not_found(monkeypatch):
 
     # Pre-fix: 'missing-1' reaches batch.update -> commit raises _FakeNotFound.
     # Post-fix: 'missing-1' is filtered out via db.get_all and skipped.
-    mod.batch_update_action_items('uid', items)
+    updated_count = mod.batch_update_action_items('uid', items)
 
     # Only the existing id should have been written.
     assert fake_batch.updated_ids == [
         'exists-1'
     ], f"batch.update must run only for existing ids, got {fake_batch.updated_ids}"
+
+    # The returned count must reflect only the id that was actually updated.
+    # A skipped missing id must NOT inflate the count the router reports to the
+    # client (cubic P2): 2 items requested, 1 missing -> updated_count == 1.
+    assert updated_count == 1, f"updated_count must exclude skipped missing ids, got {updated_count}"
 
 
 def test_all_missing_ids_commits_nothing(monkeypatch):
@@ -177,9 +189,27 @@ def test_all_missing_ids_commits_nothing(monkeypatch):
 
     items = [_Item('gone-1', sort_order=1), _Item('gone-2', indent_level=2)]
 
-    mod.batch_update_action_items('uid', items)
+    updated_count = mod.batch_update_action_items('uid', items)
 
     assert fake_batch.updated_ids == []
+    assert updated_count == 0, f"all-missing batch must report 0 updates, got {updated_count}"
+
+
+def test_noop_only_items_skip_existence_read(monkeypatch):
+    """Entries with neither sort_order nor indent_level are no-ops and must not
+    incur a Firestore existence read (cubic P3) nor inflate the count."""
+    db, fake_batch = _build_db(existing_ids={'a', 'b'})
+    monkeypatch.setattr(mod, 'db', db)
+
+    items = [_Item('a'), _Item('b')]  # no sort_order / indent_level on either
+
+    updated_count = mod.batch_update_action_items('uid', items)
+
+    # No actionable entries -> nothing written, count is 0, and crucially the
+    # existence read is skipped entirely (no wasted get_all reads).
+    assert fake_batch.updated_ids == []
+    assert updated_count == 0
+    db.get_all.assert_not_called()
 
 
 def test_valid_ids_still_updated(monkeypatch):
@@ -190,7 +220,36 @@ def test_valid_ids_still_updated(monkeypatch):
 
     items = [_Item('a', sort_order=1), _Item('b', indent_level=3)]
 
-    mod.batch_update_action_items('uid', items)
+    updated_count = mod.batch_update_action_items('uid', items)
 
     assert sorted(fake_batch.updated_ids) == ['a', 'b']
     assert fake_batch.commits >= 1
+    assert updated_count == 2, f"both valid ids must be counted, got {updated_count}"
+
+
+def test_existence_read_excludes_noop_entries(monkeypatch):
+    """A mixed batch must only read the actionable ids from Firestore — no-op
+    entries are dropped before db.get_all (cubic P3)."""
+    db, fake_batch = _build_db(existing_ids={'a', 'b', 'c'})
+    monkeypatch.setattr(mod, 'db', db)
+
+    seen_ids = []
+
+    def _record_get_all(doc_refs):
+        refs = list(doc_refs)
+        seen_ids.extend(ref._doc_id for ref in refs)
+        return [_FakeDocSnapshot(ref._doc_id, ref._doc_id in {'a', 'b', 'c'}) for ref in refs]
+
+    db.get_all.side_effect = _record_get_all
+
+    items = [
+        _Item('a', sort_order=1),  # actionable
+        _Item('b'),  # no-op: must not be read
+        _Item('c', indent_level=2),  # actionable
+    ]
+
+    updated_count = mod.batch_update_action_items('uid', items)
+
+    assert sorted(seen_ids) == ['a', 'c'], f"only actionable ids should be read, got {sorted(seen_ids)}"
+    assert sorted(fake_batch.updated_ids) == ['a', 'c']
+    assert updated_count == 2


### PR DESCRIPTION
## Summary

`PATCH /v1/action-items/batch` forwards the client-supplied list of reorder entries straight into `batch_update_action_items` in `backend/database/action_items.py`, which calls `batch.update()` for every id with no existence check. In Firestore, `batch.update()` on a document that does not exist raises `google.api_core.exceptions.NotFound` when the batch commits, so a single stale or deleted id in the request returns HTTP 500 and drops every other valid reorder in the same batch. This pre-filters the requested ids to the ones that actually exist and skips the rest, so one stale id no longer takes down the whole batch. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/database/action_items.py`, `batch_update_action_items` builds the batch in a bare loop with no guard:

```python
for item in items:
    update_data = {'updated_at': now}
    if item.sort_order is not None:
        update_data['sort_order'] = item.sort_order
    if item.indent_level is not None:
        update_data['indent_level'] = item.indent_level

    if len(update_data) > 1:  # More than just updated_at
        doc_ref = action_items_ref.document(item.id)
        batch.update(doc_ref, update_data)
        count += 1
```

The ids come from the request body, so the caller can send an id for an item that was already deleted or never existed. `batch.update()` requires the target document to exist. The write is queued without complaint, but at `batch.commit()` Firestore raises `google.api_core.exceptions.NotFound` for the missing target, and because a batch is atomic the whole commit fails. FastAPI surfaces that as a 500, and none of the other reorders in the batch land.

## Fix

Resolve which requested ids exist up front with a single `db.get_all` call, then skip any id that is not in that set before queuing its update:

```python
# Pre-filter to existing docs: batch.update() on a missing doc raises
# google NotFound, which would 500 the whole batch on one stale id.
requested_ids = [item.id for item in items]
existing_ids = {
    doc.id
    for doc in db.get_all([action_items_ref.document(i) for i in requested_ids])
    if doc is not None and doc.exists
}

for item in items:
    if item.id not in existing_ids:
        continue
    update_data = {'updated_at': now}
    ...
```

This is the same existence-batch pattern `folders.bulk_move_conversations_to_folder` already uses. When every id exists the behavior is unchanged: the same documents get the same updates and the batch commits as before.

## Testing

Added `backend/tests/unit/test_action_items_batch_update_missing_id.py`, registered in `backend/test.sh`. `database.action_items` imports the Firestore SDK and the client singleton at module top, so the test stubs those and loads the real module from source, then swaps in a fake `db` whose `get_all` reports only the seeded ids as existing and whose fake batch raises a NotFound stand-in at commit if any update targeted a missing doc, matching real commit-time behavior. The cases: a mix of one existing and one stale id updates only the existing one and never raises; an all-missing request is a clean no-op with nothing committed; and the happy path where all ids exist still updates each one. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The existence filter added here does not appear anywhere in the history of `backend/database/action_items.py`, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

