### PR TITLE
desktop: fix OpenClaw/Hermes logos missing on release builds + match More tiles

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Connect your AI: centered the omi title together with the What-omi-knows cards"
+    "Connect your AI: centered the omi title together with the What-omi-knows cards",
+    "Fixed OpenClaw and Hermes brand logos not appearing on release builds; matched the two More tile icons"
   ],
   "releases": [
     {

--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -49,6 +49,10 @@ let package = Package(
       path: "Sources",
       resources: [
         .process("GoogleService-Info.plist"),
+        // Bundles everything under Resources/ (incl. *_logo.png brand marks).
+        // NOTE: SwiftPM caches the resource manifest, so new files added to
+        // Resources/ are only picked up when the manifest regenerates — editing
+        // this file forces incremental builds to re-scan and include them.
         .process("Resources"),
       ]
     ),

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -546,7 +546,7 @@ struct DashboardPage: View {
             HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
                 navigate(to: .chat)
             }
-            HomeAIChoiceButton(title: "More", brand: .agents) {
+            HomeAIChoiceButton(title: "More", systemImage: "plus") {
                 openAppsPage()
             }
         }


### PR DESCRIPTION
**Logos:** OpenClaw/Hermes brand PNGs fell back to SF Symbols on the release build. Root cause: SwiftPM caches the `.process("Resources")` manifest, so logo PNGs added after the manifest was first generated weren't bundled (gmail_logo, generated earlier, stayed). Editing Package.swift forces the manifest to regenerate so all current Resources/ files (incl. the new brand marks) bundle reliably.

**More tiles:** the two "More" tiles used different icons; both now use the `+` icon to match.

Verified on a clean named-bundle build: OpenClaw shows the red lobster, Hermes the caduceus, both More tiles show `+`. Release build compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

