### PR TITLE
fix(cli): preserve structured local screenshot errors

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -141,6 +141,23 @@ omi --json local sql "SELECT appName, COUNT(*) FROM screenshots GROUP BY appName
 omi --json local task search "taxes" --include-completed
 ```
 
+Agent screen-history workflow:
+
+1. Check availability with `omi --json local status`; look for
+   `screen_history_available`, `screenshot_count`, and `indexed_screenshot_count`.
+2. Discover tool schemas with `omi --json local tools`.
+3. Search OCR/screen history with `omi --json local search-screen "query" --days 7`
+   or run exact SQL against `screenshots` when you need app/window filters.
+4. Use a returned `screenshot_id` with
+   `omi --json local screenshot <id> --output /tmp/omi-shot.jpg`.
+5. Validate the file before handing it to vision tooling, for example
+   `file /tmp/omi-shot.jpg`.
+
+If pixels are not available, JSON-mode errors preserve Desktop's structured
+fields such as `status_code`, `error`, `reason`, `hint`, and `screenshot_id`.
+For example, `screenshot_pending` means the frame is still in the active video
+segment; retry shortly or choose an older screenshot ID from search results.
+
 Task writes should only run after the user clearly asks for that change:
 
 ```bash

--- a/sdks/python-cli/examples/agent_quickstart.md
+++ b/sdks/python-cli/examples/agent_quickstart.md
@@ -88,7 +88,13 @@ omi --json local task delete task_123 --yes
 ```
 
 `omi local screenshot SCREENSHOT_ID --output PATH` writes the screenshot to
-disk and still prints JSON to stdout for scripts.
+disk and still prints JSON to stdout for scripts. The screenshot ID usually
+comes from `local search-screen` or SQL over the `screenshots` table. If Desktop
+returns a structured failure such as `screenshot_pending`, `screenshot_file_missing`,
+or `screenshot_chunk_corrupted`, JSON mode preserves the `reason`, `hint`, and
+`screenshot_id` fields on stderr so agents can retry an older ID or report the
+exact blocker. Validate successful outputs with `file PATH` before passing them
+to vision tools.
 
 ## Worked example: Python agent loop
 

--- a/sdks/python-cli/omi_cli/errors.py
+++ b/sdks/python-cli/omi_cli/errors.py
@@ -105,8 +105,9 @@ class RateLimitError(CliError):
         detail: Optional[str] = None,
         retry_after_seconds: Optional[float] = None,
         policy: Optional[str] = None,
+        extra: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        super().__init__(message=message, detail=detail)
+        super().__init__(message=message, detail=detail, extra=extra)
         self.retry_after_seconds = retry_after_seconds
         self.policy = policy
 

--- a/sdks/python-cli/omi_cli/errors.py
+++ b/sdks/python-cli/omi_cli/errors.py
@@ -19,7 +19,7 @@ current Click context — falling back to plain stderr otherwise.
 from __future__ import annotations
 
 import sys
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import click
 
@@ -47,11 +47,13 @@ class CliError(click.ClickException):
         message: str,
         exit_code: Optional[int] = None,
         detail: Optional[str] = None,
+        extra: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__(message)
         if exit_code is not None:
             self.exit_code = exit_code
         self.detail = detail
+        self.extra = dict(extra or {})
 
     # ``self.message`` is set by ClickException.__init__ — we don't override it
     # because ClickException assigns to ``self.message`` directly.
@@ -61,7 +63,7 @@ class CliError(click.ClickException):
         ctx = click.get_current_context(silent=True)
         renderer = getattr(ctx.obj, "renderer", None) if ctx is not None and ctx.obj is not None else None
         if renderer is not None:
-            renderer.error(self.message, detail=self.detail)
+            renderer.error(self.message, detail=self.detail, extra=self.extra)
             return
         # Fallback path — covers the rare case where the error fires before the
         # root callback finished initializing the Renderer.

--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping, Optional
 import httpx
 
 from omi_cli.client import DEFAULT_TIMEOUT, USER_AGENT, _extract_detail, _safe_parse_json
-from omi_cli.errors import CliError, ServerError, from_status
+from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
 
 LOCAL_TOOL_PATH = "/v1/local/tool"
 LOCAL_TOOLS_PATH = "/v1/local/tools"
@@ -118,13 +118,14 @@ class LocalOmiClient:
                 detail=detail,
                 extra=extra,
             )
-        error = from_status(response.status_code, detail=detail)
-        return CliError(
-            message=f"Local Omi Desktop API error ({response.status_code})",
-            detail=detail,
-            exit_code=error.exit_code,
-            extra=extra,
-        )
+        message = f"Local Omi Desktop API error ({response.status_code})"
+        if response.status_code in {401, 403}:
+            return AuthError(message, detail=detail, extra=extra)
+        if response.status_code == 404:
+            return NotFoundError(message, detail=detail, extra=extra)
+        if response.status_code == 429:
+            return RateLimitError(message, detail=detail, extra=extra)
+        return CliError(message=message, detail=detail, extra=extra)
 
 
 def _structured_local_error(status_code: int, body: Any) -> dict[str, Any]:

--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -110,9 +110,31 @@ class LocalOmiClient:
 
     def _error_from_response(self, response: httpx.Response) -> CliError:
         detail = _extract_detail(response)
+        body = _safe_parse_json(response)
+        extra = _structured_local_error(response.status_code, body)
         if 500 <= response.status_code < 600:
-            return ServerError(message=f"Local Omi Desktop API error ({response.status_code})", detail=detail)
-        return from_status(response.status_code, detail=detail)
+            return ServerError(
+                message=f"Local Omi Desktop API error ({response.status_code})",
+                detail=detail,
+                extra=extra,
+            )
+        error = from_status(response.status_code, detail=detail)
+        return CliError(
+            message=f"Local Omi Desktop API error ({response.status_code})",
+            detail=detail,
+            exit_code=error.exit_code,
+            extra=extra,
+        )
+
+
+def _structured_local_error(status_code: int, body: Any) -> dict[str, Any]:
+    """Preserve Desktop-local structured error payloads for JSON-mode agents."""
+    payload: dict[str, Any] = {"status_code": status_code}
+    if isinstance(body, Mapping):
+        for key in ("ok", "error", "reason", "hint", "screenshot_id", "name"):
+            if key in body:
+                payload[key] = body[key]
+    return payload
 
 
 def _unwrap_tool_response(body: Any) -> Any:

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -198,8 +198,10 @@ def main() -> None:
         app(standalone_mode=False)
     except CliError as exc:
         # If the error happens before the root callback ran, ``ctx.obj`` might
-        # not exist — fall back to a default Renderer reading the env.
-        renderer = _LAST_RENDERER or Renderer(json_mode=False)
+        # not exist — fall back to a default Renderer preserving --json.
+        renderer = _LAST_RENDERER or Renderer(
+            json_mode="--json" in sys.argv,
+        )
         sys.exit(_exit_with_cli_error(exc, renderer))
     except click.ClickException as exc:
         # Click's own usage errors (unknown flag, missing argument, etc.).

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -167,7 +167,7 @@ app.add_typer(local_cmd.app, name="local", help="Local Omi Desktop API tools.")
 
 
 def _exit_with_cli_error(error: CliError, renderer: Renderer) -> int:
-    renderer.error(error.message, detail=error.detail)
+    renderer.error(error.message, detail=error.detail, extra=error.extra)
     return error.exit_code
 
 

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -38,6 +38,8 @@ from omi_cli.errors import CliError
 from omi_cli.local_client import LocalOmiClient
 from omi_cli.output import Renderer
 
+_LAST_RENDERER: Optional[Renderer] = None
+
 app = typer.Typer(
     name="omi",
     help=(
@@ -135,6 +137,8 @@ def _root(
     profile_name = cfg.resolve_profile_name(profile, config)
 
     renderer = Renderer(json_mode=json_output, no_color=no_color, verbose=verbose)
+    global _LAST_RENDERER
+    _LAST_RENDERER = renderer
     ctx.obj = AppContext(
         profile_name=profile_name,
         api_base_override=api_base,
@@ -188,12 +192,14 @@ def main() -> None:
     * KeyboardInterrupt / EOFError — Ctrl-C / Ctrl-D. Conventional 130.
     * Anything else — last-chance handler. Print a clean line, exit 1.
     """
+    global _LAST_RENDERER
+    _LAST_RENDERER = None
     try:
         app(standalone_mode=False)
     except CliError as exc:
         # If the error happens before the root callback ran, ``ctx.obj`` might
         # not exist — fall back to a default Renderer reading the env.
-        renderer = Renderer(json_mode=False)
+        renderer = _LAST_RENDERER or Renderer(json_mode=False)
         sys.exit(_exit_with_cli_error(exc, renderer))
     except click.ClickException as exc:
         # Click's own usage errors (unknown flag, missing argument, etc.).

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -146,6 +146,9 @@ class Renderer:
             line = f"[red]✗[/red] {message}"
             if detail:
                 line += f"\n  [dim]{detail}[/dim]"
+            if extra:
+                for key, value in extra.items():
+                    line += f"\n  [dim]{key}: {_stringify(value)}[/dim]"
             self._stderr.print(line)
 
     def debug(self, message: str) -> None:

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -132,13 +132,15 @@ class Renderer:
             return
         self._stderr.print(f"[yellow]![/yellow] {message}")
 
-    def error(self, message: str, *, detail: Optional[str] = None) -> None:
+    def error(self, message: str, *, detail: Optional[str] = None, extra: Optional[Mapping[str, Any]] = None) -> None:
         # Errors are emitted in BOTH modes — JSON mode keeps stdout pristine,
         # but error messages still need to reach the user via stderr.
         if self.json_mode:
             payload: dict[str, Any] = {"error": message}
             if detail:
                 payload["detail"] = detail
+            if extra:
+                payload.update(dict(extra))
             self._stderr.print(json.dumps(payload))
         else:
             line = f"[red]✗[/red] {message}"

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 
@@ -148,7 +149,7 @@ class Renderer:
                 line += f"\n  [dim]{detail}[/dim]"
             if extra:
                 for key, value in extra.items():
-                    line += f"\n  [dim]{key}: {_stringify(value)}[/dim]"
+                    line += f"\n  [dim]{escape(str(key))}: {escape(_stringify(value))}[/dim]"
             self._stderr.print(line)
 
     def debug(self, message: str) -> None:

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -142,7 +142,8 @@ class Renderer:
                 payload["detail"] = detail
             if extra:
                 payload.update(dict(extra))
-            self._stderr.print(json.dumps(payload))
+            sys.stderr.write(json.dumps(payload) + "\n")
+            sys.stderr.flush()
         else:
             line = f"[red]✗[/red] {message}"
             if detail:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -11,7 +11,7 @@ import pytest
 import respx
 
 from omi_cli import config as cfg
-from omi_cli.errors import CliError
+from omi_cli.errors import CliError, NotFoundError
 from omi_cli.local_client import LocalOmiClient
 from omi_cli.main import app
 
@@ -360,6 +360,24 @@ def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Pa
     assert payload["reason"] == error_payload["reason"]
     assert payload["hint"] == error_payload["hint"]
     assert payload["screenshot_id"] == 123
+
+
+def test_local_api_error_preserves_not_found_subclass(config_path: Path) -> None:
+    _configure_local_profile(config_path)
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(
+            return_value=httpx.Response(
+                404,
+                json={"ok": False, "error": "screenshot_not_found", "screenshot_id": "missing"},
+            )
+        )
+        with LocalOmiClient(api_url=FAKE_LOCAL_URL, token=FAKE_LOCAL_TOKEN) as client:
+            with pytest.raises(NotFoundError) as exc_info:
+                client.call_tool("get_screenshot", {"screenshot_id": "missing"})
+
+    assert exc_info.value.extra["status_code"] == 404
+    assert exc_info.value.extra["error"] == "screenshot_not_found"
+    assert exc_info.value.extra["screenshot_id"] == "missing"
 
 
 def test_main_json_screenshot_error_preserves_structured_stderr(

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 import httpx
+import pytest
 import respx
 
 from omi_cli import config as cfg
@@ -353,6 +354,43 @@ def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Pa
     assert not output.exists()
     assert isinstance(result.exception, CliError)
     payload = result.exception.extra
+    assert payload["status_code"] == 422
+    assert payload["ok"] is False
+    assert payload["error"] == "screenshot_pending"
+    assert payload["reason"] == error_payload["reason"]
+    assert payload["hint"] == error_payload["hint"]
+    assert payload["screenshot_id"] == 123
+
+
+def test_main_json_screenshot_error_preserves_structured_stderr(
+    config_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    _configure_local_profile(config_path)
+    output = tmp_path / "pending.jpg"
+    error_payload = {
+        "ok": False,
+        "error": "screenshot_pending",
+        "reason": "The frame is in the active recording segment that has not been flushed to disk yet.",
+        "hint": "Retry in ~60s, or choose an older screenshot_id whose video chunk is already finalized.",
+        "screenshot_id": 123,
+    }
+
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(422, json=error_payload))
+        monkeypatch.setattr(
+            "sys.argv",
+            ["omi", "--json", "local", "screenshot", "123", "--output", str(output)],
+        )
+        from omi_cli.main import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code != 0
+    assert not output.exists()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
     assert payload["status_code"] == 422
     assert payload["ok"] is False
     assert payload["error"] == "screenshot_pending"

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -14,6 +14,7 @@ from omi_cli import config as cfg
 from omi_cli.errors import CliError, NotFoundError
 from omi_cli.local_client import LocalOmiClient
 from omi_cli.main import app
+from omi_cli.output import Renderer
 
 FAKE_LOCAL_URL = "http://127.0.0.1:47778"
 FAKE_LOCAL_TOKEN = "local_test_token"
@@ -360,6 +361,17 @@ def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Pa
     assert payload["reason"] == error_payload["reason"]
     assert payload["hint"] == error_payload["hint"]
     assert payload["screenshot_id"] == 123
+
+
+def test_non_json_error_escapes_structured_extra_markup(capsys: pytest.CaptureFixture[str]) -> None:
+    Renderer(json_mode=False).error(
+        "Local Omi Desktop API error (422)",
+        extra={"hint": "Use [safe] text", "[danger]": "<value>"},
+    )
+
+    captured = capsys.readouterr()
+    assert "hint: Use [safe] text" in captured.err
+    assert "[danger]: <value>" in captured.err
 
 
 def test_local_api_error_preserves_not_found_subclass(config_path: Path) -> None:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -332,3 +332,47 @@ def test_screenshot_writes_base64_output_and_keeps_json_stdout(config_path: Path
     assert payload["screenshot_id"] == "9"
     assert "image_base64" not in payload["result"]
     assert payload["result"]["image_base64_redacted"] is True
+
+
+def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    _configure_local_profile(config_path)
+    output = tmp_path / "pending.jpg"
+    error_payload = {
+        "ok": False,
+        "error": "screenshot_pending",
+        "reason": "The frame is in the active recording segment that has not been flushed to disk yet.",
+        "hint": "Retry in ~60s, or choose an older screenshot_id whose video chunk is already finalized.",
+        "screenshot_id": 123,
+    }
+
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(422, json=error_payload))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "123", "--output", str(output)])
+
+    assert result.exit_code != 0
+    assert not output.exists()
+    assert isinstance(result.exception, CliError)
+    payload = result.exception.extra
+    assert payload["status_code"] == 422
+    assert payload["ok"] is False
+    assert payload["error"] == "screenshot_pending"
+    assert payload["reason"] == error_payload["reason"]
+    assert payload["hint"] == error_payload["hint"]
+    assert payload["screenshot_id"] == 123
+
+
+def test_screenshot_non_json_local_api_error_has_status_code(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    _configure_local_profile(config_path)
+    output = tmp_path / "failed.jpg"
+
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(500, text="plain failure"))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "123", "--output", str(output)])
+
+    assert result.exit_code != 0
+    assert not output.exists()
+    assert isinstance(result.exception, CliError)
+    payload = result.exception.extra
+    assert result.exception.message == "Local Omi Desktop API error (500)"
+    assert result.exception.detail == "plain failure"
+    assert payload["status_code"] == 500


### PR DESCRIPTION
## Summary
- Preserves Desktop-local structured screenshot failures in JSON-mode CLI errors (`status_code`, `error`, `reason`, `hint`, `screenshot_id`).
- Documents the agent screen-history workflow: status → tools → search/SQL → screenshot fetch → file validation.
- Adds local CLI coverage for successful base64 screenshot writes, structured 422 screenshot failures, and non-JSON 500 fallback errors.

## Test Plan
- [x] `cd sdks/python-cli && uv run --extra dev pytest tests/test_local.py -q`
- [x] `cd sdks/python-cli && uv run --extra dev black --check omi_cli tests`
- [ ] `cd sdks/python-cli && uv run --extra dev mypy omi_cli` — blocked by existing `tomli` missing-stub/import issue on Python 3.12 in `omi_cli/config.py`

## Notes
- Addresses the CLI/docs portions of #8188.
- I could not complete the real-device screenshot retrieval blocker check because no local Omi Desktop API was listening on `127.0.0.1:47778` in this environment. This PR therefore avoids claiming to fully close #8188 or changing Swift/Rewind video extraction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

