### PR TITLE
fix(backend): centralize request boundary validation

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from models.audio_file import AudioFile
 from models.calendar_context import CalendarMeetingContext
@@ -228,10 +228,22 @@ class SetConversationEventsStateRequest(BaseModel):
     events_idx: List[int]
     values: List[bool]
 
+    @model_validator(mode='after')
+    def validate_parallel_arrays(self):
+        if len(self.events_idx) != len(self.values):
+            raise ValueError('events_idx and values must have the same length')
+        return self
+
 
 class SetConversationActionItemsStateRequest(BaseModel):
     items_idx: List[int]
     values: List[bool]
+
+    @model_validator(mode='after')
+    def validate_parallel_arrays(self):
+        if len(self.items_idx) != len(self.values):
+            raise ValueError('items_idx and values must have the same length')
+        return self
 
 
 class BulkAssignSegmentsRequest(BaseModel):

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -116,7 +116,11 @@ from utils.llm.app_generator import generate_description
 from utils.llm.usage_tracker import track_usage, Features
 from utils.notifications import send_notification, send_app_review_reply_notification, send_new_app_review_notification
 from utils.other import endpoints as auth
-from utils.request_validation import parse_form_json
+from utils.request_validation import (
+    backfill_app_home_url_from_auth_steps,
+    normalize_required_webhook_url,
+    parse_form_json,
+)
 from models.app import App, ActionType, AppCreate, AppUpdate, AppBaseModel
 from utils.other.storage import upload_app_logo, delete_app_logo, upload_app_thumbnail, get_app_thumbnail_url
 from utils.social import (
@@ -496,9 +500,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
             raise HTTPException(status_code=422, detail='Triggers on or actions is required')
         # Trigger on
         if external_integration.get('triggers_on'):
-            if not external_integration.get('webhook_url'):
-                raise HTTPException(status_code=422, detail='external_integration.webhook_url is required')
-            external_integration['webhook_url'] = external_integration['webhook_url'].strip()
+            normalize_required_webhook_url(external_integration)
             if external_integration.get('setup_instructions_file_path'):
                 external_integration['setup_instructions_file_path'] = external_integration[
                     'setup_instructions_file_path'
@@ -527,9 +529,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
     data['created_at'] = datetime.now(timezone.utc)
     # Backward compatibility: Set app_home_url from first auth step if not provided
     if 'external_integration' in data:
-        ext_int = data['external_integration']
-        if not ext_int.get('app_home_url') and ext_int.get('auth_steps') and len(ext_int['auth_steps']) == 1:
-            ext_int['app_home_url'] = ext_int['auth_steps'][0]['url']
+        backfill_app_home_url_from_auth_steps(data['external_integration'])
 
     try:
         app = AppCreate.model_validate(data)
@@ -740,11 +740,7 @@ def update_app(
 
     # Backward compatibility: Set app_home_url from first auth step if not provided
     if 'external_integration' in data:
-        ext_int = data['external_integration']
-        if not ext_int.get('app_home_url') and ext_int.get('auth_steps') and len(ext_int['auth_steps']) == 1:
-            if not ext_int['auth_steps'][0].get('url'):
-                raise HTTPException(status_code=422, detail='external_integration.auth_steps[0].url is required')
-            ext_int['app_home_url'] = ext_int['auth_steps'][0]['url']
+        backfill_app_home_url_from_auth_steps(data['external_integration'])
 
     try:
         update_app = AppUpdate.model_validate(data)

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -116,6 +116,7 @@ from utils.llm.app_generator import generate_description
 from utils.llm.usage_tracker import track_usage, Features
 from utils.notifications import send_notification, send_app_review_reply_notification, send_new_app_review_notification
 from utils.other import endpoints as auth
+from utils.request_validation import parse_form_json
 from models.app import App, ActionType, AppCreate, AppUpdate, AppBaseModel
 from utils.other.storage import upload_app_logo, delete_app_logo, upload_app_thumbnail, get_app_thumbnail_url
 from utils.social import (
@@ -467,12 +468,7 @@ def get_popular_apps_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 @router.post('/v1/apps', tags=['v1'])
 def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)):
-    try:
-        data = json.loads(app_data)
-    except (json.JSONDecodeError, TypeError):
-        raise HTTPException(status_code=400, detail='Invalid app_data: must be valid JSON')
-    if not isinstance(data, dict):
-        raise HTTPException(status_code=400, detail='Invalid app_data: must be a JSON object')
+    data = parse_form_json(dict, app_data, 'app_data')
     data['approved'] = False
     data['status'] = 'under-review'
     data['name'] = (data.get('name') or '').strip()
@@ -500,6 +496,8 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
             raise HTTPException(status_code=422, detail='Triggers on or actions is required')
         # Trigger on
         if external_integration.get('triggers_on'):
+            if not external_integration.get('webhook_url'):
+                raise HTTPException(status_code=422, detail='external_integration.webhook_url is required')
             external_integration['webhook_url'] = external_integration['webhook_url'].strip()
             if external_integration.get('setup_instructions_file_path'):
                 external_integration['setup_instructions_file_path'] = external_integration[
@@ -557,7 +555,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
 async def create_persona(
     persona_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)
 ):
-    data = json.loads(persona_data)
+    data = parse_form_json(dict, persona_data, 'persona_data')
     data['approved'] = False
     data['status'] = 'under-review'
     data['category'] = 'personality-emulation'
@@ -603,7 +601,7 @@ async def update_persona(
     file: UploadFile = File(None),
     uid=Depends(auth.get_current_user_uid),
 ):
-    data = json.loads(persona_data)
+    data = parse_form_json(dict, persona_data, 'persona_data')
     persona = await run_blocking(db_executor, get_available_app_by_id, persona_id, uid)
     if not persona:
         raise HTTPException(status_code=404, detail='Persona not found')
@@ -723,7 +721,7 @@ async def get_or_create_user_persona(uid: str = Depends(auth.get_current_user_ui
 def update_app(
     app_id: str, app_data: str = Form(...), file: UploadFile = File(None), uid=Depends(auth.get_current_user_uid)
 ):
-    data = json.loads(app_data)
+    data = parse_form_json(dict, app_data, 'app_data')
     app = get_available_app_by_id(app_id, uid)
     if not app:
         raise HTTPException(status_code=404, detail='App not found')
@@ -744,6 +742,8 @@ def update_app(
     if 'external_integration' in data:
         ext_int = data['external_integration']
         if not ext_int.get('app_home_url') and ext_int.get('auth_steps') and len(ext_int['auth_steps']) == 1:
+            if not ext_int['auth_steps'][0].get('url'):
+                raise HTTPException(status_code=422, detail='external_integration.auth_steps[0].url is required')
             ext_int['app_home_url'] = ext_int['auth_steps'][0]['url']
 
     try:

--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 import database.calendar_meetings as calendar_db
 from models.calendar_context import CalendarMeetingContext, MeetingParticipant
 from utils.other import endpoints as auth
+from utils.request_validation import CalendarMeetingsLimit
 
 router = APIRouter()
 
@@ -96,7 +97,7 @@ def list_calendar_meetings(
     uid: str = Depends(auth.get_current_user_uid),
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
-    limit: int = 50,
+    limit: CalendarMeetingsLimit = 50,
 ):
     """List calendar meetings within a date range"""
     meetings = calendar_db.list_meetings(uid, start_date=start_date, end_date=end_date, limit=limit)

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -46,6 +46,7 @@ from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
 from utils.other.storage import get_conversation_recording_if_exists
 from utils.app_integrations import trigger_external_integrations
+from utils.request_validation import NonNegativeOffset, PositiveLimit
 from utils.conversations.calendar_linking import (
     get_overlapping_calendar_event,
     write_conversation_link_to_calendar_event,
@@ -178,8 +179,8 @@ def reprocess_conversation(
     ),
 )
 def get_conversations(
-    limit: int = 100,
-    offset: int = 0,
+    limit: PositiveLimit = 100,
+    offset: NonNegativeOffset = 0,
     statuses: Optional[str] = "processing,completed",
     include_discarded: bool = True,
     start_date: Optional[datetime] = Query(None, description="Filter by start date (inclusive)"),
@@ -513,7 +514,7 @@ def set_action_item_status(
     conversation = deserialize_conversation(conversation)
     action_items = conversation.structured.action_items
     for i, action_item_idx in enumerate(data.items_idx):
-        if action_item_idx >= len(action_items):
+        if not (0 <= action_item_idx < len(action_items)):
             continue
 
         action_item = action_items[action_item_idx]
@@ -550,7 +551,7 @@ def set_action_item_status(
             description_to_ids.setdefault(desc, []).append(ai['id'])
 
         for i, action_item_idx in enumerate(data.items_idx):
-            if action_item_idx >= len(action_items):
+            if not (0 <= action_item_idx < len(action_items)):
                 continue
             action_item = action_items[action_item_idx]
             new_completed_status = data.values[i]

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -46,6 +46,7 @@ from utils.apps import update_personas_async
 from utils.notifications import send_action_item_data_message, sync_action_item_reminder
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations.location import get_google_maps_location
+from utils.request_validation import HistoryDays
 from utils.llm.memories import identify_category_for_memory
 import logging
 
@@ -1450,7 +1451,7 @@ def update_goal_progress(
 @router.get("/v1/dev/user/goals/{goal_id}/history", tags=["developer"])
 def get_goal_history(
     goal_id: str,
-    days: int = Query(default=30, le=365),
+    days: HistoryDays = 30,
     uid: str = Depends(get_uid_with_goals_read),
 ) -> List[dict]:
     """

--- a/backend/routers/focus_sessions.py
+++ b/backend/routers/focus_sessions.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 import database.focus_sessions as focus_sessions_db
 from utils.other import endpoints as auth
+from utils.request_validation import validate_calendar_date
 
 router = APIRouter()
 
@@ -49,6 +50,7 @@ def get_focus_sessions(
     date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    date = validate_calendar_date(date)
     return focus_sessions_db.get_focus_sessions(uid, limit=limit, offset=offset, date=date)
 
 
@@ -66,4 +68,5 @@ def get_focus_stats(
     date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    date = validate_calendar_date(date)
     return focus_sessions_db.get_focus_stats(uid, date=date)

--- a/backend/routers/goals.py
+++ b/backend/routers/goals.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from database import goals as goals_db
 from utils.other import endpoints as auth
+from utils.request_validation import HistoryDays
 from utils.llm.goals import (
     suggest_goal as suggest_goal_llm,
     get_goal_advice as get_goal_advice_llm,
@@ -182,9 +183,7 @@ def update_goal_progress(
 
 
 @router.get('/v1/goals/{goal_id}/history', tags=['goals'])
-def get_goal_history(
-    goal_id: str, days: int = Query(default=30, le=365), uid: str = Depends(auth.get_current_user_uid)
-) -> List[dict]:
+def get_goal_history(goal_id: str, days: HistoryDays = 30, uid: str = Depends(auth.get_current_user_uid)) -> List[dict]:
     """Get progress history for a goal."""
     history = goals_db.get_goal_history(uid, goal_id, days)
 

--- a/backend/routers/scores.py
+++ b/backend/routers/scores.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 
 import database.action_items as action_items_db
 from utils.other import endpoints as auth
+from utils.request_validation import validate_calendar_date
 
 router = APIRouter()
 
@@ -13,6 +14,7 @@ def get_daily_score(
     date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    date = validate_calendar_date(date)
     return action_items_db.get_daily_score(uid, date=date)
 
 
@@ -21,4 +23,5 @@ def get_scores(
     date: str | None = Query(None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    date = validate_calendar_date(date)
     return action_items_db.get_scores(uid, date=date)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -97,6 +97,7 @@ from utils.cloud_tasks import (
 )
 from utils.http_client import _get_semaphore
 from utils.log_sanitizer import sanitize
+from utils.request_validation import parse_sync_filename_timestamp
 from utils.stt.pre_recorded import postprocess_words, prerecorded
 from utils.stt.vad import vad_is_empty
 from utils.fair_use import (
@@ -669,10 +670,7 @@ def decode_opus_file_to_wav(opus_file_path, wav_file_path, sample_rate=16000, ch
 
 
 def get_timestamp_from_path(path: str):
-    timestamp = int(path.split('/')[-1].split('_')[-1].split('.')[0])
-    if timestamp > 1e10:
-        return int(timestamp / 1000)
-    return timestamp
+    return parse_sync_filename_timestamp(path)
 
 
 def retrieve_file_paths(files: List[UploadFile], uid: str):
@@ -682,6 +680,8 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
     for file in files:
         filename = file.filename
         # Validate the file is .bin and contains a _$timestamp.bin, if not, 400 bad request
+        if not filename:
+            raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
         if not filename.endswith('.bin'):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
         if '_' not in filename:
@@ -691,8 +691,8 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time = datetime.fromtimestamp(timestamp)
-        if time > datetime.now() or time < datetime(2024, 1, 1):
+        time = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        if time > datetime.now(timezone.utc) or time < datetime(2024, 1, 1, tzinfo=timezone.utc):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
         path = f"{directory}{filename}"
@@ -1648,8 +1648,8 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time_val = datetime.fromtimestamp(timestamp)
-        if time_val > datetime.now() or time_val < datetime(2024, 1, 1):
+        time_val = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        if time_val > datetime.now(timezone.utc) or time_val < datetime(2024, 1, 1, tzinfo=timezone.utc):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
         path = f"{directory}{filename}"

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -691,10 +691,6 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        time = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-        if time > datetime.now(timezone.utc) or time < datetime(2024, 1, 1, tzinfo=timezone.utc):
-            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
-
         path = f"{directory}{filename}"
         try:
             with open(path, "wb") as buffer:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -84,6 +84,7 @@ from utils.notifications import send_credit_limit_notification, send_silent_user
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists, get_user_has_speech_profile
 from utils.pusher import connect_to_trigger_pusher, PusherCircuitBreakerOpen, get_circuit_breaker, CircuitState
+from utils.request_validation import ImageChunkEnvelope
 from utils.speaker_identification import detect_speaker_from_text
 from utils.stt.streaming import (
     STTService,
@@ -2411,21 +2412,21 @@ async def _stream_handler(
         await send_event_func(PhotoDescribedEvent(photo_id=photo_id, description=description, discarded=discarded))
 
     async def handle_image_chunk(uid: str, chunk_data: dict, image_chunks_cache: dict, send_event_func, photo_buffer):
-        temp_id = chunk_data.get('id')
-        index = chunk_data.get('index')
-        total = chunk_data.get('total')
-        data = chunk_data.get('data')
+        try:
+            chunk = ImageChunkEnvelope.model_validate(chunk_data)
+        except ValueError as e:
+            logger.error(f"Invalid image chunk received: {sanitize(chunk_data)} {uid} {session_id}: {e}")
+            raise ValueError('invalid image chunk') from e
 
-        if not temp_id or not isinstance(index, int) or not isinstance(total, int) or not data:
-            logger.error(f"Invalid image chunk received: {sanitize(chunk_data)} {uid} {session_id}")
-            return
+        temp_id = chunk.id
+        index = chunk.index
+        total = chunk.total
+        data = chunk.data
 
         # Cleanup expired chunks periodically
         _cleanup_expired_image_chunks()
 
         if temp_id not in image_chunks_cache:
-            if total <= 0:
-                return
             # Enforce max concurrent uploads - O(1) with OrderedDict
             if len(image_chunks_cache) >= MAX_IMAGE_CHUNKS:
                 # Remove oldest entry (first inserted)
@@ -2434,7 +2435,13 @@ async def _stream_handler(
             image_chunks_cache[temp_id] = {'chunks': [None] * total, 'created_at': time.time()}
 
         chunks_data = image_chunks_cache[temp_id]['chunks']
-        if index < total and chunks_data[index] is None:
+        try:
+            chunk.validate_against_cached_total(len(chunks_data))
+        except ValueError as e:
+            logger.error(f"Invalid image chunk sequence received: {sanitize(chunk_data)} {uid} {session_id}: {e}")
+            raise ValueError('invalid image chunk sequence') from e
+
+        if chunks_data[index] is None:
             chunks_data[index] = data
 
         if all(chunk is not None for chunk in chunks_data):
@@ -2639,9 +2646,14 @@ async def _stream_handler(
                     try:
                         json_data = json.loads(message.get("text"))
                         if json_data.get('type') == 'image_chunk':
-                            await handle_image_chunk(
-                                uid, json_data, image_chunks, _asend_message_event, realtime_photo_buffers
-                            )
+                            try:
+                                await handle_image_chunk(
+                                    uid, json_data, image_chunks, _asend_message_event, realtime_photo_buffers
+                                )
+                            except ValueError:
+                                websocket_close_code = 1008
+                                websocket_active = False
+                                break
                         elif json_data.get('type') == 'skip_question':
                             if onboarding_handler and not onboarding_handler.completed:
                                 await onboarding_handler.skip_current_question()

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -111,6 +111,7 @@ pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_request_validation_contracts.py -v
 pytest tests/unit/test_conversation_structure_timezone.py -v
 pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v

--- a/backend/testing/e2e/listen_test_helpers.py
+++ b/backend/testing/e2e/listen_test_helpers.py
@@ -1,0 +1,42 @@
+"""Shared helpers for hermetic listen websocket e2e tests."""
+
+import json
+
+from fakes.firestore import get_mock_firestore
+
+
+def seed_listen_user(uid: str):
+    get_mock_firestore().collection("users").document(uid).set(
+        {
+            "id": uid,
+            "language": "en",
+            "private_cloud_sync_enabled": False,
+            "transcription_preferences": {"uses_custom_stt": True},
+        }
+    )
+
+
+def receive_until(websocket, predicate, *, limit=20):
+    for _ in range(limit):
+        message = websocket.receive()
+        if message.get("type") == "websocket.close":
+            raise AssertionError(f"websocket closed before expected message: {message}")
+        text = message.get("text")
+        if not text or text == "ping":
+            continue
+        payload = json.loads(text)
+        if predicate(payload):
+            return payload
+    raise AssertionError("expected websocket payload was not received")
+
+
+def is_ready_event(payload):
+    return isinstance(payload, dict) and payload.get("type") == "service_status" and payload.get("status") == "ready"
+
+
+def is_conversation_session_event(payload):
+    return isinstance(payload, dict) and payload.get("type") == "conversation_session"
+
+
+def is_segment_batch(payload):
+    return isinstance(payload, list) and payload and payload[0].get("id") == "seg-custom-stt-1"

--- a/backend/testing/e2e/test_boundary_contract_compatibility.py
+++ b/backend/testing/e2e/test_boundary_contract_compatibility.py
@@ -1,0 +1,134 @@
+"""Boundary contract e2e coverage for mobile/client-facing validation.
+
+These tests exercise the real FastAPI routes through the hermetic harness. Unit
+coverage owns the pure validation helpers; this file pins the integration seams:
+FastAPI parameter binding, auth, multipart parsing, fake storage side effects,
+sync upload filename handling, and listen WebSocket close behavior.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+from fakes.storage import list_storage_files
+
+
+def _fake_png_file():
+    return {"file": ("logo.png", b"not-a-real-png-but-validation-runs-first", "image/png")}
+
+
+def test_malformed_app_form_json_is_rejected_before_storage_write(client, auth_headers):
+    response = client.post(
+        "/v1/apps",
+        data={"app_data": "not-json"},
+        files=_fake_png_file(),
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422, response.text
+    assert "app_data" in response.json()["detail"]
+    assert list_storage_files("plugins-logos") == []
+    assert list_storage_files("app-thumbnails") == []
+
+
+def test_persona_form_json_must_be_an_object(client, auth_headers):
+    response = client.post(
+        "/v1/personas",
+        data={"persona_data": "[]"},
+        files=_fake_png_file(),
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422, response.text
+    assert "persona_data" in response.json()["detail"]
+    assert list_storage_files("plugins-logos") == []
+
+
+def test_real_routes_reject_invalid_boundary_query_values_without_500(client, auth_headers):
+    cases = [
+        ("/v1/conversations?limit=0", 422),
+        ("/v1/conversations?offset=-1", 422),
+        ("/v1/calendar/meetings?limit=101", 422),
+        ("/v1/goals/goal-123/history?days=0", 422),
+        ("/v1/goals/goal-123/history?days=366", 422),
+        ("/v1/scores?date=2024-02-30", 422),
+        ("/v1/daily-score?date=2024-02-30", 422),
+        ("/v1/focus-sessions?date=2024-02-30", 422),
+    ]
+
+    for path, expected_status in cases:
+        response = client.get(path, headers=auth_headers)
+
+        assert response.status_code == expected_status, f"{path}: {response.text}"
+        assert response.status_code < 500
+        assert "detail" in response.json()
+
+
+def test_v2_sync_rejects_invalid_upload_timestamps_before_creating_job(client, auth_headers):
+    sync_dir = Path("syncing/123")
+    for filename in [
+        "audio_0.bin",
+        "audio_999999999999999999999999.bin",
+        "audio_not-a-timestamp.bin",
+    ]:
+        shutil.rmtree(sync_dir, ignore_errors=True)
+
+        response = client.post(
+            "/v2/sync-local-files",
+            files=[("files", (filename, b"invalid-opus-data", "application/octet-stream"))],
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, f"{filename}: {response.text}"
+        assert "invalid timestamp" in response.json()["detail"]
+        assert list_storage_files("sync-temporal") == []
+        assert [path for path in sync_dir.glob("**/*") if path.is_file()] == []
+    shutil.rmtree(sync_dir, ignore_errors=True)
+
+
+def _seed_listen_user(uid: str):
+    from fakes.firestore import get_mock_firestore
+
+    get_mock_firestore().collection("users").document(uid).set(
+        {
+            "id": uid,
+            "language": "en",
+            "private_cloud_sync_enabled": False,
+            "transcription_preferences": {"uses_custom_stt": True},
+        }
+    )
+
+
+def _receive_until(websocket, predicate, *, limit=20):
+    for _ in range(limit):
+        message = websocket.receive()
+        if message.get("type") == "websocket.close":
+            raise AssertionError(f"websocket closed before expected message: {message}")
+        text = message.get("text")
+        if not text or text == "ping":
+            continue
+        payload = json.loads(text)
+        if predicate(payload):
+            return payload
+    raise AssertionError("expected websocket payload was not received")
+
+
+def _is_ready_event(payload):
+    return isinstance(payload, dict) and payload.get("type") == "service_status" and payload.get("status") == "ready"
+
+
+def test_invalid_listen_image_chunk_closes_websocket_with_policy_violation(client, test_uid):
+    _seed_listen_user(test_uid)
+
+    with client.websocket_connect(
+        "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&channels=2&source=phone_call"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        _receive_until(websocket, _is_ready_event)
+
+        websocket.send_text(json.dumps({"type": "image_chunk", "id": "img-1", "index": 2, "total": 2, "data": "abc"}))
+        close_message = websocket.receive()
+
+    assert close_message["type"] == "websocket.close"
+    assert close_message["code"] == 1008

--- a/backend/testing/e2e/test_boundary_contract_compatibility.py
+++ b/backend/testing/e2e/test_boundary_contract_compatibility.py
@@ -11,6 +11,7 @@ import shutil
 from pathlib import Path
 
 from fakes.storage import list_storage_files
+from listen_test_helpers import is_ready_event, receive_until, seed_listen_user
 
 
 def _fake_png_file():
@@ -86,46 +87,15 @@ def test_v2_sync_rejects_invalid_upload_timestamps_before_creating_job(client, a
     shutil.rmtree(sync_dir, ignore_errors=True)
 
 
-def _seed_listen_user(uid: str):
-    from fakes.firestore import get_mock_firestore
-
-    get_mock_firestore().collection("users").document(uid).set(
-        {
-            "id": uid,
-            "language": "en",
-            "private_cloud_sync_enabled": False,
-            "transcription_preferences": {"uses_custom_stt": True},
-        }
-    )
-
-
-def _receive_until(websocket, predicate, *, limit=20):
-    for _ in range(limit):
-        message = websocket.receive()
-        if message.get("type") == "websocket.close":
-            raise AssertionError(f"websocket closed before expected message: {message}")
-        text = message.get("text")
-        if not text or text == "ping":
-            continue
-        payload = json.loads(text)
-        if predicate(payload):
-            return payload
-    raise AssertionError("expected websocket payload was not received")
-
-
-def _is_ready_event(payload):
-    return isinstance(payload, dict) and payload.get("type") == "service_status" and payload.get("status") == "ready"
-
-
 def test_invalid_listen_image_chunk_closes_websocket_with_policy_violation(client, test_uid):
-    _seed_listen_user(test_uid)
+    seed_listen_user(test_uid)
 
     with client.websocket_connect(
         "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&channels=2&source=phone_call"
     ) as websocket:
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
         assert websocket.receive_json() == {"type": "auth_response", "success": True}
-        _receive_until(websocket, _is_ready_event)
+        receive_until(websocket, is_ready_event)
 
         websocket.send_text(json.dumps({"type": "image_chunk", "id": "img-1", "index": 2, "total": 2, "data": "abc"}))
         close_message = websocket.receive()

--- a/backend/testing/e2e/test_listen_stt.py
+++ b/backend/testing/e2e/test_listen_stt.py
@@ -5,43 +5,13 @@ import uuid
 
 from fakes.firestore import get_mock_firestore, read_conversation
 from fakes.stt import fake_suggested_transcript_event
-
-
-def _seed_listen_user(uid: str):
-    get_mock_firestore().collection("users").document(uid).set(
-        {
-            "id": uid,
-            "language": "en",
-            "private_cloud_sync_enabled": False,
-            "transcription_preferences": {"uses_custom_stt": True},
-        }
-    )
-
-
-def _receive_until(websocket, predicate, *, limit=20):
-    for _ in range(limit):
-        message = websocket.receive()
-        if message.get("type") == "websocket.close":
-            raise AssertionError(f"websocket closed before expected message: {message}")
-        text = message.get("text")
-        if not text or text == "ping":
-            continue
-        payload = json.loads(text)
-        if predicate(payload):
-            return payload
-    raise AssertionError("expected websocket payload was not received")
-
-
-def _is_ready_event(payload):
-    return isinstance(payload, dict) and payload.get("type") == "service_status" and payload.get("status") == "ready"
-
-
-def _is_conversation_session_event(payload):
-    return isinstance(payload, dict) and payload.get("type") == "conversation_session"
-
-
-def _is_segment_batch(payload):
-    return isinstance(payload, list) and payload and payload[0].get("id") == "seg-custom-stt-1"
+from listen_test_helpers import (
+    is_conversation_session_event,
+    is_ready_event,
+    is_segment_batch,
+    receive_until,
+    seed_listen_user,
+)
 
 
 def test_web_listen_custom_stt_dispatches_to_stream_handler(client, monkeypatch):
@@ -118,7 +88,7 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
     Deepgram is not contacted, but the real route, websocket loop, transcript
     normalization, client emission, and fake-Firestore persistence all run.
     """
-    _seed_listen_user(test_uid)
+    seed_listen_user(test_uid)
 
     with client.websocket_connect(
         "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&source=desktop"
@@ -126,15 +96,15 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
         auth_response = websocket.receive_json()
         assert auth_response == {"type": "auth_response", "success": True}
-        session_event = _receive_until(websocket, _is_conversation_session_event)
+        session_event = receive_until(websocket, is_conversation_session_event)
         uuid.UUID(session_event["conversation_id"])
         assert session_event["status"] == "in_progress"
-        _receive_until(websocket, _is_ready_event)
+        receive_until(websocket, is_ready_event)
 
         websocket.send_bytes(b"\x80" * 320)
         websocket.send_text(json.dumps(fake_suggested_transcript_event()))
 
-        emitted_segments = _receive_until(websocket, _is_segment_batch)
+        emitted_segments = receive_until(websocket, is_segment_batch)
 
     expected_segment = {
         "id": "seg-custom-stt-1",
@@ -174,24 +144,24 @@ def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(cli
 
 def test_web_listen_reconnect_emits_existing_conversation_session_id(client, test_uid):
     """A fast reconnect should expose the same active conversation id instead of making clients infer it."""
-    _seed_listen_user(test_uid)
+    seed_listen_user(test_uid)
 
     with client.websocket_connect(
         "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
     ) as websocket:
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
         assert websocket.receive_json() == {"type": "auth_response", "success": True}
-        first_event = _receive_until(websocket, _is_conversation_session_event)
+        first_event = receive_until(websocket, is_conversation_session_event)
         uuid.UUID(first_event["conversation_id"])
-        _receive_until(websocket, _is_ready_event)
+        receive_until(websocket, is_ready_event)
 
     with client.websocket_connect(
         "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
     ) as websocket:
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
         assert websocket.receive_json() == {"type": "auth_response", "success": True}
-        second_event = _receive_until(websocket, _is_conversation_session_event)
-        _receive_until(websocket, _is_ready_event)
+        second_event = receive_until(websocket, is_conversation_session_event)
+        receive_until(websocket, is_ready_event)
 
     assert second_event["conversation_id"] == first_event["conversation_id"]
     conversations = list(

--- a/backend/tests/unit/test_apps_create_app_json.py
+++ b/backend/tests/unit/test_apps_create_app_json.py
@@ -1,127 +1,23 @@
-"""POST /v1/apps (create_app) must return 400, not 500, on a malformed app_data JSON form field.
-
-routers/apps.py has a very heavy import graph, so we import it under a stub finder that auto-mocks those
-namespaces (keeping models/fastapi/pydantic real), then call the handler directly.
-"""
-
-import importlib.abc
-import importlib.machinery
-import importlib.util
-import os
-import sys
-import types
-from unittest.mock import MagicMock
+"""App/persona multipart JSON form contract tests."""
 
 import pytest
+from fastapi import HTTPException
 
-os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
-os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
-
-_STUB = (
-    'database',
-    'utils',
-    'firebase_admin',
-    'google',
-    'pinecone',
-    'typesense',
-    'opuslib',
-    'pydub',
-    'pusher',
-    'modal',
-    'ulid',
-    'langchain',
-    'langchain_core',
-    'stripe',
-    'openai',
-    'anthropic',
-    'redis',
-    'sentry_sdk',
-    'requests',
-)
+from utils.request_validation import parse_form_json
 
 
-def _is_stubbed_name(name):
-    return any(name == p or name.startswith(p + '.') for p in _STUB)
+def test_create_app_invalid_json_returns_422_before_handler_io():
+    with pytest.raises(HTTPException) as exc_info:
+        parse_form_json(dict, 'this is not json', 'app_data')
+
+    assert exc_info.value.status_code == 422
+    assert 'app_data' in exc_info.value.detail
 
 
-def _snapshot():
-    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+@pytest.mark.parametrize('payload', ['[1, 2, 3]', '"a string"', '42'])
+def test_create_app_non_object_json_returns_422_before_handler_io(payload):
+    with pytest.raises(HTTPException) as exc_info:
+        parse_form_json(dict, payload, 'app_data')
 
-
-def _clear():
-    for name in list(sys.modules):
-        if _is_stubbed_name(name):
-            sys.modules.pop(name, None)
-
-
-def _restore(snapshot):
-    for name in list(sys.modules):
-        if _is_stubbed_name(name) and name not in snapshot:
-            sys.modules.pop(name, None)
-    sys.modules.update(snapshot)
-
-
-def _install_python_multipart_stub():
-    if 'python_multipart' in sys.modules:
-        return False
-    if importlib.util.find_spec('python_multipart') is not None:
-        return False
-    mod = types.ModuleType('python_multipart')
-    mod.__version__ = '0.0.20'
-    sys.modules['python_multipart'] = mod
-    return True
-
-
-class _AutoMock(types.ModuleType):
-    __path__ = []
-
-    def __getattr__(self, name):
-        if name.startswith('__') and name.endswith('__'):
-            raise AttributeError(name)
-        m = MagicMock()
-        setattr(self, name, m)
-        return m
-
-
-class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
-    def find_spec(self, name, path=None, target=None):
-        if _is_stubbed_name(name):
-            return importlib.machinery.ModuleSpec(name, self, is_package=True)
-        return None
-
-    def create_module(self, spec):
-        return _AutoMock(spec.name)
-
-    def exec_module(self, module):
-        pass
-
-
-_finder = _Finder()
-_snap = _snapshot()
-_clear()
-_rm = _install_python_multipart_stub()
-sys.meta_path.insert(0, _finder)
-try:
-    from routers import apps as apps_mod
-finally:
-    sys.meta_path.remove(_finder)
-    _restore(_snap)
-    if _rm:
-        sys.modules.pop('python_multipart', None)
-
-from fastapi import HTTPException  # noqa: E402
-
-
-def test_create_app_invalid_json_returns_400_not_500():
-    with pytest.raises(HTTPException) as e:
-        apps_mod.create_app(app_data='this is not json', file=MagicMock(), uid='uid1')
-    assert e.value.status_code == 400
-
-
-def test_create_app_non_object_json_returns_400_not_500():
-    # Valid JSON that is not an object (array/scalar) must also be rejected with 400, not 500: the
-    # handler immediately does dict-style writes like data['approved'] = False.
-    for payload in ('[1, 2, 3]', '"a string"', '42'):
-        with pytest.raises(HTTPException) as e:
-            apps_mod.create_app(app_data=payload, file=MagicMock(), uid='uid1')
-        assert e.value.status_code == 400
+    assert exc_info.value.status_code == 422
+    assert 'app_data' in exc_info.value.detail

--- a/backend/tests/unit/test_apps_create_app_json.py
+++ b/backend/tests/unit/test_apps_create_app_json.py
@@ -3,7 +3,11 @@
 import pytest
 from fastapi import HTTPException
 
-from utils.request_validation import parse_form_json
+from utils.request_validation import (
+    backfill_app_home_url_from_auth_steps,
+    normalize_required_webhook_url,
+    parse_form_json,
+)
 
 
 def test_create_app_invalid_json_returns_422_before_handler_io():
@@ -21,3 +25,39 @@ def test_create_app_non_object_json_returns_422_before_handler_io(payload):
 
     assert exc_info.value.status_code == 422
     assert 'app_data' in exc_info.value.detail
+
+
+@pytest.mark.parametrize('webhook_url', ['', '   ', None, 123])
+def test_trigger_webhook_url_must_be_nonblank_string(webhook_url):
+    external_integration = {'webhook_url': webhook_url}
+
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_required_webhook_url(external_integration)
+
+    assert exc_info.value.status_code == 422
+
+
+def test_trigger_webhook_url_is_trimmed_after_validation():
+    external_integration = {'webhook_url': '  https://example.com/webhook  '}
+
+    normalize_required_webhook_url(external_integration)
+
+    assert external_integration['webhook_url'] == 'https://example.com/webhook'
+
+
+@pytest.mark.parametrize('auth_steps', ['not-a-list', {'url': 'https://example.com'}, [None], ['bad'], [{}]])
+def test_auth_steps_app_home_backfill_rejects_malformed_single_step(auth_steps):
+    external_integration = {'auth_steps': auth_steps}
+
+    with pytest.raises(HTTPException) as exc_info:
+        backfill_app_home_url_from_auth_steps(external_integration)
+
+    assert exc_info.value.status_code == 422
+
+
+def test_auth_steps_app_home_backfill_accepts_single_url_step():
+    external_integration = {'auth_steps': [{'url': 'https://example.com/oauth'}]}
+
+    backfill_app_home_url_from_auth_steps(external_integration)
+
+    assert external_integration['app_home_url'] == 'https://example.com/oauth'

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -173,6 +173,7 @@ _endpoints.get_user = MagicMock()
 _register_module('utils.other.endpoints', _endpoints)
 
 from fastapi import HTTPException  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
 _remove_module_for_fresh_import('routers.conversations')
 _remove_module_for_fresh_import('routers')
@@ -200,15 +201,9 @@ def _fake_conversation_with_events(count):
 
 
 def test_mismatched_lengths_returns_422():
-    """events_idx longer than values must 422, not IndexError -> 500."""
-    convo, _events = _fake_conversation_with_events(2)
-    with patch.object(conv, '_get_valid_conversation_by_id', return_value={'id': 'c1'}), patch.object(
-        conv, 'deserialize_conversation', return_value=convo
-    ):
-        data = SetConversationEventsStateRequest(events_idx=[0, 1], values=[True])
-        with pytest.raises(HTTPException) as exc:
-            conv.set_conversation_events_state('c1', data, uid='u1')
-        assert exc.value.status_code == 422
+    """events_idx longer than values must fail request validation before router code runs."""
+    with pytest.raises(ValidationError):
+        SetConversationEventsStateRequest(events_idx=[0, 1], values=[True])
 
 
 def test_negative_index_is_skipped_not_corrupting():

--- a/backend/tests/unit/test_request_validation_contracts.py
+++ b/backend/tests/unit/test_request_validation_contracts.py
@@ -9,6 +9,7 @@ from models.conversation import SetConversationActionItemsStateRequest, SetConve
 from utils.request_validation import (
     HistoryDays,
     ImageChunkEnvelope,
+    MAX_IMAGE_CHUNK_TOTAL,
     NonNegativeOffset,
     PositiveLimit,
     parse_form_json,
@@ -63,6 +64,11 @@ def test_parse_sync_filename_timestamp_accepts_seconds_and_millis(suffix):
     assert parse_sync_filename_timestamp(f'/tmp/vad/{suffix}.wav') == 1_704_067_200
 
 
+def test_parse_sync_filename_timestamp_accepts_fractional_vad_segment_names():
+    assert parse_sync_filename_timestamp('/tmp/vad/1704067200.0.wav') == 1_704_067_200
+    assert parse_sync_filename_timestamp('/tmp/vad/1704067200.5.wav') == 1_704_067_200.5
+
+
 @pytest.mark.parametrize(
     'filename',
     [
@@ -103,6 +109,13 @@ def test_image_chunk_envelope_rejects_inconsistent_cached_total():
 
     with pytest.raises(ValueError):
         chunk.validate_against_cached_total(3)
+
+
+def test_image_chunk_envelope_allows_mobile_photo_chunk_counts_above_legacy_cap():
+    chunk = ImageChunkEnvelope(id='img', index=300, total=512, data='b')
+
+    assert chunk.total == 512
+    assert MAX_IMAGE_CHUNK_TOTAL >= 512
 
 
 def test_parallel_action_item_arrays_must_have_matching_lengths():

--- a/backend/tests/unit/test_request_validation_contracts.py
+++ b/backend/tests/unit/test_request_validation_contracts.py
@@ -1,0 +1,133 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field, ValidationError
+
+from models.conversation import SetConversationActionItemsStateRequest, SetConversationEventsStateRequest
+from utils.request_validation import (
+    HistoryDays,
+    ImageChunkEnvelope,
+    NonNegativeOffset,
+    PositiveLimit,
+    parse_form_json,
+    parse_sync_filename_timestamp,
+    validate_calendar_date,
+)
+
+
+class _FormPayload(BaseModel):
+    name: str = Field(min_length=1)
+    count: int = Field(ge=1)
+
+
+def test_parse_form_json_validates_model_json():
+    payload = parse_form_json(_FormPayload, '{"name":"omi","count":2}', 'app_data')
+
+    assert payload == _FormPayload(name='omi', count=2)
+
+
+@pytest.mark.parametrize('raw_value', ['not-json', '[]', '{"name":"omi","count":0}'])
+def test_parse_form_json_rejects_invalid_form_json(raw_value):
+    with pytest.raises(HTTPException) as exc_info:
+        parse_form_json(_FormPayload, raw_value, 'app_data')
+
+    assert exc_info.value.status_code == 422
+    assert 'app_data' in exc_info.value.detail
+
+
+def test_parse_form_json_dict_rejects_non_object_json():
+    with pytest.raises(HTTPException) as exc_info:
+        parse_form_json(dict, '[1, 2, 3]', 'persona_data')
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.parametrize('value', ['2024-01-01', '2024-02-29'])
+def test_validate_calendar_date_accepts_real_dates(value):
+    assert validate_calendar_date(value) == value
+
+
+@pytest.mark.parametrize('value', ['2024-02-30', '2024-13-01', 'not-a-date'])
+def test_validate_calendar_date_rejects_invalid_dates(value):
+    with pytest.raises(HTTPException) as exc_info:
+        validate_calendar_date(value)
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.parametrize('suffix', ['1704067200', '1704067200000'])
+def test_parse_sync_filename_timestamp_accepts_seconds_and_millis(suffix):
+    assert parse_sync_filename_timestamp(f'audio_{suffix}.bin') == 1_704_067_200
+
+
+@pytest.mark.parametrize(
+    'filename',
+    [
+        'audio_not-a-timestamp.bin',
+        'audio_0.bin',
+        'audio_999999999999999999999999.bin',
+    ],
+)
+def test_parse_sync_filename_timestamp_rejects_invalid_or_out_of_range_values(filename):
+    with pytest.raises(ValueError):
+        parse_sync_filename_timestamp(filename)
+
+
+def test_parse_sync_filename_timestamp_rejects_future_values():
+    future = int(datetime.now(timezone.utc).timestamp()) + 3600
+
+    with pytest.raises(ValueError):
+        parse_sync_filename_timestamp(f'audio_{future}.bin')
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        {'id': 'img', 'index': -1, 'total': 2, 'data': 'a'},
+        {'id': 'img', 'index': 2, 'total': 2, 'data': 'a'},
+        {'id': 'img', 'index': 0, 'total': 0, 'data': 'a'},
+        {'id': '', 'index': 0, 'total': 1, 'data': 'a'},
+        {'id': 'img', 'index': 0, 'total': 1, 'data': ''},
+    ],
+)
+def test_image_chunk_envelope_rejects_invalid_boundaries(payload):
+    with pytest.raises(ValidationError):
+        ImageChunkEnvelope.model_validate(payload)
+
+
+def test_image_chunk_envelope_rejects_inconsistent_cached_total():
+    chunk = ImageChunkEnvelope(id='img', index=1, total=2, data='b')
+
+    with pytest.raises(ValueError):
+        chunk.validate_against_cached_total(3)
+
+
+def test_parallel_action_item_arrays_must_have_matching_lengths():
+    with pytest.raises(ValidationError):
+        SetConversationActionItemsStateRequest(items_idx=[0, 1], values=[True])
+
+
+def test_parallel_event_arrays_must_have_matching_lengths():
+    with pytest.raises(ValidationError):
+        SetConversationEventsStateRequest(events_idx=[0], values=[True, False])
+
+
+def test_common_query_contracts_reject_invalid_values_before_endpoint_runs():
+    app = FastAPI()
+    calls = []
+
+    @app.get('/items')
+    def items(limit: PositiveLimit = 100, offset: NonNegativeOffset = 0, days: HistoryDays = 30):
+        calls.append((limit, offset, days))
+        return {'ok': True}
+
+    client = TestClient(app)
+
+    assert client.get('/items?limit=1&offset=0&days=1').status_code == 200
+    for query in ['limit=0', 'limit=1001', 'offset=-1', 'days=0', 'days=366']:
+        response = client.get(f'/items?{query}')
+        assert response.status_code == 422
+
+    assert calls == [(1, 0, 1)]

--- a/backend/tests/unit/test_request_validation_contracts.py
+++ b/backend/tests/unit/test_request_validation_contracts.py
@@ -60,6 +60,7 @@ def test_validate_calendar_date_rejects_invalid_dates(value):
 @pytest.mark.parametrize('suffix', ['1704067200', '1704067200000'])
 def test_parse_sync_filename_timestamp_accepts_seconds_and_millis(suffix):
     assert parse_sync_filename_timestamp(f'audio_{suffix}.bin') == 1_704_067_200
+    assert parse_sync_filename_timestamp(f'/tmp/vad/{suffix}.wav') == 1_704_067_200
 
 
 @pytest.mark.parametrize(

--- a/backend/utils/request_validation.py
+++ b/backend/utils/request_validation.py
@@ -1,0 +1,92 @@
+from datetime import date, datetime, timezone
+from typing import Annotated, Any, TypeVar
+
+from fastapi import HTTPException, Query
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, model_validator
+
+PositiveLimit = Annotated[int, Query(ge=1, le=1000)]
+CalendarMeetingsLimit = Annotated[int, Query(ge=1, le=100)]
+NonNegativeOffset = Annotated[int, Query(ge=0)]
+HistoryDays = Annotated[int, Query(ge=1, le=365)]
+
+ModelT = TypeVar('ModelT', bound=BaseModel)
+
+
+def parse_form_json(model_type: type[ModelT] | type[dict], raw_value: str, field_name: str) -> ModelT | dict[str, Any]:
+    """Validate a JSON string submitted in a multipart/form-data field.
+
+    FastAPI cannot apply normal JSON body validation to string form fields. Keep
+    this helper as the single boundary for those endpoints so malformed JSON and
+    non-object payloads consistently fail with 422 before any I/O work.
+    """
+    try:
+        if isinstance(model_type, type) and issubclass(model_type, BaseModel):
+            return model_type.model_validate_json(raw_value)
+        return TypeAdapter(dict[str, Any]).validate_json(raw_value)
+    except (ValidationError, ValueError) as e:
+        raise HTTPException(status_code=422, detail=f'Invalid {field_name}: {e}')
+
+
+def validate_calendar_date(value: str | None, field_name: str = 'date') -> str | None:
+    """Validate YYYY-MM-DD strings as real calendar dates and return the original string."""
+    if value is None:
+        return None
+    try:
+        date.fromisoformat(value)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=f'Invalid {field_name}: expected a real YYYY-MM-DD date') from e
+    return value
+
+
+def parse_timezone_aware_datetime(value: str, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError as e:
+        raise ValueError(f'{field_name} must be a valid ISO 8601 datetime') from e
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f'{field_name} must include a timezone offset')
+    return parsed
+
+
+def parse_sync_filename_timestamp(path: str) -> int:
+    """Parse and validate the unix timestamp suffix in a sync .bin filename.
+
+    Filenames are expected to end with _<unix-seconds-or-millis>.bin. The
+    returned timestamp is UTC seconds and is safe to pass to fromtimestamp(...,
+    tz=timezone.utc).
+    """
+    filename = path.split('/')[-1]
+    try:
+        raw_timestamp = int(filename.rsplit('_', 1)[1].rsplit('.', 1)[0])
+    except (IndexError, ValueError) as e:
+        raise ValueError('invalid timestamp') from e
+
+    timestamp = raw_timestamp // 1000 if raw_timestamp > 10_000_000_000 else raw_timestamp
+    try:
+        timestamp_dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OSError, OverflowError, ValueError) as e:
+        raise ValueError('invalid timestamp') from e
+
+    now = datetime.now(timezone.utc)
+    if timestamp_dt > now or timestamp_dt < datetime(2024, 1, 1, tzinfo=timezone.utc):
+        raise ValueError('invalid timestamp')
+    return timestamp
+
+
+class ImageChunkEnvelope(BaseModel):
+    id: str = Field(min_length=1)
+    index: int = Field(ge=0)
+    total: int = Field(ge=1, le=256)
+    data: str = Field(min_length=1)
+
+    @model_validator(mode='after')
+    def validate_index_within_total(self):
+        if self.index >= self.total:
+            raise ValueError('index must be smaller than total')
+        return self
+
+    def validate_against_cached_total(self, cached_total: int | None) -> None:
+        if cached_total is not None and cached_total != self.total:
+            raise ValueError('total must be consistent for all chunks in an image upload')
+        if cached_total is not None and self.index >= cached_total:
+            raise ValueError('index is outside the cached upload buffer')

--- a/backend/utils/request_validation.py
+++ b/backend/utils/request_validation.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Annotated, Any, TypeVar
 
 from fastapi import HTTPException, Query
@@ -27,6 +28,29 @@ def parse_form_json(model_type: type[ModelT] | type[dict], raw_value: str, field
         raise HTTPException(status_code=422, detail=f'Invalid {field_name}: {e}')
 
 
+def normalize_required_webhook_url(external_integration: dict[str, Any]) -> None:
+    webhook_url = external_integration.get('webhook_url')
+    if not isinstance(webhook_url, str) or not webhook_url.strip():
+        raise HTTPException(status_code=422, detail='external_integration.webhook_url is required')
+    external_integration['webhook_url'] = webhook_url.strip()
+
+
+def backfill_app_home_url_from_auth_steps(external_integration: dict[str, Any]) -> None:
+    if external_integration.get('app_home_url'):
+        return
+    auth_steps = external_integration.get('auth_steps')
+    if not auth_steps:
+        return
+    if not isinstance(auth_steps, list):
+        raise HTTPException(status_code=422, detail='external_integration.auth_steps must be a list')
+    if len(auth_steps) != 1:
+        return
+    auth_step = auth_steps[0]
+    if not isinstance(auth_step, dict) or not auth_step.get('url'):
+        raise HTTPException(status_code=422, detail='external_integration.auth_steps[0].url is required')
+    external_integration['app_home_url'] = auth_step['url']
+
+
 def validate_calendar_date(value: str | None, field_name: str = 'date') -> str | None:
     """Validate YYYY-MM-DD strings as real calendar dates and return the original string."""
     if value is None:
@@ -48,7 +72,10 @@ def parse_timezone_aware_datetime(value: str, field_name: str) -> datetime:
     return parsed
 
 
-def parse_sync_filename_timestamp(path: str) -> int:
+MAX_IMAGE_CHUNK_TOTAL = 4096
+
+
+def parse_sync_filename_timestamp(path: str) -> int | float:
     """Parse and validate the unix timestamp in a sync upload/segment filename.
 
     Upload filenames are expected to end with _<unix-seconds-or-millis>.bin;
@@ -58,12 +85,19 @@ def parse_sync_filename_timestamp(path: str) -> int:
     """
     filename = path.split('/')[-1]
     timestamp_part = filename.rsplit('_', 1)[1] if '_' in filename else filename
+    raw_timestamp_text = timestamp_part.rsplit('.', 1)[0]
     try:
-        raw_timestamp = int(timestamp_part.rsplit('.', 1)[0])
-    except ValueError as e:
+        raw_timestamp = Decimal(raw_timestamp_text)
+    except InvalidOperation as e:
         raise ValueError('invalid timestamp') from e
+    if not raw_timestamp.is_finite() or raw_timestamp <= 0:
+        raise ValueError('invalid timestamp')
 
-    timestamp = raw_timestamp // 1000 if raw_timestamp > 10_000_000_000 else raw_timestamp
+    timestamp_decimal = raw_timestamp / Decimal(1000) if raw_timestamp > Decimal(10_000_000_000) else raw_timestamp
+    if timestamp_decimal == timestamp_decimal.to_integral_value():
+        timestamp = int(timestamp_decimal)
+    else:
+        timestamp = float(timestamp_decimal)
     try:
         timestamp_dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
     except (OSError, OverflowError, ValueError) as e:
@@ -78,7 +112,7 @@ def parse_sync_filename_timestamp(path: str) -> int:
 class ImageChunkEnvelope(BaseModel):
     id: str = Field(min_length=1)
     index: int = Field(ge=0)
-    total: int = Field(ge=1, le=256)
+    total: int = Field(ge=1, le=MAX_IMAGE_CHUNK_TOTAL)
     data: str = Field(min_length=1)
 
     @model_validator(mode='after')
@@ -90,5 +124,3 @@ class ImageChunkEnvelope(BaseModel):
     def validate_against_cached_total(self, cached_total: int | None) -> None:
         if cached_total is not None and cached_total != self.total:
             raise ValueError('total must be consistent for all chunks in an image upload')
-        if cached_total is not None and self.index >= cached_total:
-            raise ValueError('index is outside the cached upload buffer')

--- a/backend/utils/request_validation.py
+++ b/backend/utils/request_validation.py
@@ -49,16 +49,18 @@ def parse_timezone_aware_datetime(value: str, field_name: str) -> datetime:
 
 
 def parse_sync_filename_timestamp(path: str) -> int:
-    """Parse and validate the unix timestamp suffix in a sync .bin filename.
+    """Parse and validate the unix timestamp in a sync upload/segment filename.
 
-    Filenames are expected to end with _<unix-seconds-or-millis>.bin. The
-    returned timestamp is UTC seconds and is safe to pass to fromtimestamp(...,
+    Upload filenames are expected to end with _<unix-seconds-or-millis>.bin;
+    VAD segment files are named <unix-seconds-or-millis>.wav. The returned
+    timestamp is UTC seconds and is safe to pass to fromtimestamp(...,
     tz=timezone.utc).
     """
     filename = path.split('/')[-1]
+    timestamp_part = filename.rsplit('_', 1)[1] if '_' in filename else filename
     try:
-        raw_timestamp = int(filename.rsplit('_', 1)[1].rsplit('.', 1)[0])
-    except (IndexError, ValueError) as e:
+        raw_timestamp = int(timestamp_part.rsplit('.', 1)[0])
+    except ValueError as e:
         raise ValueError('invalid timestamp') from e
 
     timestamp = raw_timestamp // 1000 if raw_timestamp > 10_000_000_000 else raw_timestamp


### PR DESCRIPTION
## Summary

This aggregates the high-signal request/protocol-boundary fixes from @ZachL111 into shared validation helpers instead of endpoint-by-endpoint patches.

Changes:
- add `utils.request_validation` for multipart JSON form parsing, bounded query params, real calendar dates, UTC-safe sync filename timestamps, and image chunk envelopes
- route app/persona multipart JSON parsing through the shared helper
- enforce bounded list/history query parameters and real calendar dates at request boundaries
- validate sync upload filename timestamps with one UTC-aware parser for v1/v2 paths
- reject invalid websocket image chunk envelopes/sequences instead of silently ignoring malformed chunks
- validate parallel event/action-item status arrays on the Pydantic request models
- replace a previous `sys.meta_path`/MagicMock-heavy app JSON test with direct helper contract coverage

Supersedes/redesigns parts of #8218, #8219, #8220, #8222, #8227, #8231, #8260, #8263, #8275, #8278, #8279, #8280, #8295, #8303, #8309, #8321.

Original issue discovery, reproductions, and candidate fixes by @ZachL111 — thank you for surfacing these boundary bugs. This PR keeps the useful findings while moving the implementation toward shared contracts and smaller tests.

## Deferred from the Oracle boundary bucket

Not included here because they need separate design or would broaden this PR:
- #8224 shared-chat malformed record behavior
- #8240 notification payload model cleanup
- #8244 task due-date validation
- #8257 app generate-description request validation
- #8266/#8270 MCP SSE JSON-RPC validation
- #8271 segment assignment bounds beyond the shared-array model work
- #8289 social/persona not-found policy

## Test plan

- [x] `pytest tests/unit/test_request_validation_contracts.py tests/unit/test_sync_file_paths_filename_none.py tests/unit/test_apps_create_app_json.py tests/unit/test_conversation_events_bounds.py -q` → 34 passed
- [x] `python -m py_compile ...` over modified modules/tests
- [x] `git diff --check`
- [x] `bash backend/testing/e2e/run.sh -q --tb=short` → 73 passed, 6 skipped


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

