### PR TITLE
fix(backend): fail soft in get_omi_product_info_tool when docs fetch fails

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
 pytest tests/unit/test_transcript_segment.py -v
+pytest tests/unit/test_omi_product_tool_failsoft.py -v
 pytest tests/unit/test_import_job_status_detail_enum.py -v
 pytest tests/unit/test_text_similarity.py -v
 pytest tests/unit/test_text_containment.py -v

--- a/backend/tests/unit/test_omi_product_tool_failsoft.py
+++ b/backend/tests/unit/test_omi_product_tool_failsoft.py
@@ -1,0 +1,150 @@
+"""
+Unit test for get_omi_product_info_tool fail-soft behavior.
+
+The retrieval agent tool `get_omi_product_info_tool` fetches product
+documentation via `get_github_docs_content()` and formats it. Before the fix
+this call was unguarded: if the docs fetch raised (e.g. an httpx transport
+error) or returned a non-dict / empty value, the tool propagated the exception
+(or crashed on `.items()`), taking down the agent turn instead of degrading
+gracefully like its sibling retrieval tools.
+
+This test loads the REAL `omi_tools.py` module from file (so the actual,
+fixed function body executes) while stubbing its heavy dependency
+`utils.app_integrations` and providing a lightweight, invokable `@tool`
+decorator. It then:
+
+  1. patches `get_github_docs_content` to raise -> asserts a string starting
+     with "Error" is returned (fail-soft) instead of the exception propagating.
+  2. patches `get_github_docs_content` to return {} (empty) -> asserts an
+     "Error"/unavailable string is returned instead of an empty payload.
+
+RED (before fix): the exception propagates out of invoke() -> test raises.
+GREEN (after fix): a graceful "Error: ..." string is returned.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight, invokable @tool stand-in.
+#
+# The global Python 3.13 env ships an incompatible langchain_core/langsmith
+# pair (langchain_core 1.x expects langsmith.RunTree, which the installed
+# langsmith does not export), so the real `@tool` decorator cannot import.
+# We substitute a tiny decorator that preserves the contract this test relies
+# on: `.invoke({...})` runs the wrapped function body with the dict expanded
+# as kwargs, and `.func` exposes the underlying callable. The REAL function
+# body from omi_tools.py still executes, so the fail-soft behavior is exercised
+# for real.
+# ---------------------------------------------------------------------------
+class _FakeTool:
+    def __init__(self, func):
+        self.func = func
+        self.name = getattr(func, "__name__", "tool")
+        self.description = (func.__doc__ or "").strip()
+
+    def invoke(self, input):
+        if isinstance(input, dict):
+            return self.func(**input)
+        return self.func(input)
+
+
+def _tool_decorator(*dargs, **dkwargs):
+    # Support both `@tool` and `@tool(...)` usage.
+    if len(dargs) == 1 and callable(dargs[0]) and not dkwargs:
+        return _FakeTool(dargs[0])
+
+    def _wrap(func):
+        return _FakeTool(func)
+
+    return _wrap
+
+
+def _stub_package(name):
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    sys.modules[name] = mod
+    return mod
+
+
+def _stub_module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_omi_tools():
+    """Load the real omi_tools.py with deps stubbed, returning the module."""
+    # langchain_core.tools.tool -> lightweight invokable decorator.
+    lc = _stub_package("langchain_core")
+    lc_tools = _stub_package("langchain_core.tools")
+    lc_tools.tool = _tool_decorator
+    lc.tools = lc_tools
+
+    # utils.app_integrations.get_github_docs_content -> patchable MagicMock.
+    utils_pkg = _stub_package("utils")
+    app_integrations = _stub_module("utils.app_integrations")
+    app_integrations.get_github_docs_content = MagicMock(return_value={"Overview": "Omi is a wearable."})
+    utils_pkg.app_integrations = app_integrations
+
+    target = BACKEND_DIR / "utils" / "retrieval" / "tools" / "omi_tools.py"
+    spec = importlib.util.spec_from_file_location("omi_tools_under_test", str(target))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["omi_tools_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_MOD = _load_omi_tools()
+
+
+def test_returns_error_string_when_docs_fetch_raises():
+    """Fail-soft: a raising get_github_docs_content yields an 'Error' string, not an exception."""
+
+    class _Boom(Exception):
+        pass
+
+    with patch.object(_MOD, "get_github_docs_content", side_effect=_Boom("connect failed")):
+        result = _MOD.get_omi_product_info_tool.invoke({"query": "How does the device connect?"})
+
+    assert isinstance(result, str)
+    assert result.startswith("Error"), f"expected a fail-soft 'Error...' string, got: {result!r}"
+
+
+def test_returns_error_string_when_docs_unavailable_empty():
+    """A non-dict / empty docs payload degrades to an 'Error'/unavailable string instead of empty output."""
+    with patch.object(_MOD, "get_github_docs_content", return_value={}):
+        result = _MOD.get_omi_product_info_tool.invoke({"query": "What is the battery life?"})
+
+    assert isinstance(result, str)
+    assert result.startswith("Error"), f"expected a fail-soft 'Error...' string for empty docs, got: {result!r}"
+
+
+def test_happy_path_still_returns_documentation():
+    """When docs load normally the tool still returns the formatted documentation string."""
+    with patch.object(
+        _MOD,
+        "get_github_docs_content",
+        return_value={"Setup": "Pair via Bluetooth.", "Battery": "Up to 24h."},
+    ):
+        result = _MOD.get_omi_product_info_tool.invoke({"query": "How do I set up Omi?"})
+
+    assert isinstance(result, str)
+    assert not result.startswith("Error")
+    assert "Pair via Bluetooth." in result
+    assert "Up to 24h." in result

--- a/backend/tests/unit/test_omi_product_tool_failsoft.py
+++ b/backend/tests/unit/test_omi_product_tool_failsoft.py
@@ -23,6 +23,7 @@ GREEN (after fix): a graceful "Error: ..." string is returned.
 """
 
 import importlib.util
+import logging
 import os
 import sys
 import types
@@ -124,6 +125,48 @@ def test_returns_error_string_when_docs_fetch_raises():
 
     assert isinstance(result, str)
     assert result.startswith("Error"), f"expected a fail-soft 'Error...' string, got: {result!r}"
+
+
+class _RecordingHandler(logging.Handler):
+    """Captures emitted LogRecords so we can assert on exc_info/traceback."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def test_docs_fetch_failure_logs_with_traceback():
+    """The failure path must log via logger.exception (exc_info set) so the
+    traceback is preserved for debugging, not a bare logger.error("...{e}")
+    that drops the stack and interpolates the raw exception text."""
+
+    class _Boom(Exception):
+        pass
+
+    handler = _RecordingHandler()
+    _MOD.logger.addHandler(handler)
+    previous_level = _MOD.logger.level
+    _MOD.logger.setLevel(logging.DEBUG)
+    try:
+        with patch.object(_MOD, "get_github_docs_content", side_effect=_Boom("connect failed")):
+            result = _MOD.get_omi_product_info_tool.invoke({"query": "How does the device connect?"})
+    finally:
+        _MOD.logger.removeHandler(handler)
+        _MOD.logger.setLevel(previous_level)
+
+    assert result.startswith("Error")
+    # Exactly one error record for the failed docs fetch.
+    error_records = [r for r in handler.records if r.levelno >= logging.ERROR]
+    assert error_records, "expected an error-level log record on docs fetch failure"
+    record = error_records[0]
+    # logger.exception(...) attaches the active exception tuple; logger.error(f"...{e}") does not.
+    assert record.exc_info is not None, "failure must be logged with traceback (logger.exception/exc_info)"
+    assert record.exc_info[0] is _Boom
+    # The raw exception text must not be interpolated into the log message itself.
+    assert "connect failed" not in record.getMessage()
 
 
 def test_returns_error_string_when_docs_unavailable_empty():

--- a/backend/utils/retrieval/tools/omi_tools.py
+++ b/backend/utils/retrieval/tools/omi_tools.py
@@ -2,8 +2,12 @@
 Tools for answering questions about the Omi/Friend product.
 """
 
+import logging
+
 from langchain_core.tools import tool
 from utils.app_integrations import get_github_docs_content
+
+logger = logging.getLogger(__name__)
 
 
 @tool
@@ -37,8 +41,15 @@ def get_omi_product_info_tool(query: str) -> str:
         query="How do I update the firmware on my Omi device?"
         Returns documentation about firmware updates and device management
     """
-    # Get GitHub docs content
-    context = get_github_docs_content()
+    # Get GitHub docs content (fail soft like the sibling retrieval tools)
+    try:
+        context = get_github_docs_content()
+    except Exception as e:
+        logger.error(f"get_omi_product_info_tool - failed to load product docs: {e}")
+        return "Error: Could not load Omi/Friend product documentation right now. Please try again later."
+
+    if not isinstance(context, dict) or not context:
+        return "Error: Omi/Friend product documentation is currently unavailable. Please try again later."
 
     # Format context as a comprehensive documentation string
     context_str = 'Omi/Friend Product Documentation:\n\n'

--- a/backend/utils/retrieval/tools/omi_tools.py
+++ b/backend/utils/retrieval/tools/omi_tools.py
@@ -44,8 +44,8 @@ def get_omi_product_info_tool(query: str) -> str:
     # Get GitHub docs content (fail soft like the sibling retrieval tools)
     try:
         context = get_github_docs_content()
-    except Exception as e:
-        logger.error(f"get_omi_product_info_tool - failed to load product docs: {e}")
+    except Exception:
+        logger.exception("get_omi_product_info_tool - failed to load product docs")
         return "Error: Could not load Omi/Friend product documentation right now. Please try again later."
 
     if not isinstance(context, dict) or not context:


### PR DESCRIPTION
## Summary

`get_omi_product_info_tool` is a retrieval-agent tool that answers product questions by fetching the Omi/Friend docs through `get_github_docs_content()` and formatting them into a string. The fetch is unguarded, so when it raises (for example an httpx transport error reaching GitHub) the exception propagates straight out of the tool and crashes the whole agent turn instead of letting the agent recover. The same call returning `None` or any non-dict also crashes, because the function immediately calls `.items()` on it. This wraps the fetch in a try/except and validates the payload so a docs outage degrades to a short error string, matching how the sibling retrieval tools already behave. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/retrieval/tools/omi_tools.py`, `get_omi_product_info_tool` calls the docs fetch and then iterates the result with no guard around either step:

```python
    # Get GitHub docs content
    context = get_github_docs_content()

    # Format context as a comprehensive documentation string
    context_str = 'Omi/Friend Product Documentation:\n\n'
    for section, content in context.items():
        context_str += f'## {section}\n\n{content}\n\n'
```

`get_github_docs_content()` reaches out over the network, so a transient failure raises (an `httpx` transport error, a timeout, and so on). Nothing catches it here, so the exception unwinds through the tool and ends the agent turn the user was in. Separately, if the fetch returns `None` or any non-dict value, `context.items()` raises `AttributeError` and the turn dies the same way. The other retrieval tools in this package return a plain error string on failure rather than letting it propagate, so this one was the odd one out.

## Fix

Guard the fetch and check the shape of what comes back before formatting. On a raised exception, log it and return a short error string; on an empty or non-dict payload, return an unavailable string:

```python
    # Get GitHub docs content (fail soft like the sibling retrieval tools)
    try:
        context = get_github_docs_content()
    except Exception as e:
        logger.error(f"get_omi_product_info_tool - failed to load product docs: {e}")
        return "Error: Could not load Omi/Friend product documentation right now. Please try again later."

    if not isinstance(context, dict) or not context:
        return "Error: Omi/Friend product documentation is currently unavailable. Please try again later."
```

A module-level `logger` is added for the error path. When the fetch succeeds and returns a populated dict, the formatting loop runs exactly as before, so valid input is unchanged.

## Testing

Added `backend/tests/unit/test_omi_product_tool_failsoft.py`, registered in `backend/test.sh`. The global env ships a mismatched `langchain_core`/`langsmith` pair, so the real `@tool` decorator cannot import. The test loads the real `omi_tools.py` from source with its heavy dependency `utils.app_integrations` stubbed and a lightweight invokable `@tool` stand-in whose `.invoke({...})` runs the actual function body, so the fixed code path is exercised for real. Cases covered: `get_github_docs_content` raising returns a string starting with `Error` instead of propagating; an empty `{}` payload returns the unavailable string; and the happy path with a populated dict still returns the formatted documentation containing the section content. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The fail-soft guard added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

