### PR TITLE
fix(backend): offload fair-use classifier Firestore read off the event loop

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -25,6 +25,7 @@ pytest tests/unit/test_parakeet_prerecorded.py -v
 pytest tests/unit/test_parakeet_nim.py -v
 pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_parakeet_gpu_worker.py -v
+pytest tests/unit/test_fair_use_classifier_async_offload.py -v
 pytest tests/unit/test_parakeet_batch_engine.py -v
 pytest tests/unit/test_parakeet_batch_routing.py -v
 pytest tests/unit/test_parakeet_builtin_embedding.py -v

--- a/backend/tests/unit/test_fair_use_classifier_async_offload.py
+++ b/backend/tests/unit/test_fair_use_classifier_async_offload.py
@@ -1,0 +1,132 @@
+"""Regression test: the async fair-use classifier must offload its blocking
+Firestore read off the event loop.
+
+`classify_user_purpose` is an ``async def`` but `_prepare_conversation_summaries`
+runs the synchronous Firestore SDK (`database.conversations.get_conversations`).
+Calling it directly blocks the event loop. The fix offloads it via
+``await run_blocking(db_executor, _prepare_conversation_summaries, uid)`` from
+``utils.executors``.
+
+This test drives ``classify_user_purpose`` with ``run_blocking`` and
+``_prepare_conversation_summaries`` patched, and asserts the summaries are
+produced through ``run_blocking`` (i.e. offloaded) rather than by a direct
+in-loop call.
+
+Without the fix, ``run_blocking`` is never invoked -> the assertions fail (RED).
+"""
+
+import json
+import sys
+import types
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before importing the module under test
+# ---------------------------------------------------------------------------
+_db_client = types.ModuleType('database._client')
+_db_client.db = MagicMock()
+sys.modules.setdefault('database._client', _db_client)
+
+_redis_mod = types.ModuleType('database.redis_db')
+_redis_mod.r = MagicMock()
+sys.modules.setdefault('database.redis_db', _redis_mod)
+
+sys.modules.setdefault('google.cloud.firestore', MagicMock())
+sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
+
+# Stub database.conversations (the blocking Firestore read lives here)
+_conversations_db = types.ModuleType('database.conversations')
+_conversations_db.get_conversations = MagicMock(return_value=[])
+sys.modules.setdefault('database.conversations', _conversations_db)
+
+# Stub llm clients
+_llm_clients = types.ModuleType('utils.llm.clients')
+_llm_clients.llm_mini = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _llm_clients)
+
+_langchain_openai = types.ModuleType('langchain_openai')
+_langchain_openai.ChatOpenAI = MagicMock(return_value=_llm_clients.llm_mini)
+sys.modules['langchain_openai'] = _langchain_openai
+
+_USAGE_TRACKER_MODULE = 'utils.llm.usage_tracker'
+_original_usage_tracker = sys.modules.get(_USAGE_TRACKER_MODULE)
+_usage_tracker = types.ModuleType('utils.llm.usage_tracker')
+_usage_tracker.get_usage_callback = MagicMock(return_value=MagicMock())
+sys.modules[_USAGE_TRACKER_MODULE] = _usage_tracker
+
+try:
+    import utils.llm.fair_use_classifier as classifier_mod
+finally:
+    if _original_usage_tracker is None:
+        sys.modules.pop(_USAGE_TRACKER_MODULE, None)
+    else:
+        sys.modules[_USAGE_TRACKER_MODULE] = _original_usage_tracker
+
+_classifier_llm = classifier_mod._classifier_llm
+
+
+class TestClassifierOffloadsBlockingRead:
+    """`classify_user_purpose` must offload `_prepare_conversation_summaries`
+    via `run_blocking(db_executor, ...)` instead of calling it on the loop."""
+
+    @pytest.mark.asyncio
+    async def test_prepare_summaries_is_offloaded_via_run_blocking(self):
+        sentinel_summaries = [{'conversation_id': 'c1', 'title': 'Meeting', 'duration_minutes': 30}]
+
+        async def fake_run_blocking(executor, fn, *args, **kwargs):
+            # run_blocking offloads `fn` to a thread pool; emulate the result.
+            return fn(*args, **kwargs)
+
+        # Make the underlying sync function return our sentinel so we can verify
+        # the offloaded result is what flows into the rest of classify_user_purpose.
+        prep_mock = MagicMock(return_value=sentinel_summaries)
+
+        llm_response = MagicMock()
+        llm_response.content = json.dumps(
+            {'misuse_score': 0.1, 'usage_type': 'none', 'confidence': 0.9, 'evidence': [], 'reasoning': 'ok'}
+        )
+        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
+
+        with patch.object(
+            classifier_mod, 'run_blocking', side_effect=fake_run_blocking
+        ) as mock_run_blocking, patch.object(classifier_mod, '_prepare_conversation_summaries', prep_mock):
+            result = await classifier_mod.classify_user_purpose('user1')
+
+        # The blocking read MUST be performed through run_blocking (offloaded),
+        # on the db_executor pool, with the uid as the argument.
+        assert mock_run_blocking.call_count == 1, "blocking Firestore read was not offloaded via run_blocking"
+        call_args = mock_run_blocking.call_args.args
+        assert call_args[0] is classifier_mod.db_executor, "must offload onto db_executor"
+        # The function reference passed to run_blocking is the (patched) summaries fn.
+        assert call_args[1] is prep_mock, "run_blocking must wrap _prepare_conversation_summaries"
+        assert call_args[2] == 'user1', "uid must be passed through to the offloaded call"
+
+        # And the function must keep working end-to-end through the offloaded result.
+        assert result['usage_type'] == 'none'
+        prep_mock.assert_called_once_with('user1')
+
+    @pytest.mark.asyncio
+    async def test_offloaded_empty_summaries_short_circuits(self):
+        """When the offloaded read yields nothing, the classifier returns the
+        default result without ever calling the LLM -- proving the offloaded
+        value is the one actually consumed."""
+
+        async def fake_run_blocking(executor, fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        _classifier_llm.ainvoke = AsyncMock()  # must NOT be awaited
+
+        with patch.object(
+            classifier_mod, 'run_blocking', side_effect=fake_run_blocking
+        ) as mock_run_blocking, patch.object(
+            classifier_mod, '_prepare_conversation_summaries', MagicMock(return_value=[])
+        ):
+            result = await classifier_mod.classify_user_purpose('user2')
+
+        mock_run_blocking.assert_called_once()
+        assert result['misuse_score'] == 0.0
+        assert result['usage_type'] == 'none'
+        _classifier_llm.ainvoke.assert_not_called()

--- a/backend/tests/unit/test_fair_use_classifier_async_offload.py
+++ b/backend/tests/unit/test_fair_use_classifier_async_offload.py
@@ -66,6 +66,9 @@ finally:
         sys.modules[_USAGE_TRACKER_MODULE] = _original_usage_tracker
 
 _classifier_llm = classifier_mod._classifier_llm
+# Snapshot the original `ainvoke` so a guard test can prove the patches above
+# restore it (no AsyncMock leaks onto the shared module-level singleton).
+_ORIGINAL_AINVOKE = _classifier_llm.ainvoke
 
 
 class TestClassifierOffloadsBlockingRead:
@@ -88,9 +91,10 @@ class TestClassifierOffloadsBlockingRead:
         llm_response.content = json.dumps(
             {'misuse_score': 0.1, 'usage_type': 'none', 'confidence': 0.9, 'evidence': [], 'reasoning': 'ok'}
         )
-        _classifier_llm.ainvoke = AsyncMock(return_value=llm_response)
 
-        with patch.object(
+        # Patch `ainvoke` via patch.object so the module-level `_classifier_llm`
+        # singleton is restored on exit -- no leak across tests.
+        with patch.object(_classifier_llm, 'ainvoke', AsyncMock(return_value=llm_response)), patch.object(
             classifier_mod, 'run_blocking', side_effect=fake_run_blocking
         ) as mock_run_blocking, patch.object(classifier_mod, '_prepare_conversation_summaries', prep_mock):
             result = await classifier_mod.classify_user_purpose('user1')
@@ -117,9 +121,9 @@ class TestClassifierOffloadsBlockingRead:
         async def fake_run_blocking(executor, fn, *args, **kwargs):
             return fn(*args, **kwargs)
 
-        _classifier_llm.ainvoke = AsyncMock()  # must NOT be awaited
-
-        with patch.object(
+        # Patch `ainvoke` via patch.object (restored on exit) so the mock never
+        # leaks onto the module-level `_classifier_llm`; it must NOT be awaited.
+        with patch.object(_classifier_llm, 'ainvoke', AsyncMock()) as mock_ainvoke, patch.object(
             classifier_mod, 'run_blocking', side_effect=fake_run_blocking
         ) as mock_run_blocking, patch.object(
             classifier_mod, '_prepare_conversation_summaries', MagicMock(return_value=[])
@@ -129,4 +133,12 @@ class TestClassifierOffloadsBlockingRead:
         mock_run_blocking.assert_called_once()
         assert result['misuse_score'] == 0.0
         assert result['usage_type'] == 'none'
-        _classifier_llm.ainvoke.assert_not_called()
+        mock_ainvoke.assert_not_called()
+
+    def test_classifier_llm_ainvoke_not_leaked_by_other_tests(self):
+        """Guard: the patched `ainvoke` must not leak onto the shared module-level
+        `_classifier_llm`. After the patched tests run, the attribute must be the
+        original reference (not a left-over AsyncMock), so test order can't carry a
+        stale mock between cases."""
+        assert _classifier_llm.ainvoke is _ORIGINAL_AINVOKE
+        assert not isinstance(_classifier_llm.ainvoke, AsyncMock)

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import database.conversations as conversations_db
 from langchain_openai import ChatOpenAI
+from utils.executors import db_executor, run_blocking
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,8 @@ async def classify_user_purpose(uid: str) -> dict:
     }
 
     try:
-        summaries = _prepare_conversation_summaries(uid)
+        # Offload the blocking Firestore read off the event loop (utils.executors db_executor).
+        summaries = await run_blocking(db_executor, _prepare_conversation_summaries, uid)
         if not summaries:
             logger.info(f'fair_use: no conversations to classify for {uid}')
             return default_result


### PR DESCRIPTION
## Summary

`classify_user_purpose` in the fair-use classifier is an `async def`, but it calls `_prepare_conversation_summaries(uid)` directly, and that function runs the synchronous Firestore SDK (`database.conversations.get_conversations`). A blocking Firestore read inside an async coroutine blocks the event loop for the whole process while the query is in flight, so every other concurrent request, health check, and background task stalls until it returns. This PR offloads that read onto the `db_executor` thread pool with `run_blocking`, so the coroutine yields while Firestore is queried instead of holding the loop. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/llm/fair_use_classifier.py`, `classify_user_purpose` fetches the conversation summaries inline:

```python
    try:
        summaries = _prepare_conversation_summaries(uid)
        if not summaries:
            logger.info(f'fair_use: no conversations to classify for {uid}')
            return default_result
```

`_prepare_conversation_summaries` is a plain `def` that calls `conversations_db.get_conversations(...)`, which is the synchronous Firestore client. When a sync Firestore call runs straight inside an `async def`, it does not raise; it just sits on the event loop thread and blocks it for the duration of the network round trip. While that classifier runs, no other coroutine on the same loop can make progress, which is exactly the failure mode the backend async rules call out for `database.*` functions. The classifier fires after a user crosses the speech-hour soft cap, so under load this is on a hot path where a stalled loop has wide blast radius.

## Fix

Import `db_executor` and `run_blocking` from `utils.executors` and offload the blocking read so the coroutine awaits it on the thread pool instead of calling it inline:

```python
    try:
        # Offload the blocking Firestore read off the event loop (utils.executors db_executor).
        summaries = await run_blocking(db_executor, _prepare_conversation_summaries, uid)
        if not summaries:
            logger.info(f'fair_use: no conversations to classify for {uid}')
            return default_result
```

`run_blocking` runs `_prepare_conversation_summaries(uid)` on `db_executor` (the pool reserved for Firestore and Redis CRUD) and returns its result, so the summaries and the rest of the classification logic are unchanged. For valid input the output is identical; the only difference is that the Firestore query no longer runs on the event loop thread.

## Testing

Added `backend/tests/unit/test_fair_use_classifier_async_offload.py`, registered in `backend/test.sh`. The classifier pulls in heavy dependencies (langchain, the LLM clients, Firestore), so the test stubs those modules before importing `utils.llm.fair_use_classifier`, then calls `classify_user_purpose` directly with `run_blocking` and `_prepare_conversation_summaries` patched via `patch.object`. One case asserts the read goes through `run_blocking` exactly once, onto `db_executor`, wrapping `_prepare_conversation_summaries` with the uid passed through, and that the offloaded summaries flow end to end into the result. A second case feeds empty summaries through the offloaded path and confirms the classifier short-circuits to the default result without ever awaiting the LLM, proving the offloaded value is the one actually consumed. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The offload of `_prepare_conversation_summaries` through `run_blocking` does not appear anywhere in this file's history, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

