### PR TITLE
test(parakeet): upload DER diagnostics artifact

### DIFF
--- a/.github/workflows/parakeet_gpu_tests.yml
+++ b/.github/workflows/parakeet_gpu_tests.yml
@@ -138,6 +138,14 @@ jobs:
                         python -m pytest tests/container/test_parakeet_der_benchmark.py -v -s \
                           --tb=short 2>&1
                         BENCH_EXIT=$?
+                        echo "--- DER Diagnostics Artifact ---"
+                        if [ -f /tmp/parakeet-gpu-artifacts/der-benchmark-results.json ]; then
+                          echo "DER_DIAGNOSTICS_JSON_BEGIN"
+                          cat /tmp/parakeet-gpu-artifacts/der-benchmark-results.json
+                          echo "DER_DIAGNOSTICS_JSON_END"
+                        else
+                          echo "DER diagnostics artifact was not produced"
+                        fi
                         set -e
 
                         if [ $BENCH_EXIT -ne 0 ]; then
@@ -256,33 +264,38 @@ jobs:
       - name: Collect test logs
         if: always()
         run: |
+          mkdir -p artifacts/parakeet
           echo "=== GPU Test Job Logs ==="
-          kubectl -n ${{ env.NAMESPACE }} logs job/${{ env.JOB_NAME }} --tail=200 2>&1 || true
+          kubectl -n ${{ env.NAMESPACE }} logs job/${{ env.JOB_NAME }} 2>&1 | tee artifacts/parakeet/gpu-test.log || true
           echo ""
           echo "=== Job/Pod Details ==="
           kubectl -n ${{ env.NAMESPACE }} describe job/${{ env.JOB_NAME }} 2>&1 || true
           kubectl -n ${{ env.NAMESPACE }} get events --field-selector involvedObject.name=${{ env.JOB_NAME }} 2>&1 || true
 
-      - name: Collect DER diagnostics artifact
+      - name: Extract DER diagnostics artifact
         if: always()
         run: |
-          mkdir -p artifacts/parakeet
-          POD=$(kubectl -n ${{ env.NAMESPACE }} get pod -l job-name=${{ env.JOB_NAME }} \
-            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          if [[ -z "$POD" ]]; then
-            echo "No GPU test pod found; skipping DER artifact copy"
-            exit 0
-          fi
-          kubectl -n ${{ env.NAMESPACE }} cp \
-            "$POD:/tmp/parakeet-gpu-artifacts/der-benchmark-results.json" \
-            artifacts/parakeet/der-benchmark-results.json || \
-            echo "DER diagnostics artifact was not produced"
+          python - <<'PY'
+          from pathlib import Path
+
+          log_path = Path("artifacts/parakeet/gpu-test.log")
+          output_path = Path("artifacts/parakeet/der-benchmark-results.json")
+          text = log_path.read_text() if log_path.exists() else ""
+          start = "DER_DIAGNOSTICS_JSON_BEGIN"
+          end = "DER_DIAGNOSTICS_JSON_END"
+          if start not in text or end not in text:
+              print("DER diagnostics JSON markers not found; skipping artifact extraction")
+              raise SystemExit(0)
+          json_text = text.split(start, 1)[1].split(end, 1)[0].strip()
+          output_path.write_text(json_text + "\n")
+          print(f"Wrote {output_path}")
+          PY
 
       - name: Upload DER diagnostics artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: parakeet-der-diagnostics-${{ github.run_id }}
+          name: parakeet-der-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/parakeet/der-benchmark-results.json
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/parakeet_gpu_tests.yml
+++ b/.github/workflows/parakeet_gpu_tests.yml
@@ -283,10 +283,12 @@ jobs:
           text = log_path.read_text() if log_path.exists() else ""
           start = "DER_DIAGNOSTICS_JSON_BEGIN"
           end = "DER_DIAGNOSTICS_JSON_END"
-          if start not in text or end not in text:
-              print("DER diagnostics JSON markers not found; skipping artifact extraction")
+          start_index = text.find(start)
+          end_index = text.find(end, start_index + len(start)) if start_index != -1 else -1
+          if start_index == -1 or end_index == -1:
+              print("DER diagnostics JSON markers not found in order; skipping artifact extraction")
               raise SystemExit(0)
-          json_text = text.split(start, 1)[1].split(end, 1)[0].strip()
+          json_text = text[start_index + len(start) : end_index].strip()
           output_path.write_text(json_text + "\n")
           print(f"Wrote {output_path}")
           PY

--- a/.github/workflows/parakeet_gpu_tests.yml
+++ b/.github/workflows/parakeet_gpu_tests.yml
@@ -134,6 +134,7 @@ jobs:
 
                         set +e
                         DER_REPORT_ONLY=${DER_REPORT_ONLY:-false} \
+                        DER_RESULTS_PATH=/tmp/parakeet-gpu-artifacts/der-benchmark-results.json \
                         python -m pytest tests/container/test_parakeet_der_benchmark.py -v -s \
                           --tb=short 2>&1
                         BENCH_EXIT=$?
@@ -261,6 +262,30 @@ jobs:
           echo "=== Job/Pod Details ==="
           kubectl -n ${{ env.NAMESPACE }} describe job/${{ env.JOB_NAME }} 2>&1 || true
           kubectl -n ${{ env.NAMESPACE }} get events --field-selector involvedObject.name=${{ env.JOB_NAME }} 2>&1 || true
+
+      - name: Collect DER diagnostics artifact
+        if: always()
+        run: |
+          mkdir -p artifacts/parakeet
+          POD=$(kubectl -n ${{ env.NAMESPACE }} get pod -l job-name=${{ env.JOB_NAME }} \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [[ -z "$POD" ]]; then
+            echo "No GPU test pod found; skipping DER artifact copy"
+            exit 0
+          fi
+          kubectl -n ${{ env.NAMESPACE }} cp \
+            "$POD:/tmp/parakeet-gpu-artifacts/der-benchmark-results.json" \
+            artifacts/parakeet/der-benchmark-results.json || \
+            echo "DER diagnostics artifact was not produced"
+
+      - name: Upload DER diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parakeet-der-diagnostics-${{ github.run_id }}
+          path: artifacts/parakeet/der-benchmark-results.json
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Check job result
         run: |

--- a/backend/tests/container/test_parakeet_der_benchmark.py
+++ b/backend/tests/container/test_parakeet_der_benchmark.py
@@ -27,6 +27,7 @@ import tempfile
 import time
 import urllib.request
 import zipfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,40 @@ MAX_CLIPS = int(os.getenv("VOXCONVERSE_MAX_CLIPS", "15"))
 DER_THRESHOLD = float(os.getenv("DER_THRESHOLD", "0.40"))
 PER_CLIP_DER_MAX = float(os.getenv("PER_CLIP_DER_MAX", "0.85"))
 REPORT_ONLY = os.getenv("DER_REPORT_ONLY", "false").lower() == "true"
+DER_RESULTS_PATH = os.getenv("DER_RESULTS_PATH")
+DER_REPORT_SCHEMA_VERSION = 1
+
+
+def _aggregate_components(ok_results):
+    total_scored = sum(r["total"] for r in ok_results)
+    total_missed = sum(r["missed"] for r in ok_results)
+    total_fa = sum(r["false_alarm"] for r in ok_results)
+    total_confusion = sum(r["confusion"] for r in ok_results)
+    agg_der = (total_missed + total_fa + total_confusion) / total_scored if total_scored > 0 else 1.0
+    return {
+        "der": agg_der,
+        "total": total_scored,
+        "missed": total_missed,
+        "false_alarm": total_fa,
+        "confusion": total_confusion,
+    }
+
+
+def write_der_results_artifact(results, output_path=None):
+    """Persist structured DER diagnostics for CI artifact upload."""
+    target = output_path or DER_RESULTS_PATH
+    if not target:
+        return None
+
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    with open(tmp_path, "w") as f:
+        json.dump(results, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp_path.replace(path)
+    print(f"DER diagnostics written to {path}")
+    return path
 
 
 def load_manifest():
@@ -235,14 +270,18 @@ def run_benchmark():
 
     ok_results = [r for r in results if r["status"] == "ok"]
 
-    if ok_results:
-        total_scored = sum(r["total"] for r in ok_results)
-        total_missed = sum(r["missed"] for r in ok_results)
-        total_fa = sum(r["false_alarm"] for r in ok_results)
-        total_confusion = sum(r["confusion"] for r in ok_results)
-        agg_der = (total_missed + total_fa + total_confusion) / total_scored if total_scored > 0 else 1.0
-    else:
-        agg_der = 1.0
+    aggregate = (
+        _aggregate_components(ok_results)
+        if ok_results
+        else {
+            "der": 1.0,
+            "total": 0,
+            "missed": 0,
+            "false_alarm": 0,
+            "confusion": 0,
+        }
+    )
+    agg_der = aggregate["der"]
 
     high_der_clips = [r for r in ok_results if r["der"] > PER_CLIP_DER_MAX]
     skipped = [r for r in results if r["status"] == "skipped"]
@@ -255,15 +294,79 @@ def run_benchmark():
         print(f"High-DER clips (>{PER_CLIP_DER_MAX:.0%}): {[r['id'] for r in high_der_clips]}")
     print(f"{'=' * 60}\n")
 
-    return {
+    result = {
+        "schema_version": DER_REPORT_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "config": {
+            "parakeet_url": PARAKEET_URL,
+            "max_clips": MAX_CLIPS,
+            "der_threshold": DER_THRESHOLD,
+            "per_clip_der_max": PER_CLIP_DER_MAX,
+            "report_only": REPORT_ONLY,
+            "collar_s": 0.25,
+            "skip_overlap": True,
+        },
         "aggregate_der": agg_der,
+        "aggregate": aggregate,
         "per_clip": results,
         "threshold": DER_THRESHOLD,
         "per_clip_max": PER_CLIP_DER_MAX,
         "report_only": REPORT_ONLY,
         "clips_scored": len(ok_results),
         "clips_total": len(clips),
+        "clips_skipped": len(skipped),
+        "clips_errored": len(errors),
     }
+    write_der_results_artifact(result)
+    return result
+
+
+class TestDERDiagnosticsArtifact:
+    def test_aggregate_components_from_synthetic_records(self):
+        aggregate = _aggregate_components(
+            [
+                {"total": 10.0, "missed": 1.0, "false_alarm": 0.5, "confusion": 0.5},
+                {"total": 30.0, "missed": 3.0, "false_alarm": 1.0, "confusion": 0.0},
+            ]
+        )
+
+        assert aggregate == {
+            "der": 0.15,
+            "total": 40.0,
+            "missed": 4.0,
+            "false_alarm": 1.5,
+            "confusion": 0.5,
+        }
+
+    def test_write_der_results_artifact(self, tmp_path):
+        artifact_path = tmp_path / "der" / "results.json"
+        results = {
+            "schema_version": DER_REPORT_SCHEMA_VERSION,
+            "aggregate_der": 0.341,
+            "aggregate": {"der": 0.341, "total": 100.0, "missed": 10.0, "false_alarm": 4.0, "confusion": 20.1},
+            "per_clip": [
+                {
+                    "id": "dohag",
+                    "status": "ok",
+                    "der": 0.052,
+                    "missed": 1.0,
+                    "false_alarm": 0.0,
+                    "confusion": 0.1,
+                    "total": 21.0,
+                    "ref_speakers": 1,
+                    "hyp_speakers": 1,
+                }
+            ],
+        }
+
+        written = write_der_results_artifact(results, artifact_path)
+
+        assert written == artifact_path
+        loaded = json.loads(artifact_path.read_text())
+        assert loaded["schema_version"] == DER_REPORT_SCHEMA_VERSION
+        assert loaded["aggregate"]["confusion"] == 20.1
+        assert loaded["per_clip"][0]["ref_speakers"] == 1
+        assert loaded["per_clip"][0]["hyp_speakers"] == 1
 
 
 class TestVoxConverseDERBenchmark:


### PR DESCRIPTION
## Summary

- persist structured VoxConverse DER diagnostics from Phase 5 when `DER_RESULTS_PATH` is set
- include aggregate DER components, per-clip components, reference/hypothesis speaker counts, and benchmark config in the JSON report
- copy the report from the GPU test Kubernetes pod and upload it as a GitHub Actions artifact
- add CPU-only coverage for aggregate/report artifact generation

Enables #8110.
Closes #8350.

## Verification

```bash
cd backend
VIRTUAL_ENV= uv run python -m pytest tests/container/test_parakeet_der_benchmark.py -q -k DERDiagnosticsArtifact
python - <<'PY'
import yaml, pathlib
p = pathlib.Path('../.github/workflows/parakeet_gpu_tests.yml')
data = yaml.safe_load(p.read_text())
assert 'gpu-tests' in data['jobs']
print('workflow yaml ok')
PY
git diff --check
```

Result:

```text
2 passed, 3 deselected
workflow yaml ok
```

Full Phase 5 DER execution still requires the GPU workflow/container environment.