### PR TITLE
fix(backend): degrade daily summary on non-object LLM JSON

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -139,6 +139,7 @@ pytest tests/unit/test_fair_use_free_tier.py -v
 pytest tests/unit/test_fair_use_upgrade.py -v
 pytest tests/unit/test_skip_classifier_restrict.py -v
 pytest tests/unit/test_timeout_middleware.py -v
+pytest tests/unit/test_daily_summary_nonobject_json.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_async_tasks.py -v

--- a/backend/tests/unit/test_daily_summary_nonobject_json.py
+++ b/backend/tests/unit/test_daily_summary_nonobject_json.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for generate_comprehensive_daily_summary non-object JSON handling.
+
+Bug: json.loads() succeeds on valid-but-non-object JSON (e.g. "[]" or "5"), then
+summary_data.get(...) raises AttributeError. The handler only caught
+json.JSONDecodeError, so the AttributeError escaped and 500'd the endpoint / crashed
+the daily-summary cron.
+
+Fix: guard with isinstance(summary_data, dict) (raising JSONDecodeError into the
+existing fallback) and broaden the except to (json.JSONDecodeError, TypeError,
+AttributeError) so a malformed LLM response degrades to the basic summary instead of
+crashing.
+
+These tests call the real generate_comprehensive_daily_summary directly, stubbing only
+the heavy collaborator modules (database.*, utils.* siblings) via a meta-path finder.
+Red without the fix (AttributeError), green with it.
+"""
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+_STUB = (
+    "database",
+    "utils",
+    "firebase_admin",
+    "google",
+    "pinecone",
+    "opuslib",
+    "pydub",
+    "redis",
+    "langchain",
+    "langchain_core",
+    "langchain_openai",
+    "stripe",
+    "openai",
+    "anthropic",
+    "modal",
+    "ulid",
+    "sentry_sdk",
+    "requests",
+    "typesense",
+    "pusher",
+    "httpx",
+)
+
+_TARGET = "utils.llm.external_integrations"
+# Let the target module and its (empty) parent packages load from disk so the real loader
+# can find the leaf module; heavy sibling modules under utils.* still get stubbed.
+_KEEP_REAL = {"utils", "utils.llm", _TARGET}
+
+
+def _is(n):
+    if n in _KEEP_REAL:
+        return False
+    return any(n == p or n.startswith(p + ".") for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith("__") and n.endswith("__"):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from utils.llm import external_integrations as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+def _drive(llm_content: str):
+    """Invoke generate_comprehensive_daily_summary with the LLM returning llm_content."""
+    mod.users_db.get_user_profile = MagicMock(return_value={"time_zone": "UTC", "language": "en"})
+    mod.get_prompt_memories = MagicMock(return_value=("TestUser", "mem"))
+    mod.conversations_to_string = MagicMock(return_value="convo text")
+
+    fake_llm = MagicMock()
+    fake_llm.invoke.return_value.content = llm_content
+    mod.get_llm = MagicMock(return_value=fake_llm)
+
+    return mod.generate_comprehensive_daily_summary("uid1", [], "2026-06-24")
+
+
+class TestNonObjectJsonDegrades:
+    """A non-object (but valid) JSON LLM response must degrade, not raise."""
+
+    def test_top_level_list_returns_basic_summary(self):
+        # Without the fix: AttributeError ('list' object has no attribute 'get').
+        result = _drive("[]")
+        assert isinstance(result, dict)
+        assert result["headline"] == "Your Day in Review"
+        # Basic-summary shape: stats populated, empty content lists.
+        assert result["stats"]["total_conversations"] == 0
+        assert result["highlights"] == []
+
+    def test_top_level_scalar_returns_basic_summary(self):
+        # Without the fix: AttributeError ('int' object has no attribute 'get').
+        result = _drive("5")
+        assert isinstance(result, dict)
+        assert result["headline"] == "Your Day in Review"
+        assert result["stats"]["total_conversations"] == 0
+
+    def test_nonlist_subfield_returns_basic_summary(self):
+        # 'highlights' is a dict, not a list: iterating yields keys (str), and
+        # h.get(...) on a str raises AttributeError without the fix.
+        result = _drive('{"highlights": {"conversation_numbers": 1}}')
+        assert isinstance(result, dict)
+        assert result["headline"] == "Your Day in Review"
+
+    def test_valid_object_still_processed(self):
+        # Regression guard: a proper object must NOT be forced into the fallback.
+        result = _drive('{"headline": "Custom Headline", "highlights": []}')
+        assert isinstance(result, dict)
+        assert result["headline"] == "Custom Headline"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/backend/tests/unit/test_daily_summary_nonobject_json.py
+++ b/backend/tests/unit/test_daily_summary_nonobject_json.py
@@ -118,6 +118,19 @@ def _drive(llm_content: str):
     return mod.generate_comprehensive_daily_summary("uid1", [], "2026-06-24")
 
 
+def _drive_raising(exc: Exception):
+    """Invoke the summary with the LLM call itself raising before `response` is assigned."""
+    mod.users_db.get_user_profile = MagicMock(return_value={"time_zone": "UTC", "language": "en"})
+    mod.get_prompt_memories = MagicMock(return_value=("TestUser", "mem"))
+    mod.conversations_to_string = MagicMock(return_value="convo text")
+
+    fake_llm = MagicMock()
+    fake_llm.invoke.side_effect = exc
+    mod.get_llm = MagicMock(return_value=fake_llm)
+
+    return mod.generate_comprehensive_daily_summary("uid1", [], "2026-06-24")
+
+
 class TestNonObjectJsonDegrades:
     """A non-object (but valid) JSON LLM response must degrade, not raise."""
 
@@ -149,6 +162,27 @@ class TestNonObjectJsonDegrades:
         result = _drive('{"headline": "Custom Headline", "highlights": []}')
         assert isinstance(result, dict)
         assert result["headline"] == "Custom Headline"
+
+
+class TestLlmCallFailureDegrades:
+    """When the LLM call raises before `response` is assigned, the broadened except must
+    still degrade to the basic summary, not blow up with UnboundLocalError while logging
+    `response`."""
+
+    def test_llm_invoke_attributeerror_returns_basic_summary(self):
+        # Mirrors get_llm(...).invoke(...).content failing (e.g. a misbehaving client)
+        # with an AttributeError caught by the broadened except. `response` is never
+        # assigned, so without `response = None` the except's `logger.info(... response)`
+        # raises UnboundLocalError instead of returning the fallback.
+        result = _drive_raising(AttributeError("'NoneType' object has no attribute 'content'"))
+        assert isinstance(result, dict)
+        assert result["headline"] == "Your Day in Review"
+        assert result["stats"]["total_conversations"] == 0
+
+    def test_llm_invoke_typeerror_returns_basic_summary(self):
+        result = _drive_raising(TypeError("bad call"))
+        assert isinstance(result, dict)
+        assert result["headline"] == "Your Day in Review"
 
 
 if __name__ == "__main__":

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -286,6 +286,8 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
         response = response.replace('\\"', '"')
 
         summary_data = json.loads(response)
+        if not isinstance(summary_data, dict):
+            raise json.JSONDecodeError("Top-level JSON is not an object", response, 0)
 
         # Helper to map conversation number to ID
         def get_convo_id(num):
@@ -349,7 +351,7 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "knowledge_nuggets": knowledge_nuggets,
             "locations": locations,
         }
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, TypeError, AttributeError) as e:
         logger.error(f"Failed to parse LLM response as JSON: {e}")
         logger.info(f"Response was: {response}")
         # Return a basic summary on parse failure

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -270,6 +270,9 @@ RULES:
 
 Respond with ONLY valid JSON. Do not include any other text or comments."""
 
+    # Initialise before the try so the broadened except can log it even when the LLM call
+    # itself raises (e.g. TypeError/AttributeError) before `response` is assigned.
+    response = None
     try:
         with track_usage(uid, Features.DAILY_SUMMARY):
             response = get_llm('daily_summary', cache_key='omi-daily-summary').invoke(prompt).content


### PR DESCRIPTION
## Summary

`generate_comprehensive_daily_summary` in `backend/utils/llm/external_integrations.py` parses the LLM response with `json.loads` and then treats the result as a dict. If the model returns valid JSON that is not an object (a top-level list like `[]`, or a scalar like `5`), `json.loads` succeeds and the next `summary_data.get(...)` raises `AttributeError`. The handler only catches `json.JSONDecodeError`, so that `AttributeError` escapes the try block and 500s the caller, which also crashes the daily-summary cron run for that user. This PR guards the parsed value so a malformed model response degrades to the basic summary instead of raising. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/llm/external_integrations.py`, `generate_comprehensive_daily_summary` parses and then immediately starts reading keys off the result:

```python
summary_data = json.loads(response)

# Helper to map conversation number to ID
def get_convo_id(num):
    if num and isinstance(num, int) and num in convo_id_map:
        return convo_id_map[num]
    return None

# Process highlights - map conversation_numbers to conversation_ids
highlights = []
for h in summary_data.get("highlights", []):
```

`json.loads` returns whatever valid JSON the model produced. `[]`, `5`, `"text"`, and `true` are all valid JSON but are not dicts, so `summary_data.get("highlights", [])` raises `AttributeError` (for example `'list' object has no attribute 'get'`). The except clause at the end of the block only handles JSON parse failures:

```python
except json.JSONDecodeError as e:
    logger.error(f"Failed to parse LLM response as JSON: {e}")
    logger.info(f"Response was: {response}")
    # Return a basic summary on parse failure
```

Because the value parsed cleanly, no `JSONDecodeError` is raised. The `AttributeError` is not caught, so it propagates out of the function. There is a related case where the top level is an object but a subfield like `highlights` comes back as a dict instead of a list: iterating it yields string keys, and `h.get(...)` on a string raises `AttributeError` the same way.

## Fix

Reject a non-object top level by raising `JSONDecodeError`, which routes it into the existing fallback, and widen the except so the subfield-shape case (`TypeError`/`AttributeError`) lands in the same basic-summary path:

```python
summary_data = json.loads(response)
if not isinstance(summary_data, dict):
    raise json.JSONDecodeError("Top-level JSON is not an object", response, 0)
```

```python
except (json.JSONDecodeError, TypeError, AttributeError) as e:
    logger.error(f"Failed to parse LLM response as JSON: {e}")
    logger.info(f"Response was: {response}")
    # Return a basic summary on parse failure
```

A well-formed object response is unchanged: it passes the `isinstance` check and is processed exactly as before, returning the full summary.

## Testing

Added `backend/tests/unit/test_daily_summary_nonobject_json.py`, registered in `backend/test.sh`. This module has a heavy import graph (`database.*`, `utils.*` siblings, LLM clients), so the test installs a meta-path finder that stubs those collaborators and lets the real `utils.llm.external_integrations` load from source, then calls `generate_comprehensive_daily_summary` directly with the LLM mocked to return a chosen string. Cases: a top-level list (`[]`) and a top-level scalar (`5`) both return the basic summary (`headline == "Your Day in Review"`, zeroed stats, empty content lists) instead of raising; a response whose `highlights` is a dict rather than a list also degrades to the basic summary; and a proper object response is still processed and keeps its custom headline so the guard does not force valid input into the fallback. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The `isinstance` guard and the widened except clause do not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

