### PR TITLE
fix(backend): consolidate Firestore mutation invariants

### DIFF
--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -1,9 +1,9 @@
-import hashlib
 import json
 import os
-import uuid
 
 from google.cloud import firestore
+
+from database.document_ids import document_id_from_seed
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -17,10 +17,3 @@ db = firestore.Client()
 def get_users_uid():
     users_ref = db.collection('users')
     return [str(doc.id) for doc in users_ref.stream()]
-
-
-def document_id_from_seed(seed: str) -> uuid.UUID:
-    """Avoid repeating the same data"""
-    seed_hash = hashlib.sha256(seed.encode('utf-8')).digest()
-    generated_uuid = uuid.UUID(bytes=seed_hash[:16], version=4)
-    return str(generated_uuid)

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from typing import Optional, List
 from google.cloud import firestore
@@ -11,6 +12,27 @@ logger = logging.getLogger(__name__)
 
 # Collection name
 action_items_collection = 'action_items'
+
+
+@dataclass
+class BatchMutationResult:
+    """Outcome for partial batch mutations where missing ids must be explicit."""
+
+    updated_ids: List[str] = field(default_factory=list)
+    missing_ids: List[str] = field(default_factory=list)
+    noop_ids: List[str] = field(default_factory=list)
+
+    @property
+    def updated_count(self) -> int:
+        return len(self.updated_ids)
+
+    def model(self) -> dict:
+        return {
+            'updated_count': len(self.updated_ids),
+            'updated_ids': self.updated_ids,
+            'missing_ids': self.missing_ids,
+            'noop_ids': self.noop_ids,
+        }
 
 
 def get_action_item_ids(uid: str) -> List[str]:
@@ -428,16 +450,17 @@ def update_action_item(uid: str, action_item_id: str, update_data: dict) -> bool
     return True
 
 
-def batch_update_action_items(uid: str, items: list) -> None:
+def batch_update_action_items(uid: str, items: list) -> BatchMutationResult:
     """
     Batch update sort_order and/or indent_level for multiple action items.
 
-    Args:
-        uid: User ID
-        items: List of objects with id, sort_order (optional), indent_level (optional)
+    Missing IDs are returned explicitly instead of letting Firestore's batch
+    update fail the whole request or silently pretending every requested id
+    changed.
     """
+    result = BatchMutationResult()
     if not items:
-        return
+        return result
 
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
@@ -447,16 +470,24 @@ def batch_update_action_items(uid: str, items: list) -> None:
     count = 0
 
     for item in items:
+        doc_ref = action_items_ref.document(item.id)
+        if not doc_ref.get().exists:
+            result.missing_ids.append(item.id)
+            continue
+
         update_data = {'updated_at': now}
         if item.sort_order is not None:
             update_data['sort_order'] = item.sort_order
         if item.indent_level is not None:
             update_data['indent_level'] = item.indent_level
 
-        if len(update_data) > 1:  # More than just updated_at
-            doc_ref = action_items_ref.document(item.id)
-            batch.update(doc_ref, update_data)
-            count += 1
+        if len(update_data) == 1:
+            result.noop_ids.append(item.id)
+            continue
+
+        batch.update(doc_ref, update_data)
+        result.updated_ids.append(item.id)
+        count += 1
 
         if count >= 499:  # Firestore batch limit is 500
             batch.commit()
@@ -465,6 +496,8 @@ def batch_update_action_items(uid: str, items: list) -> None:
 
     if count > 0:
         batch.commit()
+
+    return result
 
 
 def mark_action_item_completed(uid: str, action_item_id: str, completed: bool = True) -> bool:
@@ -635,16 +668,16 @@ def get_pending_apple_reminders_sync(uid: str) -> dict:
     return {"pending_export": pending_export, "synced_items": synced_items}
 
 
-def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
+def batch_sync_update_action_items(uid: str, updates: List[dict]) -> BatchMutationResult:
     """
     Batch update action items during reminders sync. Single Firestore batch commit.
 
-    Args:
-        uid: User ID
-        updates: List of {'id': str, 'data': dict} entries
+    Missing IDs are returned explicitly; callers should use only updated_ids for
+    downstream vector/cache work.
     """
+    result = BatchMutationResult()
     if not updates:
-        return
+        return result
 
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
@@ -654,13 +687,18 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
     count = 0
 
     for entry in updates:
+        doc_ref = action_items_ref.document(entry['id'])
+        if not doc_ref.get().exists:
+            result.missing_ids.append(entry['id'])
+            continue
+
         update_data = _prepare_action_item_for_write(entry['data'])
         update_data['updated_at'] = now
         # Clear sync_requested when item is successfully exported
         if update_data.get('exported') is True:
             update_data['sync_requested'] = False
-        doc_ref = action_items_ref.document(entry['id'])
         batch.update(doc_ref, update_data)
+        result.updated_ids.append(entry['id'])
         count += 1
 
         if count >= 499:
@@ -670,6 +708,8 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> None:
 
     if count > 0:
         batch.commit()
+
+    return result
 
 
 def unlock_all_action_items(uid: str):

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from typing import Optional, List
+from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -454,9 +455,9 @@ def batch_update_action_items(uid: str, items: list) -> BatchMutationResult:
     """
     Batch update sort_order and/or indent_level for multiple action items.
 
-    Missing IDs are returned explicitly instead of letting Firestore's batch
-    update fail the whole request or silently pretending every requested id
-    changed.
+    Missing IDs are returned explicitly. Each document update is applied
+    independently so a concurrent delete cannot make Firestore reject an entire
+    mutation after an earlier existence pre-read succeeded.
     """
     result = BatchMutationResult()
     if not items:
@@ -466,15 +467,8 @@ def batch_update_action_items(uid: str, items: list) -> BatchMutationResult:
     action_items_ref = user_ref.collection(action_items_collection)
     now = datetime.now(timezone.utc)
 
-    batch = db.batch()
-    count = 0
-
     for item in items:
         doc_ref = action_items_ref.document(item.id)
-        if not doc_ref.get().exists:
-            result.missing_ids.append(item.id)
-            continue
-
         update_data = {'updated_at': now}
         if item.sort_order is not None:
             update_data['sort_order'] = item.sort_order
@@ -485,17 +479,12 @@ def batch_update_action_items(uid: str, items: list) -> BatchMutationResult:
             result.noop_ids.append(item.id)
             continue
 
-        batch.update(doc_ref, update_data)
+        try:
+            doc_ref.update(update_data)
+        except NotFound:
+            result.missing_ids.append(item.id)
+            continue
         result.updated_ids.append(item.id)
-        count += 1
-
-        if count >= 499:  # Firestore batch limit is 500
-            batch.commit()
-            batch = db.batch()
-            count = 0
-
-    if count > 0:
-        batch.commit()
 
     return result
 
@@ -670,10 +659,12 @@ def get_pending_apple_reminders_sync(uid: str) -> dict:
 
 def batch_sync_update_action_items(uid: str, updates: List[dict]) -> BatchMutationResult:
     """
-    Batch update action items during reminders sync. Single Firestore batch commit.
+    Batch update action items during reminders sync.
 
-    Missing IDs are returned explicitly; callers should use only updated_ids for
-    downstream vector/cache work.
+    Missing IDs are returned explicitly; each document update is applied
+    independently so a concurrent delete cannot fail the whole request after an
+    existence pre-read. Callers should use only updated_ids for downstream
+    vector/cache work.
     """
     result = BatchMutationResult()
     if not updates:
@@ -683,31 +674,19 @@ def batch_sync_update_action_items(uid: str, updates: List[dict]) -> BatchMutati
     action_items_ref = user_ref.collection(action_items_collection)
     now = datetime.now(timezone.utc)
 
-    batch = db.batch()
-    count = 0
-
     for entry in updates:
         doc_ref = action_items_ref.document(entry['id'])
-        if not doc_ref.get().exists:
-            result.missing_ids.append(entry['id'])
-            continue
-
         update_data = _prepare_action_item_for_write(entry['data'])
         update_data['updated_at'] = now
         # Clear sync_requested when item is successfully exported
         if update_data.get('exported') is True:
             update_data['sync_requested'] = False
-        batch.update(doc_ref, update_data)
+        try:
+            doc_ref.update(update_data)
+        except NotFound:
+            result.missing_ids.append(entry['id'])
+            continue
         result.updated_ids.append(entry['id'])
-        count += 1
-
-        if count >= 499:
-            batch.commit()
-            batch = db.batch()
-            count = 0
-
-    if count > 0:
-        batch.commit()
 
     return result
 

--- a/backend/database/calendar_meetings.py
+++ b/backend/database/calendar_meetings.py
@@ -1,9 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from google.cloud import firestore
+from google.cloud.firestore_v1 import transactional
 
 from ._client import db
+from database.document_ids import calendar_meeting_doc_id
 
 
 def _get_meetings_collection(uid: str):
@@ -11,25 +13,29 @@ def _get_meetings_collection(uid: str):
     return db.collection('users').document(uid).collection('meetings')
 
 
+@transactional
+def _upsert_meeting_transaction(transaction, doc_ref, meeting_data: Dict, now: datetime) -> None:
+    """Upsert a natural-key meeting while preserving first-created metadata."""
+    snapshot = doc_ref.get(transaction=transaction)
+    payload = dict(meeting_data)
+    payload['synced_at'] = now
+    if not snapshot.exists:
+        payload['created_at'] = now
+    transaction.set(doc_ref, payload, merge=True)
+
+
 def create_meeting(uid: str, meeting_data: Dict) -> str:
     """
-    Create a new calendar meeting in Firestore.
-    Returns the Firestore document ID.
+    Create or idempotently upsert a calendar meeting in Firestore.
+    Returns the deterministic Firestore document ID.
 
     NOTE: Times should already be in UTC before calling this function.
     """
-    # Add timestamps (always in UTC for consistent querying)
-    from datetime import timezone
-
-    now = datetime.now(timezone.utc)
-    meeting_data['created_at'] = now
-    meeting_data['synced_at'] = now
-
-    # Create document
-    doc_ref = _get_meetings_collection(uid).document()
-    doc_ref.set(meeting_data)
-
-    return doc_ref.id
+    meeting_id = calendar_meeting_doc_id(uid, meeting_data['calendar_source'], meeting_data['calendar_event_id'])
+    doc_ref = _get_meetings_collection(uid).document(meeting_id)
+    transaction = db.transaction()
+    _upsert_meeting_transaction(transaction, doc_ref, meeting_data, datetime.now(timezone.utc))
+    return meeting_id
 
 
 def update_meeting(uid: str, meeting_id: str, meeting_data: Dict) -> None:
@@ -39,8 +45,6 @@ def update_meeting(uid: str, meeting_id: str, meeting_data: Dict) -> None:
     NOTE: Times should already be in UTC before calling this function.
     """
     # Update synced_at timestamp (always in UTC for consistent querying)
-    from datetime import timezone
-
     meeting_data['synced_at'] = datetime.now(timezone.utc)
 
     # Update document

--- a/backend/database/document_ids.py
+++ b/backend/database/document_ids.py
@@ -1,0 +1,29 @@
+"""Deterministic Firestore document id helpers.
+
+Keep natural-key seed construction in one low-dependency module so database
+callers do not hand-roll subtly different id formats.
+"""
+
+import hashlib
+import uuid
+
+
+def document_id_from_seed(seed: str) -> str:
+    """Return a stable UUIDv4-shaped document id for a natural-key seed."""
+    seed_hash = hashlib.sha256(seed.encode('utf-8')).digest()
+    return str(uuid.UUID(bytes=seed_hash[:16], version=4))
+
+
+def system_folder_doc_id(uid: str, category_mapping: str) -> str:
+    """Stable id for a user's built-in system folder category."""
+    return document_id_from_seed(f"user:{uid}:system_folder:{category_mapping}")
+
+
+def calendar_meeting_doc_id(uid: str, calendar_source: str, calendar_event_id: str) -> str:
+    """Stable id for a meeting from an external calendar provider.
+
+    The current API exposes `calendar_source` and `calendar_event_id` as the
+    available provider uniqueness dimensions. If provider account/calendar ids
+    are added later, extend this helper rather than adding call-site seed logic.
+    """
+    return document_id_from_seed(f"user:{uid}:calendar_meeting:{calendar_source}:{calendar_event_id}")

--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -6,6 +6,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
+from database.document_ids import system_folder_doc_id
 from models.folder import Folder
 
 # System folders that are created for new users
@@ -225,7 +226,7 @@ def initialize_system_folders(uid: str) -> List[dict]:
     now = datetime.now(timezone.utc)
 
     for i, folder_config in enumerate(SYSTEM_FOLDERS):
-        folder_id = str(uuid.uuid4())
+        folder_id = system_folder_doc_id(uid, folder_config['category_mapping'])
         folder_data = {
             'id': folder_id,
             'name': folder_config['name'],

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -375,6 +375,37 @@ def get_person_speech_samples_count(uid: str, person_id: str) -> int:
     return len(person_data.get('speech_samples', []))
 
 
+@transactional
+def _remove_sample_transaction(transaction, person_ref, sample_path: str) -> bool:
+    """Atomically remove a sample and its aligned transcript."""
+    snapshot = person_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+
+    person_data = snapshot.to_dict()
+    samples = list(person_data.get('speech_samples', []))
+    transcripts = list(person_data.get('speech_sample_transcripts', []))
+
+    try:
+        idx = samples.index(sample_path)
+    except ValueError:
+        return False
+
+    samples.pop(idx)
+    if idx < len(transcripts):
+        transcripts.pop(idx)
+
+    transaction.update(
+        person_ref,
+        {
+            'speech_samples': samples,
+            'speech_sample_transcripts': transcripts,
+            'updated_at': datetime.now(timezone.utc),
+        },
+    )
+    return True
+
+
 def remove_person_speech_sample(uid: str, person_id: str, sample_path: str) -> bool:
     """
     Remove a speech sample path from person's speech_samples list.
@@ -389,34 +420,8 @@ def remove_person_speech_sample(uid: str, person_id: str, sample_path: str) -> b
         True if removed, False if person or sample not found
     """
     person_ref = db.collection('users').document(uid).collection('people').document(person_id)
-    person_doc = person_ref.get()
-
-    if not person_doc.exists:
-        return False
-
-    person_data = person_doc.to_dict()
-    samples = person_data.get('speech_samples', [])
-    transcripts = person_data.get('speech_sample_transcripts', [])
-
-    # Find index of sample to remove
-    try:
-        idx = samples.index(sample_path)
-    except ValueError:
-        return False  # Sample not found
-
-    # Remove from both arrays by index
-    samples.pop(idx)
-    if idx < len(transcripts):
-        transcripts.pop(idx)
-
-    person_ref.update(
-        {
-            'speech_samples': samples,
-            'speech_sample_transcripts': transcripts,
-            'updated_at': datetime.now(timezone.utc),
-        }
-    )
-    return True
+    transaction = db.transaction()
+    return _remove_sample_transaction(transaction, person_ref, sample_path)
 
 
 def set_user_speaker_embedding(uid: str, embedding: list) -> bool:

--- a/backend/models/folder.py
+++ b/backend/models/folder.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from typing import List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class Folder(BaseModel):
@@ -64,4 +64,11 @@ class BulkMoveConversationsRequest(BaseModel):
 class ReorderFoldersRequest(BaseModel):
     """Request model for reordering folders."""
 
-    folder_ids: List[str]  # Ordered list of folder IDs
+    folder_ids: List[str] = Field(..., min_length=1, max_length=100)  # Ordered list of folder IDs
+
+    @field_validator('folder_ids')
+    @classmethod
+    def reject_duplicate_folder_ids(cls, folder_ids: List[str]) -> List[str]:
+        if len(folder_ids) != len(set(folder_ids)):
+            raise ValueError('folder_ids must not contain duplicates')
+        return folder_ids

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -37,6 +37,22 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+def _batch_mutation_response(result, *, locked_ids: Optional[set[str]] = None) -> dict:
+    """Preserve legacy success shape unless there is partial-outcome detail.
+
+    Mobile clients historically treat batch endpoints as boolean success paths,
+    and the hermetic e2e harness pins that happy-path contract. Missing/no-op
+    details are only emitted when they carry actionable information.
+    """
+    body = {"status": "ok", "updated_count": result.updated_count}
+    locked_ids = locked_ids or set()
+    if result.missing_ids or result.noop_ids or locked_ids:
+        body.update(result.model())
+        if locked_ids:
+            body["locked_ids"] = sorted(locked_ids)
+    return body
+
+
 # Request models specific to action items
 class CreateActionItemRequest(BaseModel):
     description: str = Field(description="The action item description")
@@ -107,7 +123,7 @@ class BatchUpdateActionItemsRequest(BaseModel):
 def batch_update_action_items(request: BatchUpdateActionItemsRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Batch update sort_order and indent_level for multiple action items."""
     result = action_items_db.batch_update_action_items(uid, request.items)
-    return {"status": "ok", **result.model()}
+    return _batch_mutation_response(result)
 
 
 # *****************************
@@ -191,7 +207,7 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
             [{'action_item_id': u['id'], 'description': u['data']['description']} for u in desc_updates],
         )
 
-    return {"status": "ok", **result.model(), "locked_ids": sorted(locked_ids)}
+    return _batch_mutation_response(result, locked_ids=locked_ids)
 
 
 # *****************************

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -106,8 +106,8 @@ class BatchUpdateActionItemsRequest(BaseModel):
 @router.patch("/v1/action-items/batch", tags=['action-items'])
 def batch_update_action_items(request: BatchUpdateActionItemsRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Batch update sort_order and indent_level for multiple action items."""
-    action_items_db.batch_update_action_items(uid, request.items)
-    return {"status": "ok", "updated_count": len(request.items)}
+    result = action_items_db.batch_update_action_items(uid, request.items)
+    return {"status": "ok", **result.model()}
 
 
 # *****************************
@@ -181,16 +181,17 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
         if update_data:
             updates.append({'id': item.id, 'data': update_data})
 
-    action_items_db.batch_sync_update_action_items(uid, updates)
+    result = action_items_db.batch_sync_update_action_items(uid, updates)
 
-    desc_updates = [u for u in updates if 'description' in u['data']]
+    updated_ids = set(result.updated_ids)
+    desc_updates = [u for u in updates if u['id'] in updated_ids and 'description' in u['data']]
     if desc_updates:
         upsert_action_item_vectors_batch(
             uid,
             [{'action_item_id': u['id'], 'description': u['data']['description']} for u in desc_updates],
         )
 
-    return {"status": "ok", "updated_count": len(updates)}
+    return {"status": "ok", **result.model(), "locked_ids": sorted(locked_ids)}
 
 
 # *****************************

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -91,12 +91,23 @@ def delete_folder(
     if folder.get('is_system'):
         raise HTTPException(status_code=400, detail="Cannot delete system folder")
 
+    if move_to_folder_id:
+        if move_to_folder_id == folder_id:
+            raise HTTPException(status_code=400, detail="Cannot move conversations to the folder being deleted")
+        if not folders_db.get_folder(uid, move_to_folder_id):
+            raise HTTPException(status_code=404, detail="Target folder not found")
+
     folders_db.delete_folder(uid, folder_id, move_to_folder_id)
 
 
 @router.post('/v1/folders/reorder', tags=['folders'])
 def reorder_folders(request: ReorderFoldersRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Reorder folders by providing an ordered list of folder IDs."""
+    existing_ids = {folder['id'] for folder in folders_db.get_folders(uid)}
+    unknown_ids = [folder_id for folder_id in request.folder_ids if folder_id not in existing_ids]
+    if unknown_ids:
+        raise HTTPException(status_code=422, detail={"message": "Unknown folder IDs", "folder_ids": unknown_ids})
+
     folders_db.reorder_folders(uid, request.folder_ids)
     return {"status": "ok"}
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -72,6 +72,7 @@ pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v
 pytest tests/unit/test_firestore_cache.py -v
+pytest tests/unit/test_firestore_invariant_helpers.py -v
 pytest tests/unit/test_task_sharing.py -v
 pytest tests/unit/test_action_items_conversation_list_malformed.py -v
 pytest tests/unit/test_firmware_pagination.py -v

--- a/backend/tests/unit/test_firestore_invariant_helpers.py
+++ b/backend/tests/unit/test_firestore_invariant_helpers.py
@@ -1,0 +1,32 @@
+"""Shared Firestore invariant helpers used by aggregated ZachL111 fixes."""
+
+import pytest
+from pydantic import ValidationError
+
+from database.document_ids import calendar_meeting_doc_id, system_folder_doc_id
+from models.folder import ReorderFoldersRequest
+
+
+def test_system_folder_doc_ids_are_stable_per_uid_and_category():
+    first = system_folder_doc_id('uid-1', 'work')
+    second = system_folder_doc_id('uid-1', 'work')
+
+    assert first == second
+    assert first != system_folder_doc_id('uid-1', 'personal')
+    assert first != system_folder_doc_id('uid-2', 'work')
+
+
+def test_calendar_meeting_doc_ids_include_available_provider_dimensions():
+    base = calendar_meeting_doc_id('uid-1', 'google_calendar', 'event-1')
+
+    assert base == calendar_meeting_doc_id('uid-1', 'google_calendar', 'event-1')
+    assert base != calendar_meeting_doc_id('uid-1', 'outlook_calendar', 'event-1')
+    assert base != calendar_meeting_doc_id('uid-2', 'google_calendar', 'event-1')
+    assert base != calendar_meeting_doc_id('uid-1', 'google_calendar', 'event-2')
+
+
+def test_reorder_folder_request_rejects_duplicate_ids_before_writes():
+    with pytest.raises(ValidationError):
+        ReorderFoldersRequest(folder_ids=['folder-a', 'folder-a'])
+
+    assert ReorderFoldersRequest(folder_ids=['folder-a', 'folder-b']).folder_ids == ['folder-a', 'folder-b']

--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -669,7 +669,19 @@ class TestSyncBatchSkipsLocked:
                 {"id": "t1", "description": "OK", "is_locked": False},
                 {"id": "t2", "description": "Secret", "is_locked": True},
             ]
-            mock_db.batch_sync_update_action_items = MagicMock()
+            batch_result = types.SimpleNamespace(
+                updated_ids=["t1"],
+                missing_ids=[],
+                noop_ids=[],
+                updated_count=1,
+            )
+            batch_result.model = lambda: {
+                "updated_count": 1,
+                "updated_ids": ["t1"],
+                "missing_ids": [],
+                "noop_ids": [],
+            }
+            mock_db.batch_sync_update_action_items = MagicMock(return_value=batch_result)
 
             request = SyncBatchRequest(
                 items=[


### PR DESCRIPTION
## Summary

This is an aggregated, systematic replacement for ZachL111's Firestore/data-mutation hardening PRs. Rather than merging a set of one-off patches that silently skip missing records, this PR adds explicit invariants and shared helpers:

- shared deterministic document-id helpers for system folders and calendar meetings
- idempotent calendar meeting create/upsert that preserves the original `created_at`
- transactional speech-sample removal so `speech_samples` and `speech_sample_transcripts` stay aligned
- explicit `BatchMutationResult` reporting for action-item batch updates/sync (`updated_ids`, `missing_ids`, `noop_ids`)
- downstream vector updates now run only for successfully updated sync items
- folder delete/reorder validates targets before mutating instead of silently skipping unknown IDs

Supersedes #8294, #8297, #8298, #8301, #8307, #8316, #8322.

Original issue discovery, reproductions, and candidate fixes by @ZachL111 — thank you for surfacing these reliability problems. This PR rewrites them into a smaller shared-contract shape to reduce long-term maintenance cost.

## Test plan

- [x] `uv run --with pytest --with pydantic python -m pytest tests/unit/test_firestore_invariant_helpers.py -q`
- [x] `python3 -m py_compile backend/database/document_ids.py backend/database/_client.py backend/database/folders.py backend/database/calendar_meetings.py backend/database/users.py backend/database/action_items.py backend/routers/action_items.py backend/routers/folders.py backend/models/folder.py backend/tests/unit/test_firestore_invariant_helpers.py`

## Notes / intentional differences from source PRs

- #8298/#8301/#8307 are redesigned: missing IDs are explicit in the response instead of being silently skipped or allowed to fail a whole Firestore batch invisibly.
- #8322 uses a shared `system_folder_doc_id()` helper instead of local seed-string construction.
- #8294 uses a shared `calendar_meeting_doc_id()` helper. The current public API only exposes `calendar_source` and `calendar_event_id` as provider uniqueness dimensions; if provider-account/calendar IDs are added later, this helper is the single extension point.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

