### PR TITLE
fix(backend): guard missing person name in populate_speaker_names

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -31,6 +31,7 @@ pytest tests/unit/test_parakeet_builtin_embedding.py -v
 pytest tests/unit/test_parakeet_endpoints.py -v
 pytest tests/unit/test_audiobuffer_guard.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
+pytest tests/unit/test_render_speaker_names_keyerror.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
 pytest tests/unit/test_mcp_search_conversations_poison.py -v
 pytest tests/unit/test_mcp_memory_filters.py -v

--- a/backend/tests/unit/test_render_speaker_names_keyerror.py
+++ b/backend/tests/unit/test_render_speaker_names_keyerror.py
@@ -1,0 +1,93 @@
+"""Regression test for populate_speaker_names KeyError on people docs missing 'name'.
+
+get_people_by_ids backfills 'id' but not 'name' (legacy docs may lack it), so the
+people_map comprehension {p['id']: p['name'] ...} raised KeyError for such a doc and
+took down the whole list/render path. The fix uses p.get('name') or '' so a missing
+name degrades to a blank speaker name instead of crashing.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _ensure_stub(name):
+    existing = sys.modules.get(name)
+    if existing is not None and getattr(existing, "__file__", None):
+        return existing
+    if existing is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return sys.modules[name]
+
+
+# Stub database chain so render.py can import at module level without Firestore
+_ensure_stub("database")
+sys.modules["database"].__path__ = getattr(sys.modules["database"], "__path__", [])
+for _sub in ["_client", "redis_db", "users", "folders"]:
+    _ensure_stub(f"database.{_sub}")
+sys.modules["database._client"].db = MagicMock()
+sys.modules["database.users"].get_user_profile = MagicMock(return_value={"name": "TestUser"})
+sys.modules["database.users"].get_people_by_ids = MagicMock(return_value=[])
+sys.modules["database.folders"].get_folders = MagicMock(return_value=[])
+
+# Stub-cleanup preamble: force-reimport real modules if earlier test files
+# left empty ModuleType stubs in sys.modules.
+for _mod in [
+    "models",
+    "models.conversation",
+    "models.conversation_enums",
+    "models.structured",
+    "utils",
+    "utils.conversations",
+    "utils.conversations.render",
+]:
+    _existing = sys.modules.get(_mod)
+    if _existing is not None and not getattr(_existing, "__file__", None):
+        del sys.modules[_mod]
+
+from utils.conversations import render
+
+
+class TestPopulateSpeakerNamesMissingName:
+    def test_person_doc_missing_name_does_not_raise(self):
+        """A person doc with an 'id' but no 'name' must not KeyError; blank name instead."""
+        conversations = [
+            {
+                "transcript_segments": [
+                    {"person_id": "a", "speaker_id": 1},
+                    {"person_id": "b", "speaker_id": 2},
+                ]
+            }
+        ]
+        # 'a' has a name, 'b' (legacy doc) is missing it.
+        people = [{"id": "a", "name": "Alice"}, {"id": "b"}]
+
+        with patch.object(render.users_db, "get_user_profile", return_value={"name": "Zach"}), patch.object(
+            render.users_db, "get_people_by_ids", return_value=people
+        ):
+            # Before the fix this raises KeyError('name').
+            render.populate_speaker_names("uid-1", conversations)
+
+        segs = conversations[0]["transcript_segments"]
+        assert segs[0]["speaker_name"] == "Alice"
+        # Missing-name person degrades to an empty speaker name, not a crash.
+        assert segs[1]["speaker_name"] == ""
+
+    def test_present_names_still_assigned(self):
+        """Sanity: when every person has a name, mapping is unchanged by the fix."""
+        conversations = [{"transcript_segments": [{"person_id": "p1", "speaker_id": 0}]}]
+        people = [{"id": "p1", "name": "Bob"}]
+
+        with patch.object(render.users_db, "get_user_profile", return_value={"name": "Zach"}), patch.object(
+            render.users_db, "get_people_by_ids", return_value=people
+        ):
+            render.populate_speaker_names("uid-1", conversations)
+
+        assert conversations[0]["transcript_segments"][0]["speaker_name"] == "Bob"

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -48,7 +48,7 @@ def populate_speaker_names(uid: str, conversations: List[Dict]) -> None:
     people_map = {}
     if all_person_ids:
         people_data = users_db.get_people_by_ids(uid, list(all_person_ids))
-        people_map = {p['id']: p['name'] for p in people_data}
+        people_map = {p['id']: (p.get('name') or '') for p in people_data if p.get('id')}
 
     for conv in conversations:
         for seg in conv.get('transcript_segments', []):


### PR DESCRIPTION
## Summary

`populate_speaker_names` adds a `speaker_name` to each transcript segment by mapping its `person_id` to a stored person's name. It is called on the conversation list and single-conversation paths in `routers/developer.py` and `routers/mcp.py`, and on the webhook payload path in `utils/webhooks.py`. If any one person doc the conversations reference is missing its `name` field, the function raises `KeyError` and the whole response 500s, so one legacy or partial person record takes down the entire conversation list, not just the segment that references it. This change reads the name defensively so a missing name degrades to a blank speaker name instead of crashing. This is a proactive hardening change; there is no filed GitHub issue for it.

## Root cause

In `backend/utils/conversations/render.py`, `populate_speaker_names` builds the id-to-name map in one comprehension:

```python
people_map = {}
if all_person_ids:
    people_data = users_db.get_people_by_ids(uid, list(all_person_ids))
    people_map = {p['id']: p['name'] for p in people_data}
```

`get_people_by_ids` in `backend/database/users.py` returns raw Firestore dicts and only backfills the `id` key for legacy docs (`data.setdefault('id', doc.id)`); it never backfills `name`. A person doc written before `name` was required, or a partial write, comes back without that key, so `p['name']` raises `KeyError('name')`. That exception is unhandled all the way up, so FastAPI turns it into a 500 for the full conversation list, even though every other person in the batch is fine.

## Fix

Read `name` with `.get`, fall back to an empty string, and skip any record that has no id:

```python
people_map = {p['id']: (p.get('name') or '') for p in people_data if p.get('id')}
```

A person with no stored name now maps to `''`, so its segments get a blank `speaker_name` and the rest of the list renders normally. For records that already have an id and a name, the map is identical to before, so there is no change in behavior for valid input.

## Testing

Added `backend/tests/unit/test_render_speaker_names_keyerror.py`, registered in `backend/test.sh`. `render.py` imports `database` at module load, so the test stubs the `database` chain (`_client`, `users`, `folders`) under a stub finder, then imports `utils.conversations.render` from source and calls `populate_speaker_names` directly, patching `render.users_db.get_people_by_ids` to control the returned docs. One case feeds a people list where one doc has `id` and `name` and a second (legacy) doc has only `id`: it asserts the named segment gets the real name and the missing-name segment gets `''` rather than raising. A second case feeds only named docs and asserts the mapping is unchanged. Verified red to green: the test fails on current main and passes with this change.

## PR status check

No open PR changes this logic. The guarded comprehension added here does not appear anywhere in the history of `render.py`; the function has had the bare `p['name']` subscript since the conversation rendering modules were consolidated, so this is not a previously reverted fix being resubmitted. No filed GitHub issue matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

