### PR TITLE
Fix async resource boundaries

### DIFF
--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -9,10 +9,10 @@ Endpoints:
 - POST /v1/agent/keepalive     — pings the VM to reset its idle auto-stop timer
 """
 
+import asyncio
 import logging
 
 from utils.executors import db_executor, run_blocking
-from datetime import datetime, timezone
 
 import google.auth
 import google.auth.transport.requests

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -70,11 +70,12 @@ def get_route_info(decorators):
 
 
 def _get_offloaded_lines(node):
-    """Find line numbers of calls inside asyncio.to_thread/run_in_executor wrappers.
+    """Find line numbers of calls inside recognized executor wrappers.
 
     These are lambda bodies and nested def functions passed as arguments to
-    asyncio.to_thread() or loop.run_in_executor(). Calls inside those are
-    already offloaded and should not be flagged.
+    asyncio.to_thread(), loop.run_in_executor(), or the repository's
+    utils.executors.run_blocking(). Calls inside those are already offloaded and
+    should not be flagged.
     """
     offloaded = set()
     for child in ast.walk(node):
@@ -82,7 +83,8 @@ def _get_offloaded_lines(node):
             continue
         is_to_thread = isinstance(child.func, ast.Attribute) and child.func.attr == 'to_thread'
         is_run_in_executor = isinstance(child.func, ast.Attribute) and child.func.attr == 'run_in_executor'
-        if not is_to_thread and not is_run_in_executor:
+        is_run_blocking = isinstance(child.func, ast.Name) and child.func.id == 'run_blocking'
+        if not is_to_thread and not is_run_in_executor and not is_run_blocking:
             continue
         for arg in child.args + [kw.value for kw in child.keywords]:
             if isinstance(arg, ast.Lambda):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -142,6 +142,7 @@ pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_async_tasks.py -v
+pytest tests/unit/test_async_resource_correctness.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_integration_malformed_records.py -v
 pytest tests/unit/test_oauth_callback_uid_guard.py -v

--- a/backend/tests/unit/test_async_resource_correctness.py
+++ b/backend/tests/unit/test_async_resource_correctness.py
@@ -1,0 +1,220 @@
+import asyncio
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+TOOLS_DIR = BACKEND_DIR / "utils" / "retrieval" / "tools"
+
+
+class _ToolWrapper:
+    def __init__(self, func):
+        self.func = func
+        if asyncio.iscoroutinefunction(func):
+            self.coroutine = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def gmail_module(monkeypatch):
+    for name, path in (
+        ("utils", BACKEND_DIR / "utils"),
+        ("utils.retrieval", BACKEND_DIR / "utils" / "retrieval"),
+        ("utils.retrieval.tools", TOOLS_DIR),
+    ):
+        pkg = types.ModuleType(name)
+        pkg.__path__ = [str(path)]
+        monkeypatch.setitem(sys.modules, name, pkg)
+
+    agentic = types.ModuleType("utils.retrieval.agentic")
+    agentic.agent_config_context = MagicMock()
+    monkeypatch.setitem(sys.modules, "utils.retrieval.agentic", agentic)
+
+    database = types.ModuleType("database")
+    database.__path__ = []
+    users_db = types.ModuleType("database.users")
+    users_db.get_integration = MagicMock()
+    monkeypatch.setitem(sys.modules, "database", database)
+    monkeypatch.setitem(sys.modules, "database.users", users_db)
+
+    tools_mod = types.ModuleType("langchain_core.tools")
+    tools_mod.tool = _ToolWrapper
+    runnables_mod = types.ModuleType("langchain_core.runnables")
+    runnables_mod.RunnableConfig = dict
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "langchain_core.runnables", runnables_mod)
+
+    log_sanitizer = types.ModuleType("utils.log_sanitizer")
+    log_sanitizer.sanitize = lambda value: value
+    monkeypatch.setitem(sys.modules, "utils.log_sanitizer", log_sanitizer)
+
+    http_client = types.ModuleType("utils.http_client")
+    http_client.get_auth_client = MagicMock()
+    monkeypatch.setitem(sys.modules, "utils.http_client", http_client)
+
+    _load_module("utils.retrieval.tools.integration_base", TOOLS_DIR / "integration_base.py")
+    _load_module("utils.retrieval.tools.google_utils", TOOLS_DIR / "google_utils.py")
+    module = _load_module("utils.retrieval.tools.gmail_tools", TOOLS_DIR / "gmail_tools.py")
+    yield module
+
+    for name in [
+        "utils.retrieval.tools.gmail_tools",
+        "utils.retrieval.tools.google_utils",
+        "utils.retrieval.tools.integration_base",
+    ]:
+        sys.modules.pop(name, None)
+
+
+@pytest.mark.asyncio
+async def test_gmail_tool_exercises_async_interface_and_refreshes_once(gmail_module, monkeypatch):
+    calls = []
+
+    async def fake_get_gmail_messages(access_token, query=None, max_results=10, label_ids=None):
+        calls.append(access_token)
+        if access_token == "old-token":
+            raise Exception("Google API error 401: expired")
+        return [
+            {
+                "id": "m1",
+                "threadId": "t1",
+                "snippet": "hello",
+                "payload": {"headers": [{"name": "Subject", "value": "Async"}]},
+            }
+        ]
+
+    async def fake_refresh(uid, integration):
+        assert uid == "uid-1"
+        assert integration == {"connected": True, "access_token": "old-token"}
+        return "new-token"
+
+    monkeypatch.setattr(
+        gmail_module,
+        "prepare_access",
+        lambda *args, **kwargs: ("uid-1", {"connected": True, "access_token": "old-token"}, "old-token", None),
+    )
+    monkeypatch.setattr(gmail_module, "get_gmail_messages", fake_get_gmail_messages)
+    monkeypatch.setattr(gmail_module, "refresh_google_token", fake_refresh)
+
+    result = await gmail_module.get_gmail_messages_tool.coroutine(query="subject:async", config={})
+
+    assert calls == ["old-token", "new-token"]
+    assert "Gmail Messages (1 found)" in result
+    assert "Async" in result
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_messages_awaits_list_and_fetch_requests(gmail_module, monkeypatch):
+    awaited_urls = []
+
+    async def fake_google_api_request(method, url, access_token, params=None, body=None, allow_204=False):
+        awaited_urls.append(url)
+        if url.endswith("/messages"):
+            return {"messages": [{"id": "m1"}, {"id": "m2"}]}
+        return {"id": url.rsplit("/", 1)[-1], "payload": {"headers": []}, "snippet": "ok"}
+
+    monkeypatch.setattr(gmail_module, "google_api_request", fake_google_api_request)
+
+    messages = await gmail_module.get_gmail_messages("token", max_results=2)
+
+    assert [message["id"] for message in messages] == ["m1", "m2"]
+    assert len(awaited_urls) == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_on_auth_async_preserves_refresh_flow(gmail_module):
+    integration_base = sys.modules["utils.retrieval.tools.integration_base"]
+    attempts = []
+
+    async def call_fn(access_token):
+        attempts.append(access_token)
+        if access_token == "old-token":
+            raise Exception("401 token may be expired")
+        return "ok"
+
+    async def refresh_fn(uid, integration):
+        return "new-token"
+
+    result, err = await integration_base.retry_on_auth_async(
+        call_fn,
+        {"access_token": "old-token"},
+        refresh_fn,
+        "uid-1",
+        {},
+        "expired",
+    )
+
+    assert (result, err) == ("ok", None)
+    assert attempts == ["old-token", "new-token"]
+
+
+def test_speech_profile_closes_audio_file_handle(monkeypatch, tmp_path):
+    storage = types.ModuleType("utils.other.storage")
+    for attr in (
+        "get_profile_audio_if_exists",
+        "get_additional_profile_recordings",
+        "get_user_people_ids",
+        "get_user_person_speech_samples",
+    ):
+        setattr(storage, attr, MagicMock())
+    monkeypatch.setitem(sys.modules, "utils.other.storage", storage)
+
+    http_client = types.ModuleType("utils.http_client")
+    http_client.get_stt_client = MagicMock()
+    monkeypatch.setitem(sys.modules, "utils.http_client", http_client)
+
+    executors = types.ModuleType("utils.executors")
+    executors.storage_executor = MagicMock()
+    executors.run_blocking = MagicMock()
+    monkeypatch.setitem(sys.modules, "utils.executors", executors)
+
+    log_sanitizer = types.ModuleType("utils.log_sanitizer")
+    log_sanitizer.sanitize = lambda value: value
+    monkeypatch.setitem(sys.modules, "utils.log_sanitizer", log_sanitizer)
+
+    module = _load_module("utils.stt.speech_profile", BACKEND_DIR / "utils" / "stt" / "speech_profile.py")
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"RIFF....WAVEfmt ")
+    captured = {}
+
+    def fake_post(url, data=None, files=None, **kwargs):
+        captured["fh"] = files[0][1][1]
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = [False]
+        return response
+
+    monkeypatch.setenv("HOSTED_SPEECH_PROFILE_API_URL", "http://speech.test/match")
+    monkeypatch.setattr(module.httpx, "post", fake_post)
+
+    module.get_speech_profile_matching_predictions("uid-1", str(audio_path), [{"text": "hi"}])
+
+    assert captured["fh"].closed is True
+
+
+def test_scan_async_blockers_treats_run_blocking_lambda_as_safe():
+    scanner = _load_module("scan_async_blockers_for_test", BACKEND_DIR / "scripts" / "scan_async_blockers.py")
+    source = """
+async def helper():
+    await run_blocking(db_executor, lambda: open('x').read())
+"""
+    tree = ast.parse(source)
+    node = next(n for n in tree.body if getattr(n, "name", None) == "helper")
+
+    _db, file_io, _network, _sleeps = scanner.scan_async_function(node, set(), set(), set())
+
+    assert file_io == []

--- a/backend/tests/unit/test_async_resource_correctness.py
+++ b/backend/tests/unit/test_async_resource_correctness.py
@@ -186,24 +186,33 @@ def test_speech_profile_closes_audio_file_handle(monkeypatch, tmp_path):
     log_sanitizer.sanitize = lambda value: value
     monkeypatch.setitem(sys.modules, "utils.log_sanitizer", log_sanitizer)
 
-    module = _load_module("utils.stt.speech_profile", BACKEND_DIR / "utils" / "stt" / "speech_profile.py")
-    audio_path = tmp_path / "sample.wav"
-    audio_path.write_bytes(b"RIFF....WAVEfmt ")
-    captured = {}
+    pydub = types.ModuleType("pydub")
+    setattr(pydub, "AudioSegment", MagicMock())
+    monkeypatch.setitem(sys.modules, "pydub", pydub)
 
-    def fake_post(url, data=None, files=None, **kwargs):
-        captured["fh"] = files[0][1][1]
-        response = MagicMock()
-        response.status_code = 200
-        response.json.return_value = [False]
-        return response
+    module_name = "utils.stt.speech_profile"
+    module = _load_module(module_name, BACKEND_DIR / "utils" / "stt" / "speech_profile.py")
+    try:
+        audio_path = tmp_path / "sample.wav"
+        audio_path.write_bytes(b"RIFF....WAVEfmt ")
+        captured = {}
 
-    monkeypatch.setenv("HOSTED_SPEECH_PROFILE_API_URL", "http://speech.test/match")
-    monkeypatch.setattr(module.httpx, "post", fake_post)
+        def fake_post(url, data=None, files=None, **kwargs):
+            assert files is not None
+            captured["fh"] = files[0][1][1]
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = [False]
+            return response
 
-    module.get_speech_profile_matching_predictions("uid-1", str(audio_path), [{"text": "hi"}])
+        monkeypatch.setenv("HOSTED_SPEECH_PROFILE_API_URL", "http://speech.test/match")
+        monkeypatch.setattr(module.httpx, "post", fake_post)
 
-    assert captured["fh"].closed is True
+        module.get_speech_profile_matching_predictions("uid-1", str(audio_path), [{"text": "hi"}])
+
+        assert captured["fh"].closed is True
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def test_scan_async_blockers_treats_run_blocking_lambda_as_safe():

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -166,7 +166,7 @@ async def trigger_external_integrations(uid: str, conversation: Conversation) ->
     if conversation.is_locked:
         return []
 
-    apps: List[App] = get_available_apps(uid)
+    apps: List[App] = await run_blocking(db_executor, get_available_apps, uid)
     filtered_apps = [app for app in apps if app.triggers_on_conversation_creation() and app.enabled]
     if not filtered_apps:
         return []

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import database.conversations as conversations_db
 from langchain_openai import ChatOpenAI
+from utils.executors import db_executor, run_blocking
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ async def classify_user_purpose(uid: str) -> dict:
     }
 
     try:
-        summaries = _prepare_conversation_summaries(uid)
+        summaries = await run_blocking(db_executor, _prepare_conversation_summaries, uid)
         if not summaries:
             logger.info(f'fair_use: no conversations to classify for {uid}')
             return default_result

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -3,6 +3,7 @@ from typing import Tuple, List
 from .clients import get_llm
 from .usage_tracker import track_usage, Features
 from database.memories import get_memories
+from utils.executors import db_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def get_relevant_memories(uid: str, limit: int = 100) -> List[dict]:
     """Get recent relevant memories to personalize notifications."""
-    memories = get_memories(uid, limit=limit)
+    memories = await run_blocking(db_executor, get_memories, uid, limit)
     return [m for m in memories if not m.get('is_locked')]
 
 

--- a/backend/utils/retrieval/tools/gmail_tools.py
+++ b/backend/utils/retrieval/tools/gmail_tools.py
@@ -11,6 +11,7 @@ from typing import Optional, List
 from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
+from utils.executors import db_executor, run_blocking
 from utils.retrieval.tools.integration_base import (
     ensure_capped,
     prepare_access,
@@ -201,7 +202,9 @@ async def get_gmail_messages_tool(
     Returns:
         Formatted list of emails with their details.
     """
-    uid, integration, access_token, access_err = prepare_access(
+    uid, integration, access_token, access_err = await run_blocking(
+        db_executor,
+        prepare_access,
         config,
         'google_calendar',
         'Gmail',

--- a/backend/utils/retrieval/tools/gmail_tools.py
+++ b/backend/utils/retrieval/tools/gmail_tools.py
@@ -3,17 +3,18 @@ Tools for accessing Gmail messages.
 """
 
 import contextvars
-from datetime import datetime, timedelta, timezone
+import base64
+import traceback
+from email.utils import parsedate_to_datetime
 from typing import Optional, List
 
 from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
-import database.users as users_db
 from utils.retrieval.tools.integration_base import (
     ensure_capped,
     prepare_access,
-    retry_on_auth,
+    retry_on_auth_async,
 )
 
 # Import shared Google utilities
@@ -30,7 +31,7 @@ except ImportError:
     agent_config_context = contextvars.ContextVar('agent_config', default=None)
 
 
-def get_gmail_messages(
+async def get_gmail_messages(
     access_token: str,
     query: Optional[str] = None,
     max_results: int = 10,
@@ -67,7 +68,7 @@ def get_gmail_messages(
         if page_token:
             page_params['pageToken'] = page_token
 
-        data = google_api_request(
+        data = await google_api_request(
             "GET",
             'https://www.googleapis.com/gmail/v1/users/me/messages',
             access_token,
@@ -87,7 +88,7 @@ def get_gmail_messages(
 
     messages = []
     for msg_id in message_ids:
-        msg_data = google_api_request(
+        msg_data = await google_api_request(
             "GET",
             f'https://www.googleapis.com/gmail/v1/users/me/messages/{msg_id}',
             access_token,
@@ -122,16 +123,12 @@ def parse_gmail_message(message: dict) -> dict:
             if part.get('mimeType') == 'text/plain':
                 data = part.get('body', {}).get('data', '')
                 if data:
-                    import base64
-
                     body_text = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
                     break
             elif part.get('mimeType') == 'text/html':
                 # Fallback to HTML if plain text not available
                 data = part.get('body', {}).get('data', '')
                 if data:
-                    import base64
-
                     body_text = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
                     break
     else:
@@ -139,8 +136,6 @@ def parse_gmail_message(message: dict) -> dict:
         if payload.get('mimeType') == 'text/plain':
             data = payload.get('body', {}).get('data', '')
             if data:
-                import base64
-
                 body_text = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
 
     # Parse date
@@ -148,8 +143,6 @@ def parse_gmail_message(message: dict) -> dict:
     date_parsed = None
     if date_str:
         try:
-            from email.utils import parsedate_to_datetime
-
             date_parsed = parsedate_to_datetime(date_str)
         except:
             pass
@@ -167,7 +160,7 @@ def parse_gmail_message(message: dict) -> dict:
 
 
 @tool
-def get_gmail_messages_tool(
+async def get_gmail_messages_tool(
     query: Optional[str] = None,
     max_results: int = 10,
     label: Optional[str] = None,
@@ -218,6 +211,9 @@ def get_gmail_messages_tool(
     )
     if access_err:
         return access_err
+    assert uid is not None
+    assert integration is not None
+    assert access_token is not None
 
     try:
         max_results = ensure_capped(max_results, 50, "⚠️ get_gmail_messages_tool - max_results capped from {} to {}")
@@ -238,7 +234,7 @@ def get_gmail_messages_tool(
                 label_ids = [label_upper]
 
         # Fetch messages
-        messages, err = retry_on_auth(
+        messages, err = await retry_on_auth_async(
             get_gmail_messages,
             {
                 'access_token': access_token,
@@ -254,12 +250,11 @@ def get_gmail_messages_tool(
                 "Authentication failed",
                 "401",
                 "token may be expired",
+                "Google API error 401",
             ),
         )
         if err:
             return err
-
-        messages_count = len(messages) if messages else 0
 
         if not messages:
             query_info = f" matching '{query}'" if query else ""
@@ -285,7 +280,5 @@ def get_gmail_messages_tool(
         return result.strip()
     except Exception as e:
         logger.error(f"❌ Unexpected error in get_gmail_messages_tool: {e}")
-        import traceback
-
         traceback.print_exc()
         return f"Unexpected error fetching Gmail messages: {str(e)}"

--- a/backend/utils/retrieval/tools/integration_base.py
+++ b/backend/utils/retrieval/tools/integration_base.py
@@ -136,3 +136,34 @@ def retry_on_auth(
                     return None, f"Error after token refresh: {str(e2)}"
             return None, expired_msg
         return None, f"Error: {msg}"
+
+
+async def retry_on_auth_async(
+    call_fn,
+    call_kwargs: dict,
+    refresh_fn,
+    uid: str,
+    integration: dict,
+    expired_msg: str,
+    markers: Tuple[str, ...] = (
+        "Authentication failed",
+        "401",
+        "token may be expired",
+        "token may be expired or invalid",
+    ),
+):
+    try:
+        return await call_fn(**call_kwargs), None
+    except Exception as e:
+        msg = str(e)
+        if any(m in msg for m in markers):
+            new_token = await refresh_fn(uid, integration)
+            if new_token:
+                call_kwargs = dict(call_kwargs)
+                call_kwargs['access_token'] = new_token
+                try:
+                    return await call_fn(**call_kwargs), None
+                except Exception as e2:
+                    return None, f"Error after token refresh: {str(e2)}"
+            return None, expired_msg
+        return None, f"Error: {msg}"

--- a/backend/utils/stt/speech_profile.py
+++ b/backend/utils/stt/speech_profile.py
@@ -21,13 +21,16 @@ logger = logging.getLogger(__name__)
 
 def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segments: List) -> List[dict]:
     logger.info('get_speech_profile_matching_predictions')
-    files = [
-        ('audio_file', (os.path.basename(audio_file_path), open(audio_file_path, 'rb'), 'audio/wav')),
-    ]
-    response = httpx.post(
-        os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}', data={'segments': json.dumps(segments)}, files=files
-    )
     default = [{'is_user': False, 'person_id': None}] * len(segments)
+    with open(audio_file_path, 'rb') as audio_f:
+        files = [
+            ('audio_file', (os.path.basename(audio_file_path), audio_f, 'audio/wav')),
+        ]
+        response = httpx.post(
+            os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}',
+            data={'segments': json.dumps(segments)},
+            files=files,
+        )
 
     if response.status_code != 200:
         logger.info(f'get_speech_profile_matching_predictions {sanitize(response.text)}')


### PR DESCRIPTION
## Summary

This aggregates ZachL111's async/resource correctness fixes into one maintained PR:

- Offload synchronous Firestore/database reads from async code with `utils.executors.run_blocking(..., db_executor, ...)` in app integrations, notification memories, and the fair-use classifier.
- Make the Gmail retrieval path async end-to-end: the tool is async, message list/fetch Google API calls are awaited, and auth refresh goes through a shared `retry_on_auth_async` helper beside the existing sync helper.
- Add the missing `asyncio` import in `routers/agent_tools.py` and verify changed modules with a static undefined-name check.
- Ensure speech-profile matching closes the uploaded audio file handle deterministically.
- Teach `scan_async_blockers.py` that work wrapped by repository `run_blocking` is executor-offloaded.
- Add a focused async/resource regression test module to the backend test runner.

Supersedes #8268, #8274, #8296, #8300, #8314, #8323. Original issue discovery, reproductions, and candidate fixes by @ZachL111.

Deferred: #8265, per the aggregation plan, because it mixes Firestore writes, cache work, and potentially expensive memory/LLM postprocessing and needs a fuller executor design.

## Tests

- `uv run --with pytest --with pytest-asyncio --with httpx --with pydub pytest tests/unit/test_async_resource_correctness.py -v`
- `uv run python -m py_compile routers/agent_tools.py utils/app_integrations.py utils/llm/notifications.py utils/retrieval/tools/gmail_tools.py utils/retrieval/tools/integration_base.py utils/llm/fair_use_classifier.py utils/stt/speech_profile.py scripts/scan_async_blockers.py tests/unit/test_async_resource_correctness.py`
- `uv run python scripts/scan_async_blockers.py --dirs routers utils` (exit 0; reports 0 high network I/O / 0 file I/O / 0 no-await endpoints, plus pre-existing async helper/sync DB findings elsewhere)
- `uv run --with pyflakes pyflakes routers/agent_tools.py utils/retrieval/tools/gmail_tools.py tests/unit/test_async_resource_correctness.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

