### PR TITLE
[codex] Quiet named dev bundle permissions

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Developer named bundles now start quiet — lazy permissions, no auto screen/audio capture — unless explicitly seeded eager"
+  ],
   "releases": [
     {
       "version": "0.11.538",

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum AppBuild {
   static let productionBundleIdentifier = "com.omi.computer-macos"
+  static let desktopDevBundleIdentifier = "com.omi.desktop-dev"
   private static let updateChannelDefaultsKey = "update_channel"
   private static let betaOverwriteMigrationKey = "didMigrateBetaOverwrite_v1"
   private static let desktopAppcastURL = URL(
@@ -17,6 +18,14 @@ enum AppBuild {
 
   static var isProductionBundle: Bool {
     bundleIdentifier == productionBundleIdentifier
+  }
+
+  static var isNamedDevelopmentBundle: Bool {
+    isNonProduction && bundleIdentifier != desktopDevBundleIdentifier
+  }
+
+  static var usesLazyDevPermissions: Bool {
+    isNamedDevelopmentBundle && UserDefaults.standard.bool(forKey: "devLazyPermissionsEnabled")
   }
 
   static var displayName: String {

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -994,9 +994,15 @@ class AppState: ObservableObject {
   func checkAllPermissions() {
     checkNotificationPermission()
     checkScreenRecordingPermission()
-    checkAutomationPermission()
     checkMicrophonePermission()
     checkSystemAudioPermission()
+
+    if AppBuild.usesLazyDevPermissions {
+      log("Permissions: lazy dev mode enabled, skipping startup automation/accessibility/FDA probes")
+      return
+    }
+
+    checkAutomationPermission()
     checkAccessibilityPermission()
     checkFullDiskAccess()
     // One-time startup diagnostic for accessibility

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -145,7 +145,9 @@ struct DesktopHomeView: View {
               appState.checkAllPermissions()
 
               // For existing users who haven't indexed files yet, run a background scan
-              if !UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") {
+              if !AppBuild.usesLazyDevPermissions
+                && !UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing")
+              {
                 UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
                 Task {
                   log("DesktopHomeView: Running background file scan for existing user")
@@ -319,6 +321,7 @@ struct DesktopHomeView: View {
               while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(3 * 60 * 60))
                 guard !Task.isCancelled else { break }
+                guard !AppBuild.usesLazyDevPermissions else { continue }
                 guard UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") else {
                   continue
                 }

--- a/desktop/macos/Desktop/Sources/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingView.swift
@@ -183,7 +183,9 @@ struct OnboardingView: View {
           requiresRestart: true,
           onContinue: {
             AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "ScreenRecording")
-            startMonitoringIfNeeded()
+            if !AppBuild.usesLazyDevPermissions {
+              startMonitoringIfNeeded()
+            }
             currentStep = 5
           },
           onSkip: {
@@ -421,7 +423,7 @@ struct OnboardingView: View {
           totalSteps: OnboardingFlow.introStepCount,
           onContinue: {
             AnalyticsManager.shared.onboardingStepCompleted(step: 16, stepName: "Goal")
-            if !ProactiveAssistantsPlugin.shared.isMonitoring {
+            if !AppBuild.usesLazyDevPermissions, !ProactiveAssistantsPlugin.shared.isMonitoring {
               ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
             }
             currentStep = 17
@@ -429,7 +431,7 @@ struct OnboardingView: View {
           onSkip: {
             AnalyticsManager.shared.onboardingStepCompleted(
               step: 16, stepName: "Goal_Skipped")
-            if !ProactiveAssistantsPlugin.shared.isMonitoring {
+            if !AppBuild.usesLazyDevPermissions, !ProactiveAssistantsPlugin.shared.isMonitoring {
               ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
             }
             currentStep = 17

--- a/desktop/macos/Desktop/Sources/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingView.swift
@@ -475,7 +475,9 @@ struct OnboardingView: View {
 
     // Navigate to Tasks page after transition
     UserDefaults.standard.set(true, forKey: "onboardingJustCompleted")
-    UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
+    if !AppBuild.usesLazyDevPermissions {
+      UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
+    }
     PostOnboardingPromptSuggestions.save(
       OnboardingPromptSuggestionBuilder.build(from: introCoordinator))
 
@@ -501,8 +503,14 @@ struct OnboardingView: View {
     if LaunchAtLoginManager.shared.setEnabled(true) {
       AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "onboarding_complete")
     }
-    startMonitoringIfNeeded()
-    appState.startTranscription()
+    if AppBuild.usesLazyDevPermissions {
+      AssistantSettings.shared.screenAnalysisEnabled = false
+      AssistantSettings.shared.transcriptionEnabled = false
+      log("OnboardingView: Lazy dev permissions enabled, skipping monitoring/transcription autostart")
+    } else {
+      startMonitoringIfNeeded()
+      appState.startTranscription()
+    }
 
     // Create welcome task
     Task {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -49,7 +49,9 @@ class SettingsSyncManager {
             if let v = shared.cooldownInterval { AssistantSettings.shared.cooldownInterval = v }
             if let v = shared.glowOverlayEnabled { AssistantSettings.shared.glowOverlayEnabled = v }
             if let v = shared.analysisDelay { AssistantSettings.shared.analysisDelay = v }
-            if let v = shared.screenAnalysisEnabled { AssistantSettings.shared.screenAnalysisEnabled = v }
+            if let v = shared.screenAnalysisEnabled, !shouldKeepLocalScreenAnalysisDefault {
+                AssistantSettings.shared.screenAnalysisEnabled = v
+            }
         }
 
         // Focus settings
@@ -106,6 +108,10 @@ class SettingsSyncManager {
     }
 
     // MARK: - Build Local → Response
+
+    private var shouldKeepLocalScreenAnalysisDefault: Bool {
+        AppBuild.usesLazyDevPermissions
+    }
 
     private func buildFromLocal() -> AssistantSettingsResponse {
         let shared = SharedAssistantSettingsResponse(

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -20,6 +20,7 @@ Options (via environment variables):
   OMI_APP_NAME="Omi Dev"   App name (default: "Omi Dev")
   OMI_SKIP_AUTH_SEED=1     Do not copy auth/onboarding from Omi Dev into named bundles
   OMI_SKIP_SETTINGS_SEED=1  Do not copy shortcuts/settings from Omi Dev into named bundles
+  OMI_DEV_EAGER_PERMISSIONS=1  Preserve eager mic/screen/file startup behavior in named bundles
   OMI_PYTHON_API_URL="..."  Python backend URL (subscriptions, payments, etc; default: https://api.omi.me)
   OMI_SIGN_IDENTITY="..."  Code signing identity (auto-detected if not set)
   OMI_ENABLE_LOCAL_AUTOMATION=1   Force the automation bridge on (auto-on for non-prod bundles; see scripts/omi-ctl)
@@ -706,6 +707,7 @@ if [ "$IS_NAMED_BUNDLE" = true ] && [ "${OMI_SKIP_SETTINGS_SEED:-0}" != "1" ]; t
     step "Seeding shortcuts/settings from Omi Dev..."
     if ./scripts/omi-settings-seed.sh "$BUNDLE_ID" com.omi.desktop-dev; then
         auth_debug "AFTER settings seed: shortcut_askOmiEnabled=$(defaults read "$BUNDLE_ID" shortcut_askOmiEnabled 2>&1 || true)"
+        auth_debug "AFTER settings seed: devLazyPermissionsEnabled=$(defaults read "$BUNDLE_ID" devLazyPermissionsEnabled 2>&1 || true)"
     else
         echo "Warning: could not seed shortcuts/settings from Omi Dev. Continuing with bundle defaults."
     fi

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -8,6 +8,9 @@
 # Usage: omi-settings-seed.sh <target-bundle-id> [source-bundle-id]
 #   target-bundle-id  e.g. com.omi.omi-fix-rewind  (a named test bundle)
 #   source-bundle-id  default: com.omi.desktop-dev   (the "Omi Dev" build)
+#
+# Set OMI_DEV_EAGER_PERMISSIONS=1 to preserve eager post-onboarding behavior
+# for permission-flow parity testing.
 set -euo pipefail
 
 TARGET="${1:?usage: omi-settings-seed.sh <target-bundle-id> [source-bundle-id]}"
@@ -15,6 +18,7 @@ SRC="${2:-com.omi.desktop-dev}"
 
 python3 - "$SRC" "$TARGET" <<'PY'
 import plistlib
+import os
 import subprocess
 import sys
 import tempfile
@@ -74,6 +78,10 @@ KEYS = [
 ]
 
 
+def env_truthy(name):
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def defaults_export(domain):
     proc = subprocess.run(
         ["defaults", "export", domain, "-"],
@@ -87,13 +95,29 @@ def defaults_export(domain):
 
 source = defaults_export(src)
 if not source:
-    sys.exit(f"No defaults found for {src}")
+    print(f"No defaults found for {src}; applying target-only dev defaults")
 
 target_data = defaults_export(target)
 selected = {key: source[key] for key in KEYS if key in source}
-if not selected:
-    print(f"Seeded 0 settings from {src} -> {target}")
-    sys.exit(0)
+
+if not env_truthy("OMI_DEV_EAGER_PERMISSIONS"):
+    # Named dev bundles reuse auth/onboarding from Omi Dev, but macOS treats
+    # each bundle ID as a fresh TCC identity. Keep startup quiet until the
+    # developer explicitly enables a feature that needs a permission.
+    selected.update(
+        {
+            "devLazyPermissionsEnabled": True,
+            "screenAnalysisEnabled": False,
+            "transcriptionEnabled": False,
+            "disableSystemAudioCapture": True,
+            "systemAudioCaptureMode": "never",
+            # Prevent the main-window startup migration from re-enabling screen
+            # analysis immediately after the quiet default is seeded.
+            "screenAnalysisAutoStartFixed_v2": True,
+        }
+    )
+else:
+    selected["devLazyPermissionsEnabled"] = False
 
 target_data.update(selected)
 with tempfile.NamedTemporaryFile(suffix=".plist") as plist:

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -109,7 +109,12 @@ if not env_truthy("OMI_DEV_EAGER_PERMISSIONS"):
             "devLazyPermissionsEnabled": True,
             "screenAnalysisEnabled": False,
             "transcriptionEnabled": False,
-            "disableSystemAudioCapture": True,
+            # Use systemAudioCaptureMode="never" (a user-visible setting) instead of
+            # disableSystemAudioCapture (a hidden kill switch). The hidden flag is
+            # checked by AppState.effectiveSystemAudioMode BEFORE the user-visible
+            # mode, so seeding it would trap system audio off even after the
+            # developer picks "Always" in Settings. systemAudioCaptureMode can be
+            # toggled freely from the Settings UI.
             "systemAudioCaptureMode": "never",
             # Prevent the main-window startup migration from re-enabling screen
             # analysis immediately after the quiet default is seeded.
@@ -117,7 +122,15 @@ if not env_truthy("OMI_DEV_EAGER_PERMISSIONS"):
         }
     )
 else:
-    selected["devLazyPermissionsEnabled"] = False
+    # Eager mode: fully undo quiet-permission defaults so permission-flow
+    # parity testing can exercise the normal startup paths.
+    selected.update(
+        {
+            "devLazyPermissionsEnabled": False,
+            "systemAudioCaptureMode": source.get("systemAudioCaptureMode", "always"),
+        }
+    )
+    target_data.pop("screenAnalysisAutoStartFixed_v2", None)
 
 target_data.update(selected)
 with tempfile.NamedTemporaryFile(suffix=".plist") as plist:

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -128,6 +128,11 @@ else:
     selected.update(
         {
             "devLazyPermissionsEnabled": False,
+            # Restore capture flags so a previously quiet-seeded bundle runs
+            # the full eager startup path. Fall back to True (normal default)
+            # when the source domain doesn't define them.
+            "screenAnalysisEnabled": source.get("screenAnalysisEnabled", True),
+            "transcriptionEnabled": source.get("transcriptionEnabled", True),
             "systemAudioCaptureMode": source.get("systemAudioCaptureMode", "always"),
         }
     )
@@ -139,6 +144,12 @@ with tempfile.NamedTemporaryFile(suffix=".plist") as plist:
     plistlib.dump(target_data, plist)
     plist.flush()
     subprocess.run(["defaults", "import", target, plist.name], check=True)
+
+# Keys removed from target_data above need to be explicitly deleted from the
+# target domain — `defaults import` merges and never removes keys.
+for key in ("disableSystemAudioCapture", "screenAnalysisAutoStartFixed_v2"):
+    if key not in target_data:
+        subprocess.run(["defaults", "delete", target, key], check=False)
 
 print(f"Seeded {len(selected)} settings from {src} -> {target}")
 PY

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -57,7 +57,6 @@ KEYS = [
     "disabledSkillsJSON",
     "screenAnalysisEnabled",
     "transcriptionEnabled",
-    "disableSystemAudioCapture",
     "dashboardWidgetsCollapsed",
     "tasksChatPanelWidth",
 
@@ -121,6 +120,8 @@ if not env_truthy("OMI_DEV_EAGER_PERMISSIONS"):
             "screenAnalysisAutoStartFixed_v2": True,
         }
     )
+    # Never carry over the hidden kill switch from a previous seed or the source.
+    target_data.pop("disableSystemAudioCapture", None)
 else:
     # Eager mode: fully undo quiet-permission defaults so permission-flow
     # parity testing can exercise the normal startup paths.
@@ -131,6 +132,7 @@ else:
         }
     )
     target_data.pop("screenAnalysisAutoStartFixed_v2", None)
+    target_data.pop("disableSystemAudioCapture", None)
 
 target_data.update(selected)
 with tempfile.NamedTemporaryFile(suffix=".plist") as plist:

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "=== Desktop Launcher Script Tests ==="
 cd "$SCRIPT_DIR"
 bash tests/test-app-config.sh
+bash tests/test-settings-seed.sh
 echo ""
 
 echo "=== Rust Backend Tests ==="

--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -42,6 +42,8 @@ cleanup_domains+=("$source_domain" "$quiet_target" "$eager_target" "$missing_tar
 defaults write "$source_domain" screenAnalysisEnabled -bool true
 defaults write "$source_domain" transcriptionEnabled -bool true
 defaults write "$source_domain" shortcut_askOmiEnabled -bool true
+# Set the hidden kill switch in the source to verify it is NOT copied to targets.
+defaults write "$source_domain" disableSystemAudioCapture -bool true
 
 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >/tmp/omi-settings-seed-quiet.out
 assert_defaults "$quiet_target" screenAnalysisEnabled 0

--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -68,4 +68,21 @@ assert_defaults "$missing_target" screenAnalysisEnabled 0
 assert_defaults "$missing_target" transcriptionEnabled 0
 assert_defaults "$missing_target" devLazyPermissionsEnabled 1
 
+# Verify eager mode fully undoes quiet defaults when re-seeding the same target.
+# Seed quiet first, then eager on the same target without source capture flags.
+quiet_then_eager_target="com.omi.codex-settings-qe-$$"
+cleanup_domains+=("$quiet_then_eager_target")
+"$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_then_eager_target" "$source_domain" >/dev/null
+# Source without capture flags to verify eager defaults kick in.
+bare_source="com.omi.codex-settings-bare-$$"
+cleanup_domains+=("$bare_source")
+defaults write "$bare_source" shortcut_askOmiEnabled -bool true
+OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_then_eager_target" "$bare_source" >/dev/null
+assert_defaults "$quiet_then_eager_target" screenAnalysisEnabled 1
+assert_defaults "$quiet_then_eager_target" transcriptionEnabled 1
+assert_defaults "$quiet_then_eager_target" devLazyPermissionsEnabled 0
+assert_defaults "$quiet_then_eager_target" systemAudioCaptureMode always
+assert_unset "$quiet_then_eager_target" disableSystemAudioCapture
+assert_unset "$quiet_then_eager_target" screenAnalysisAutoStartFixed_v2
+
 echo "settings-seed tests passed"

--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_defaults() {
+  local domain="$1" key="$2" expected="$3"
+  local actual
+  actual="$(defaults read "$domain" "$key")"
+  if [ "$actual" != "$expected" ]; then
+    fail "$domain $key: expected '$expected', got '$actual'"
+  fi
+}
+
+assert_unset() {
+  local domain="$1" key="$2"
+  if defaults read "$domain" "$key" >/dev/null 2>&1; then
+    fail "$domain $key: expected unset"
+  fi
+}
+
+cleanup_domains=()
+cleanup() {
+  for domain in "${cleanup_domains[@]}"; do
+    defaults delete "$domain" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+source_domain="com.omi.codex-settings-source-$$"
+quiet_target="com.omi.codex-settings-quiet-$$"
+eager_target="com.omi.codex-settings-eager-$$"
+missing_target="com.omi.codex-settings-missing-$$"
+cleanup_domains+=("$source_domain" "$quiet_target" "$eager_target" "$missing_target")
+
+defaults write "$source_domain" screenAnalysisEnabled -bool true
+defaults write "$source_domain" transcriptionEnabled -bool true
+defaults write "$source_domain" shortcut_askOmiEnabled -bool true
+
+"$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >/tmp/omi-settings-seed-quiet.out
+assert_defaults "$quiet_target" screenAnalysisEnabled 0
+assert_defaults "$quiet_target" transcriptionEnabled 0
+assert_defaults "$quiet_target" disableSystemAudioCapture 1
+assert_defaults "$quiet_target" systemAudioCaptureMode never
+assert_defaults "$quiet_target" devLazyPermissionsEnabled 1
+assert_defaults "$quiet_target" screenAnalysisAutoStartFixed_v2 1
+assert_defaults "$quiet_target" shortcut_askOmiEnabled 1
+assert_unset "$quiet_target" hasCompletedFileIndexing
+
+OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$eager_target" "$source_domain" >/tmp/omi-settings-seed-eager.out
+assert_defaults "$eager_target" screenAnalysisEnabled 1
+assert_defaults "$eager_target" transcriptionEnabled 1
+assert_defaults "$eager_target" devLazyPermissionsEnabled 0
+assert_unset "$eager_target" disableSystemAudioCapture
+assert_unset "$eager_target" systemAudioCaptureMode
+assert_unset "$eager_target" screenAnalysisAutoStartFixed_v2
+
+"$MACOS_DIR/scripts/omi-settings-seed.sh" "$missing_target" "com.omi.missing-source-$$" >/tmp/omi-settings-seed-missing.out
+assert_defaults "$missing_target" screenAnalysisEnabled 0
+assert_defaults "$missing_target" transcriptionEnabled 0
+assert_defaults "$missing_target" devLazyPermissionsEnabled 1
+
+echo "settings-seed tests passed"

--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -46,10 +46,10 @@ defaults write "$source_domain" shortcut_askOmiEnabled -bool true
 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >/tmp/omi-settings-seed-quiet.out
 assert_defaults "$quiet_target" screenAnalysisEnabled 0
 assert_defaults "$quiet_target" transcriptionEnabled 0
-assert_defaults "$quiet_target" disableSystemAudioCapture 1
 assert_defaults "$quiet_target" systemAudioCaptureMode never
 assert_defaults "$quiet_target" devLazyPermissionsEnabled 1
 assert_defaults "$quiet_target" screenAnalysisAutoStartFixed_v2 1
+assert_unset "$quiet_target" disableSystemAudioCapture
 assert_defaults "$quiet_target" shortcut_askOmiEnabled 1
 assert_unset "$quiet_target" hasCompletedFileIndexing
 
@@ -58,7 +58,7 @@ assert_defaults "$eager_target" screenAnalysisEnabled 1
 assert_defaults "$eager_target" transcriptionEnabled 1
 assert_defaults "$eager_target" devLazyPermissionsEnabled 0
 assert_unset "$eager_target" disableSystemAudioCapture
-assert_unset "$eager_target" systemAudioCaptureMode
+assert_defaults "$eager_target" systemAudioCaptureMode always
 assert_unset "$eager_target" screenAnalysisAutoStartFixed_v2
 
 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$missing_target" "com.omi.missing-source-$$" >/tmp/omi-settings-seed-missing.out


### PR DESCRIPTION
## Summary
- add a named-dev-bundle lazy permission policy keyed by `devLazyPermissionsEnabled`
- seed quiet defaults for named bundles: screen analysis off, transcription off, system audio disabled, and screen-analysis migration marked done
- keep backend settings sync from re-enabling screen analysis in quiet named bundles
- skip startup automation/accessibility/FDA probes and automatic file indexing in lazy dev mode
- add launcher script coverage for quiet and eager settings seeding

## Why
Named desktop dev bundles reuse auth/onboarding state from `Omi Dev`, but macOS treats each bundle ID as a fresh TCC identity. That made throwaway bundles immediately ask for mic/screen/folder-adjacent permissions even though the developer just wanted an already-onboarded app. Quiet mode keeps those prompts until the relevant feature is explicitly enabled.

`OMI_DEV_EAGER_PERMISSIONS=1` preserves the old eager startup behavior for permission-flow parity testing.

## Validation
- `bash tests/test-app-config.sh && bash tests/test-settings-seed.sh`
- `xcrun swift build -c debug --package-path Desktop`
- `bash test.sh` reached Swift tests after passing launcher script tests and Rust backend tests (`259 passed`), then failed in Swift tests with `FirebaseAuth/Auth.swift:154: Fatal error: The default FirebaseApp instance must be configured...`
- reran Swift tests with the existing skips plus `QueryTracerTests`; it hit the same FirebaseApp-not-configured crash later in `RewindRetentionCleanupTests`
- launched named bundle `omi-lazy-dev-perms` with `./run.sh --yolo`; verified defaults had `devLazyPermissionsEnabled=1`, `screenAnalysisEnabled=0`, `transcriptionEnabled=0`, `disableSystemAudioCapture=1`, `systemAudioCaptureMode=never`, `hasCompletedFileIndexing` unset
- verified app reached main signed-in state via `OMI_AUTOMATION_PORT=47799 ./scripts/omi-ctl state`
- verified logs showed lazy startup behavior: skipped automation/accessibility/FDA probes, skipped transcription autostart, skipped screen-analysis autostart


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

