### PR TITLE
fix map not available crash when launching location in conversation detail

### DIFF
--- a/app/lib/pages/conversation_detail/maps_util.dart
+++ b/app/lib/pages/conversation_detail/maps_util.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:map_launcher/map_launcher.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/env/env.dart';
 
@@ -71,10 +72,22 @@ class MapsUtil {
   }
 
   static void launchMap(double lat, double lng) async {
-    if (Platform.isIOS) {
-      await MapLauncher.showMarker(mapType: MapType.apple, coords: Coords(lat, lng), title: '');
-    } else {
-      await MapLauncher.showMarker(mapType: MapType.google, coords: Coords(lat, lng), title: '');
+    try {
+      final preferredType = Platform.isIOS ? MapType.apple : MapType.google;
+      if (await MapLauncher.isMapAvailable(preferredType) == true) {
+        await MapLauncher.showMarker(mapType: preferredType, coords: Coords(lat, lng), title: '');
+        return;
+      }
+      final installed = await MapLauncher.installedMaps;
+      if (installed.isNotEmpty) {
+        await installed.first.showMarker(coords: Coords(lat, lng), title: '');
+        return;
+      }
+    } catch (_) {}
+    // Fallback: open in browser
+    final uri = Uri.parse('https://www.google.com/maps/search/?api=1&query=$lat,$lng');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 }

--- a/app/lib/pages/conversation_detail/maps_util.dart
+++ b/app/lib/pages/conversation_detail/maps_util.dart
@@ -86,8 +86,6 @@ class MapsUtil {
     } catch (_) {}
     // Fallback: open in browser
     final uri = Uri.parse('https://www.google.com/maps/search/?api=1&query=$lat,$lng');
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }


### PR DESCRIPTION
## Summary

- Fixes crash `PlatformException(MAP_NOT_AVAILABLE, Map is not installed on a device, null, null)` in `MapsUtil.launchMap` reported via Firebase Crashlytics
- Root cause: `MapLauncher.showMarker` was called unconditionally with `MapType.google` on Android without checking if Google Maps is installed
- Fix adds a 3-tier fallback: preferred map app (Apple/Google) → any installed map app → browser (`google.com/maps`)

## Crash

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError:
PlatformException(MAP_NOT_AVAILABLE, Map is not installed on a device, null, null)
  at MapsUtil.launchMap (maps_util.dart:77)
```

## Test plan

- [ ] Tap a location in conversation detail on a device with Google Maps installed — opens Google Maps as before
- [ ] Tap a location on a device/emulator without Google Maps — falls back to another installed map or browser
- [ ] No crash when no map app is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

