### PR TITLE
fix(backend): return contact email when Google contact has empty names list

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -115,6 +115,7 @@ pytest tests/unit/test_conversation_structure_timezone.py -v
 pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
 pytest tests/unit/test_action_item_idempotency.py -v
+pytest tests/unit/test_calendar_contacts_empty_names.py -v
 pytest tests/unit/test_goals_id_fallback.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v

--- a/backend/tests/unit/test_calendar_contacts_empty_names.py
+++ b/backend/tests/unit/test_calendar_contacts_empty_names.py
@@ -1,0 +1,156 @@
+"""search_google_contacts must not drop a found email when the contact has an empty 'names' list.
+
+In the "Other Contacts" branch, the code read the display name with
+``person.get('names', [{}])[0].get('displayName', query)``. The ``[{}]`` default is only used when
+the ``'names'`` key is ABSENT; when the People API returns a contact that has an email but
+``'names': []`` (an empty list), ``person.get('names', [{}])`` returns ``[]`` and ``[][0]`` raises
+IndexError. That IndexError is swallowed by the broad ``except Exception`` around the block, so the
+email that was already extracted is silently discarded and the function returns ``None`` -- the
+contact is dropped.
+
+The fix guards the index access (``names = person.get('names') or [{}]``; only index when truthy) so
+the email is still returned. This test loads the real calendar_tools module under a stub finder
+(its database/utils/langchain deps are stubbed) and drives search_google_contacts with a mocked
+auth client whose otherContacts:search returns a contact with an email but ``'names': []``.
+"""
+
+import asyncio
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# The module under test lives at this path. We load it directly by file location (it uses only
+# absolute imports) so its heavy database/utils/langchain dependencies can be stubbed out.
+_TARGET_NAME = 'utils.retrieval.tools.calendar_tools'
+_TARGET_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    'utils',
+    'retrieval',
+    'tools',
+    'calendar_tools.py',
+)
+
+# Heavy deps to stub. We stub the whole ``utils`` and ``database`` trees so the parent package
+# ``utils.retrieval.tools`` is replaced with an empty stub (its real __init__ pulls in every sibling
+# tool, e.g. langchain_openai) -- the target leaf is loaded directly by file path and is the only
+# real ``utils.*`` module. The ``_TARGET_NAME`` exclusion in ``_is`` / ``find_spec`` keeps it real.
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+)
+
+
+def _is(name):
+    if name == _TARGET_NAME:
+        return False
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if name == _TARGET_NAME:
+            return importlib.util.spec_from_file_location(name, _TARGET_PATH)
+        if _is(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AM(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n) or n == _TARGET_NAME}
+for n in list(sys.modules):
+    if _is(n) or n == _TARGET_NAME:
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    mod = importlib.import_module(_TARGET_NAME)
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if (_is(n) or n == _TARGET_NAME) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+def _make_response(payload):
+    """Build a fake httpx-style response returning the given JSON payload with status 200."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.text = ''
+    return resp
+
+
+def _make_client(other_contacts_payload):
+    """Fake auth client: My Contacts returns no results; Other Contacts returns the payload."""
+    client = MagicMock()
+
+    async def _get(url, headers=None, params=None):
+        if 'searchContacts' in url:
+            # My Contacts: nothing found, so the code falls through to Other Contacts.
+            return _make_response({'results': []})
+        # otherContacts:search (both the warm-up empty query and the real query).
+        return _make_response(other_contacts_payload)
+
+    client.get = AsyncMock(side_effect=_get)
+    return client
+
+
+def test_email_returned_when_names_is_empty_list():
+    """A contact with an email but 'names': [] must still yield the email, not be dropped."""
+    payload = {'results': [{'person': {'emailAddresses': [{'value': 'a@b.com'}], 'names': []}}]}
+    client = _make_client(payload)
+    with patch.object(mod, 'get_auth_client', return_value=client), patch.object(mod.asyncio, 'sleep', AsyncMock()):
+        result = asyncio.run(mod.search_google_contacts('token-123', 'Riddhi Gupta'))
+    assert result == 'a@b.com'
+
+
+def test_email_returned_when_names_present():
+    """Sanity: a contact that has a name still returns the email (happy path unbroken)."""
+    payload = {'results': [{'person': {'emailAddresses': [{'value': 'c@d.com'}], 'names': [{'displayName': 'Carol'}]}}]}
+    client = _make_client(payload)
+    with patch.object(mod, 'get_auth_client', return_value=client), patch.object(mod.asyncio, 'sleep', AsyncMock()):
+        result = asyncio.run(mod.search_google_contacts('token-123', 'Carol'))
+    assert result == 'c@d.com'

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -129,7 +129,8 @@ async def search_google_contacts(access_token: str, query: str) -> Optional[str]
 
                 if email_addresses:
                     email = email_addresses[0].get('value')
-                    name = person.get('names', [{}])[0].get('displayName', query)
+                    names = person.get('names') or [{}]
+                    name = names[0].get('displayName', query) if names else query
                     logger.info(f"✅ Found contact in Other Contacts: {sanitize_pii(name)} -> {sanitize_pii(email)}")
                     return email
                 else:

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -130,7 +130,7 @@ async def search_google_contacts(access_token: str, query: str) -> Optional[str]
                 if email_addresses:
                     email = email_addresses[0].get('value')
                     names = person.get('names') or [{}]
-                    name = names[0].get('displayName', query) if names else query
+                    name = names[0].get('displayName', query)
                     logger.info(f"✅ Found contact in Other Contacts: {sanitize_pii(name)} -> {sanitize_pii(email)}")
                     return email
                 else:


### PR DESCRIPTION
## Summary

`search_google_contacts` in the calendar tools resolves an attendee name to an email by querying the Google People API, first against My Contacts and then against Other Contacts. In the Other Contacts branch, a contact that has an email but an empty `names` list makes the handler raise `IndexError` while reading the display name for a log line. The broad `except Exception` around that block swallows the error, so the email that was already extracted is thrown away and the function returns `None`. The result is a contact that should resolve gets silently dropped, and the calendar tool reports the attendee as unfound even though their email was in hand. This change reads the names list defensively so the email is still returned. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/retrieval/tools/calendar_tools.py`, `search_google_contacts` handles the Other Contacts result like this:

```python
if email_addresses:
    email = email_addresses[0].get('value')
    name = person.get('names', [{}])[0].get('displayName', query)
    logger.info(f"✅ Found contact in Other Contacts: {sanitize_pii(name)} -> {sanitize_pii(email)}")
    return email
```

The `[{}]` default passed to `person.get('names', [{}])` is only used when the `names` key is missing from the dict. The People API can return a contact that has an email but `'names': []`, an empty list that is present. In that case `person.get('names', [{}])` returns the empty list, and `[][0]` raises `IndexError`. The `return email` on the next line never runs. That `IndexError` propagates up to the `except Exception` wrapping the Other Contacts lookup, which logs it and falls through to the final `return None`, so the email is dropped even though it was already read into `email`.

## Fix

Read the names list once and only index it when it is non-empty, falling back to the query string for the log label otherwise:

```python
if email_addresses:
    email = email_addresses[0].get('value')
    names = person.get('names') or [{}]
    name = names[0].get('displayName', query) if names else query
    logger.info(f"✅ Found contact in Other Contacts: {sanitize_pii(name)} -> {sanitize_pii(email)}")
    return email
```

`person.get('names') or [{}]` treats both a missing key and an empty list the same way, so the index is always safe. A contact that has a real name is unchanged: it logs that name and returns the email exactly as before. The only difference in behavior is that a contact with an email and no name now returns the email instead of being discarded.

## Testing

Added `backend/tests/unit/test_calendar_contacts_empty_names.py`, registered in `backend/test.sh`. The module under test pulls in heavy database, utils, and langchain dependencies through its package, so the test loads `calendar_tools` directly from its file path under a stub meta-path finder that replaces the `database` and `utils` trees (and other heavy roots) with empty stubs, while keeping the target leaf module real. It drives `search_google_contacts` with a mocked auth client whose My Contacts search returns nothing and whose `otherContacts:search` returns the chosen payload, and patches `asyncio.sleep` so the warm-up delay does not slow the test. One case sends a contact with an email and `'names': []` and asserts the email is returned rather than dropped; a second case sends a contact that has a name and asserts the email still comes back, so the happy path stays intact. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The index access and its fix live entirely inside this handler's body, and no pending PR touches `search_google_contacts` or the Other Contacts name read. The defensive read added here does not appear anywhere in this file's history, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

