### PR TITLE
fix(backend): include short conversations in RAG context

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -133,6 +133,7 @@ pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_sync_pcm_decode.py -v
 pytest tests/unit/test_sync_opus_decode.py -v
 pytest tests/unit/test_transcribe_lc3_optional.py -v
+pytest tests/unit/test_rag_short_conversation_dropped.py -v
 pytest tests/unit/test_sync_silent_failure.py -v
 pytest tests/unit/test_sync_ordered_assignment.py -v
 pytest tests/unit/test_fair_use_free_tier.py -v

--- a/backend/tests/unit/test_rag_short_conversation_dropped.py
+++ b/backend/tests/unit/test_rag_short_conversation_dropped.py
@@ -1,0 +1,148 @@
+"""Regression test for rag.get_better_conversation_chunk dropping short conversations.
+
+Bug: for conversations under 250 tokens the function `return`ed the rendered
+string, but the caller (retrieve_rag_conversation_context) ignores the futures'
+return values and only consumes `context_data.values()`. So short conversations
+were silently dropped from the assembled RAG context. The fix writes the rendered
+chunk into `context_data[memory.id]` (the path the caller reads) instead of
+returning it.
+
+Test strategy: import the real `utils.retrieval.rag` module via the meta-path
+stub-finder (so its heavy database/utils imports resolve to stubs), then patch the
+module-level helpers it calls so we can drive `get_better_conversation_chunk`
+directly with a short conversation and assert the chunk ends up in `context_data`.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+_STUB = (
+    "database",
+    "utils",
+    "firebase_admin",
+    "google",
+    "pinecone",
+    "opuslib",
+    "pydub",
+    "redis",
+    "langchain",
+    "langchain_core",
+    "stripe",
+    "openai",
+    "anthropic",
+    "modal",
+    "ulid",
+    "sentry_sdk",
+    "requests",
+    "typesense",
+    "pusher",
+    "httpx",
+)
+
+
+# The module under test (and the parent packages the import machinery must
+# descend through to reach it) must stay REAL even though they fall under the
+# `utils` stub prefix. Everything else under `utils.*` / `database.*` is stubbed.
+_REAL = ("utils", "utils.retrieval", "utils.retrieval.rag")
+
+
+def _is(n):
+    if n in _REAL:
+        return False
+    return any(n == p or n.startswith(p + ".") for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith("__") and n.endswith("__"):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils.retrieval import rag as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+class _FakeMemory:
+    def __init__(self, mem_id):
+        self.id = mem_id
+        self.transcript_segments = []
+
+
+def test_short_conversation_written_into_context_data():
+    """A short (<250 token) conversation must land in context_data, not be dropped."""
+    memory = _FakeMemory("mem-short-1")
+    context_data = {}
+    rendered = "SHORT CONVERSATION RENDERED TEXT"
+
+    with patch.object(mod.TranscriptSegment, "segments_as_string", return_value="hi there"), patch.object(
+        mod, "num_tokens_from_string", return_value=10
+    ), patch.object(mod, "conversations_to_string", return_value=rendered), patch.object(
+        mod, "chunk_extraction"
+    ) as chunk_extraction_mock:
+        result = mod.get_better_conversation_chunk(memory, ["topic"], context_data)
+
+    # The short-conversation path must NOT call chunk_extraction.
+    chunk_extraction_mock.assert_not_called()
+    # The function follows the same contract as the long branch: mutate, return None.
+    assert result is None
+    # The rendered chunk must be in the dict the caller actually consumes.
+    assert context_data.get(memory.id) == rendered
+    # And it must be visible via .values() (exactly how the caller assembles context).
+    assert rendered in list(context_data.values())
+
+
+def test_long_conversation_still_written_into_context_data():
+    """Sanity: the long-conversation path already writes into context_data (unchanged)."""
+    memory = _FakeMemory("mem-long-1")
+    context_data = {}
+
+    with patch.object(mod.TranscriptSegment, "segments_as_string", return_value="long convo"), patch.object(
+        mod, "num_tokens_from_string", return_value=5000
+    ), patch.object(mod, "conversations_to_string", return_value="should-not-be-used"), patch.object(
+        mod, "chunk_extraction", return_value="EXTRACTED CHUNK CONTENT"
+    ):
+        result = mod.get_better_conversation_chunk(memory, ["topic"], context_data)
+
+    assert result is None
+    assert context_data.get(memory.id) == "EXTRACTED CHUNK CONTENT"

--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -58,7 +58,8 @@ def get_better_conversation_chunk(
         memory.transcript_segments, include_timestamps=True, people=people, user_name=user_name
     )
     if num_tokens_from_string(conversation) < 250:
-        return conversations_to_string([memory], people=people, user_name=user_name)
+        context_data[memory.id] = conversations_to_string([memory], people=people, user_name=user_name)
+        return
     chunk = chunk_extraction(memory.transcript_segments, topics, people=people, user_name=user_name)
     if not chunk or len(chunk) < 10:
         return

--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -52,7 +52,7 @@ def retrieve_memories_for_topics(uid: str, topics: List[str], dates_range: List)
 
 def get_better_conversation_chunk(
     memory: Conversation, topics: List[str], context_data: dict, people: List[Person] = None, user_name: str = None
-) -> str:
+) -> None:
     logger.info(f'get_better_memory_chunk {memory.id} {topics}')
     conversation = TranscriptSegment.segments_as_string(
         memory.transcript_segments, include_timestamps=True, people=people, user_name=user_name


### PR DESCRIPTION
## Summary

`get_better_conversation_chunk` in the RAG retrieval pipeline assembles each matched conversation into a shared `context_data` dict that the caller later joins into the model's context. For conversations under 250 tokens the function returned the rendered text instead of writing it into `context_data`, and the caller ignores the return value. The result is that short conversations were silently dropped from the assembled RAG context, so chat answers that depended on a brief conversation lost that source with no error. This PR writes the short-conversation render into `context_data[memory.id]`, the same place the long-conversation branch already writes, so the caller picks it up.

## Root cause

In `backend/utils/retrieval/rag.py`, `get_better_conversation_chunk` takes a `context_data: dict` argument and is meant to mutate it. The long branch does exactly that, but the short branch returns instead:

```python
def get_better_conversation_chunk(
    memory: Conversation, topics: List[str], context_data: dict, people: List[Person] = None, user_name: str = None
) -> str:
    logger.info(f'get_better_memory_chunk {memory.id} {topics}')
    conversation = TranscriptSegment.segments_as_string(
        memory.transcript_segments, include_timestamps=True, people=people, user_name=user_name
    )
    if num_tokens_from_string(conversation) < 250:
        return conversations_to_string([memory], people=people, user_name=user_name)
    chunk = chunk_extraction(memory.transcript_segments, topics, people=people, user_name=user_name)
    if not chunk or len(chunk) < 10:
        return
    context_data[memory.id] = chunk
```

The caller `retrieve_rag_conversation_context` runs these through `db_executor` and never looks at what they return:

```python
futures = [
    db_executor.submit(
        get_better_conversation_chunk, m, memories_id_to_topics.get(m.id, []), context_data, people, user_name
    )
    for m in memories
]
for f in futures:
    f.result()
context_str = '\n'.join(context_data.values()).strip()
```

`f.result()` is called only to surface exceptions; the value is discarded. The assembled context comes entirely from `context_data.values()`. So when a conversation is under 250 tokens, its rendered text is returned into a future that nobody reads, and it never reaches `context_str`. There is no exception, the answer is just built from fewer sources than it should be. Longer conversations are unaffected because they write into `context_data` directly.

## Fix

Make the short branch follow the same contract as the rest of the function: write into `context_data` keyed by `memory.id`, then return `None`.

```python
    if num_tokens_from_string(conversation) < 250:
        context_data[memory.id] = conversations_to_string([memory], people=people, user_name=user_name)
        return
```

Both branches now mutate `context_data` and return nothing, which is what the caller expects. Behavior for conversations of 250 tokens or more is unchanged.

## Testing

Added `backend/tests/unit/test_rag_short_conversation_dropped.py` (registered in `backend/test.sh`). `utils.retrieval.rag` has a heavy database and utils import graph, so the test imports it under a meta-path stub finder that resolves those imports to stubs while keeping `utils.retrieval.rag` real, then patches the module-level helpers (`num_tokens_from_string`, `conversations_to_string`, `chunk_extraction`, and `TranscriptSegment.segments_as_string`) and calls `get_better_conversation_chunk` directly. One case drives a short conversation (token count below 250) and asserts the rendered chunk lands in `context_data[memory.id]` and is visible via `context_data.values()`, the exact path the caller consumes, and that `chunk_extraction` is not called and the function returns `None`. A second case checks the long-conversation branch still writes its extracted chunk into `context_data`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. This `context_data` write does not appear anywhere in the history of `backend/utils/retrieval/rag.py`, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

