### PR TITLE
feat(mcp): add people cleanup tools

### DIFF
--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TypedDict
 
 from google.cloud import firestore
 
@@ -8,6 +8,11 @@ import database.redis_db as redis_db
 from database._client import db
 from models.mcp_api_key import McpApiKey
 from utils.mcp_api_keys import generate_api_key, hash_api_key
+
+
+class McpApiKeyAuth(TypedDict):
+    user_id: str
+    scopes: Optional[List[str]]
 
 
 def create_mcp_key(user_id: str, name: str) -> Tuple[str, McpApiKey]:
@@ -101,3 +106,29 @@ def get_user_id_by_api_key(api_key: str) -> Optional[str]:
         key_ref.update({"last_used_at": datetime.utcnow()})
 
     return user_id
+
+
+def get_auth_by_api_key(api_key: str) -> Optional[McpApiKeyAuth]:
+    """Verify an MCP API key and return its user id plus explicit scopes.
+
+    This bypasses the legacy user-id-only cache so write tools can fail closed
+    when a key has no stored scopes.
+    """
+    if not api_key.startswith("omi_mcp_"):
+        return None
+    secret_part = api_key.replace("omi_mcp_", "", 1)
+    hashed_key = hash_api_key(secret_part)
+
+    keys_ref = db.collection("mcp_api_keys").where("hashed_key", "==", hashed_key).limit(1)
+    docs = list(keys_ref.stream())
+    if not docs:
+        return None
+
+    key_doc = docs[0]
+    key_data = key_doc.to_dict()
+    user_id = key_data.get("user_id")
+    if not user_id:
+        return None
+
+    key_doc.reference.update({"last_used_at": datetime.utcnow()})
+    return {"user_id": user_id, "scopes": key_data.get("scopes")}

--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -138,6 +138,8 @@ def get_auth_by_api_key(api_key: str) -> Optional[McpApiKeyAuth]:
         return None
 
     scopes = key_data.get("scopes")
+    if scopes is None:
+        scopes = []
     key_doc.reference.update({"last_used_at": datetime.utcnow()})
     redis_db.cache_mcp_api_key_auth(hashed_key, user_id, scopes)
     return {"user_id": user_id, "scopes": scopes}

--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -7,7 +7,7 @@ from google.cloud import firestore
 
 import database.redis_db as redis_db
 from database._client import db
-from models.mcp_api_key import McpApiKey
+from models.mcp_api_key import McpApiKeyDB, McpApiKey, MCP_LEGACY_API_KEY_SCOPES
 from utils.mcp_api_keys import generate_api_key, hash_api_key
 
 
@@ -139,7 +139,7 @@ def get_auth_by_api_key(api_key: str) -> Optional[McpApiKeyAuth]:
 
     scopes = key_data.get("scopes")
     if scopes is None:
-        scopes = []
+        scopes = list(MCP_LEGACY_API_KEY_SCOPES)
     key_doc.reference.update({"last_used_at": datetime.utcnow()})
     redis_db.cache_mcp_api_key_auth(hashed_key, user_id, scopes)
     return {"user_id": user_id, "scopes": scopes}

--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 from typing import List, Optional, Tuple, TypedDict
+from typing import cast
 
 from google.cloud import firestore
 
@@ -15,7 +16,7 @@ class McpApiKeyAuth(TypedDict):
     scopes: Optional[List[str]]
 
 
-def create_mcp_key(user_id: str, name: str) -> Tuple[str, McpApiKey]:
+def create_mcp_key(user_id: str, name: str, scopes: Optional[List[str]] = None) -> Tuple[str, McpApiKey]:
     """
     Creates a new MCP API key for a user.
     Returns the raw key and the key's metadata.
@@ -32,6 +33,7 @@ def create_mcp_key(user_id: str, name: str) -> Tuple[str, McpApiKey]:
         "key_prefix": key_prefix,
         "created_at": now,
         "last_used_at": None,
+        "scopes": scopes,
     }
     db.collection("mcp_api_keys").document(key_id).set(api_key_doc)
 
@@ -41,6 +43,7 @@ def create_mcp_key(user_id: str, name: str) -> Tuple[str, McpApiKey]:
         key_prefix=key_prefix,
         created_at=now,
         last_used_at=None,
+        scopes=scopes,
     )
     return raw_key, api_key_data
 
@@ -119,6 +122,10 @@ def get_auth_by_api_key(api_key: str) -> Optional[McpApiKeyAuth]:
     secret_part = api_key.replace("omi_mcp_", "", 1)
     hashed_key = hash_api_key(secret_part)
 
+    cached_auth = redis_db.get_cached_mcp_api_key_auth(hashed_key)
+    if cached_auth:
+        return cast(McpApiKeyAuth, cached_auth)
+
     keys_ref = db.collection("mcp_api_keys").where("hashed_key", "==", hashed_key).limit(1)
     docs = list(keys_ref.stream())
     if not docs:
@@ -130,5 +137,7 @@ def get_auth_by_api_key(api_key: str) -> Optional[McpApiKeyAuth]:
     if not user_id:
         return None
 
+    scopes = key_data.get("scopes")
     key_doc.reference.update({"last_used_at": datetime.utcnow()})
-    return {"user_id": user_id, "scopes": key_data.get("scopes")}
+    redis_db.cache_mcp_api_key_auth(hashed_key, user_id, scopes)
+    return {"user_id": user_id, "scopes": scopes}

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -486,7 +486,7 @@ def cache_mcp_api_key(hashed_key: str, user_id: str, ttl: int = 3600):
 @try_catch_decorator
 def cache_mcp_api_key_auth(hashed_key: str, user_id: str, scopes: Optional[List[str]] = None, ttl: int = 3600):
     """Caches the user_id and explicit scopes for a given MCP API key."""
-    cache_data = {"user_id": user_id, "scopes": scopes}
+    cache_data = {"user_id": user_id, "scopes": scopes or []}
     r.set(f'mcp_api_key_auth:{hashed_key}', json.dumps(cache_data), ex=ttl)
 
 

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -484,6 +484,13 @@ def cache_mcp_api_key(hashed_key: str, user_id: str, ttl: int = 3600):
 
 
 @try_catch_decorator
+def cache_mcp_api_key_auth(hashed_key: str, user_id: str, scopes: Optional[List[str]] = None, ttl: int = 3600):
+    """Caches the user_id and explicit scopes for a given MCP API key."""
+    cache_data = {"user_id": user_id, "scopes": scopes}
+    r.set(f'mcp_api_key_auth:{hashed_key}', json.dumps(cache_data), ex=ttl)
+
+
+@try_catch_decorator
 def get_cached_mcp_api_key_user_id(hashed_key: str) -> Optional[str]:
     """Retrieves the user_id for a given hashed MCP API key from cache."""
     user_id = r.get(f'mcp_api_key:{hashed_key}')
@@ -491,9 +498,17 @@ def get_cached_mcp_api_key_user_id(hashed_key: str) -> Optional[str]:
 
 
 @try_catch_decorator
+def get_cached_mcp_api_key_auth(hashed_key: str) -> Optional[dict]:
+    """Retrieves the user_id and explicit scopes for a given MCP API key from cache."""
+    cached = r.get(f'mcp_api_key_auth:{hashed_key}')
+    return json.loads(cached) if cached else None
+
+
+@try_catch_decorator
 def delete_cached_mcp_api_key(hashed_key: str):
     """Deletes a cached MCP API key."""
     r.delete(f'mcp_api_key:{hashed_key}')
+    r.delete(f'mcp_api_key_auth:{hashed_key}')
 
 
 # ******************************************************

--- a/backend/models/mcp_api_key.py
+++ b/backend/models/mcp_api_key.py
@@ -14,7 +14,8 @@ MCP_SCOPES_SUPPORTED = [
     "people.read",
     "people.write",
 ]
-MCP_DEFAULT_API_KEY_SCOPES = MCP_SCOPES_SUPPORTED
+MCP_DEFAULT_API_KEY_SCOPES = list(MCP_SCOPES_SUPPORTED)
+MCP_LEGACY_API_KEY_SCOPES = [scope for scope in MCP_SCOPES_SUPPORTED if scope.endswith(".read")]
 
 
 class McpApiKey(BaseModel):

--- a/backend/models/mcp_api_key.py
+++ b/backend/models/mcp_api_key.py
@@ -15,7 +15,7 @@ MCP_SCOPES_SUPPORTED = [
     "people.write",
 ]
 MCP_DEFAULT_API_KEY_SCOPES = list(MCP_SCOPES_SUPPORTED)
-MCP_LEGACY_API_KEY_SCOPES = [scope for scope in MCP_SCOPES_SUPPORTED if scope.endswith(".read")]
+MCP_LEGACY_API_KEY_SCOPES = [scope for scope in MCP_SCOPES_SUPPORTED if scope.endswith(".read")] + ["memories.write"]
 
 
 class McpApiKey(BaseModel):

--- a/backend/models/mcp_api_key.py
+++ b/backend/models/mcp_api_key.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,6 +10,7 @@ class McpApiKey(BaseModel):
     key_prefix: str
     created_at: datetime
     last_used_at: Optional[datetime] = None
+    scopes: Optional[List[str]] = None
 
 
 class McpApiKeyDB(McpApiKey):
@@ -19,6 +20,7 @@ class McpApiKeyDB(McpApiKey):
 
 class McpApiKeyCreate(BaseModel):
     name: str
+    scopes: Optional[List[str]] = None
 
 
 class McpApiKeyCreated(McpApiKey):

--- a/backend/models/mcp_api_key.py
+++ b/backend/models/mcp_api_key.py
@@ -3,6 +3,19 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+MCP_SCOPES_SUPPORTED = [
+    "memories.read",
+    "memories.write",
+    "conversations.read",
+    "action_items.read",
+    "goals.read",
+    "chat.read",
+    "screen_activity.read",
+    "people.read",
+    "people.write",
+]
+MCP_DEFAULT_API_KEY_SCOPES = MCP_SCOPES_SUPPORTED
+
 
 class McpApiKey(BaseModel):
     id: str

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -36,21 +36,16 @@ from utils.mcp_memories import (
     parse_mcp_int,
     parse_optional_mcp_bool,
 )
-import database.mcp_api_key as mcp_api_key_db
-from models.mcp_api_key import McpApiKey, McpApiKeyCreate, McpApiKeyCreated
-
-MCP_DEFAULT_API_KEY_SCOPES = [
-    "memories.read",
-    "memories.write",
-    "conversations.read",
-    "action_items.read",
-    "goals.read",
-    "chat.read",
-    "screen_activity.read",
-    "people.read",
-    "people.write",
-]
 import logging
+
+import database.mcp_api_key as mcp_api_key_db
+from models.mcp_api_key import (
+    MCP_DEFAULT_API_KEY_SCOPES,
+    MCP_SCOPES_SUPPORTED,
+    McpApiKey,
+    McpApiKeyCreate,
+    McpApiKeyCreated,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -55,7 +55,18 @@ def create_key(key_data: McpApiKeyCreate, uid: str = Depends(get_current_user_id
     if not key_data.name or len(key_data.name.strip()) == 0:
         raise HTTPException(status_code=422, detail="Key name cannot be empty")
 
-    raw_key, api_key_data = mcp_api_key_db.create_mcp_key(uid, key_data.name.strip())
+    scopes = key_data.scopes or [
+        "memories.read",
+        "memories.write",
+        "conversations.read",
+        "action_items.read",
+        "goals.read",
+        "chat.read",
+        "screen_activity.read",
+        "people.read",
+        "people.write",
+    ]
+    raw_key, api_key_data = mcp_api_key_db.create_mcp_key(uid, key_data.name.strip(), scopes)
     return McpApiKeyCreated(**api_key_data.model_dump(), key=raw_key)
 
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 
 from utils.executors import db_executor, postprocess_executor
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Security
+from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
 
 import database.memories as memories_db
@@ -25,7 +26,7 @@ from utils.conversations.render import populate_speaker_names, redact_conversati
 from utils.apps import update_personas_async
 from utils.llm.memories import identify_category_for_memory
 from utils.retrieval.hybrid import rrf_rerank
-from dependencies import get_uid_from_mcp_api_key, get_current_user_id
+from dependencies import get_current_user_id
 from utils.other.endpoints import with_rate_limit
 from utils.log_sanitizer import sanitize_pii
 from utils.mcp_data import clean_action_item, clean_chat_message, clean_person, clean_screen_activity_row
@@ -50,6 +51,39 @@ from models.mcp_api_key import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+mcp_api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+
+
+async def get_mcp_api_key_auth(api_key: str = Security(mcp_api_key_header)) -> mcp_api_key_db.McpApiKeyAuth:
+    if not api_key or not api_key.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid Authorization header. Must be 'Bearer API_KEY'",
+        )
+
+    auth = mcp_api_key_db.get_auth_by_api_key(api_key.replace("Bearer ", ""))
+    if not auth:
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+    return auth
+
+
+def require_mcp_scope(required_scope: str):
+    async def dependency(auth: mcp_api_key_db.McpApiKeyAuth = Depends(get_mcp_api_key_auth)) -> str:
+        if required_scope not in (auth.get("scopes") or []):
+            raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {required_scope}")
+        return auth["user_id"]
+
+    return dependency
+
+
+get_uid_with_mcp_memories_read = require_mcp_scope("memories.read")
+get_uid_with_mcp_memories_write = require_mcp_scope("memories.write")
+get_uid_with_mcp_conversations_read = require_mcp_scope("conversations.read")
+get_uid_with_mcp_action_items_read = require_mcp_scope("action_items.read")
+get_uid_with_mcp_goals_read = require_mcp_scope("goals.read")
+get_uid_with_mcp_chat_read = require_mcp_scope("chat.read")
+get_uid_with_mcp_screen_activity_read = require_mcp_scope("screen_activity.read")
+get_uid_with_mcp_people_read = require_mcp_scope("people.read")
 
 
 @router.get("/v1/mcp/keys", response_model=List[McpApiKey], tags=["mcp"])
@@ -76,7 +110,9 @@ def delete_key(key_id: str, uid: str = Depends(get_current_user_id)):
 
 
 @router.post("/v1/mcp/memories", tags=["mcp"], response_model=Memory)
-def create_memory(memory: Memory, uid: str = Depends(with_rate_limit(get_uid_from_mcp_api_key, "memories:create"))):
+def create_memory(
+    memory: Memory, uid: str = Depends(with_rate_limit(get_uid_with_mcp_memories_write, "memories:create"))
+):
     # Auto-categorize memories from external sources
     memory.category = identify_category_for_memory(memory.content)
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
@@ -99,7 +135,7 @@ def _validate_mcp_memory(uid: str, memory_id: str) -> dict:
 
 
 @router.delete("/v1/mcp/memories/{memory_id}", tags=["mcp"])
-def delete_memory(memory_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
+def delete_memory(memory_id: str, uid: str = Depends(get_uid_with_mcp_memories_write)):
     _validate_mcp_memory(uid, memory_id)
     memories_db.delete_memory(uid, memory_id)
     try:
@@ -110,7 +146,7 @@ def delete_memory(memory_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
 
 
 @router.patch("/v1/mcp/memories/{memory_id}", tags=["mcp"])
-def edit_memory(memory_id: str, value: str, uid: str = Depends(get_uid_from_mcp_api_key)):
+def edit_memory(memory_id: str, value: str, uid: str = Depends(get_uid_with_mcp_memories_write)):
     memory = _validate_mcp_memory(uid, memory_id)
     memories_db.edit_memory(uid, memory_id, value)
     try:
@@ -127,7 +163,7 @@ class UserProfile(BaseModel):
 
 
 @router.get("/v1/mcp/profile", tags=["mcp"], response_model=UserProfile)
-def get_user_profile(uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_user_profile(uid: str = Depends(get_uid_with_mcp_memories_read)):
     """Omi's cached high-level user profile, if one has been generated."""
     profile = users_db.get_ai_user_profile(uid) or {}
     generated_at = profile.get("generated_at")
@@ -152,7 +188,7 @@ class SearchedMemory(CleanerMemory):
 def search_memories(
     query: str,
     limit: int = 10,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_memories_read),
 ):
     logger.info(f"search_memories {uid} query={sanitize_pii(query)} limit={limit}")
     limit = max(1, min(limit, 20))
@@ -201,7 +237,7 @@ def search_memories(
 
 @router.get("/v1/mcp/memories", tags=["mcp"], response_model=List[CleanerMemory])
 def get_memories(
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_memories_read),
     limit: int = 25,
     offset: int = 0,
     categories: Optional[str] = None,
@@ -299,7 +335,7 @@ def get_conversations(
     categories: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_conversations_read),
 ):
     logger.info(f"get_conversations {uid} {limit} {offset} {start_date} {end_date} {categories}")
     try:
@@ -336,7 +372,7 @@ def search_conversations(
     limit: int = 10,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_conversations_read),
 ):
     logger.info(f"search_conversations {uid} query={sanitize_pii(query)} limit={limit}")
 
@@ -375,7 +411,7 @@ def search_conversations(
     response_model=FullConversation,
     tags=["mcp"],
 )
-def get_conversation_by_id(conversation_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_conversation_by_id(conversation_id: str, uid: str = Depends(get_uid_with_mcp_conversations_read)):
     logger.info(f"get_conversation_by_id {uid} {conversation_id}")
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -411,7 +447,7 @@ def get_action_items(
     due_end_date: Optional[datetime] = None,
     limit: int = 100,
     offset: int = 0,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_action_items_read),
 ):
     logger.info(f"get_action_items {uid} completed={completed} limit={limit} offset={offset}")
     limit = max(1, min(limit, 500))
@@ -433,7 +469,7 @@ def get_action_items(
 
 
 @router.get("/v1/mcp/goals", tags=["mcp"])
-def get_goals(include_inactive: bool = False, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_goals(include_inactive: bool = False, uid: str = Depends(get_uid_with_mcp_goals_read)):
     logger.info(f"get_goals {uid} include_inactive={include_inactive}")
     return goals_db.get_all_goals(uid, include_inactive=include_inactive)
 
@@ -452,7 +488,7 @@ class SimpleChatMessage(BaseModel):
 
 
 @router.get("/v1/mcp/chat", response_model=List[SimpleChatMessage], tags=["mcp"])
-def get_chat_messages(limit: int = 50, offset: int = 0, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_chat_messages(limit: int = 50, offset: int = 0, uid: str = Depends(get_uid_with_mcp_chat_read)):
     logger.info(f"get_chat_messages {uid} limit={limit} offset={offset}")
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
@@ -473,7 +509,7 @@ class SimplePerson(BaseModel):
 
 
 @router.get("/v1/mcp/people", response_model=List[SimplePerson], tags=["mcp"])
-def get_people(uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_people(uid: str = Depends(get_uid_with_mcp_people_read)):
     logger.info(f"get_people {uid}")
     return [clean_person(p) for p in users_db.get_people(uid)]
 
@@ -490,7 +526,7 @@ def get_screen_activity(
     app: Optional[str] = None,
     summary: bool = False,
     limit: int = 200,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_screen_activity_read),
 ):
     logger.info(f"get_screen_activity {uid} summary={summary} app={app} limit={limit}")
     if summary:
@@ -513,7 +549,7 @@ def get_daily_summaries(
     offset: int = 0,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    uid: str = Depends(get_uid_from_mcp_api_key),
+    uid: str = Depends(get_uid_with_mcp_memories_read),
 ):
     logger.info(f"get_daily_summaries {uid} limit={limit} offset={offset}")
     limit = max(1, min(limit, 100))

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -38,6 +38,18 @@ from utils.mcp_memories import (
 )
 import database.mcp_api_key as mcp_api_key_db
 from models.mcp_api_key import McpApiKey, McpApiKeyCreate, McpApiKeyCreated
+
+MCP_DEFAULT_API_KEY_SCOPES = [
+    "memories.read",
+    "memories.write",
+    "conversations.read",
+    "action_items.read",
+    "goals.read",
+    "chat.read",
+    "screen_activity.read",
+    "people.read",
+    "people.write",
+]
 import logging
 
 logger = logging.getLogger(__name__)
@@ -55,17 +67,9 @@ def create_key(key_data: McpApiKeyCreate, uid: str = Depends(get_current_user_id
     if not key_data.name or len(key_data.name.strip()) == 0:
         raise HTTPException(status_code=422, detail="Key name cannot be empty")
 
-    scopes = key_data.scopes or [
-        "memories.read",
-        "memories.write",
-        "conversations.read",
-        "action_items.read",
-        "goals.read",
-        "chat.read",
-        "screen_activity.read",
-        "people.read",
-        "people.write",
-    ]
+    scopes = MCP_DEFAULT_API_KEY_SCOPES if key_data.scopes is None else key_data.scopes
+    if invalid_scopes := sorted(set(scopes) - set(MCP_DEFAULT_API_KEY_SCOPES)):
+        raise HTTPException(status_code=422, detail={"invalid_scopes": invalid_scopes})
     raw_key, api_key_data = mcp_api_key_db.create_mcp_key(uid, key_data.name.strip(), scopes)
     return McpApiKeyCreated(**api_key_data.model_dump(), key=raw_key)
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -549,7 +549,7 @@ def get_daily_summaries(
     offset: int = 0,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    uid: str = Depends(get_uid_with_mcp_memories_read),
+    uid: str = Depends(get_uid_with_mcp_conversations_read),
 ):
     logger.info(f"get_daily_summaries {uid} limit={limit} offset={offset}")
     limit = max(1, min(limit, 100))

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -12,7 +12,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
-from typing import Optional, Union, List, Any
+from typing import Optional, Union, List, Any, TypedDict
 
 from fastapi import APIRouter, HTTPException, Header, Request, Response
 from fastapi.responses import StreamingResponse, JSONResponse
@@ -32,6 +32,7 @@ import database.screen_activity as screen_activity_db
 import database.daily_summaries as daily_summaries_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from utils.conversations.render import redact_conversation_for_list
+from utils.other.storage import delete_user_person_speech_samples
 from models.conversation_enums import CategoryEnum
 from utils.llm.memories import identify_category_for_memory
 from utils.mcp_data import clean_action_item, clean_chat_message, clean_person, clean_screen_activity_row
@@ -94,6 +95,13 @@ CHAT_READ_SECURITY = [{"type": "oauth2", "scopes": ["chat.read"]}]
 SCREEN_ACTIVITY_READ_SECURITY = [{"type": "oauth2", "scopes": ["screen_activity.read"]}]
 PEOPLE_READ_SECURITY = [{"type": "oauth2", "scopes": ["people.read"]}]
 PEOPLE_WRITE_SECURITY = [{"type": "oauth2", "scopes": ["people.write"]}]
+PEOPLE_WRITE_SCOPE = "people.write"
+PEOPLE_WRITE_TOOLS = {"rename_person", "delete_person"}
+
+
+class McpAuth(TypedDict):
+    user_id: str
+    scopes: Optional[List[str]]
 
 
 class MCPSession:
@@ -106,8 +114,8 @@ class MCPSession:
         self.initialized = False
 
 
-def authenticate_api_key(authorization: Optional[str]) -> Optional[str]:
-    """Validate API key from Authorization header and return user_id if valid."""
+def authenticate_api_key(authorization: Optional[str]) -> Optional[McpAuth]:
+    """Validate API key from Authorization header and return auth details if valid."""
     if not authorization:
         return None
 
@@ -119,7 +127,7 @@ def authenticate_api_key(authorization: Optional[str]) -> Optional[str]:
     if not token.startswith("omi_mcp_"):
         return None
 
-    return mcp_api_key_db.get_user_id_by_api_key(token)
+    return mcp_api_key_db.get_auth_by_api_key(token)
 
 
 def invalid_mcp_auth_exception(
@@ -553,8 +561,10 @@ def _validated_person_name(arguments: dict) -> str:
     return name
 
 
-def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
+def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: Optional[List[str]] = None) -> dict:
     """Execute an MCP tool and return the result. Raises ToolExecutionError on failure."""
+    if tool_name in PEOPLE_WRITE_TOOLS and PEOPLE_WRITE_SCOPE not in (granted_scopes or []):
+        raise ToolExecutionError(f"Insufficient permissions. Required scope: {PEOPLE_WRITE_SCOPE}", code=-32003)
 
     if tool_name == "get_user_profile":
         profile = users_db.get_ai_user_profile(user_id)
@@ -898,6 +908,7 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         person_id = _required_mcp_string(arguments, "person_id")
         if not users_db.get_person(user_id, person_id):
             raise ToolExecutionError("Person not found", code=-32001)
+        delete_user_person_speech_samples(user_id, person_id)
         users_db.delete_person(user_id, person_id)
         return {"success": True}
 
@@ -947,7 +958,10 @@ def create_mcp_error(id: Any, code: int, message: str) -> dict:
 
 
 def handle_mcp_message(
-    user_id: str, message: dict, session: Optional[MCPSession] = None
+    user_id: str,
+    message: dict,
+    session: Optional[MCPSession] = None,
+    granted_scopes: Optional[List[str]] = None,
 ) -> tuple[Optional[dict], Optional[str]]:
     """
     Process an incoming MCP JSON-RPC message and return a response.
@@ -999,7 +1013,7 @@ def handle_mcp_message(
             return create_mcp_error(msg_id, -32602, "Tool name is required"), None
 
         try:
-            result = execute_tool(user_id, tool_name, arguments)
+            result = execute_tool(user_id, tool_name, arguments, granted_scopes)
         except ToolExecutionError as e:
             return create_mcp_error(msg_id, e.code, e.message), None
 
@@ -1059,8 +1073,8 @@ async def mcp_token(request: Request):
     if client_id != "omi":
         raise HTTPException(status_code=400, detail="Invalid client_id")
 
-    user_id = authenticate_api_key(client_secret)
-    if not user_id:
+    auth = authenticate_api_key(client_secret)
+    if not auth:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     return {
@@ -1086,9 +1100,11 @@ async def mcp_streamable_http(
     - Session ID is returned in Mcp-Session-Id header after initialization
     """
     # Authenticate
-    user_id = authenticate_api_key(authorization)
-    if not user_id:
+    auth = authenticate_api_key(authorization)
+    if not auth:
         raise invalid_mcp_auth_exception()
+    user_id = auth["user_id"]
+    granted_scopes = auth.get("scopes")
 
     # Rate limit per-user
     check_rate_limit_inline(user_id, "mcp:sse")
@@ -1116,7 +1132,7 @@ async def mcp_streamable_http(
     if all_notifications:
         # Process notifications without response
         for msg in messages:
-            handle_mcp_message(user_id, msg, session)
+            handle_mcp_message(user_id, msg, session, granted_scopes)
         return Response(status_code=202)
 
     # Process messages and collect responses
@@ -1124,7 +1140,7 @@ async def mcp_streamable_http(
     new_session_id = None
 
     for msg in messages:
-        response, session_id = handle_mcp_message(user_id, msg, session)
+        response, session_id = handle_mcp_message(user_id, msg, session, granted_scopes)
         if session_id:
             new_session_id = session_id
         if response:
@@ -1170,8 +1186,8 @@ async def mcp_sse_get(
     This is optional per the MCP spec and mainly used for long-polling scenarios.
     """
     # Authenticate
-    user_id = authenticate_api_key(authorization)
-    if not user_id:
+    auth = authenticate_api_key(authorization)
+    if not auth:
         raise invalid_mcp_auth_exception()
 
     # For backwards compatibility, also support the old SSE flow
@@ -1204,9 +1220,10 @@ def mcp_delete_session(
     """
     Delete/terminate an MCP session.
     """
-    user_id = authenticate_api_key(authorization)
-    if not user_id:
+    auth = authenticate_api_key(authorization)
+    if not auth:
         raise invalid_mcp_auth_exception("Invalid or missing API key")
+    user_id = auth["user_id"]
 
     if not mcp_session_id:
         raise HTTPException(status_code=400, detail="Mcp-Session-Id header required")

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -64,6 +64,7 @@ MCP_SCOPES_SUPPORTED = [
     "chat.read",
     "screen_activity.read",
     "people.read",
+    "people.write",
 ]
 
 READ_ONLY_ANNOTATIONS = {
@@ -92,6 +93,7 @@ GOALS_READ_SECURITY = [{"type": "oauth2", "scopes": ["goals.read"]}]
 CHAT_READ_SECURITY = [{"type": "oauth2", "scopes": ["chat.read"]}]
 SCREEN_ACTIVITY_READ_SECURITY = [{"type": "oauth2", "scopes": ["screen_activity.read"]}]
 PEOPLE_READ_SECURITY = [{"type": "oauth2", "scopes": ["people.read"]}]
+PEOPLE_WRITE_SECURITY = [{"type": "oauth2", "scopes": ["people.write"]}]
 
 
 class MCPSession:
@@ -407,6 +409,39 @@ MCP_TOOLS = [
         "inputSchema": {"type": "object", "properties": {}},
     },
     {
+        "name": "rename_person",
+        "description": (
+            "Rename one of the user's people/contacts by id. Use only when the user explicitly asks to correct "
+            "a person's display name. Names must be 2-40 characters after trimming."
+        ),
+        "annotations": WRITE_ANNOTATIONS,
+        "securitySchemes": PEOPLE_WRITE_SECURITY,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "person_id": {"type": "string", "description": "The Omi person/contact id to rename"},
+                "name": {"type": "string", "description": "The corrected display name (2-40 characters)"},
+            },
+            "required": ["person_id", "name"],
+        },
+    },
+    {
+        "name": "delete_person",
+        "description": (
+            "Delete one of the user's people/contacts by id. This is destructive and should only be used after "
+            "the user clearly asks to remove a false-positive or unwanted person record."
+        ),
+        "annotations": DESTRUCTIVE_WRITE_ANNOTATIONS,
+        "securitySchemes": PEOPLE_WRITE_SECURITY,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "person_id": {"type": "string", "description": "The Omi person/contact id to delete"},
+            },
+            "required": ["person_id"],
+        },
+    },
+    {
         "name": "get_screen_activity",
         "description": (
             "Retrieve the user's desktop screen activity (Rewind) — what apps and windows they used and the OCR'd "
@@ -502,6 +537,20 @@ def _parse_mcp_date(value: Optional[str], field: str) -> Optional[datetime]:
         return datetime.strptime(value, "%Y-%m-%d")
     except ValueError:
         raise ToolExecutionError(f"Invalid {field} format: '{value}'. Expected YYYY-MM-DD.", code=-32602)
+
+
+def _required_mcp_string(arguments: dict, field: str) -> str:
+    value = arguments.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ToolExecutionError(f"{field} is required", code=-32602)
+    return value.strip()
+
+
+def _validated_person_name(arguments: dict) -> str:
+    name = _required_mcp_string(arguments, "name")
+    if len(name) < 2 or len(name) > 40:
+        raise ToolExecutionError("name must be between 2 and 40 characters", code=-32602)
+    return name
 
 
 def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
@@ -835,6 +884,22 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
 
     elif tool_name == "get_people":
         return {"people": [clean_person(p) for p in users_db.get_people(user_id)]}
+
+    elif tool_name == "rename_person":
+        person_id = _required_mcp_string(arguments, "person_id")
+        name = _validated_person_name(arguments)
+        if not users_db.get_person(user_id, person_id):
+            raise ToolExecutionError("Person not found", code=-32001)
+        users_db.update_person(user_id, person_id, name)
+        updated = users_db.get_person(user_id, person_id)
+        return {"success": True, "person": clean_person(updated or {"id": person_id, "name": name})}
+
+    elif tool_name == "delete_person":
+        person_id = _required_mcp_string(arguments, "person_id")
+        if not users_db.get_person(user_id, person_id):
+            raise ToolExecutionError("Person not found", code=-32001)
+        users_db.delete_person(user_id, person_id)
+        return {"success": True}
 
     elif tool_name == "get_screen_activity":
         start = _parse_mcp_date(arguments.get("start_date"), "start_date")

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -31,7 +31,9 @@ import database.chat as chat_db
 import database.screen_activity as screen_activity_db
 import database.daily_summaries as daily_summaries_db
 from models.memories import MemoryDB, Memory, MemoryCategory
+from models.mcp_api_key import MCP_SCOPES_SUPPORTED
 from utils.conversations.render import redact_conversation_for_list
+from utils.executors import storage_executor
 from utils.other.storage import delete_user_person_speech_samples
 from models.conversation_enums import CategoryEnum
 from utils.llm.memories import identify_category_for_memory
@@ -45,6 +47,7 @@ from utils.mcp_memories import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 # Store active sessions
 active_sessions: dict = {}
@@ -56,17 +59,6 @@ MCP_TOKEN_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/token"
 MCP_PROTECTED_RESOURCE_METADATA_URL = f"{MCP_AUTHORIZATION_SERVER_URL}/.well-known/oauth-protected-resource"
 OPENAI_APPS_CHALLENGE_TOKEN = "ZsVB_wpc4R35_tHloCZCokY6H2fBkKyBJrz-4MtXjYE"
 
-MCP_SCOPES_SUPPORTED = [
-    "memories.read",
-    "memories.write",
-    "conversations.read",
-    "action_items.read",
-    "goals.read",
-    "chat.read",
-    "screen_activity.read",
-    "people.read",
-    "people.write",
-]
 
 READ_ONLY_ANNOTATIONS = {
     "readOnlyHint": True,
@@ -95,8 +87,6 @@ CHAT_READ_SECURITY = [{"type": "oauth2", "scopes": ["chat.read"]}]
 SCREEN_ACTIVITY_READ_SECURITY = [{"type": "oauth2", "scopes": ["screen_activity.read"]}]
 PEOPLE_READ_SECURITY = [{"type": "oauth2", "scopes": ["people.read"]}]
 PEOPLE_WRITE_SECURITY = [{"type": "oauth2", "scopes": ["people.write"]}]
-PEOPLE_WRITE_SCOPE = "people.write"
-PEOPLE_WRITE_TOOLS = {"rename_person", "delete_person"}
 
 
 class McpAuth(TypedDict):
@@ -568,6 +558,13 @@ def _validated_person_name(arguments: dict) -> str:
     return name
 
 
+def _delete_person_speech_samples_async(user_id: str, person_id: str) -> None:
+    try:
+        delete_user_person_speech_samples(user_id, person_id)
+    except Exception:
+        logger.exception("Failed to delete person speech samples uid=%s person_id=%s", user_id, person_id)
+
+
 def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: Optional[List[str]] = None) -> dict:
     """Execute an MCP tool and return the result. Raises ToolExecutionError on failure."""
     granted_scope_set = set(MCP_SCOPES_SUPPORTED if granted_scopes is None else granted_scopes)
@@ -917,7 +914,7 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: 
         person_id = _required_mcp_string(arguments, "person_id")
         if not users_db.get_person(user_id, person_id):
             raise ToolExecutionError("Person not found", code=-32001)
-        delete_user_person_speech_samples(user_id, person_id)
+        storage_executor.submit(_delete_person_speech_samples_async, user_id, person_id)
         users_db.delete_person(user_id, person_id)
         return {"success": True}
 

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -911,8 +911,7 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: 
         if not users_db.get_person(user_id, person_id):
             raise ToolExecutionError("Person not found", code=-32001)
         users_db.update_person(user_id, person_id, name)
-        updated = users_db.get_person(user_id, person_id)
-        return {"success": True, "person": clean_person(updated or {"id": person_id, "name": name})}
+        return {"success": True, "person": {"id": person_id, "name": name}}
 
     elif tool_name == "delete_person":
         person_id = _required_mcp_string(arguments, "person_id")

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -562,7 +562,7 @@ def _delete_person_speech_samples_async(user_id: str, person_id: str) -> None:
     try:
         delete_user_person_speech_samples(user_id, person_id)
     except Exception:
-        logger.exception("Failed to delete person speech samples uid=%s person_id=%s", user_id, person_id)
+        logger.exception("Failed to delete person speech samples")
 
 
 def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: Optional[List[str]] = None) -> dict:

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -497,6 +497,13 @@ MCP_TOOLS = [
     },
 ]
 
+TOOL_REQUIRED_SCOPES = {
+    tool["name"]: sorted(
+        {scope for security_scheme in tool.get("securitySchemes", []) for scope in security_scheme.get("scopes", [])}
+    )
+    for tool in MCP_TOOLS
+}
+
 
 @router.get("/.well-known/oauth-protected-resource", tags=["mcp"])
 def oauth_protected_resource_metadata():
@@ -563,8 +570,11 @@ def _validated_person_name(arguments: dict) -> str:
 
 def execute_tool(user_id: str, tool_name: str, arguments: dict, granted_scopes: Optional[List[str]] = None) -> dict:
     """Execute an MCP tool and return the result. Raises ToolExecutionError on failure."""
-    if tool_name in PEOPLE_WRITE_TOOLS and PEOPLE_WRITE_SCOPE not in (granted_scopes or []):
-        raise ToolExecutionError(f"Insufficient permissions. Required scope: {PEOPLE_WRITE_SCOPE}", code=-32003)
+    granted_scope_set = set(MCP_SCOPES_SUPPORTED if granted_scopes is None else granted_scopes)
+    required_scopes = TOOL_REQUIRED_SCOPES.get(tool_name, [])
+    missing_scopes = [scope for scope in required_scopes if scope not in granted_scope_set]
+    if missing_scopes:
+        raise ToolExecutionError(f"Insufficient permissions. Required scope: {', '.join(missing_scopes)}", code=-32003)
 
     if tool_name == "get_user_profile":
         profile = users_db.get_ai_user_profile(user_id)

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -260,7 +260,9 @@ class TestPeople:
         renamed = {**original, 'name': 'Robert'}
         mock_db.get_person.side_effect = [original, renamed]
 
-        result = sse.execute_tool(UID, 'rename_person', {'person_id': ' p1 ', 'name': ' Robert '})
+        result = sse.execute_tool(
+            UID, 'rename_person', {'person_id': ' p1 ', 'name': ' Robert '}, granted_scopes=['people.write']
+        )
 
         mock_db.update_person.assert_called_once_with(UID, 'p1', 'Robert')
         assert result['success'] is True
@@ -272,7 +274,9 @@ class TestPeople:
     def test_rename_person_rejects_bad_name(self, mock_db):
         for value in ['', ' ', 'x', 'x' * 41]:
             with pytest.raises(sse.ToolExecutionError) as exc_info:
-                sse.execute_tool(UID, 'rename_person', {'person_id': 'p1', 'name': value})
+                sse.execute_tool(
+                    UID, 'rename_person', {'person_id': 'p1', 'name': value}, granted_scopes=['people.write']
+                )
             assert exc_info.value.code == -32602
         mock_db.update_person.assert_not_called()
 
@@ -280,24 +284,39 @@ class TestPeople:
     def test_rename_person_requires_existing_person(self, mock_db):
         mock_db.get_person.return_value = None
         with pytest.raises(sse.ToolExecutionError) as exc_info:
-            sse.execute_tool(UID, 'rename_person', {'person_id': 'missing', 'name': 'Robert'})
+            sse.execute_tool(
+                UID, 'rename_person', {'person_id': 'missing', 'name': 'Robert'}, granted_scopes=['people.write']
+            )
         assert exc_info.value.code == -32001
         mock_db.update_person.assert_not_called()
 
+    @patch('routers.mcp_sse.delete_user_person_speech_samples')
     @patch('routers.mcp_sse.users_db')
-    def test_delete_person_tool_deletes_existing_person(self, mock_db):
+    def test_delete_person_tool_deletes_existing_person(self, mock_db, mock_delete_samples):
         mock_db.get_person.return_value = self._person()
-        result = sse.execute_tool(UID, 'delete_person', {'person_id': ' p1 '})
+        result = sse.execute_tool(UID, 'delete_person', {'person_id': ' p1 '}, granted_scopes=['people.write'])
         assert result == {'success': True}
+        mock_delete_samples.assert_called_once_with(UID, 'p1')
         mock_db.delete_person.assert_called_once_with(UID, 'p1')
 
     @patch('routers.mcp_sse.users_db')
     def test_delete_person_requires_existing_person(self, mock_db):
         mock_db.get_person.return_value = None
         with pytest.raises(sse.ToolExecutionError) as exc_info:
-            sse.execute_tool(UID, 'delete_person', {'person_id': 'missing'})
+            sse.execute_tool(UID, 'delete_person', {'person_id': 'missing'}, granted_scopes=['people.write'])
         assert exc_info.value.code == -32001
         mock_db.delete_person.assert_not_called()
+
+    @patch('routers.mcp_sse.users_db')
+    def test_people_write_tools_require_people_write_scope(self, mock_db):
+        for tool_name, arguments in [
+            ('rename_person', {'person_id': 'p1', 'name': 'Robert'}),
+            ('delete_person', {'person_id': 'p1'}),
+        ]:
+            with pytest.raises(sse.ToolExecutionError) as exc_info:
+                sse.execute_tool(UID, tool_name, arguments, granted_scopes=['people.read'])
+            assert exc_info.value.code == -32003
+        mock_db.get_person.assert_not_called()
 
 
 class TestScreenActivity:

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -146,6 +146,45 @@ NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
 UID = "user-1"
 
 
+class TestMcpKeys:
+    @patch('routers.mcp.mcp_api_key_db')
+    def test_create_key_defaults_to_people_write_scope(self, mock_db):
+        api_key_data = MagicMock()
+        api_key_data.model_dump.return_value = {
+            'id': 'key-1',
+            'name': 'Agent',
+            'key_prefix': 'omi_mcp_test',
+            'created_at': NOW,
+            'last_used_at': None,
+            'scopes': ['people.write'],
+        }
+        mock_db.create_mcp_key.return_value = ('omi_mcp_secret', api_key_data)
+
+        result = rest.create_key(rest.McpApiKeyCreate(name=' Agent '), uid=UID)
+
+        _, _, scopes = mock_db.create_mcp_key.call_args.args
+        assert 'people.write' in scopes
+        assert 'people.read' in scopes
+        assert result.scopes == ['people.write']
+
+    @patch('routers.mcp.mcp_api_key_db')
+    def test_create_key_preserves_explicit_scope_subset(self, mock_db):
+        api_key_data = MagicMock()
+        api_key_data.model_dump.return_value = {
+            'id': 'key-1',
+            'name': 'Agent',
+            'key_prefix': 'omi_mcp_test',
+            'created_at': NOW,
+            'last_used_at': None,
+            'scopes': ['people.read'],
+        }
+        mock_db.create_mcp_key.return_value = ('omi_mcp_secret', api_key_data)
+
+        rest.create_key(rest.McpApiKeyCreate(name='Agent', scopes=['people.read']), uid=UID)
+
+        mock_db.create_mcp_key.assert_called_once_with(UID, 'Agent', ['people.read'])
+
+
 def _action_item(item_id='a1', desc='Email Bob', completed=False, deleted=False, locked=False):
     return {
         'id': item_id,

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -312,20 +312,16 @@ class TestPeople:
         assert 'speech_samples' not in result['people'][0]
 
     @patch('routers.mcp_sse.users_db')
-    def test_rename_person_tool_validates_and_returns_cleaned_person(self, mock_db):
-        original = self._person()
-        renamed = {**original, 'name': 'Robert'}
-        mock_db.get_person.side_effect = [original, renamed]
+    def test_rename_person_tool_validates_and_returns_minimal_person(self, mock_db):
+        mock_db.get_person.return_value = self._person()
 
         result = sse.execute_tool(
             UID, 'rename_person', {'person_id': ' p1 ', 'name': ' Robert '}, granted_scopes=['people.write']
         )
 
         mock_db.update_person.assert_called_once_with(UID, 'p1', 'Robert')
-        assert result['success'] is True
-        assert result['person']['name'] == 'Robert'
-        assert 'speech_samples' not in result['person']
-        assert 'speaker_embedding' not in result['person']
+        assert result == {'success': True, 'person': {'id': 'p1', 'name': 'Robert'}}
+        assert mock_db.get_person.call_count == 1
 
     @patch('routers.mcp_sse.users_db')
     def test_rename_person_rejects_bad_name(self, mock_db):

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -184,6 +184,24 @@ class TestMcpKeys:
 
         mock_db.create_mcp_key.assert_called_once_with(UID, 'Agent', ['people.read'])
 
+    @patch('routers.mcp.mcp_api_key_db')
+    def test_create_key_preserves_explicit_empty_scopes(self, mock_db):
+        api_key_data = MagicMock()
+        api_key_data.model_dump.return_value = {
+            'id': 'key-1',
+            'name': 'Agent',
+            'key_prefix': 'omi_mcp_test',
+            'created_at': NOW,
+            'last_used_at': None,
+            'scopes': [],
+        }
+        mock_db.create_mcp_key.return_value = ('omi_mcp_secret', api_key_data)
+
+        result = rest.create_key(rest.McpApiKeyCreate(name='Agent', scopes=[]), uid=UID)
+
+        mock_db.create_mcp_key.assert_called_once_with(UID, 'Agent', [])
+        assert result.scopes == []
+
 
 def _action_item(item_id='a1', desc='Email Bob', completed=False, deleted=False, locked=False):
     return {
@@ -356,6 +374,15 @@ class TestPeople:
                 sse.execute_tool(UID, tool_name, arguments, granted_scopes=['people.read'])
             assert exc_info.value.code == -32003
         mock_db.get_person.assert_not_called()
+
+    @patch('routers.mcp_sse.chat_db')
+    def test_read_tools_require_their_advertised_scope(self, mock_db):
+        with pytest.raises(sse.ToolExecutionError) as exc_info:
+            sse.execute_tool(UID, 'get_chat_messages', {'limit': 1}, granted_scopes=['memories.read'])
+
+        assert exc_info.value.code == -32003
+        assert 'chat.read' in exc_info.value.message
+        mock_db.get_messages.assert_not_called()
 
 
 class TestScreenActivity:

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -143,6 +143,7 @@ sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError',
 
 from routers import mcp as rest  # noqa: E402
 from routers import mcp_sse as sse  # noqa: E402
+from models.mcp_api_key import MCP_LEGACY_API_KEY_SCOPES  # noqa: E402
 
 NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
 UID = "user-1"
@@ -203,6 +204,11 @@ class TestMcpKeys:
 
         mock_db.create_mcp_key.assert_called_once_with(UID, 'Agent', [])
         assert result.scopes == []
+
+    def test_legacy_scopes_preserve_existing_memory_write_without_people_write(self):
+        assert 'memories.write' in MCP_LEGACY_API_KEY_SCOPES
+        assert 'memories.read' in MCP_LEGACY_API_KEY_SCOPES
+        assert 'people.write' not in MCP_LEGACY_API_KEY_SCOPES
 
 
 class TestMcpRestScopes:

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -343,13 +343,13 @@ class TestPeople:
         assert exc_info.value.code == -32001
         mock_db.update_person.assert_not_called()
 
-    @patch('routers.mcp_sse.delete_user_person_speech_samples')
+    @patch('routers.mcp_sse.storage_executor')
     @patch('routers.mcp_sse.users_db')
-    def test_delete_person_tool_deletes_existing_person(self, mock_db, mock_delete_samples):
+    def test_delete_person_tool_deletes_existing_person(self, mock_db, mock_storage_executor):
         mock_db.get_person.return_value = self._person()
         result = sse.execute_tool(UID, 'delete_person', {'person_id': ' p1 '}, granted_scopes=['people.write'])
         assert result == {'success': True}
-        mock_delete_samples.assert_called_once_with(UID, 'p1')
+        mock_storage_executor.submit.assert_called_once_with(sse._delete_person_speech_samples_async, UID, 'p1')
         mock_db.delete_person.assert_called_once_with(UID, 'p1')
 
     @patch('routers.mcp_sse.users_db')

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -243,7 +243,7 @@ class TestMcpRestScopes:
             rest.get_chat_messages: rest.get_uid_with_mcp_chat_read,
             rest.get_people: rest.get_uid_with_mcp_people_read,
             rest.get_screen_activity: rest.get_uid_with_mcp_screen_activity_read,
-            rest.get_daily_summaries: rest.get_uid_with_mcp_memories_read,
+            rest.get_daily_summaries: rest.get_uid_with_mcp_conversations_read,
         }
 
         for endpoint, dependency in expected.items():

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -8,6 +8,8 @@ stubbing pattern in test_mcp_search_memories.py.
 
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
+import asyncio
+import inspect
 import os
 import sys
 from types import ModuleType
@@ -201,6 +203,51 @@ class TestMcpKeys:
 
         mock_db.create_mcp_key.assert_called_once_with(UID, 'Agent', [])
         assert result.scopes == []
+
+
+class TestMcpRestScopes:
+    def test_scope_dependency_rejects_missing_scope(self):
+        with pytest.raises(rest.HTTPException) as exc:
+            asyncio.run(rest.get_uid_with_mcp_people_read({'user_id': UID, 'scopes': ['memories.read']}))
+
+        assert exc.value.status_code == 403
+        assert 'people.read' in exc.value.detail
+
+    def test_scope_dependency_allows_required_scope(self):
+        uid = asyncio.run(rest.get_uid_with_mcp_people_read({'user_id': UID, 'scopes': ['people.read']}))
+
+        assert uid == UID
+
+    @patch('routers.mcp.mcp_api_key_db')
+    def test_api_key_auth_reads_stored_scopes(self, mock_db):
+        mock_db.get_auth_by_api_key.return_value = {'user_id': UID, 'scopes': ['people.read']}
+
+        auth = asyncio.run(rest.get_mcp_api_key_auth('Bearer omi_mcp_secret'))
+
+        mock_db.get_auth_by_api_key.assert_called_once_with('omi_mcp_secret')
+        assert auth == {'user_id': UID, 'scopes': ['people.read']}
+
+    def test_rest_routes_use_scope_specific_dependencies(self):
+        expected = {
+            rest.create_memory: rest.get_uid_with_mcp_memories_write,
+            rest.delete_memory: rest.get_uid_with_mcp_memories_write,
+            rest.edit_memory: rest.get_uid_with_mcp_memories_write,
+            rest.get_user_profile: rest.get_uid_with_mcp_memories_read,
+            rest.search_memories: rest.get_uid_with_mcp_memories_read,
+            rest.get_memories: rest.get_uid_with_mcp_memories_read,
+            rest.get_conversations: rest.get_uid_with_mcp_conversations_read,
+            rest.search_conversations: rest.get_uid_with_mcp_conversations_read,
+            rest.get_conversation_by_id: rest.get_uid_with_mcp_conversations_read,
+            rest.get_action_items: rest.get_uid_with_mcp_action_items_read,
+            rest.get_goals: rest.get_uid_with_mcp_goals_read,
+            rest.get_chat_messages: rest.get_uid_with_mcp_chat_read,
+            rest.get_people: rest.get_uid_with_mcp_people_read,
+            rest.get_screen_activity: rest.get_uid_with_mcp_screen_activity_read,
+            rest.get_daily_summaries: rest.get_uid_with_mcp_memories_read,
+        }
+
+        for endpoint, dependency in expected.items():
+            assert inspect.signature(endpoint).parameters['uid'].default.dependency is dependency
 
 
 def _action_item(item_id='a1', desc='Email Bob', completed=False, deleted=False, locked=False):

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -254,6 +254,51 @@ class TestPeople:
         assert result['people'][0]['id'] == 'p1'
         assert 'speech_samples' not in result['people'][0]
 
+    @patch('routers.mcp_sse.users_db')
+    def test_rename_person_tool_validates_and_returns_cleaned_person(self, mock_db):
+        original = self._person()
+        renamed = {**original, 'name': 'Robert'}
+        mock_db.get_person.side_effect = [original, renamed]
+
+        result = sse.execute_tool(UID, 'rename_person', {'person_id': ' p1 ', 'name': ' Robert '})
+
+        mock_db.update_person.assert_called_once_with(UID, 'p1', 'Robert')
+        assert result['success'] is True
+        assert result['person']['name'] == 'Robert'
+        assert 'speech_samples' not in result['person']
+        assert 'speaker_embedding' not in result['person']
+
+    @patch('routers.mcp_sse.users_db')
+    def test_rename_person_rejects_bad_name(self, mock_db):
+        for value in ['', ' ', 'x', 'x' * 41]:
+            with pytest.raises(sse.ToolExecutionError) as exc_info:
+                sse.execute_tool(UID, 'rename_person', {'person_id': 'p1', 'name': value})
+            assert exc_info.value.code == -32602
+        mock_db.update_person.assert_not_called()
+
+    @patch('routers.mcp_sse.users_db')
+    def test_rename_person_requires_existing_person(self, mock_db):
+        mock_db.get_person.return_value = None
+        with pytest.raises(sse.ToolExecutionError) as exc_info:
+            sse.execute_tool(UID, 'rename_person', {'person_id': 'missing', 'name': 'Robert'})
+        assert exc_info.value.code == -32001
+        mock_db.update_person.assert_not_called()
+
+    @patch('routers.mcp_sse.users_db')
+    def test_delete_person_tool_deletes_existing_person(self, mock_db):
+        mock_db.get_person.return_value = self._person()
+        result = sse.execute_tool(UID, 'delete_person', {'person_id': ' p1 '})
+        assert result == {'success': True}
+        mock_db.delete_person.assert_called_once_with(UID, 'p1')
+
+    @patch('routers.mcp_sse.users_db')
+    def test_delete_person_requires_existing_person(self, mock_db):
+        mock_db.get_person.return_value = None
+        with pytest.raises(sse.ToolExecutionError) as exc_info:
+            sse.execute_tool(UID, 'delete_person', {'person_id': 'missing'})
+        assert exc_info.value.code == -32001
+        mock_db.delete_person.assert_not_called()
+
 
 class TestScreenActivity:
     def _row(self):
@@ -321,10 +366,20 @@ class TestToolRegistry:
             'get_goals',
             'get_chat_messages',
             'get_people',
+            'rename_person',
+            'delete_person',
             'get_screen_activity',
             'get_daily_summaries',
         ]:
             assert expected in names, f"{expected} missing from MCP_TOOLS"
+
+    def test_people_write_tools_have_write_scope(self):
+        by_name = {tool['name']: tool for tool in sse.MCP_TOOLS}
+        assert 'people.write' in sse.MCP_SCOPES_SUPPORTED
+        assert by_name['rename_person']['securitySchemes'] == sse.PEOPLE_WRITE_SECURITY
+        assert by_name['rename_person']['annotations'] == sse.WRITE_ANNOTATIONS
+        assert by_name['delete_person']['securitySchemes'] == sse.PEOPLE_WRITE_SECURITY
+        assert by_name['delete_person']['annotations'] == sse.DESTRUCTIVE_WRITE_ANNOTATIONS
 
     def test_every_tool_has_a_dispatch_branch(self):
         # Each declared read-only data tool must dispatch (not fall through to "Unknown tool").


### PR DESCRIPTION
## Summary
- Adds hosted MCP `rename_person` and `delete_person` tools for people/contact cleanup.
- Introduces `people.write` OAuth metadata/security scheme for the new mutation tools while keeping `get_people` read-only.
- Validates required person ids and 2–40 char trimmed names; checks person existence before mutating.
- Adds unit coverage for descriptors, scope metadata, validation, 404 handling, rename behavior, and delete behavior.

## Testing
```text
cd backend
ENCRYPTION_SECRET=*** VIRTUAL_ENV= uv run python -m pytest tests/unit/test_mcp_data_endpoints.py -q
# 25 passed, 1 warning

VIRTUAL_ENV= uv run python -m py_compile routers/mcp_sse.py
git diff --check
```

Notes:
- Scope intentionally excludes merge/dismiss. Those need product semantics and/or DB primitives beyond existing hard-delete/rename behavior.
- Local test venv was bootstrapped with pytest/fastapi/pydantic because this worktree had no backend `.venv`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

