### PR TITLE
fix(backend): write proactive-noti in-process rate-limit key under app.id

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -199,6 +199,7 @@ pytest tests/unit/test_phone_calls.py -v
 pytest tests/unit/test_twilio_service.py -v
 pytest tests/unit/test_twilio_account_deletion.py -v
 pytest tests/unit/test_phone_verification_created_at.py -v
+pytest tests/unit/test_proactive_noti_key_mismatch.py -v
 pytest tests/unit/test_conversation_search_date_validation.py -v
 pytest tests/unit/test_conversation_events_bounds.py -v
 pytest tests/unit/test_conversation_hybrid_search.py -v

--- a/backend/tests/unit/test_proactive_noti_key_mismatch.py
+++ b/backend/tests/unit/test_proactive_noti_key_mismatch.py
@@ -1,0 +1,173 @@
+"""Regression test for the proactive-notification in-process rate-limit key mismatch.
+
+`_set_proactive_noti_sent_at` must write the in-process (mem_db) rate-limit key
+under `app.id`, the same key `_hit_proactive_notification_rate_limits` reads with.
+The original bug passed the whole `App` object as the key to
+`mem_db.set_proactive_noti_sent_at`, so the in-process rate-limit layer never
+matched on a subsequent read (the write landed under str(App), the read under
+app.id) — silently disabling that layer.
+
+Harness: meta-path stub-finder for heavy deps. The module under test
+(utils.app_integrations) is explicitly excluded from stubbing so it imports from
+disk; mem_db and redis_db are then patched on the imported module so we can
+observe the exact key each layer writes under.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Module under test — must import from disk, never get stubbed.
+_TARGET = 'utils.app_integrations'
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'httpx',
+    'models',
+)
+
+
+def _is(n):
+    if n == _TARGET:
+        return False
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+
+# Give the real `utils` package a filesystem path so the finder can locate the
+# real utils.app_integrations on disk (the finder declines to stub _TARGET).
+_real_utils = types.ModuleType('utils')
+_real_utils.__path__ = [os.path.join(_BACKEND_DIR, 'utils')]
+sys.modules['utils'] = _real_utils
+
+sys.meta_path.insert(0, _f)
+try:
+    from utils import app_integrations as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.pop('utils', None)
+    sys.modules.update(_sav)
+
+
+def _make_app(app_id):
+    """Minimal App-like object: only `.id` is used by the function under test."""
+    return SimpleNamespace(id=app_id)
+
+
+def test_set_proactive_noti_sent_at_writes_under_app_id():
+    """The in-process (mem_db) write must use app.id so a later read with app.id hits.
+
+    Red (bug): mem_db.set_proactive_noti_sent_at is called with the App object as
+    the key, so the captured key != app.id and a read keyed by app.id misses.
+    """
+    app = _make_app('app-xyz')
+    uid = 'user-1'
+
+    # Simulate the real in-process store: key by f'{uid}:{key}', so passing the
+    # App object instead of app.id produces a different (never-matching) key.
+    store = {}
+
+    def fake_set(u, key, ts, ttl=30):
+        store[f'{u}:{key}'] = ts
+
+    def fake_get(u, key):
+        return store.get(f'{u}:{key}')
+
+    fake_mem = MagicMock()
+    fake_mem.set_proactive_noti_sent_at.side_effect = fake_set
+    fake_mem.get_proactive_noti_sent_at.side_effect = fake_get
+
+    fake_redis = MagicMock()
+
+    with patch.object(mod, 'mem_db', fake_mem), patch.object(mod, 'redis_db', fake_redis):
+        mod._set_proactive_noti_sent_at(uid, app)
+
+        # The reader keys the in-process lookup by app.id; it must hit what the
+        # writer just stored. With the bug, the writer stored under str(App), so
+        # this read returns None.
+        assert (
+            fake_mem.get_proactive_noti_sent_at(uid, app.id) is not None
+        ), "in-process rate-limit write did not land under app.id (read keyed by app.id missed)"
+
+    # Also assert the exact positional key handed to mem_db is app.id, not the App.
+    call_uid, call_key, call_ts = fake_mem.set_proactive_noti_sent_at.call_args.args
+    assert call_key == app.id, f"mem_db write key was {call_key!r}, expected app.id={app.id!r}"
+    assert call_key is not app, "mem_db write key was the App object, not app.id (the bug)"
+
+
+def test_mem_db_and_redis_keys_agree():
+    """mem_db and redis_db rate-limit layers must be keyed identically (both app.id)."""
+    app = _make_app('app-abc')
+    uid = 'user-2'
+
+    fake_mem = MagicMock()
+    fake_redis = MagicMock()
+
+    with patch.object(mod, 'mem_db', fake_mem), patch.object(mod, 'redis_db', fake_redis):
+        mod._set_proactive_noti_sent_at(uid, app)
+
+    mem_key = fake_mem.set_proactive_noti_sent_at.call_args.args[1]
+    redis_key = fake_redis.set_proactive_noti_sent_at.call_args.args[1]
+    assert (
+        mem_key == redis_key == app.id
+    ), f"mem_db key={mem_key!r} and redis_db key={redis_key!r} must both equal app.id={app.id!r}"

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -311,7 +311,7 @@ def _hit_proactive_notification_rate_limits(uid: str, app: App):
 
 def _set_proactive_noti_sent_at(uid: str, app: App):
     ts = time.time()
-    mem_db.set_proactive_noti_sent_at(uid, app, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
+    mem_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
     redis_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
 
 


### PR DESCRIPTION
## Summary

The proactive notification rate limiter has two layers: an in-process cache (`mem_db`) and Redis. `_set_proactive_noti_sent_at` in `backend/utils/app_integrations.py` records the last-sent timestamp in both. It writes the Redis entry keyed by `app.id` but writes the in-process entry keyed by the whole `App` object, so the two layers store the same value under different keys. The reader, `_hit_proactive_notification_rate_limits`, looks up the in-process entry by `app.id`, which never matches what was written, so the in-process limiter is silently disabled and only the Redis layer enforces the limit. This PR keys the in-process write by `app.id` so both layers agree and the reader hits.

## Root cause

In `backend/utils/app_integrations.py`, `_set_proactive_noti_sent_at` writes the in-process timestamp with the `App` object as the key instead of `app.id`:

```python
def _set_proactive_noti_sent_at(uid: str, app: App):
    ts = time.time()
    mem_db.set_proactive_noti_sent_at(uid, app, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
    redis_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
```

The Redis write on the next line already uses `app.id`, and the reader keys its in-process lookup by `app.id` as well:

```python
def _hit_proactive_notification_rate_limits(uid: str, app: App):
    sent_at = mem_db.get_proactive_noti_sent_at(uid, app.id)
    ...
    if ttl > 0:
        mem_db.set_proactive_noti_sent_at(uid, app.id, int(time.time() + ttl), ttl=ttl)
```

Because the write uses the `App` object and the read uses `app.id`, the in-process key never lines up. The lookup returns `None`, so the in-process check is skipped and the limiter falls through to Redis on every call. No exception is raised; the result is just wrong. The in-process layer exists to absorb load before hitting Redis, and it stops doing that.

## Fix

Pass `app.id` to the in-process write so it matches the Redis write and the reader:

```python
def _set_proactive_noti_sent_at(uid: str, app: App):
    ts = time.time()
    mem_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
    redis_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
```

One argument changes, from `app` to `app.id`. Behavior for valid input is unchanged except that the in-process layer now records under the key the reader uses, so it starts matching as intended.

## Testing

Added `backend/tests/unit/test_proactive_noti_key_mismatch.py`, registered in `backend/test.sh`. The module under test (`utils.app_integrations`) has a heavy import graph, so the test installs a meta-path stub finder for the heavy dependencies and excludes the target module so it loads from disk, then patches `mem_db` and `redis_db` on the imported module to capture the exact key each layer writes under. One case backs the in-process store with a real dict keyed by `f'{uid}:{key}'` and asserts that a read keyed by `app.id` hits what the write stored, and that the positional key handed to `mem_db.set_proactive_noti_sent_at` is `app.id` and not the `App` object. A second case asserts the `mem_db` and `redis_db` write keys are equal and both equal `app.id`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The `app.id` form on this in-process write does not appear anywhere in the history of `backend/utils/app_integrations.py`, so this is not a previously reverted fix being resubmitted; the only `app.id` change in the file's past was a `plugin.id` to `app.id` rename inside `_hit_proactive_notification_rate_limits`, not this write. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

