### PR TITLE
Fix retrieval and output semantic correctness

### DIFF
--- a/backend/database/mem_db.py
+++ b/backend/database/mem_db.py
@@ -3,7 +3,7 @@ import time
 proactive_noti_sent_at = {}  # {<uid:app_id>: (ts, ex)}
 
 
-def set_proactive_noti_sent_at(uid: str, app_id: str, ts: int, ttl: int = 30):
+def set_proactive_noti_sent_at(uid: str, *, app_id: str, ts: int, ttl: int = 30):
     k = f'{uid}:{app_id}'
     proactive_noti_sent_at[k] = (ts, ttl + time.time())
 

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -406,7 +406,7 @@ def save_migrated_retrieval_conversation_id(conversation_id: str):
     r.expire('migrated_retrieval_memory_ids', 60 * 60 * 24 * 7)
 
 
-def set_proactive_noti_sent_at(uid: str, app_id: str, ts: int, ttl: int = 30):
+def set_proactive_noti_sent_at(uid: str, *, app_id: str, ts: int, ttl: int = 30):
     r.set(f'{uid}:{app_id}:proactive_noti_sent_at', ts, ex=ttl)
 
 

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -6,6 +6,7 @@ from typing import List
 
 from pinecone import Pinecone
 
+from models.conversation_metadata import ConversationMetadataKeys, metadata_list
 from utils.llm.clients import embeddings
 import logging
 
@@ -83,9 +84,9 @@ def query_vectors_by_metadata(
         filter_data['$and'].append(
             {
                 '$or': [
-                    {'people': {'$in': people}},
-                    {'topics': {'$in': topics}},
-                    {'entities': {'$in': entities}},
+                    {ConversationMetadataKeys.PEOPLE: {'$in': people}},
+                    {ConversationMetadataKeys.TOPICS: {'$in': topics}},
+                    {ConversationMetadataKeys.ENTITIES: {'$in': entities}},
                     # {'dates': {'$in': dates_mentioned}},
                 ]
             }
@@ -119,13 +120,13 @@ def query_vectors_by_metadata(
         metadata = item['metadata']
         conversation_id = metadata['memory_id']
         for topic in topics:
-            if topic in metadata.get('topics', []):
+            if topic in metadata_list(metadata, ConversationMetadataKeys.TOPICS):
                 conversation_id_to_matches[conversation_id] += 1
         for entity in entities:
-            if entity in metadata.get('entities', []):
+            if entity in metadata_list(metadata, ConversationMetadataKeys.ENTITIES):
                 conversation_id_to_matches[conversation_id] += 1
         for person in people:
-            if person in metadata.get('people_mentioned', []):
+            if person in metadata_list(metadata, ConversationMetadataKeys.PEOPLE):
                 conversation_id_to_matches[conversation_id] += 1
 
     conversations_id = [item['id'].replace(f'{uid}-', '') for item in xc['matches']]

--- a/backend/models/calendar_mutation.py
+++ b/backend/models/calendar_mutation.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class CalendarMutationResult:
+    succeeded: list[dict] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+
+
+def event_title(event: dict) -> str:
+    return event.get('summary', 'Untitled')
+
+
+def format_deleted_calendar_events(result: CalendarMutationResult) -> str:
+    if result.succeeded:
+        message = f"✅ Successfully deleted {len(result.succeeded)} calendar event(s):\n"
+        for event in result.succeeded:
+            summary = event_title(event)
+            start = event.get('start', {})
+            if 'dateTime' in start:
+                try:
+                    start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
+                    message += f"   - {summary} ({start_dt.strftime('%Y-%m-%d %H:%M')})\n"
+                except ValueError:
+                    message += f"   - {summary}\n"
+            else:
+                message += f"   - {summary}\n"
+
+        if result.failed:
+            message += f"\n⚠️ Failed to delete {len(result.failed)} event(s):\n"
+            for title, error in result.failed:
+                message += f"   - {title}: {error}\n"
+        return message.strip()
+
+    if result.failed:
+        error_msgs = '; '.join([f"{title}: {error}" for title, error in result.failed])
+        return f"Error: Failed to delete events: {error_msgs}"
+    return "No events were deleted."

--- a/backend/models/conversation_metadata.py
+++ b/backend/models/conversation_metadata.py
@@ -1,12 +1,9 @@
-from typing import Any, Iterable
+from typing import Any
 
 from pydantic import BaseModel, Field
 
 
 class ConversationMetadataKeys:
-    UID = 'uid'
-    MEMORY_ID = 'memory_id'
-    CREATED_AT = 'created_at'
     PEOPLE = 'people'
     TOPICS = 'topics'
     ENTITIES = 'entities'
@@ -35,7 +32,3 @@ def metadata_list(metadata: dict[str, Any], key: str) -> list[str]:
     if isinstance(value, tuple):
         return list(value)
     return []
-
-
-def normalize_metadata_values(values: Iterable[str]) -> list[str]:
-    return [value for value in values if value]

--- a/backend/models/conversation_metadata.py
+++ b/backend/models/conversation_metadata.py
@@ -1,0 +1,41 @@
+from typing import Any, Iterable
+
+from pydantic import BaseModel, Field
+
+
+class ConversationMetadataKeys:
+    UID = 'uid'
+    MEMORY_ID = 'memory_id'
+    CREATED_AT = 'created_at'
+    PEOPLE = 'people'
+    TOPICS = 'topics'
+    ENTITIES = 'entities'
+    DATES = 'dates'
+
+
+class ConversationMetadata(BaseModel):
+    people: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
+    entities: list[str] = Field(default_factory=list)
+    dates: list[str] = Field(default_factory=list)
+
+    def to_vector_metadata(self) -> dict[str, list[str]]:
+        return {
+            ConversationMetadataKeys.PEOPLE: self.people,
+            ConversationMetadataKeys.TOPICS: self.topics,
+            ConversationMetadataKeys.ENTITIES: self.entities,
+            ConversationMetadataKeys.DATES: self.dates,
+        }
+
+
+def metadata_list(metadata: dict[str, Any], key: str) -> list[str]:
+    value = metadata.get(key, [])
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def normalize_metadata_values(values: Iterable[str]) -> list[str]:
+    return [value for value in values if value]

--- a/backend/models/daily_summary_payload.py
+++ b/backend/models/daily_summary_payload.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+
+class DailySummaryPayload(BaseModel):
+    headline: str = "Your Day in Review"
+    overview: str = ""
+    day_emoji: str = "📅"
+    highlights: list[dict] = Field(default_factory=list)
+    unresolved_questions: list[dict] = Field(default_factory=list)
+    decisions_made: list[dict] = Field(default_factory=list)
+    knowledge_nuggets: list[dict] = Field(default_factory=list)

--- a/backend/models/daily_summary_payload.py
+++ b/backend/models/daily_summary_payload.py
@@ -1,11 +1,33 @@
 from pydantic import BaseModel, Field
 
 
+class DailySummaryHighlight(BaseModel):
+    topic: str
+    emoji: str = ""
+    summary: str
+    conversation_numbers: list[int] = Field(default_factory=list)
+
+
+class DailySummaryQuestion(BaseModel):
+    question: str
+    conversation_number: int | None = None
+
+
+class DailySummaryDecision(BaseModel):
+    decision: str
+    conversation_number: int | None = None
+
+
+class DailySummaryKnowledgeNugget(BaseModel):
+    insight: str
+    conversation_number: int | None = None
+
+
 class DailySummaryPayload(BaseModel):
     headline: str = "Your Day in Review"
     overview: str = ""
     day_emoji: str = "📅"
-    highlights: list[dict] = Field(default_factory=list)
-    unresolved_questions: list[dict] = Field(default_factory=list)
-    decisions_made: list[dict] = Field(default_factory=list)
-    knowledge_nuggets: list[dict] = Field(default_factory=list)
+    highlights: list[DailySummaryHighlight] = Field(default_factory=list)
+    unresolved_questions: list[DailySummaryQuestion] = Field(default_factory=list)
+    decisions_made: list[DailySummaryDecision] = Field(default_factory=list)
+    knowledge_nuggets: list[DailySummaryKnowledgeNugget] = Field(default_factory=list)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -65,6 +65,7 @@ pytest tests/unit/test_conversations_to_string.py -v
 pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
+pytest tests/unit/test_retrieval_semantics.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v

--- a/backend/tests/unit/test_retrieval_semantics.py
+++ b/backend/tests/unit/test_retrieval_semantics.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from database import mem_db, redis_db
+from models.calendar_mutation import CalendarMutationResult, format_deleted_calendar_events
+from models.conversation_metadata import ConversationMetadata, ConversationMetadataKeys, metadata_list
+from models.daily_summary_payload import DailySummaryPayload
+from utils.conversations.datetime_utils import coerce_utc_datetime
+
+
+def test_conversation_metadata_uses_single_vector_schema_and_entities_field():
+    metadata = ConversationMetadata(
+        people=['alice'],
+        topics=['vector search'],
+        entities=['pinecone'],
+        dates=['2026-06-25'],
+    ).to_vector_metadata()
+
+    assert metadata == {
+        ConversationMetadataKeys.PEOPLE: ['alice'],
+        ConversationMetadataKeys.TOPICS: ['vector search'],
+        ConversationMetadataKeys.ENTITIES: ['pinecone'],
+        ConversationMetadataKeys.DATES: ['2026-06-25'],
+    }
+    assert 'people_mentioned' not in metadata
+    assert metadata[ConversationMetadataKeys.ENTITIES] != metadata[ConversationMetadataKeys.TOPICS]
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        (['alice'], ['alice']),
+        (('alice', 'bob'), ['alice', 'bob']),
+        ('alice', []),
+        (None, []),
+    ],
+)
+def test_metadata_list_only_returns_list_like_values(raw, expected):
+    assert metadata_list({'people': raw}, ConversationMetadataKeys.PEOPLE) == expected
+
+
+def test_calendar_delete_result_reports_only_successful_events_as_deleted():
+    result = CalendarMutationResult(
+        succeeded=[
+            {
+                'summary': 'Design review',
+                'start': {'dateTime': '2026-06-25T16:30:00Z'},
+            }
+        ],
+        failed=[('Dentist', 'permission denied')],
+    )
+
+    message = format_deleted_calendar_events(result)
+
+    assert 'Successfully deleted 1 calendar event(s)' in message
+    assert 'Design review (2026-06-25 16:30)' in message
+    assert 'Failed to delete 1 event(s)' in message
+    assert 'Dentist: permission denied' in message
+    assert 'Successfully deleted 2' not in message
+
+
+def test_calendar_delete_result_with_only_failures_is_not_success_message():
+    message = format_deleted_calendar_events(CalendarMutationResult(failed=[('Dentist', 'not found')]))
+
+    assert message == 'Error: Failed to delete events: Dentist: not found'
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('2026-06-25T12:00:00Z', datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc)),
+        (
+            '2026-06-25T08:00:00-04:00',
+            datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2026, 6, 25, 8, 0, tzinfo=timezone(timedelta(hours=-4))),
+            datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc),
+        ),
+        (datetime(2026, 6, 25, 12, 0), datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc)),
+    ],
+)
+def test_coerce_utc_datetime_normalizes_supported_timestamps(value, expected):
+    assert coerce_utc_datetime(value) == expected
+
+
+@pytest.mark.parametrize('value', [None, 'not-a-date', object()])
+def test_coerce_utc_datetime_returns_none_for_missing_or_malformed_values(value):
+    assert coerce_utc_datetime(value) is None
+
+
+def test_daily_summary_payload_rejects_malformed_section_shape():
+    with pytest.raises(ValidationError):
+        DailySummaryPayload.model_validate({'headline': 'Today', 'highlights': ['not an object']})
+
+
+def test_daily_summary_payload_allows_omitted_optional_sections():
+    payload = DailySummaryPayload.model_validate({'headline': 'Today'})
+
+    assert payload.headline == 'Today'
+    assert payload.highlights == []
+    assert payload.unresolved_questions == []
+
+
+def test_proactive_notification_cache_setters_require_keyword_app_id():
+    bad_args = ('uid', object(), 123)
+    with pytest.raises(TypeError):
+        mem_db.set_proactive_noti_sent_at(*bad_args)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        redis_db.set_proactive_noti_sent_at(*bad_args)  # type: ignore[call-arg]
+
+    mem_db.set_proactive_noti_sent_at('uid', app_id='app', ts=123, ttl=1)
+    assert mem_db.get_proactive_noti_sent_at('uid', 'app') == 123

--- a/backend/tests/unit/test_retrieval_semantics.py
+++ b/backend/tests/unit/test_retrieval_semantics.py
@@ -94,6 +94,10 @@ def test_coerce_utc_datetime_returns_none_for_missing_or_malformed_values(value)
 def test_daily_summary_payload_rejects_malformed_section_shape():
     with pytest.raises(ValidationError):
         DailySummaryPayload.model_validate({'headline': 'Today', 'highlights': ['not an object']})
+    with pytest.raises(ValidationError):
+        DailySummaryPayload.model_validate(
+            {'headline': 'Today', 'highlights': [{'topic_name': 'wrong key', 'summary': 'Summary'}]}
+        )
 
 
 def test_daily_summary_payload_allows_omitted_optional_sections():

--- a/backend/tests/unit/test_retrieval_semantics.py
+++ b/backend/tests/unit/test_retrieval_semantics.py
@@ -8,6 +8,7 @@ from models.calendar_mutation import CalendarMutationResult, format_deleted_cale
 from models.conversation_metadata import ConversationMetadata, ConversationMetadataKeys, metadata_list
 from models.daily_summary_payload import DailySummaryPayload
 from utils.conversations.datetime_utils import coerce_utc_datetime
+from utils.log_sanitizer import sanitize_validation_error
 
 
 def test_conversation_metadata_uses_single_vector_schema_and_entities_field():
@@ -106,6 +107,31 @@ def test_daily_summary_payload_allows_omitted_optional_sections():
     assert payload.headline == 'Today'
     assert payload.highlights == []
     assert payload.unresolved_questions == []
+
+
+def test_daily_summary_validation_log_summary_omits_private_input_value():
+    private_summary_text = "Private therapy conversation about Alice and Bob"
+    try:
+        DailySummaryPayload.model_validate(
+            {
+                "headline": "Today",
+                "highlights": [
+                    {
+                        "topic": "Personal",
+                        "summary": private_summary_text,
+                        "conversation_numbers": "not-a-list",
+                    }
+                ],
+            }
+        )
+    except ValidationError as exc:
+        safe_summary = sanitize_validation_error(exc)
+    else:
+        raise AssertionError("expected malformed daily summary payload to fail validation")
+
+    assert private_summary_text not in safe_summary
+    assert "input_value" not in safe_summary
+    assert "conversation_numbers" in safe_summary
 
 
 def test_proactive_notification_cache_setters_require_keyword_app_id():

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -304,15 +304,15 @@ def _hit_proactive_notification_rate_limits(uid: str, app: App):
         return False
     ttl = redis_db.get_proactive_noti_sent_at_ttl(uid, app.id)
     if ttl > 0:
-        mem_db.set_proactive_noti_sent_at(uid, app.id, int(time.time() + ttl), ttl=ttl)
+        mem_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(time.time() + ttl), ttl=ttl)
 
     return time.time() - sent_at < PROACTIVE_NOTI_LIMIT_SECONDS
 
 
 def _set_proactive_noti_sent_at(uid: str, app: App):
     ts = time.time()
-    mem_db.set_proactive_noti_sent_at(uid, app, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
-    redis_db.set_proactive_noti_sent_at(uid, app.id, int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
+    mem_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
+    redis_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
 
 
 MENTOR_RATE_LIMIT_SECONDS = 300  # 5 minutes between mentor notifications
@@ -501,8 +501,8 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
 
     # Update rate limit and daily count
     ts = int(time.time())
-    mem_db.set_proactive_noti_sent_at(uid, 'mentor', ts, ttl=MENTOR_RATE_LIMIT_SECONDS)
-    redis_db.set_proactive_noti_sent_at(uid, 'mentor', ts, ttl=MENTOR_RATE_LIMIT_SECONDS)
+    mem_db.set_proactive_noti_sent_at(uid, app_id='mentor', ts=ts, ttl=MENTOR_RATE_LIMIT_SECONDS)
+    redis_db.set_proactive_noti_sent_at(uid, app_id='mentor', ts=ts, ttl=MENTOR_RATE_LIMIT_SECONDS)
     incr_daily_notification_count(uid)
 
     return notification_text

--- a/backend/utils/conversations/datetime_utils.py
+++ b/backend/utils/conversations/datetime_utils.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timezone
+from typing import Any
+
+
+def coerce_utc_datetime(value: Any) -> datetime | None:
+    """Coerce a datetime/ISO timestamp to a timezone-aware UTC datetime.
+
+    Returns None for missing or malformed values so callers can retain records
+    while emitting domain-specific metrics instead of crashing on mixed timestamp
+    shapes.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -19,6 +19,7 @@ from models.audio_file import AudioFile
 from models.conversation import Conversation
 from models.conversation_enums import ConversationStatus
 from models.structured import Structured
+from utils.conversations.datetime_utils import coerce_utc_datetime
 from utils.other.storage import (
     delete_conversation_audio_files,
     list_audio_chunks,
@@ -32,29 +33,21 @@ logger = logging.getLogger(__name__)
 
 
 def _coerce_dt(value):
-    """Coerce a timestamp (datetime or ISO 8601 string) to a tz-aware UTC datetime.
+    return coerce_utc_datetime(value)
 
-    Conversation docs can carry ``started_at`` / ``finished_at`` as either a
-    Firestore-deserialised ``datetime`` (tz-aware) or as an ISO string (older
-    write paths persisted ``.isoformat()`` instead of a native timestamp).
-    Subtracting two strings throws ``TypeError``; mixing tz-aware with
-    tz-naive also throws. Coercing both sides to a single tz-aware UTC
-    representation keeps the gap math safe regardless of source.
 
-    Returns ``None`` for unparseable input rather than raising — gap warnings
-    are best-effort and a malformed timestamp must not fail the merge call.
-    """
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, str):
-        try:
-            parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
-        except ValueError:
-            return None
-        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
-    return None
+_UTC_MIN = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _photo_created_at_sort_key(photo: Dict) -> datetime:
+    created_at = coerce_utc_datetime(photo.get('created_at'))
+    if created_at is None:
+        logger.warning(
+            'conversation_merge_photo_missing_or_invalid_created_at',
+            extra={'photo_id': photo.get('id'), 'has_created_at': 'created_at' in photo},
+        )
+        return _UTC_MIN
+    return created_at
 
 
 # Timestamp fields touched by the merge pipeline. Coerced once at the entry
@@ -390,8 +383,9 @@ def _collect_all_photos(uid: str, conversations: List[Dict]) -> List[Dict]:
         except Exception as e:
             logger.error(f"Error fetching photos for {conv['id']}: {e}")
 
-    # Sort by creation time
-    all_photos.sort(key=lambda p: p.get('created_at', datetime.min))
+    # Sort by creation time with a uniform tz-aware UTC key. Missing or malformed
+    # created_at values are retained and ordered first, with structured metrics.
+    all_photos.sort(key=_photo_created_at_sort_key)
     return all_photos
 
 

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -16,6 +16,7 @@ from database.auth import get_user_name
 from models.app import App
 from models.chat import Message, MessageSender, PageContext
 from models.conversation_enums import CategoryEnum
+from models.conversation_metadata import ConversationMetadata
 from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, Event
 from models.other import Person
@@ -25,6 +26,27 @@ from utils.llm.usage_tracker import track_usage, Features
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_filter(value: str) -> str:
+    # Convert to lowercase and strip whitespace
+    value = value.lower().strip()
+
+    # Remove special characters and extra spaces
+    value = re.sub(r'[^\w\s-]', '', value)
+    value = re.sub(r'\s+', ' ', value)
+
+    # Remove common filler words
+    filler_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to'}
+    value = ' '.join(word for word in value.split() if word not in filler_words)
+
+    # Standardize common variations
+    value = value.replace('artificial intelligence', 'ai')
+    value = value.replace('machine learning', 'ml')
+    value = value.replace('natural language processing', 'nlp')
+
+    return value.strip()
+
 
 # ****************************************
 # ************* CHAT BASICS **************
@@ -1089,31 +1111,12 @@ def retrieve_metadata_fields_from_transcript(
         logger.error(f'e {e}')
         return {'people': [], 'topics': [], 'entities': [], 'dates': []}
 
-    def normalize_filter(value: str) -> str:
-        # Convert to lowercase and strip whitespace
-        value = value.lower().strip()
-
-        # Remove special characters and extra spaces
-        value = re.sub(r'[^\w\s-]', '', value)
-        value = re.sub(r'\s+', ' ', value)
-
-        # Remove common filler words
-        filler_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to'}
-        value = ' '.join(word for word in value.split() if word not in filler_words)
-
-        # Standardize common variations
-        value = value.replace('artificial intelligence', 'ai')
-        value = value.replace('machine learning', 'ml')
-        value = value.replace('natural language processing', 'nlp')
-
-        return value.strip()
-
-    metadata = {
-        'people': [normalize_filter(p) for p in result.people],
-        'topics': [normalize_filter(t) for t in result.topics],
-        'entities': [normalize_filter(e) for e in result.topics],
-        'dates': [],
-    }
+    metadata = ConversationMetadata(
+        people=[normalize_filter(p) for p in result.people],
+        topics=[normalize_filter(t) for t in result.topics],
+        entities=[normalize_filter(e) for e in result.entities],
+        dates=[],
+    ).to_vector_metadata()
     # 'dates': [date.strftime('%Y-%m-%d') for date in result.dates],
     for date in result.dates:
         try:
@@ -1214,31 +1217,12 @@ def _process_extracted_metadata(uid: str, prompt: str) -> dict:
         logger.error(f'Error extracting metadata: {e}')
         return {'people': [], 'topics': [], 'entities': [], 'dates': []}
 
-    def normalize_filter(value: str) -> str:
-        # Convert to lowercase and strip whitespace
-        value = value.lower().strip()
-
-        # Remove special characters and extra spaces
-        value = re.sub(r'[^\w\s-]', '', value)
-        value = re.sub(r'\s+', ' ', value)
-
-        # Remove common filler words
-        filler_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to'}
-        value = ' '.join(word for word in value.split() if word not in filler_words)
-
-        # Standardize common variations
-        value = value.replace('artificial intelligence', 'ai')
-        value = value.replace('machine learning', 'ml')
-        value = value.replace('natural language processing', 'nlp')
-
-        return value.strip()
-
-    metadata = {
-        'people': [normalize_filter(p) for p in result.people],
-        'topics': [normalize_filter(t) for t in result.topics],
-        'entities': [normalize_filter(e) for e in result.entities],
-        'dates': [],
-    }
+    metadata = ConversationMetadata(
+        people=[normalize_filter(p) for p in result.people],
+        topics=[normalize_filter(t) for t in result.topics],
+        entities=[normalize_filter(e) for e in result.entities],
+        dates=[],
+    ).to_vector_metadata()
 
     for date in result.dates:
         try:

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -5,9 +5,11 @@ from datetime import datetime, timezone
 from typing import List
 import pytz
 from langchain_core.prompts import ChatPromptTemplate
+from pydantic import ValidationError
 import database.action_items as action_items_db
 import database.users as users_db
 from models.conversation import Conversation
+from models.daily_summary_payload import DailySummaryPayload
 from models.structured import Structured
 from models.other import Person
 from utils.conversations.render import conversations_to_string
@@ -17,6 +19,34 @@ from utils.llms.memory import get_prompt_memories
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _basic_daily_summary(
+    date_str: str,
+    total_conversations: int,
+    total_duration_minutes: float,
+    actual_action_items: list,
+    locations: list,
+) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "date": date_str,
+        "created_at": datetime.utcnow().isoformat(),
+        "headline": "Your Day in Review",
+        "overview": f"You had {total_conversations} conversations today.",
+        "day_emoji": "📅",
+        "stats": {
+            "total_conversations": total_conversations,
+            "total_duration_minutes": int(total_duration_minutes),
+            "action_items_count": len(actual_action_items),
+        },
+        "highlights": [],
+        "action_items": actual_action_items,
+        "unresolved_questions": [],
+        "decisions_made": [],
+        "knowledge_nuggets": [],
+        "locations": locations,
+    }
 
 
 def get_message_structure(
@@ -285,7 +315,7 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
         response = re.sub(r':\s*\\"([^"]*)\\"', r': "\1"', response)
         response = response.replace('\\"', '"')
 
-        summary_data = json.loads(response)
+        summary_data = DailySummaryPayload.model_validate(json.loads(response))
 
         # Helper to map conversation number to ID
         def get_convo_id(num):
@@ -295,7 +325,7 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
 
         # Process highlights - map conversation_numbers to conversation_ids
         highlights = []
-        for h in summary_data.get("highlights", []):
+        for h in summary_data.highlights:
             convo_nums = h.get("conversation_numbers", [])
             convo_ids = [get_convo_id(n) for n in convo_nums if get_convo_id(n)]
             highlights.append(
@@ -309,21 +339,21 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
 
         # Process unresolved questions
         unresolved_questions = []
-        for q in summary_data.get("unresolved_questions", []):
+        for q in summary_data.unresolved_questions:
             unresolved_questions.append(
                 {"question": q.get("question", ""), "conversation_id": get_convo_id(q.get("conversation_number"))}
             )
 
         # Process decisions made
         decisions_made = []
-        for d in summary_data.get("decisions_made", []):
+        for d in summary_data.decisions_made:
             decisions_made.append(
                 {"decision": d.get("decision", ""), "conversation_id": get_convo_id(d.get("conversation_number"))}
             )
 
         # Process knowledge nuggets
         knowledge_nuggets = []
-        for k in summary_data.get("knowledge_nuggets", []):
+        for k in summary_data.knowledge_nuggets:
             knowledge_nuggets.append(
                 {"insight": k.get("insight", ""), "conversation_id": get_convo_id(k.get("conversation_number"))}
             )
@@ -334,9 +364,9 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "id": summary_id,
             "date": date_str,
             "created_at": datetime.utcnow().isoformat(),
-            "headline": summary_data.get("headline", "Your Day in Review"),
-            "overview": summary_data.get("overview", ""),
-            "day_emoji": summary_data.get("day_emoji", "📅"),
+            "headline": summary_data.headline,
+            "overview": summary_data.overview,
+            "day_emoji": summary_data.day_emoji,
             "stats": {
                 "total_conversations": total_conversations,
                 "total_duration_minutes": int(total_duration_minutes),
@@ -349,26 +379,8 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "knowledge_nuggets": knowledge_nuggets,
             "locations": locations,
         }
-    except json.JSONDecodeError as e:
-        logger.error(f"Failed to parse LLM response as JSON: {e}")
-        logger.info(f"Response was: {response}")
-        # Return a basic summary on parse failure
-        return {
-            "id": str(uuid.uuid4()),
-            "date": date_str,
-            "created_at": datetime.utcnow().isoformat(),
-            "headline": "Your Day in Review",
-            "overview": f"You had {total_conversations} conversations today.",
-            "day_emoji": "📅",
-            "stats": {
-                "total_conversations": total_conversations,
-                "total_duration_minutes": int(total_duration_minutes),
-                "action_items_count": len(actual_action_items),
-            },
-            "highlights": [],
-            "action_items": actual_action_items,
-            "unresolved_questions": [],
-            "decisions_made": [],
-            "knowledge_nuggets": [],
-            "locations": locations,
-        }
+    except (json.JSONDecodeError, ValidationError) as e:
+        logger.error(f"Failed to parse daily summary payload: {e}")
+        return _basic_daily_summary(
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations
+        )

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -16,7 +16,7 @@ from utils.conversations.render import conversations_to_string
 from utils.llm.clients import get_llm, parser
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llms.memory import get_prompt_memories
-from utils.log_sanitizer import sanitize
+from utils.log_sanitizer import sanitize, sanitize_validation_error
 import logging
 
 logger = logging.getLogger(__name__)
@@ -376,8 +376,13 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "knowledge_nuggets": knowledge_nuggets,
             "locations": locations,
         }
-    except (json.JSONDecodeError, ValidationError) as e:
-        logger.error("Failed to parse daily summary payload: %s", sanitize(str(e)))
+    except json.JSONDecodeError as e:
+        logger.error("Failed to decode daily summary payload JSON: %s", sanitize(str(e)))
+        return _basic_daily_summary(
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations
+        )
+    except ValidationError as e:
+        logger.error("Failed to validate daily summary payload: %s", sanitize_validation_error(e))
         return _basic_daily_summary(
             date_str, total_conversations, total_duration_minutes, actual_action_items, locations
         )

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -16,6 +16,7 @@ from utils.conversations.render import conversations_to_string
 from utils.llm.clients import get_llm, parser
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llms.memory import get_prompt_memories
+from utils.log_sanitizer import sanitize
 import logging
 
 logger = logging.getLogger(__name__)
@@ -326,13 +327,13 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
         # Process highlights - map conversation_numbers to conversation_ids
         highlights = []
         for h in summary_data.highlights:
-            convo_nums = h.get("conversation_numbers", [])
+            convo_nums = h.conversation_numbers
             convo_ids = [get_convo_id(n) for n in convo_nums if get_convo_id(n)]
             highlights.append(
                 {
-                    "topic": h.get("topic", ""),
-                    "emoji": h.get("emoji", "💡"),
-                    "summary": h.get("summary", ""),
+                    "topic": h.topic,
+                    "emoji": h.emoji or "💡",
+                    "summary": h.summary,
                     "conversation_ids": convo_ids,
                 }
             )
@@ -341,22 +342,18 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
         unresolved_questions = []
         for q in summary_data.unresolved_questions:
             unresolved_questions.append(
-                {"question": q.get("question", ""), "conversation_id": get_convo_id(q.get("conversation_number"))}
+                {"question": q.question, "conversation_id": get_convo_id(q.conversation_number)}
             )
 
         # Process decisions made
         decisions_made = []
         for d in summary_data.decisions_made:
-            decisions_made.append(
-                {"decision": d.get("decision", ""), "conversation_id": get_convo_id(d.get("conversation_number"))}
-            )
+            decisions_made.append({"decision": d.decision, "conversation_id": get_convo_id(d.conversation_number)})
 
         # Process knowledge nuggets
         knowledge_nuggets = []
         for k in summary_data.knowledge_nuggets:
-            knowledge_nuggets.append(
-                {"insight": k.get("insight", ""), "conversation_id": get_convo_id(k.get("conversation_number"))}
-            )
+            knowledge_nuggets.append({"insight": k.insight, "conversation_id": get_convo_id(k.conversation_number)})
 
         # Build the complete summary object
         summary_id = str(uuid.uuid4())
@@ -380,7 +377,7 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "locations": locations,
         }
     except (json.JSONDecodeError, ValidationError) as e:
-        logger.error(f"Failed to parse daily summary payload: {e}")
+        logger.error("Failed to parse daily summary payload: %s", sanitize(str(e)))
         return _basic_daily_summary(
             date_str, total_conversations, total_duration_minutes, actual_action_items, locations
         )

--- a/backend/utils/log_sanitizer.py
+++ b/backend/utils/log_sanitizer.py
@@ -13,6 +13,7 @@ Usage:
     logger.info(f"Found contact: {sanitize_pii(name)} -> {sanitize_pii(email)}")
 """
 
+import json
 import re
 import logging
 
@@ -49,6 +50,25 @@ def sanitize(value) -> str:
     # Mask emails first (before token regex can match parts of them)
     text = _EMAIL_PATTERN.sub(_mask_email, text)
     return _TOKEN_CHARS.sub(_mask_token, text)
+
+
+def sanitize_validation_error(error) -> str:
+    """Return validation diagnostics without logging raw input values.
+
+    Pydantic's default ``ValidationError.__str__`` includes ``input_value``;
+    for LLM/user-derived payloads that can expose private text. Keep only the
+    structural fields needed to debug malformed payloads.
+    """
+    safe_errors = []
+    for item in error.errors(include_input=False):
+        safe_errors.append(
+            {
+                'type': item.get('type'),
+                'loc': item.get('loc'),
+                'msg': item.get('msg'),
+            }
+        )
+    return sanitize(json.dumps(safe_errors, default=str))
 
 
 def _mask_email(match: re.Match) -> str:

--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -1,5 +1,5 @@
 from collections import Counter, defaultdict
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import database.users as users_db
 from database.auth import get_user_name
@@ -50,10 +50,12 @@ def retrieve_memories_for_topics(uid: str, topics: List[str], dates_range: List)
     return memories_id, get_conversations_by_id(uid, memories_id.keys())
 
 
-def get_better_conversation_chunk(
-    memory: Conversation, topics: List[str], context_data: dict, people: List[Person] = None, user_name: str = None
-) -> str:
+def build_conversation_context(
+    memory: Conversation, topics: List[str], people: Optional[List[Person]] = None, user_name: Optional[str] = None
+) -> str | None:
     logger.info(f'get_better_memory_chunk {memory.id} {topics}')
+    people = people or []
+    user_name = user_name or ''
     conversation = TranscriptSegment.segments_as_string(
         memory.transcript_segments, include_timestamps=True, people=people, user_name=user_name
     )
@@ -61,8 +63,20 @@ def get_better_conversation_chunk(
         return conversations_to_string([memory], people=people, user_name=user_name)
     chunk = chunk_extraction(memory.transcript_segments, topics, people=people, user_name=user_name)
     if not chunk or len(chunk) < 10:
-        return
-    context_data[memory.id] = chunk
+        return None
+    return chunk
+
+
+def get_better_conversation_chunk(
+    memory: Conversation,
+    topics: List[str],
+    context_data: dict,
+    people: Optional[List[Person]] = None,
+    user_name: Optional[str] = None,
+) -> None:
+    chunk = build_conversation_context(memory, topics, people=people, user_name=user_name)
+    if chunk:
+        context_data[memory.id] = chunk
 
 
 def retrieve_rag_conversation_context(uid: str, memory: Conversation) -> Tuple[str, List[Conversation]]:

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -13,6 +13,11 @@ from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
 import database.users as users_db
+from models.calendar_mutation import (
+    CalendarMutationResult,
+    event_title as calendar_event_title,
+    format_deleted_calendar_events,
+)
 from utils.http_client import get_auth_client
 from utils.retrieval.tools.integration_base import (
     ensure_capped,
@@ -27,6 +32,7 @@ from utils.log_sanitizer import sanitize, sanitize_pii
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 # Import the context variable from agentic module
 try:
@@ -129,7 +135,8 @@ async def search_google_contacts(access_token: str, query: str) -> Optional[str]
 
                 if email_addresses:
                     email = email_addresses[0].get('value')
-                    name = person.get('names', [{}])[0].get('displayName', query)
+                    names = person.get('names') or [{}]
+                    name = names[0].get('displayName', query)
                     logger.info(f"✅ Found contact in Other Contacts: {sanitize_pii(name)} -> {sanitize_pii(email)}")
                     return email
                 else:
@@ -1071,9 +1078,8 @@ async def delete_calendar_event_tool(
 
             logger.info(f"📅 Found {len(matching_events)} matching event(s) to delete")
 
-            # Delete all matching events
-            deleted_count = 0
-            failed_deletions = []
+            # Delete all matching events, keeping success and failure attribution separate.
+            mutation_result = CalendarMutationResult()
 
             for event in matching_events:
                 event_id = event.get('id')
@@ -1085,39 +1091,13 @@ async def delete_calendar_event_tool(
 
                 try:
                     await delete_google_calendar_event(access_token, event_id)
-                    deleted_count += 1
+                    mutation_result.succeeded.append(event)
                 except Exception as e:
                     error_msg = str(e)
                     logger.error(f"❌ Failed to delete {event_title_found}: {error_msg}")
-                    failed_deletions.append((event_title_found, error_msg))
+                    mutation_result.failed.append((event_title_found, error_msg))
 
-            # Build result message
-            if deleted_count > 0:
-                result = f"✅ Successfully deleted {deleted_count} calendar event(s):\n"
-                for event in matching_events[:deleted_count]:
-                    summary = event.get('summary', 'Untitled')
-                    start = event.get('start', {})
-                    if 'dateTime' in start:
-                        try:
-                            start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
-                            result += f"   - {summary} ({start_dt.strftime('%Y-%m-%d %H:%M')})\n"
-                        except:
-                            result += f"   - {summary}\n"
-                    else:
-                        result += f"   - {summary}\n"
-
-                if failed_deletions:
-                    result += f"\n⚠️ Failed to delete {len(failed_deletions)} event(s):\n"
-                    for title, error in failed_deletions:
-                        result += f"   - {title}: {error}\n"
-
-                return result.strip()
-            else:
-                if failed_deletions:
-                    error_msgs = '; '.join([f"{title}: {error}" for title, error in failed_deletions])
-                    return f"Error: Failed to delete events: {error_msgs}"
-                else:
-                    return "No events were deleted."
+            return format_deleted_calendar_events(mutation_result)
 
         except GoogleAPIError as e:
             logger.error(f"❌ Google API error searching events to delete: status={e.status_code}, msg={e.message}")
@@ -1151,20 +1131,18 @@ async def delete_calendar_event_tool(
                         if not matching_events:
                             return f"No calendar events found matching '{event_title}'{date_info_retry}."
 
-                        deleted_count = 0
+                        mutation_result = CalendarMutationResult()
                         for event in matching_events:
                             event_id = event.get('id')
+                            event_title_found = calendar_event_title(event)
                             if event_id:
                                 try:
                                     await delete_google_calendar_event(new_token, event_id)
-                                    deleted_count += 1
-                                except Exception:
-                                    pass
+                                    mutation_result.succeeded.append(event)
+                                except Exception as delete_error:
+                                    mutation_result.failed.append((event_title_found, str(delete_error)))
 
-                        if deleted_count > 0:
-                            return f"✅ Successfully deleted {deleted_count} calendar event(s)"
-                        else:
-                            return "No events were deleted."
+                        return format_deleted_calendar_events(mutation_result)
                     except Exception as retry_error:
                         return f"Error deleting calendar events: {retry_error}"
                 else:


### PR DESCRIPTION
## Summary

Supersedes #8290, #8291, #8306, #8310, #8311, #8313, #8319, #8320.

Original issue discovery, reproductions, and candidate fixes by @ZachL111.

This aggregates the retrieval/output semantic correctness fixes into one focused backend PR:

- adds shared conversation metadata keys/model and uses them for vector metadata production + reranking
- fixes metadata entity extraction so entities no longer copy topics
- refactors RAG chunking through a pure `build_conversation_context(...) -> str | None` path so short conversations are included consistently
- separates calendar deletion successes from failures before building user-visible output
- normalizes merge/photo timestamps through a UTC-aware helper and keeps malformed/missing photo dates with a structured warning
- makes proactive-notification cache setters keyword-only for `app_id` to prevent passing an `App` object as the cache key
- validates daily-summary LLM JSON with a Pydantic payload, falls back only on JSON/model-validation failures, and stops logging raw LLM output
- safely handles Google contacts with absent names while preserving email extraction

## Included Zach PRs

Included/redesigned in this aggregate: #8290, #8291, #8306, #8310, #8311, #8313, #8319, #8320.

Deferred from this aggregate: none.

## Tests

- `cd backend && ./scripts/sync-python-deps.sh`
- `cd backend && source .venv/bin/activate && pytest tests/unit/test_retrieval_semantics.py tests/unit/test_daily_summary_regenerate.py tests/unit/test_daily_summary_race_condition.py tests/unit/test_conversations_to_string.py`
- `cd backend && source .venv/bin/activate && python -m py_compile models/conversation_metadata.py models/calendar_mutation.py models/daily_summary_payload.py utils/conversations/datetime_utils.py utils/conversations/merge_conversations.py utils/retrieval/rag.py utils/llm/chat.py utils/llm/external_integrations.py utils/retrieval/tools/calendar_tools.py database/mem_db.py database/redis_db.py database/vector_db.py tests/unit/test_retrieval_semantics.py`
- `cd backend && bash testing/e2e/run.sh` — 73 passed, 6 skipped

Also ran `python backend/scripts/scan_async_blockers.py` from repo root; it exits 0 and reports existing async-blocker findings unrelated to this PR. Running it from `backend/` currently fails with `Error: backend/routers not found`, so root invocation was used.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

