### PR TITLE
fix(backend): guard v2 sync oversized timestamp with HTTP 400

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1645,10 +1645,10 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, missing timestamp")
         try:
             timestamp = get_timestamp_from_path(filename)
-        except ValueError:
+            time_val = datetime.fromtimestamp(timestamp)
+        except (ValueError, OverflowError, OSError):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time_val = datetime.fromtimestamp(timestamp)
         if time_val > datetime.now() or time_val < datetime(2024, 1, 1):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -91,6 +91,7 @@ pytest tests/unit/test_translation_cost_optimization.py -v
 pytest tests/unit/test_translation_dedup_edge_cases.py -v
 pytest tests/unit/test_conversation_source_unknown.py -v
 pytest tests/unit/test_conversation_model_split.py -v
+pytest tests/unit/test_sync_v2_timestamp_overflow.py -v
 pytest tests/unit/test_transcribe_conversation_cache.py -v
 pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
 pytest tests/unit/test_pusher_batch_upload.py -v

--- a/backend/tests/unit/test_sync_v2_timestamp_overflow.py
+++ b/backend/tests/unit/test_sync_v2_timestamp_overflow.py
@@ -1,0 +1,144 @@
+"""Regression test: _retrieve_file_paths_v2 must reject an oversized timestamp with 400.
+
+get_timestamp_from_path() uses an unbounded int(), so a filename whose timestamp
+segment is enormous (e.g. 'audio_99999999999999999999.bin') parses past the
+`except ValueError` guard, then datetime.fromtimestamp() raises OverflowError/OSError
+OUTSIDE that guard -> an uncaught error (HTTP 500). The fix moves the
+datetime.fromtimestamp() call inside the try and broadens the caught types to
+(ValueError, OverflowError, OSError) so a malformed timestamp becomes the same
+clean HTTP 400 as every other bad-filename branch.
+
+Red (pre-fix): OverflowError/OSError escapes as a non-HTTPException -> 500.
+Green (post-fix): HTTPException(400).
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+# routers/sync.py pulls in Firestore/Redis/GCS/opus/pydub/models and friends.
+# Stub every heavy package so importing the router stays light; fastapi, pydantic,
+# numpy and httpx are real (the function under test raises a real HTTPException).
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'models',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import sync as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException  # noqa: E402  (import after the finder block)
+
+
+class _StubUploadFile:
+    """Minimal UploadFile stand-in with a configurable filename."""
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.file = MagicMock()
+
+
+def test_retrieve_file_paths_v2_oversized_timestamp_raises_400(tmp_path, monkeypatch):
+    """An oversized timestamp must surface as HTTPException(400), not an uncaught 500.
+
+    'audio_99999999999999999999.bin' parses through int() fine (no ValueError) but
+    datetime.fromtimestamp() of the resulting value raises OverflowError/OSError.
+    Pre-fix that escapes the `except ValueError`; post-fix it is caught -> 400.
+    """
+    # Run inside a temp cwd so the 'syncing/<uid>/<job_id>/' makedirs is harmless.
+    monkeypatch.chdir(tmp_path)
+
+    upload = _StubUploadFile(filename='audio_99999999999999999999.bin')
+
+    with pytest.raises(HTTPException) as exc_info:
+        mod._retrieve_file_paths_v2([upload], 'u1', 'job-1')
+
+    assert exc_info.value.status_code == 400
+
+
+def test_retrieve_file_paths_v2_valid_timestamp_not_rejected(tmp_path, monkeypatch):
+    """Sanity: a well-formed in-range timestamp does NOT hit the invalid-timestamp 400.
+
+    Guards against the fix over-rejecting valid input. A 2024 timestamp passes the
+    timestamp checks; the only failure path left is the file-write branch (the stub
+    UploadFile.file is a MagicMock), which raises a 500, never the 'invalid timestamp'
+    400. So: no HTTPException at all, or a non-400 -> the timestamp guard let it through.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # 1719230400 = 2024-06-24, comfortably within [2024-01-01, now) in any local timezone.
+    upload = _StubUploadFile(filename='audio_1719230400.bin')
+
+    try:
+        mod._retrieve_file_paths_v2([upload], 'u1', 'job-1')
+    except HTTPException as exc:
+        # A 500 from the file-copy step is fine; a 400 would mean the timestamp guard rejected it.
+        assert exc.status_code != 400, 'valid timestamp must not be rejected as invalid'


### PR DESCRIPTION
## Summary

The v2 sync upload path `POST /v2/sync-local-files` validates each uploaded `.bin` filename's embedded timestamp before staging the file. When a filename carries an out-of-range timestamp (for example `audio_99999999999999999999.bin`), the handler returns HTTP 500 instead of the clean 400 it returns for every other bad filename. This PR moves the `datetime.fromtimestamp()` conversion inside the existing guard and widens the caught exception types so an oversized timestamp becomes the same 400 as the rest of the validation. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/sync.py`, `_retrieve_file_paths_v2` parses the timestamp and then converts it, but the conversion sits outside the `try`:

```python
        try:
            timestamp = get_timestamp_from_path(filename)
        except ValueError:
            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")

        time_val = datetime.fromtimestamp(timestamp)
        if time_val > datetime.now() or time_val < datetime(2024, 1, 1):
            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
```

`get_timestamp_from_path` runs the segment through an unbounded `int()`, so a huge digit string parses fine and never trips the `except ValueError`. The value then reaches `datetime.fromtimestamp(timestamp)`, where a year far past the platform's range raises `OverflowError` (or `OSError` on some platforms). That exception is not a `ValueError` and is not an `HTTPException`, so it escapes the handler uncaught and FastAPI returns 500. The range check on the next line (the `< datetime(2024, 1, 1)` bound that is supposed to reject bad timestamps) is never reached because the conversion that feeds it is what blows up.

## Fix

Pull the `datetime.fromtimestamp()` call into the `try` block and catch `OverflowError` and `OSError` alongside `ValueError`:

```python
        try:
            timestamp = get_timestamp_from_path(filename)
            time_val = datetime.fromtimestamp(timestamp)
        except (ValueError, OverflowError, OSError):
            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")

        if time_val > datetime.now() or time_val < datetime(2024, 1, 1):
            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
```

A well-formed in-range timestamp converts and passes the range check exactly as before. The only change is that a timestamp that overflows the conversion now lands on the 400 branch instead of escaping as a 500.

## Testing

Added `backend/tests/unit/test_sync_v2_timestamp_overflow.py` (registered in `backend/test.sh`). `routers/sync.py` pulls in Firestore, Redis, GCS, opus, pydub, and the model layer, so the test imports the router under a stub meta-path finder that auto-mocks those heavy packages while keeping fastapi real, then calls `_retrieve_file_paths_v2` directly with a stub `UploadFile`. Two cases: a filename with an oversized timestamp (`audio_99999999999999999999.bin`) must raise `HTTPException` with status 400, and a valid in-range timestamp (`audio_1719230400.bin`, June 2024) must not be rejected with a 400 by the timestamp guard. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this validation logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

