### PR TITLE
fix: reconcile conversations with server authority

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2946,6 +2946,7 @@ class AppState: ObservableObject {
   func setConversationStarred(_ conversationId: String, starred: Bool) {
     var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
     mutation.starred = starred
+    mutation.recordedAt = Date()
     pendingConversationMutations[conversationId] = mutation
 
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
@@ -3053,6 +3054,7 @@ class AppState: ObservableObject {
 
       var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
       mutation.setFolderId(folderId)
+      mutation.recordedAt = Date()
       pendingConversationMutations[conversationId] = mutation
 
       // Update local state
@@ -3077,6 +3079,7 @@ class AppState: ObservableObject {
   func updateConversationTitle(_ conversationId: String, title: String) {
     var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
     mutation.title = title
+    mutation.recordedAt = Date()
     pendingConversationMutations[conversationId] = mutation
 
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -2945,8 +2945,7 @@ class AppState: ObservableObject {
   /// Update the starred status of a conversation locally after a successful mutation.
   func setConversationStarred(_ conversationId: String, starred: Bool) {
     var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
-    mutation.starred = starred
-    mutation.recordedAt = Date()
+    mutation.setStarred(starred)
     pendingConversationMutations[conversationId] = mutation
 
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
@@ -3054,7 +3053,6 @@ class AppState: ObservableObject {
 
       var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
       mutation.setFolderId(folderId)
-      mutation.recordedAt = Date()
       pendingConversationMutations[conversationId] = mutation
 
       // Update local state
@@ -3078,8 +3076,7 @@ class AppState: ObservableObject {
   /// Update a conversation title locally after a successful mutation.
   func updateConversationTitle(_ conversationId: String, title: String) {
     var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
-    mutation.title = title
-    mutation.recordedAt = Date()
+    mutation.setTitle(title)
     pendingConversationMutations[conversationId] = mutation
 
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -160,6 +160,7 @@ class AppState: ObservableObject {
   @Published var conversationsError: String? = nil
   @Published var totalConversationsCount: Int? = nil  // Unfiltered total count for dashboard metrics.
   @Published var filteredConversationsCount: Int? = nil  // Count matching the active conversations filters.
+  private var pendingConversationMutations: [String: ConversationPendingMutation] = [:]
 
   // Conversation filters
   @Published var showStarredOnly: Bool = false
@@ -2776,7 +2777,13 @@ class AppState: ObservableObject {
     do {
       let fetchedConversations = try await conversationsTask
       if requestFiltersAreCurrent() {
-        conversations = fetchedConversations
+        let reconciliation = ConversationReconciliationPolicy.mergeList(
+          server: fetchedConversations,
+          current: conversations,
+          pendingMutations: pendingConversationMutations
+        )
+        pendingConversationMutations = reconciliation.pendingMutations
+        conversations = reconciliation.conversations
       } else {
         log("Conversations: Ignoring stale response for superseded filters")
       }
@@ -2883,11 +2890,15 @@ class AppState: ObservableObject {
       )
 
       if requestFiltersAreCurrent() {
-        // Merge in-place: update existing, add new, remove gone
-        let merged = mergeConversations(source: fetchedConversations, current: conversations)
-        if merged != conversations {
-          conversations = merged
-          log("Conversations: Auto-refresh updated (\(merged.count) items)")
+        let reconciliation = ConversationReconciliationPolicy.mergeList(
+          server: fetchedConversations,
+          current: conversations,
+          pendingMutations: pendingConversationMutations
+        )
+        pendingConversationMutations = reconciliation.pendingMutations
+        if reconciliation.conversations != conversations {
+          conversations = reconciliation.conversations
+          log("Conversations: Auto-refresh updated (\(reconciliation.conversations.count) items)")
         }
       } else {
         log("Conversations: Ignoring stale auto-refresh response for superseded filters")
@@ -2931,41 +2942,12 @@ class AppState: ObservableObject {
     }
   }
 
-  /// Merge fetched conversations into the current list in-place.
-  /// Updates changed items, adds new ones, removes ones no longer in source.
-  private func mergeConversations(source: [ServerConversation], current: [ServerConversation])
-    -> [ServerConversation]
-  {
-    let sourceById = Dictionary(uniqueKeysWithValues: source.map { ($0.id, $0) })
-    let sourceIds = Set(source.map { $0.id })
-    let currentIds = Set(current.map { $0.id })
-
-    var result = current
-
-    // Update existing items in-place
-    for i in result.indices {
-      if let updated = sourceById[result[i].id], updated != result[i] {
-        result[i] = updated
-      }
-    }
-
-    // Remove items no longer in source
-    result.removeAll { !sourceIds.contains($0.id) }
-
-    // Add new items from source that aren't in current
-    let newIds = sourceIds.subtracting(currentIds)
-    if !newIds.isEmpty {
-      let newItems = source.filter { newIds.contains($0.id) }
-      result.append(contentsOf: newItems)
-      // Re-sort by createdAt descending (newest first) to maintain order
-      result.sort { $0.createdAt > $1.createdAt }
-    }
-
-    return result
-  }
-
-  /// Update the starred status of a conversation locally
+  /// Update the starred status of a conversation locally after a successful mutation.
   func setConversationStarred(_ conversationId: String, starred: Bool) {
+    var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
+    mutation.starred = starred
+    pendingConversationMutations[conversationId] = mutation
+
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
       conversations[index].starred = starred
     }
@@ -3069,6 +3051,10 @@ class AppState: ObservableObject {
       try await TranscriptionStorage.shared.updateFolderByBackendId(
         conversationId, folderId: folderId)
 
+      var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
+      mutation.setFolderId(folderId)
+      pendingConversationMutations[conversationId] = mutation
+
       // Update local state
       if conversations.contains(where: { $0.id == conversationId }) {
         // Reload to get updated conversation
@@ -3087,8 +3073,12 @@ class AppState: ObservableObject {
     }
   }
 
-  /// Update a conversation title locally (after successful API call)
+  /// Update a conversation title locally after a successful mutation.
   func updateConversationTitle(_ conversationId: String, title: String) {
+    var mutation = pendingConversationMutations[conversationId] ?? ConversationPendingMutation()
+    mutation.title = title
+    pendingConversationMutations[conversationId] = mutation
+
     if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
       conversations[index].structured.title = title
     }

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -149,6 +149,7 @@ enum ConversationReconciliationPolicy {
       finishedAt: serverConversation.finishedAt,
       structured: structured,
       transcriptSegments: serverConversation.transcriptSegments,
+      transcriptSegmentsIncluded: serverConversation.transcriptSegmentsIncluded,
       geolocation: serverConversation.geolocation,
       photos: serverConversation.photos,
       appsResults: serverConversation.appsResults,

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -5,32 +5,72 @@ import Foundation
 ///
 /// The reconciliation layer treats these as short-lived overlays. Everything
 /// else in the server list remains authoritative over cache data.
+///
+/// Each field carries its own `recordedAt` so that a later star or folder change
+/// does not accidentally refresh the TTL of an older title overlay (and vice-versa).
 struct ConversationPendingMutation: Equatable {
   var title: String?
   var starred: Bool?
-  var recordedAt: Date = Date()
+  var titleRecordedAt: Date?
+  var starredRecordedAt: Date?
   private(set) var folderId: String?
   private(set) var hasFolderIdMutation: Bool = false
+  private(set) var folderIdRecordedAt: Date?
 
   var isEmpty: Bool {
     title == nil && starred == nil && !hasFolderIdMutation
   }
 
+  mutating func setTitle(_ title: String?) {
+    self.title = title
+    titleRecordedAt = Date()
+  }
+
+  mutating func setStarred(_ starred: Bool) {
+    self.starred = starred
+    starredRecordedAt = Date()
+  }
+
   mutating func setFolderId(_ folderId: String?) {
     self.folderId = folderId
     hasFolderIdMutation = true
+    folderIdRecordedAt = Date()
+  }
+
+  /// Expire individual fields whose TTL has elapsed. The whole mutation is
+  /// removed once every field has either resolved or expired.
+  mutating func expireFields(now: Date, ttl: TimeInterval) {
+    if title != nil, let recorded = titleRecordedAt,
+       now.timeIntervalSince(recorded) > ttl {
+      title = nil
+      titleRecordedAt = nil
+    }
+    if starred != nil, let recorded = starredRecordedAt,
+       now.timeIntervalSince(recorded) > ttl {
+      starred = nil
+      starredRecordedAt = nil
+    }
+    if hasFolderIdMutation, let recorded = folderIdRecordedAt,
+       now.timeIntervalSince(recorded) > ttl {
+      folderId = nil
+      hasFolderIdMutation = false
+      folderIdRecordedAt = nil
+    }
   }
 
   mutating func clearResolvedFields(matching server: ServerConversation) {
     if title == server.structured.title {
       title = nil
+      titleRecordedAt = nil
     }
     if starred == server.starred {
       starred = nil
+      starredRecordedAt = nil
     }
     if hasFolderIdMutation && folderId == server.folderId {
       folderId = nil
       hasFolderIdMutation = false
+      folderIdRecordedAt = nil
     }
   }
 }
@@ -52,8 +92,15 @@ enum ConversationReconciliationPolicy {
     pendingMutationTTL: TimeInterval = 120
   ) -> ConversationReconciliationResult {
     let serverIds = Set(server.map(\.id))
-    var nextPending = pendingMutations.filter { _, mutation in
-      now.timeIntervalSince(mutation.recordedAt) <= pendingMutationTTL
+    var nextPending = pendingMutations
+
+    // Per-field TTL expiration: each overlay field is independently evaluated
+    // so a recent star change doesn't keep an older title overlay alive.
+    for id in nextPending.keys {
+      nextPending[id]?.expireFields(now: now, ttl: pendingMutationTTL)
+      if nextPending[id]?.isEmpty ?? true {
+        nextPending.removeValue(forKey: id)
+      }
     }
 
     var merged = server.map { serverConversation in

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Local user edits that have succeeded locally/API-side but may not be reflected
+/// in the next eventually-consistent server list response yet.
+///
+/// The reconciliation layer treats these as short-lived overlays. Everything
+/// else in the server list remains authoritative over cache data.
+struct ConversationPendingMutation: Equatable {
+  var title: String?
+  var starred: Bool?
+  private(set) var folderId: String?
+  private(set) var hasFolderIdMutation: Bool = false
+
+  var isEmpty: Bool {
+    title == nil && starred == nil && !hasFolderIdMutation
+  }
+
+  mutating func setFolderId(_ folderId: String?) {
+    self.folderId = folderId
+    hasFolderIdMutation = true
+  }
+
+  mutating func clearResolvedFields(matching server: ServerConversation) {
+    if title == server.structured.title {
+      title = nil
+    }
+    if starred == server.starred {
+      starred = nil
+    }
+    if hasFolderIdMutation && folderId == server.folderId {
+      folderId = nil
+      hasFolderIdMutation = false
+    }
+  }
+}
+
+struct ConversationReconciliationResult: Equatable {
+  let conversations: [ServerConversation]
+  let pendingMutations: [String: ConversationPendingMutation]
+}
+
+enum ConversationReconciliationPolicy {
+  /// Merge a server-authoritative list response over whatever the UI currently
+  /// renders. The server controls list ordering and all non-pending fields;
+  /// local state only survives as explicit pending user-edit overlays.
+  static func mergeList(
+    server: [ServerConversation],
+    current: [ServerConversation],
+    pendingMutations: [String: ConversationPendingMutation] = [:]
+  ) -> ConversationReconciliationResult {
+    let serverIds = Set(server.map(\.id))
+    var nextPending = pendingMutations
+
+    var merged = server.map { serverConversation in
+      var mutation = nextPending[serverConversation.id]
+      let mergedConversation = apply(mutation: mutation, to: serverConversation)
+      mutation?.clearResolvedFields(matching: serverConversation)
+      if let mutation, !mutation.isEmpty {
+        nextPending[serverConversation.id] = mutation
+      } else {
+        nextPending.removeValue(forKey: serverConversation.id)
+      }
+      return mergedConversation
+    }
+
+    // Preserve genuinely local in-progress rows that have not reached the
+    // backend yet. Synced cache rows missing from the server response are not
+    // retained, because doing so masks filtered/deleted/backend-updated state.
+    let localOnly = current.filter { conversation in
+      !serverIds.contains(conversation.id) && shouldPreserveLocalOnly(conversation)
+    }
+    merged.append(contentsOf: localOnly)
+
+    return ConversationReconciliationResult(
+      conversations: merged,
+      pendingMutations: nextPending
+    )
+  }
+
+  static func apply(
+    mutation: ConversationPendingMutation?,
+    to serverConversation: ServerConversation
+  ) -> ServerConversation {
+    guard let mutation, !mutation.isEmpty else {
+      return serverConversation
+    }
+
+    var structured = serverConversation.structured
+    if let title = mutation.title {
+      structured.title = title
+    }
+
+    return ServerConversation(
+      id: serverConversation.id,
+      createdAt: serverConversation.createdAt,
+      startedAt: serverConversation.startedAt,
+      finishedAt: serverConversation.finishedAt,
+      structured: structured,
+      transcriptSegments: serverConversation.transcriptSegments,
+      geolocation: serverConversation.geolocation,
+      photos: serverConversation.photos,
+      appsResults: serverConversation.appsResults,
+      source: serverConversation.source,
+      language: serverConversation.language,
+      status: serverConversation.status,
+      discarded: serverConversation.discarded,
+      deleted: serverConversation.deleted,
+      isLocked: serverConversation.isLocked,
+      starred: mutation.starred ?? serverConversation.starred,
+      folderId: mutation.hasFolderIdMutation ? mutation.folderId : serverConversation.folderId,
+      inputDeviceName: serverConversation.inputDeviceName,
+      deferred: serverConversation.deferred
+    )
+  }
+
+  private static func shouldPreserveLocalOnly(_ conversation: ServerConversation) -> Bool {
+    conversation.status == .inProgress && !conversation.deleted && !conversation.discarded
+  }
+}

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -8,6 +8,7 @@ import Foundation
 struct ConversationPendingMutation: Equatable {
   var title: String?
   var starred: Bool?
+  var recordedAt: Date = Date()
   private(set) var folderId: String?
   private(set) var hasFolderIdMutation: Bool = false
 
@@ -46,13 +47,21 @@ enum ConversationReconciliationPolicy {
   static func mergeList(
     server: [ServerConversation],
     current: [ServerConversation],
-    pendingMutations: [String: ConversationPendingMutation] = [:]
+    pendingMutations: [String: ConversationPendingMutation] = [:],
+    now: Date = Date(),
+    pendingMutationTTL: TimeInterval = 120
   ) -> ConversationReconciliationResult {
     let serverIds = Set(server.map(\.id))
     var nextPending = pendingMutations
 
     var merged = server.map { serverConversation in
       var mutation = nextPending[serverConversation.id]
+      if let pendingMutation = mutation,
+        now.timeIntervalSince(pendingMutation.recordedAt) > pendingMutationTTL
+      {
+        mutation = nil
+        nextPending.removeValue(forKey: serverConversation.id)
+      }
       let mergedConversation = apply(mutation: mutation, to: serverConversation)
       mutation?.clearResolvedFields(matching: serverConversation)
       if let mutation, !mutation.isEmpty {

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -52,16 +52,12 @@ enum ConversationReconciliationPolicy {
     pendingMutationTTL: TimeInterval = 120
   ) -> ConversationReconciliationResult {
     let serverIds = Set(server.map(\.id))
-    var nextPending = pendingMutations
+    var nextPending = pendingMutations.filter { _, mutation in
+      now.timeIntervalSince(mutation.recordedAt) <= pendingMutationTTL
+    }
 
     var merged = server.map { serverConversation in
       var mutation = nextPending[serverConversation.id]
-      if let pendingMutation = mutation,
-        now.timeIntervalSince(pendingMutation.recordedAt) > pendingMutationTTL
-      {
-        mutation = nil
-        nextPending.removeValue(forKey: serverConversation.id)
-      }
       let mergedConversation = apply(mutation: mutation, to: serverConversation)
       mutation?.clearResolvedFields(matching: serverConversation)
       if let mutation, !mutation.isEmpty {

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import Omi_Computer
+
+final class ConversationReconciliationPolicyTests: XCTestCase {
+  func testServerStatusAndSummaryWinOverStaleCache() {
+    let local = makeConversation(
+      id: "c1",
+      title: "Cache title",
+      overview: "old summary",
+      status: .processing
+    )
+    let server = makeConversation(
+      id: "c1",
+      title: "Server title",
+      overview: "fresh summary",
+      status: .completed
+    )
+
+    let result = ConversationReconciliationPolicy.mergeList(server: [server], current: [local])
+
+    XCTAssertEqual(result.conversations.map(\.id), ["c1"])
+    XCTAssertEqual(result.conversations[0].status, .completed)
+    XCTAssertEqual(result.conversations[0].structured.overview, "fresh summary")
+    XCTAssertEqual(result.conversations[0].structured.title, "Server title")
+    XCTAssertTrue(result.pendingMutations.isEmpty)
+  }
+
+  func testStaleLocalTitleDoesNotMaskServerWithoutPendingMutation() {
+    let local = makeConversation(id: "c1", title: "Local stale")
+    let server = makeConversation(id: "c1", title: "Server fresh")
+
+    let result = ConversationReconciliationPolicy.mergeList(server: [server], current: [local])
+
+    XCTAssertEqual(result.conversations[0].structured.title, "Server fresh")
+  }
+
+  func testPendingTitleMutationTemporarilyWinsUntilServerMatches() {
+    let local = makeConversation(id: "c1", title: "Optimistic local")
+    let serverLagging = makeConversation(id: "c1", title: "Server old")
+    var mutation = ConversationPendingMutation()
+    mutation.title = "Optimistic local"
+
+    let lagging = ConversationReconciliationPolicy.mergeList(
+      server: [serverLagging],
+      current: [local],
+      pendingMutations: ["c1": mutation]
+    )
+
+    XCTAssertEqual(lagging.conversations[0].structured.title, "Optimistic local")
+    XCTAssertEqual(lagging.pendingMutations["c1"]?.title, "Optimistic local")
+
+    let serverCaughtUp = makeConversation(id: "c1", title: "Optimistic local")
+    let caughtUp = ConversationReconciliationPolicy.mergeList(
+      server: [serverCaughtUp],
+      current: lagging.conversations,
+      pendingMutations: lagging.pendingMutations
+    )
+
+    XCTAssertEqual(caughtUp.conversations[0].structured.title, "Optimistic local")
+    XCTAssertNil(caughtUp.pendingMutations["c1"])
+  }
+
+  func testPendingStarAndFolderMutationsTemporarilyWinAndThenClear() {
+    let local = makeConversation(id: "c1", starred: true, folderId: "local-folder")
+    let serverLagging = makeConversation(id: "c1", starred: false, folderId: "server-folder")
+    var mutation = ConversationPendingMutation()
+    mutation.starred = true
+    mutation.setFolderId("local-folder")
+
+    let lagging = ConversationReconciliationPolicy.mergeList(
+      server: [serverLagging],
+      current: [local],
+      pendingMutations: ["c1": mutation]
+    )
+
+    XCTAssertTrue(lagging.conversations[0].starred)
+    XCTAssertEqual(lagging.conversations[0].folderId, "local-folder")
+    XCTAssertEqual(lagging.pendingMutations["c1"]?.starred, true)
+
+    let serverCaughtUp = makeConversation(id: "c1", starred: true, folderId: "local-folder")
+    let caughtUp = ConversationReconciliationPolicy.mergeList(
+      server: [serverCaughtUp],
+      current: lagging.conversations,
+      pendingMutations: lagging.pendingMutations
+    )
+
+    XCTAssertTrue(caughtUp.conversations[0].starred)
+    XCTAssertEqual(caughtUp.conversations[0].folderId, "local-folder")
+    XCTAssertNil(caughtUp.pendingMutations["c1"])
+  }
+
+  func testServerOrderIsPreservedAndSyncedCacheRowsMissingFromServerAreDropped() {
+    let localOnlySynced = makeConversation(id: "stale", createdAt: Date(timeIntervalSince1970: 999))
+    let serverOlder = makeConversation(id: "older", createdAt: Date(timeIntervalSince1970: 100))
+    let serverNewer = makeConversation(id: "newer", createdAt: Date(timeIntervalSince1970: 200))
+
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [serverOlder, serverNewer],
+      current: [localOnlySynced, serverNewer, serverOlder]
+    )
+
+    XCTAssertEqual(result.conversations.map(\.id), ["older", "newer"])
+  }
+
+  func testLocalInProgressRowsSurviveUntilBackendCreatesServerConversation() {
+    let localRecording = makeConversation(id: "local-live", status: .inProgress)
+    let server = makeConversation(id: "server-conversation")
+
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [server],
+      current: [localRecording]
+    )
+
+    XCTAssertEqual(result.conversations.map(\.id), ["server-conversation", "local-live"])
+  }
+
+  private func makeConversation(
+    id: String,
+    title: String = "Title",
+    overview: String = "Overview",
+    status: ConversationStatus = .completed,
+    starred: Bool = false,
+    folderId: String? = nil,
+    createdAt: Date = Date(timeIntervalSince1970: 1_000)
+  ) -> ServerConversation {
+    ServerConversation(
+      id: id,
+      createdAt: createdAt,
+      startedAt: createdAt,
+      finishedAt: createdAt.addingTimeInterval(60),
+      structured: Structured(
+        title: title,
+        overview: overview,
+        emoji: "💬",
+        category: "other",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: [],
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: "en",
+      status: status,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: starred,
+      folderId: folderId,
+      inputDeviceName: nil,
+      deferred: false
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -38,7 +38,7 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     let local = makeConversation(id: "c1", title: "Optimistic local")
     let serverLagging = makeConversation(id: "c1", title: "Server old")
     var mutation = ConversationPendingMutation()
-    mutation.title = "Optimistic local"
+    mutation.setTitle("Optimistic local")
 
     let lagging = ConversationReconciliationPolicy.mergeList(
       server: [serverLagging],
@@ -65,8 +65,8 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     let local = makeConversation(id: "c1", title: "Optimistic local")
     let serverSuperseded = makeConversation(id: "c1", title: "Server from another client")
     var mutation = ConversationPendingMutation()
-    mutation.title = "Optimistic local"
-    mutation.recordedAt = baseTime
+    mutation.setTitle("Optimistic local")
+    mutation.titleRecordedAt = baseTime
 
     let result = ConversationReconciliationPolicy.mergeList(
       server: [serverSuperseded],
@@ -84,8 +84,8 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     let baseTime = Date(timeIntervalSince1970: 10_000)
     let server = makeConversation(id: "server-row")
     var expired = ConversationPendingMutation()
-    expired.title = "Never returned again"
-    expired.recordedAt = baseTime
+    expired.setTitle("Never returned again")
+    expired.titleRecordedAt = baseTime
 
     let result = ConversationReconciliationPolicy.mergeList(
       server: [server],
@@ -103,7 +103,7 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     let local = makeConversation(id: "c1", starred: true, folderId: "local-folder")
     let serverLagging = makeConversation(id: "c1", starred: false, folderId: "server-folder")
     var mutation = ConversationPendingMutation()
-    mutation.starred = true
+    mutation.setStarred(true)
     mutation.setFolderId("local-folder")
 
     let lagging = ConversationReconciliationPolicy.mergeList(
@@ -126,6 +126,63 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     XCTAssertTrue(caughtUp.conversations[0].starred)
     XCTAssertEqual(caughtUp.conversations[0].folderId, "local-folder")
     XCTAssertNil(caughtUp.pendingMutations["c1"])
+  }
+
+  // MARK: - Per-field TTL independence (review feedback)
+
+  /// A later star change must NOT refresh the TTL of an older title overlay.
+  func testLaterStarMutationDoesNotRefreshOlderTitleOverlayTTL() {
+    let baseTime = Date(timeIntervalSince1970: 10_000)
+    let server = makeConversation(id: "c1", title: "Server title", starred: false)
+
+    var mutation = ConversationPendingMutation()
+    mutation.setTitle("Optimistic title")
+    mutation.titleRecordedAt = baseTime  // title recorded at T+0
+
+    // 60 seconds later, user also stars the conversation — title is 60s old
+    mutation.setStarred(true)
+    // setStarred stamps starredRecordedAt, but does NOT touch titleRecordedAt
+
+    // At T+121, title is expired (121 > 120) but star is only 61s old (not expired)
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [server],
+      current: [server],
+      pendingMutations: ["c1": mutation],
+      now: baseTime.addingTimeInterval(121),
+      pendingMutationTTL: 120
+    )
+
+    // Title overlay should have expired — server title wins
+    XCTAssertEqual(result.conversations[0].structured.title, "Server title")
+    // Star overlay is still within TTL — pending star still wins
+    XCTAssertTrue(result.conversations[0].starred)
+    XCTAssertEqual(result.pendingMutations["c1"]?.starred, true)
+    XCTAssertNil(result.pendingMutations["c1"]?.title)
+  }
+
+  /// Each field expires independently; when all fields are expired the
+  /// whole mutation entry is removed even if the conversation is in the server list.
+  func testAllFieldsExpiredRemovesMutationEvenWhenConversationPresent() {
+    let baseTime = Date(timeIntervalSince1970: 10_000)
+    let server = makeConversation(id: "c1", title: "Server title", starred: false)
+
+    var mutation = ConversationPendingMutation()
+    mutation.setTitle("Old title")
+    mutation.titleRecordedAt = baseTime
+    mutation.setStarred(true)
+    mutation.starredRecordedAt = baseTime
+
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [server],
+      current: [server],
+      pendingMutations: ["c1": mutation],
+      now: baseTime.addingTimeInterval(121),
+      pendingMutationTTL: 120
+    )
+
+    XCTAssertTrue(result.pendingMutations.isEmpty)
+    XCTAssertEqual(result.conversations[0].structured.title, "Server title")
+    XCTAssertFalse(result.conversations[0].starred)
   }
 
   func testServerOrderIsPreservedAndSyncedCacheRowsMissingFromServerAreDropped() {

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -233,6 +233,7 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
         events: []
       ),
       transcriptSegments: [],
+      transcriptSegmentsIncluded: true,
       geolocation: nil,
       photos: [],
       appsResults: [],

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -80,6 +80,25 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     XCTAssertNil(result.pendingMutations["c1"])
   }
 
+  func testExpiredPendingMutationForMissingServerRowIsDropped() {
+    let baseTime = Date(timeIntervalSince1970: 10_000)
+    let server = makeConversation(id: "server-row")
+    var expired = ConversationPendingMutation()
+    expired.title = "Never returned again"
+    expired.recordedAt = baseTime
+
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [server],
+      current: [server],
+      pendingMutations: ["missing-row": expired],
+      now: baseTime.addingTimeInterval(121),
+      pendingMutationTTL: 120
+    )
+
+    XCTAssertEqual(result.conversations.map(\.id), ["server-row"])
+    XCTAssertTrue(result.pendingMutations.isEmpty)
+  }
+
   func testPendingStarAndFolderMutationsTemporarilyWinAndThenClear() {
     let local = makeConversation(id: "c1", starred: true, folderId: "local-folder")
     let serverLagging = makeConversation(id: "c1", starred: false, folderId: "server-folder")

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -60,6 +60,26 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     XCTAssertNil(caughtUp.pendingMutations["c1"])
   }
 
+  func testExpiredPendingMutationDoesNotMaskNewerServerValue() {
+    let baseTime = Date(timeIntervalSince1970: 10_000)
+    let local = makeConversation(id: "c1", title: "Optimistic local")
+    let serverSuperseded = makeConversation(id: "c1", title: "Server from another client")
+    var mutation = ConversationPendingMutation()
+    mutation.title = "Optimistic local"
+    mutation.recordedAt = baseTime
+
+    let result = ConversationReconciliationPolicy.mergeList(
+      server: [serverSuperseded],
+      current: [local],
+      pendingMutations: ["c1": mutation],
+      now: baseTime.addingTimeInterval(121),
+      pendingMutationTTL: 120
+    )
+
+    XCTAssertEqual(result.conversations[0].structured.title, "Server from another client")
+    XCTAssertNil(result.pendingMutations["c1"])
+  }
+
   func testPendingStarAndFolderMutationsTemporarilyWinAndThenClear() {
     let local = makeConversation(id: "c1", starred: true, folderId: "local-folder")
     let serverLagging = makeConversation(id: "c1", starred: false, folderId: "server-folder")


### PR DESCRIPTION
## Summary
- Adds a pure desktop `ConversationReconciliationPolicy` for cache-first/server-refresh list merging.
- Makes server list responses authoritative for non-pending fields so stale SQLite cache rows cannot permanently mask backend-updated status, summary, title, folder, or starred state.
- Tracks short-lived successful local title/star/folder mutations as explicit pending overlays until the server list catches up.
- Preserves only true local in-progress rows that have not appeared in the backend yet.

## Oracle
- Consulted Oracle for issue #8197 before implementation.
- Recommendation: keep this first PR small, base it on `origin/main`, avoid backend schema/index changes, and introduce a pure reconciliation helper plus focused tests rather than a broad repository/store refactor.

## Test plan
- [x] `git diff --check`
- [x] `xcrun swiftc -parse desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift desktop/macos/Desktop/Sources/AppState.swift desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift`
- [x] `xcrun swift test --package-path desktop/macos/Desktop --filter ConversationReconciliationPolicyTests` — 6 tests passed

Refs #8197


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

