### PR TITLE
fix: distinguish omitted conversation transcripts

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -168,7 +168,15 @@ def reprocess_conversation(
     return processed_conversation
 
 
-@router.get('/v1/conversations', response_model=List[Conversation], tags=['conversations'])
+@router.get(
+    '/v1/conversations',
+    response_model=List[Conversation],
+    tags=['conversations'],
+    description=(
+        "List responses may omit detail-only fields such as transcript_segments. "
+        "Clients should treat omitted transcript_segments as unknown/not loaded, not as an empty transcript."
+    ),
+)
 def get_conversations(
     limit: int = 100,
     offset: int = 0,
@@ -212,7 +220,15 @@ def get_conversations_count(
     return {'count': count}
 
 
-@router.get("/v1/conversations/{conversation_id}", response_model=Conversation, tags=['conversations'])
+@router.get(
+    "/v1/conversations/{conversation_id}",
+    response_model=Conversation,
+    tags=['conversations'],
+    description=(
+        "Detail responses include transcript fields when available. Locked or redacted conversations "
+        "may include an empty transcript_segments array even though transcript data exists."
+    ),
+)
 def get_conversation_by_id(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
     logger.info(f'get_conversation_by_id {uid} {conversation_id}')
     conversation = _get_valid_conversation_by_id(uid, conversation_id)

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -751,7 +751,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     finishedAt: Date?,
     structured: Structured,
     transcriptSegments: [TranscriptSegment],
-    transcriptSegmentsIncluded: Bool = true,
+    transcriptSegmentsIncluded: Bool,
     geolocation: Geolocation?,
     photos: [ConversationPhoto],
     appsResults: [AppResponse],

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -665,7 +665,8 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     lhs.id == rhs.id && lhs.createdAt == rhs.createdAt && lhs.startedAt == rhs.startedAt
       && lhs.finishedAt == rhs.finishedAt && lhs.structured == rhs.structured
       && lhs.status == rhs.status && lhs.discarded == rhs.discarded && lhs.deleted == rhs.deleted
-      && lhs.starred == rhs.starred && lhs.folderId == rhs.folderId && lhs.source == rhs.source
+      && lhs.isLocked == rhs.isLocked && lhs.starred == rhs.starred && lhs.folderId == rhs.folderId
+      && lhs.source == rhs.source
       && lhs.transcriptSegmentsIncluded == rhs.transcriptSegmentsIncluded
   }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -828,11 +828,11 @@ struct ServerConversation: Codable, Identifiable, Equatable {
   }
 
   var transcriptPresenceState: TranscriptPresenceState {
-    if !transcriptSegmentsIncluded {
-      return .omittedFromResponse
-    }
     if isLocked {
       return .lockedOrRedacted
+    }
+    if !transcriptSegmentsIncluded {
+      return .omittedFromResponse
     }
     if transcriptSegments.isEmpty {
       return .includedEmpty

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -653,12 +653,20 @@ enum ConversationSource: String, Codable {
   }
 }
 
+enum TranscriptPresenceState: Equatable {
+  case omittedFromResponse
+  case lockedOrRedacted
+  case includedEmpty
+  case includedNonEmpty
+}
+
 struct ServerConversation: Codable, Identifiable, Equatable {
   static func == (lhs: ServerConversation, rhs: ServerConversation) -> Bool {
     lhs.id == rhs.id && lhs.createdAt == rhs.createdAt && lhs.startedAt == rhs.startedAt
       && lhs.finishedAt == rhs.finishedAt && lhs.structured == rhs.structured
       && lhs.status == rhs.status && lhs.discarded == rhs.discarded && lhs.deleted == rhs.deleted
       && lhs.starred == rhs.starred && lhs.folderId == rhs.folderId && lhs.source == rhs.source
+      && lhs.transcriptSegmentsIncluded == rhs.transcriptSegmentsIncluded
   }
 
   let id: String
@@ -668,6 +676,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
 
   var structured: Structured
   var transcriptSegments: [TranscriptSegment]
+  var transcriptSegmentsIncluded: Bool
   let geolocation: Geolocation?
   let photos: [ConversationPhoto]
 
@@ -716,6 +725,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt)
     finishedAt = try container.decodeIfPresent(Date.self, forKey: .finishedAt)
     structured = try container.decode(Structured.self, forKey: .structured)
+    transcriptSegmentsIncluded = container.contains(.transcriptSegments)
     transcriptSegments =
       try container.decodeIfPresent([TranscriptSegment].self, forKey: .transcriptSegments) ?? []
     geolocation = try container.decodeIfPresent(Geolocation.self, forKey: .geolocation)
@@ -741,6 +751,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     finishedAt: Date?,
     structured: Structured,
     transcriptSegments: [TranscriptSegment],
+    transcriptSegmentsIncluded: Bool = true,
     geolocation: Geolocation?,
     photos: [ConversationPhoto],
     appsResults: [AppResponse],
@@ -761,6 +772,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     self.finishedAt = finishedAt
     self.structured = structured
     self.transcriptSegments = transcriptSegments
+    self.transcriptSegmentsIncluded = transcriptSegmentsIncluded
     self.geolocation = geolocation
     self.photos = photos
     self.appsResults = appsResults
@@ -813,6 +825,23 @@ struct ServerConversation: Codable, Identifiable, Equatable {
       let speaker = segment.isUser ? "You" : "Speaker \(segment.speakerId)"
       return "\(speaker): \(segment.text)"
     }.joined(separator: "\n\n")
+  }
+
+  var transcriptPresenceState: TranscriptPresenceState {
+    if !transcriptSegmentsIncluded {
+      return .omittedFromResponse
+    }
+    if isLocked {
+      return .lockedOrRedacted
+    }
+    if transcriptSegments.isEmpty {
+      return .includedEmpty
+    }
+    return .includedNonEmpty
+  }
+
+  var shouldFetchDetailForTranscript: Bool {
+    transcriptPresenceState == .omittedFromResponse
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -198,9 +198,10 @@ struct ConversationDetailView: View {
                 return
             }
 
-            // Load segments from local database if not already present
-            // Segments are stored locally but not loaded with the list view for performance
-            if conversation.transcriptSegments.isEmpty {
+            // Load detail-only transcript data only when the list response omitted it.
+            // An explicit empty transcript means either genuinely empty or locked/redacted;
+            // do not refetch forever just because the decoded array is empty.
+            if conversation.shouldFetchDetailForTranscript {
                 isLoadingConversation = true
                 do {
                     // First try local database (faster, works offline)
@@ -211,6 +212,7 @@ struct ConversationDetailView: View {
                             let segments = segmentRecords.map { $0.toTranscriptSegment() }
                             var updatedConversation = conversation
                             updatedConversation.transcriptSegments = segments
+                            updatedConversation.transcriptSegmentsIncluded = true
                             loadedConversation = updatedConversation
                             log("ConversationDetail: Loaded \(segments.count) segments from local database")
                         } else {
@@ -678,7 +680,18 @@ struct ConversationDetailView: View {
             .background(OmiColors.backgroundTertiary.opacity(0.5))
 
             // Drawer content
-            if displayConversation.transcriptSegments.isEmpty && !isLoadingConversation {
+            if displayConversation.transcriptPresenceState == .lockedOrRedacted && !isLoadingConversation {
+                VStack(spacing: 12) {
+                    Image(systemName: "lock")
+                        .scaledFont(size: 40)
+                        .foregroundColor(OmiColors.textTertiary.opacity(0.5))
+
+                    Text("Transcript locked")
+                        .scaledFont(size: 14)
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if displayConversation.transcriptSegments.isEmpty && !isLoadingConversation {
                 // Empty state
                 VStack(spacing: 12) {
                     Image(systemName: "text.quote")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -435,6 +435,7 @@ struct ConversationDetailView: View {
                     )
             }
             .buttonStyle(.plain)
+            .disabled(!canCopyTranscript)
             .help("Copy transcript")
 
             // Move to folder button (menu)
@@ -493,9 +494,15 @@ struct ConversationDetailView: View {
         }
     }
 
+    private var canCopyTranscript: Bool {
+        displayConversation.transcriptPresenceState != .lockedOrRedacted
+    }
+
     // MARK: - Actions
 
     private func copyTranscript() {
+        guard canCopyTranscript else { return }
+
         let peopleDict = Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
         let transcript: String = displayConversation.transcriptSegments.map { segment -> String in
             let speakerName: String

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -515,6 +515,7 @@ extension TranscriptionSessionRecord {
                 events: events
             ),
             transcriptSegments: transcriptSegments,
+            transcriptSegmentsIncluded: !segments.isEmpty,
             geolocation: geolocation,
             photos: photos,
             appsResults: appsResults,

--- a/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
@@ -49,6 +49,15 @@ final class ServerConversationDecodingTests: XCTestCase {
         XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
     }
 
+    func testLockedOmittedTranscriptIsRedactedAndDoesNotFetchDetail() throws {
+        let conversation = try decodeConversation(",\n\"is_locked\": true")
+
+        XCTAssertFalse(conversation.transcriptSegmentsIncluded)
+        XCTAssertTrue(conversation.transcriptSegments.isEmpty)
+        XCTAssertEqual(conversation.transcriptPresenceState, .lockedOrRedacted)
+        XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+
     func testLockedExplicitEmptyTranscriptIsRedacted() throws {
         let conversation = try decodeConversation(",\n\"is_locked\": true,\n\"transcript_segments\": []")
 

--- a/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Omi_Computer
+
+final class ServerConversationDecodingTests: XCTestCase {
+    private func decodeConversation(_ extraFields: String) throws -> ServerConversation {
+        let json = """
+        {
+          "id": "conversation-1",
+          "created_at": "2026-06-25T10:00:00Z",
+          "started_at": "2026-06-25T10:00:00Z",
+          "finished_at": "2026-06-25T10:01:00Z",
+          "structured": {
+            "title": "Test conversation",
+            "overview": "Overview",
+            "emoji": "🧪",
+            "category": "other",
+            "action_items": [],
+            "events": []
+          },
+          "status": "completed",
+          "source": "desktop",
+          "discarded": false,
+          "deleted": false,
+          "starred": false,
+          "deferred": false
+          \(extraFields)
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ServerConversation.self, from: Data(json.utf8))
+    }
+
+    func testOmittedTranscriptSegmentsAreMarkedOmitted() throws {
+        let conversation = try decodeConversation("")
+
+        XCTAssertTrue(conversation.transcriptSegments.isEmpty)
+        XCTAssertFalse(conversation.transcriptSegmentsIncluded)
+        XCTAssertEqual(conversation.transcriptPresenceState, .omittedFromResponse)
+        XCTAssertTrue(conversation.shouldFetchDetailForTranscript)
+    }
+
+    func testExplicitEmptyTranscriptIsIncludedEmpty() throws {
+        let conversation = try decodeConversation(",\n\"transcript_segments\": []")
+
+        XCTAssertTrue(conversation.transcriptSegmentsIncluded)
+        XCTAssertTrue(conversation.transcriptSegments.isEmpty)
+        XCTAssertEqual(conversation.transcriptPresenceState, .includedEmpty)
+        XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+
+    func testLockedExplicitEmptyTranscriptIsRedacted() throws {
+        let conversation = try decodeConversation(",\n\"is_locked\": true,\n\"transcript_segments\": []")
+
+        XCTAssertTrue(conversation.transcriptSegmentsIncluded)
+        XCTAssertTrue(conversation.transcriptSegments.isEmpty)
+        XCTAssertEqual(conversation.transcriptPresenceState, .lockedOrRedacted)
+        XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+
+    func testIncludedTranscriptIsIncludedNonEmpty() throws {
+        let conversation = try decodeConversation(
+            ",\n\"transcript_segments\": [{\"id\": \"segment-1\", \"text\": \"hello\", \"speaker\": \"speaker_0\", \"is_user\": true, \"start\": 0, \"end\": 1}]"
+        )
+
+        XCTAssertTrue(conversation.transcriptSegmentsIncluded)
+        XCTAssertEqual(conversation.transcriptSegments.count, 1)
+        XCTAssertEqual(conversation.transcriptPresenceState, .includedNonEmpty)
+        XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+
+    func testNullTranscriptSegmentsArePresentButEmpty() throws {
+        let conversation = try decodeConversation(",\n\"transcript_segments\": null")
+
+        XCTAssertTrue(conversation.transcriptSegmentsIncluded)
+        XCTAssertTrue(conversation.transcriptSegments.isEmpty)
+        XCTAssertEqual(conversation.transcriptPresenceState, .includedEmpty)
+        XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
+    }
+}

--- a/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
+++ b/desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift
@@ -86,4 +86,11 @@ final class ServerConversationDecodingTests: XCTestCase {
         XCTAssertEqual(conversation.transcriptPresenceState, .includedEmpty)
         XCTAssertFalse(conversation.shouldFetchDetailForTranscript)
     }
+
+    func testLockStateParticipatesInConversationEquality() throws {
+        let unlocked = try decodeConversation(",\n\"is_locked\": false,\n\"transcript_segments\": []")
+        let locked = try decodeConversation(",\n\"is_locked\": true,\n\"transcript_segments\": []")
+
+        XCTAssertNotEqual(unlocked, locked)
+    }
 }

--- a/desktop/macos/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
@@ -139,6 +139,7 @@ final class TranscriptSpeakerAssignmentTests: XCTestCase {
         events: []
       ),
       transcriptSegments: segments,
+      transcriptSegmentsIncluded: true,
       geolocation: nil,
       photos: [],
       appsResults: [],

--- a/desktop/macos/Desktop/Tests/TranscriptionSessionRecordTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionSessionRecordTests.swift
@@ -51,4 +51,34 @@ final class TranscriptionSessionRecordTests: XCTestCase {
 
         XCTAssertFalse(record.canAcceptCompletion(backendId: "conversation-b"))
     }
+
+    func testLocalListConversationMarksEmptySegmentsAsOmitted() {
+        let record = TranscriptionSessionRecord(source: "desktop", backendId: "conversation-a")
+
+        let conversation = record.toServerConversation(segments: [])
+
+        XCTAssertNotNil(conversation)
+        XCTAssertFalse(conversation!.transcriptSegmentsIncluded)
+        XCTAssertEqual(conversation!.transcriptPresenceState, .omittedFromResponse)
+        XCTAssertTrue(conversation!.shouldFetchDetailForTranscript)
+    }
+
+    func testLocalConversationWithSegmentsMarksTranscriptIncluded() {
+        let record = TranscriptionSessionRecord(source: "desktop", backendId: "conversation-a")
+        let segment = TranscriptionSegmentRecord(
+            sessionId: 1,
+            speaker: 0,
+            text: "hello",
+            startTime: 0,
+            endTime: 1,
+            segmentOrder: 0
+        )
+
+        let conversation = record.toServerConversation(segments: [segment])
+
+        XCTAssertNotNil(conversation)
+        XCTAssertTrue(conversation!.transcriptSegmentsIncluded)
+        XCTAssertEqual(conversation!.transcriptPresenceState, .includedNonEmpty)
+        XCTAssertFalse(conversation!.shouldFetchDetailForTranscript)
+    }
 }


### PR DESCRIPTION
## Summary
- add explicit `transcriptSegmentsIncluded` / `TranscriptPresenceState` semantics to desktop conversation decoding
- only fetch conversation detail transcripts when the list response omitted transcript data, not when detail explicitly returns an empty/redacted transcript
- show a distinct locked transcript state in the detail transcript drawer
- document list/detail transcript semantics on the backend route descriptions
- add decoder coverage for omitted, explicit empty, locked/redacted, non-empty, and `null` transcript fields

Fixes #8194

## Test Plan
- `git diff --check origin/main...HEAD`
- `xcrun swiftc -parse desktop/macos/Desktop/Sources/APIClient.swift desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift desktop/macos/Desktop/Tests/ServerConversationDecodingTests.swift`
- `python3 -m py_compile backend/routers/conversations.py`
- `xcrun swift test --package-path Desktop --filter ServerConversationDecodingTests` — 5 tests passed

## Oracle
Consulted Oracle before implementation. It recommended the small PR scope used here: desktop decode presence marker + semantic enum + UI fetch-condition update + decoder tests + minimal backend route descriptions, while avoiding a backend DTO migration in this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

