### PR TITLE
fix(desktop): get_work_context screen-now latency (skip pending active-chunk frames)

### DIFF
--- a/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
+++ b/desktop/macos/Desktop/Sources/LocalAgentAPIServer.swift
@@ -285,12 +285,19 @@ final class LocalAgentAPIServer {
     let start = now.addingTimeInterval(-Double(minutes) * 60)
     let formatter = ISO8601DateFormatter()
 
-    // 1) Screen now — most recent frame whose pixels are currently loadable
-    //    (skips frames still buffering in the unflushed active video chunk).
+    // 1) Screen now — most recent frame whose pixels are currently loadable.
+    //    Frames still buffering in the unflushed active video chunk can't be
+    //    decoded yet; skip them up front so we don't repeatedly attempt (and
+    //    fail) a load — each failed load re-inits storage, a real latency spike
+    //    since the newest frames are commonly in the active chunk.
     var screenNow: [String: Any] = ["available": false]
+    let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
     if let recent = try? await RewindDatabase.shared.getRecentScreenshots(limit: 25) {
       for shot in recent {
         guard let sid = shot.id else { continue }
+        if shot.usesVideoStorage, let chunk = shot.videoChunkPath, chunk == activeChunk {
+          continue  // pending: still in the active, unflushed chunk
+        }
         if let data = try? await loadScreenshotDataEnsuringStorage(for: shot) {
           screenNow = [
             "available": true,
@@ -300,7 +307,8 @@ final class LocalAgentAPIServer {
             "window_title": shot.windowTitle ?? NSNull(),
             "ocr_preview": String((shot.ocrText ?? "").prefix(800)),
             "image_bytes": data.count,
-            "note": "Call get_screenshot with this screenshot_id to SEE the full-screen image.",
+            "note":
+              "Latest available finalized frame (may be up to ~1 min old, and can predate window_minutes). Call get_screenshot with this screenshot_id to SEE the full-screen image.",
           ]
           break
         }


### PR DESCRIPTION
Follow-up to #8379, addressing an independent review nit.

**Problem:** the screen-now loop attempted `loadScreenshotDataEnsuringStorage` on the newest frames even when they're still buffering in the unflushed active video chunk. Each failed load re-inits storage, and since the newest frames are *commonly* in the active chunk, a single `get_work_context` call could trigger several storage re-inits + double-load attempts — a real latency spike on the common path.

**Fix:** skip frames whose `videoChunkPath == VideoChunkEncoder.shared.currentChunkPath` up front (cheap), so we only attempt to load finalized frames. Also clarified the `screen_now.note` that the frame may be ~1 min old / predate `window_minutes`.

Purely additive/contained; clean debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

