### PR TITLE
fix(backend): skip malformed action items in search instead of 500ing whole search

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -320,7 +320,14 @@ def search_action_items(
 
     action_items = action_items_db.get_action_items_by_ids(uid, action_item_ids)
     action_items = [item for item in action_items if not item.get('is_locked', False)]
-    return {"action_items": [ActionItemResponse(**item) for item in action_items]}
+    response_items = []
+    for item in action_items:
+        try:
+            response_items.append(ActionItemResponse(**item))
+        except ValidationError:
+            logger.warning(f"Skipping malformed action item {item.get('id')} in search for uid {uid}")
+            continue
+    return {"action_items": response_items}
 
 
 @router.get("/v1/action-items/{action_item_id}", response_model=ActionItemResponse, tags=['action-items'])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -187,6 +187,7 @@ pytest tests/unit/test_thread_join_elimination.py -v
 pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
+pytest tests/unit/test_action_items_search_malformed.py -v
 pytest tests/unit/test_byok_security.py -v
 pytest tests/unit/test_paywall_reconnect_gate.py -v
 pytest tests/unit/test_trial_metadata.py -v

--- a/backend/tests/unit/test_action_items_search_malformed.py
+++ b/backend/tests/unit/test_action_items_search_malformed.py
@@ -1,0 +1,126 @@
+"""GET /v1/action-items/search must skip a malformed action item instead of 500ing the whole search.
+
+search_action_items built ActionItemResponse(**item) per item with no guard, so one malformed/legacy
+item (missing a required field like 'completed') raised ValidationError and failed the entire search
+(poison-page). The sibling get_conversation_action_items already guards each record; this mirrors it.
+routers/action_items.py has a heavy import graph, so we import it under a stub finder and call the
+endpoint handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if any(name == p or name.startswith(p + '.') for p in _STUB):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_stubbed_modules_snapshot = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_remove_python_multipart_stub = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import action_items as ai_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_stubbed_modules_snapshot)
+    if _remove_python_multipart_stub:
+        sys.modules.pop('python_multipart', None)
+
+
+def _valid(aid, completed=False):
+    return {'id': aid, 'description': 'do a thing', 'completed': completed}
+
+
+def test_search_skips_malformed_not_500():
+    bad = {'id': 'a2', 'description': 'missing completed'}  # missing required field -> ValidationError
+    page = [_valid('a1'), bad]
+    with patch.object(ai_mod, 'search_action_items_by_vector', return_value=['a1', 'a2']), patch.object(
+        ai_mod.action_items_db, 'get_action_items_by_ids', return_value=page
+    ):
+        resp = ai_mod.search_action_items(query='thing', limit=10, uid='uid1')
+    # The malformed item is dropped, the valid one is returned, no 500/ValidationError propagates.
+    assert [i.id for i in resp['action_items']] == ['a1']


### PR DESCRIPTION
## Summary

`GET /v1/action-items/search` runs a semantic vector search over a user's action items and serializes each hit into an `ActionItemResponse`. Today it builds every result in one unguarded list comprehension, so a single malformed or legacy item (one missing a required field) raises `pydantic.ValidationError` and FastAPI turns the whole request into a 500. The search returns nothing even though every other matching item is fine. This PR serializes each item with a per-record guard, skipping and logging the bad one so the rest of the results still come back. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/action_items.py`, `search_action_items` builds the response in a single comprehension over the raw Firestore dicts:

```python
action_items = action_items_db.get_action_items_by_ids(uid, action_item_ids)
action_items = [item for item in action_items if not item.get('is_locked', False)]
return {"action_items": [ActionItemResponse(**item) for item in action_items]}
```

`ActionItemResponse` declares `id`, `description`, and `completed` as required fields with no defaults. If any item in the page is missing one of those (a partial write or an older document that predates the field), `ActionItemResponse(**item)` raises `pydantic.ValidationError`. The comprehension has no guard, so that one bad record aborts the whole loop and surfaces as a 500 for the entire search. The sibling handler `get_conversation_action_items` in this same file already guards each record this way, so the search path was the inconsistent one.

## Fix

Build the list item by item and wrap each construction in `try/except ValidationError`. On a bad record, log it and `continue`, dropping just that item:

```python
response_items = []
for item in action_items:
    try:
        response_items.append(ActionItemResponse(**item))
    except ValidationError:
        logger.warning(f"Skipping malformed action item {item.get('id')} in search for uid {uid}")
        continue
return {"action_items": response_items}
```

`ValidationError` and `logger` are already imported in this module. There is no signature or response-shape change, and a page where every item is valid serializes exactly as before.

## Testing

Added `backend/tests/unit/test_action_items_search_malformed.py`, registered in `backend/test.sh`. `routers/action_items.py` has a heavy import graph, so the test imports it under a stub meta-path finder (with `database`, `utils`, and the external SDKs stubbed) and calls `search_action_items` directly. The vector lookup and `get_action_items_by_ids` are patched with `patch.object` to return a page holding one valid item plus one missing the required `completed` field. The test asserts the malformed item is dropped, the valid item is returned, and no `ValidationError` or 500 propagates. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The per-record guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

