### PR TITLE
fix(backend): return 400 for out-of-range sync file timestamps

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -688,10 +688,10 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, missing timestamp")
         try:
             timestamp = get_timestamp_from_path(filename)
-        except ValueError:
+            time = datetime.fromtimestamp(timestamp)
+        except (ValueError, OSError, OverflowError):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time = datetime.fromtimestamp(timestamp)
         if time > datetime.now() or time < datetime(2024, 1, 1):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
@@ -1645,10 +1645,10 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, missing timestamp")
         try:
             timestamp = get_timestamp_from_path(filename)
-        except ValueError:
+            time_val = datetime.fromtimestamp(timestamp)
+        except (ValueError, OSError, OverflowError):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time_val = datetime.fromtimestamp(timestamp)
         if time_val > datetime.now() or time_val < datetime(2024, 1, 1):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -79,6 +79,7 @@ pytest tests/unit/test_vad_gate.py -v
 pytest tests/unit/test_vad_onnx.py -v
 pytest tests/unit/test_log_sanitizer.py -v
 pytest tests/unit/test_hume_callback_malformed.py -v
+pytest tests/unit/test_sync_timestamp_overflow_guard.py -v
 pytest tests/unit/test_file_upload_security.py -v
 pytest tests/unit/test_file_upload_endpoint_security.py -v
 pytest tests/unit/test_auth_redirect_uri.py -v

--- a/backend/tests/unit/test_sync_timestamp_overflow_guard.py
+++ b/backend/tests/unit/test_sync_timestamp_overflow_guard.py
@@ -1,0 +1,132 @@
+"""Regression test: retrieve_file_paths must reject an oversized timestamp with 400.
+
+A .bin filename like 'recording_99999999999999999999.bin' parses to a valid int,
+but datetime.fromtimestamp(timestamp) on that out-of-range value raises
+OverflowError / OSError (NOT ValueError). That call used to sit OUTSIDE the
+`try/except ValueError` guard, so the error propagated uncaught -> 500. The fix
+moves the conversion inside the guard and widens it to
+(ValueError, OSError, OverflowError), returning a clean 400 like the endpoint's
+other invalid-timestamp paths. This covers both retrieve_file_paths and its
+job-scoped twin _retrieve_file_paths_v2.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+# routers/sync.py pulls in Firestore/Redis/GCS/opus/pydub/models and friends.
+# Stub every heavy package so importing the router stays light; fastapi, pydantic,
+# numpy and httpx are real (the function under test raises a real HTTPException).
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'ulid',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'models',
+)
+
+
+def _is_stubbed(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        return importlib.machinery.ModuleSpec(name, self, is_package=True) if _is_stubbed(name) else None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_f = _Finder()
+_saved = {n: m for n, m in sys.modules.items() if _is_stubbed(n)}
+for n in list(sys.modules):
+    if _is_stubbed(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from routers import sync as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is_stubbed(n) and n not in _saved:
+            sys.modules.pop(n, None)
+    sys.modules.update(_saved)
+
+from fastapi import HTTPException  # noqa: E402  (import after the finder block)
+
+# A 20-digit timestamp is a valid int (passes the ValueError-only guard) but is far
+# out of range for datetime.fromtimestamp, which raises OverflowError/OSError.
+_OVERSIZED_BIN = 'recording_99999999999999999999.bin'
+
+
+class _StubUploadFile:
+    """Minimal UploadFile stand-in with a configurable filename."""
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.file = MagicMock()
+
+
+def test_retrieve_file_paths_oversized_timestamp_raises_400(tmp_path, monkeypatch):
+    """An out-of-range timestamp must raise HTTPException(400), not an uncaught OSError/OverflowError -> 500."""
+    monkeypatch.chdir(tmp_path)
+
+    upload = _StubUploadFile(filename=_OVERSIZED_BIN)
+
+    with pytest.raises(HTTPException) as exc_info:
+        mod.retrieve_file_paths([upload], 'u1')
+
+    assert exc_info.value.status_code == 400
+
+
+def test_retrieve_file_paths_v2_oversized_timestamp_raises_400(tmp_path, monkeypatch):
+    """The job-scoped twin must apply the same guard."""
+    monkeypatch.chdir(tmp_path)
+
+    upload = _StubUploadFile(filename=_OVERSIZED_BIN)
+
+    with pytest.raises(HTTPException) as exc_info:
+        mod._retrieve_file_paths_v2([upload], 'u1', 'job-1')
+
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary

The sync upload endpoints accept `.bin` files named with a `_$timestamp.bin` suffix and validate that the embedded timestamp falls in a sane range before writing the file. A filename whose timestamp parses to a valid integer but is far out of range, like `recording_99999999999999999999.bin`, returns HTTP 500 instead of the 400 the endpoint already returns for other bad timestamps. The conversion `datetime.fromtimestamp(timestamp)` runs outside the try block that catches timestamp errors, so an out-of-range value crashes the whole upload. This moves the conversion inside the guard and widens it to also catch the out-of-range cases. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/routers/sync.py`, `retrieve_file_paths` parses the timestamp under a guard that only catches `ValueError`, then does the `datetime` conversion on the next line, outside the guard:

```python
try:
    timestamp = get_timestamp_from_path(filename)
except ValueError:
    raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")

time = datetime.fromtimestamp(timestamp)
if time > datetime.now() or time < datetime(2024, 1, 1):
    raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
```

A 20-digit timestamp parses fine as an int, so it passes `get_timestamp_from_path` without raising `ValueError`. But `datetime.fromtimestamp` on a value that large is out of range for the platform, and it raises `OverflowError` (or `OSError` on some platforms), not `ValueError`. That exception is not caught anywhere in the loop, so it propagates out of the handler and FastAPI returns 500. The range check on the next line never gets a chance to run, even though it exists to reject exactly this kind of nonsense timestamp with a 400.

`_retrieve_file_paths_v2`, the job-scoped twin used by the v2 sync path, has the same structure and the same bug.

## Fix

Move the `datetime.fromtimestamp` call inside the try block and widen the except to cover the out-of-range exceptions:

```python
try:
    timestamp = get_timestamp_from_path(filename)
    time = datetime.fromtimestamp(timestamp)
except (ValueError, OSError, OverflowError):
    raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")

if time > datetime.now() or time < datetime(2024, 1, 1):
    raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
```

The same change is applied to `_retrieve_file_paths_v2`. A valid in-range timestamp converts and passes the range check exactly as before, so there is no behavior change for valid input. Only the out-of-range case changes, from a 500 to the 400 the endpoint already meant to return.

## Testing

Added `backend/tests/unit/test_sync_timestamp_overflow_guard.py`, registered in `backend/test.sh`. The router pulls in Firestore, Redis, GCS, opus, and the models layer, so the test imports `routers/sync.py` under a stub meta-path finder that fakes those heavy packages while keeping fastapi and pydantic real, then calls the functions directly. One case feeds `retrieve_file_paths` the oversized filename `recording_99999999999999999999.bin` and asserts it raises `HTTPException` with status 400 rather than letting an `OSError`/`OverflowError` escape as a 500. A second case applies the same check to `_retrieve_file_paths_v2`. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. PR #6946 (the unified auth and BYOK middleware refactor) rewires the auth dependencies across many routers including this one, but it does not change this handler's body logic, so it does not address this bug. The guard added here does not appear anywhere in the history of `routers/sync.py`, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

