### PR TITLE
fix: align conversation count filters

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -228,12 +228,31 @@ def get_conversations(
     return conversations
 
 
-def get_conversations_count(uid: str, include_discarded: bool = False, statuses: List[str] = []):
+def get_conversations_count(
+    uid: str,
+    include_discarded: bool = False,
+    statuses: Optional[List[str]] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    categories: Optional[List[str]] = None,
+    folder_id: Optional[str] = None,
+    starred: Optional[bool] = None,
+):
     conversations_ref = db.collection('users').document(uid).collection(conversations_collection)
     if not include_discarded:
         conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
     if statuses:
         conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
+    if categories:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('structured.category', 'in', categories))
+    if folder_id:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
+    if starred is not None:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
+    if start_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
     result = conversations_ref.count().get()
     return int(result[0][0].value)
 

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -205,10 +205,22 @@ def get_conversations(
 def get_conversations_count(
     statuses: Optional[str] = Query(None, description="Comma-separated status filter (e.g. processing,completed)"),
     include_discarded: bool = Query(False),
+    start_date: Optional[datetime] = Query(None, description="Filter by start date (inclusive)"),
+    end_date: Optional[datetime] = Query(None, description="Filter by end date (inclusive)"),
+    folder_id: Optional[str] = Query(None, description="Filter by folder ID"),
+    starred: Optional[bool] = Query(None, description="Filter by starred status"),
     uid: str = Depends(auth.get_current_user_uid),
 ):
     status_list = [s.strip() for s in statuses.split(',') if s.strip()] if statuses else []
-    count = conversations_db.get_conversations_count(uid, include_discarded=include_discarded, statuses=status_list)
+    count = conversations_db.get_conversations_count(
+        uid,
+        include_discarded=include_discarded,
+        statuses=status_list,
+        start_date=start_date,
+        end_date=end_date,
+        folder_id=folder_id,
+        starred=starred,
+    )
     return {'count': count}
 
 

--- a/backend/tests/unit/test_conversations_count.py
+++ b/backend/tests/unit/test_conversations_count.py
@@ -70,13 +70,32 @@ sys.modules["database._client"].db = mock_db
 sys.modules["database._client"].document_id_from_seed = lambda *a: "test"
 
 
-def get_conversations_count(uid, include_discarded=False, statuses=[]):
+def get_conversations_count(
+    uid,
+    include_discarded=False,
+    statuses=None,
+    start_date=None,
+    end_date=None,
+    categories=None,
+    folder_id=None,
+    starred=None,
+):
     """Mirrors database.conversations.get_conversations_count."""
     conversations_ref = mock_db.collection('users').document(uid).collection('conversations')
     if not include_discarded:
         conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
     if statuses:
         conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
+    if categories:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('structured.category', 'in', categories))
+    if folder_id:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
+    if starred is not None:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
+    if start_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
     result = conversations_ref.count().get()
     return int(result[0][0].value)
 
@@ -98,6 +117,10 @@ class TestConversationsCount:
         assert 'def get_conversations_count(' in source
         assert "FieldFilter('discarded', '==', False)" in source
         assert "FieldFilter('status', 'in', statuses)" in source
+        assert "FieldFilter('folder_id', '==', folder_id)" in source
+        assert "FieldFilter('starred', '==', starred)" in source
+        assert "FieldFilter('created_at', '>=', start_date)" in source
+        assert "FieldFilter('created_at', '<=', end_date)" in source
         assert '.count().get()' in source
         assert 'result[0][0].value' in source
 
@@ -174,6 +197,32 @@ class TestConversationsCount:
         assert f.field_path == 'status'
         assert f.value == ['processing']
 
+    def test_count_applies_list_filter_parity(self):
+        ref = MagicMock()
+        mock_db.collection.return_value.document.return_value.collection.return_value = ref
+        ref.where.return_value = ref
+        ref.count.return_value.get.return_value = self._make_result(3)
+
+        result = get_conversations_count(
+            'uid1',
+            statuses=['completed'],
+            start_date='2026-06-01T00:00:00Z',
+            end_date='2026-06-02T00:00:00Z',
+            folder_id='folder-a',
+            starred=False,
+        )
+
+        assert result == 3
+        filters = [call.kwargs['filter'] for call in ref.where.call_args_list]
+        assert [(f.field_path, f.op_string, f.value) for f in filters] == [
+            ('discarded', '==', False),
+            ('status', 'in', ['completed']),
+            ('folder_id', '==', 'folder-a'),
+            ('starred', '==', False),
+            ('created_at', '>=', '2026-06-01T00:00:00Z'),
+            ('created_at', '<=', '2026-06-02T00:00:00Z'),
+        ]
+
 
 class TestConversationsCountEndpointParsing:
     """Test the router-level statuses parsing logic."""
@@ -241,6 +290,15 @@ class TestConversationsCountRouteSource:
         with open(source_path, encoding='utf-8') as f:
             source = f.read()
         assert 'statuses=status_list' in source
+
+    def test_route_forwards_visible_list_filters(self):
+        source_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')
+        with open(source_path, encoding='utf-8') as f:
+            source = f.read()
+        assert 'start_date=start_date' in source
+        assert 'end_date=end_date' in source
+        assert 'folder_id=folder_id' in source
+        assert 'starred=starred' in source
 
     def test_route_returns_count_dict(self):
         source_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'conversations.py')

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -436,6 +436,7 @@ extension APIClient {
   /// Deletes a conversation by ID
   func deleteConversation(id: String) async throws {
     try await delete("v1/conversations/\(id)")
+    invalidateConversationsCountCache()
   }
 
   /// Updates the starred status of a conversation
@@ -611,7 +612,9 @@ extension APIClient {
     }
 
     let body = MergeRequest(conversationIds: ids, reprocess: reprocess)
-    return try await post("v1/conversations/merge", body: body)
+    let response: MergeConversationsResponse = try await post("v1/conversations/merge", body: body)
+    invalidateConversationsCountCache()
+    return response
   }
 
   // MARK: - Folder API
@@ -645,6 +648,7 @@ extension APIClient {
       endpoint += "?move_to_folder_id=\(moveToId)"
     }
     try await delete(endpoint)
+    invalidateConversationsCountCache()
   }
 
   /// Moves a conversation to a folder
@@ -1431,7 +1435,10 @@ extension APIClient {
   func createConversationFromSegments(_ request: CreateConversationFromSegmentsRequest)
     async throws -> CreateConversationFromSegmentsResponse
   {
-    return try await post("v1/conversations/from-segments", body: request, customBaseURL: nil)
+    let response: CreateConversationFromSegmentsResponse = try await post(
+      "v1/conversations/from-segments", body: request, customBaseURL: nil)
+    invalidateConversationsCountCache()
+    return response
   }
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -508,11 +508,14 @@ extension APIClient {
     return try await post("v1/conversations/search", body: body)
   }
 
-  /// Gets the total count of conversations. Uses 5-second cache to deduplicate parallel calls.
-  func getConversationsCount(
+  static func conversationsCountEndpoint(
     includeDiscarded: Bool = false,
-    statuses: [ConversationStatus] = [.completed, .processing]
-  ) async throws -> Int {
+    statuses: [ConversationStatus] = [.completed, .processing],
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    folderId: String? = nil,
+    starred: Bool? = nil
+  ) -> String {
     var queryItems: [String] = [
       "include_discarded=\(includeDiscarded)"
     ]
@@ -522,7 +525,44 @@ extension APIClient {
       queryItems.append("statuses=\(statusStrings)")
     }
 
-    let endpoint = "v1/conversations/count?\(queryItems.joined(separator: "&"))"
+    if let startDate = startDate {
+      let formatter = ISO8601DateFormatter()
+      queryItems.append("start_date=\(formatter.string(from: startDate))")
+    }
+
+    if let endDate = endDate {
+      let formatter = ISO8601DateFormatter()
+      queryItems.append("end_date=\(formatter.string(from: endDate))")
+    }
+
+    if let folderId = folderId {
+      queryItems.append("folder_id=\(folderId)")
+    }
+
+    if let starred = starred {
+      queryItems.append("starred=\(starred)")
+    }
+
+    return "v1/conversations/count?\(queryItems.joined(separator: "&"))"
+  }
+
+  /// Gets the total count of conversations. Uses 5-second cache to deduplicate parallel calls.
+  func getConversationsCount(
+    includeDiscarded: Bool = false,
+    statuses: [ConversationStatus] = [.completed, .processing],
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    folderId: String? = nil,
+    starred: Bool? = nil
+  ) async throws -> Int {
+    let endpoint = Self.conversationsCountEndpoint(
+      includeDiscarded: includeDiscarded,
+      statuses: statuses,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: folderId,
+      starred: starred
+    )
 
     if let cache = conversationsCountCache[endpoint], Date().timeIntervalSince(cache.time) < 5 {
       return cache.count

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -362,21 +362,16 @@ extension APIClient {
 
 extension APIClient {
 
-  /// Fetches conversations from the API with optional filtering
-  func getConversations(
-    limit: Int = 50,
-    offset: Int = 0,
+  static func conversationFilterQueryItems(
     statuses: [ConversationStatus] = [],
     includeDiscarded: Bool = false,
     startDate: Date? = nil,
     endDate: Date? = nil,
     folderId: String? = nil,
     starred: Bool? = nil
-  ) async throws -> [ServerConversation] {
+  ) -> [String] {
     var queryItems: [String] = [
-      "limit=\(limit)",
-      "offset=\(offset)",
-      "include_discarded=\(includeDiscarded)",
+      "include_discarded=\(includeDiscarded)"
     ]
 
     if !statuses.isEmpty {
@@ -401,6 +396,33 @@ extension APIClient {
     if let starred = starred {
       queryItems.append("starred=\(starred)")
     }
+
+    return queryItems
+  }
+
+  /// Fetches conversations from the API with optional filtering
+  func getConversations(
+    limit: Int = 50,
+    offset: Int = 0,
+    statuses: [ConversationStatus] = [],
+    includeDiscarded: Bool = false,
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    folderId: String? = nil,
+    starred: Bool? = nil
+  ) async throws -> [ServerConversation] {
+    var queryItems: [String] = [
+      "limit=\(limit)",
+      "offset=\(offset)",
+    ]
+    queryItems += Self.conversationFilterQueryItems(
+      statuses: statuses,
+      includeDiscarded: includeDiscarded,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: folderId,
+      starred: starred
+    )
 
     let endpoint = "v1/conversations?\(queryItems.joined(separator: "&"))"
     return try await get(endpoint)
@@ -429,6 +451,7 @@ extension APIClient {
     else {
       throw APIError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0)
     }
+    invalidateConversationsCountCache()
   }
 
   /// Sets the visibility of a conversation for sharing
@@ -516,34 +539,20 @@ extension APIClient {
     folderId: String? = nil,
     starred: Bool? = nil
   ) -> String {
-    var queryItems: [String] = [
-      "include_discarded=\(includeDiscarded)"
-    ]
-
-    if !statuses.isEmpty {
-      let statusStrings = statuses.map { $0.rawValue }.joined(separator: ",")
-      queryItems.append("statuses=\(statusStrings)")
-    }
-
-    if let startDate = startDate {
-      let formatter = ISO8601DateFormatter()
-      queryItems.append("start_date=\(formatter.string(from: startDate))")
-    }
-
-    if let endDate = endDate {
-      let formatter = ISO8601DateFormatter()
-      queryItems.append("end_date=\(formatter.string(from: endDate))")
-    }
-
-    if let folderId = folderId {
-      queryItems.append("folder_id=\(folderId)")
-    }
-
-    if let starred = starred {
-      queryItems.append("starred=\(starred)")
-    }
+    let queryItems = Self.conversationFilterQueryItems(
+      statuses: statuses,
+      includeDiscarded: includeDiscarded,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: folderId,
+      starred: starred
+    )
 
     return "v1/conversations/count?\(queryItems.joined(separator: "&"))"
+  }
+
+  func invalidateConversationsCountCache() {
+    conversationsCountCache.removeAll()
   }
 
   /// Gets the total count of conversations. Uses 5-second cache to deduplicate parallel calls.
@@ -653,6 +662,7 @@ extension APIClient {
     else {
       throw APIError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0)
     }
+    invalidateConversationsCountCache()
   }
 
 }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -122,6 +122,10 @@ class AppState: ObservableObject {
   // Access via RecordingTimer.shared.duration
   var recordingDuration: TimeInterval { RecordingTimer.shared.duration }
 
+  private var hasActiveConversationFilters: Bool {
+    showStarredOnly || selectedDateFilter != nil || selectedFolderId != nil
+  }
+
   // Live speaker segments moved to LiveTranscriptMonitor to avoid triggering global re-renders
   // Access via LiveTranscriptMonitor.shared.segments
   var liveSpeakerSegments: [SpeakerSegment] { LiveTranscriptMonitor.shared.segments }
@@ -130,7 +134,8 @@ class AppState: ObservableObject {
   @Published var conversations: [ServerConversation] = []
   @Published var isLoadingConversations: Bool = false
   @Published var conversationsError: String? = nil
-  @Published var totalConversationsCount: Int? = nil  // Total count (fetched separately)
+  @Published var totalConversationsCount: Int? = nil  // Unfiltered total count for dashboard metrics.
+  @Published var filteredConversationsCount: Int? = nil  // Count matching the active conversations filters.
 
   // Conversation filters
   @Published var showStarredOnly: Bool = false
@@ -2538,6 +2543,15 @@ class AppState: ObservableObject {
 
   // MARK: - Conversations
 
+  private func updateConversationCountForCurrentFilters(_ count: Int) {
+    if hasActiveConversationFilters {
+      filteredConversationsCount = count
+    } else {
+      totalConversationsCount = count
+      filteredConversationsCount = nil
+    }
+  }
+
   /// Load conversations - first from local cache (instant), then from API (background refresh)
   func loadConversations() async {
     guard !isLoadingConversations else { return }
@@ -2576,7 +2590,7 @@ class AppState: ObservableObject {
           let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
             starredOnly: showStarredOnly,
             folderId: selectedFolderId)
-          totalConversationsCount = localCount
+          updateConversationCountForCurrentFilters(localCount)
 
           // Stop loading state so UI shows cached data immediately
           isLoadingConversations = false
@@ -2589,7 +2603,7 @@ class AppState: ObservableObject {
       }
     } else {
       conversations = []
-      totalConversationsCount = 0
+      filteredConversationsCount = 0
     }
 
     // Step 2: Fetch from API in background to get fresh data
@@ -2667,8 +2681,8 @@ class AppState: ObservableObject {
     // Update total count from API (more accurate than local)
     do {
       let count = try await countTask
-      totalConversationsCount = count
-      log("Conversations: Total count from API = \(count)")
+      updateConversationCountForCurrentFilters(count)
+      log("Conversations: Count from API = \(count) (filtered=\(hasActiveConversationFilters))")
     } catch {
       logError("Conversations: Failed to get count from API", error: error)
       // Keep local count if API fails
@@ -2749,8 +2763,13 @@ class AppState: ObservableObject {
         folderId: selectedFolderId,
         starred: showStarredOnly ? true : nil
       )
-      if totalConversationsCount != count {
+      if hasActiveConversationFilters {
+        if filteredConversationsCount != count {
+          filteredConversationsCount = count
+        }
+      } else if totalConversationsCount != count {
         totalConversationsCount = count
+        filteredConversationsCount = nil
       }
     } catch {
       // Keep existing count

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2546,43 +2546,47 @@ class AppState: ObservableObject {
     conversationsError = nil
 
     // Step 1: Load from local cache first (instant display)
-    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery)
-    do {
-      let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) {
-        group in
-        group.addTask {
-          try await TranscriptionStorage.shared.getLocalConversations(
-            limit: 50,
-            starredOnly: self.showStarredOnly,
-            folderId: self.selectedFolderId
-          )
+    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery).
+    // The local cache currently supports starred/folder filters but not server date ranges;
+    // skip it for date-filtered views so the visible list and total count share semantics.
+    if selectedDateFilter == nil {
+      do {
+        let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) { group in
+          group.addTask {
+            try await TranscriptionStorage.shared.getLocalConversations(
+              limit: 50,
+              starredOnly: self.showStarredOnly,
+              folderId: self.selectedFolderId
+            )
+          }
+          group.addTask {
+            try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
+            throw CancellationError()
+          }
+          let result = try await group.next()!
+          group.cancelAll()
+          return result
         }
-        group.addTask {
-          try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
-          throw CancellationError()
+
+        if !cachedConversations.isEmpty {
+          conversations = cachedConversations
+          log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
+
+          // Get local count
+          let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
+            starredOnly: showStarredOnly,
+            folderId: selectedFolderId)
+          totalConversationsCount = localCount
+
+          // Stop loading state so UI shows cached data immediately
+          isLoadingConversations = false
+          // Notify sidebar immediately so loading indicator clears with cached data
+          NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
         }
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
+      } catch {
+        log("Conversations: Local cache unavailable, falling back to API")
+        // Continue to API fetch even if local fails
       }
-
-      if !cachedConversations.isEmpty {
-        conversations = cachedConversations
-        log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
-
-        // Get local count
-        let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
-          starredOnly: showStarredOnly)
-        totalConversationsCount = localCount
-
-        // Stop loading state so UI shows cached data immediately
-        isLoadingConversations = false
-        // Notify sidebar immediately so loading indicator clears with cached data
-        NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-      }
-    } catch {
-      log("Conversations: Local cache unavailable, falling back to API")
-      // Continue to API fetch even if local fails
     }
 
     // Step 2: Fetch from API in background to get fresh data
@@ -2609,7 +2613,14 @@ class AppState: ObservableObject {
       folderId: selectedFolderId,
       starred: showStarredOnly ? true : nil
     )
-    async let countTask = APIClient.shared.getConversationsCount(includeDiscarded: false)
+    async let countTask = APIClient.shared.getConversationsCount(
+      includeDiscarded: false,
+      statuses: [.completed, .processing],
+      startDate: startDate,
+      endDate: endDate,
+      folderId: selectedFolderId,
+      starred: showStarredOnly ? true : nil
+    )
 
     do {
       let fetchedConversations = try await conversationsTask
@@ -2727,7 +2738,14 @@ class AppState: ObservableObject {
     }
 
     do {
-      let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
+      let count = try await APIClient.shared.getConversationsCount(
+        includeDiscarded: false,
+        statuses: [.completed, .processing],
+        startDate: startDate,
+        endDate: endDate,
+        folderId: selectedFolderId,
+        starred: showStarredOnly ? true : nil
+      )
       if totalConversationsCount != count {
         totalConversationsCount = count
       }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2543,8 +2543,8 @@ class AppState: ObservableObject {
 
   // MARK: - Conversations
 
-  private func updateConversationCountForCurrentFilters(_ count: Int) {
-    if hasActiveConversationFilters {
+  private func updateConversationCount(_ count: Int, filtered: Bool) {
+    if filtered {
       filteredConversationsCount = count
     } else {
       totalConversationsCount = count
@@ -2559,18 +2559,29 @@ class AppState: ObservableObject {
     isLoadingConversations = true
     conversationsError = nil
 
+    let requestShowStarredOnly = showStarredOnly
+    let requestSelectedDateFilter = selectedDateFilter
+    let requestSelectedFolderId = selectedFolderId
+    let requestHasActiveFilters = hasActiveConversationFilters
+
+    func requestFiltersAreCurrent() -> Bool {
+      showStarredOnly == requestShowStarredOnly
+        && selectedDateFilter == requestSelectedDateFilter
+        && selectedFolderId == requestSelectedFolderId
+    }
+
     // Step 1: Load from local cache first (instant display)
     // Use timeout to avoid blocking UI if database is initializing (e.g. recovery).
     // The local cache currently supports starred/folder filters but not server date ranges;
     // skip it for date-filtered views so the visible list and total count share semantics.
-    if selectedDateFilter == nil {
+    if requestSelectedDateFilter == nil {
       do {
         let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) { group in
           group.addTask {
             try await TranscriptionStorage.shared.getLocalConversations(
               limit: 50,
-              starredOnly: self.showStarredOnly,
-              folderId: self.selectedFolderId
+              starredOnly: requestShowStarredOnly,
+              folderId: requestSelectedFolderId
             )
           }
           group.addTask {
@@ -2582,15 +2593,15 @@ class AppState: ObservableObject {
           return result
         }
 
-        if !cachedConversations.isEmpty {
+        if !cachedConversations.isEmpty && requestFiltersAreCurrent() {
           conversations = cachedConversations
           log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
 
           // Get local count
           let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
-            starredOnly: showStarredOnly,
-            folderId: selectedFolderId)
-          updateConversationCountForCurrentFilters(localCount)
+            starredOnly: requestShowStarredOnly,
+            folderId: requestSelectedFolderId)
+          updateConversationCount(localCount, filtered: requestHasActiveFilters)
 
           // Stop loading state so UI shows cached data immediately
           isLoadingConversations = false
@@ -2610,7 +2621,7 @@ class AppState: ObservableObject {
     // Calculate date range if date filter is set
     let startDate: Date?
     let endDate: Date?
-    if let filterDate = selectedDateFilter {
+    if let filterDate = requestSelectedDateFilter {
       let calendar = Calendar.current
       startDate = calendar.startOfDay(for: filterDate)
       endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
@@ -2627,23 +2638,27 @@ class AppState: ObservableObject {
       includeDiscarded: false,
       startDate: startDate,
       endDate: endDate,
-      folderId: selectedFolderId,
-      starred: showStarredOnly ? true : nil
+      folderId: requestSelectedFolderId,
+      starred: requestShowStarredOnly ? true : nil
     )
     async let countTask = APIClient.shared.getConversationsCount(
       includeDiscarded: false,
       statuses: [.completed, .processing],
       startDate: startDate,
       endDate: endDate,
-      folderId: selectedFolderId,
-      starred: showStarredOnly ? true : nil
+      folderId: requestSelectedFolderId,
+      starred: requestShowStarredOnly ? true : nil
     )
 
     do {
       let fetchedConversations = try await conversationsTask
-      conversations = fetchedConversations
+      if requestFiltersAreCurrent() {
+        conversations = fetchedConversations
+      } else {
+        log("Conversations: Ignoring stale response for superseded filters")
+      }
       log(
-        "Conversations: Refreshed \(fetchedConversations.count) from API (starred=\(showStarredOnly), date=\(selectedDateFilter?.description ?? "nil"))"
+        "Conversations: Refreshed \(fetchedConversations.count) from API (starred=\(requestShowStarredOnly), date=\(requestSelectedDateFilter?.description ?? "nil"))"
       )
 
       // DEBUG: Log any conversations with empty titles
@@ -2681,8 +2696,12 @@ class AppState: ObservableObject {
     // Update total count from API (more accurate than local)
     do {
       let count = try await countTask
-      updateConversationCountForCurrentFilters(count)
-      log("Conversations: Count from API = \(count) (filtered=\(hasActiveConversationFilters))")
+      if requestFiltersAreCurrent() {
+        updateConversationCount(count, filtered: requestHasActiveFilters)
+        log("Conversations: Count from API = \(count) (filtered=\(requestHasActiveFilters))")
+      } else {
+        log("Conversations: Ignoring stale count for superseded filters")
+      }
     } catch {
       logError("Conversations: Failed to get count from API", error: error)
       // Keep local count if API fails
@@ -2690,6 +2709,9 @@ class AppState: ObservableObject {
 
     isLoadingConversations = false
     NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+    if !requestFiltersAreCurrent() {
+      await loadConversations()
+    }
   }
 
   /// Refresh conversations silently (for app-activation and Cmd+R event-driven refreshes).
@@ -2702,10 +2724,21 @@ class AppState: ObservableObject {
     // Skip if currently doing a full load
     guard !isLoadingConversations else { return }
 
+    let requestShowStarredOnly = showStarredOnly
+    let requestSelectedDateFilter = selectedDateFilter
+    let requestSelectedFolderId = selectedFolderId
+    let requestHasActiveFilters = hasActiveConversationFilters
+
+    func requestFiltersAreCurrent() -> Bool {
+      showStarredOnly == requestShowStarredOnly
+        && selectedDateFilter == requestSelectedDateFilter
+        && selectedFolderId == requestSelectedFolderId
+    }
+
     // Calculate date range if date filter is set
     let startDate: Date?
     let endDate: Date?
-    if let filterDate = selectedDateFilter {
+    if let filterDate = requestSelectedDateFilter {
       let calendar = Calendar.current
       startDate = calendar.startOfDay(for: filterDate)
       endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
@@ -2722,15 +2755,19 @@ class AppState: ObservableObject {
         includeDiscarded: false,
         startDate: startDate,
         endDate: endDate,
-        folderId: selectedFolderId,
-        starred: showStarredOnly ? true : nil
+        folderId: requestSelectedFolderId,
+        starred: requestShowStarredOnly ? true : nil
       )
 
-      // Merge in-place: update existing, add new, remove gone
-      let merged = mergeConversations(source: fetchedConversations, current: conversations)
-      if merged != conversations {
-        conversations = merged
-        log("Conversations: Auto-refresh updated (\(merged.count) items)")
+      if requestFiltersAreCurrent() {
+        // Merge in-place: update existing, add new, remove gone
+        let merged = mergeConversations(source: fetchedConversations, current: conversations)
+        if merged != conversations {
+          conversations = merged
+          log("Conversations: Auto-refresh updated (\(merged.count) items)")
+        }
+      } else {
+        log("Conversations: Ignoring stale auto-refresh response for superseded filters")
       }
 
       // Sync to local database in background
@@ -2760,16 +2797,11 @@ class AppState: ObservableObject {
         statuses: [.completed, .processing],
         startDate: startDate,
         endDate: endDate,
-        folderId: selectedFolderId,
-        starred: showStarredOnly ? true : nil
+        folderId: requestSelectedFolderId,
+        starred: requestShowStarredOnly ? true : nil
       )
-      if hasActiveConversationFilters {
-        if filteredConversationsCount != count {
-          filteredConversationsCount = count
-        }
-      } else if totalConversationsCount != count {
-        totalConversationsCount = count
-        filteredConversationsCount = nil
+      if requestFiltersAreCurrent() {
+        updateConversationCount(count, filtered: requestHasActiveFilters)
       }
     } catch {
       // Keep existing count

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2545,10 +2545,16 @@ class AppState: ObservableObject {
 
   private func updateConversationCount(_ count: Int, filtered: Bool) {
     if filtered {
-      filteredConversationsCount = count
+      if filteredConversationsCount != count {
+        filteredConversationsCount = count
+      }
     } else {
-      totalConversationsCount = count
-      filteredConversationsCount = nil
+      if totalConversationsCount != count {
+        totalConversationsCount = count
+      }
+      if filteredConversationsCount != nil {
+        filteredConversationsCount = nil
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2587,6 +2587,9 @@ class AppState: ObservableObject {
         log("Conversations: Local cache unavailable, falling back to API")
         // Continue to API fetch even if local fails
       }
+    } else {
+      conversations = []
+      totalConversationsCount = 0
     }
 
     // Step 2: Fetch from API in background to get fresh data

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -822,7 +822,7 @@ actor TranscriptionStorage {
     }
 
     /// Get count of local conversations
-    func getLocalConversationsCount(starredOnly: Bool = false) async throws -> Int {
+    func getLocalConversationsCount(starredOnly: Bool = false, folderId: String? = nil) async throws -> Int {
         let db = try await ensureInitialized()
 
         return try await db.read { database in
@@ -833,6 +833,10 @@ actor TranscriptionStorage {
 
             if starredOnly {
                 query = query.filter(Column("starred") == true)
+            }
+
+            if let folderId = folderId {
+                query = query.filter(Column("folderId") == folderId)
             }
 
             return try query.fetchCount(database)

--- a/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
@@ -61,4 +61,36 @@ final class APIClientConversationCountTests: XCTestCase {
       "starred=false",
     ])
   }
+
+  func testConversationMutationsInvalidateCountCache() throws {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let sourceURL = testFile
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/APIClient.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    for method in [
+      "deleteConversation(id:",
+      "setConversationStarred(id:",
+      "mergeConversations(ids:",
+      "deleteFolder(id:",
+      "moveConversationToFolder(conversationId:",
+      "createConversationFromSegments(_ request:",
+    ] {
+      guard let methodRange = source.range(of: method) else {
+        XCTFail("Missing method \(method)")
+        continue
+      }
+      let suffix = source[methodRange.upperBound...]
+      guard let nextMethodRange = suffix.range(of: "\n  ///") ?? suffix.range(of: "\n}") else {
+        XCTFail("Could not find end of method \(method)")
+        continue
+      }
+      let methodBody = suffix[..<nextMethodRange.lowerBound]
+      XCTAssertTrue(
+        methodBody.contains("invalidateConversationsCountCache()"),
+        "\(method) should clear the filtered count cache after mutating conversations or folder membership")
+    }
+  }
 }

--- a/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Omi_Computer
+
+final class APIClientConversationCountTests: XCTestCase {
+  func testConversationCountEndpointIncludesVisibleFilters() throws {
+    let formatter = ISO8601DateFormatter()
+    let start = try XCTUnwrap(formatter.date(from: "2026-06-01T00:00:00Z"))
+    let end = try XCTUnwrap(formatter.date(from: "2026-06-02T00:00:00Z"))
+
+    let endpoint = APIClient.conversationsCountEndpoint(
+      includeDiscarded: false,
+      statuses: [.completed, .processing],
+      startDate: start,
+      endDate: end,
+      folderId: "folder-a",
+      starred: true
+    )
+
+    XCTAssertTrue(endpoint.hasPrefix("v1/conversations/count?"))
+    XCTAssertTrue(endpoint.contains("include_discarded=false"))
+    XCTAssertTrue(endpoint.contains("statuses=completed,processing"))
+    XCTAssertTrue(endpoint.contains("start_date=2026-06-01T00:00:00Z"))
+    XCTAssertTrue(endpoint.contains("end_date=2026-06-02T00:00:00Z"))
+    XCTAssertTrue(endpoint.contains("folder_id=folder-a"))
+    XCTAssertTrue(endpoint.contains("starred=true"))
+  }
+
+  func testConversationCountEndpointDistinguishesFilterCacheKeys() {
+    let unfiltered = APIClient.conversationsCountEndpoint(includeDiscarded: false)
+    let folderFiltered = APIClient.conversationsCountEndpoint(
+      includeDiscarded: false,
+      folderId: "folder-a"
+    )
+    let starredFalse = APIClient.conversationsCountEndpoint(
+      includeDiscarded: false,
+      starred: false
+    )
+
+    XCTAssertNotEqual(unfiltered, folderFiltered)
+    XCTAssertNotEqual(unfiltered, starredFalse)
+    XCTAssertTrue(starredFalse.contains("starred=false"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
@@ -40,4 +40,25 @@ final class APIClientConversationCountTests: XCTestCase {
     XCTAssertNotEqual(unfiltered, starredFalse)
     XCTAssertTrue(starredFalse.contains("starred=false"))
   }
+
+  func testConversationFilterQueryItemsAreSharedByListAndCount() throws {
+    let formatter = ISO8601DateFormatter()
+    let start = try XCTUnwrap(formatter.date(from: "2026-06-01T00:00:00Z"))
+
+    let queryItems = APIClient.conversationFilterQueryItems(
+      statuses: [.completed],
+      includeDiscarded: true,
+      startDate: start,
+      folderId: "folder-a",
+      starred: false
+    )
+
+    XCTAssertEqual(queryItems, [
+      "include_discarded=true",
+      "statuses=completed",
+      "start_date=2026-06-01T00:00:00Z",
+      "folder_id=folder-a",
+      "starred=false",
+    ])
+  }
 }


### PR DESCRIPTION
## Summary
- Extend `/v1/conversations/count` to accept the same practical filters the desktop list endpoint already uses: status, discarded, date range, folder, and starred.
- Pass active desktop filters into count requests and key the short-lived client cache by the full count endpoint.
- Keep local cached totals consistent with local visible filters by adding folder filtering to local counts and skipping local cache for date-filtered views.
- Add backend count filter tests and desktop count endpoint/cache-key tests.

## Verification
- `python -m py_compile backend/database/conversations.py backend/routers/conversations.py backend/tests/unit/test_conversations_count.py`
- `cd backend && python -m pytest tests/unit/test_conversations_count.py -q` — 28 passed
- `git diff --check`
- `xcrun swiftc -parse desktop/macos/Desktop/Sources/APIClient.swift desktop/macos/Desktop/Sources/AppState.swift desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift`
- `xcrun swift test --package-path desktop/macos/Desktop --filter APIClientConversationCountTests` — 2 passed

Fixes #8195


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

