### PR TITLE
fix(backend): close audio file handle in speech profile matching predictions

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -67,6 +67,7 @@ pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
+pytest tests/unit/test_speech_profile_fd_leak.py -v
 pytest tests/unit/test_conversations_count.py -v
 pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v

--- a/backend/tests/unit/test_speech_profile_fd_leak.py
+++ b/backend/tests/unit/test_speech_profile_fd_leak.py
@@ -1,0 +1,166 @@
+"""Unit test for the speech-profile matching-prediction file-descriptor leak.
+
+`get_speech_profile_matching_predictions` (utils/stt/speech_profile.py) opened the
+audio file inline inside the `files=[...]` list passed to `httpx.post(...)` and never
+closed it. Every call leaked a file descriptor (httpx does not close caller-provided
+file objects). The fix wraps the open() in a `with open(audio_file_path, 'rb') as f:`
+block that encloses the httpx.post call, mirroring the sibling `_read_file` helper.
+
+This test patches `httpx.post` to capture the file object handed to it and asserts the
+handle is `.closed` after the call returns. It is RED on the unguarded code (the inline
+open is never closed -> handle.closed is False) and GREEN once the `with` block closes
+it deterministically.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+
+# Heavy / native packages pulled in (directly or transitively) by utils.stt.speech_profile.
+# httpx is kept REAL so we can patch the real httpx.post attribute on the module.
+_STUB = (
+    "database",
+    "firebase_admin",
+    "google",
+    "pinecone",
+    "opuslib",
+    "pydub",
+    "redis",
+    "utils.executors",
+    "utils.http_client",
+    "utils.other.storage",
+)
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + ".") for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith("__") and n.endswith("__"):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for _n in list(sys.modules):
+    if _is(_n):
+        sys.modules.pop(_n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils.stt import speech_profile as mod
+finally:
+    sys.meta_path.remove(_f)
+    for _n in list(sys.modules):
+        if _is(_n) and _n not in _sav:
+            sys.modules.pop(_n, None)
+    sys.modules.update(_sav)
+
+
+def _make_wav():
+    fd, path = tempfile.mkstemp(suffix=".wav")
+    os.write(fd, b"RIFF....WAVEfmt ")
+    os.close(fd)
+    return path
+
+
+def _cleanup(path, captured):
+    """Best-effort temp-file removal.
+
+    On Windows an un-closed handle (the bug) blocks os.remove, so close the
+    captured handle first if it is still open. This keeps the *assertion* (not
+    the cleanup) the thing that fails, on both Windows and Linux/CI.
+    """
+    fh = captured.get("fh")
+    if fh is not None and not fh.closed:
+        try:
+            fh.close()
+        except Exception:
+            pass
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+class TestSpeechProfileMatchingPredictionsFdLeak:
+    def test_audio_file_handle_closed_after_success(self):
+        """The opened audio file handle must be closed once the call returns (no FD leak)."""
+        path = _make_wav()
+        captured = {}
+
+        def _fake_post(url, data=None, files=None, **kwargs):
+            # files = [('audio_file', (basename, <file object>, 'audio/wav'))]
+            fh = files[0][1][1]
+            captured["fh"] = fh
+            captured["closed_at_call_return"] = None
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = [False]
+            return resp
+
+        try:
+            with patch.dict(os.environ, {"HOSTED_SPEECH_PROFILE_API_URL": "http://stt.test/match"}), patch.object(
+                mod.httpx, "post", side_effect=_fake_post
+            ):
+                mod.get_speech_profile_matching_predictions("uid-1", path, segments=[{"text": "hi"}])
+                # Capture closed-state at the moment the function returned, before cleanup.
+                captured["closed_at_call_return"] = captured["fh"].closed
+        finally:
+            _cleanup(path, captured)
+
+        assert "fh" in captured, "httpx.post was not called with a files= payload"
+        assert (
+            captured["closed_at_call_return"] is True
+        ), "audio file handle was left open after the call returned (FD leak)"
+
+    def test_audio_file_handle_closed_even_when_post_raises(self):
+        """Even if httpx.post raises mid-request the handle must not be leaked."""
+        path = _make_wav()
+        captured = {}
+
+        def _raising_post(url, data=None, files=None, **kwargs):
+            captured["fh"] = files[0][1][1]
+            raise RuntimeError("boom")
+
+        try:
+            with patch.dict(os.environ, {"HOSTED_SPEECH_PROFILE_API_URL": "http://stt.test/match"}), patch.object(
+                mod.httpx, "post", side_effect=_raising_post
+            ):
+                try:
+                    mod.get_speech_profile_matching_predictions("uid-1", path, segments=[{"text": "hi"}])
+                except RuntimeError:
+                    pass
+                captured["closed_at_call_return"] = captured["fh"].closed
+        finally:
+            _cleanup(path, captured)
+
+        assert "fh" in captured, "httpx.post was not called with a files= payload"
+        assert (
+            captured.get("closed_at_call_return") is True
+        ), "audio file handle was left open after post raised (FD leak)"

--- a/backend/utils/stt/speech_profile.py
+++ b/backend/utils/stt/speech_profile.py
@@ -21,13 +21,16 @@ logger = logging.getLogger(__name__)
 
 def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segments: List) -> List[dict]:
     logger.info('get_speech_profile_matching_predictions')
-    files = [
-        ('audio_file', (os.path.basename(audio_file_path), open(audio_file_path, 'rb'), 'audio/wav')),
-    ]
-    response = httpx.post(
-        os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}', data={'segments': json.dumps(segments)}, files=files
-    )
     default = [{'is_user': False, 'person_id': None}] * len(segments)
+    with open(audio_file_path, 'rb') as audio_f:
+        files = [
+            ('audio_file', (os.path.basename(audio_file_path), audio_f, 'audio/wav')),
+        ]
+        response = httpx.post(
+            os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}',
+            data={'segments': json.dumps(segments)},
+            files=files,
+        )
 
     if response.status_code != 200:
         logger.info(f'get_speech_profile_matching_predictions {sanitize(response.text)}')


### PR DESCRIPTION
## Summary

`get_speech_profile_matching_predictions` in `backend/utils/stt/speech_profile.py` opens the user's audio file and hands the raw file object to `httpx.post(...)` inside the `files=[...]` list, but it never closes it. httpx does not close caller-provided file objects, so every call to this function leaks one open file descriptor. This function runs during conversation post-processing for speaker matching, so on a busy backend the leaked descriptors accumulate until the process hits its open-files limit, after which `open()` starts raising `OSError: [Errno 24] Too many open files` and any code in that process that opens a file or socket begins failing. This PR opens the file inside a `with` block so the descriptor is released when the call returns. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/stt/speech_profile.py`, `get_speech_profile_matching_predictions` opens the audio file inline as an argument to the `files` payload:

```python
def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segments: List) -> List[dict]:
    logger.info('get_speech_profile_matching_predictions')
    files = [
        ('audio_file', (os.path.basename(audio_file_path), open(audio_file_path, 'rb'), 'audio/wav')),
    ]
    response = httpx.post(
        os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}', data={'segments': json.dumps(segments)}, files=files
    )
```

The file object created by `open(audio_file_path, 'rb')` is only referenced from the `files` list. httpx reads from it to build the multipart body but does not take ownership and does not close it, and nothing in this function closes it either. There is no `close()`, no `with`, and no `try/finally`, so the handle is left open on every path: success, a non-200 response, and an exception out of `httpx.post`. Each invocation leaks one descriptor. The sibling helper `_read_file` in the same module already reads its file under `with open(path, 'rb') as f:`, so the safe pattern was right there but this function did not use it.

## Fix

Open the file inside a `with` block that encloses the `httpx.post` call, so the descriptor is closed deterministically when the block exits, on every return path including when `httpx.post` raises:

```python
def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segments: List) -> List[dict]:
    logger.info('get_speech_profile_matching_predictions')
    default = [{'is_user': False, 'person_id': None}] * len(segments)
    with open(audio_file_path, 'rb') as audio_f:
        files = [
            ('audio_file', (os.path.basename(audio_file_path), audio_f, 'audio/wav')),
        ]
        response = httpx.post(
            os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}',
            data={'segments': json.dumps(segments)},
            files=files,
        )
```

httpx finishes reading the file while building the request body inside the `with` block, so closing on exit is safe. The request payload, the return values, and the response handling below are unchanged, so behavior for valid input is identical apart from no longer leaking the handle.

## Testing

Added `backend/tests/unit/test_speech_profile_fd_leak.py`, registered in `backend/test.sh`. The module pulls in heavy and native dependencies (firebase, pinecone, opuslib, pydub, redis, and the storage and executor utils), so the test installs a stub meta-path finder for those packages and imports `utils.stt.speech_profile` under it, while keeping `httpx` real so `httpx.post` can be patched on the module. Two cases: one patches `httpx.post` to capture the file object from the `files` payload and asserts the handle is `.closed` after a successful call returns, and one makes `httpx.post` raise mid-request and asserts the handle is still closed afterward. Cleanup closes any leaked handle before removing the temp file so the assertion, not the temp-file removal, is what fails on the buggy code (this matters on Windows where an open handle blocks deletion). Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The most recent commit to touch this file, the async-native HTTP refactor (#7343 / #6369), added the separate `async_get_speech_profile_matching_predictions` variant and the `_read_file` helper but left this synchronous function with the unguarded inline `open()`, so it does not fix the leak. The `with`-block fix added here does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

