### PR TITLE
desktop: center omi title with the metric cards

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Connect your AI: centered the omi title together with the What-omi-knows cards"
+  ],
   "releases": [
     {
       "version": "0.11.534",

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -448,15 +448,13 @@ struct DashboardPage: View {
                 }
                 .frame(width: 320)
 
-                VStack(spacing: 12) {
+                VStack(spacing: 18) {
                     centerMemoryHeader
-                    // Center the metric block in an area exactly as tall as the six
-                    // side-list rows (6×48 + 5×12 spacing) so the column matches the
-                    // side columns' height and the block lines up with their center.
                     homeMetricsStrip
-                        .frame(height: CGFloat(6 * 48 + 5 * 12))
                 }
-                .frame(width: 340)
+                // Group the title directly above the cards and center the unit in a
+                // column the same height as the side lists.
+                .frame(width: 340, height: CGFloat(62 + 12 + (6 * 48 + 5 * 12)), alignment: .center)
 
                 destinationStack
                     .frame(width: 300)


### PR DESCRIPTION
Small dashboard polish: groups the "omi. / What omi knows" title directly above the "What omi knows" metric cards and centers the unit, removing the awkward gap above the cards. The title+cards now read as one centered centerpiece between the two side columns.

Verified live on a named bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

