### PR TITLE
fix(backend): guard merge photo sort against naive datetime fallback

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -145,6 +145,7 @@ pytest tests/unit/test_async_tasks.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_oauth_callback_uid_guard.py -v
+pytest tests/unit/test_merge_photos_naive_datetime.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
 pytest tests/unit/test_dev_api_conversations_poison.py -v

--- a/backend/tests/unit/test_merge_photos_naive_datetime.py
+++ b/backend/tests/unit/test_merge_photos_naive_datetime.py
@@ -1,0 +1,163 @@
+"""Tests for ``utils.conversations.merge_conversations._collect_all_photos``.
+
+Regression coverage for a ``TypeError: can't compare offset-naive and
+offset-aware datetimes`` crash while merging conversations. ``_collect_all_photos``
+sorts the merged photo list by ``created_at`` with a naive ``datetime.min``
+fallback for photos missing the field. Firestore photo ``created_at`` values
+are tz-aware, so as soon as one photo lacks ``created_at`` (uses the naive
+fallback) and another has a tz-aware value, the sort comparison raises and the
+entire merge fails for that user (caught by ``perform_merge_async``'s outer
+``except`` -> merge silently aborts).
+
+The fix coerces every sort key to a uniform tz-aware UTC ``datetime``
+(``datetime.min.replace(tzinfo=timezone.utc)`` sentinel for the missing case,
+plus ISO-string coercion), mirroring the ``_coerce_dt`` pattern already used
+for conversation-level timestamps.
+
+Stub harness mirrors ``test_merge_validation.py`` (same module, same heavy
+import graph that initialises Firestore / GCS at module load).
+"""
+
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _ensure_stub(name):
+    existing = sys.modules.get(name)
+    if existing is not None and getattr(existing, "__file__", None):
+        return existing
+    if existing is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return sys.modules[name]
+
+
+# Stub the database modules that merge_conversations imports — these init
+# Firestore at module load. utils.other.storage is also pre-stubbed because it
+# pulls google.cloud.storage + opuslib at import time.
+_ensure_stub("database")
+sys.modules["database"].__path__ = getattr(sys.modules["database"], "__path__", [])
+for _sub in ["_client", "conversations", "vector_db", "redis_db", "users"]:
+    _ensure_stub(f"database.{_sub}")
+sys.modules["database._client"].db = MagicMock()
+sys.modules["database.conversations"].get_conversation = MagicMock(return_value=None)
+sys.modules["database.conversations"].get_conversation_photos = MagicMock(return_value=[])
+sys.modules["database.vector_db"].delete_vector = MagicMock()
+
+# Do NOT stub `utils` or `utils.other` — they are real packages on disk.
+import utils  # noqa: F401, E402
+import utils.other  # noqa: F401, E402
+
+_fake_storage = types.ModuleType("utils.other.storage")
+for _name in [
+    "delete_conversation_audio_files",
+    "list_audio_chunks",
+    "storage_client",
+    "private_cloud_sync_bucket",
+    "_get_extension_for_path",
+]:
+    setattr(_fake_storage, _name, MagicMock())
+sys.modules["utils.other.storage"] = _fake_storage
+
+# Stub the models.* chain referenced by top-level imports / perform_merge_async.
+_fake_models = types.ModuleType("models")
+_fake_models.__path__ = []
+sys.modules["models"] = _fake_models
+for _modname, _attrs in [
+    ("models.audio_file", ["AudioFile"]),
+    ("models.conversation", ["Conversation"]),
+    ("models.conversation_enums", ["ConversationStatus"]),
+    ("models.structured", ["Structured"]),
+]:
+    _mod = types.ModuleType(_modname)
+    for _attr in _attrs:
+        setattr(_mod, _attr, MagicMock())
+    sys.modules[_modname] = _mod
+
+# Drop any earlier empty stub of the module so the real file is re-loaded.
+for _modname in ["utils.conversations", "utils.conversations.merge_conversations"]:
+    _existing = sys.modules.get(_modname)
+    if _existing is not None and not getattr(_existing, "__file__", None):
+        del sys.modules[_modname]
+
+import database.conversations as conversations_db  # noqa: E402
+from utils.conversations import merge_conversations as mod  # noqa: E402
+
+
+def _photo(photo_id, created_at=...):
+    p = {"id": photo_id, "data": f"img-{photo_id}"}
+    if created_at is not ...:
+        p["created_at"] = created_at
+    return p
+
+
+class TestCollectAllPhotosSortKey:
+    def test_missing_created_at_with_tz_aware_does_not_raise(self):
+        # The regression: one photo has no created_at (naive datetime.min
+        # fallback pre-fix) while others are tz-aware -> sort comparison
+        # raised TypeError and aborted the whole merge.
+        photos = [
+            _photo("p_aware", datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)),
+            _photo("p_missing"),  # no created_at -> fallback sentinel
+            _photo("p_aware2", datetime(2026, 5, 30, 10, 0, tzinfo=timezone.utc)),
+        ]
+        conversations_db.get_conversation_photos = MagicMock(return_value=photos)
+
+        # Must not raise TypeError.
+        result = mod._collect_all_photos("uid-1", [{"id": "c1"}])
+
+        ids = [p["id"] for p in result]
+        assert set(ids) == {"p_aware", "p_missing", "p_aware2"}
+        # Missing-created_at photo sorts first (epoch sentinel), then the
+        # tz-aware ones in ascending order.
+        assert ids[0] == "p_missing"
+        assert ids.index("p_aware2") < ids.index("p_aware")
+
+    def test_string_created_at_coerced_and_sorted(self):
+        # Older write paths persisted created_at as an ISO string; mixing a
+        # string with tz-aware datetimes must also not raise and must order
+        # correctly.
+        photos = [
+            _photo("p_str_late", "2026-05-30T15:00:00Z"),
+            _photo("p_dt_early", datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)),
+        ]
+        conversations_db.get_conversation_photos = MagicMock(return_value=photos)
+
+        result = mod._collect_all_photos("uid-1", [{"id": "c1"}])
+        ids = [p["id"] for p in result]
+        assert ids == ["p_dt_early", "p_str_late"]
+
+    def test_all_tz_aware_sorted_ascending(self):
+        photos = [
+            _photo("p3", datetime(2026, 5, 30, 14, 0, tzinfo=timezone.utc)),
+            _photo("p1", datetime(2026, 5, 30, 8, 0, tzinfo=timezone.utc)),
+            _photo("p2", datetime(2026, 5, 30, 11, 0, tzinfo=timezone.utc)),
+        ]
+        conversations_db.get_conversation_photos = MagicMock(return_value=photos)
+
+        result = mod._collect_all_photos("uid-1", [{"id": "c1"}])
+        assert [p["id"] for p in result] == ["p1", "p2", "p3"]
+
+    def test_dedup_across_conversations(self):
+        # Sanity: the dedup-by-id behaviour still holds with the new key.
+        def _photos(uid, conv_id):
+            if conv_id == "c1":
+                return [_photo("dup", datetime(2026, 5, 30, 10, 0, tzinfo=timezone.utc))]
+            return [
+                _photo("dup", datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)),
+                _photo("only2"),
+            ]
+
+        conversations_db.get_conversation_photos = MagicMock(side_effect=_photos)
+        result = mod._collect_all_photos("uid-1", [{"id": "c1"}, {"id": "c2"}])
+        ids = [p["id"] for p in result]
+        assert ids.count("dup") == 1
+        assert "only2" in ids

--- a/backend/tests/unit/test_merge_photos_naive_datetime.py
+++ b/backend/tests/unit/test_merge_photos_naive_datetime.py
@@ -146,6 +146,24 @@ class TestCollectAllPhotosSortKey:
         result = mod._collect_all_photos("uid-1", [{"id": "c1"}])
         assert [p["id"] for p in result] == ["p1", "p2", "p3"]
 
+    def test_unparseable_created_at_degrades_to_sentinel(self):
+        # The sort key now routes through _coerce_dt (one normalization
+        # contract). _coerce_dt returns None for a bad ISO string and for any
+        # non-datetime/non-string type (e.g. an int) -> both must degrade to
+        # the epoch sentinel and sort first, never raise.
+        photos = [
+            _photo("p_aware", datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)),
+            _photo("p_badstr", "not-a-timestamp"),
+            _photo("p_int", 1717000000),  # non-str/non-datetime type
+        ]
+        conversations_db.get_conversation_photos = MagicMock(return_value=photos)
+
+        result = mod._collect_all_photos("uid-1", [{"id": "c1"}])
+        ids = [p["id"] for p in result]
+        assert set(ids) == {"p_aware", "p_badstr", "p_int"}
+        # The two sentinel-valued photos sort ahead of the tz-aware one.
+        assert ids[-1] == "p_aware"
+
     def test_dedup_across_conversations(self):
         # Sanity: the dedup-by-id behaviour still holds with the new key.
         def _photos(uid, conv_id):

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -390,8 +390,25 @@ def _collect_all_photos(uid: str, conversations: List[Dict]) -> List[Dict]:
         except Exception as e:
             logger.error(f"Error fetching photos for {conv['id']}: {e}")
 
-    # Sort by creation time
-    all_photos.sort(key=lambda p: p.get('created_at', datetime.min))
+    # Sort by creation time. Firestore photo created_at is tz-aware, but a
+    # photo missing the field must fall back to a tz-aware sentinel — a naive
+    # datetime.min would raise TypeError when compared against aware values
+    # and fail the whole merge. String created_at (older write paths) is
+    # coerced too so every sort key is a uniform tz-aware datetime.
+    _EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+    def _photo_sort_key(p):
+        ca = p.get('created_at')
+        if isinstance(ca, str):
+            try:
+                ca = datetime.fromisoformat(ca.replace('Z', '+00:00'))
+            except ValueError:
+                ca = None
+        if isinstance(ca, datetime):
+            return ca if ca.tzinfo else ca.replace(tzinfo=timezone.utc)
+        return _EPOCH
+
+    all_photos.sort(key=_photo_sort_key)
     return all_photos
 
 

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -393,22 +393,12 @@ def _collect_all_photos(uid: str, conversations: List[Dict]) -> List[Dict]:
     # Sort by creation time. Firestore photo created_at is tz-aware, but a
     # photo missing the field must fall back to a tz-aware sentinel — a naive
     # datetime.min would raise TypeError when compared against aware values
-    # and fail the whole merge. String created_at (older write paths) is
-    # coerced too so every sort key is a uniform tz-aware datetime.
+    # and fail the whole merge. Reuse _coerce_dt so timestamp normalization
+    # (datetime/ISO-string/None handling) stays under one contract; _EPOCH is
+    # the sentinel for the None it returns on a missing/unparseable value.
     _EPOCH = datetime.min.replace(tzinfo=timezone.utc)
 
-    def _photo_sort_key(p):
-        ca = p.get('created_at')
-        if isinstance(ca, str):
-            try:
-                ca = datetime.fromisoformat(ca.replace('Z', '+00:00'))
-            except ValueError:
-                ca = None
-        if isinstance(ca, datetime):
-            return ca if ca.tzinfo else ca.replace(tzinfo=timezone.utc)
-        return _EPOCH
-
-    all_photos.sort(key=_photo_sort_key)
+    all_photos.sort(key=lambda p: _coerce_dt(p.get('created_at')) or _EPOCH)
     return all_photos
 
 


### PR DESCRIPTION
## Summary

`_collect_all_photos` in the conversation merge path sorts the combined photo list by `created_at`, using a naive `datetime.min` as the fallback for photos that are missing the field. Firestore photo `created_at` values are tz-aware, so the moment one photo lacks `created_at` (and gets the naive fallback) while another carries a tz-aware value, the sort comparison raises `TypeError: can't compare offset-naive and offset-aware datetimes`. That exception propagates up to `perform_merge_async`, whose outer `try/except` only logs it, so the whole merge silently aborts for that user and the merged conversation is never created. This change coerces every sort key to a uniform tz-aware UTC datetime so the sort never raises and the merge completes.

## Root cause

In `backend/utils/conversations/merge_conversations.py`, `_collect_all_photos` builds `all_photos` from every source conversation and then sorts them:

```python
    # Sort by creation time
    all_photos.sort(key=lambda p: p.get('created_at', datetime.min))
    return all_photos
```

`datetime.min` is offset-naive. Firestore deserializes photo `created_at` to an offset-aware `datetime`. Python refuses to order naive against aware values, so as soon as the list mixes a real (aware) `created_at` with a fallback (naive) one, `list.sort` raises `TypeError: can't compare offset-naive and offset-aware datetimes`. `_collect_all_photos` is called at the top of `perform_merge_async` (`merged_photos = _collect_all_photos(uid, sorted_convs)`), and that function wraps its whole body in `except Exception as e: logger.error(...)`. The TypeError is swallowed there, so the user gets no merged conversation and no error surfaced, just a logged failure. The same file already solves the identical naive-vs-aware problem for conversation-level timestamps with the `_coerce_dt` helper, but the photo sort key was never given the same treatment.

## Fix

Replace the bare `datetime.min` key with a helper that normalizes each key to a tz-aware UTC datetime: a tz-aware epoch sentinel for the missing case, ISO-string coercion for older write paths that persisted `created_at` as a string, and a tz attach for any naive datetime that slips through.

```python
    _EPOCH = datetime.min.replace(tzinfo=timezone.utc)

    def _photo_sort_key(p):
        ca = p.get('created_at')
        if isinstance(ca, str):
            try:
                ca = datetime.fromisoformat(ca.replace('Z', '+00:00'))
            except ValueError:
                ca = None
        if isinstance(ca, datetime):
            return ca if ca.tzinfo else ca.replace(tzinfo=timezone.utc)
        return _EPOCH

    all_photos.sort(key=_photo_sort_key)
    return all_photos
```

`datetime` and `timezone` are already imported at module top, so no new import is needed. For the normal case where every photo has a tz-aware `created_at`, the ordering is unchanged. Photos missing the field sort first under the epoch sentinel, which matches the previous intent of `datetime.min`.

## Testing

Added `backend/tests/unit/test_merge_photos_naive_datetime.py`, registered in `backend/test.sh`. `merge_conversations` initializes Firestore and GCS at import time, so the test mirrors `test_merge_validation.py`: it installs the database modules under a stub finder, stubs `utils.other.storage` and the `models.*` chain, then imports the real `merge_conversations` from source and calls `_collect_all_photos` directly with `get_conversation_photos` mocked. Cases covered: a photo with no `created_at` mixed with tz-aware photos does not raise and orders correctly, an ISO-string `created_at` mixed with tz-aware datetimes coerces and sorts, an all tz-aware list sorts ascending, and dedup-by-id still holds with the new key. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The photo sort key in `_collect_all_photos` does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

