### PR TITLE
test: cover desktop named bundle OAuth schemes

### DIFF
--- a/desktop/macos/README.md
+++ b/desktop/macos/README.md
@@ -20,11 +20,16 @@ Requires macOS 14.0+, Rust toolchain, and code signing with an Apple Developer I
 # Run (builds Swift app, starts Rust backend, launches app)
 ./run.sh
 
+# Run an isolated named bundle for parallel testing
+OMI_APP_NAME="omi-subagent-test" ./run.sh
+
 # Run with the prod backend (skips local Rust + tunnel)
 ./run.sh --yolo
 ```
 
 `run.sh` auto-detects an `Apple Development` or `Developer ID Application` signing identity from your login keychain. Override with `OMI_SIGN_IDENTITY="..." ./run.sh`.
+
+Named bundles derive an isolated bundle ID and OAuth callback URL scheme from `OMI_APP_NAME`. `Omi Dev` keeps `com.omi.desktop-dev` / `omi-computer-dev`, while `OMI_APP_NAME="omi-subagent-test"` uses `com.omi.omi-subagent-test` / `omi-omi-subagent-test`. The app reads that scheme from `CFBundleURLTypes` for OAuth redirects, so parallel dev bundles do not claim the canonical `omi-computer-dev` callback.
 
 ## License
 

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -110,30 +110,9 @@ export PORT="$BACKEND_PORT"
 
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
-APP_NAME="${OMI_APP_NAME:-Omi Dev}"
-IS_NAMED_BUNDLE=false
-if [ "$APP_NAME" != "Omi Dev" ]; then
-    IS_NAMED_BUNDLE=true
-fi
+source "$SCRIPT_DIR/scripts/app-config.sh"
+derive_omi_app_config "${OMI_APP_NAME:-Omi Dev}"
 
-slugify_identifier() {
-    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
-}
-
-if [ "$IS_NAMED_BUNDLE" = false ]; then
-    EXPECTED_BUNDLE_ID="com.omi.desktop-dev"
-    EXPECTED_URL_SCHEME="omi-computer-dev"
-else
-    APP_SLUG="$(slugify_identifier "$APP_NAME")"
-    if [ -z "$APP_SLUG" ]; then
-        echo "ERROR: OMI_APP_NAME must contain at least one letter or number"
-        exit 1
-    fi
-    EXPECTED_BUNDLE_ID="com.omi.$APP_SLUG"
-    EXPECTED_URL_SCHEME="omi-$APP_SLUG"
-fi
-
-BUNDLE_ID="${OMI_BUNDLE_ID:-$EXPECTED_BUNDLE_ID}"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
@@ -144,17 +123,6 @@ AGENT_DIR="$SCRIPT_DIR/agent"
 APP_DESKTOP_PATH="$HOME/Desktop/$APP_NAME.app"
 APP_DOWNLOADS_PATH="$HOME/Downloads/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
-URL_SCHEME="${OMI_URL_SCHEME:-$EXPECTED_URL_SCHEME}"
-
-if [ "$BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]; then
-    echo "ERROR: APP_NAME '$APP_NAME' must use bundle ID '$EXPECTED_BUNDLE_ID' (got '$BUNDLE_ID')"
-    exit 1
-fi
-
-if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
-    echo "ERROR: APP_NAME '$APP_NAME' must use URL scheme '$EXPECTED_URL_SCHEME' (got '$URL_SCHEME')"
-    exit 1
-fi
 AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-${AUTOMATION_PORT:-47777}}"
 AUTOMATION_CAPTURE_ROOT="${OMI_AUTOMATION_CAPTURE_ROOT:-$SCRIPT_DIR/.harness/runs}"
 AUTOMATION_ARGS=("--automation-port=$AUTOMATION_PORT" "--automation-capture-root=$AUTOMATION_CAPTURE_ROOT")

--- a/desktop/macos/scripts/app-config.sh
+++ b/desktop/macos/scripts/app-config.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Derive the macOS desktop dev app identity from OMI_APP_NAME.
+# Sourced by run.sh and by tests; keep this file side-effect-light.
+
+slugify_identifier() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+derive_omi_app_config() {
+    local app_name="${1:-Omi Dev}"
+    local is_named_bundle="false"
+    local app_slug=""
+    local expected_bundle_id
+    local expected_url_scheme
+    local bundle_id
+    local url_scheme
+
+    if [ "$app_name" != "Omi Dev" ]; then
+        is_named_bundle="true"
+    fi
+
+    if [ "$is_named_bundle" = "false" ]; then
+        expected_bundle_id="com.omi.desktop-dev"
+        expected_url_scheme="omi-computer-dev"
+    else
+        app_slug="$(slugify_identifier "$app_name")"
+        if [ -z "$app_slug" ]; then
+            echo "ERROR: OMI_APP_NAME must contain at least one letter or number" >&2
+            return 1
+        fi
+        expected_bundle_id="com.omi.$app_slug"
+        expected_url_scheme="omi-$app_slug"
+    fi
+
+    bundle_id="${OMI_BUNDLE_ID:-$expected_bundle_id}"
+    url_scheme="${OMI_URL_SCHEME:-$expected_url_scheme}"
+
+    if [ "$bundle_id" != "$expected_bundle_id" ]; then
+        echo "ERROR: APP_NAME '$app_name' must use bundle ID '$expected_bundle_id' (got '$bundle_id')" >&2
+        return 1
+    fi
+
+    if [ "$url_scheme" != "$expected_url_scheme" ]; then
+        echo "ERROR: APP_NAME '$app_name' must use URL scheme '$expected_url_scheme' (got '$url_scheme')" >&2
+        return 1
+    fi
+
+    APP_NAME="$app_name"
+    IS_NAMED_BUNDLE="$is_named_bundle"
+    APP_SLUG="$app_slug"
+    EXPECTED_BUNDLE_ID="$expected_bundle_id"
+    EXPECTED_URL_SCHEME="$expected_url_scheme"
+    BUNDLE_ID="$bundle_id"
+    URL_SCHEME="$url_scheme"
+}

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+echo "=== Desktop Launcher Script Tests ==="
+cd "$SCRIPT_DIR"
+bash tests/test-app-config.sh
+echo ""
+
 echo "=== Rust Backend Tests ==="
 cd "$SCRIPT_DIR/Backend-Rust"
 cargo test

--- a/desktop/macos/tests/test-app-config.sh
+++ b/desktop/macos/tests/test-app-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$MACOS_DIR/scripts/app-config.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected '$expected', got '$actual'"
+  fi
+}
+
+assert_config() {
+  local app_name="$1" expected_is_named="$2" expected_bundle="$3" expected_scheme="$4"
+  derive_omi_app_config "$app_name"
+  assert_eq "$app_name" "$APP_NAME" "APP_NAME for $app_name"
+  assert_eq "$expected_is_named" "$IS_NAMED_BUNDLE" "IS_NAMED_BUNDLE for $app_name"
+  assert_eq "$expected_bundle" "$EXPECTED_BUNDLE_ID" "EXPECTED_BUNDLE_ID for $app_name"
+  assert_eq "$expected_scheme" "$EXPECTED_URL_SCHEME" "EXPECTED_URL_SCHEME for $app_name"
+  assert_eq "$expected_bundle" "$BUNDLE_ID" "BUNDLE_ID for $app_name"
+  assert_eq "$expected_scheme" "$URL_SCHEME" "URL_SCHEME for $app_name"
+}
+
+assert_config "Omi Dev" "false" "com.omi.desktop-dev" "omi-computer-dev"
+assert_config "omi-subagent-test" "true" "com.omi.omi-subagent-test" "omi-omi-subagent-test"
+assert_config "Omi Subagent Test!!" "true" "com.omi.omi-subagent-test" "omi-omi-subagent-test"
+
+if derive_omi_app_config "!!!" >/tmp/omi-app-config-invalid.out 2>/tmp/omi-app-config-invalid.err; then
+  fail "invalid app name unexpectedly succeeded"
+fi
+if ! grep -q "OMI_APP_NAME must contain at least one letter or number" /tmp/omi-app-config-invalid.err; then
+  fail "invalid app name did not explain the slug requirement"
+fi
+
+if OMI_BUNDLE_ID="com.omi.wrong" derive_omi_app_config "omi-subagent-test" >/tmp/omi-app-config-bundle.out 2>/tmp/omi-app-config-bundle.err; then
+  fail "mismatched OMI_BUNDLE_ID unexpectedly succeeded"
+fi
+if ! grep -q "must use bundle ID 'com.omi.omi-subagent-test'" /tmp/omi-app-config-bundle.err; then
+  fail "mismatched OMI_BUNDLE_ID did not report expected bundle id"
+fi
+
+if OMI_URL_SCHEME="omi-wrong" derive_omi_app_config "omi-subagent-test" >/tmp/omi-app-config-scheme.out 2>/tmp/omi-app-config-scheme.err; then
+  fail "mismatched OMI_URL_SCHEME unexpectedly succeeded"
+fi
+if ! grep -q "must use URL scheme 'omi-omi-subagent-test'" /tmp/omi-app-config-scheme.err; then
+  fail "mismatched OMI_URL_SCHEME did not report expected URL scheme"
+fi
+
+echo "app-config tests passed"


### PR DESCRIPTION
## Summary

- extract desktop dev app identity / URL scheme derivation into a small testable shell helper
- add launcher regression coverage for default `Omi Dev`, named bundles, slug normalization, and invalid/mismatched overrides
- document named-bundle OAuth callback scheme behavior for parallel desktop testing

Closes #8174.

## Oracle review

Consulted Oracle before implementation. It concluded current `main` already implements the runtime behavior (`run.sh` writes a derived scheme into `CFBundleURLTypes`, and `AuthService` builds `redirect_uri` from the runtime bundle scheme), so the safest upstream PR is a focused regression test + docs rather than backend/auth/LaunchServices changes.

## Verification

- `bash -n desktop/macos/scripts/app-config.sh`
- `bash -n desktop/macos/tests/test-app-config.sh`
- `bash -n desktop/macos/run.sh`
- `bash -n desktop/macos/test.sh`
- `bash desktop/macos/tests/test-app-config.sh`
- `git diff --check`
- `bash desktop/macos/test.sh` partially completed:
  - desktop launcher script tests passed
  - Rust backend tests passed: `259 passed`
  - Swift test phase timed out locally while downloading SwiftPM binary artifacts after dependency resolution/downloads began; no Swift source changed in this PR

## Notes

The local Rust failure encountered during verification was environment setup (`rustup` had no active/default toolchain). I installed/selected stable locally and reran the suite. I did not include a Rust toolchain pin in this PR to keep the OAuth launcher regression scope tight.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

