### PR TITLE
fix(backend): make remove_person_speech_sample transactional

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -375,10 +375,47 @@ def get_person_speech_samples_count(uid: str, person_id: str) -> int:
     return len(person_data.get('speech_samples', []))
 
 
+@transactional
+def _remove_sample_transaction(transaction, person_ref, sample_path):
+    """Transaction to atomically remove a sample and its aligned transcript."""
+    snapshot = person_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+
+    person_data = snapshot.to_dict()
+    samples = person_data.get('speech_samples', [])
+    transcripts = person_data.get('speech_sample_transcripts', [])
+
+    # Find index of sample to remove
+    try:
+        idx = samples.index(sample_path)
+    except ValueError:
+        return False  # Sample not found
+
+    # Remove from both arrays by index to keep them aligned
+    samples.pop(idx)
+    if idx < len(transcripts):
+        transcripts.pop(idx)
+
+    transaction.update(
+        person_ref,
+        {
+            'speech_samples': samples,
+            'speech_sample_transcripts': transcripts,
+            'updated_at': datetime.now(timezone.utc),
+        },
+    )
+    return True
+
+
 def remove_person_speech_sample(uid: str, person_id: str, sample_path: str) -> bool:
     """
     Remove a speech sample path from person's speech_samples list.
     Also removes the corresponding transcript at the same index to keep arrays in sync.
+
+    Uses a Firestore transaction to ensure atomic read-modify-write, preventing
+    the two parallel arrays from drifting under concurrent updates (mirrors
+    add_person_speech_sample).
 
     Args:
         uid: User ID
@@ -389,34 +426,7 @@ def remove_person_speech_sample(uid: str, person_id: str, sample_path: str) -> b
         True if removed, False if person or sample not found
     """
     person_ref = db.collection('users').document(uid).collection('people').document(person_id)
-    person_doc = person_ref.get()
-
-    if not person_doc.exists:
-        return False
-
-    person_data = person_doc.to_dict()
-    samples = person_data.get('speech_samples', [])
-    transcripts = person_data.get('speech_sample_transcripts', [])
-
-    # Find index of sample to remove
-    try:
-        idx = samples.index(sample_path)
-    except ValueError:
-        return False  # Sample not found
-
-    # Remove from both arrays by index
-    samples.pop(idx)
-    if idx < len(transcripts):
-        transcripts.pop(idx)
-
-    person_ref.update(
-        {
-            'speech_samples': samples,
-            'speech_sample_transcripts': transcripts,
-            'updated_at': datetime.now(timezone.utc),
-        }
-    )
-    return True
+    return _remove_sample_transaction(db.transaction(), person_ref, sample_path)
 
 
 def set_user_speaker_embedding(uid: str, embedding: list) -> bool:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -55,6 +55,7 @@ pytest tests/unit/test_create_persona_user_none.py -v
 pytest tests/unit/test_daily_summary_race_condition.py -v
 pytest tests/unit/test_daily_summary_regenerate.py -v
 pytest tests/unit/test_chat_tools_messages.py -v
+pytest tests/unit/test_users_remove_sample_transaction.py -v
 pytest tests/unit/test_chat_tool_parameters_json.py -v
 pytest tests/unit/test_prompt_caching.py -v
 pytest tests/unit/test_mentor_notifications.py -v

--- a/backend/tests/unit/test_users_remove_sample_transaction.py
+++ b/backend/tests/unit/test_users_remove_sample_transaction.py
@@ -1,0 +1,161 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+# Mock heavy deps to avoid needing GCP credentials / firebase_admin (CI-only).
+sys.modules["database._client"] = MagicMock()
+sys.modules["database.firestore_cache"] = MagicMock()
+sys.modules["database.redis_db"] = MagicMock()
+sys.modules["stripe"] = MagicMock()
+sys.modules["firebase_admin"] = MagicMock()
+sys.modules["firebase_admin.auth"] = MagicMock()
+# utils.subscription has a deep import chain (firebase_admin/stripe/fastapi) and is
+# only used by code paths we don't exercise here; stub the whole module.
+sys.modules["utils"] = types.ModuleType("utils")
+sys.modules["utils"].__path__ = []
+sys.modules["utils.subscription"] = MagicMock()
+
+
+class NotFound(Exception):
+    pass
+
+
+_google_module = sys.modules.setdefault("google", types.ModuleType("google"))
+_google_cloud_module = sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+_google_exceptions_module = types.ModuleType("google.cloud.exceptions")
+_google_exceptions_module.NotFound = NotFound
+sys.modules.setdefault("google.cloud.exceptions", _google_exceptions_module)
+_google_firestore_module = types.ModuleType("google.cloud.firestore")
+sys.modules.setdefault("google.cloud.firestore", _google_firestore_module)
+_google_firestore_v1_module = types.ModuleType("google.cloud.firestore_v1")
+_google_firestore_v1_module.FieldFilter = MagicMock()
+# `transactional` is a pass-through so the decorated helper runs inline in tests
+_google_firestore_v1_module.transactional = lambda func: func
+sys.modules.setdefault("google.cloud.firestore_v1", _google_firestore_v1_module)
+setattr(_google_module, "cloud", _google_cloud_module)
+setattr(_google_cloud_module, "exceptions", _google_exceptions_module)
+setattr(_google_cloud_module, "firestore", _google_firestore_module)
+
+from database import users as users_db
+
+
+class _FakeSnapshot:
+    def __init__(self, data, exists=True):
+        self._data = data
+        self.exists = exists
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakePersonRef:
+    """Records whether reads/writes were routed through a transaction."""
+
+    def __init__(self, data, exists=True):
+        self._data = data
+        self._exists = exists
+        self.get_transactions = []  # the `transaction=` kwarg passed to each get()
+        self.direct_updates = []  # any non-transactional person_ref.update(...) calls
+
+    def get(self, transaction=None):
+        self.get_transactions.append(transaction)
+        return _FakeSnapshot(self._data, exists=self._exists)
+
+    def update(self, update_data):
+        # A non-transactional write -> the read-modify-write was NOT atomic.
+        self.direct_updates.append(update_data)
+
+
+class _FakeTransaction:
+    def __init__(self):
+        self.updated_ref = None
+        self.updated_data = None
+
+    def update(self, person_ref, update_data):
+        self.updated_ref = person_ref
+        self.updated_data = update_data
+
+
+def test_remove_sample_uses_transaction_for_read_and_write():
+    """The remove must read AND write through the SAME transaction (atomic).
+
+    Before the fix the helper did a bare person_ref.get() (no transaction) and a
+    bare person_ref.update(...), so the two parallel arrays could drift under
+    concurrency. After the fix get(transaction=...) and transaction.update(...)
+    are used, mirroring _add_sample_transaction.
+    """
+    person_data = {
+        "speech_samples": ["a.wav", "b.wav", "c.wav"],
+        "speech_sample_transcripts": ["ta", "tb", "tc"],
+    }
+    person_ref = _FakePersonRef(person_data)
+    transaction = _FakeTransaction()
+
+    result = users_db._remove_sample_transaction(transaction, person_ref, "b.wav")
+
+    assert result is True
+    # Read happened inside the transaction (not a bare get()).
+    assert person_ref.get_transactions == [transaction]
+    # Write happened via transaction.update, NOT a bare person_ref.update.
+    assert person_ref.direct_updates == []
+    assert transaction.updated_ref is person_ref
+    # Aligned removal of the matching index from both arrays.
+    assert transaction.updated_data["speech_samples"] == ["a.wav", "c.wav"]
+    assert transaction.updated_data["speech_sample_transcripts"] == ["ta", "tc"]
+    assert "updated_at" in transaction.updated_data
+
+
+def test_remove_person_speech_sample_drives_the_transactional_helper():
+    """Public entrypoint must hand a real db.transaction() to the @transactional helper."""
+    captured = {}
+
+    def fake_helper(transaction, person_ref, sample_path):
+        captured["transaction"] = transaction
+        captured["sample_path"] = sample_path
+        return True
+
+    sentinel_txn = object()
+    users_db.db.transaction.return_value = sentinel_txn
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(users_db, "_remove_sample_transaction", side_effect=fake_helper):
+        result = users_db.remove_person_speech_sample("uid-1", "person-1", "b.wav")
+
+    assert result is True
+    # The transaction passed to the helper came from db.transaction(), proving the
+    # read-modify-write is wrapped in a Firestore transaction.
+    assert captured["transaction"] is sentinel_txn
+    assert captured["sample_path"] == "b.wav"
+
+
+def test_remove_sample_transaction_sample_not_found():
+    person_data = {
+        "speech_samples": ["a.wav"],
+        "speech_sample_transcripts": ["ta"],
+    }
+    person_ref = _FakePersonRef(person_data)
+    transaction = _FakeTransaction()
+
+    result = users_db._remove_sample_transaction(transaction, person_ref, "missing.wav")
+
+    assert result is False
+    assert transaction.updated_data is None
+    assert person_ref.direct_updates == []
+
+
+def test_remove_sample_transaction_person_not_found():
+    person_ref = _FakePersonRef({}, exists=False)
+    transaction = _FakeTransaction()
+
+    result = users_db._remove_sample_transaction(transaction, person_ref, "a.wav")
+
+    assert result is False
+    assert transaction.updated_data is None
+    assert person_ref.direct_updates == []

--- a/backend/tests/unit/test_users_remove_sample_transaction.py
+++ b/backend/tests/unit/test_users_remove_sample_transaction.py
@@ -146,6 +146,9 @@ def test_remove_sample_transaction_sample_not_found():
     result = users_db._remove_sample_transaction(transaction, person_ref, "missing.wav")
 
     assert result is False
+    # The read still has to go through the transaction, not a bare get(), so a
+    # regression on this error path is caught.
+    assert person_ref.get_transactions == [transaction]
     assert transaction.updated_data is None
     assert person_ref.direct_updates == []
 
@@ -157,5 +160,8 @@ def test_remove_sample_transaction_person_not_found():
     result = users_db._remove_sample_transaction(transaction, person_ref, "a.wav")
 
     assert result is False
+    # The existence check still has to read inside the transaction, not a bare
+    # get(), so a regression on this error path is caught.
+    assert person_ref.get_transactions == [transaction]
     assert transaction.updated_data is None
     assert person_ref.direct_updates == []


### PR DESCRIPTION
## Summary

`remove_person_speech_sample` in `backend/database/users.py` deletes a speech sample path and its aligned transcript from two parallel arrays (`speech_samples` and `speech_sample_transcripts`) on a person document. It does a plain read, mutates the lists in memory, then writes both back. Because the read and the write are separate Firestore calls with nothing tying them together, two removes (or a remove racing an add) running at the same time both read the same starting state and the second write clobbers the first, so one deletion is silently lost and the two arrays can drift out of alignment. This change wraps the read-modify-write in a Firestore transaction so the whole operation is atomic, matching `add_person_speech_sample`, which is already transactional.

## Root cause

In `backend/database/users.py`, `remove_person_speech_sample` reads with a bare `get()` and writes with a bare `update()`:

```python
person_ref = db.collection('users').document(uid).collection('people').document(person_id)
person_doc = person_ref.get()

if not person_doc.exists:
    return False

person_data = person_doc.to_dict()
samples = person_data.get('speech_samples', [])
transcripts = person_data.get('speech_sample_transcripts', [])

# Find index of sample to remove
try:
    idx = samples.index(sample_path)
except ValueError:
    return False  # Sample not found

# Remove from both arrays by index
samples.pop(idx)
if idx < len(transcripts):
    transcripts.pop(idx)

person_ref.update(
    {
        'speech_samples': samples,
        'speech_sample_transcripts': transcripts,
        'updated_at': datetime.now(timezone.utc),
    }
)
return True
```

The `get()` and the `update()` are independent operations. There is no transaction and no optimistic check on the document version, so this is a classic read-modify-write race. If two requests remove different samples at the same time, both read the original list, each pops one entry, and each writes the whole list back. The last write wins and the other removal is dropped. The same window lets the `speech_samples` and `speech_sample_transcripts` arrays go out of sync, which then corrupts the by-index pairing the function depends on. `add_person_speech_sample` right above it already guards against exactly this by running its read-modify-write inside `db.transaction()`, so the remove path was the inconsistent one.

## Fix

Move the read-modify-write into a `@transactional` helper and have the public function drive it with a real `db.transaction()`. The read now uses `get(transaction=transaction)` and the write uses `transaction.update(...)`, so Firestore retries the whole block on a conflicting concurrent write instead of letting one update overwrite another.

```python
@transactional
def _remove_sample_transaction(transaction, person_ref, sample_path):
    """Transaction to atomically remove a sample and its aligned transcript."""
    snapshot = person_ref.get(transaction=transaction)
    if not snapshot.exists:
        return False

    person_data = snapshot.to_dict()
    samples = person_data.get('speech_samples', [])
    transcripts = person_data.get('speech_sample_transcripts', [])

    try:
        idx = samples.index(sample_path)
    except ValueError:
        return False  # Sample not found

    samples.pop(idx)
    if idx < len(transcripts):
        transcripts.pop(idx)

    transaction.update(
        person_ref,
        {
            'speech_samples': samples,
            'speech_sample_transcripts': transcripts,
            'updated_at': datetime.now(timezone.utc),
        },
    )
    return True


def remove_person_speech_sample(uid: str, person_id: str, sample_path: str) -> bool:
    person_ref = db.collection('users').document(uid).collection('people').document(person_id)
    return _remove_sample_transaction(db.transaction(), person_ref, sample_path)
```

The return values and the by-index removal logic are unchanged. A single, uncontended remove behaves exactly as before and still returns `True` on success, `False` when the person or the sample is not found.

## Testing

Added `backend/tests/unit/test_users_remove_sample_transaction.py`, registered in `backend/test.sh`. `database.users` pulls in `firebase_admin`, `stripe`, and the Firestore client, so the test stubs those modules first (including a pass-through `transactional` that runs the decorated helper inline) and then imports `database.users` from source. The cases use a fake person ref and fake transaction that record how reads and writes are routed:

- The remove reads with `get(transaction=...)` and writes with `transaction.update(...)`, never a bare `person_ref.update(...)`, proving the read-modify-write is atomic.
- The matching index is popped from both `speech_samples` and `speech_sample_transcripts`, and `updated_at` is set.
- The public `remove_person_speech_sample` hands the helper a transaction obtained from `db.transaction()`.
- A missing sample and a missing person each return `False` and write nothing.

Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The transactional remove added here does not appear anywhere in the history of `backend/database/users.py`, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

