### PR TITLE
fix daily summary detail and settings page bugs

### DIFF
--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -511,15 +511,6 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
     return parts.first.trim();
   }
 
-  // Get truly unique location count (by short name)
-  int _getUniqueLocationCount(List<LocationPin> locations) {
-    final uniqueNames = <String>{};
-    for (final loc in locations) {
-      uniqueNames.add(_getShortLocationName(loc.address));
-    }
-    return uniqueNames.length;
-  }
-
   // Parse time string to minutes for comparison (e.g., "14:42" -> 882)
   int _parseTimeToMinutes(String? timeStr) {
     if (timeStr == null || timeStr.isEmpty) return 0;
@@ -564,7 +555,6 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
         // New location (different from previous)
         current = _TimelineLocation(
           shortName: shortName,
-          fullAddress: loc.address,
           latitude: loc.latitude,
           longitude: loc.longitude,
           startTime: loc.time,
@@ -780,17 +770,6 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
         ),
       ),
     );
-  }
-
-  Color _getPriorityColor(String priority) {
-    switch (priority.toLowerCase()) {
-      case 'high':
-        return const Color(0xFFFF6B6B);
-      case 'medium':
-        return const Color(0xFFFFB347);
-      default:
-        return const Color(0xFF6BCB77);
-    }
   }
 
   Widget _buildUnresolvedQuestionsSection(DailySummary summary) {
@@ -1030,7 +1009,6 @@ Future<bool?> showDeleteRecapConfirmDialog(BuildContext context) {
 // Helper class for timeline locations
 class _TimelineLocation {
   final String shortName;
-  final String? fullAddress;
   final double latitude;
   final double longitude;
   final String? startTime;
@@ -1038,7 +1016,6 @@ class _TimelineLocation {
 
   _TimelineLocation({
     required this.shortName,
-    this.fullAddress,
     required this.latitude,
     required this.longitude,
     this.startTime,

--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -147,6 +147,7 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
     } catch (e) {
       if (!mounted) return;
       Navigator.pop(context); // Dismiss loading
+      AppSnackbar.showSnackbarError(context.l10n.somethingWentWrong);
     }
   }
 
@@ -395,7 +396,6 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
           ),
         ),
         IconButton(
-          tooltip: context.l10n.deleteRecap,
           icon: Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.3), shape: BoxShape.circle),

--- a/app/lib/pages/settings/daily_summary_settings_page.dart
+++ b/app/lib/pages/settings/daily_summary_settings_page.dart
@@ -29,17 +29,16 @@ class _DailySummarySettingsPageState extends State<DailySummarySettingsPage> {
   }
 
   Future<void> _loadSettings() async {
-    final settings = await getDailySummarySettings();
-    if (settings != null && mounted) {
-      setState(() {
-        _enabled = settings.enabled;
-        _selectedHour = settings.hour;
-        _isLoading = false;
-      });
-    } else if (mounted) {
-      setState(() {
-        _isLoading = false;
-      });
+    try {
+      final settings = await getDailySummarySettings();
+      if (settings != null && mounted) {
+        setState(() {
+          _enabled = settings.enabled;
+          _selectedHour = settings.hour;
+        });
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
     }
   }
 

--- a/app/lib/pages/settings/daily_summary_settings_page.dart
+++ b/app/lib/pages/settings/daily_summary_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class DailySummarySettingsPage extends StatefulWidget {
@@ -49,15 +50,29 @@ class _DailySummarySettingsPageState extends State<DailySummarySettingsPage> {
   }
 
   Future<void> _updateEnabled(bool value) async {
+    final previous = _enabled;
     setState(() => _enabled = value);
-    await setDailySummarySettings(enabled: value);
-    PlatformManager.instance.analytics.dailySummaryToggled(enabled: value);
+    final success = await setDailySummarySettings(enabled: value);
+    if (!mounted) return;
+    if (success) {
+      PlatformManager.instance.analytics.dailySummaryToggled(enabled: value);
+    } else {
+      setState(() => _enabled = previous);
+      AppSnackbar.showSnackbarError(context.l10n.somethingWentWrong);
+    }
   }
 
   Future<void> _updateHour(int hour) async {
+    final previous = _selectedHour;
     setState(() => _selectedHour = hour);
-    await setDailySummarySettings(hour: hour);
-    PlatformManager.instance.analytics.dailySummaryTimeChanged(hour: hour);
+    final success = await setDailySummarySettings(hour: hour);
+    if (!mounted) return;
+    if (success) {
+      PlatformManager.instance.analytics.dailySummaryTimeChanged(hour: hour);
+    } else {
+      setState(() => _selectedHour = previous);
+      AppSnackbar.showSnackbarError(context.l10n.somethingWentWrong);
+    }
   }
 
   Future<void> _showHourPicker() async {

--- a/app/lib/pages/settings/daily_summary_settings_page.dart
+++ b/app/lib/pages/settings/daily_summary_settings_page.dart
@@ -56,7 +56,7 @@ class _DailySummarySettingsPageState extends State<DailySummarySettingsPage> {
     if (!mounted) return;
     if (success) {
       PlatformManager.instance.analytics.dailySummaryToggled(enabled: value);
-    } else {
+    } else if (_enabled == value) {
       setState(() => _enabled = previous);
       AppSnackbar.showSnackbarError(context.l10n.somethingWentWrong);
     }
@@ -69,7 +69,7 @@ class _DailySummarySettingsPageState extends State<DailySummarySettingsPage> {
     if (!mounted) return;
     if (success) {
       PlatformManager.instance.analytics.dailySummaryTimeChanged(hour: hour);
-    } else {
+    } else if (_selectedHour == hour) {
       setState(() => _selectedHour = previous);
       AppSnackbar.showSnackbarError(context.l10n.somethingWentWrong);
     }


### PR DESCRIPTION
## Summary

- Remove orphaned comment and dead `fullAddress` field in `_TimelineLocation` (never read anywhere)
- Show `somethingWentWrong` error snackbar when conversation load fails in `_openConversation` instead of silently dismissing the spinner
- Remove misleading `deleteRecap` tooltip from the 3-dot actions button (it opens both regenerate and delete options)
- Fix `_loadSettings` spinner hanging forever when `getDailySummarySettings` throws — wrapped in `try/finally`
- Fix `_updateEnabled` / `_updateHour` silent failures — rollback optimistic state and show error snackbar if `setDailySummarySettings` returns false

## Test plan

- [ ] Open a daily summary detail page — tap a highlight/action item/question with a valid conversation ID and confirm it navigates correctly
- [ ] Simulate a network failure on conversation tap and confirm the error snackbar appears
- [ ] Tap the 3-dot button and confirm both "Regenerate" and "Delete" actions are present (no misleading tooltip)
- [ ] Open Daily Summary settings — toggle the switch off and back on; confirm the UI reflects the change and no stale state remains after a simulated API error
- [ ] Simulate an API failure on time/toggle change and confirm the previous value is restored with an error snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

