### PR TITLE
[codex] Gate desktop changelogs and release tags

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Require desktop user-facing PRs to add an unreleased changelog entry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+CHANGELOG_PATH = Path("desktop/macos/CHANGELOG.json")
+DESKTOP_PREFIX = "desktop/macos/"
+EXEMPT_DESKTOP_PATHS = {
+    "desktop/macos/CHANGELOG.json",
+    "desktop/macos/AGENTS.md",
+}
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def changed_files(base_ref: str, head_ref: str) -> list[str]:
+    output = run_git(["diff", "--name-only", "--diff-filter=ACM", f"{base_ref}...{head_ref}"])
+    return [line for line in output.splitlines() if line]
+
+
+def is_desktop_change_requiring_changelog(path: str) -> bool:
+    if not path.startswith(DESKTOP_PREFIX):
+        return False
+    if path in EXEMPT_DESKTOP_PATHS:
+        return False
+    return True
+
+
+def unreleased_entries(ref: str) -> list[str]:
+    try:
+        raw = run_git(["show", f"{ref}:{CHANGELOG_PATH}"])
+    except subprocess.CalledProcessError:
+        return []
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"FAIL: {CHANGELOG_PATH} is not valid JSON at {ref}: {exc}") from exc
+
+    unreleased = data.get("unreleased", [])
+    if not isinstance(unreleased, list):
+        raise SystemExit(f"FAIL: {CHANGELOG_PATH} field 'unreleased' must be a list")
+    return [entry for entry in unreleased if isinstance(entry, str) and entry.strip()]
+
+
+def has_new_unreleased_entry(base_ref: str, head_ref: str) -> bool:
+    before = Counter(unreleased_entries(base_ref))
+    after = Counter(unreleased_entries(head_ref))
+    return bool(after - before)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="Base git ref, usually origin/main")
+    parser.add_argument("--head", default="HEAD", help="Head git ref to inspect")
+    parser.add_argument(
+        "--skip",
+        action="store_true",
+        help="Skip enforcement, used for PRs labeled no-changelog-needed",
+    )
+    args = parser.parse_args()
+
+    if args.skip:
+        print("Desktop changelog check skipped by no-changelog-needed label.")
+        return 0
+
+    files = changed_files(args.base, args.head)
+    requiring_changelog = [path for path in files if is_desktop_change_requiring_changelog(path)]
+
+    if not requiring_changelog:
+        print("No desktop changes require a changelog entry.")
+        return 0
+
+    if has_new_unreleased_entry(args.base, args.head):
+        print("Desktop changelog entry found.")
+        return 0
+
+    print("FAIL: desktop changes require an unreleased changelog entry.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Changed desktop files:", file=sys.stderr)
+    for path in requiring_changelog:
+        print(f"  - {path}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Add a one-line user-facing entry to desktop/macos/CHANGELOG.json under "
+        "'unreleased', or label the PR no-changelog-needed for internal-only changes.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Decide whether the desktop auto-release workflow should create a new tag."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import time
+from pathlib import Path
+
+
+CODEMAGIC_CHECK_NAME = "Release OMI Desktop (Swift)"
+RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
+
+
+def run(args: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(args, check=check, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return result.stdout.strip()
+
+
+def git(args: list[str], *, check: bool = True) -> str:
+    return run(["git", *args], check=check)
+
+
+def version_sort_key(tag: str) -> tuple[int, ...]:
+    version = tag.removeprefix("v").split("+", 1)[0]
+    return tuple(int(part) for part in version.split("."))
+
+
+def latest_desktop_tag() -> str | None:
+    tags = git(["tag", "-l", "v*-macos"]).splitlines()
+    if not tags:
+        return None
+    return sorted(tags, key=version_sort_key)[-1]
+
+
+def releasable_desktop_changes_since(ref: str | None) -> list[str]:
+    if ref is None:
+        output = git(["ls-files", "desktop/macos"])
+    else:
+        output = git(["diff", "--name-only", "--diff-filter=ACM", f"{ref}..HEAD", "--", "desktop/macos"])
+
+    changes = []
+    for path in output.splitlines():
+        if not path:
+            continue
+        if path == "desktop/macos/CHANGELOG.json":
+            continue
+        if path == "desktop/macos/AGENTS.md":
+            continue
+        if path.startswith("desktop/macos/Backend-Rust/"):
+            continue
+        changes.append(path)
+    return changes
+
+
+def tag_sha(tag: str) -> str | None:
+    try:
+        return git(["rev-list", "-n", "1", tag])
+    except subprocess.CalledProcessError:
+        return None
+
+
+def tag_age_seconds(tag: str) -> int | None:
+    try:
+        raw = git(["log", "-1", "--format=%ct", tag])
+        return int(time.time()) - int(raw)
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str | None]:
+    output = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repository}/commits/{sha}/check-runs",
+            "--jq",
+            f'.check_runs[] | select(.name=="{CODEMAGIC_CHECK_NAME}") | [.status, (.conclusion // "")] | @tsv',
+        ],
+        check=False,
+    )
+    first = next((line for line in output.splitlines() if line.strip()), "")
+    if not first:
+        return None, None
+    parts = first.split("\t", 1)
+    status = parts[0] if parts else None
+    conclusion = parts[1] if len(parts) > 1 else None
+    return status, conclusion
+
+
+def active_release_reason(repository: str, latest_tag: str | None) -> str | None:
+    if latest_tag is None:
+        return None
+
+    sha = tag_sha(latest_tag)
+    if not sha:
+        return None
+
+    status, conclusion = codemagic_check_status(repository, sha)
+    if status and status != "completed":
+        return f"{CODEMAGIC_CHECK_NAME} for {latest_tag} is {status}"
+
+    if status is None:
+        age = tag_age_seconds(latest_tag)
+        if age is not None and age < RECENT_TAG_WITHOUT_CHECK_SECONDS:
+            return f"{latest_tag} is recent and has no Codemagic check yet"
+
+    if status == "completed":
+        print(f"Latest Codemagic release check: {latest_tag} completed ({conclusion or 'n/a'}).")
+    return None
+
+
+def set_output(name: str, value: str) -> None:
+    print(f"{name}={value}")
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--mode", choices=["auto", "release_now", "force_release"], default="auto")
+    args = parser.parse_args()
+
+    latest_tag = latest_desktop_tag()
+    changes = releasable_desktop_changes_since(latest_tag)
+    set_output("latest_tag", latest_tag or "")
+
+    if not changes:
+        set_output("should_release", "false")
+        set_output("reason", "No releasable desktop app changes since the latest desktop tag.")
+        return 0
+
+    print("Releasable desktop app changes since latest tag:")
+    for path in changes:
+        print(f"  - {path}")
+
+    if args.mode != "force_release":
+        active_reason = active_release_reason(args.repository, latest_tag)
+        if active_reason:
+            set_output("should_release", "false")
+            set_output("reason", f"Release already active: {active_reason}.")
+            return 0
+
+    set_output("should_release", "true")
+    set_output("reason", f"Ready to release {len(changes)} changed desktop app file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -39,7 +39,7 @@ def releasable_desktop_changes_since(ref: str | None) -> list[str]:
     if ref is None:
         output = git(["ls-files", "desktop/macos"])
     else:
-        output = git(["diff", "--name-only", "--diff-filter=ACM", f"{ref}..HEAD", "--", "desktop/macos"])
+        output = git(["diff", "--name-only", "--diff-filter=ACDMR", f"{ref}..HEAD", "--", "desktop/macos"])
 
     changes = []
     for path in output.splitlines():
@@ -70,8 +70,8 @@ def tag_age_seconds(tag: str) -> int | None:
         return None
 
 
-def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str | None]:
-    output = run(
+def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str | None, str | None]:
+    result = subprocess.run(
         [
             "gh",
             "api",
@@ -79,15 +79,22 @@ def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str |
             "--jq",
             f'.check_runs[] | select(.name=="{CODEMAGIC_CHECK_NAME}") | [.status, (.conclusion // "")] | @tsv',
         ],
-        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip() or "unknown gh api error"
+        return None, None, error
+
+    output = result.stdout.strip()
     first = next((line for line in output.splitlines() if line.strip()), "")
     if not first:
-        return None, None
+        return None, None, None
     parts = first.split("\t", 1)
     status = parts[0] if parts else None
     conclusion = parts[1] if len(parts) > 1 else None
-    return status, conclusion
+    return status, conclusion, None
 
 
 def active_release_reason(repository: str, latest_tag: str | None) -> str | None:
@@ -98,7 +105,10 @@ def active_release_reason(repository: str, latest_tag: str | None) -> str | None
     if not sha:
         return None
 
-    status, conclusion = codemagic_check_status(repository, sha)
+    status, conclusion, error = codemagic_check_status(repository, sha)
+    if error:
+        return f"could not read GitHub check runs for {latest_tag}: {error}"
+
     if status and status != "completed":
         return f"{CODEMAGIC_CHECK_NAME} for {latest_tag} is {status}"
 

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -6,95 +6,33 @@ on:
     paths:
       - 'desktop/macos/**'
       - '!desktop/macos/CHANGELOG.json'
+  schedule:
+    # Pick up desktop merges that accumulated while Codemagic was busy.
+    - cron: '*/5 * * * *'
   workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Release behavior'
+        required: false
+        default: 'release_now'
+        type: choice
+        options:
+          - release_now
+          - force_release
 
 permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: desktop-auto-release-main
-  cancel-in-progress: false
-
-env:
-  SERVICE: desktop-backend
-  REGION: us-central1
-
 jobs:
-  deploy-desktop-backend:
-    environment: development
-    permissions:
-      contents: read
-      id-token: write
-
-    runs-on: ubuntu-latest-m
-    steps:
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Google Auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
-
-      - name: Login to GCR
-        run: gcloud auth configure-docker
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Google Service Account
-        run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./desktop/macos/Backend-Rust/google-credentials.json
-
-      - name: Build and Push Desktop Backend Image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./desktop/macos/Backend-Rust
-          file: ./desktop/macos/Backend-Rust/Dockerfile
-          push: true
-          tags: |
-            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}
-            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
-          cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
-          cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
-
-      - name: Deploy Desktop Backend to Development
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          service: ${{ env.SERVICE }}
-          region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}
-          flags: '--allow-unauthenticated'
-          env_vars: |
-            FIREBASE_PROJECT_ID=based-hardware
-            GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
-            AGENT_GCS_BUCKET=based-hardware-agent
-          secrets: |
-            GEMINI_API_KEY=GEMINI_API_KEY:latest
-            OPENAI_API_KEY=OPENAI_API_KEY:latest
-            ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
-            REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
-            FIREBASE_API_KEY=FIREBASE_API_KEY:latest
-            PINECONE_API_KEY=PINECONE_API_KEY:latest
-            REDIS_DB_HOST=REDIS_DB_HOST:latest
-            REDIS_DB_PORT=REDIS_DB_PORT:latest
-            PINECONE_HOST=PINECONE_HOST:latest
-            DEEPGRAM_API_KEY=DESKTOP_DEEPGRAM_API_KEY:latest
-            ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
-            DESKTOP_LEGACY_ANTHROPIC_KEY=DESKTOP_LEGACY_ANTHROPIC_KEY:latest
-            GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
-
-  # NOTE: Production deploys are NO LONGER automatic on merge. The desktop
-  # backend ships to prod only when a release is promoted to `channel: stable`
-  # — see .github/workflows/desktop_promote_prod.yml. Merges to main deploy to
-  # development only, so beta testers get every build without risking prod.
-
-  tag-release:
-    needs: [deploy-desktop-backend]
+  plan-release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: desktop-release-planner-main
+      cancel-in-progress: ${{ github.event_name == 'push' }}
+    outputs:
+      should_release: ${{ steps.plan.outputs.should_release }}
+      reason: ${{ steps.plan.outputs.reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,48 +46,60 @@ jobs:
           app-id: ${{ secrets.OMI_BOT_APP_ID }}
           private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
 
-      - name: Wait for previous desktop release build
+      - name: Debounce desktop app release
+        if: github.event_name == 'push'
+        run: sleep 180
+
+      - name: Plan desktop release
+        id: plan
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_MODE: ${{ github.event.inputs.release_mode || 'auto' }}
+        run: |
+          python3 .github/scripts/plan-desktop-release.py \
+            --repository "${{ github.repository }}" \
+            --mode "$RELEASE_MODE"
+
+      - name: Show release plan
+        run: echo "${{ steps.plan.outputs.reason }}"
+
+  tag-release:
+    needs: [plan-release]
+    if: needs.plan-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: desktop-auto-release-tag-main
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Omi Bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+
+      - name: Recheck desktop release queue before tagging
+        id: recheck
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_MODE: ${{ github.event.inputs.release_mode || 'auto' }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "Omi Bot token not available; cannot inspect previous release build status."
             exit 1
           fi
 
-          LATEST=$(git tag -l 'v*-macos' | sort -V | tail -1)
-          if [ -z "$LATEST" ]; then
-            echo "No previous macOS tag found."
-            exit 0
-          fi
-
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/$LATEST" --jq '.object.sha')
-          echo "Latest tag: $LATEST ($SHA)"
-
-          for i in {1..120}; do
-            STATUS=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
-              --jq '.check_runs[] | select(.name=="Release OMI Desktop (Swift)") | .status' | head -n1 || true)
-            CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
-              --jq '.check_runs[] | select(.name=="Release OMI Desktop (Swift)") | .conclusion' | head -n1 || true)
-
-            if [ -z "$STATUS" ]; then
-              echo "No Codemagic release check found for $LATEST yet; continuing."
-              exit 0
-            fi
-
-            echo "Previous release build status: $STATUS (${CONCLUSION:-n/a})"
-
-            if [ "$STATUS" = "completed" ]; then
-              exit 0
-            fi
-
-            sleep 60
-          done
-
-          echo "Timed out waiting for previous desktop release build to finish."
-          exit 1
+          python3 .github/scripts/plan-desktop-release.py \
+            --repository "${{ github.repository }}" \
+            --mode "$RELEASE_MODE"
 
       - name: Compute next version and consolidate changelog
+        if: steps.recheck.outputs.should_release == 'true'
         id: version
         run: |
           # Get latest desktop release tag
@@ -207,6 +157,7 @@ jobs:
           "
 
       - name: Commit changelog and create tag
+        if: steps.recheck.outputs.should_release == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
@@ -222,6 +173,7 @@ jobs:
           git push origin "$RELEASE_TAG"
 
       - name: Create and auto-merge PR to sync changelog back to main
+        if: steps.recheck.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changelog/v')
         run: |
           SKIP_FLAG=""
-          if [ "${{ contains(join(github.event.pull_request.labels.*.name, ','), 'no-changelog-needed') }}" = "true" ]; then
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}" = "true" ]; then
             SKIP_FLAG="--skip"
           fi
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,19 @@ jobs:
             exit 1
           fi
 
+      - name: Check desktop changelog entry
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changelog/v')
+        run: |
+          SKIP_FLAG=""
+          if [ "${{ contains(join(github.event.pull_request.labels.*.name, ','), 'no-changelog-needed') }}" = "true" ]; then
+            SKIP_FLAG="--skip"
+          fi
+
+          python3 .github/scripts/check-desktop-changelog.py \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            $SKIP_FLAG
+
       # -- Dart --
       - name: Setup Flutter
         if: steps.changed.outputs.has_dart == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Key rules:
 ### Desktop (macOS — Swift app + Rust backend)
 
 The desktop app is a **Swift Package Manager** project (no Xcode project, no `.xcodeproj`). The Rust backend lives in `desktop/macos/Backend-Rust/`.
+- For user-visible desktop changes, follow `desktop/macos/AGENTS.md` → Changelog Entries and add a one-line `desktop/macos/CHANGELOG.json` `unreleased` entry.
 
 #### Building & Running
 


### PR DESCRIPTION
## Summary
- Add a PR lint guard requiring desktop changes to include a `desktop/macos/CHANGELOG.json` unreleased entry, with a `no-changelog-needed` label escape hatch for internal-only changes.
- Point root `AGENTS.md` desktop guidance to the existing desktop changelog authoring instructions.
- Replace per-merge desktop release tagging with a 3-minute release planner that skips tag creation while the latest Codemagic desktop release is queued or running, plus a scheduled retry path for accumulated merges.
- Remove the app release workflow's duplicate desktop backend dev deploy; `desktop_backend_auto_dev.yml` remains responsible for Backend-Rust dev deploys.

## Validation
- Independent subagent review found no actionable issues.
- `python3 -m py_compile .github/scripts/check-desktop-changelog.py .github/scripts/plan-desktop-release.py`
- `python3 -m json.tool desktop/macos/CHANGELOG.json`
- `/Users/dazheng/go/1.23.4/bin/actionlint .github/workflows/desktop_auto_release.yml .github/workflows/lint.yml`
- `git diff --check`
- Live release planner check correctly returned `should_release=false` while `v0.11.533+11533-macos` Codemagic release was `in_progress`.
- `force_release` mode returned `should_release=true` for the same pending desktop changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

