### PR TITLE
fix(android): fail closed when Background Mode has no native BLE route

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3028,5 +3028,6 @@
     "recordingMode": "وضع التسجيل",
     "captureModeLater": "لاحقًا",
     "captureModeLiveDescription": "تفريغ نصي فوري أثناء حديثك.",
-    "captureModeLaterDescription": "احفظ الصوت الآن وفرّغه نصيًا متى شئت."
+    "captureModeLaterDescription": "احفظ الصوت الآن وفرّغه نصيًا متى شئت.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3029,5 +3029,5 @@
     "captureModeLater": "لاحقًا",
     "captureModeLiveDescription": "تفريغ نصي فوري أثناء حديثك.",
     "captureModeLaterDescription": "احفظ الصوت الآن وفرّغه نصيًا متى شئت.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "وضع الخلفية غير متاح لأنه لا يوجد جهاز متوافق متصل. وصّل جهاز Omi أو OpenGlass أو Friend Pendant لاستخدام هذه الميزة."
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Рэжым запісу",
     "captureModeLater": "Пазней",
     "captureModeLiveDescription": "Транскрыбаванне ў рэальным часе падчас размовы.",
-    "captureModeLaterDescription": "Захавайце аўдыя зараз і транскрыбуйце калі заўгодна."
+    "captureModeLaterDescription": "Захавайце аўдыя зараз і транскрыбуйце калі заўгодна.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Пазней",
     "captureModeLiveDescription": "Транскрыбаванне ў рэальным часе падчас размовы.",
     "captureModeLaterDescription": "Захавайце аўдыя зараз і транскрыбуйце калі заўгодна.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Фонавы рэжым недаступны, бо не падключана сумяшчальная прылада. Падключыце Omi, OpenGlass або Friend Pendant, каб выкарыстоўваць гэту функцыю."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3031,5 +3031,5 @@
     "captureModeLater": "По-късно",
     "captureModeLiveDescription": "Транскрибиране в реално време, докато говорите.",
     "captureModeLaterDescription": "Запазете звука сега и го транскрибирайте, когато пожелаете.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Фоновият режим не е наличен, защото няма свързано съвместимо устройство. Свържете устройство Omi, OpenGlass или Friend Pendant, за да използвате тази функция."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3030,5 +3030,6 @@
     "recordingMode": "Режим на запис",
     "captureModeLater": "По-късно",
     "captureModeLiveDescription": "Транскрибиране в реално време, докато говорите.",
-    "captureModeLaterDescription": "Запазете звука сега и го транскрибирайте, когато пожелаете."
+    "captureModeLaterDescription": "Запазете звука сега и го транскрибирайте, когато пожелаете.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "পরে",
     "captureModeLiveDescription": "আপনি কথা বলার সাথে সাথে রিয়েল-টাইমে ট্রান্সক্রাইব করুন।",
     "captureModeLaterDescription": "এখন অডিও সংরক্ষণ করুন এবং যখন খুশি ট্রান্সক্রাইব করুন।",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "কোনো সামঞ্জস্যপূর্ণ ডিভাইস সংযুক্ত না থাকায় ব্যাকগ্রাউন্ড মোড উপলভ্য নয়। এই ফিচারটি ব্যবহার করতে একটি Omi, OpenGlass বা Friend Pendant ডিভাইস সংযুক্ত করুন।"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "রেকর্ডিং মোড",
     "captureModeLater": "পরে",
     "captureModeLiveDescription": "আপনি কথা বলার সাথে সাথে রিয়েল-টাইমে ট্রান্সক্রাইব করুন।",
-    "captureModeLaterDescription": "এখন অডিও সংরক্ষণ করুন এবং যখন খুশি ট্রান্সক্রাইব করুন।"
+    "captureModeLaterDescription": "এখন অডিও সংরক্ষণ করুন এবং যখন খুশি ট্রান্সক্রাইব করুন।",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Način snimanja",
     "captureModeLater": "Kasnije",
     "captureModeLiveDescription": "Transkribirajte u stvarnom vremenu dok govorite.",
-    "captureModeLaterDescription": "Spremite zvuk sada i transkribirajte kad god želite."
+    "captureModeLaterDescription": "Spremite zvuk sada i transkribirajte kad god želite.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Kasnije",
     "captureModeLiveDescription": "Transkribirajte u stvarnom vremenu dok govorite.",
     "captureModeLaterDescription": "Spremite zvuk sada i transkribirajte kad god želite.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Pozadinski način rada nije dostupan jer nije povezan kompatibilan uređaj. Povežite Omi, OpenGlass ili Friend Pendant uređaj da koristite ovu funkciju."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3030,5 +3030,6 @@
     "recordingMode": "Mode de gravació",
     "captureModeLater": "Més tard",
     "captureModeLiveDescription": "Transcriu en temps real mentre parles.",
-    "captureModeLaterDescription": "Desa l'àudio ara i transcriu-lo quan vulguis."
+    "captureModeLaterDescription": "Desa l'àudio ara i transcriu-lo quan vulguis.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3031,5 +3031,5 @@
     "captureModeLater": "Més tard",
     "captureModeLiveDescription": "Transcriu en temps real mentre parles.",
     "captureModeLaterDescription": "Desa l'àudio ara i transcriu-lo quan vulguis.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "El mode en segon pla no està disponible perquè no hi ha cap dispositiu compatible connectat. Connecta un dispositiu Omi, OpenGlass o Friend Pendant per utilitzar aquesta funció."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3031,5 +3031,5 @@
     "captureModeLater": "Později",
     "captureModeLiveDescription": "Přepis v reálném čase, jak mluvíte.",
     "captureModeLaterDescription": "Uložte zvuk nyní a přepište jej, kdykoli budete chtít.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Režim na pozadí není k dispozici, protože není připojeno žádné kompatibilní zařízení. Pro použití této funkce připojte zařízení Omi, OpenGlass nebo Friend Pendant."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3030,5 +3030,6 @@
     "recordingMode": "Režim nahrávání",
     "captureModeLater": "Později",
     "captureModeLiveDescription": "Přepis v reálném čase, jak mluvíte.",
-    "captureModeLaterDescription": "Uložte zvuk nyní a přepište jej, kdykoli budete chtít."
+    "captureModeLaterDescription": "Uložte zvuk nyní a přepište jej, kdykoli budete chtít.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3070,5 +3070,6 @@
     "recordingMode": "Optagetilstand",
     "captureModeLater": "Senere",
     "captureModeLiveDescription": "Transskriber i realtid, mens du taler.",
-    "captureModeLaterDescription": "Gem lyden nu, og transskriber den, når du vil."
+    "captureModeLaterDescription": "Gem lyden nu, og transskriber den, når du vil.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3071,5 +3071,5 @@
     "captureModeLater": "Senere",
     "captureModeLiveDescription": "Transskriber i realtid, mens du taler.",
     "captureModeLaterDescription": "Gem lyden nu, og transskriber den, når du vil.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Baggrundstilstand er ikke tilgængelig, fordi der ikke er tilsluttet en kompatibel enhed. Tilslut en Omi-, OpenGlass- eller Friend Pendant-enhed for at bruge denne funktion."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3030,5 +3030,5 @@
     "captureModeLater": "Später",
     "captureModeLiveDescription": "Transkribiere in Echtzeit, während du sprichst.",
     "captureModeLaterDescription": "Audio jetzt speichern und transkribieren, wann du willst.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Der Hintergrundmodus ist nicht verfügbar, weil kein kompatibles Gerät verbunden ist. Verbinde ein Omi-, OpenGlass- oder Friend Pendant-Gerät, um diese Funktion zu nutzen."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3029,5 +3029,6 @@
     "recordingMode": "Aufnahmemodus",
     "captureModeLater": "Später",
     "captureModeLiveDescription": "Transkribiere in Echtzeit, während du sprichst.",
-    "captureModeLaterDescription": "Audio jetzt speichern und transkribieren, wann du willst."
+    "captureModeLaterDescription": "Audio jetzt speichern und transkribieren, wann du willst.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Αργότερα",
     "captureModeLiveDescription": "Μεταγραφή σε πραγματικό χρόνο καθώς μιλάτε.",
     "captureModeLaterDescription": "Αποθηκεύστε τον ήχο τώρα και μεταγράψτε τον όποτε θέλετε.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Η λειτουργία παρασκηνίου δεν είναι διαθέσιμη επειδή δεν είναι συνδεδεμένη κάποια συμβατή συσκευή. Συνδέστε μια συσκευή Omi, OpenGlass ή Friend Pendant για να χρησιμοποιήσετε αυτήν τη λειτουργία."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Λειτουργία εγγραφής",
     "captureModeLater": "Αργότερα",
     "captureModeLiveDescription": "Μεταγραφή σε πραγματικό χρόνο καθώς μιλάτε.",
-    "captureModeLaterDescription": "Αποθηκεύστε τον ήχο τώρα και μεταγράψτε τον όποτε θέλετε."
+    "captureModeLaterDescription": "Αποθηκεύστε τον ήχο τώρα και μεταγράψτε τον όποτε θέλετε.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11010,6 +11010,10 @@
     "@backgroundModeNote": {
         "description": "Caveat note shown in the Background Mode sheet"
     },
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature.",
+    "@backgroundModeUnavailable": {
+        "description": "Warning shown in Background Mode sheet when no device with a native BLE audio route is connected"
+    },
     "regenerateRecap": "Regenerate recap",
     "recapRegeneratedSnackbar": "Recap regenerated",
     "recapRegenerateFailed": "Couldn't regenerate the recap. Try again later.",

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3063,5 +3063,5 @@
     "captureModeLater": "Después",
     "captureModeLiveDescription": "Transcribe en tiempo real mientras hablas.",
     "captureModeLaterDescription": "Guarda el audio ahora y transcríbelo cuando quieras.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "El modo en segundo plano no está disponible porque no hay ningún dispositivo compatible conectado. Conecta un dispositivo Omi, OpenGlass o Friend Pendant para usar esta función."
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3062,5 +3062,6 @@
     "recordingMode": "Modo de grabación",
     "captureModeLater": "Después",
     "captureModeLiveDescription": "Transcribe en tiempo real mientras hablas.",
-    "captureModeLaterDescription": "Guarda el audio ahora y transcríbelo cuando quieras."
+    "captureModeLaterDescription": "Guarda el audio ahora y transcríbelo cuando quieras.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Salvestusrežiim",
     "captureModeLater": "Hiljem",
     "captureModeLiveDescription": "Transkribeeri reaalajas, kui räägid.",
-    "captureModeLaterDescription": "Salvesta heli kohe ja transkribeeri, millal soovid."
+    "captureModeLaterDescription": "Salvesta heli kohe ja transkribeeri, millal soovid.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Hiljem",
     "captureModeLiveDescription": "Transkribeeri reaalajas, kui räägid.",
     "captureModeLaterDescription": "Salvesta heli kohe ja transkribeeri, millal soovid.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Taustarežiim pole saadaval, sest ühtegi ühilduvat seadet pole ühendatud. Selle funktsiooni kasutamiseks ühenda Omi, OpenGlass või Friend Pendant seade."
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "بعداً",
     "captureModeLiveDescription": "رونویسی همزمان هنگام صحبت کردن.",
     "captureModeLaterDescription": "صدا را اکنون ذخیره کنید و هر وقت خواستید رونویسی کنید.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "حالت پس‌زمینه در دسترس نیست چون هیچ دستگاه سازگاری متصل نیست. برای استفاده از این ویژگی، یک دستگاه Omi، OpenGlass یا Friend Pendant وصل کنید."
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "حالت ضبط",
     "captureModeLater": "بعداً",
     "captureModeLiveDescription": "رونویسی همزمان هنگام صحبت کردن.",
-    "captureModeLaterDescription": "صدا را اکنون ذخیره کنید و هر وقت خواستید رونویسی کنید."
+    "captureModeLaterDescription": "صدا را اکنون ذخیره کنید و هر وقت خواستید رونویسی کنید.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Myöhemmin",
     "captureModeLiveDescription": "Litteroi reaaliajassa puhuessasi.",
     "captureModeLaterDescription": "Tallenna ääni nyt ja litteroi milloin haluat.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Taustatila ei ole käytettävissä, koska yhteensopivaa laitetta ei ole yhdistetty. Yhdistä Omi-, OpenGlass- tai Friend Pendant -laite käyttääksesi tätä ominaisuutta."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Tallennustila",
     "captureModeLater": "Myöhemmin",
     "captureModeLiveDescription": "Litteroi reaaliajassa puhuessasi.",
-    "captureModeLaterDescription": "Tallenna ääni nyt ja litteroi milloin haluat."
+    "captureModeLaterDescription": "Tallenna ääni nyt ja litteroi milloin haluat.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3097,5 +3097,5 @@
     "captureModeLater": "Plus tard",
     "captureModeLiveDescription": "Transcrivez en temps réel pendant que vous parlez.",
     "captureModeLaterDescription": "Enregistrez l'audio maintenant et transcrivez quand vous voulez.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Le mode arrière-plan n’est pas disponible, car aucun appareil compatible n’est connecté. Connectez un appareil Omi, OpenGlass ou Friend Pendant pour utiliser cette fonctionnalité."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3096,5 +3096,6 @@
     "recordingMode": "Mode d'enregistrement",
     "captureModeLater": "Plus tard",
     "captureModeLiveDescription": "Transcrivez en temps réel pendant que vous parlez.",
-    "captureModeLaterDescription": "Enregistrez l'audio maintenant et transcrivez quand vous voulez."
+    "captureModeLaterDescription": "Enregistrez l'audio maintenant et transcrivez quand vous voulez.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "מאוחר יותר",
     "captureModeLiveDescription": "תמלול בזמן אמת תוך כדי דיבור.",
     "captureModeLaterDescription": "שמרו את האודיו עכשיו ותמללו מתי שתרצו.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "מצב רקע אינו זמין כי לא מחובר מכשיר תואם. חבר מכשיר Omi, OpenGlass או Friend Pendant כדי להשתמש בתכונה הזו."
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "מצב הקלטה",
     "captureModeLater": "מאוחר יותר",
     "captureModeLiveDescription": "תמלול בזמן אמת תוך כדי דיבור.",
-    "captureModeLaterDescription": "שמרו את האודיו עכשיו ותמללו מתי שתרצו."
+    "captureModeLaterDescription": "שמרו את האודיו עכשיו ותמללו מתי שתרצו.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3062,5 +3062,6 @@
     "recordingMode": "रिकॉर्डिंग मोड",
     "captureModeLater": "बाद में",
     "captureModeLiveDescription": "बोलते समय रीयल-टाइम में ट्रांसक्राइब करें।",
-    "captureModeLaterDescription": "अभी ऑडियो सहेजें और जब चाहें ट्रांसक्राइब करें।"
+    "captureModeLaterDescription": "अभी ऑडियो सहेजें और जब चाहें ट्रांसक्राइब करें।",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3063,5 +3063,5 @@
     "captureModeLater": "बाद में",
     "captureModeLiveDescription": "बोलते समय रीयल-टाइम में ट्रांसक्राइब करें।",
     "captureModeLaterDescription": "अभी ऑडियो सहेजें और जब चाहें ट्रांसक्राइब करें।",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "बैकग्राउंड मोड उपलब्ध नहीं है क्योंकि कोई संगत डिवाइस कनेक्ट नहीं है। इस सुविधा का उपयोग करने के लिए Omi, OpenGlass या Friend Pendant डिवाइस कनेक्ट करें।"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Kasnije",
     "captureModeLiveDescription": "Transkribiraj u stvarnom vremenu dok govoriš.",
     "captureModeLaterDescription": "Spremi zvuk sada i transkribiraj kad god želiš.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Pozadinski način nije dostupan jer nije povezan kompatibilan uređaj. Povežite Omi, OpenGlass ili Friend Pendant uređaj da biste koristili ovu značajku."
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Način snimanja",
     "captureModeLater": "Kasnije",
     "captureModeLiveDescription": "Transkribiraj u stvarnom vremenu dok govoriš.",
-    "captureModeLaterDescription": "Spremi zvuk sada i transkribiraj kad god želiš."
+    "captureModeLaterDescription": "Spremi zvuk sada i transkribiraj kad god želiš.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3158,5 +3158,5 @@
     "captureModeLater": "Később",
     "captureModeLiveDescription": "Átírás valós időben, miközben beszélsz.",
     "captureModeLaterDescription": "Mentsd el a hangot most, és írd át, amikor csak akarod.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "A Háttér mód nem érhető el, mert nincs csatlakoztatva kompatibilis eszköz. A funkció használatához csatlakoztass egy Omi, OpenGlass vagy Friend Pendant eszközt."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3157,5 +3157,6 @@
     "recordingMode": "Felvételi mód",
     "captureModeLater": "Később",
     "captureModeLiveDescription": "Átírás valós időben, miközben beszélsz.",
-    "captureModeLaterDescription": "Mentsd el a hangot most, és írd át, amikor csak akarod."
+    "captureModeLaterDescription": "Mentsd el a hangot most, és írd át, amikor csak akarod.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3103,5 +3103,6 @@
     "recordingMode": "Mode perekaman",
     "captureModeLater": "Nanti",
     "captureModeLiveDescription": "Transkripsikan secara langsung saat Anda berbicara.",
-    "captureModeLaterDescription": "Simpan audio sekarang dan transkripsikan kapan saja."
+    "captureModeLaterDescription": "Simpan audio sekarang dan transkripsikan kapan saja.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3104,5 +3104,5 @@
     "captureModeLater": "Nanti",
     "captureModeLiveDescription": "Transkripsikan secara langsung saat Anda berbicara.",
     "captureModeLaterDescription": "Simpan audio sekarang dan transkripsikan kapan saja.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Mode Latar Belakang tidak tersedia karena tidak ada perangkat kompatibel yang terhubung. Hubungkan perangkat Omi, OpenGlass, atau Friend Pendant untuk menggunakan fitur ini."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Più tardi",
     "captureModeLiveDescription": "Trascrivi in tempo reale mentre parli.",
     "captureModeLaterDescription": "Salva l'audio ora e trascrivilo quando vuoi.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "La modalità in background non è disponibile perché non è connesso alcun dispositivo compatibile. Collega un dispositivo Omi, OpenGlass o Friend Pendant per usare questa funzione."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Modalità di registrazione",
     "captureModeLater": "Più tardi",
     "captureModeLiveDescription": "Trascrivi in tempo reale mentre parli.",
-    "captureModeLaterDescription": "Salva l'audio ora e trascrivilo quando vuoi."
+    "captureModeLaterDescription": "Salva l'audio ora e trascrivilo quando vuoi.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3062,5 +3062,6 @@
     "recordingMode": "録音モード",
     "captureModeLater": "後で",
     "captureModeLiveDescription": "話しながらリアルタイムで文字起こしします。",
-    "captureModeLaterDescription": "今すぐ音声を保存して、好きなときに文字起こしできます。"
+    "captureModeLaterDescription": "今すぐ音声を保存して、好きなときに文字起こしできます。",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3063,5 +3063,5 @@
     "captureModeLater": "後で",
     "captureModeLiveDescription": "話しながらリアルタイムで文字起こしします。",
     "captureModeLaterDescription": "今すぐ音声を保存して、好きなときに文字起こしできます。",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "互換性のあるデバイスが接続されていないため、バックグラウンドモードは利用できません。この機能を使用するには、Omi、OpenGlass、またはFriend Pendantデバイスを接続してください。"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "ರೆಕಾರ್ಡಿಂಗ್ ಮೋಡ್",
     "captureModeLater": "ನಂತರ",
     "captureModeLiveDescription": "ನೀವು ಮಾತನಾಡುತ್ತಿರುವಾಗ ನೈಜ ಸಮಯದಲ್ಲಿ ಲಿಪ್ಯಂತರಿಸಿ.",
-    "captureModeLaterDescription": "ಈಗ ಆಡಿಯೋ ಉಳಿಸಿ ಮತ್ತು ನಿಮಗೆ ಬೇಕಾದಾಗ ಲಿಪ್ಯಂತರಿಸಿ."
+    "captureModeLaterDescription": "ಈಗ ಆಡಿಯೋ ಉಳಿಸಿ ಮತ್ತು ನಿಮಗೆ ಬೇಕಾದಾಗ ಲಿಪ್ಯಂತರಿಸಿ.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "ನಂತರ",
     "captureModeLiveDescription": "ನೀವು ಮಾತನಾಡುತ್ತಿರುವಾಗ ನೈಜ ಸಮಯದಲ್ಲಿ ಲಿಪ್ಯಂತರಿಸಿ.",
     "captureModeLaterDescription": "ಈಗ ಆಡಿಯೋ ಉಳಿಸಿ ಮತ್ತು ನಿಮಗೆ ಬೇಕಾದಾಗ ಲಿಪ್ಯಂತರಿಸಿ.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "ಹೊಂದಾಣಿಕೆಯ ಸಾಧನ ಸಂಪರ್ಕಗೊಂಡಿಲ್ಲದ ಕಾರಣ ಹಿನ್ನೆಲೆ ಮೋಡ್ ಲಭ್ಯವಿಲ್ಲ. ಈ ವೈಶಿಷ್ಟ್ಯವನ್ನು ಬಳಸಲು Omi, OpenGlass ಅಥವಾ Friend Pendant ಸಾಧನವನ್ನು ಸಂಪರ್ಕಿಸಿ."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "나중에",
     "captureModeLiveDescription": "말하는 동안 실시간으로 변환합니다.",
     "captureModeLaterDescription": "지금 오디오를 저장하고 원할 때 변환하세요.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "호환되는 기기가 연결되어 있지 않아 백그라운드 모드를 사용할 수 없습니다. 이 기능을 사용하려면 Omi, OpenGlass 또는 Friend Pendant 기기를 연결하세요."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "녹음 모드",
     "captureModeLater": "나중에",
     "captureModeLiveDescription": "말하는 동안 실시간으로 변환합니다.",
-    "captureModeLaterDescription": "지금 오디오를 저장하고 원할 때 변환하세요."
+    "captureModeLaterDescription": "지금 오디오를 저장하고 원할 때 변환하세요.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17337,6 +17337,12 @@ abstract class AppLocalizations {
   /// **'Works with Omi devices only for now, and is being improved continuously.'**
   String get backgroundModeNote;
 
+  /// Warning shown in Background Mode sheet when no device with a native BLE audio route is connected
+  ///
+  /// In en, this message translates to:
+  /// **'Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature.'**
+  String get backgroundModeUnavailable;
+
   /// No description provided for @regenerateRecap.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9248,6 +9248,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get backgroundModeNote => 'يعمل حاليًا مع أجهزة Omi فقط، ويجري تحسينه باستمرار.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'وضع الخلفية غير متاح لأنه لا يوجد جهاز متوافق متصل. وصّل جهاز Omi أو OpenGlass أو Friend Pendant لاستخدام هذه الميزة.';
+
+  @override
   String get regenerateRecap => 'إعادة إنشاء الملخص';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9331,6 +9331,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get backgroundModeNote => 'Пакуль працуе толькі з прыладамі Omi і пастаянна ўдасканальваецца.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Фонавы рэжым недаступны, бо не падключана сумяшчальная прылада. Падключыце Omi, OpenGlass або Friend Pendant, каб выкарыстоўваць гэту функцыю.';
+
+  @override
   String get regenerateRecap => 'Згенераваць рэзюмэ паўторна';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9338,6 +9338,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get backgroundModeNote => 'Засега работи само с устройства Omi и непрекъснато се подобрява.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Фоновият режим не е наличен, защото няма свързано съвместимо устройство. Свържете устройство Omi, OpenGlass или Friend Pendant, за да използвате тази функция.';
+
+  @override
   String get regenerateRecap => 'Регенерирай резюмето';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9310,6 +9310,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get backgroundModeNote => 'আপাতত শুধু Omi ডিভাইসের সাথে কাজ করে এবং ক্রমাগত উন্নত করা হচ্ছে।';
 
   @override
+  String get backgroundModeUnavailable =>
+      'কোনো সামঞ্জস্যপূর্ণ ডিভাইস সংযুক্ত না থাকায় ব্যাকগ্রাউন্ড মোড উপলভ্য নয়। এই ফিচারটি ব্যবহার করতে একটি Omi, OpenGlass বা Friend Pendant ডিভাইস সংযুক্ত করুন।';
+
+  @override
   String get regenerateRecap => 'রিক্যাপ পুনরায় তৈরি করুন';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9328,6 +9328,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get backgroundModeNote => 'Zasad radi samo s Omi uređajima i kontinuirano se poboljšava.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Pozadinski način rada nije dostupan jer nije povezan kompatibilan uređaj. Povežite Omi, OpenGlass ili Friend Pendant uređaj da koristite ovu funkciju.';
+
+  @override
   String get regenerateRecap => 'Ponovo generiši rezime';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9357,6 +9357,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get backgroundModeNote => 'De moment només funciona amb dispositius Omi i es millora contínuament.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'El mode en segon pla no està disponible perquè no hi ha cap dispositiu compatible connectat. Connecta un dispositiu Omi, OpenGlass o Friend Pendant per utilitzar aquesta funció.';
+
+  @override
   String get regenerateRecap => 'Regenera el resum';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9303,6 +9303,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get backgroundModeNote => 'Zatím funguje pouze se zařízeními Omi a průběžně se vylepšuje.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Režim na pozadí není k dispozici, protože není připojeno žádné kompatibilní zařízení. Pro použití této funkce připojte zařízení Omi, OpenGlass nebo Friend Pendant.';
+
+  @override
   String get regenerateRecap => 'Znovu vygenerovat shrnutí';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9288,6 +9288,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get backgroundModeNote => 'Fungerer indtil videre kun med Omi-enheder og forbedres løbende.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Baggrundstilstand er ikke tilgængelig, fordi der ikke er tilsluttet en kompatibel enhed. Tilslut en Omi-, OpenGlass- eller Friend Pendant-enhed for at bruge denne funktion.';
+
+  @override
   String get regenerateRecap => 'Generér resumé igen';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9379,6 +9379,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backgroundModeNote => 'Funktioniert vorerst nur mit Omi-Geräten und wird kontinuierlich verbessert.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Der Hintergrundmodus ist nicht verfügbar, weil kein kompatibles Gerät verbunden ist. Verbinde ein Omi-, OpenGlass- oder Friend Pendant-Gerät, um diese Funktion zu nutzen.';
+
+  @override
   String get regenerateRecap => 'Zusammenfassung neu erstellen';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9369,6 +9369,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get backgroundModeNote => 'Προς το παρόν λειτουργεί μόνο με συσκευές Omi και βελτιώνεται συνεχώς.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Η λειτουργία παρασκηνίου δεν είναι διαθέσιμη επειδή δεν είναι συνδεδεμένη κάποια συμβατή συσκευή. Συνδέστε μια συσκευή Omi, OpenGlass ή Friend Pendant για να χρησιμοποιήσετε αυτήν τη λειτουργία.';
+
+  @override
   String get regenerateRecap => 'Αναδημιουργία ανακεφαλαίωσης';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9298,6 +9298,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backgroundModeNote => 'Works with Omi devices only for now, and is being improved continuously.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature.';
+
+  @override
   String get regenerateRecap => 'Regenerate recap';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9324,6 +9324,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backgroundModeNote => 'Por ahora solo funciona con dispositivos Omi y se mejora continuamente.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'El modo en segundo plano no está disponible porque no hay ningún dispositivo compatible conectado. Conecta un dispositivo Omi, OpenGlass o Friend Pendant para usar esta función.';
+
+  @override
   String get regenerateRecap => 'Regenerar resumen';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9300,6 +9300,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get backgroundModeNote => 'Praegu töötab ainult Omi seadmetega ja seda täiustatakse pidevalt.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Taustarežiim pole saadaval, sest ühtegi ühilduvat seadet pole ühendatud. Selle funktsiooni kasutamiseks ühenda Omi, OpenGlass või Friend Pendant seade.';
+
+  @override
   String get regenerateRecap => 'Loo kokkuvõte uuesti';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9305,6 +9305,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get backgroundModeNote => 'فعلاً فقط با دستگاه‌های Omi کار می‌کند و به‌طور مداوم در حال بهبود است.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'حالت پس‌زمینه در دسترس نیست چون هیچ دستگاه سازگاری متصل نیست. برای استفاده از این ویژگی، یک دستگاه Omi، OpenGlass یا Friend Pendant وصل کنید.';
+
+  @override
   String get regenerateRecap => 'بازسازی خلاصه';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9303,6 +9303,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get backgroundModeNote => 'Toimii toistaiseksi vain Omi-laitteiden kanssa ja sitä kehitetään jatkuvasti.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Taustatila ei ole käytettävissä, koska yhteensopivaa laitetta ei ole yhdistetty. Yhdistä Omi-, OpenGlass- tai Friend Pendant -laite käyttääksesi tätä ominaisuutta.';
+
+  @override
   String get regenerateRecap => 'Luo yhteenveto uudelleen';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9387,6 +9387,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Fonctionne uniquement avec les appareils Omi pour l\'instant, et s\'améliore en continu.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Le mode arrière-plan n’est pas disponible, car aucun appareil compatible n’est connecté. Connectez un appareil Omi, OpenGlass ou Friend Pendant pour utiliser cette fonctionnalité.';
+
+  @override
   String get regenerateRecap => 'Régénérer le récapitulatif';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9233,6 +9233,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get backgroundModeNote => 'כרגע עובד רק עם מכשירי Omi ומשתפר באופן מתמיד.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'מצב רקע אינו זמין כי לא מחובר מכשיר תואם. חבר מכשיר Omi, OpenGlass או Friend Pendant כדי להשתמש בתכונה הזו.';
+
+  @override
   String get regenerateRecap => 'צור סיכום מחדש';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9280,6 +9280,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get backgroundModeNote => 'फ़िलहाल केवल Omi डिवाइस के साथ काम करता है और इसे लगातार बेहतर बनाया जा रहा है।';
 
   @override
+  String get backgroundModeUnavailable =>
+      'बैकग्राउंड मोड उपलब्ध नहीं है क्योंकि कोई संगत डिवाइस कनेक्ट नहीं है। इस सुविधा का उपयोग करने के लिए Omi, OpenGlass या Friend Pendant डिवाइस कनेक्ट करें।';
+
+  @override
   String get regenerateRecap => 'रीकैप पुनः बनाएं';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9335,6 +9335,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get backgroundModeNote => 'Zasad radi samo s Omi uređajima i neprestano se poboljšava.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Pozadinski način nije dostupan jer nije povezan kompatibilan uređaj. Povežite Omi, OpenGlass ili Friend Pendant uređaj da biste koristili ovu značajku.';
+
+  @override
   String get regenerateRecap => 'Ponovno generiraj sažetak';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9343,6 +9343,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get backgroundModeNote => 'Egyelőre csak Omi eszközökkel működik, és folyamatosan fejlesztjük.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'A Háttér mód nem érhető el, mert nincs csatlakoztatva kompatibilis eszköz. A funkció használatához csatlakoztass egy Omi, OpenGlass vagy Friend Pendant eszközt.';
+
+  @override
   String get regenerateRecap => 'Összegzés újragenerálása';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9311,6 +9311,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get backgroundModeNote => 'Untuk saat ini hanya berfungsi dengan perangkat Omi dan terus ditingkatkan.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Mode Latar Belakang tidak tersedia karena tidak ada perangkat kompatibel yang terhubung. Hubungkan perangkat Omi, OpenGlass, atau Friend Pendant untuk menggunakan fitur ini.';
+
+  @override
   String get regenerateRecap => 'Buat ulang ringkasan';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9358,6 +9358,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get backgroundModeNote => 'Per ora funziona solo con i dispositivi Omi ed è in continuo miglioramento.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'La modalità in background non è disponibile perché non è connesso alcun dispositivo compatibile. Collega un dispositivo Omi, OpenGlass o Friend Pendant per usare questa funzione.';
+
+  @override
   String get regenerateRecap => 'Rigenera il riepilogo';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9152,6 +9152,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get backgroundModeNote => '現在は Omi デバイスのみ対応しており、継続的に改善しています。';
 
   @override
+  String get backgroundModeUnavailable =>
+      '互換性のあるデバイスが接続されていないため、バックグラウンドモードは利用できません。この機能を使用するには、Omi、OpenGlass、またはFriend Pendantデバイスを接続してください。';
+
+  @override
   String get regenerateRecap => '要約を再生成';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9334,6 +9334,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get backgroundModeNote => 'ಸದ್ಯಕ್ಕೆ Omi ಸಾಧನಗಳೊಂದಿಗೆ ಮಾತ್ರ ಕೆಲಸ ಮಾಡುತ್ತದೆ ಮತ್ತು ನಿರಂತರವಾಗಿ ಸುಧಾರಿಸಲಾಗುತ್ತಿದೆ.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'ಹೊಂದಾಣಿಕೆಯ ಸಾಧನ ಸಂಪರ್ಕಗೊಂಡಿಲ್ಲದ ಕಾರಣ ಹಿನ್ನೆಲೆ ಮೋಡ್ ಲಭ್ಯವಿಲ್ಲ. ಈ ವೈಶಿಷ್ಟ್ಯವನ್ನು ಬಳಸಲು Omi, OpenGlass ಅಥವಾ Friend Pendant ಸಾಧನವನ್ನು ಸಂಪರ್ಕಿಸಿ.';
+
+  @override
   String get regenerateRecap => 'ಸಾರಾಂಶವನ್ನು ಪುನರುತ್ಪಾದಿಸಿ';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9154,6 +9154,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get backgroundModeNote => '현재는 Omi 기기에서만 작동하며 지속적으로 개선되고 있습니다.';
 
   @override
+  String get backgroundModeUnavailable =>
+      '호환되는 기기가 연결되어 있지 않아 백그라운드 모드를 사용할 수 없습니다. 이 기능을 사용하려면 Omi, OpenGlass 또는 Friend Pendant 기기를 연결하세요.';
+
+  @override
   String get regenerateRecap => '요약 재생성';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9317,6 +9317,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get backgroundModeNote => 'Kol kas veikia tik su Omi įrenginiais ir nuolat tobulinama.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Foninis režimas nepasiekiamas, nes neprijungtas suderinamas įrenginys. Prijunkite Omi, OpenGlass arba Friend Pendant įrenginį, kad galėtumėte naudoti šią funkciją.';
+
+  @override
   String get regenerateRecap => 'Sukurti santrauką iš naujo';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9325,6 +9325,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get backgroundModeNote => 'Pagaidām darbojas tikai ar Omi ierīcēm un tiek nepārtraukti uzlabota.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Fona režīms nav pieejams, jo nav pievienota saderīga ierīce. Pievienojiet Omi, OpenGlass vai Friend Pendant ierīci, lai izmantotu šo funkciju.';
+
+  @override
   String get regenerateRecap => 'Atjaunot kopsavilkumu';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9352,6 +9352,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get backgroundModeNote => 'Засега работи само со уреди Omi и постојано се подобрува.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Режимот во заднина не е достапен бидејќи не е поврзан компатибилен уред. Поврзете Omi, OpenGlass или Friend Pendant уред за да ја користите оваа функција.';
+
+  @override
   String get regenerateRecap => 'Регенерирај резиме';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9313,6 +9313,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get backgroundModeNote => 'सध्या फक्त Omi उपकरणांसह कार्य करते आणि सतत सुधारित केले जात आहे.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'सुसंगत डिव्हाइस कनेक्ट नसल्यामुळे बॅकग्राउंड मोड उपलब्ध नाही. हे वैशिष्ट्य वापरण्यासाठी Omi, OpenGlass किंवा Friend Pendant डिव्हाइस कनेक्ट करा.';
+
+  @override
   String get regenerateRecap => 'सारांश पुन्हा तयार करा';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9326,6 +9326,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get backgroundModeNote => 'Buat masa ini hanya berfungsi dengan peranti Omi dan sentiasa diperbaiki.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Mod Latar Belakang tidak tersedia kerana tiada peranti serasi yang disambungkan. Sambungkan peranti Omi, OpenGlass atau Friend Pendant untuk menggunakan ciri ini.';
+
+  @override
   String get regenerateRecap => 'Jana semula ringkasan';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9329,6 +9329,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get backgroundModeNote => 'Werkt voorlopig alleen met Omi-apparaten en wordt voortdurend verbeterd.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Achtergrondmodus is niet beschikbaar omdat er geen compatibel apparaat is verbonden. Verbind een Omi-, OpenGlass- of Friend Pendant-apparaat om deze functie te gebruiken.';
+
+  @override
   String get regenerateRecap => 'Samenvatting opnieuw genereren';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9300,6 +9300,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get backgroundModeNote => 'Fungerer foreløpig bare med Omi-enheter og forbedres kontinuerlig.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Bakgrunnsmodus er ikke tilgjengelig fordi ingen kompatibel enhet er tilkoblet. Koble til en Omi-, OpenGlass- eller Friend Pendant-enhet for å bruke denne funksjonen.';
+
+  @override
   String get regenerateRecap => 'Generer sammendrag på nytt';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9328,6 +9328,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get backgroundModeNote => 'Na razie działa tylko z urządzeniami Omi i jest stale ulepszany.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Tryb w tle jest niedostępny, ponieważ nie podłączono zgodnego urządzenia. Podłącz urządzenie Omi, OpenGlass lub Friend Pendant, aby użyć tej funkcji.';
+
+  @override
   String get regenerateRecap => 'Wygeneruj podsumowanie ponownie';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9308,6 +9308,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Por enquanto funciona apenas com dispositivos Omi e está em constante aprimoramento.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'O modo em segundo plano não está disponível porque nenhum dispositivo compatível está conectado. Conecte um dispositivo Omi, OpenGlass ou Friend Pendant para usar este recurso.';
+
+  @override
   String get regenerateRecap => 'Regenerar resumo';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9348,6 +9348,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backgroundModeNote => 'Deocamdată funcționează doar cu dispozitive Omi și este îmbunătățit continuu.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Modul de fundal nu este disponibil deoarece nu este conectat niciun dispozitiv compatibil. Conectează un dispozitiv Omi, OpenGlass sau Friend Pendant pentru a folosi această funcție.';
+
+  @override
   String get regenerateRecap => 'Regenerează rezumatul';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9336,6 +9336,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get backgroundModeNote => 'Пока работает только с устройствами Omi и постоянно улучшается.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Фоновый режим недоступен, потому что не подключено совместимое устройство. Подключите устройство Omi, OpenGlass или Friend Pendant, чтобы использовать эту функцию.';
+
+  @override
   String get regenerateRecap => 'Создать резюме заново';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9295,6 +9295,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get backgroundModeNote => 'Zatiaľ funguje len so zariadeniami Omi a priebežne sa vylepšuje.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Režim na pozadí nie je dostupný, pretože nie je pripojené žiadne kompatibilné zariadenie. Ak chcete túto funkciu používať, pripojte zariadenie Omi, OpenGlass alebo Friend Pendant.';
+
+  @override
   String get regenerateRecap => 'Znovu vygenerovať zhrnutie';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9330,6 +9330,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get backgroundModeNote => 'Zaenkrat deluje le z napravami Omi in se nenehno izboljšuje.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Način v ozadju ni na voljo, ker ni povezana nobena združljiva naprava. Za uporabo te funkcije povežite napravo Omi, OpenGlass ali Friend Pendant.';
+
+  @override
   String get regenerateRecap => 'Ponovno ustvari povzetek';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9315,6 +9315,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get backgroundModeNote => 'Засад ради само са Omi уређајима и непрекидно се побољшава.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Режим у позадини није доступан јер није повезан компатибилан уређај. Повежите Omi, OpenGlass или Friend Pendant уређај да бисте користили ову функцију.';
+
+  @override
   String get regenerateRecap => 'Поново генериши резиме';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9308,6 +9308,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get backgroundModeNote => 'Fungerar än så länge bara med Omi-enheter och förbättras kontinuerligt.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Bakgrundsläge är inte tillgängligt eftersom ingen kompatibel enhet är ansluten. Anslut en Omi-, OpenGlass- eller Friend Pendant-enhet för att använda den här funktionen.';
+
+  @override
   String get regenerateRecap => 'Återskapa sammanfattningen';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9369,6 +9369,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get backgroundModeNote => 'தற்போது Omi சாதனங்களுடன் மட்டுமே செயல்படுகிறது, தொடர்ந்து மேம்படுத்தப்படுகிறது.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'இணக்கமான சாதனம் எதுவும் இணைக்கப்படாததால் பின்னணி முறை கிடைக்கவில்லை. இந்த அம்சத்தைப் பயன்படுத்த Omi, OpenGlass அல்லது Friend Pendant சாதனத்தை இணைக்கவும்.';
+
+  @override
   String get regenerateRecap => 'சுருக்கத்தை மீண்டும் உருவாக்கு';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9352,6 +9352,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get backgroundModeNote => 'ప్రస్తుతం Omi పరికరాలతో మాత్రమే పనిచేస్తుంది మరియు నిరంతరం మెరుగుపరచబడుతోంది.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'అనుకూలమైన పరికరం కనెక్ట్ కాలేదు కాబట్టి బ్యాక్‌గ్రౌండ్ మోడ్ అందుబాటులో లేదు. ఈ ఫీచర్‌ను ఉపయోగించడానికి Omi, OpenGlass లేదా Friend Pendant పరికరాన్ని కనెక్ట్ చేయండి.';
+
+  @override
   String get regenerateRecap => 'సారాంశాన్ని పునరుత్పత్తి చేయండి';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9253,6 +9253,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get backgroundModeNote => 'ขณะนี้ใช้ได้กับอุปกรณ์ Omi เท่านั้น และกำลังพัฒนาอย่างต่อเนื่อง';
 
   @override
+  String get backgroundModeUnavailable =>
+      'โหมดพื้นหลังไม่พร้อมใช้งานเนื่องจากไม่มีอุปกรณ์ที่รองรับเชื่อมต่ออยู่ เชื่อมต่ออุปกรณ์ Omi, OpenGlass หรือ Friend Pendant เพื่อใช้ฟีเจอร์นี้';
+
+  @override
   String get regenerateRecap => 'สร้างสรุปใหม่';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9388,6 +9388,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get backgroundModeNote => 'Sa ngayon ay gumagana lang sa mga Omi device at patuloy na pinapabuti.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Hindi available ang Background Mode dahil walang nakakonektang compatible na device. Magkonekta ng Omi, OpenGlass, o Friend Pendant device para magamit ang feature na ito.';
+
+  @override
   String get regenerateRecap => 'Buuin muli ang buod';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9314,6 +9314,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get backgroundModeNote => 'Şimdilik yalnızca Omi cihazlarıyla çalışır ve sürekli geliştirilmektedir.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Arka Plan Modu kullanılamıyor çünkü uyumlu bir cihaz bağlı değil. Bu özelliği kullanmak için bir Omi, OpenGlass veya Friend Pendant cihazı bağlayın.';
+
+  @override
   String get regenerateRecap => 'Özeti yeniden oluştur';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9321,6 +9321,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get backgroundModeNote => 'Наразі працює лише з пристроями Omi і постійно вдосконалюється.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Фоновий режим недоступний, оскільки не підключено сумісний пристрій. Підключіть пристрій Omi, OpenGlass або Friend Pendant, щоб скористатися цією функцією.';
+
+  @override
   String get regenerateRecap => 'Створити підсумок знову';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9317,6 +9317,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get backgroundModeNote => 'فی الحال صرف Omi آلات کے ساتھ کام کرتا ہے اور مسلسل بہتر بنایا جا رہا ہے۔';
 
   @override
+  String get backgroundModeUnavailable =>
+      'پس منظر موڈ دستیاب نہیں ہے کیونکہ کوئی مطابقت رکھنے والا آلہ منسلک نہیں ہے۔ اس خصوصیت کو استعمال کرنے کے لیے Omi، OpenGlass یا Friend Pendant ڈیوائس منسلک کریں۔';
+
+  @override
   String get regenerateRecap => 'خلاصہ دوبارہ بنائیں';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9301,6 +9301,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get backgroundModeNote => 'Hiện chỉ hoạt động với thiết bị Omi và đang được cải thiện liên tục.';
 
   @override
+  String get backgroundModeUnavailable =>
+      'Chế độ nền không khả dụng vì chưa có thiết bị tương thích nào được kết nối. Kết nối thiết bị Omi, OpenGlass hoặc Friend Pendant để sử dụng tính năng này.';
+
+  @override
   String get regenerateRecap => 'Tạo lại tóm tắt';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9138,6 +9138,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backgroundModeNote => '目前仅支持 Omi 设备，并在持续改进中。';
 
   @override
+  String get backgroundModeUnavailable => '后台模式不可用，因为未连接兼容设备。请连接 Omi、OpenGlass 或 Friend Pendant 设备以使用此功能。';
+
+  @override
   String get regenerateRecap => '重新生成回顾';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Vėliau",
     "captureModeLiveDescription": "Transkribuokite tikruoju laiku, kol kalbate.",
     "captureModeLaterDescription": "Išsaugokite garsą dabar ir transkribuokite kada panorėję.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Foninis režimas nepasiekiamas, nes neprijungtas suderinamas įrenginys. Prijunkite Omi, OpenGlass arba Friend Pendant įrenginį, kad galėtumėte naudoti šią funkciją."
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Įrašymo režimas",
     "captureModeLater": "Vėliau",
     "captureModeLiveDescription": "Transkribuokite tikruoju laiku, kol kalbate.",
-    "captureModeLaterDescription": "Išsaugokite garsą dabar ir transkribuokite kada panorėję."
+    "captureModeLaterDescription": "Išsaugokite garsą dabar ir transkribuokite kada panorėję.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Vēlāk",
     "captureModeLiveDescription": "Transkribējiet reāllaikā, kamēr runājat.",
     "captureModeLaterDescription": "Saglabājiet audio tagad un transkribējiet, kad vēlaties.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Fona režīms nav pieejams, jo nav pievienota saderīga ierīce. Pievienojiet Omi, OpenGlass vai Friend Pendant ierīci, lai izmantotu šo funkciju."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Ierakstīšanas režīms",
     "captureModeLater": "Vēlāk",
     "captureModeLiveDescription": "Transkribējiet reāllaikā, kamēr runājat.",
-    "captureModeLaterDescription": "Saglabājiet audio tagad un transkribējiet, kad vēlaties."
+    "captureModeLaterDescription": "Saglabājiet audio tagad un transkribējiet, kad vēlaties.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Режим на снимање",
     "captureModeLater": "Подоцна",
     "captureModeLiveDescription": "Транскрибирајте во реално време додека зборувате.",
-    "captureModeLaterDescription": "Зачувајте го звукот сега и транскрибирајте кога сакате."
+    "captureModeLaterDescription": "Зачувајте го звукот сега и транскрибирајте кога сакате.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Подоцна",
     "captureModeLiveDescription": "Транскрибирајте во реално време додека зборувате.",
     "captureModeLaterDescription": "Зачувајте го звукот сега и транскрибирајте кога сакате.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Режимот во заднина не е достапен бидејќи не е поврзан компатибилен уред. Поврзете Omi, OpenGlass или Friend Pendant уред за да ја користите оваа функција."
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "नंतर",
     "captureModeLiveDescription": "तुम्ही बोलत असताना रिअल-टाइममध्ये ट्रान्सक्राइब करा.",
     "captureModeLaterDescription": "आता ऑडिओ जतन करा आणि तुम्हाला हवे तेव्हा ट्रान्सक्राइब करा.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "सुसंगत डिव्हाइस कनेक्ट नसल्यामुळे बॅकग्राउंड मोड उपलब्ध नाही. हे वैशिष्ट्य वापरण्यासाठी Omi, OpenGlass किंवा Friend Pendant डिव्हाइस कनेक्ट करा."
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "रेकॉर्डिंग मोड",
     "captureModeLater": "नंतर",
     "captureModeLiveDescription": "तुम्ही बोलत असताना रिअल-टाइममध्ये ट्रान्सक्राइब करा.",
-    "captureModeLaterDescription": "आता ऑडिओ जतन करा आणि तुम्हाला हवे तेव्हा ट्रान्सक्राइब करा."
+    "captureModeLaterDescription": "आता ऑडिओ जतन करा आणि तुम्हाला हवे तेव्हा ट्रान्सक्राइब करा.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Kemudian",
     "captureModeLiveDescription": "Transkripsi secara masa nyata semasa anda bercakap.",
     "captureModeLaterDescription": "Simpan audio sekarang dan transkripsi bila-bila masa.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Mod Latar Belakang tidak tersedia kerana tiada peranti serasi yang disambungkan. Sambungkan peranti Omi, OpenGlass atau Friend Pendant untuk menggunakan ciri ini."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Mod rakaman",
     "captureModeLater": "Kemudian",
     "captureModeLiveDescription": "Transkripsi secara masa nyata semasa anda bercakap.",
-    "captureModeLaterDescription": "Simpan audio sekarang dan transkripsi bila-bila masa."
+    "captureModeLaterDescription": "Simpan audio sekarang dan transkripsi bila-bila masa.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Opnamemodus",
     "captureModeLater": "Later",
     "captureModeLiveDescription": "Transcribeer in realtime terwijl je praat.",
-    "captureModeLaterDescription": "Sla audio nu op en transcribeer wanneer je wilt."
+    "captureModeLaterDescription": "Sla audio nu op en transcribeer wanneer je wilt.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Later",
     "captureModeLiveDescription": "Transcribeer in realtime terwijl je praat.",
     "captureModeLaterDescription": "Sla audio nu op en transcribeer wanneer je wilt.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Achtergrondmodus is niet beschikbaar omdat er geen compatibel apparaat is verbonden. Verbind een Omi-, OpenGlass- of Friend Pendant-apparaat om deze functie te gebruiken."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Senere",
     "captureModeLiveDescription": "Transkriber i sanntid mens du snakker.",
     "captureModeLaterDescription": "Lagre lyden nå og transkriber når du vil.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Bakgrunnsmodus er ikke tilgjengelig fordi ingen kompatibel enhet er tilkoblet. Koble til en Omi-, OpenGlass- eller Friend Pendant-enhet for å bruke denne funksjonen."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Opptaksmodus",
     "captureModeLater": "Senere",
     "captureModeLiveDescription": "Transkriber i sanntid mens du snakker.",
-    "captureModeLaterDescription": "Lagre lyden nå og transkriber når du vil."
+    "captureModeLaterDescription": "Lagre lyden nå og transkriber når du vil.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3097,5 +3097,5 @@
     "captureModeLater": "Później",
     "captureModeLiveDescription": "Transkrybuj w czasie rzeczywistym podczas mówienia.",
     "captureModeLaterDescription": "Zapisz dźwięk teraz i transkrybuj, kiedy chcesz.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Tryb w tle jest niedostępny, ponieważ nie podłączono zgodnego urządzenia. Podłącz urządzenie Omi, OpenGlass lub Friend Pendant, aby użyć tej funkcji."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3096,5 +3096,6 @@
     "recordingMode": "Tryb nagrywania",
     "captureModeLater": "Później",
     "captureModeLiveDescription": "Transkrybuj w czasie rzeczywistym podczas mówienia.",
-    "captureModeLaterDescription": "Zapisz dźwięk teraz i transkrybuj, kiedy chcesz."
+    "captureModeLaterDescription": "Zapisz dźwięk teraz i transkrybuj, kiedy chcesz.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3098,5 +3098,5 @@
     "captureModeLater": "Depois",
     "captureModeLiveDescription": "Transcreva em tempo real enquanto fala.",
     "captureModeLaterDescription": "Salve o áudio agora e transcreva quando quiser.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "O modo em segundo plano não está disponível porque nenhum dispositivo compatível está conectado. Conecte um dispositivo Omi, OpenGlass ou Friend Pendant para usar este recurso."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3097,5 +3097,6 @@
     "recordingMode": "Modo de gravação",
     "captureModeLater": "Depois",
     "captureModeLiveDescription": "Transcreva em tempo real enquanto fala.",
-    "captureModeLaterDescription": "Salve o áudio agora e transcreva quando quiser."
+    "captureModeLaterDescription": "Salve o áudio agora e transcreva quando quiser.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Mai târziu",
     "captureModeLiveDescription": "Transcrie în timp real în timp ce vorbești.",
     "captureModeLaterDescription": "Salvează audio acum și transcrie oricând dorești.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Modul de fundal nu este disponibil deoarece nu este conectat niciun dispozitiv compatibil. Conectează un dispozitiv Omi, OpenGlass sau Friend Pendant pentru a folosi această funcție."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Mod de înregistrare",
     "captureModeLater": "Mai târziu",
     "captureModeLiveDescription": "Transcrie în timp real în timp ce vorbești.",
-    "captureModeLaterDescription": "Salvează audio acum și transcrie oricând dorești."
+    "captureModeLaterDescription": "Salvează audio acum și transcrie oricând dorești.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3096,5 +3096,6 @@
     "recordingMode": "Режим записи",
     "captureModeLater": "Позже",
     "captureModeLiveDescription": "Расшифровка в реальном времени, пока вы говорите.",
-    "captureModeLaterDescription": "Сохраните аудио сейчас и расшифруйте, когда захотите."
+    "captureModeLaterDescription": "Сохраните аудио сейчас и расшифруйте, когда захотите.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3097,5 +3097,5 @@
     "captureModeLater": "Позже",
     "captureModeLiveDescription": "Расшифровка в реальном времени, пока вы говорите.",
     "captureModeLaterDescription": "Сохраните аудио сейчас и расшифруйте, когда захотите.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Фоновый режим недоступен, потому что не подключено совместимое устройство. Подключите устройство Omi, OpenGlass или Friend Pendant, чтобы использовать эту функцию."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3067,5 +3067,5 @@
     "captureModeLater": "Neskôr",
     "captureModeLiveDescription": "Prepis v reálnom čase počas rozprávania.",
     "captureModeLaterDescription": "Uložte zvuk teraz a prepíšte ho, kedykoľvek chcete.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Režim na pozadí nie je dostupný, pretože nie je pripojené žiadne kompatibilné zariadenie. Ak chcete túto funkciu používať, pripojte zariadenie Omi, OpenGlass alebo Friend Pendant."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3066,5 +3066,6 @@
     "recordingMode": "Režim nahrávania",
     "captureModeLater": "Neskôr",
     "captureModeLiveDescription": "Prepis v reálnom čase počas rozprávania.",
-    "captureModeLaterDescription": "Uložte zvuk teraz a prepíšte ho, kedykoľvek chcete."
+    "captureModeLaterDescription": "Uložte zvuk teraz a prepíšte ho, kedykoľvek chcete.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Način snemanja",
     "captureModeLater": "Pozneje",
     "captureModeLiveDescription": "Prepisujte v realnem času, medtem ko govorite.",
-    "captureModeLaterDescription": "Shranite zvok zdaj in ga prepišite, kadar koli želite."
+    "captureModeLaterDescription": "Shranite zvok zdaj in ga prepišite, kadar koli želite.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Pozneje",
     "captureModeLiveDescription": "Prepisujte v realnem času, medtem ko govorite.",
     "captureModeLaterDescription": "Shranite zvok zdaj in ga prepišite, kadar koli želite.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Način v ozadju ni na voljo, ker ni povezana nobena združljiva naprava. Za uporabo te funkcije povežite napravo Omi, OpenGlass ali Friend Pendant."
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Режим снимања",
     "captureModeLater": "Касније",
     "captureModeLiveDescription": "Транскрибујте у реалном времену док говорите.",
-    "captureModeLaterDescription": "Сачувајте звук сада и транскрибујте кад год желите."
+    "captureModeLaterDescription": "Сачувајте звук сада и транскрибујте кад год желите.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Касније",
     "captureModeLiveDescription": "Транскрибујте у реалном времену док говорите.",
     "captureModeLaterDescription": "Сачувајте звук сада и транскрибујте кад год желите.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Режим у позадини није доступан јер није повезан компатибилан уређај. Повежите Omi, OpenGlass или Friend Pendant уређај да бисте користили ову функцију."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Inspelningsläge",
     "captureModeLater": "Senare",
     "captureModeLiveDescription": "Transkribera i realtid medan du talar.",
-    "captureModeLaterDescription": "Spara ljudet nu och transkribera när du vill."
+    "captureModeLaterDescription": "Spara ljudet nu och transkribera när du vill.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Senare",
     "captureModeLiveDescription": "Transkribera i realtid medan du talar.",
     "captureModeLaterDescription": "Spara ljudet nu och transkribera när du vill.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Bakgrundsläge är inte tillgängligt eftersom ingen kompatibel enhet är ansluten. Anslut en Omi-, OpenGlass- eller Friend Pendant-enhet för att använda den här funktionen."
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "பதிவு பயன்முறை",
     "captureModeLater": "பின்னர்",
     "captureModeLiveDescription": "நீங்கள் பேசும்போது நிகழ்நேரத்தில் எழுத்தாக்கம் செய்யுங்கள்.",
-    "captureModeLaterDescription": "இப்போது ஆடியோவை சேமித்து, நீங்கள் விரும்பும்போது எழுத்தாக்கம் செய்யுங்கள்."
+    "captureModeLaterDescription": "இப்போது ஆடியோவை சேமித்து, நீங்கள் விரும்பும்போது எழுத்தாக்கம் செய்யுங்கள்.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "பின்னர்",
     "captureModeLiveDescription": "நீங்கள் பேசும்போது நிகழ்நேரத்தில் எழுத்தாக்கம் செய்யுங்கள்.",
     "captureModeLaterDescription": "இப்போது ஆடியோவை சேமித்து, நீங்கள் விரும்பும்போது எழுத்தாக்கம் செய்யுங்கள்.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "இணக்கமான சாதனம் எதுவும் இணைக்கப்படாததால் பின்னணி முறை கிடைக்கவில்லை. இந்த அம்சத்தைப் பயன்படுத்த Omi, OpenGlass அல்லது Friend Pendant சாதனத்தை இணைக்கவும்."
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "రికార్డింగ్ మోడ్",
     "captureModeLater": "తర్వాత",
     "captureModeLiveDescription": "మీరు మాట్లాడుతున్నప్పుడు రియల్ టైమ్‌లో ట్రాన్‌స్క్రైబ్ చేయండి.",
-    "captureModeLaterDescription": "ఇప్పుడు ఆడియోను సేవ్ చేసి, మీకు నచ్చినప్పుడు ట్రాన్‌స్క్రైబ్ చేయండి."
+    "captureModeLaterDescription": "ఇప్పుడు ఆడియోను సేవ్ చేసి, మీకు నచ్చినప్పుడు ట్రాన్‌స్క్రైబ్ చేయండి.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "తర్వాత",
     "captureModeLiveDescription": "మీరు మాట్లాడుతున్నప్పుడు రియల్ టైమ్‌లో ట్రాన్‌స్క్రైబ్ చేయండి.",
     "captureModeLaterDescription": "ఇప్పుడు ఆడియోను సేవ్ చేసి, మీకు నచ్చినప్పుడు ట్రాన్‌స్క్రైబ్ చేయండి.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "అనుకూలమైన పరికరం కనెక్ట్ కాలేదు కాబట్టి బ్యాక్‌గ్రౌండ్ మోడ్ అందుబాటులో లేదు. ఈ ఫీచర్‌ను ఉపయోగించడానికి Omi, OpenGlass లేదా Friend Pendant పరికరాన్ని కనెక్ట్ చేయండి."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "โหมดการบันทึก",
     "captureModeLater": "ภายหลัง",
     "captureModeLiveDescription": "ถอดเสียงแบบเรียลไทม์ขณะที่คุณพูด",
-    "captureModeLaterDescription": "บันทึกเสียงตอนนี้แล้วถอดเสียงเมื่อใดก็ได้ที่ต้องการ"
+    "captureModeLaterDescription": "บันทึกเสียงตอนนี้แล้วถอดเสียงเมื่อใดก็ได้ที่ต้องการ",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "ภายหลัง",
     "captureModeLiveDescription": "ถอดเสียงแบบเรียลไทม์ขณะที่คุณพูด",
     "captureModeLaterDescription": "บันทึกเสียงตอนนี้แล้วถอดเสียงเมื่อใดก็ได้ที่ต้องการ",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "โหมดพื้นหลังไม่พร้อมใช้งานเนื่องจากไม่มีอุปกรณ์ที่รองรับเชื่อมต่ออยู่ เชื่อมต่ออุปกรณ์ Omi, OpenGlass หรือ Friend Pendant เพื่อใช้ฟีเจอร์นี้"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "Mode ng pag-record",
     "captureModeLater": "Mamaya",
     "captureModeLiveDescription": "I-transcribe nang real time habang nagsasalita ka.",
-    "captureModeLaterDescription": "I-save ang audio ngayon at i-transcribe kahit kailan mo gusto."
+    "captureModeLaterDescription": "I-save ang audio ngayon at i-transcribe kahit kailan mo gusto.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "Mamaya",
     "captureModeLiveDescription": "I-transcribe nang real time habang nagsasalita ka.",
     "captureModeLaterDescription": "I-save ang audio ngayon at i-transcribe kahit kailan mo gusto.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Hindi available ang Background Mode dahil walang nakakonektang compatible na device. Magkonekta ng Omi, OpenGlass, o Friend Pendant device para magamit ang feature na ito."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3097,5 +3097,5 @@
     "captureModeLater": "Sonra",
     "captureModeLiveDescription": "Siz konuşurken gerçek zamanlı olarak yazıya dökün.",
     "captureModeLaterDescription": "Sesi şimdi kaydedin ve istediğiniz zaman yazıya dökün.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Arka Plan Modu kullanılamıyor çünkü uyumlu bir cihaz bağlı değil. Bu özelliği kullanmak için bir Omi, OpenGlass veya Friend Pendant cihazı bağlayın."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3096,5 +3096,6 @@
     "recordingMode": "Kayıt modu",
     "captureModeLater": "Sonra",
     "captureModeLiveDescription": "Siz konuşurken gerçek zamanlı olarak yazıya dökün.",
-    "captureModeLaterDescription": "Sesi şimdi kaydedin ve istediğiniz zaman yazıya dökün."
+    "captureModeLaterDescription": "Sesi şimdi kaydedin ve istediğiniz zaman yazıya dökün.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3062,5 +3062,5 @@
     "captureModeLater": "Пізніше",
     "captureModeLiveDescription": "Транскрибуйте в реальному часі, поки говорите.",
     "captureModeLaterDescription": "Збережіть аудіо зараз і транскрибуйте коли завгодно.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Фоновий режим недоступний, оскільки не підключено сумісний пристрій. Підключіть пристрій Omi, OpenGlass або Friend Pendant, щоб скористатися цією функцією."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3061,5 +3061,6 @@
     "recordingMode": "Режим запису",
     "captureModeLater": "Пізніше",
     "captureModeLiveDescription": "Транскрибуйте в реальному часі, поки говорите.",
-    "captureModeLaterDescription": "Збережіть аудіо зараз і транскрибуйте коли завгодно."
+    "captureModeLaterDescription": "Збережіть аудіо зараз і транскрибуйте коли завгодно.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10639,5 +10639,6 @@
     "recordingMode": "ریکارڈنگ موڈ",
     "captureModeLater": "بعد میں",
     "captureModeLiveDescription": "بولتے وقت حقیقی وقت میں ٹرانسکرائب کریں۔",
-    "captureModeLaterDescription": "ابھی آڈیو محفوظ کریں اور جب چاہیں ٹرانسکرائب کریں۔"
+    "captureModeLaterDescription": "ابھی آڈیو محفوظ کریں اور جب چاہیں ٹرانسکرائب کریں۔",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10640,5 +10640,5 @@
     "captureModeLater": "بعد میں",
     "captureModeLiveDescription": "بولتے وقت حقیقی وقت میں ٹرانسکرائب کریں۔",
     "captureModeLaterDescription": "ابھی آڈیو محفوظ کریں اور جب چاہیں ٹرانسکرائب کریں۔",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "پس منظر موڈ دستیاب نہیں ہے کیونکہ کوئی مطابقت رکھنے والا آلہ منسلک نہیں ہے۔ اس خصوصیت کو استعمال کرنے کے لیے Omi، OpenGlass یا Friend Pendant ڈیوائس منسلک کریں۔"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3066,5 +3066,6 @@
     "recordingMode": "Chế độ ghi",
     "captureModeLater": "Sau",
     "captureModeLiveDescription": "Phiên âm theo thời gian thực khi bạn nói.",
-    "captureModeLaterDescription": "Lưu âm thanh ngay bây giờ và phiên âm bất cứ khi nào bạn muốn."
+    "captureModeLaterDescription": "Lưu âm thanh ngay bây giờ và phiên âm bất cứ khi nào bạn muốn.",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3067,5 +3067,5 @@
     "captureModeLater": "Sau",
     "captureModeLiveDescription": "Phiên âm theo thời gian thực khi bạn nói.",
     "captureModeLaterDescription": "Lưu âm thanh ngay bây giờ và phiên âm bất cứ khi nào bạn muốn.",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "Chế độ nền không khả dụng vì chưa có thiết bị tương thích nào được kết nối. Kết nối thiết bị Omi, OpenGlass hoặc Friend Pendant để sử dụng tính năng này."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3083,5 +3083,6 @@
     "recordingMode": "录制模式",
     "captureModeLater": "稍后",
     "captureModeLiveDescription": "在你说话时实时转写。",
-    "captureModeLaterDescription": "立即保存音频，随时转写。"
+    "captureModeLaterDescription": "立即保存音频，随时转写。",
+    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3084,5 +3084,5 @@
     "captureModeLater": "稍后",
     "captureModeLiveDescription": "在你说话时实时转写。",
     "captureModeLaterDescription": "立即保存音频，随时转写。",
-    "backgroundModeUnavailable": "Background Mode is not available because no compatible device is connected. Connect an Omi, OpenGlass, or Friend Pendant device to use this feature."
+    "backgroundModeUnavailable": "后台模式不可用，因为未连接兼容设备。请连接 Omi、OpenGlass 或 Friend Pendant 设备以使用此功能。"
 }

--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -243,12 +243,16 @@ class _ProfilePageState extends State<ProfilePage> {
       builder: (sheetContext) {
         return StatefulBuilder(
           builder: (context, setSheetState) {
+            final captureProvider = context.read<CaptureProvider>();
             final enabled = SharedPreferencesUtil().backgroundModeEnabled;
-            void setEnabled(bool value) {
-              SharedPreferencesUtil().backgroundModeEnabled = value;
-              SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', value);
-              setSheetState(() {});
-              setState(() {});
+            final canEnable = captureProvider.hasNativeBleAudioRoute;
+            void setEnabled(bool value) async {
+              if (value && !canEnable) return;
+              final accepted = await captureProvider.setBackgroundModeEnabled(value);
+              if (accepted) {
+                setSheetState(() {});
+                setState(() {});
+              }
             }
 
             return SafeArea(
@@ -263,8 +267,10 @@ class _ProfilePageState extends State<ProfilePage> {
                         margin: const EdgeInsets.only(bottom: 16),
                         width: 36,
                         height: 4,
-                        decoration:
-                            BoxDecoration(color: const Color(0xFF3C3C43), borderRadius: BorderRadius.circular(2)),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF3C3C43),
+                          borderRadius: BorderRadius.circular(2),
+                        ),
                       ),
                     ),
                     Row(
@@ -279,7 +285,7 @@ class _ProfilePageState extends State<ProfilePage> {
                           value: enabled,
                           activeThumbColor: Colors.white,
                           activeTrackColor: const Color(0xFF8B5CF6),
-                          onChanged: setEnabled,
+                          onChanged: enabled ? (v) => setEnabled(v) : null,
                         ),
                       ],
                     ),
@@ -291,8 +297,10 @@ class _ProfilePageState extends State<ProfilePage> {
                     const SizedBox(height: 16),
                     Container(
                       padding: const EdgeInsets.all(12),
-                      decoration:
-                          BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(12)),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF2A2A2E),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -307,6 +315,29 @@ class _ProfilePageState extends State<ProfilePage> {
                         ],
                       ),
                     ),
+                    if (!canEnable) ...[
+                      const SizedBox(height: 12),
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF3A2A2A),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Icon(Icons.warning_amber_rounded, color: Color(0xFFE0A030), size: 18),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Text(
+                                context.l10n.backgroundModeUnavailable,
+                                style: TextStyle(color: Colors.orange.shade200, fontSize: 13, height: 1.4),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -345,8 +376,10 @@ class _ProfilePageState extends State<ProfilePage> {
                         margin: const EdgeInsets.only(bottom: 16),
                         width: 36,
                         height: 4,
-                        decoration:
-                            BoxDecoration(color: const Color(0xFF3C3C43), borderRadius: BorderRadius.circular(2)),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF3C3C43),
+                          borderRadius: BorderRadius.circular(2),
+                        ),
                       ),
                     ),
                     Row(
@@ -373,8 +406,10 @@ class _ProfilePageState extends State<ProfilePage> {
                     const SizedBox(height: 16),
                     Container(
                       padding: const EdgeInsets.all(12),
-                      decoration:
-                          BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(12)),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF2A2A2E),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -393,8 +428,10 @@ class _ProfilePageState extends State<ProfilePage> {
                       const SizedBox(height: 12),
                       Container(
                         padding: const EdgeInsets.all(12),
-                        decoration:
-                            BoxDecoration(color: const Color(0xFF3A2A2A), borderRadius: BorderRadius.circular(12)),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF3A2A2A),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                         child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -462,8 +499,9 @@ class _ProfilePageState extends State<ProfilePage> {
                 const Divider(height: 1, color: Color(0xFF3C3C43)),
                 _buildProfileItem(
                   title: context.l10n.email,
-                  chipValue:
-                      SharedPreferencesUtil().email.isEmpty ? context.l10n.notSet : SharedPreferencesUtil().email,
+                  chipValue: SharedPreferencesUtil().email.isEmpty
+                      ? context.l10n.notSet
+                      : SharedPreferencesUtil().email,
                   icon: const FaIcon(FontAwesomeIcons.solidEnvelope, color: Color(0xFF8E8E93), size: 20),
                   onTap: () {},
                   showChevron: false,
@@ -572,8 +610,9 @@ class _ProfilePageState extends State<ProfilePage> {
                 Builder(
                   builder: (context) {
                     final uid = SharedPreferencesUtil().uid;
-                    final truncatedUid =
-                        uid.length > 6 ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}' : uid;
+                    final truncatedUid = uid.length > 6
+                        ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}'
+                        : uid;
                     return _buildProfileItem(
                       title: context.l10n.userId,
                       chipValue: truncatedUid,

--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -285,7 +285,7 @@ class _ProfilePageState extends State<ProfilePage> {
                           value: enabled,
                           activeThumbColor: Colors.white,
                           activeTrackColor: const Color(0xFF8B5CF6),
-                          onChanged: enabled ? (v) => setEnabled(v) : null,
+                          onChanged: (enabled || canEnable) ? (v) => setEnabled(v) : null,
                         ),
                       ],
                     ),

--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -499,9 +499,8 @@ class _ProfilePageState extends State<ProfilePage> {
                 const Divider(height: 1, color: Color(0xFF3C3C43)),
                 _buildProfileItem(
                   title: context.l10n.email,
-                  chipValue: SharedPreferencesUtil().email.isEmpty
-                      ? context.l10n.notSet
-                      : SharedPreferencesUtil().email,
+                  chipValue:
+                      SharedPreferencesUtil().email.isEmpty ? context.l10n.notSet : SharedPreferencesUtil().email,
                   icon: const FaIcon(FontAwesomeIcons.solidEnvelope, color: Color(0xFF8E8E93), size: 20),
                   onTap: () {},
                   showChevron: false,
@@ -610,9 +609,8 @@ class _ProfilePageState extends State<ProfilePage> {
                 Builder(
                   builder: (context) {
                     final uid = SharedPreferencesUtil().uid;
-                    final truncatedUid = uid.length > 6
-                        ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}'
-                        : uid;
+                    final truncatedUid =
+                        uid.length > 6 ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}' : uid;
                     return _buildProfileItem(
                       title: context.l10n.userId,
                       chipValue: truncatedUid,

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -246,29 +246,29 @@ class CaptureProvider extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().mic.start(
-          onByteReceived: (bytes) {
-            final frames = _activeSource?.processBytes(bytes) ?? [];
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_callActive) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-        );
+      onByteReceived: (bytes) {
+        final frames = _activeSource?.processBytes(bytes) ?? [];
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_callActive) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+    );
   }
 
   void _onMicStalled() {
@@ -549,8 +549,10 @@ class CaptureProvider extends ChangeNotifier
     PlatformManager.instance.analytics.transcribeLaterToggled(enabled: enabled);
     final docs = await getApplicationDocumentsDirectory();
     await SharedPreferencesUtil().saveString('batchAudioDir', docs.path);
-    await SharedPreferencesUtil()
-        .saveBool('nativeBleStreamingEnabled', !enabled && SharedPreferencesUtil().backgroundModeEnabled);
+    // Only re-enable native streaming when turning batch OFF, a device with a
+    // native BLE route is connected, and background mode is opted in.
+    final enableNativeStreaming = !enabled && hasNativeBleAudioRoute && SharedPreferencesUtil().backgroundModeEnabled;
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', enableNativeStreaming);
     notifyListeners();
     try {
       await onRecordProfileSettingChanged();
@@ -626,8 +628,9 @@ class CaptureProvider extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -641,13 +644,13 @@ class CaptureProvider extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-          codec: codec,
-          sampleRate: sampleRate,
-          language: language,
-          force: force,
-          source: source,
-          customSttConfig: effectiveConfig,
-        );
+      codec: codec,
+      sampleRate: sampleRate,
+      language: language,
+      force: force,
+      source: source,
+      customSttConfig: effectiveConfig,
+    );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -755,20 +758,24 @@ class CaptureProvider extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error resuming device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              resumeDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error resuming device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error pausing device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              pauseDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error pausing device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -862,7 +869,8 @@ class CaptureProvider extends ChangeNotifier
 
         // Local storage syncs. In batch mode the native layer owns writing the
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
-        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
+        var checkWalSupported =
+            !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
@@ -970,8 +978,9 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1025,8 +1034,14 @@ class CaptureProvider extends ChangeNotifier
   Future<void> _saveNativeBleStreamConfig(BtDevice device, BleAudioCodec codec) async {
     final audioTarget = _nativeBleAudioTarget(device);
     if (audioTarget == null) {
+      // No native route — clear all background/streaming state and stale config.
+      Logger.debug(
+        '[saveNativeBleStreamConfig] no native BLE route for device ${device.id} type=${device.type} — clearing state',
+      );
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      SharedPreferencesUtil().backgroundModeEnabled = false;
+      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
       return;
     }
 
@@ -1051,10 +1066,14 @@ class CaptureProvider extends ChangeNotifier
     await SharedPreferencesUtil().saveString('batchAudioDir', docsDir.path);
 
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
-    await SharedPreferencesUtil()
-        .saveBool('nativeBleStreamingEnabled', !batchMode && SharedPreferencesUtil().backgroundModeEnabled);
-    Logger.debug('[batch] config saved: batchMode=$batchMode dir=${docsDir.path} '
-        'deviceId=${device.id} svc=${audioTarget.key} char=${audioTarget.value} type=${device.type.name}');
+    await SharedPreferencesUtil().saveBool(
+      'nativeBleStreamingEnabled',
+      !batchMode && SharedPreferencesUtil().backgroundModeEnabled,
+    );
+    Logger.debug(
+      '[batch] config saved: batchMode=$batchMode dir=${docsDir.path} '
+      'deviceId=${device.id} svc=${audioTarget.key} char=${audioTarget.value} type=${device.type.name}',
+    );
   }
 
   MapEntry<String, String>? _nativeBleAudioTarget(BtDevice device) {
@@ -1072,6 +1091,72 @@ class CaptureProvider extends ChangeNotifier
       case DeviceType.plaud:
         return null;
     }
+  }
+
+  /// Whether the currently-connected recording device has a concrete native BLE
+  /// audio route that the Background Mode / native streaming layer can use.
+  /// Returns false for device types with no native route (Apple Watch, Bee,
+  /// Fieldy, Frame, Limitless, Plaud) and for empty-device-id sentinel entries
+  /// that may linger in preferences from stale state.
+  @visibleForTesting
+  bool get hasNativeBleAudioRoute {
+    final device = _recordingDevice;
+    if (device == null) return false;
+    if (device.id.isEmpty) return false;
+    return _nativeBleAudioTarget(device) != null;
+  }
+
+  /// Enable or disable Background Mode through CaptureProvider so the provider
+  /// can validate against the actual native BLE route before committing prefs.
+  ///
+  /// Returns `true` if the change was accepted, `false` if rejected (e.g. no
+  /// connected device or the device lacks a native BLE audio route).
+  ///
+  /// When disabling: clears `backgroundModeEnabled`, `nativeBleStreamingEnabled`,
+  /// `nativeBleForegroundReady` and removes stale `nativeBleStreamConfig`.
+  ///
+  /// When enabling with no concrete device or no native route: rejects the
+  /// change and leaves all prefs false / removes stale config.
+  ///
+  /// When enabling with a valid route: sets global opt-in and enables effective
+  /// native streaming only when batch mode is off.
+  Future<bool> setBackgroundModeEnabled(bool requested) async {
+    if (!requested) {
+      // Disable: clear everything unconditionally.
+      SharedPreferencesUtil().backgroundModeEnabled = false;
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
+      Logger.debug('[BackgroundMode] disabled — cleared all prefs and config');
+      notifyListeners();
+      return true;
+    }
+
+    // Enable: must have a concrete device with a native BLE audio route.
+    if (!hasNativeBleAudioRoute) {
+      Logger.debug(
+        '[BackgroundMode] enable rejected — no device with native BLE route '
+        '(device=${_recordingDevice?.id}, type=${_recordingDevice?.type})',
+      );
+      // Defensive: ensure prefs stay false and remove any stale config.
+      SharedPreferencesUtil().backgroundModeEnabled = false;
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
+      notifyListeners();
+      return false;
+    }
+
+    // Valid route — enable.
+    SharedPreferencesUtil().backgroundModeEnabled = true;
+    final batchMode = SharedPreferencesUtil().batchModeEnabled;
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', !batchMode);
+    Logger.debug(
+      '[BackgroundMode] enabled — device ${_recordingDevice!.id} '
+      'type=${_recordingDevice!.type}, batchMode=$batchMode',
+    );
+    notifyListeners();
+    return true;
   }
 
   Future<void> _initiateDevicePhotoStreaming() async {
@@ -1282,32 +1367,32 @@ class CaptureProvider extends ChangeNotifier
 
     // record
     await ServiceManager.instance().mic.start(
-          onByteReceived: (bytes) {
-            // Process through AudioSource for frame splitting and sync key generation
-            final frames = _activeSource?.processBytes(bytes) ?? [];
+      onByteReceived: (bytes) {
+        // Process through AudioSource for frame splitting and sync key generation
+        final frames = _activeSource?.processBytes(bytes) ?? [];
 
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
 
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_callActive) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-        );
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_callActive) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+    );
   }
 
   stopStreamRecording() async {

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1106,7 +1106,9 @@ class CaptureProvider extends ChangeNotifier
   /// connected device or the device lacks a native BLE audio route).
   ///
   /// When disabling: clears `backgroundModeEnabled`, `nativeBleStreamingEnabled`,
-  /// `nativeBleForegroundReady` and removes stale `nativeBleStreamConfig`.
+  /// and `nativeBleForegroundReady`. It keeps `nativeBleStreamConfig` only when
+  /// batch mode is still enabled and the current device has a valid native route,
+  /// because native batch writers use the same config for offline capture.
   ///
   /// When enabling with no concrete device or no native route: rejects the
   /// change and leaves all prefs false / removes stale config.
@@ -1115,12 +1117,17 @@ class CaptureProvider extends ChangeNotifier
   /// native streaming only when batch mode is off.
   Future<bool> setBackgroundModeEnabled(bool requested) async {
     if (!requested) {
-      // Disable: clear everything unconditionally.
+      // Disable realtime background streaming. Preserve nativeBleStreamConfig
+      // only when Transcribe Later is still enabled for a concrete native route;
+      // batch capture uses the same config to write offline audio.
+      final keepBatchConfig = SharedPreferencesUtil().batchModeEnabled && hasNativeBleAudioRoute;
       SharedPreferencesUtil().backgroundModeEnabled = false;
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
-      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
-      Logger.debug('[BackgroundMode] disabled — cleared all prefs and config');
+      if (!keepBatchConfig) {
+        await SharedPreferencesUtil().remove('nativeBleStreamConfig');
+      }
+      Logger.debug('[BackgroundMode] disabled — keepBatchConfig=$keepBatchConfig');
       notifyListeners();
       return true;
     }

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1118,9 +1118,10 @@ class CaptureProvider extends ChangeNotifier
   Future<bool> setBackgroundModeEnabled(bool requested) async {
     if (!requested) {
       // Disable realtime background streaming. Preserve nativeBleStreamConfig
-      // only when Transcribe Later is still enabled for a concrete native route;
-      // batch capture uses the same config to write offline audio.
-      final keepBatchConfig = SharedPreferencesUtil().batchModeEnabled && hasNativeBleAudioRoute;
+      // whenever Transcribe Later remains enabled; batch capture uses the same
+      // config for offline audio and may need it even while no route is
+      // currently live. Reconnect/setup paths will refresh it when needed.
+      final keepBatchConfig = SharedPreferencesUtil().batchModeEnabled;
       SharedPreferencesUtil().backgroundModeEnabled = false;
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1156,7 +1156,11 @@ class CaptureProvider extends ChangeNotifier
     SharedPreferencesUtil().backgroundModeEnabled = true;
     final device = _recordingDevice!;
     final codec = await _getAudioCodec(device.id);
+    final wasForegroundReady = SharedPreferencesUtil().getBool('nativeBleForegroundReady');
     await _saveNativeBleStreamConfig(device, codec);
+    if (wasForegroundReady) {
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+    }
     Logger.debug(
       '[BackgroundMode] enabled — device ${device.id} '
       'type=${device.type}, batchMode=${SharedPreferencesUtil().batchModeEnabled}',

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1147,13 +1147,18 @@ class CaptureProvider extends ChangeNotifier
       return false;
     }
 
-    // Valid route — enable.
+    // Valid route — enable and recreate the native config immediately. A user
+    // can toggle Background Mode off and back on without reconnecting; in that
+    // case the disable/reject paths may have removed nativeBleStreamConfig and
+    // the native background streamer cannot start from nativeBleStreamingEnabled
+    // alone.
     SharedPreferencesUtil().backgroundModeEnabled = true;
-    final batchMode = SharedPreferencesUtil().batchModeEnabled;
-    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', !batchMode);
+    final device = _recordingDevice!;
+    final codec = await _getAudioCodec(device.id);
+    await _saveNativeBleStreamConfig(device, codec);
     Logger.debug(
-      '[BackgroundMode] enabled — device ${_recordingDevice!.id} '
-      'type=${_recordingDevice!.type}, batchMode=$batchMode',
+      '[BackgroundMode] enabled — device ${device.id} '
+      'type=${device.type}, batchMode=${SharedPreferencesUtil().batchModeEnabled}',
     );
     notifyListeners();
     return true;

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -246,29 +246,29 @@ class CaptureProvider extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        final frames = _activeSource?.processBytes(bytes) ?? [];
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_callActive) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-    );
+          onByteReceived: (bytes) {
+            final frames = _activeSource?.processBytes(bytes) ?? [];
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_callActive) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+        );
   }
 
   void _onMicStalled() {
@@ -628,9 +628,8 @@ class CaptureProvider extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    String language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -644,13 +643,13 @@ class CaptureProvider extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-      codec: codec,
-      sampleRate: sampleRate,
-      language: language,
-      force: force,
-      source: source,
-      customSttConfig: effectiveConfig,
-    );
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+          source: source,
+          customSttConfig: effectiveConfig,
+        );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -758,24 +757,20 @@ class CaptureProvider extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error resuming device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              resumeDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error resuming device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error pausing device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              pauseDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error pausing device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -869,8 +864,7 @@ class CaptureProvider extends ChangeNotifier
 
         // Local storage syncs. In batch mode the native layer owns writing the
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
-        var checkWalSupported =
-            !SharedPreferencesUtil().batchModeEnabled &&
+        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
@@ -978,9 +972,8 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    var language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1367,32 +1360,32 @@ class CaptureProvider extends ChangeNotifier
 
     // record
     await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        // Process through AudioSource for frame splitting and sync key generation
-        final frames = _activeSource?.processBytes(bytes) ?? [];
+          onByteReceived: (bytes) {
+            // Process through AudioSource for frame splitting and sync key generation
+            final frames = _activeSource?.processBytes(bytes) ?? [];
 
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
 
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_callActive) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-    );
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_callActive) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+        );
   }
 
   stopStreamRecording() async {

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
@@ -59,6 +60,9 @@ TranscriptSegment _segment(String id, String text) {
   );
 }
 
+BtDevice _device({required String id, required DeviceType type, String name = 'TestDevice'}) =>
+    BtDevice(id: id, name: name, type: type);
+
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -70,6 +74,10 @@ void main() {
       // Ignore if already initialized by another test.
     }
   });
+
+  // ------------------------------------------------------------------ //
+  // Existing tests (preserved verbatim from the original file)          //
+  // ------------------------------------------------------------------ //
 
   test('removes segments and related state on deletion event', () {
     final provider = CaptureProvider();
@@ -553,6 +561,340 @@ void main() {
       expect(provider.recordingDeviceServiceReady, isTrue);
 
       provider.updateRecordingState(RecordingState.stop);
+      provider.dispose();
+    });
+  });
+
+  // ------------------------------------------------------------------ //
+  // Issue #7548: Background Mode fail-closed guardrail tests           //
+  // ------------------------------------------------------------------ //
+
+  group('hasNativeBleAudioRoute', () {
+    test('returns false when no device connected', () {
+      final provider = CaptureProvider();
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for empty device id (stale sentinel)', () {
+      final provider = CaptureProvider();
+      // Simulate an Omi device with empty id — should be rejected to avoid
+      // false positive where a sentinel device is treated as available.
+      provider.updateRecordingDevice(_device(id: '', type: DeviceType.omi));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns true for Omi device with non-empty id', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+      provider.dispose();
+    });
+
+    test('returns true for OpenGlass device with non-empty id', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: '11:22:33:44:55:66', type: DeviceType.openglass));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+      provider.dispose();
+    });
+
+    test('returns true for Friend Pendant device with non-empty id', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.friendPendant));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+      provider.dispose();
+    });
+
+    test('returns false for Apple Watch', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.appleWatch));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for Bee', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.bee));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for Fieldy', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.fieldy));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for Frame', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for Limitless', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.limitless));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('returns false for Plaud', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.plaud));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+  });
+
+  group('setBackgroundModeEnabled', () {
+    test('disable always succeeds and clears all prefs', () async {
+      final provider = CaptureProvider();
+      // Pre-set prefs to true to verify they get cleared
+      SharedPreferencesUtil().backgroundModeEnabled = true;
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+      await SharedPreferencesUtil().saveString('nativeBleStreamConfig', '{"test": true}');
+
+      final result = await provider.setBackgroundModeEnabled(false);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
+      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isNull);
+      provider.dispose();
+    });
+
+    test('enable rejects when no device connected', () async {
+      final provider = CaptureProvider();
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Apple Watch)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.appleWatch));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Bee)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.bee));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Fieldy)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.fieldy));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Frame)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Limitless)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.limitless));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for device with no native route (Plaud)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.plaud));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable rejects for empty-id Omi device (stale sentinel)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: '', type: DeviceType.omi));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      provider.dispose();
+    });
+
+    test('enable accepts for Omi device with valid id', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+      // Batch mode is off by default, so nativeBleStreamingEnabled should be true
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+      provider.dispose();
+    });
+
+    test('enable accepts for OpenGlass device with valid id', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: '11:22:33:44:55:66', type: DeviceType.openglass));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+      provider.dispose();
+    });
+
+    test('enable accepts for Friend Pendant device with valid id', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.friendPendant));
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+      provider.dispose();
+    });
+
+    test('enable with batch mode on sets backgroundModeEnabled but not nativeBleStreaming', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      SharedPreferencesUtil().batchModeEnabled = true;
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+      // Batch mode is on, so native streaming should stay false
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      provider.dispose();
+    });
+
+    test('rejected enable clears stale config', () async {
+      final provider = CaptureProvider();
+      // No device connected — should reject
+      await SharedPreferencesUtil().saveString('nativeBleStreamConfig', '{"stale": true}');
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+      SharedPreferencesUtil().backgroundModeEnabled = true;
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isFalse);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
+      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isNull);
+      provider.dispose();
+    });
+
+    test('enable/disable cycle works for valid device', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+
+      // Enable
+      expect(await provider.setBackgroundModeEnabled(true), isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+
+      // Disable
+      expect(await provider.setBackgroundModeEnabled(false), isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+
+      provider.dispose();
+    });
+  });
+
+  group('stale reconciliation — hasNativeBleAudioRoute after device switch', () {
+    test('switching from valid device to no device clears route', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+
+      provider.updateRecordingDevice(null);
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('switching from Omi to Apple Watch clears route', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+
+      provider.updateRecordingDevice(_device(id: '11:22:33:44:55:66', type: DeviceType.appleWatch));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+      provider.dispose();
+    });
+
+    test('switching from no-route device to Omi gains route', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
+      expect(provider.hasNativeBleAudioRoute, isFalse);
+
+      provider.updateRecordingDevice(_device(id: '11:22:33:44:55:66', type: DeviceType.omi));
+      expect(provider.hasNativeBleAudioRoute, isTrue);
+      provider.dispose();
+    });
+  });
+
+  group('Background Mode + batch mode interaction', () {
+    test('enable background, then enable batch: streaming should be false', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+
+      await provider.setBackgroundModeEnabled(true);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+
+      // setBatchMode turns batch on
+      await provider.setBatchMode(true);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      provider.dispose();
+    });
+
+    test('batch on, then enable background: streaming should be false (batch wins)', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      SharedPreferencesUtil().batchModeEnabled = true;
+
+      await provider.setBackgroundModeEnabled(true);
+      // setBackgroundModeEnabled with batch mode on should keep nativeBleStreaming false
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
       provider.dispose();
     });
   });

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -651,6 +651,11 @@ void main() {
   });
 
   group('setBackgroundModeEnabled', () {
+    setUp(() {
+      SharedPreferencesUtil().batchModeEnabled = false;
+      SharedPreferencesUtil().backgroundModeEnabled = false;
+    });
+
     test('disable clears realtime prefs and stale config when batch mode is off', () async {
       final provider = CaptureProvider();
       // Pre-set prefs to true to verify they get cleared
@@ -894,6 +899,11 @@ void main() {
   });
 
   group('Background Mode + batch mode interaction', () {
+    setUp(() {
+      SharedPreferencesUtil().batchModeEnabled = false;
+      SharedPreferencesUtil().backgroundModeEnabled = false;
+    });
+
     test('enable background, then enable batch: streaming should be false', () async {
       final provider = CaptureProvider();
       provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -651,9 +651,12 @@ void main() {
   });
 
   group('setBackgroundModeEnabled', () {
-    setUp(() {
+    setUp(() async {
       SharedPreferencesUtil().batchModeEnabled = false;
       SharedPreferencesUtil().backgroundModeEnabled = false;
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
     });
 
     test('disable clears realtime prefs and stale config when batch mode is off', () async {
@@ -790,6 +793,20 @@ void main() {
       expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
       // Batch mode is off by default, so nativeBleStreamingEnabled should be true
       expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+      provider.dispose();
+    });
+
+    test('enable preserves foreground-ready when foreground streaming is already active', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+
+      final result = await provider.setBackgroundModeEnabled(true);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isTrue);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isTrue);
+      expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isTrue);
       provider.dispose();
     });
 

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -674,9 +674,8 @@ void main() {
       provider.dispose();
     });
 
-    test('disable keeps native config when batch mode still needs it', () async {
+    test('disable keeps native config when batch mode still needs it without a live route', () async {
       final provider = CaptureProvider();
-      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
       SharedPreferencesUtil().batchModeEnabled = true;
       SharedPreferencesUtil().backgroundModeEnabled = true;
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message_event.dart';
@@ -61,7 +62,7 @@ TranscriptSegment _segment(String id, String text) {
 }
 
 BtDevice _device({required String id, required DeviceType type, String name = 'TestDevice'}) =>
-    BtDevice(id: id, name: name, type: type);
+    BtDevice(id: id, name: name, type: type, rssi: -50);
 
 void main() {
   setUpAll(() async {
@@ -650,7 +651,7 @@ void main() {
   });
 
   group('setBackgroundModeEnabled', () {
-    test('disable always succeeds and clears all prefs', () async {
+    test('disable clears realtime prefs and stale config when batch mode is off', () async {
       final provider = CaptureProvider();
       // Pre-set prefs to true to verify they get cleared
       SharedPreferencesUtil().backgroundModeEnabled = true;
@@ -665,6 +666,25 @@ void main() {
       expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
       expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
       expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isNull);
+      provider.dispose();
+    });
+
+    test('disable keeps native config when batch mode still needs it', () async {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+      SharedPreferencesUtil().batchModeEnabled = true;
+      SharedPreferencesUtil().backgroundModeEnabled = true;
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+      await SharedPreferencesUtil().saveString('nativeBleStreamConfig', '{"test": true}');
+
+      final result = await provider.setBackgroundModeEnabled(false);
+
+      expect(result, isTrue);
+      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
+      expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
+      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), '{"test": true}');
       provider.dispose();
     });
 

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -68,6 +70,14 @@ void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return Directory.systemTemp.path;
+        return null;
+      },
+    );
     ConnectivityPlatform.instance = _TestConnectivityPlatform();
     try {
       await ServiceManager.init();
@@ -652,6 +662,8 @@ void main() {
 
   group('setBackgroundModeEnabled', () {
     setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
       SharedPreferencesUtil().batchModeEnabled = false;
       SharedPreferencesUtil().backgroundModeEnabled = false;
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);


### PR DESCRIPTION
## Summary

Partial mitigation for #7548 — **fail-closed guardrail only, no new device protocol support.**

Background Mode now validates that the currently-connected device has a concrete native BLE audio route before accepting the enable request. This prevents users from enabling Background Mode when no compatible device can actually stream audio in the background, which would silently fail and leave them with non-functional recording.

### What this changes

| Area | Change |
|------|--------|
| **CaptureProvider** | New `setBackgroundModeEnabled(bool)` method owns all Background Mode state. Enable is gated behind `hasNativeBleAudioRoute` predicate. Disable clears `backgroundModeEnabled`, `nativeBleStreamingEnabled`, `nativeBleForegroundReady`, and removes stale `nativeBleStreamConfig`. |
| **CaptureProvider** | New `hasNativeBleAudioRoute` predicate: requires `device != null`, `device.id.isNotEmpty`, and `_nativeBleAudioTarget(device) != null`. Rejects empty-id Omi sentinel entries that may linger from stale state. |
| **CaptureProvider** | `setBatchMode` now only re-enables native streaming when turning batch OFF **and** a concrete device with a native route is connected. |
| **CaptureProvider** | `_saveNativeBleStreamConfig`: when `audioTarget` is null (device has no native route), also clears `backgroundModeEnabled` and removes stale config. |
| **Profile settings** | `_showBackgroundModeSheet` delegates to `CaptureProvider.setBackgroundModeEnabled()` instead of writing prefs directly. Switch is disabled when no route is available, with a warning banner explaining why. |
| **l10n** | Added `backgroundModeUnavailable` string to all 49 locale ARB files. |
| **Tests** | 34 new tests covering: route availability matrix (all 9 device types), empty-id Omi sentinel, rejected enable keeps prefs false, stale reconciliation, enable/disable cycle, batch mode interaction, device switching. |

### Available native BLE routes

Only these device types have a native BLE audio target:
- **Omi** (`DeviceType.omi`)
- **OpenGlass** (`DeviceType.openglass`)
- **Friend Pendant** (`DeviceType.friendPendant`)

All others (Apple Watch, Bee, Fieldy, Frame, Limitless, Plaud) return `null` from `_nativeBleAudioTarget` and are correctly blocked.

### What this does NOT do

- Does **not** add new native protocol or device support for Apple Watch, Bee, Fieldy, Frame, Limitless, or Plaud.
- Does **not** modify any Kotlin/native files.
- Does **not** claim to fully resolve #7548 — this is a partial mitigation / fail-closed guardrail.

### Testing

- `dart format --line-length 120` passes on all 3 modified Dart files.
- `flutter test` cannot run in this environment (Flutter SDK not installed), but 34 new unit tests have been added covering all specified matrix cases.
- Pre-commit hook formatting passes.

Refs #7548


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

