### PR TITLE
fix: offload token persistence during async Google token refresh

### DIFF
--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -9,6 +9,7 @@ from typing import Optional
 import httpx
 
 import database.users as users_db
+from utils.executors import db_executor, run_blocking
 from utils.http_client import get_auth_client
 from utils.log_sanitizer import sanitize
 import logging
@@ -88,9 +89,11 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
             new_access_token = token_data.get('access_token')
 
             if new_access_token:
-                # Update stored token
+                # Update stored token — offload the sync Firestore write to the
+                # DB executor so it does not block the event loop during
+                # concurrent chat/tool streaming.
                 integration['access_token'] = new_access_token
-                users_db.set_integration(uid, 'google_calendar', integration)
+                await run_blocking(db_executor, users_db.set_integration, uid, 'google_calendar', integration)
                 logger.info(f"🔄 Successfully refreshed Google token for uid={uid}")
                 return new_access_token
 


### PR DESCRIPTION
## Summary

The async `refresh_google_token` coroutine persisted the new access token via `users_db.set_integration()` — a synchronous Firestore write — directly on the event loop. When a Gmail request hit an expired token, the refresh path blocked concurrent chat/tool streaming until Firestore returned.

Wrap the Firestore write with `await run_blocking(db_executor, ...)` so it runs in the DB thread pool, consistent with backend async I/O rules (AGENTS.md: "never call sync DB/storage/file functions directly inside async def").

This was originally flagged as P2 by Codex review on PR #8364 (`retry_on_auth_async`), but the fix targets `google_utils.py` which was not part of that PR's diff. Opening as a standalone fix.

## Test Plan

- [x] `scan_async_blockers.py` reports zero blocking calls for `refresh_google_token`
- [x] Pre-commit formatting passes (black)
- [ ] CI Hermetic Backend E2E passes


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

