### PR TITLE
fix(backend): make system folder ids deterministic to prevent duplicate folders on concurrent init

### DIFF
--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Dict, Any
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
-from ._client import db
+from ._client import db, document_id_from_seed
 from models.folder import Folder
 
 # System folders that are created for new users
@@ -225,7 +225,10 @@ def initialize_system_folders(uid: str) -> List[dict]:
     now = datetime.now(timezone.utc)
 
     for i, folder_config in enumerate(SYSTEM_FOLDERS):
-        folder_id = str(uuid.uuid4())
+        # Derive a deterministic doc id from uid + category so two concurrent
+        # initializers write the SAME three doc ids; the second .set() then
+        # harmlessly overwrites instead of creating duplicate system folders.
+        folder_id = document_id_from_seed(f"{uid}:system_folder:{folder_config['category_mapping']}")
         folder_data = {
             'id': folder_id,
             'name': folder_config['name'],

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -61,6 +61,7 @@ pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v
 pytest tests/unit/test_notification_token_cleanup.py -v
 pytest tests/unit/test_integration_notification_validation.py -v
+pytest tests/unit/test_system_folders_deterministic_ids.py -v
 pytest tests/unit/test_conversations_to_string.py -v
 pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v

--- a/backend/tests/unit/test_system_folders_deterministic_ids.py
+++ b/backend/tests/unit/test_system_folders_deterministic_ids.py
@@ -1,0 +1,157 @@
+"""Regression test for fix/system-folders-race.
+
+initialize_system_folders used to assign each system folder a random uuid4 doc
+id under a check-then-create pattern. Two concurrent first-access callers both
+see an empty collection and both create three folders with different random
+ids -> six duplicate system folders.
+
+The fix derives each system folder's doc id deterministically from
+uid + category_mapping (via document_id_from_seed), so concurrent creates
+converge on the SAME three doc ids and the second .set() is a harmless
+overwrite. This test asserts the created doc ids are deterministic for a given
+uid (call twice -> identical id set), which is false with random uuids.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# Stub heavy third-party packages. database._client and database.folders are
+# imported for real so document_id_from_seed (pure hashlib/uuid) runs for real;
+# only the firestore client behind `db` is a MagicMock.
+_STUB = (
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'opuslib',
+    'pydub',
+    'redis',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'modal',
+    'sentry_sdk',
+    'requests',
+    'typesense',
+    'pusher',
+    'httpx',
+)
+
+
+def _is(n):
+    return any(n == p or n.startswith(p + '.') for p in _STUB)
+
+
+class _AM(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(s, n):
+        if n.startswith('__') and n.endswith('__'):
+            raise AttributeError(n)
+        m = MagicMock()
+        setattr(s, n, m)
+        return m
+
+
+class _F(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(s, n, p=None, t=None):
+        return importlib.machinery.ModuleSpec(n, s, is_package=True) if _is(n) else None
+
+    def create_module(s, sp):
+        return _AM(sp.name)
+
+    def exec_module(s, m):
+        pass
+
+
+_f = _F()
+_sav = {n: m for n, m in sys.modules.items() if _is(n)}
+for n in list(sys.modules):
+    if _is(n):
+        sys.modules.pop(n, None)
+sys.meta_path.insert(0, _f)
+try:
+    from database import folders as mod
+finally:
+    sys.meta_path.remove(_f)
+    for n in list(sys.modules):
+        if _is(n) and n not in _sav:
+            sys.modules.pop(n, None)
+    sys.modules.update(_sav)
+
+
+def _run_initialize_and_collect_ids(uid):
+    """Drive initialize_system_folders with a fresh (empty) mocked Firestore
+    and return the list of doc ids passed to folders_ref.document(...)."""
+    requested_ids = []
+
+    folders_ref = MagicMock()
+
+    def _document(doc_id):
+        requested_ids.append(doc_id)
+        return MagicMock()
+
+    folders_ref.document.side_effect = _document
+    # Empty collection -> initializer proceeds to create system folders.
+    folders_ref.limit.return_value.stream.return_value = iter([])
+
+    user_ref = MagicMock()
+    user_ref.collection.return_value = folders_ref
+
+    fake_db = MagicMock()
+    fake_db.collection.return_value.document.return_value = user_ref
+
+    # Patch the module-level db so no real Firestore is touched.
+    original_db = mod.db
+    mod.db = fake_db
+    try:
+        created = mod.initialize_system_folders(uid)
+    finally:
+        mod.db = original_db
+
+    return requested_ids, created
+
+
+def test_system_folder_ids_are_deterministic_per_uid():
+    uid = 'user-abc-123'
+
+    ids_first, created_first = _run_initialize_and_collect_ids(uid)
+    ids_second, _ = _run_initialize_and_collect_ids(uid)
+
+    # Three system folders created each time.
+    assert len(ids_first) == len(mod.SYSTEM_FOLDERS) == 3
+    assert len(ids_second) == 3
+
+    # Determinism: two independent first-access runs for the same uid must
+    # produce the IDENTICAL set of doc ids. With random uuid4 ids this fails
+    # (the two runs would have six distinct ids), which is exactly the race
+    # that creates duplicate system folders.
+    assert ids_first == ids_second, (
+        f"system-folder doc ids are non-deterministic for uid={uid}: " f"{ids_first} != {ids_second}"
+    )
+
+    # The returned folder docs carry those same deterministic ids.
+    assert [f['id'] for f in created_first] == ids_first
+
+    # Sanity: ids match the seeded derivation contract (uid + category_mapping).
+    expected = [
+        mod.document_id_from_seed(f"{uid}:system_folder:{cfg['category_mapping']}") for cfg in mod.SYSTEM_FOLDERS
+    ]
+    assert ids_first == expected
+
+
+def test_system_folder_ids_differ_across_users():
+    ids_a, _ = _run_initialize_and_collect_ids('user-a')
+    ids_b, _ = _run_initialize_and_collect_ids('user-b')
+
+    # Different uids must not collide on the same doc ids.
+    assert set(ids_a).isdisjoint(set(ids_b))


### PR DESCRIPTION
## Summary

`initialize_system_folders` in `backend/database/folders.py` seeds a new user's three system folders on first access. It checks whether the folders collection is empty and, if so, creates each folder under a fresh random `uuid4` doc id. Two requests that hit this path at the same time (for example two clients, or a retry firing while the first call is still running) both read an empty collection and both create three folders with different random ids, so the user ends up with six system folders instead of three. This change derives each folder's doc id deterministically from the uid and the folder category, so concurrent initializers write the same three doc ids and the second write overwrites instead of duplicating.

## Root cause

In `backend/database/folders.py`, `initialize_system_folders` is a check-then-create with no idempotency on the write:

```python
def initialize_system_folders(uid: str) -> List[dict]:
    user_ref = db.collection('users').document(uid)
    folders_ref = user_ref.collection('folders')

    # Check if already initialized
    existing = list(folders_ref.limit(1).stream())
    if existing:
        return get_folders(uid)

    created_folders = []
    now = datetime.now(timezone.utc)

    for i, folder_config in enumerate(SYSTEM_FOLDERS):
        folder_id = str(uuid.uuid4())
        folder_data = {
            'id': folder_id,
            ...
        }
        folders_ref.document(folder_id).set(folder_data)
        created_folders.append(folder_data)

    return created_folders
```

The empty-collection read and the creating writes are not atomic, so the check does not protect against a concurrent caller. Because each doc id comes from `str(uuid.uuid4())`, the two callers pick six different ids and each `set` creates a brand new document. Nothing collides, so nothing is deduplicated, and the user is left with two copies of every system folder. This is a TOCTOU race that produces duplicate documents, not a crash.

## Fix

Derive each system folder's doc id from a natural key (`uid` + the folder's `category_mapping`) using the existing `document_id_from_seed` helper in `database/_client.py`, instead of a random uuid:

```python
from ._client import db, document_id_from_seed

...

for i, folder_config in enumerate(SYSTEM_FOLDERS):
    # Derive a deterministic doc id from uid + category so two concurrent
    # initializers write the SAME three doc ids; the second .set() then
    # harmlessly overwrites instead of creating duplicate system folders.
    folder_id = document_id_from_seed(f"{uid}:system_folder:{folder_config['category_mapping']}")
```

`document_id_from_seed` is a pure SHA-256 over the seed, so a given uid and category always map to the same id. Concurrent initializers now target the same three documents, and the slower writer overwrites the faster one with identical content. For a single, non-racing caller the behavior is unchanged: three system folders are created with stable ids and the same returned shape.

## Testing

Added `backend/tests/unit/test_system_folders_deterministic_ids.py`, registered in `backend/test.sh`. `database.folders` is imported under a stub finder that fakes the heavy third-party packages (firebase_admin, google, pinecone, redis, and so on) while running `database._client` and `database.folders` for real, so the actual `document_id_from_seed` derivation executes. The test drives `initialize_system_folders` with a fresh mocked Firestore (empty collection so it proceeds to create) and records the doc ids passed to `folders_ref.document(...)`. It covers: two independent first-access runs for the same uid produce the identical set of three doc ids (this is the duplicate-folder race, and it fails with random uuids), the returned docs carry those same ids, the ids match the seeded `uid + category_mapping` derivation, and two different uids never collide on the same ids. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The deterministic doc id derivation added here does not appear anywhere in the history of `backend/database/folders.py`, so it is not a previously reverted fix being resubmitted. No filed GitHub issue matches this duplicate-folder behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

