### PR TITLE
fix: repair action items FTS before retrying local inserts

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -736,7 +736,7 @@ actor ActionItemStorage {
             }
 
             logError("ActionItemStorage: action_items_fts write failed; repairing FTS index and retrying once")
-            try await RewindDatabase.shared.repairActionItemsFTS(reason: "insertLocalActionItem")
+            try await RewindDatabase.shared.repairActionItemsFTS(in: db, reason: "insertLocalActionItem")
 
             let inserted = try await db.write { database in
                 try recordToInsert.inserted(database)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -724,12 +724,26 @@ actor ActionItemStorage {
         insertRecord.backendSynced = false
         let recordToInsert = insertRecord
 
-        let inserted = try await db.write { database in
-            try recordToInsert.inserted(database)
-        }
+        do {
+            let inserted = try await db.write { database in
+                try recordToInsert.inserted(database)
+            }
+            log("ActionItemStorage: Inserted local action item (id: \(inserted.id ?? -1))")
+            return inserted
+        } catch {
+            guard await RewindDatabase.shared.isActionItemsFTSError(error) else {
+                throw error
+            }
 
-        log("ActionItemStorage: Inserted local action item (id: \(inserted.id ?? -1))")
-        return inserted
+            logError("ActionItemStorage: action_items_fts write failed; repairing FTS index and retrying once")
+            try await RewindDatabase.shared.repairActionItemsFTS(reason: "insertLocalActionItem")
+
+            let inserted = try await db.write { database in
+                try recordToInsert.inserted(database)
+            }
+            log("ActionItemStorage: Inserted local action item after FTS repair (id: \(inserted.id ?? -1))")
+            return inserted
+        }
     }
 
     /// Insert a screen observation (context captured during task extraction)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -105,6 +105,80 @@ actor RewindDatabase {
         }
     }
 
+    /// Return true for SQLite failures that specifically implicate action_items_fts.
+    /// Keep this narrow so unrelated write/constraint failures are never hidden by an FTS repair retry.
+    func isActionItemsFTSError(_ error: Error) -> Bool {
+        guard let dbError = error as? DatabaseError else { return false }
+        let message = "\(dbError)".lowercased()
+        guard message.contains("action_items_fts") || message.contains("vtable constructor failed") else {
+            return false
+        }
+
+        return dbError.resultCode == .SQLITE_IOERR
+            || dbError.resultCode == .SQLITE_CORRUPT
+            || message.contains("no such table")
+            || message.contains("malformed")
+            || message.contains("database disk image is malformed")
+            || dbError.extendedResultCode.rawValue == 6922
+    }
+
+    /// Rebuild only the action_items full-text-search table and triggers from durable action_items rows.
+    /// This intentionally never drops or rewrites action_items itself.
+    func repairActionItemsFTS(reason: String) async throws {
+        guard let queue = dbQueue else {
+            throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "database is not initialized")
+        }
+
+        try await queue.write { db in
+            try Self.recreateActionItemsFTS(in: db)
+        }
+        log("RewindDatabase: Rebuilt action_items_fts after \(reason)")
+    }
+
+    private static func recreateActionItemsFTS(in db: Database) throws {
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ai")
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ad")
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_au")
+        try db.execute(sql: "DROP TABLE IF EXISTS action_items_fts")
+
+        try db.execute(sql: """
+            CREATE VIRTUAL TABLE action_items_fts USING fts5(
+                description,
+                content='action_items',
+                content_rowid='id',
+                tokenize='unicode61'
+            )
+            """)
+
+        try db.execute(sql: """
+            CREATE TRIGGER action_items_fts_ai AFTER INSERT ON action_items BEGIN
+                INSERT INTO action_items_fts(rowid, description)
+                VALUES (new.id, new.description);
+            END
+            """)
+
+        try db.execute(sql: """
+            CREATE TRIGGER action_items_fts_ad AFTER DELETE ON action_items BEGIN
+                INSERT INTO action_items_fts(action_items_fts, rowid, description)
+                VALUES ('delete', old.id, old.description);
+            END
+            """)
+
+        try db.execute(sql: """
+            CREATE TRIGGER action_items_fts_au AFTER UPDATE ON action_items BEGIN
+                INSERT INTO action_items_fts(action_items_fts, rowid, description)
+                VALUES ('delete', old.id, old.description);
+                INSERT INTO action_items_fts(rowid, description)
+                VALUES (new.id, new.description);
+            END
+            """)
+
+        try db.execute(sql: """
+            INSERT INTO action_items_fts(rowid, description)
+            SELECT id, description FROM action_items
+            """)
+    }
+
     /// Configure the database for a specific user.
     /// Does NOT close or reopen the database — call initialize() after this.
     /// initialize() will detect the user mismatch and reopen if needed.

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -128,19 +128,32 @@ actor RewindDatabase {
         guard let queue = dbQueue else {
             throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "database is not initialized")
         }
+        try await repairActionItemsFTS(in: queue, reason: reason)
+    }
 
+    /// Rebuild action_items_fts on a specific database queue. Callers that caught an FTS-trigger
+    /// write failure should pass the same queue they will retry on, avoiding stale queue races.
+    func repairActionItemsFTS(in queue: DatabasePool, reason: String) async throws {
         try await queue.write { db in
             try Self.recreateActionItemsFTS(in: db)
         }
         log("RewindDatabase: Rebuilt action_items_fts after \(reason)")
     }
 
-    private static func recreateActionItemsFTS(in db: Database) throws {
-        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ai")
-        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ad")
-        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_au")
-        try db.execute(sql: "DROP TABLE IF EXISTS action_items_fts")
+    private static let actionItemsFTSShadowTables = [
+        "action_items_fts_data",
+        "action_items_fts_idx",
+        "action_items_fts_content",
+        "action_items_fts_docsize",
+        "action_items_fts_config",
+    ]
 
+    private static func recreateActionItemsFTS(in db: Database) throws {
+        try dropActionItemsFTSIfPresent(in: db)
+        try installActionItemsFTS(in: db, populateExistingRows: true)
+    }
+
+    private static func installActionItemsFTS(in db: Database, populateExistingRows: Bool) throws {
         try db.execute(sql: """
             CREATE VIRTUAL TABLE action_items_fts USING fts5(
                 description,
@@ -173,10 +186,40 @@ actor RewindDatabase {
             END
             """)
 
+        guard populateExistingRows else { return }
         try db.execute(sql: """
             INSERT INTO action_items_fts(rowid, description)
             SELECT id, description FROM action_items
             """)
+    }
+
+    private static func dropActionItemsFTSIfPresent(in db: Database) throws {
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ai")
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_ad")
+        try db.execute(sql: "DROP TRIGGER IF EXISTS action_items_fts_au")
+
+        do {
+            try db.execute(sql: "DROP TABLE IF EXISTS action_items_fts")
+        } catch {
+            try forceRemoveBrokenActionItemsFTSMetadata(in: db)
+        }
+    }
+
+    private static func forceRemoveBrokenActionItemsFTSMetadata(in db: Database) throws {
+        try db.execute(sql: "PRAGMA writable_schema = ON")
+        defer { try? db.execute(sql: "PRAGMA writable_schema = OFF") }
+
+        try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = 'action_items_fts'")
+        for table in actionItemsFTSShadowTables {
+            do {
+                try db.execute(sql: "DROP TABLE IF EXISTS \(table)")
+            } catch {
+                try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = '\(table)'")
+            }
+        }
+
+        let schemaVersion = (try Int.fetchOne(db, sql: "PRAGMA schema_version")) ?? 0
+        try db.execute(sql: "PRAGMA schema_version = \(schemaVersion + 1)")
     }
 
     /// Configure the database for a specific user.
@@ -1499,44 +1542,7 @@ actor RewindDatabase {
 
         // Migration 19: Create FTS5 virtual table on action_items.description for keyword search
         migrator.registerMigration("createActionItemsFTS") { db in
-            try db.execute(sql: """
-                CREATE VIRTUAL TABLE action_items_fts USING fts5(
-                    description,
-                    content='action_items',
-                    content_rowid='id',
-                    tokenize='unicode61'
-                )
-                """)
-
-            // Sync triggers
-            try db.execute(sql: """
-                CREATE TRIGGER action_items_fts_ai AFTER INSERT ON action_items BEGIN
-                    INSERT INTO action_items_fts(rowid, description)
-                    VALUES (new.id, new.description);
-                END
-                """)
-
-            try db.execute(sql: """
-                CREATE TRIGGER action_items_fts_ad AFTER DELETE ON action_items BEGIN
-                    INSERT INTO action_items_fts(action_items_fts, rowid, description)
-                    VALUES ('delete', old.id, old.description);
-                END
-                """)
-
-            try db.execute(sql: """
-                CREATE TRIGGER action_items_fts_au AFTER UPDATE ON action_items BEGIN
-                    INSERT INTO action_items_fts(action_items_fts, rowid, description)
-                    VALUES ('delete', old.id, old.description);
-                    INSERT INTO action_items_fts(rowid, description)
-                    VALUES (new.id, new.description);
-                END
-                """)
-
-            // Populate with existing data
-            try db.execute(sql: """
-                INSERT INTO action_items_fts(rowid, description)
-                SELECT id, description FROM action_items
-                """)
+            try Self.installActionItemsFTS(in: db, populateExistingRows: true)
         }
 
         // Migration 20: Create ai_user_profiles table for daily AI-generated user profile history

--- a/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
@@ -73,18 +73,24 @@ final class ActionItemsFTSRepairTests: XCTestCase {
     XCTAssertEqual(ftsDescriptions, durableDescriptions)
   }
 
-  func testRepairRecreatesActionItemsFTSTriggers() async throws {
+  func testRepairToleratesMissingActionItemsFTSShadowTable() async throws {
+    let existing = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "shadow table durable row", source: "test"))
+    XCTAssertNotNil(existing.id)
+
     guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
       return XCTFail("database should be initialized")
     }
 
-    _ = try await ActionItemStorage.shared.insertLocalActionItem(
-      ActionItemRecord(description: "before direct repair", source: "test"))
+    try await dbQueue.write { db in
+      try db.execute(sql: "PRAGMA writable_schema = ON")
+      let schemaVersion = (try Int.fetchOne(db, sql: "PRAGMA schema_version")) ?? 0
+      defer { try? db.execute(sql: "PRAGMA writable_schema = OFF") }
+      try db.execute(sql: "DELETE FROM sqlite_master WHERE type = 'table' AND name = 'action_items_fts_data'")
+      try db.execute(sql: "PRAGMA schema_version = \(schemaVersion + 1)")
+    }
 
-    try await RewindDatabase.shared.repairActionItemsFTS(reason: "unit test")
-
-    _ = try await ActionItemStorage.shared.insertLocalActionItem(
-      ActionItemRecord(description: "after trigger repair", source: "test"))
+    try await RewindDatabase.shared.repairActionItemsFTS(in: dbQueue, reason: "missing shadow table test")
 
     let matches = try await dbQueue.read { db in
       try String.fetchAll(
@@ -93,10 +99,10 @@ final class ActionItemsFTSRepairTests: XCTestCase {
           SELECT action_items.description
           FROM action_items_fts
           JOIN action_items ON action_items_fts.rowid = action_items.id
-          WHERE action_items_fts MATCH 'trigger'
+          WHERE action_items_fts MATCH 'shadow'
           ORDER BY action_items.id
           """)
     }
-    XCTAssertEqual(matches, ["after trigger repair"])
+    XCTAssertEqual(matches, ["shadow table durable row"])
   }
 }

--- a/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import GRDB
+
+@testable import Omi_Computer
+
+final class ActionItemsFTSRepairTests: XCTestCase {
+  private var testUserId: String!
+  private var userDir: URL!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "action-items-fts-repair-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await ActionItemStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    userDir = appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await RewindDatabase.shared.close()
+    await ActionItemStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = nil
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    try await super.tearDown()
+  }
+
+  func testLocalInsertRepairsMissingActionItemsFTSWithoutDroppingDurableRows() async throws {
+    let existing = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "preserve existing durable row", source: "test"))
+    XCTAssertNotNil(existing.id)
+
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("database should be initialized")
+    }
+
+    try await dbQueue.write { db in
+      try db.execute(sql: "DROP TABLE action_items_fts")
+    }
+
+    let repaired = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "insert after fts repair", source: "test"))
+    XCTAssertNotNil(repaired.id)
+
+    let durableDescriptions = try await dbQueue.read { db in
+      try String.fetchAll(
+        db,
+        sql: "SELECT description FROM action_items ORDER BY id")
+    }
+    XCTAssertEqual(durableDescriptions, [
+      "preserve existing durable row",
+      "insert after fts repair"
+    ])
+
+    let ftsDescriptions = try await dbQueue.read { db in
+      try String.fetchAll(
+        db,
+        sql: """
+          SELECT action_items.description
+          FROM action_items_fts
+          JOIN action_items ON action_items_fts.rowid = action_items.id
+          WHERE action_items_fts MATCH 'repair OR durable'
+          ORDER BY action_items.id
+          """)
+    }
+    XCTAssertEqual(ftsDescriptions, durableDescriptions)
+  }
+
+  func testRepairRecreatesActionItemsFTSTriggers() async throws {
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("database should be initialized")
+    }
+
+    _ = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "before direct repair", source: "test"))
+
+    try await RewindDatabase.shared.repairActionItemsFTS(reason: "unit test")
+
+    _ = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "after trigger repair", source: "test"))
+
+    let matches = try await dbQueue.read { db in
+      try String.fetchAll(
+        db,
+        sql: """
+          SELECT action_items.description
+          FROM action_items_fts
+          JOIN action_items ON action_items_fts.rowid = action_items.id
+          WHERE action_items_fts MATCH 'trigger'
+          ORDER BY action_items.id
+          """)
+    }
+    XCTAssertEqual(matches, ["after trigger repair"])
+  }
+}


### PR DESCRIPTION
## Summary

- add a targeted `action_items_fts` rebuild helper that recreates only the FTS table/triggers from durable `action_items` rows
- retry local action item insertion once when the failure specifically implicates `action_items_fts`
- add regression coverage for repairing a missing FTS table without dropping existing action items, plus trigger recreation after repair

Closes #8173

## Test Plan

- [x] Consulted Oracle for implementation scope/risk review before changing code
- [x] `git diff --check origin/main...HEAD`
- [x] `xcrun swiftc -parse desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift desktop/macos/Desktop/Tests/ActionItemsFTSRepairTests.swift`
- [ ] `xcrun swift test --package-path Desktop --filter ActionItemsFTSRepairTests` — attempted twice locally, but SwiftPM timed out while downloading binary artifacts (`onnxruntime`, `Sparkle`, `Sentry`, Firebase/grpc artifacts) before compilation/test execution

## Notes

The repair path intentionally does **not** drop or rewrite `action_items`; it drops/recreates only `action_items_fts` and its sync triggers, then repopulates the FTS index from the durable table.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

