### PR TITLE
Stabilize PTT floating bar geometry

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -1,0 +1,79 @@
+import AppKit
+
+/// Pure frame math for the floating bar.
+///
+/// Keep window state transitions in `FloatingControlBarWindow`, but keep geometry
+/// policy here so resize anchors are explicit and testable.
+enum FloatingControlBarGeometry {
+    enum CompactPlacement {
+        case canonical
+        case preservingCurrentCenter
+    }
+
+    static func centerAnchoredFrame(currentFrame: NSRect, targetSize: NSSize) -> NSRect {
+        NSRect(
+            x: currentFrame.midX - targetSize.width / 2,
+            y: currentFrame.midY - targetSize.height / 2,
+            width: targetSize.width,
+            height: targetSize.height
+        )
+    }
+
+    static func topCenterAnchoredFrame(currentFrame: NSRect, targetSize: NSSize) -> NSRect {
+        NSRect(
+            x: currentFrame.midX - targetSize.width / 2,
+            y: currentFrame.maxY - targetSize.height,
+            width: targetSize.width,
+            height: targetSize.height
+        )
+    }
+
+    static func defaultPillFrame(size: NSSize, visibleFrame: NSRect, topInset: CGFloat) -> NSRect {
+        let x = (visibleFrame.midX - size.width / 2).rounded(.toNearestOrAwayFromZero)
+        let y = visibleFrame.maxY - size.height - topInset
+        return NSRect(origin: NSPoint(x: x, y: y), size: size)
+    }
+
+    static func compactFrame(
+        currentFrame: NSRect,
+        placement: CompactPlacement,
+        visibleFrame: NSRect,
+        topInset: CGFloat,
+        compactSize: NSSize
+    ) -> NSRect {
+        switch placement {
+        case .canonical:
+            return defaultPillFrame(size: compactSize, visibleFrame: visibleFrame, topInset: topInset)
+        case .preservingCurrentCenter:
+            return centerAnchoredFrame(currentFrame: currentFrame, targetSize: compactSize)
+        }
+    }
+
+    /// PTT is a transient compact-bar state. Expanded voice UI grows from the
+    /// compact pill center; collapse either preserves the user's dragged center or
+    /// snaps back to the canonical default pill when dragging is disabled.
+    static func pushToTalkFrame(
+        currentFrame: NSRect,
+        expanded: Bool,
+        draggable: Bool,
+        visibleFrame: NSRect,
+        topInset: CGFloat,
+        compactSize: NSSize,
+        voiceSize: NSSize
+    ) -> NSRect {
+        let compactPlacement: CompactPlacement = draggable ? .preservingCurrentCenter : .canonical
+        let compactSourceFrame = compactFrame(
+            currentFrame: currentFrame,
+            placement: compactPlacement,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            compactSize: compactSize
+        )
+
+        if expanded {
+            return centerAnchoredFrame(currentFrame: compactSourceFrame, targetSize: voiceSize)
+        }
+
+        return compactSourceFrame
+    }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -828,7 +828,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             self.center()
             return
         }
-        let origin = defaultTopCenteredFrame(for: frame.size).origin
+        let origin = FloatingControlBarGeometry.defaultPillFrame(
+            size: frame.size,
+            visibleFrame: screen.visibleFrame,
+            topInset: Self.topInset
+        ).origin
         self.setFrameOrigin(origin)
         log("FloatingControlBarWindow: centered at \(origin) on screen \(screen.visibleFrame)")
     }
@@ -2434,7 +2438,9 @@ extension FloatingControlBarWindow {
     func cancelPendingDismiss() {
         resignKeyAnimationToken += 1
         frameAnimationToken += 1
-        pendingRestoreOrigin = nil
+        if !ShortcutSettings.shared.draggableBarEnabled {
+            pendingRestoreOrigin = nil
+        }
         suppressHoverResize = false
         isResizingProgrammatically = false
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -334,6 +334,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     func closeAIConversation() {
         AnalyticsManager.shared.floatingBarAskOmiClosed()
+        resignKeyAnimationToken += 1
+        let closeAnimationToken = resignKeyAnimationToken
 
         // Cancel any in-flight chat streaming to prevent re-expansion
         FloatingControlBarManager.shared.cancelChat()
@@ -390,6 +392,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         preChatCenter = nil
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
             guard let self = self else { return }
+            guard self.resignKeyAnimationToken == closeAnimationToken else { return }
             self.isResizingProgrammatically = false
             self.pendingRestoreOrigin = nil
             // Safety net: only snap if no new AI session was opened while the close settled.
@@ -403,15 +406,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         // Allow hover resizes again after the animation settles.
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
-            self?.suppressHoverResize = false
+            guard let self = self else { return }
+            guard self.resignKeyAnimationToken == closeAnimationToken else { return }
+            self.suppressHoverResize = false
             FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
 
             // If the user has the bar disabled, hide it completely after closing the
             // AI conversation instead of leaving the compact pill visible — unless a
             // queued notification was just flushed; hiding now would swallow it, and
             // its dismissal re-hides the bar anyway.
-            if !FloatingControlBarManager.shared.isEnabled && self?.state.currentNotification == nil {
-                self?.orderOut(nil)
+            if !FloatingControlBarManager.shared.isEnabled && self.state.currentNotification == nil {
+                self.orderOut(nil)
             }
         }
     }
@@ -559,19 +564,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     /// Center-center: preserves midpoint (used by hover expand/collapse).
     private func originForCenterAnchor(newSize: NSSize) -> NSPoint {
-        NSPoint(
-            x: frame.midX - newSize.width / 2,
-            y: frame.midY - newSize.height / 2
-        )
+        FloatingControlBarGeometry.centerAnchoredFrame(currentFrame: frame, targetSize: newSize).origin
     }
 
     /// Top-center: keeps top edge fixed, centers horizontally (used by chat expand/collapse).
     private func originForTopCenterAnchor(newSize: NSSize) -> NSPoint {
-        let top = frame.origin.y + frame.height
-        return NSPoint(
-            x: frame.midX - newSize.width / 2,
-            y: top - newSize.height
-        )
+        FloatingControlBarGeometry.topCenterAnchoredFrame(currentFrame: frame, targetSize: newSize).origin
     }
 
     private func resizeAnchored(
@@ -595,6 +593,21 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         log("FloatingControlBar: resizeAnchored to \(constrainedSize) resizable=\(makeResizable) animated=\(animated) from=\(frame.size)")
 
+        let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
+        resizeToFrame(
+            targetFrame,
+            makeResizable: makeResizable,
+            animated: animated,
+            animationDuration: animationDuration
+        )
+    }
+
+    private func resizeToFrame(
+        _ targetFrame: NSRect,
+        makeResizable: Bool,
+        animated: Bool = false,
+        animationDuration: TimeInterval = 0.3
+    ) {
         if makeResizable {
             styleMask.insert(.resizable)
         } else {
@@ -603,7 +616,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         isResizingProgrammatically = true
 
-        let targetFrame = NSRect(origin: newOrigin, size: constrainedSize)
         if animated {
             // Keep windowDidResize from persisting transient animation frames as
             // the user's saved response size until the final frame lands.
@@ -670,13 +682,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
                   !self.state.isShowingNotification,
                   !self.suppressHoverResize
             else { return }
-            let newOrigin = NSPoint(
-                x: self.frame.midX - targetSize.width / 2,
-                y: self.frame.midY - targetSize.height / 2
+            let targetFrame = FloatingControlBarGeometry.centerAnchoredFrame(
+                currentFrame: self.frame,
+                targetSize: targetSize
             )
             self.styleMask.remove(.resizable)
             self.isResizingProgrammatically = true
-            self.setFrame(NSRect(origin: newOrigin, size: targetSize), display: true, animate: false)
+            self.setFrame(targetFrame, display: true, animate: false)
             self.isResizingProgrammatically = false
         }
 
@@ -698,8 +710,16 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     /// Resize window for PTT state (expanded when listening, compact circle when idle)
     func resizeForPTTState(expanded: Bool) {
-        let size = expanded ? Self.voiceBarSize : Self.minBarSize
-        resizeAnchored(to: size, makeResizable: false, animated: true)
+        let targetFrame = FloatingControlBarGeometry.pushToTalkFrame(
+            currentFrame: frame,
+            expanded: expanded,
+            draggable: ShortcutSettings.shared.draggableBarEnabled,
+            visibleFrame: geometryScreenVisibleFrame(),
+            topInset: Self.topInset,
+            compactSize: Self.minBarSize,
+            voiceSize: Self.voiceBarSize
+        )
+        resizeToFrame(targetFrame, makeResizable: false, animated: true, animationDuration: 0.3)
     }
 
     func showNotification(_ notification: FloatingBarNotification, animated: Bool = true) {
@@ -784,16 +804,20 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// Compute the default origin for the collapsed pill (top-center of the key screen).
     /// Used by closeAIConversation in non-draggable mode and centerOnMainScreen.
     private func defaultPillOrigin() -> NSPoint {
-        defaultTopCenteredOrigin(for: FloatingControlBarWindow.minBarSize)
+        defaultTopCenteredFrame(for: FloatingControlBarWindow.minBarSize).origin
     }
 
-    private func defaultTopCenteredOrigin(for size: NSSize) -> NSPoint {
-        let targetScreen = NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
-        guard let screen = targetScreen else { return .zero }
-        let visibleFrame = screen.visibleFrame
-        let x = (visibleFrame.midX - size.width / 2).rounded(.toNearestOrAwayFromZero)
-        let y = visibleFrame.maxY - size.height - Self.topInset
-        return NSPoint(x: x, y: y)
+    private func defaultTopCenteredFrame(for size: NSSize) -> NSRect {
+        FloatingControlBarGeometry.defaultPillFrame(
+            size: size,
+            visibleFrame: geometryScreenVisibleFrame(),
+            topInset: Self.topInset
+        )
+    }
+
+    private func geometryScreenVisibleFrame() -> NSRect {
+        let targetScreen = self.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        return targetScreen?.visibleFrame ?? .zero
     }
 
     /// Center the bar near the top of the main screen.
@@ -804,7 +828,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             self.center()
             return
         }
-        let origin = defaultTopCenteredOrigin(for: frame.size)
+        let origin = defaultTopCenteredFrame(for: frame.size).origin
         self.setFrameOrigin(origin)
         log("FloatingControlBarWindow: centered at \(origin) on screen \(screen.visibleFrame)")
     }
@@ -2409,6 +2433,9 @@ extension FloatingControlBarWindow {
     /// query won't be immediately closed by a stale completion block.
     func cancelPendingDismiss() {
         resignKeyAnimationToken += 1
+        frameAnimationToken += 1
+        pendingRestoreOrigin = nil
+        suppressHoverResize = false
+        isResizingProgrammatically = false
     }
 }
-

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import XCTest
+@testable import Omi_Computer
+
+final class FloatingBarGeometryTests: XCTestCase {
+    private let visibleFrame = NSRect(x: 0, y: 0, width: 1440, height: 900)
+    private let compactSize = NSSize(width: 40, height: 14)
+    private let voiceSize = NSSize(width: 224, height: 42)
+    private let topInset: CGFloat = 40
+
+    func testDefaultPillFrameIsTopCenteredInVisibleFrame() {
+        let frame = FloatingControlBarGeometry.defaultPillFrame(
+            size: compactSize,
+            visibleFrame: visibleFrame,
+            topInset: topInset
+        )
+
+        XCTAssertEqual(frame.origin.x, 700)
+        XCTAssertEqual(frame.origin.y, 846)
+        XCTAssertEqual(frame.size, compactSize)
+    }
+
+    func testPTTExpansionKeepsCompactPillCenter() {
+        let compactFrame = FloatingControlBarGeometry.defaultPillFrame(
+            size: compactSize,
+            visibleFrame: visibleFrame,
+            topInset: topInset
+        )
+
+        let voiceFrame = FloatingControlBarGeometry.pushToTalkFrame(
+            currentFrame: compactFrame,
+            expanded: true,
+            draggable: false,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            compactSize: compactSize,
+            voiceSize: voiceSize
+        )
+
+        XCTAssertEqual(voiceFrame.midX, compactFrame.midX)
+        XCTAssertEqual(voiceFrame.midY, compactFrame.midY)
+        XCTAssertEqual(voiceFrame.size, voiceSize)
+    }
+
+    func testPTTExpansionIgnoresTransientFrameWhenDraggingDisabled() {
+        let notificationFrame = NSRect(x: 505, y: 738, width: 430, height: 122)
+
+        let voiceFrame = FloatingControlBarGeometry.pushToTalkFrame(
+            currentFrame: notificationFrame,
+            expanded: true,
+            draggable: false,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            compactSize: compactSize,
+            voiceSize: voiceSize
+        )
+
+        XCTAssertEqual(voiceFrame.origin.x, 608)
+        XCTAssertEqual(voiceFrame.origin.y, 832)
+        XCTAssertEqual(voiceFrame.size, voiceSize)
+    }
+
+    func testPTTCollapseSnapsToDefaultWhenDraggingDisabled() {
+        let shiftedVoiceFrame = NSRect(x: 612, y: 832, width: voiceSize.width, height: voiceSize.height)
+
+        let collapsedFrame = FloatingControlBarGeometry.pushToTalkFrame(
+            currentFrame: shiftedVoiceFrame,
+            expanded: false,
+            draggable: false,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            compactSize: compactSize,
+            voiceSize: voiceSize
+        )
+
+        XCTAssertEqual(collapsedFrame.origin.x, 700)
+        XCTAssertEqual(collapsedFrame.origin.y, 846)
+        XCTAssertEqual(collapsedFrame.size, compactSize)
+    }
+
+    func testPTTCollapsePreservesUserCenterWhenDraggingEnabled() {
+        let shiftedVoiceFrame = NSRect(x: 612, y: 832, width: voiceSize.width, height: voiceSize.height)
+
+        let collapsedFrame = FloatingControlBarGeometry.pushToTalkFrame(
+            currentFrame: shiftedVoiceFrame,
+            expanded: false,
+            draggable: true,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            compactSize: compactSize,
+            voiceSize: voiceSize
+        )
+
+        XCTAssertEqual(collapsedFrame.midX, shiftedVoiceFrame.midX)
+        XCTAssertEqual(collapsedFrame.midY, shiftedVoiceFrame.midY)
+        XCTAssertEqual(collapsedFrame.size, compactSize)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract floating control bar frame math into a pure geometry policy helper.
- Route PTT expand/collapse through one canonical geometry path so the non-draggable pill returns to the default top-centered compact frame instead of preserving transient frame drift.
- Harden stale close/dismiss animation cancellation by invalidating both close and frame animation tokens.
- Add focused geometry tests for canonical compact placement, PTT expansion, notification-frame drift, and draggable behavior.

## Subagent critique follow-up
A read-only critique flagged that the first pass still let PTT expansion inherit a transient notification frame, that cancelPendingDismiss only invalidated half of the animation state, and that geometry policy was still partly split across call sites. This PR folds those rules into FloatingControlBarGeometry and adds the transient-frame regression test.

## Verification
- xcrun swift test --package-path Desktop --filter FloatingBarGeometryTests
- xcrun swift build -c debug --package-path Desktop
- git diff --check
- OMI_APP_NAME="omi-ptt-pill-geometry" ./run.sh --yolo, then automation state via OMI_AUTOMATION_PORT=47919 ./scripts/omi-ctl state confirmed signed-in Home state and visible compact floating bar

Notes: the Swift commands still emit pre-existing warnings around PushToTalkManager Swift 6 actor isolation and the linked webp macOS version.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

