### PR TITLE
feat(mcp): include name/email/phone on get_user_profile

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -130,15 +130,18 @@ def _get_user_contact(uid: str) -> dict:
         name = user.display_name or None
         email = user.email or None
         phone_number = user.phone_number or None
-    except Exception:
-        logger.exception("get_user_profile: firebase contact lookup failed uid=%s", uid)
+    except Exception as e:
+        # Expected for uids with no Firebase Auth record; warn (no traceback).
+        logger.warning("get_user_profile: firebase contact lookup failed uid=%s: %s", uid, e)
     if not phone_number:
         try:
+            # get_phone_numbers returns decrypted dicts; prefer the primary one.
             numbers = phone_calls_db.get_phone_numbers(uid) or []
-            if numbers:
-                phone_number = numbers[0].get("phone_number")
-        except Exception:
-            logger.exception("get_user_profile: phone_numbers lookup failed uid=%s", uid)
+            primary = next((n for n in numbers if n.get("is_primary")), None) or (numbers[0] if numbers else None)
+            if primary:
+                phone_number = primary.get("phone_number")
+        except Exception as e:
+            logger.warning("get_user_profile: phone_numbers lookup failed uid=%s: %s", uid, e)
     return {"name": name, "email": email, "phone_number": phone_number}
 
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -14,6 +14,8 @@ import database.goals as goals_db
 import database.chat as chat_db
 import database.screen_activity as screen_activity_db
 import database.daily_summaries as daily_summaries_db
+import database.phone_calls as phone_calls_db
+from firebase_admin import auth as firebase_auth
 
 # from database.redis_db import get_filter_category_items
 # from database.vector_db import query_vectors_by_metadata
@@ -111,9 +113,33 @@ def edit_memory(memory_id: str, value: str, uid: str = Depends(get_uid_from_mcp_
 
 
 class UserProfile(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
     profile_text: Optional[str] = None
     generated_at: Optional[str] = None
     data_sources_used: Optional[int] = None
+
+
+def _get_user_contact(uid: str) -> dict:
+    """Best-effort name/email/phone for the profile. Never raises — a contact
+    lookup failure must not break the profile response."""
+    name = email = phone_number = None
+    try:
+        user = firebase_auth.get_user(uid)
+        name = user.display_name or None
+        email = user.email or None
+        phone_number = user.phone_number or None
+    except Exception:
+        logger.exception("get_user_profile: firebase contact lookup failed uid=%s", uid)
+    if not phone_number:
+        try:
+            numbers = phone_calls_db.get_phone_numbers(uid) or []
+            if numbers:
+                phone_number = numbers[0].get("phone_number")
+        except Exception:
+            logger.exception("get_user_profile: phone_numbers lookup failed uid=%s", uid)
+    return {"name": name, "email": email, "phone_number": phone_number}
 
 
 @router.get("/v1/mcp/profile", tags=["mcp"], response_model=UserProfile)
@@ -121,7 +147,11 @@ def get_user_profile(uid: str = Depends(get_uid_from_mcp_api_key)):
     """Omi's cached high-level user profile, if one has been generated."""
     profile = users_db.get_ai_user_profile(uid) or {}
     generated_at = profile.get("generated_at")
+    contact = _get_user_contact(uid)
     return UserProfile(
+        name=contact["name"],
+        email=contact["email"],
+        phone_number=contact["phone_number"],
         profile_text=profile.get("profile_text"),
         generated_at=str(generated_at) if generated_at is not None else None,
         data_sources_used=profile.get("data_sources_used"),

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -37,6 +37,7 @@ pytest tests/unit/test_mcp_memory_filters.py -v
 pytest tests/unit/test_mcp_client_tool_result.py -v
 pytest tests/unit/test_mcp_data_endpoints.py -v
 pytest tests/unit/test_mcp_conversations_poison.py -v
+pytest tests/unit/test_mcp_profile_contact.py -v
 pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v

--- a/backend/tests/unit/test_mcp_profile_contact.py
+++ b/backend/tests/unit/test_mcp_profile_contact.py
@@ -1,0 +1,196 @@
+"""Unit tests for name/email/phone on the MCP user profile (routers/mcp.py).
+
+`/v1/mcp/profile` now augments the cached AI profile with the user's contact
+identity (name/email from Firebase Auth, phone from Auth or the phone_numbers
+subcollection). Contact lookup must be best-effort: a Firebase/Firestore failure
+must NOT break the profile response.
+
+Heavy deps are stubbed following the proven pattern in test_mcp_data_endpoints.py.
+"""
+
+from unittest.mock import patch, MagicMock
+import os
+import sys
+from types import ModuleType
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+def _drop_stale_module(module_name, expected_file):
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    if isinstance(module_file, str) and os.path.abspath(module_file) == expected_file:
+        return
+    sys.modules.pop(module_name, None)
+    parent_name, child_name = module_name.rsplit('.', 1)
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+_drop_stale_module('utils.retrieval.hybrid', os.path.join(_BACKEND_DIR, 'utils', 'retrieval', 'hybrid.py'))
+_drop_stale_module('models.memories', os.path.join(_BACKEND_DIR, 'models', 'memories.py'))
+_drop_stale_module('models.conversation_enums', os.path.join(_BACKEND_DIR, 'models', 'conversation_enums.py'))
+_drop_stale_module('models.mcp_api_key', os.path.join(_BACKEND_DIR, 'models', 'mcp_api_key.py'))
+
+_stubs = [
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.screen_activity',
+    'database.phone_calls',
+    'database.x_posts',
+    'database.fair_use',
+    'database.auth',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.FieldFilter',
+    'google',
+    'google.cloud',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'utils.other.storage',
+    'utils.other.endpoints',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.render',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.log_sanitizer',
+    'utils.executors',
+    'dependencies',
+]
+for mod_name in _stubs:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = _AutoMockModule(mod_name)
+
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+sys.modules['utils.executors'].db_executor = MagicMock()
+sys.modules['utils.executors'].postprocess_executor = MagicMock()
+sys.modules['utils.llm.memories'].identify_category_for_memory = MagicMock(return_value='other')
+
+from routers import mcp as rest  # noqa: E402
+
+UID = "user-1"
+
+
+def _firebase_user(display_name=None, email=None, phone_number=None):
+    user = MagicMock()
+    user.display_name = display_name
+    user.email = email
+    user.phone_number = phone_number
+    return user
+
+
+class TestProfileContact:
+    @patch('routers.mcp.phone_calls_db')
+    @patch('routers.mcp.firebase_auth')
+    @patch('routers.mcp.users_db')
+    def test_includes_name_email_phone_from_auth(self, mock_users, mock_auth, mock_phone):
+        mock_users.get_ai_user_profile.return_value = {'profile_text': 'builds AI', 'data_sources_used': 3}
+        mock_auth.get_user.return_value = _firebase_user('Nik Shevchenko', 'nik@example.com', '+15551234567')
+        result = rest.get_user_profile(uid=UID)
+        assert result.name == 'Nik Shevchenko'
+        assert result.email == 'nik@example.com'
+        assert result.phone_number == '+15551234567'
+        assert result.profile_text == 'builds AI'
+        # Auth had a phone, so the subcollection must not be consulted.
+        mock_phone.get_phone_numbers.assert_not_called()
+
+    @patch('routers.mcp.phone_calls_db')
+    @patch('routers.mcp.firebase_auth')
+    @patch('routers.mcp.users_db')
+    def test_phone_falls_back_to_subcollection(self, mock_users, mock_auth, mock_phone):
+        mock_users.get_ai_user_profile.return_value = {}
+        mock_auth.get_user.return_value = _firebase_user('Nik', 'nik@example.com', None)
+        mock_phone.get_phone_numbers.return_value = [{'phone_number': '+15559998888'}]
+        result = rest.get_user_profile(uid=UID)
+        assert result.email == 'nik@example.com'
+        assert result.phone_number == '+15559998888'
+
+    @patch('routers.mcp.phone_calls_db')
+    @patch('routers.mcp.firebase_auth')
+    @patch('routers.mcp.users_db')
+    def test_contact_failure_does_not_break_profile(self, mock_users, mock_auth, mock_phone):
+        mock_users.get_ai_user_profile.return_value = {'profile_text': 'still here'}
+        mock_auth.get_user.side_effect = RuntimeError("firebase down")
+        mock_phone.get_phone_numbers.side_effect = RuntimeError("firestore down")
+        result = rest.get_user_profile(uid=UID)
+        # Contact lookups failed, but the profile itself still returns cleanly.
+        assert result.profile_text == 'still here'
+        assert result.name is None
+        assert result.email is None
+        assert result.phone_number is None
+
+    @patch('routers.mcp.phone_calls_db')
+    @patch('routers.mcp.firebase_auth')
+    @patch('routers.mcp.users_db')
+    def test_empty_strings_become_none(self, mock_users, mock_auth, mock_phone):
+        mock_users.get_ai_user_profile.return_value = {}
+        mock_auth.get_user.return_value = _firebase_user('', '', '')
+        mock_phone.get_phone_numbers.return_value = []
+        result = rest.get_user_profile(uid=UID)
+        assert result.name is None
+        assert result.email is None
+        assert result.phone_number is None

--- a/backend/tests/unit/test_mcp_profile_contact.py
+++ b/backend/tests/unit/test_mcp_profile_contact.py
@@ -172,6 +172,19 @@ class TestProfileContact:
     @patch('routers.mcp.phone_calls_db')
     @patch('routers.mcp.firebase_auth')
     @patch('routers.mcp.users_db')
+    def test_phone_fallback_prefers_primary(self, mock_users, mock_auth, mock_phone):
+        mock_users.get_ai_user_profile.return_value = {}
+        mock_auth.get_user.return_value = _firebase_user('Nik', 'nik@example.com', None)
+        mock_phone.get_phone_numbers.return_value = [
+            {'phone_number': '+15550000000', 'is_primary': False},
+            {'phone_number': '+15551111111', 'is_primary': True},
+        ]
+        result = rest.get_user_profile(uid=UID)
+        assert result.phone_number == '+15551111111'
+
+    @patch('routers.mcp.phone_calls_db')
+    @patch('routers.mcp.firebase_auth')
+    @patch('routers.mcp.users_db')
     def test_contact_failure_does_not_break_profile(self, mock_users, mock_auth, mock_phone):
         mock_users.get_ai_user_profile.return_value = {'profile_text': 'still here'}
         mock_auth.get_user.side_effect = RuntimeError("firebase down")


### PR DESCRIPTION
## What
`/v1/mcp/profile` (the `get_user_profile` MCP tool agents read) now returns the user's **name, email, and phone_number** alongside the existing AI `profile_text`, so agents have the user's contact identity without asking.

- `name`/`email` ← Firebase Auth (`UserRecord`)
- `phone_number` ← Firebase Auth, falling back to the **primary** entry in the decrypted `phone_numbers` subcollection
- All fields `Optional`; contact lookup is **best-effort** — a Firebase/Firestore failure logs a warning (uid only, no PII) and the profile still returns.

## Why
Requested: a simple user profile (name/age/etc) should include phone + email. Age has no source field anywhere, so it's omitted rather than fabricated.

## Verification
- New unit tests (5) exercise the real `get_user_profile` function: auth-phone path, subcollection fallback, **primary-phone selection**, double-failure safety, empty-string→None. All pass; registered in `test.sh`. Existing mcp tests still green (25 passed).
- Independent agent review: APPROVE-WITH-NITS (both nits applied — primary-phone-from-decrypted-list, warn-not-exception).
- **Not** yet exercised against the live deployed endpoint with a real MCP key (no local Firebase creds) — verifiable post-deploy.

## Note (PII)
This exposes the user's own phone+email to any holder of their MCP API key — intended, per request. Keyed on the api-key-derived uid; no cross-user exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

