### PR TITLE
feat: emit listen conversation session ids

### DIFF
--- a/backend/models/message_event.py
+++ b/backend/models/message_event.py
@@ -91,6 +91,18 @@ class MessageServiceStatusEvent(MessageEvent):
         return j
 
 
+class ConversationSessionEvent(MessageEvent):
+    event_type: str = "conversation_session"
+    conversation_id: str
+    status: str = "in_progress"
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
 class PingEvent(MessageEvent):
     event_type: str = "ping"
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -62,6 +62,7 @@ from models.structured import Structured
 from models.transcript_segment import TranscriptSegment
 from models.message_event import (
     ConversationEvent,
+    ConversationSessionEvent,
     FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
     FreemiumThresholdReachedEvent,
     LastConversationEvent,
@@ -920,6 +921,7 @@ async def _stream_handler(
             redis_db.set_conversation_meeting_id(new_conversation_id, detected_meeting_id)
 
         current_conversation_id = new_conversation_id
+        _send_message_event(ConversationSessionEvent(conversation_id=new_conversation_id))
 
         logger.info(f"Created new stub conversation: {new_conversation_id} {uid} {session_id}")
 
@@ -958,6 +960,7 @@ async def _stream_handler(
 
             # Continue with the existing conversation
             current_conversation_id = existing_conversation['id']
+            _send_message_event(ConversationSessionEvent(conversation_id=current_conversation_id))
             logger.info(
                 f"Resuming conversation {current_conversation_id}. Will timeout in {conversation_creation_timeout - seconds_since_last_segment:.1f}s {uid} {session_id}"
             )

--- a/backend/testing/e2e/test_listen_stt.py
+++ b/backend/testing/e2e/test_listen_stt.py
@@ -1,6 +1,7 @@
 """Listen/STT websocket seam coverage."""
 
 import json
+import uuid
 
 from fakes.firestore import get_mock_firestore, read_conversation
 from fakes.stt import fake_suggested_transcript_event
@@ -33,6 +34,10 @@ def _receive_until(websocket, predicate, *, limit=20):
 
 def _is_ready_event(payload):
     return isinstance(payload, dict) and payload.get("type") == "service_status" and payload.get("status") == "ready"
+
+
+def _is_conversation_session_event(payload):
+    return isinstance(payload, dict) and payload.get("type") == "conversation_session"
 
 
 def _is_segment_batch(payload):
@@ -121,6 +126,9 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
         auth_response = websocket.receive_json()
         assert auth_response == {"type": "auth_response", "success": True}
+        session_event = _receive_until(websocket, _is_conversation_session_event)
+        uuid.UUID(session_event["conversation_id"])
+        assert session_event["status"] == "in_progress"
         _receive_until(websocket, _is_ready_event)
 
         websocket.send_bytes(b"\x80" * 320)
@@ -151,6 +159,7 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
     assert len(conversations) == 1
     conversation = read_conversation(test_uid, conversations[0].id)
     assert conversation is not None
+    assert conversations[0].id == session_event["conversation_id"]
     assert getattr(conversation["source"], "value", conversation["source"]) == "desktop"
     assert getattr(conversation["status"], "value", conversation["status"]) == "in_progress"
     assert isinstance(conversation["transcript_segments"], str)
@@ -161,3 +170,31 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
     assert persisted_conversation["source"] == "desktop"
     assert persisted_conversation["status"] == "in_progress"
     assert persisted_conversation["transcript_segments"] == emitted_segments
+
+
+def test_web_listen_reconnect_emits_existing_conversation_session_id(client, test_uid):
+    """A fast reconnect should expose the same active conversation id instead of making clients infer it."""
+    _seed_listen_user(test_uid)
+
+    with client.websocket_connect(
+        "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        first_event = _receive_until(websocket, _is_conversation_session_event)
+        uuid.UUID(first_event["conversation_id"])
+        _receive_until(websocket, _is_ready_event)
+
+    with client.websocket_connect(
+        "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        second_event = _receive_until(websocket, _is_conversation_session_event)
+        _receive_until(websocket, _is_ready_event)
+
+    assert second_event["conversation_id"] == first_event["conversation_id"]
+    conversations = list(
+        get_mock_firestore().collection("users").document(test_uid).collection("conversations").stream()
+    )
+    assert [conversation.id for conversation in conversations] == [first_event["conversation_id"]]

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2416,7 +2416,7 @@ class AppState: ObservableObject {
     // conversation, it can briefly re-emit the old conversation id; do not bind the
     // fresh local SQLite session to that rotated id.
     recordingStartTime = Date()
-    ignoredRotatedBackendConversationId = currentBackendConversationId
+    ignoredRotatedBackendConversationId = ignoredRotatedBackendConversationId ?? currentBackendConversationId
     currentBackendConversationId = nil
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
@@ -3178,6 +3178,9 @@ class AppState: ObservableObject {
       ignoredRotatedBackendId: ignoredRotatedBackendConversationId
     ) else {
       pendingBackendConversationId = nil
+      if let currentBackendConversationId, currentBackendConversationId != backendId {
+        ignoredRotatedBackendConversationId = backendId
+      }
       log("Transcription: Ignoring rotated backend conversation id \(backendId) for fresh local session")
       return
     }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -80,6 +80,15 @@ enum DesktopConversationMatchPolicy {
     return true
   }
 
+  static func canCompleteBoundBackendConversation(
+    id conversationId: String,
+    boundBackendId: String,
+    status: ConversationStatus,
+    source: ConversationSource?
+  ) -> Bool {
+    conversationId == boundBackendId && source == .desktop && status != .inProgress
+  }
+
   static func parseMemoryEventDate(_ value: Any?) -> Date? {
     if let date = value as? Date {
       return date
@@ -2144,8 +2153,11 @@ class AppState: ObservableObject {
           // timestamp/source matching for older backend sessions that did not emit the event.
           if let sessionId = capturedSessionId,
              let backendConversationId = capturedBackendConversationId,
-             conversation.id == backendConversationId,
-             conversation.source == .desktop {
+             DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+               id: conversation.id,
+               boundBackendId: backendConversationId,
+               status: conversation.status,
+               source: conversation.source) {
             try? await TranscriptionStorage.shared.markSessionCompleted(
               id: sessionId, backendId: conversation.id)
             log("Transcription: Force-processed bound conversation \(conversation.id), session \(sessionId) completed")
@@ -2252,12 +2264,13 @@ class AppState: ObservableObject {
       if let backendConversationId, !backendConversationId.isEmpty {
         do {
           let conversation = try await APIClient.shared.getConversation(id: backendConversationId)
-          guard conversation.status != .inProgress else {
-            log("Transcription: Exact backend conversation \(backendConversationId) is still in progress; falling back to timestamp")
-            throw APIError.invalidResponse
-          }
-          guard conversation.source == .desktop else {
-            log("Transcription: Exact backend conversation \(backendConversationId) has source \(conversation.source?.rawValue ?? "nil"); falling back to timestamp")
+          guard DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+            id: conversation.id,
+            boundBackendId: backendConversationId,
+            status: conversation.status,
+            source: conversation.source
+          ) else {
+            log("Transcription: Exact backend conversation \(backendConversationId) is not a completed desktop session; falling back to timestamp")
             throw APIError.invalidResponse
           }
           try await TranscriptionStorage.shared.markSessionCompleted(

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -443,6 +443,10 @@ class AppState: ObservableObject {
 
   // Crash-safe transcription storage
   private var currentSessionId: Int64?
+  /// Backend conversation id announced by `/v4/listen` for the active recording session.
+  private var currentBackendConversationId: String?
+  /// Backend id received before the local DB session exists; consumed once startSession completes.
+  private var pendingBackendConversationId: String?
   /// Session ID captured before rotation in finishConversation(), consumed by memory_created handler
   private var finishedSessionId: Int64?
   /// Recording start time captured before rotation, used by memory_created handler for accurate duration analytics
@@ -1669,6 +1673,8 @@ class AppState: ObservableObject {
       liveSpeakerPersonMap = [:]
       LiveTranscriptMonitor.shared.clear()
       recordingStartTime = Date()
+      currentBackendConversationId = nil
+      pendingBackendConversationId = nil
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
 
@@ -1689,6 +1695,13 @@ class AppState: ObservableObject {
             self.currentSessionId = sessionId
             // Start live notes session
             LiveNotesMonitor.shared.startSession(sessionId: sessionId)
+          }
+          if let backendId = await MainActor.run(body: { self.pendingBackendConversationId ?? self.currentBackendConversationId }) {
+            try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+            await MainActor.run {
+              self.currentBackendConversationId = backendId
+              self.pendingBackendConversationId = nil
+            }
           }
           log("Transcription: Created DB session \(sessionId)")
         } catch {
@@ -2077,6 +2090,7 @@ class AppState: ObservableObject {
     // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil)
     let capturedSessionId = currentSessionId
     let capturedStartTime = recordingStartTime
+    let capturedBackendConversationId = currentBackendConversationId
     let generationAtStop = recordingGeneration
 
     stopAudioCapture()
@@ -2099,9 +2113,17 @@ class AppState: ObservableObject {
 
       do {
         if let conversation = try await APIClient.shared.forceProcessConversation() {
-          // Validate the returned conversation matches the session we just stopped
-          if let sessionId = capturedSessionId, let startTime = capturedStartTime,
-             DesktopConversationMatchPolicy.matchesDesktopConversation(
+          // Prefer the exact backend conversation id announced by /v4/listen; fall back to
+          // timestamp/source matching for older backend sessions that did not emit the event.
+          if let sessionId = capturedSessionId,
+             let backendConversationId = capturedBackendConversationId,
+             conversation.id == backendConversationId {
+            try? await TranscriptionStorage.shared.markSessionCompleted(
+              id: sessionId, backendId: conversation.id)
+            log("Transcription: Force-processed bound conversation \(conversation.id), session \(sessionId) completed")
+          } else if let sessionId = capturedSessionId, let startTime = capturedStartTime,
+                    capturedBackendConversationId == nil,
+                    DesktopConversationMatchPolicy.matchesDesktopConversation(
               startedAt: conversation.startedAt,
               source: conversation.source,
               sessionStartedAt: startTime) {
@@ -2111,13 +2133,19 @@ class AppState: ObservableObject {
           } else if let sessionId = capturedSessionId, let startTime = capturedStartTime {
             // Force-process returned a different conversation — fall back to reconciliation
             log("Transcription: Force-processed conversation \(conversation.id) does not match session \(sessionId), reconciling by timestamp")
-            await reconcileSession(sessionId: sessionId, startTime: startTime)
+            await reconcileSession(
+              sessionId: sessionId,
+              startTime: startTime,
+              backendConversationId: capturedBackendConversationId)
           }
         } else {
           // 404: No in-progress conversation — WS close handler already processed it.
-          // Reconcile by checking if a matching conversation exists on the backend.
+          // Reconcile by exact backend id when available, otherwise by timestamp/source.
           if let sessionId = capturedSessionId, let startTime = capturedStartTime {
-            await reconcileSession(sessionId: sessionId, startTime: startTime)
+            await reconcileSession(
+              sessionId: sessionId,
+              startTime: startTime,
+              backendConversationId: capturedBackendConversationId)
           }
         }
       } catch {
@@ -2187,8 +2215,28 @@ class AppState: ObservableObject {
 
   /// Reconcile a local session by checking if a matching conversation exists on the backend.
   /// If found, marks the session as completed. Otherwise leaves it as pendingUpload for retry.
-  private func reconcileSession(sessionId: Int64, startTime: Date) async {
+  private func reconcileSession(
+    sessionId: Int64,
+    startTime: Date,
+    backendConversationId: String? = nil
+  ) async {
     do {
+      if let backendConversationId, !backendConversationId.isEmpty {
+        do {
+          let conversation = try await APIClient.shared.getConversation(id: backendConversationId)
+          guard conversation.status != .inProgress else {
+            log("Transcription: Exact backend conversation \(backendConversationId) is still in progress; falling back to timestamp")
+            throw APIError.invalidResponse
+          }
+          try await TranscriptionStorage.shared.markSessionCompleted(
+            id: sessionId, backendId: conversation.id)
+          log("Transcription: Reconciled session \(sessionId) by exact backend conversation \(conversation.id)")
+          return
+        } catch {
+          logError("Transcription: Exact backend conversation reconciliation failed for session \(sessionId), falling back to timestamp", error: error)
+        }
+      }
+
       let conversations = try await APIClient.shared.getConversations(
         limit: 5,
         includeDiscarded: true,
@@ -2335,8 +2383,10 @@ class AppState: ObservableObject {
     LiveNotesMonitor.shared.endSession()
     LiveNotesMonitor.shared.clear()
 
-    // Reset the recording start time for the next conversation
+    // Reset the recording start time and backend binding for the next conversation
     recordingStartTime = Date()
+    currentBackendConversationId = nil
+    pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
 
     // Restart the 4-hour max recording timer
@@ -2414,6 +2464,13 @@ class AppState: ObservableObject {
         await MainActor.run {
           self.currentSessionId = sessionId
           LiveNotesMonitor.shared.startSession(sessionId: sessionId)
+        }
+        if let backendId = await MainActor.run(body: { self.pendingBackendConversationId ?? self.currentBackendConversationId }) {
+          try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+          await MainActor.run {
+            self.currentBackendConversationId = backendId
+            self.pendingBackendConversationId = nil
+          }
         }
         log("Transcription: Created new DB session \(sessionId) for next conversation")
       } catch {
@@ -3073,12 +3130,38 @@ class AppState: ObservableObject {
     }
   }
 
+  private func bindActiveSessionToBackendConversation(_ backendId: String) {
+    currentBackendConversationId = backendId
+
+    guard let sessionId = currentSessionId else {
+      pendingBackendConversationId = backendId
+      log("Transcription: Deferred backend conversation bind until local DB session exists (backend: \(backendId))")
+      return
+    }
+
+    pendingBackendConversationId = nil
+    Task {
+      do {
+        try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+      } catch {
+        logError("Transcription: Failed to bind DB session \(sessionId) to backend conversation \(backendId)", error: error)
+      }
+    }
+  }
+
   /// Handle message events from Python backend `/v4/listen`
   private func handleListenEvent(_ event: TranscriptionService.ListenEvent) {
     switch event.type {
     case "service_status":
       let status = event.raw["status"] as? String ?? "unknown"
       log("Transcription: Backend service status: \(status)")
+
+    case "conversation_session":
+      guard let backendId = event.raw["conversation_id"] as? String, !backendId.isEmpty else {
+        log("Transcription: Ignoring conversation_session event without conversation_id")
+        break
+      }
+      bindActiveSessionToBackendConversation(backendId)
 
     case "memory_processing_started":
       // ConversationEvent: conversation is nested under "memory"

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -68,14 +68,13 @@ enum DesktopConversationMatchPolicy {
   static func shouldBindConversationSession(
     incomingBackendId: String,
     activeBackendId: String?,
-    ignoredRotatedBackendId: String?
+    ignoredRotatedBackendIds: Set<String>
   ) -> Bool {
     guard !incomingBackendId.isEmpty else { return false }
     if let activeBackendId, !activeBackendId.isEmpty {
       return incomingBackendId == activeBackendId
     }
-    if let ignoredRotatedBackendId,
-       incomingBackendId == ignoredRotatedBackendId {
+    if ignoredRotatedBackendIds.contains(incomingBackendId) {
       return false
     }
     return true
@@ -463,8 +462,8 @@ class AppState: ObservableObject {
   private var currentBackendConversationId: String?
   /// Backend id received before the local DB session exists; consumed once startSession completes.
   private var pendingBackendConversationId: String?
-  /// Backend id from the session just rotated by finishConversation(); ignore fast-reconnect resumes of it.
-  private var ignoredRotatedBackendConversationId: String?
+  /// Backend ids from recently rotated/rejected sessions; ignore fast-reconnect resumes of them.
+  private var ignoredRotatedBackendConversationIds: Set<String> = []
   /// Session ID captured before rotation in finishConversation(), consumed by memory_created handler
   private var finishedSessionId: Int64?
   /// Recording start time captured before rotation, used by memory_created handler for accurate duration analytics
@@ -1693,7 +1692,7 @@ class AppState: ObservableObject {
       recordingStartTime = Date()
       currentBackendConversationId = nil
       pendingBackendConversationId = nil
-      ignoredRotatedBackendConversationId = nil
+      ignoredRotatedBackendConversationIds = []
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
 
@@ -1721,14 +1720,14 @@ class AppState: ObservableObject {
             return DesktopConversationMatchPolicy.shouldBindConversationSession(
               incomingBackendId: candidate,
               activeBackendId: self.currentBackendConversationId,
-              ignoredRotatedBackendId: self.ignoredRotatedBackendConversationId
+              ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds
             ) ? candidate : nil
           }) {
             try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
             await MainActor.run {
               self.currentBackendConversationId = backendId
               self.pendingBackendConversationId = nil
-              self.ignoredRotatedBackendConversationId = nil
+              self.ignoredRotatedBackendConversationIds = []
             }
           }
           log("Transcription: Created DB session \(sessionId)")
@@ -2145,7 +2144,8 @@ class AppState: ObservableObject {
           // timestamp/source matching for older backend sessions that did not emit the event.
           if let sessionId = capturedSessionId,
              let backendConversationId = capturedBackendConversationId,
-             conversation.id == backendConversationId {
+             conversation.id == backendConversationId,
+             conversation.source == .desktop {
             try? await TranscriptionStorage.shared.markSessionCompleted(
               id: sessionId, backendId: conversation.id)
             log("Transcription: Force-processed bound conversation \(conversation.id), session \(sessionId) completed")
@@ -2254,6 +2254,10 @@ class AppState: ObservableObject {
           let conversation = try await APIClient.shared.getConversation(id: backendConversationId)
           guard conversation.status != .inProgress else {
             log("Transcription: Exact backend conversation \(backendConversationId) is still in progress; falling back to timestamp")
+            throw APIError.invalidResponse
+          }
+          guard conversation.source == .desktop else {
+            log("Transcription: Exact backend conversation \(backendConversationId) has source \(conversation.source?.rawValue ?? "nil"); falling back to timestamp")
             throw APIError.invalidResponse
           }
           try await TranscriptionStorage.shared.markSessionCompleted(
@@ -2416,7 +2420,9 @@ class AppState: ObservableObject {
     // conversation, it can briefly re-emit the old conversation id; do not bind the
     // fresh local SQLite session to that rotated id.
     recordingStartTime = Date()
-    ignoredRotatedBackendConversationId = ignoredRotatedBackendConversationId ?? currentBackendConversationId
+    if let currentBackendConversationId {
+      ignoredRotatedBackendConversationIds.insert(currentBackendConversationId)
+    }
     currentBackendConversationId = nil
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
@@ -2503,14 +2509,14 @@ class AppState: ObservableObject {
           return DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: candidate,
             activeBackendId: self.currentBackendConversationId,
-            ignoredRotatedBackendId: self.ignoredRotatedBackendConversationId
+            ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds
           ) ? candidate : nil
         }) {
           try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
           await MainActor.run {
             self.currentBackendConversationId = backendId
             self.pendingBackendConversationId = nil
-            self.ignoredRotatedBackendConversationId = nil
+            self.ignoredRotatedBackendConversationIds = []
           }
         }
         log("Transcription: Created new DB session \(sessionId) for next conversation")
@@ -3175,17 +3181,17 @@ class AppState: ObservableObject {
     guard DesktopConversationMatchPolicy.shouldBindConversationSession(
       incomingBackendId: backendId,
       activeBackendId: currentBackendConversationId,
-      ignoredRotatedBackendId: ignoredRotatedBackendConversationId
+      ignoredRotatedBackendIds: ignoredRotatedBackendConversationIds
     ) else {
       pendingBackendConversationId = nil
       if let currentBackendConversationId, currentBackendConversationId != backendId {
-        ignoredRotatedBackendConversationId = backendId
+        ignoredRotatedBackendConversationIds.insert(backendId)
       }
       log("Transcription: Ignoring rotated backend conversation id \(backendId) for fresh local session")
       return
     }
 
-    ignoredRotatedBackendConversationId = nil
+    ignoredRotatedBackendConversationIds = []
     currentBackendConversationId = backendId
 
     guard let sessionId = currentSessionId else {

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -71,9 +71,11 @@ enum DesktopConversationMatchPolicy {
     ignoredRotatedBackendId: String?
   ) -> Bool {
     guard !incomingBackendId.isEmpty else { return false }
+    if let activeBackendId, !activeBackendId.isEmpty {
+      return incomingBackendId == activeBackendId
+    }
     if let ignoredRotatedBackendId,
-       incomingBackendId == ignoredRotatedBackendId,
-       activeBackendId == nil {
+       incomingBackendId == ignoredRotatedBackendId {
       return false
     }
     return true

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -65,6 +65,20 @@ enum DesktopConversationMatchPolicy {
     return abs(memoryStartedAt.timeIntervalSince(sessionStartedAt)) < startedAtTolerance
   }
 
+  static func shouldBindConversationSession(
+    incomingBackendId: String,
+    activeBackendId: String?,
+    ignoredRotatedBackendId: String?
+  ) -> Bool {
+    guard !incomingBackendId.isEmpty else { return false }
+    if let ignoredRotatedBackendId,
+       incomingBackendId == ignoredRotatedBackendId,
+       activeBackendId == nil {
+      return false
+    }
+    return true
+  }
+
   static func parseMemoryEventDate(_ value: Any?) -> Date? {
     if let date = value as? Date {
       return date
@@ -447,6 +461,8 @@ class AppState: ObservableObject {
   private var currentBackendConversationId: String?
   /// Backend id received before the local DB session exists; consumed once startSession completes.
   private var pendingBackendConversationId: String?
+  /// Backend id from the session just rotated by finishConversation(); ignore fast-reconnect resumes of it.
+  private var ignoredRotatedBackendConversationId: String?
   /// Session ID captured before rotation in finishConversation(), consumed by memory_created handler
   private var finishedSessionId: Int64?
   /// Recording start time captured before rotation, used by memory_created handler for accurate duration analytics
@@ -1675,6 +1691,7 @@ class AppState: ObservableObject {
       recordingStartTime = Date()
       currentBackendConversationId = nil
       pendingBackendConversationId = nil
+      ignoredRotatedBackendConversationId = nil
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
 
@@ -1696,11 +1713,20 @@ class AppState: ObservableObject {
             // Start live notes session
             LiveNotesMonitor.shared.startSession(sessionId: sessionId)
           }
-          if let backendId = await MainActor.run(body: { self.pendingBackendConversationId ?? self.currentBackendConversationId }) {
+          if let backendId = await MainActor.run(body: { () -> String? in
+            let candidate = self.pendingBackendConversationId ?? self.currentBackendConversationId
+            guard let candidate else { return nil }
+            return DesktopConversationMatchPolicy.shouldBindConversationSession(
+              incomingBackendId: candidate,
+              activeBackendId: self.currentBackendConversationId,
+              ignoredRotatedBackendId: self.ignoredRotatedBackendConversationId
+            ) ? candidate : nil
+          }) {
             try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
             await MainActor.run {
               self.currentBackendConversationId = backendId
               self.pendingBackendConversationId = nil
+              self.ignoredRotatedBackendConversationId = nil
             }
           }
           log("Transcription: Created DB session \(sessionId)")
@@ -2383,8 +2409,12 @@ class AppState: ObservableObject {
     LiveNotesMonitor.shared.endSession()
     LiveNotesMonitor.shared.clear()
 
-    // Reset the recording start time and backend binding for the next conversation
+    // Reset the recording start time and backend binding for the next conversation.
+    // If the new WebSocket fast-reconnects before the backend finalizes the prior
+    // conversation, it can briefly re-emit the old conversation id; do not bind the
+    // fresh local SQLite session to that rotated id.
     recordingStartTime = Date()
+    ignoredRotatedBackendConversationId = currentBackendConversationId
     currentBackendConversationId = nil
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
@@ -2465,11 +2495,20 @@ class AppState: ObservableObject {
           self.currentSessionId = sessionId
           LiveNotesMonitor.shared.startSession(sessionId: sessionId)
         }
-        if let backendId = await MainActor.run(body: { self.pendingBackendConversationId ?? self.currentBackendConversationId }) {
+        if let backendId = await MainActor.run(body: { () -> String? in
+          let candidate = self.pendingBackendConversationId ?? self.currentBackendConversationId
+          guard let candidate else { return nil }
+          return DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: candidate,
+            activeBackendId: self.currentBackendConversationId,
+            ignoredRotatedBackendId: self.ignoredRotatedBackendConversationId
+          ) ? candidate : nil
+        }) {
           try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
           await MainActor.run {
             self.currentBackendConversationId = backendId
             self.pendingBackendConversationId = nil
+            self.ignoredRotatedBackendConversationId = nil
           }
         }
         log("Transcription: Created new DB session \(sessionId) for next conversation")
@@ -3131,6 +3170,17 @@ class AppState: ObservableObject {
   }
 
   private func bindActiveSessionToBackendConversation(_ backendId: String) {
+    guard DesktopConversationMatchPolicy.shouldBindConversationSession(
+      incomingBackendId: backendId,
+      activeBackendId: currentBackendConversationId,
+      ignoredRotatedBackendId: ignoredRotatedBackendConversationId
+    ) else {
+      pendingBackendConversationId = nil
+      log("Transcription: Ignoring rotated backend conversation id \(backendId) for fresh local session")
+      return
+    }
+
+    ignoredRotatedBackendConversationId = nil
     currentBackendConversationId = backendId
 
     guard let sessionId = currentSessionId else {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -552,7 +552,6 @@ actor TranscriptionStorage {
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.pendingUpload.rawValue)
                 .filter(Column("backendSynced") == false)
-                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -567,7 +566,6 @@ actor TranscriptionStorage {
                 .filter(Column("status") == TranscriptionSessionStatus.failed.rawValue)
                 .filter(Column("retryCount") < maxRetries)
                 .filter(Column("backendSynced") == false)
-                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("updatedAt").asc)
                 .fetchAll(database)
         }
@@ -581,7 +579,6 @@ actor TranscriptionStorage {
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.recording.rawValue)
                 .filter(Column("backendSynced") == false)
-                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -598,7 +595,6 @@ actor TranscriptionStorage {
                 .filter(Column("status") == TranscriptionSessionStatus.uploading.rawValue)
                 .filter(Column("updatedAt") < cutoff)
                 .filter(Column("backendSynced") == false)
-                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -634,7 +630,6 @@ actor TranscriptionStorage {
                     (Column("status") == TranscriptionSessionStatus.failed.rawValue && Column("retryCount") < 5)
                 )
                 .filter(Column("backendSynced") == false)
-                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -70,7 +70,7 @@ actor TranscriptionStorage {
         return record.id!
     }
 
-    /// Mark session as finished (recording complete, ready for upload)
+    /// Mark session as finished (recording complete, ready for upload/reconciliation)
     func finishSession(id: Int64) async throws {
         let db = try await ensureInitialized()
 
@@ -79,8 +79,8 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
-            guard !record.hasSyncedBackendIdentity else {
-                log("TranscriptionStorage: Skipping finishSession for backend-synced session \(id)")
+            guard record.status != .completed && !record.backendSynced else {
+                log("TranscriptionStorage: Skipping finishSession for completed backend-synced session \(id)")
                 return false
             }
 
@@ -94,6 +94,30 @@ actor TranscriptionStorage {
         if didFinish {
             log("TranscriptionStorage: Finished session \(id)")
         }
+    }
+
+    /// Bind a local recording session to the backend conversation id announced by `/v4/listen`.
+    /// This is not completion: the backend conversation may still be `in_progress` until stop/finalize.
+    func bindBackendConversation(id: Int64, backendId: String) async throws {
+        let db = try await ensureInitialized()
+
+        try await db.write { database in
+            guard var record = try TranscriptionSessionRecord.fetchOne(database, key: id) else {
+                throw TranscriptionStorageError.sessionNotFound
+            }
+
+            guard record.canAcceptCompletion(backendId: backendId) else {
+                log("TranscriptionStorage: Skipping conflicting backend bind for session \(id) (existing: \(record.backendId ?? "nil"), incoming: \(backendId))")
+                return
+            }
+
+            record.backendId = backendId
+            record.conversationStatus = .inProgress
+            record.updatedAt = Date()
+            try record.update(database)
+        }
+
+        log("TranscriptionStorage: Bound session \(id) to backend conversation \(backendId)")
     }
 
     /// Mark session as pending upload
@@ -150,8 +174,8 @@ actor TranscriptionStorage {
                 log("TranscriptionStorage: Skipping markSessionFailed for already-completed session \(id)")
                 return
             }
-            guard !record.hasSyncedBackendIdentity else {
-                log("TranscriptionStorage: Skipping markSessionFailed for backend-synced session \(id)")
+            guard record.status != .completed && !record.backendSynced else {
+                log("TranscriptionStorage: Skipping markSessionFailed for completed backend-synced session \(id)")
                 return
             }
 
@@ -179,8 +203,8 @@ actor TranscriptionStorage {
                 log("TranscriptionStorage: Skipping incrementRetryCount for already-completed session \(id)")
                 return
             }
-            guard !record.hasSyncedBackendIdentity else {
-                log("TranscriptionStorage: Skipping incrementRetryCount for backend-synced session \(id)")
+            guard record.status != .completed && !record.backendSynced else {
+                log("TranscriptionStorage: Skipping incrementRetryCount for completed backend-synced session \(id)")
                 return
             }
 
@@ -215,8 +239,8 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
-            guard !record.hasSyncedBackendIdentity else {
-                log("TranscriptionStorage: Skipping status update for backend-synced session \(id)")
+            guard record.status != .completed && !record.backendSynced else {
+                log("TranscriptionStorage: Skipping status update for completed backend-synced session \(id)")
                 return
             }
 

--- a/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
@@ -214,6 +214,24 @@ class TranscriptionRetryService {
         log("TranscriptionRetryService: Reconciling session \(sessionId) (retryCount: \(session.retryCount))")
 
         do {
+            if let backendId = session.backendId, !backendId.isEmpty {
+                do {
+                    let conversation = try await APIClient.shared.getConversation(id: backendId)
+                    guard conversation.status != .inProgress else {
+                        log("TranscriptionRetryService: Backend conversation \(backendId) is still in progress, will retry")
+                        try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
+                        try await TranscriptionStorage.shared.markSessionFailed(
+                            id: sessionId, error: "Bound backend conversation is still in progress")
+                        return
+                    }
+                    log("TranscriptionRetryService: Session \(sessionId) found by exact backend id \(conversation.id), marking completed")
+                    try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: conversation.id)
+                    return
+                } catch {
+                    logError("TranscriptionRetryService: Exact backend id lookup failed for session \(sessionId), falling back to timestamp", error: error)
+                }
+            }
+
             // Check if backend already has a conversation for this time window
             let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
             if let existing = try? await APIClient.shared.getConversations(

--- a/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
@@ -224,6 +224,10 @@ class TranscriptionRetryService {
                             id: sessionId, error: "Bound backend conversation is still in progress")
                         return
                     }
+                    guard conversation.source == .desktop else {
+                        log("TranscriptionRetryService: Backend conversation \(backendId) has source \(conversation.source?.rawValue ?? "nil"), falling back to timestamp")
+                        throw APIError.invalidResponse
+                    }
                     log("TranscriptionRetryService: Session \(sessionId) found by exact backend id \(conversation.id), marking completed")
                     try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: conversation.id)
                     return

--- a/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
@@ -217,15 +217,20 @@ class TranscriptionRetryService {
             if let backendId = session.backendId, !backendId.isEmpty {
                 do {
                     let conversation = try await APIClient.shared.getConversation(id: backendId)
-                    guard conversation.status != .inProgress else {
-                        log("TranscriptionRetryService: Backend conversation \(backendId) is still in progress, will retry")
-                        try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
-                        try await TranscriptionStorage.shared.markSessionFailed(
-                            id: sessionId, error: "Bound backend conversation is still in progress")
-                        return
-                    }
-                    guard conversation.source == .desktop else {
-                        log("TranscriptionRetryService: Backend conversation \(backendId) has source \(conversation.source?.rawValue ?? "nil"), falling back to timestamp")
+                    guard DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+                        id: conversation.id,
+                        boundBackendId: backendId,
+                        status: conversation.status,
+                        source: conversation.source
+                    ) else {
+                        if conversation.status == .inProgress {
+                            log("TranscriptionRetryService: Backend conversation \(backendId) is still in progress, will retry")
+                            try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
+                            try await TranscriptionStorage.shared.markSessionFailed(
+                                id: sessionId, error: "Bound backend conversation is still in progress")
+                            return
+                        }
+                        log("TranscriptionRetryService: Backend conversation \(backendId) is not a completed desktop session, falling back to timestamp")
                         throw APIError.invalidResponse
                     }
                     log("TranscriptionRetryService: Session \(sessionId) found by exact backend id \(conversation.id), marking completed")

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -257,6 +257,22 @@ final class StopReconciliationTests: XCTestCase {
             "Binding the backend id is not completion; stop flow must still be able to mark the session pending")
     }
 
+    func testActiveBackendConversationIdAcceptsMatchingReemit() {
+        XCTAssertTrue(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: "active-conversation",
+            activeBackendId: "active-conversation",
+            ignoredRotatedBackendId: nil
+        ))
+    }
+
+    func testActiveBackendConversationIdRejectsDifferentRollover() {
+        XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: "rolled-over-conversation",
+            activeBackendId: "active-conversation",
+            ignoredRotatedBackendId: nil
+        ))
+    }
+
     func testRotatedBackendConversationIdIsNotBoundToFreshSession() {
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "previous-conversation",

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -273,6 +273,23 @@ final class StopReconciliationTests: XCTestCase {
         ))
     }
 
+    func testRejectedRolloverBackendConversationIdIsCarriedAcrossRotation() {
+        let activeBackendId = "active-conversation"
+        let rejectedRolloverId = "rolled-over-conversation"
+        let ignoredAfterFinish = rejectedRolloverId
+
+        XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: rejectedRolloverId,
+            activeBackendId: activeBackendId,
+            ignoredRotatedBackendId: nil
+        ))
+        XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: rejectedRolloverId,
+            activeBackendId: nil,
+            ignoredRotatedBackendId: ignoredAfterFinish
+        ), "A backend conversation rejected as an active-session rollover must not bind after local rotation")
+    }
+
     func testRotatedBackendConversationIdIsNotBoundToFreshSession() {
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "previous-conversation",

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -241,6 +241,15 @@ final class StopReconciliationTests: XCTestCase {
             "Force-process must not bind a different conversation when the listen session id is known")
     }
 
+    func testBoundBackendConversationIdRejectsNonDesktopExactMatch() {
+        let exactIdMatches = "backend-conversation-123" == "backend-conversation-123"
+        let convSource: ConversationSource = .phone
+
+        XCTAssertTrue(exactIdMatches)
+        XCTAssertNotEqual(convSource, .desktop,
+            "Exact listen ids still need source validation before completing a desktop session")
+    }
+
     func testRecordingSessionWithBackendIdCanStillBeFinishedForRetryReconciliation() {
         var session = TranscriptionSessionRecord(
             source: "desktop",
@@ -261,7 +270,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertTrue(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "active-conversation",
             activeBackendId: "active-conversation",
-            ignoredRotatedBackendId: nil
+            ignoredRotatedBackendIds: []
         ))
     }
 
@@ -269,24 +278,24 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "rolled-over-conversation",
             activeBackendId: "active-conversation",
-            ignoredRotatedBackendId: nil
+            ignoredRotatedBackendIds: []
         ))
     }
 
     func testRejectedRolloverBackendConversationIdIsCarriedAcrossRotation() {
         let activeBackendId = "active-conversation"
         let rejectedRolloverId = "rolled-over-conversation"
-        let ignoredAfterFinish = rejectedRolloverId
+        let ignoredAfterFinish: Set<String> = [activeBackendId, rejectedRolloverId]
 
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: rejectedRolloverId,
             activeBackendId: activeBackendId,
-            ignoredRotatedBackendId: nil
+            ignoredRotatedBackendIds: []
         ))
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: rejectedRolloverId,
             activeBackendId: nil,
-            ignoredRotatedBackendId: ignoredAfterFinish
+            ignoredRotatedBackendIds: ignoredAfterFinish
         ), "A backend conversation rejected as an active-session rollover must not bind after local rotation")
     }
 
@@ -294,7 +303,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "previous-conversation",
             activeBackendId: nil,
-            ignoredRotatedBackendId: "previous-conversation"
+            ignoredRotatedBackendIds: ["previous-conversation"]
         ))
     }
 
@@ -302,7 +311,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertTrue(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "new-conversation",
             activeBackendId: nil,
-            ignoredRotatedBackendId: "previous-conversation"
+            ignoredRotatedBackendIds: ["previous-conversation"]
         ))
     }
 
@@ -310,7 +319,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
             incomingBackendId: "",
             activeBackendId: nil,
-            ignoredRotatedBackendId: nil
+            ignoredRotatedBackendIds: []
         ))
     }
 }

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -256,6 +256,30 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertEqual(session.status, .pendingUpload,
             "Binding the backend id is not completion; stop flow must still be able to mark the session pending")
     }
+
+    func testRotatedBackendConversationIdIsNotBoundToFreshSession() {
+        XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: "previous-conversation",
+            activeBackendId: nil,
+            ignoredRotatedBackendId: "previous-conversation"
+        ))
+    }
+
+    func testNewBackendConversationIdAfterRotationCanBindFreshSession() {
+        XCTAssertTrue(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: "new-conversation",
+            activeBackendId: nil,
+            ignoredRotatedBackendId: "previous-conversation"
+        ))
+    }
+
+    func testEmptyConversationSessionIdIsRejected() {
+        XCTAssertFalse(DesktopConversationMatchPolicy.shouldBindConversationSession(
+            incomingBackendId: "",
+            activeBackendId: nil,
+            ignoredRotatedBackendId: nil
+        ))
+    }
 }
 
 private extension Date {

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -241,13 +241,31 @@ final class StopReconciliationTests: XCTestCase {
             "Force-process must not bind a different conversation when the listen session id is known")
     }
 
-    func testBoundBackendConversationIdRejectsNonDesktopExactMatch() {
-        let exactIdMatches = "backend-conversation-123" == "backend-conversation-123"
-        let convSource: ConversationSource = .phone
+    func testBoundBackendConversationCompletionRejectsNonDesktopExactMatch() {
+        XCTAssertFalse(DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+            id: "backend-conversation-123",
+            boundBackendId: "backend-conversation-123",
+            status: .completed,
+            source: .phone
+        ), "Exact listen ids still need source validation before completing a desktop session")
+    }
 
-        XCTAssertTrue(exactIdMatches)
-        XCTAssertNotEqual(convSource, .desktop,
-            "Exact listen ids still need source validation before completing a desktop session")
+    func testBoundBackendConversationCompletionRejectsInProgressExactMatch() {
+        XCTAssertFalse(DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+            id: "backend-conversation-123",
+            boundBackendId: "backend-conversation-123",
+            status: .inProgress,
+            source: .desktop
+        ), "Exact listen ids must not complete a session until backend processing finishes")
+    }
+
+    func testBoundBackendConversationCompletionAcceptsCompletedDesktopExactMatch() {
+        XCTAssertTrue(DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+            id: "backend-conversation-123",
+            boundBackendId: "backend-conversation-123",
+            status: .completed,
+            source: .desktop
+        ))
     }
 
     func testRecordingSessionWithBackendIdCanStillBeFinishedForRetryReconciliation() {

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -213,6 +213,49 @@ final class StopReconciliationTests: XCTestCase {
             sessionStartedAt: sessionStartTime
         ))
     }
+    // MARK: - Backend Conversation ID Binding
+
+    func testBoundBackendConversationIdAcceptsExactMatchBeforeTimestampFallback() {
+        let sessionStartTime = Date()
+        let boundBackendId = "backend-conversation-123"
+        let returnedBackendId = "backend-conversation-123"
+        let convStartedAt = sessionStartTime.addingTimeInterval(30)
+        let convSource: ConversationSource = .phone
+
+        let exactIdMatches = returnedBackendId == boundBackendId
+        let timestampMatches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
+
+        XCTAssertTrue(exactIdMatches, "A bound listen conversation id should identify the stopped session exactly")
+        XCTAssertFalse(timestampMatches, "This fixture would be rejected by the old timestamp/source fallback")
+    }
+
+    func testBoundBackendConversationIdRejectsDifferentForceProcessConversation() {
+        let boundBackendId = "backend-conversation-123"
+        let returnedBackendId = "backend-conversation-456"
+
+        XCTAssertNotEqual(returnedBackendId, boundBackendId,
+            "Force-process must not bind a different conversation when the listen session id is known")
+    }
+
+    func testRecordingSessionWithBackendIdCanStillBeFinishedForRetryReconciliation() {
+        var session = TranscriptionSessionRecord(
+            source: "desktop",
+            status: .recording,
+            backendId: "backend-conversation-123",
+            backendSynced: false
+        )
+
+        XCTAssertEqual(session.backendId, "backend-conversation-123")
+        XCTAssertFalse(session.backendSynced)
+        XCTAssertEqual(session.status, .recording)
+        session.status = .pendingUpload
+        XCTAssertEqual(session.status, .pendingUpload,
+            "Binding the backend id is not completion; stop flow must still be able to mark the session pending")
+    }
 }
 
 private extension Date {

--- a/desktop/macos/Desktop/Tests/TranscriptionStorageRecoveryTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionStorageRecoveryTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import Omi_Computer
+
+final class TranscriptionStorageRecoveryTests: XCTestCase {
+    private var testUserId: String!
+    private var userDir: URL?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testUserId = "transcription-storage-recovery-test-\(UUID().uuidString)"
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        RewindDatabase.currentUserId = testUserId
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        userDir = appSupport
+            .appendingPathComponent("Omi", isDirectory: true)
+            .appendingPathComponent(testUserId, isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        RewindDatabase.currentUserId = nil
+        if let userDir {
+            try? FileManager.default.removeItem(at: userDir)
+        }
+        try await super.tearDown()
+    }
+
+    func testBoundRecordingSessionIsStillCrashRecoverable() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.bindBackendConversation(
+            id: sessionId,
+            backendId: "backend-conversation-recording"
+        )
+
+        let crashed = try await TranscriptionStorage.shared.getCrashedSessions()
+
+        XCTAssertTrue(
+            crashed.contains { $0.id == sessionId },
+            "Unsynced sessions bound to a backend conversation id must remain crash-recoverable"
+        )
+    }
+
+    func testBoundPendingUploadSessionIsStillRecoverable() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.bindBackendConversation(
+            id: sessionId,
+            backendId: "backend-conversation-pending"
+        )
+        try await TranscriptionStorage.shared.finishSession(id: sessionId)
+
+        let pending = try await TranscriptionStorage.shared.getPendingUploadSessions()
+
+        XCTAssertTrue(
+            pending.contains { $0.id == sessionId },
+            "Unsynced pending sessions with a backend conversation id must still be retried"
+        )
+    }
+
+    func testBoundFailedSessionIsStillRetryable() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.bindBackendConversation(
+            id: sessionId,
+            backendId: "backend-conversation-failed"
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(id: sessionId, error: "transient test failure")
+
+        let failed = try await TranscriptionStorage.shared.getFailedSessions()
+
+        XCTAssertTrue(
+            failed.contains { $0.id == sessionId },
+            "Unsynced failed sessions with a backend conversation id must still be retried"
+        )
+    }
+
+    func testCompletedBackendSyncedSessionIsNotRecovered() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.markSessionCompleted(
+            id: sessionId,
+            backendId: "backend-conversation-completed"
+        )
+
+        let needingRecovery = try await TranscriptionStorage.shared.getSessionsNeedingRecovery()
+
+        XCTAssertFalse(
+            needingRecovery.contains { $0.id == sessionId },
+            "Completed backend-synced sessions should not re-enter recovery queues"
+        )
+    }
+}

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -26,6 +26,17 @@ before processing — this corrects non-deterministic WebSocket arrival order
 from providers like Modulate whose internal parallelism can deliver shorter
 utterances before longer ones.
 
+When `/v4/listen` creates or resumes the active in-progress conversation, it
+emits a `conversation_session` event to the client:
+
+```json
+{"type": "conversation_session", "conversation_id": "<uuid>", "status": "in_progress"}
+```
+
+Clients that persist local recording sessions should bind that local session to
+`conversation_id` and prefer exact-id reconciliation on stop/retry before
+falling back to timestamp/source matching.
+
 ```mermaid
 sequenceDiagram
     participant Client
@@ -38,6 +49,7 @@ sequenceDiagram
     Backend->>Backend: Auth check (dev-token or Firebase)
     Backend->>Backend: Select STT provider (STT_SERVICE_MODELS + language)
     Backend->>Firestore: Create stub conversation (status=in_progress)
+    Backend-->>Client: {type: "conversation_session", conversation_id, status: "in_progress"}
     Backend->>STT: Open STT WebSocket
     Backend->>Pusher: Open Pusher WebSocket
     Backend-->>Client: {type: "service_status", status: "ready"}


### PR DESCRIPTION
## Summary

- add a `/v4/listen` `conversation_session` websocket event that exposes the active backend conversation id once it has been created or resumed
- emit the same event for both newly-created and resumed in-progress listen conversations
- extend the hermetic listen/STT E2E coverage to assert the event id matches the persisted conversation and remains stable across fast reconnects

Refs #8193

## Notes

This is the Oracle-recommended first PR for #8193: it establishes the backend contract desktop needs for deterministic local-session binding without changing desktop SQLite storage or stop/retry behavior yet. A follow-up PR can consume this event on macOS and prefer exact conversation-id reconciliation before timestamp/source fallback.

## Test Plan

- [x] Consulted Oracle before implementation
- [x] `git diff --check origin/main...HEAD`
- [x] `python -m py_compile backend/models/message_event.py backend/routers/transcribe.py backend/testing/e2e/test_listen_stt.py`
- [x] `python -m pytest testing/e2e/test_listen_stt.py -q` — `3 passed, 29 warnings`
- [ ] `bash testing/e2e/run.sh -q testing/e2e/test_listen_stt.py` — local macOS run script currently requires GNU `timeout`; direct pytest command above was used instead


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

