### PR TITLE
[codex] Add PTT controls for canonical agent runs

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added PTT access to inspect and stop canonical Omi agent runs created from chat or other Omi surfaces"
+  ],
   "releases": [
     {
       "version": "0.11.539",

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -141,7 +141,7 @@ actor AgentBridge {
 
   func controlTool(name: String, input: [String: Any]) async throws -> String {
     try await start()
-    return try await runtime.controlTool(
+    return try await runtime.directControlTool(
       clientId: clientId,
       harnessMode: harnessMode,
       name: name,

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+@MainActor
+final class AgentControlService {
+  static let shared = AgentControlService()
+
+  private enum ToolName {
+    static let listAgentSessions = "list_agent_sessions"
+    static let getAgentRun = "get_agent_run"
+    static let cancelAgentRun = "cancel_agent_run"
+    static let inspectAgentArtifacts = "inspect_agent_artifacts"
+    static let updateAgentArtifactLifecycle = "update_agent_artifact_lifecycle"
+  }
+
+  private struct AgentHandle {
+    let sessionId: String?
+    let runId: String?
+    let attemptId: String?
+  }
+
+  private let runtime: AgentRuntimeProcess
+  private var agentHandles: [String: AgentHandle] = [:]
+  private var artifactHandles: [String: String] = [:]
+
+  init(runtime: AgentRuntimeProcess = .shared) {
+    self.runtime = runtime
+  }
+
+  func executeVoiceTool(name: String, arguments: [String: Any]) async throws -> String {
+    let input = resolveVoiceHandles(in: arguments)
+    let raw = try await runtime.directControlTool(
+      clientId: "realtime-hub",
+      harnessMode: Self.currentHarnessMode(),
+      name: name,
+      input: input
+    )
+    return summarizeVoiceResult(name: name, raw: raw)
+  }
+
+  static func currentHarnessMode() -> String {
+    let mode = UserDefaults.standard.string(forKey: "chatBridgeMode") ?? "piMono"
+    return mode == "piMono" ? "piMono" : "acp"
+  }
+
+  func logDetail(name: String, arguments: [String: Any]) -> String {
+    switch name {
+    case ToolName.getAgentRun, ToolName.cancelAgentRun:
+      return stringValue(arguments["agentRef"]).map { "agentRef=\($0)" } ?? hasCanonicalScope(arguments)
+    case ToolName.inspectAgentArtifacts:
+      return stringValue(arguments["agentRef"]).map { "agentRef=\($0)" }
+        ?? stringValue(arguments["artifactRef"]).map { "artifactRef=\($0)" }
+        ?? hasCanonicalScope(arguments)
+    case ToolName.updateAgentArtifactLifecycle:
+      return stringValue(arguments["artifactRef"]).map { "artifactRef=\($0)" } ?? ""
+    default:
+      return ""
+    }
+  }
+
+  func summarizeVoiceResult(name: String, raw: String) -> String {
+    guard let data = raw.data(using: .utf8),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return raw
+    }
+    if object["ok"] as? Bool == false {
+      return "Agent control failed. Try listing the agents again and retry with the matching item."
+    }
+    switch name {
+    case ToolName.listAgentSessions:
+      return summarizeAgentSessions(object)
+    case ToolName.getAgentRun:
+      return summarizeAgentRun(object)
+    case ToolName.cancelAgentRun:
+      return summarizeAgentCancellation(object)
+    case ToolName.inspectAgentArtifacts:
+      return summarizeAgentArtifacts(object)
+    case ToolName.updateAgentArtifactLifecycle:
+      return summarizeArtifactLifecycle(object)
+    default:
+      return raw
+    }
+  }
+
+  private func resolveVoiceHandles(in arguments: [String: Any]) -> [String: Any] {
+    var input = arguments
+    if let agentRef = stringValue(input["agentRef"]), let handle = agentHandles[agentRef] {
+      if input["sessionId"] == nil, let sessionId = handle.sessionId { input["sessionId"] = sessionId }
+      if input["runId"] == nil, let runId = handle.runId { input["runId"] = runId }
+      if input["attemptId"] == nil, let attemptId = handle.attemptId { input["attemptId"] = attemptId }
+    }
+    if let artifactRef = stringValue(input["artifactRef"]), let artifactId = artifactHandles[artifactRef], input["artifactId"] == nil {
+      input["artifactId"] = artifactId
+    }
+    input.removeValue(forKey: "agentRef")
+    input.removeValue(forKey: "artifactRef")
+    return input
+  }
+
+  private func summarizeAgentSessions(_ object: [String: Any]) -> String {
+    let sessions = object["sessions"] as? [[String: Any]] ?? []
+    if sessions.isEmpty { return "No canonical Omi agent sessions found." }
+
+    agentHandles.removeAll()
+    let rows = sessions.prefix(8).enumerated().map { index, summary -> String in
+      let agentRef = "agent_\(index + 1)"
+      let session = summary["session"] as? [String: Any] ?? [:]
+      let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
+      let latestAttempt = summary["latestAttempt"] as? [String: Any] ?? [:]
+      let title = stringValue(session["title"]) ?? stringValue(session["surfaceKind"]) ?? "Untitled agent"
+      let status = stringValue(latestRun["status"]) ?? stringValue(session["status"]) ?? "unknown"
+      let mode = stringValue(latestRun["mode"])
+      let updatedAt = stringValue(session["updatedAt"]) ?? stringValue(latestRun["updatedAt"])
+      agentHandles[agentRef] = AgentHandle(
+        sessionId: stringValue(session["omiSessionId"]) ?? stringValue(session["sessionId"]),
+        runId: stringValue(latestRun["runId"]),
+        attemptId: stringValue(latestAttempt["attemptId"])
+      )
+
+      var parts = ["\(agentRef): \(title)", status]
+      if let mode { parts.append("mode \(mode)") }
+      if let updatedAt { parts.append("updated \(updatedAt)") }
+      return "- \(parts.joined(separator: ", "))"
+    }.joined(separator: "\n")
+    let suffix = sessions.count > 8 ? "\nShowing 8 of \(sessions.count)." : ""
+    return "Canonical Omi agent sessions. Use agentRef values internally for follow-up tool calls; do not say them aloud.\n\(rows)\(suffix)"
+  }
+
+  private func summarizeAgentRun(_ object: [String: Any]) -> String {
+    let run = object["run"] as? [String: Any] ?? [:]
+    let attempts = object["attempts"] as? [[String: Any]] ?? []
+    let events = object["events"] as? [[String: Any]] ?? []
+    let status = stringValue(run["status"]) ?? "unknown"
+    let mode = stringValue(run["mode"]) ?? "unknown"
+    let terminalStatus = stringValue(run["terminalStatus"])
+    let terminalText = terminalStatus.map { ", terminal status \($0)" } ?? ""
+    return "The selected canonical run is \(status), mode \(mode)\(terminalText). Attempts: \(attempts.count). Events returned: \(events.count)."
+  }
+
+  private func summarizeAgentCancellation(_ object: [String: Any]) -> String {
+    let cancellation = object["cancellation"] as? [String: Any] ?? [:]
+    let run = object["run"] as? [String: Any] ?? [:]
+    let status = stringValue(run["status"]) ?? "unknown"
+    let accepted = cancellation["accepted"] as? Bool
+    let dispatched = cancellation["dispatched"] as? Bool
+    let acknowledged = cancellation["acknowledged"] as? Bool
+    return "Cancel request: accepted=\(accepted?.description ?? "unknown"), dispatched=\(dispatched?.description ?? "unknown"), acknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
+  }
+
+  private func summarizeAgentArtifacts(_ object: [String: Any]) -> String {
+    let artifacts = object["artifacts"] as? [[String: Any]] ?? []
+    if artifacts.isEmpty { return "No canonical agent artifacts found for that scope." }
+
+    artifactHandles.removeAll()
+    let rows = artifacts.prefix(8).enumerated().map { index, artifact -> String in
+      let artifactRef = "artifact_\(index + 1)"
+      if let artifactId = stringValue(artifact["artifactId"]) {
+        artifactHandles[artifactRef] = artifactId
+      }
+      let role = stringValue(artifact["role"]) ?? "unknown"
+      let state = stringValue(artifact["lifecycleState"]) ?? stringValue(artifact["state"]) ?? "unknown"
+      let name = stringValue(artifact["displayName"]) ?? stringValue(artifact["path"])
+      let label = name.map { "\($0), " } ?? ""
+      return "- \(artifactRef): \(label)role \(role), state \(state)"
+    }.joined(separator: "\n")
+    let suffix = artifacts.count > 8 ? "\nShowing 8 of \(artifacts.count)." : ""
+    return "Canonical agent artifacts. Use artifactRef values internally for follow-up tool calls; do not say them aloud.\n\(rows)\(suffix)"
+  }
+
+  private func summarizeArtifactLifecycle(_ object: [String: Any]) -> String {
+    let artifact = object["artifact"] as? [String: Any] ?? [:]
+    let state = stringValue(artifact["lifecycleState"]) ?? stringValue(artifact["state"]) ?? "unknown"
+    let changed = object["changed"] as? Bool
+    return "Artifact lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
+  }
+
+  private func hasCanonicalScope(_ arguments: [String: Any]) -> String {
+    for key in ["sessionId", "runId", "attemptId"] where stringValue(arguments[key]) != nil {
+      return "\(key)=present"
+    }
+    return ""
+  }
+
+  private func stringValue(_ value: Any?) -> String? {
+    guard let text = value as? String else { return nil }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -2,8 +2,6 @@ import Foundation
 
 @MainActor
 final class AgentControlService {
-  static let shared = AgentControlService()
-
   private enum ToolName {
     static let listAgentSessions = "list_agent_sessions"
     static let getAgentRun = "get_agent_run"
@@ -142,8 +140,8 @@ final class AgentControlService {
     let run = object["run"] as? [String: Any] ?? [:]
     let status = stringValue(run["status"]) ?? "unknown"
     let accepted = cancellation["accepted"] as? Bool
-    let dispatched = cancellation["dispatched"] as? Bool
-    let acknowledged = cancellation["acknowledged"] as? Bool
+    let dispatched = (cancellation["dispatchAttempted"] as? Bool) ?? (cancellation["dispatched"] as? Bool)
+    let acknowledged = (cancellation["adapterAcknowledged"] as? Bool) ?? (cancellation["acknowledged"] as? Bool)
     return "Cancel request: accepted=\(accepted?.description ?? "unknown"), dispatched=\(dispatched?.description ?? "unknown"), acknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -26,6 +26,9 @@ final class AgentControlService {
 
   func executeVoiceTool(name: String, arguments: [String: Any]) async throws -> String {
     let input = resolveVoiceHandles(in: arguments)
+    if let missing = missingScopeError(name: name, input: input) {
+      return missing
+    }
     let raw = try await runtime.directControlTool(
       clientId: "realtime-hub",
       harnessMode: Self.currentHarnessMode(),
@@ -33,6 +36,31 @@ final class AgentControlService {
       input: input
     )
     return summarizeVoiceResult(name: name, raw: raw)
+  }
+
+  /// Enforces the "agentRef or runId" / "artifactRef or artifactId" preconditions
+  /// that were previously expressed as root-level `anyOf` in the provider-facing
+  /// tool schemas. Keeping the schemas flat avoids provider compatibility issues
+  /// (some Realtime/Gemini environments reject or ignore root composite keywords),
+  /// while this guard gives the model a helpful voice message instead of a raw
+  /// runtime error when it omits the identifying reference.
+  func missingScopeError(name: String, input: [String: Any]) -> String? {
+    switch name {
+    case ToolName.getAgentRun, ToolName.cancelAgentRun:
+      let hasScope = stringValue(input["runId"]) != nil || stringValue(input["sessionId"]) != nil
+      return hasScope ? nil
+        : "I need an agent reference or run id for that. Try listing the agents first with list_agent_sessions."
+    case ToolName.inspectAgentArtifacts:
+      let hasScope = ["artifactId", "sessionId", "runId", "attemptId"].contains { stringValue(input[$0]) != nil }
+      return hasScope ? nil
+        : "I need an agent, artifact, session, run, or attempt reference to inspect artifacts. Try listing the agents first."
+    case ToolName.updateAgentArtifactLifecycle:
+      let hasArtifact = stringValue(input["artifactId"]) != nil
+      return hasArtifact ? nil
+        : "I need an artifact reference or id to update its lifecycle. Try inspecting the artifacts first."
+    default:
+      return nil
+    }
   }
 
   static func currentHarnessMode() -> String {

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -62,6 +62,7 @@ final class AgentControlService {
       return raw
     }
     if object["ok"] as? Bool == false {
+      clearVoiceHandles(for: name)
       return "Agent control failed. Try listing the agents again and retry with the matching item."
     }
     switch name {
@@ -80,7 +81,7 @@ final class AgentControlService {
     }
   }
 
-  private func resolveVoiceHandles(in arguments: [String: Any]) -> [String: Any] {
+  func resolveVoiceHandles(in arguments: [String: Any]) -> [String: Any] {
     var input = arguments
     if let agentRef = stringValue(input["agentRef"]), let handle = agentHandles[agentRef] {
       if input["sessionId"] == nil, let sessionId = handle.sessionId { input["sessionId"] = sessionId }
@@ -97,7 +98,10 @@ final class AgentControlService {
 
   private func summarizeAgentSessions(_ object: [String: Any]) -> String {
     let sessions = object["sessions"] as? [[String: Any]] ?? []
-    if sessions.isEmpty { return "No canonical Omi agent sessions found." }
+    if sessions.isEmpty {
+      agentHandles.removeAll()
+      return "No canonical Omi agent sessions found."
+    }
 
     agentHandles.removeAll()
     let rows = sessions.prefix(8).enumerated().map { index, summary -> String in
@@ -147,7 +151,10 @@ final class AgentControlService {
 
   private func summarizeAgentArtifacts(_ object: [String: Any]) -> String {
     let artifacts = object["artifacts"] as? [[String: Any]] ?? []
-    if artifacts.isEmpty { return "No canonical agent artifacts found for that scope." }
+    if artifacts.isEmpty {
+      artifactHandles.removeAll()
+      return "No canonical agent artifacts found for that scope."
+    }
 
     artifactHandles.removeAll()
     let rows = artifacts.prefix(8).enumerated().map { index, artifact -> String in
@@ -170,6 +177,17 @@ final class AgentControlService {
     let state = stringValue(artifact["lifecycleState"]) ?? stringValue(artifact["state"]) ?? "unknown"
     let changed = object["changed"] as? Bool
     return "Artifact lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
+  }
+
+  private func clearVoiceHandles(for name: String) {
+    switch name {
+    case ToolName.listAgentSessions:
+      agentHandles.removeAll()
+    case ToolName.inspectAgentArtifacts:
+      artifactHandles.removeAll()
+    default:
+      break
+    }
   }
 
   private func hasCanonicalScope(_ arguments: [String: Any]) -> String {

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -181,9 +181,12 @@ final class AgentControlService {
 
   private func clearVoiceHandles(for name: String) {
     switch name {
-    case ToolName.listAgentSessions:
+    case ToolName.listAgentSessions,
+      ToolName.getAgentRun,
+      ToolName.cancelAgentRun,
+      ToolName.inspectAgentArtifacts,
+      ToolName.updateAgentArtifactLifecycle:
       agentHandles.removeAll()
-    case ToolName.inspectAgentArtifacts:
       artifactHandles.removeAll()
     default:
       break

--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -108,15 +108,19 @@ final class AgentControlService {
       let agentRef = "agent_\(index + 1)"
       let session = summary["session"] as? [String: Any] ?? [:]
       let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
+      let activeRun = summary["activeRun"] as? [String: Any] ?? [:]
+      let selectedRun = activeRun.isEmpty ? latestRun : activeRun
       let latestAttempt = summary["latestAttempt"] as? [String: Any] ?? [:]
+      let activeAttempt = summary["activeAttempt"] as? [String: Any] ?? [:]
+      let selectedAttempt = activeRun.isEmpty ? latestAttempt : activeAttempt
       let title = stringValue(session["title"]) ?? stringValue(session["surfaceKind"]) ?? "Untitled agent"
-      let status = stringValue(latestRun["status"]) ?? stringValue(session["status"]) ?? "unknown"
-      let mode = stringValue(latestRun["mode"])
-      let updatedAt = stringValue(session["updatedAt"]) ?? stringValue(latestRun["updatedAt"])
+      let status = stringValue(selectedRun["status"]) ?? stringValue(session["status"]) ?? "unknown"
+      let mode = stringValue(selectedRun["mode"])
+      let updatedAt = stringValue(session["updatedAt"]) ?? stringValue(selectedRun["updatedAt"])
       agentHandles[agentRef] = AgentHandle(
         sessionId: stringValue(session["omiSessionId"]) ?? stringValue(session["sessionId"]),
-        runId: stringValue(latestRun["runId"]),
-        attemptId: stringValue(latestAttempt["attemptId"])
+        runId: stringValue(selectedRun["runId"]),
+        attemptId: stringValue(selectedAttempt["attemptId"])
       )
 
       var parts = ["\(agentRef): \(title)", status]

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -234,42 +234,6 @@ actor AgentRuntimeProcess {
     sendJson(dict)
   }
 
-  // Request-scoped control is only valid while Node has an active owner context
-  // for this exact client/request key. App surfaces should use directControlTool.
-  func requestScopedControlTool(
-    clientId: String,
-    harnessMode: String,
-    name: String,
-    input: [String: Any]
-  ) async throws -> String {
-    try await registerClient(clientId: clientId, harnessMode: harnessMode)
-
-    let requestId = UUID().uuidString
-    let requestKey = RuntimeMessage.RequestKey(clientId: clientId, requestId: requestId)
-    return try await withCheckedThrowingContinuation { continuation in
-      activeControlRequests[requestKey] = ActiveControlRequest(
-        clientId: clientId,
-        requestId: requestId,
-        continuation: continuation
-      )
-      var dict: [String: Any] = [
-        "type": "control_tool",
-        "protocolVersion": 2,
-        "requestId": requestId,
-        "clientId": clientId,
-        "name": name,
-        "input": input,
-      ]
-      if let ownerId = currentOwnerId() {
-        dict["ownerId"] = ownerId
-      }
-      let sent = sendJson(dict)
-      if !sent, let request = activeControlRequests.removeValue(forKey: requestKey) {
-        request.continuation.resume(throwing: BridgeError.agentError("Failed to send control tool request"))
-      }
-    }
-  }
-
   func directControlTool(
     clientId: String,
     harnessMode: String,

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -234,7 +234,9 @@ actor AgentRuntimeProcess {
     sendJson(dict)
   }
 
-  func controlTool(
+  // Request-scoped control is only valid while Node has an active owner context
+  // for this exact client/request key. App surfaces should use directControlTool.
+  func requestScopedControlTool(
     clientId: String,
     harnessMode: String,
     name: String,
@@ -264,6 +266,41 @@ actor AgentRuntimeProcess {
       let sent = sendJson(dict)
       if !sent, let request = activeControlRequests.removeValue(forKey: requestKey) {
         request.continuation.resume(throwing: BridgeError.agentError("Failed to send control tool request"))
+      }
+    }
+  }
+
+  func directControlTool(
+    clientId: String,
+    harnessMode: String,
+    name: String,
+    input: [String: Any]
+  ) async throws -> String {
+    guard let ownerId = currentOwnerId() else {
+      throw BridgeError.agentError("Agent control requires a signed-in owner")
+    }
+    try await registerClient(clientId: clientId, harnessMode: harnessMode)
+
+    let requestId = UUID().uuidString
+    let requestKey = RuntimeMessage.RequestKey(clientId: clientId, requestId: requestId)
+    return try await withCheckedThrowingContinuation { continuation in
+      activeControlRequests[requestKey] = ActiveControlRequest(
+        clientId: clientId,
+        requestId: requestId,
+        continuation: continuation
+      )
+      let dict: [String: Any] = [
+        "type": "direct_control_tool",
+        "protocolVersion": 2,
+        "requestId": requestId,
+        "clientId": clientId,
+        "name": name,
+        "input": input,
+        "ownerId": ownerId,
+      ]
+      let sent = sendJson(dict)
+      if !sent, let request = activeControlRequests.removeValue(forKey: requestKey) {
+        request.continuation.resume(throwing: BridgeError.agentError("Failed to send direct control tool request"))
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -207,17 +207,17 @@ enum DesktopCapabilityRegistry {
       toolName: "list_agent_sessions",
       title: "List Agent Sessions",
       latency: .fastLocal,
-      surfaces: [.desktopChat],
+      surfaces: [.desktopChat, .realtimeHub],
       summary: "List Omi-managed agent sessions from the local runtime kernel.",
       bullets: [
-        "Use for current or recent kernel-backed Omi agents/subagents across main chat, task chat, and any future migrated floating-pill sessions.",
+        "Use for current or recent kernel-backed Omi agents/subagents across chat, PTT/realtime, task chat, and any future migrated floating-pill sessions.",
         "Returns durable Omi session IDs, latest/active run summaries, and adapter binding metadata."
       ]),
     Capability(
       toolName: "get_agent_run",
       title: "Get Agent Run",
       latency: .fastLocal,
-      surfaces: [.desktopChat],
+      surfaces: [.desktopChat, .realtimeHub],
       summary: "Inspect one canonical Omi agent run.",
       bullets: [
         "Use a runId from list_agent_sessions or a correlated Omi result.",
@@ -227,7 +227,7 @@ enum DesktopCapabilityRegistry {
       toolName: "cancel_agent_run",
       title: "Cancel Agent Run",
       latency: .fastLocal,
-      surfaces: [.desktopChat],
+      surfaces: [.desktopChat, .realtimeHub],
       summary: "Request cancellation for one canonical Omi agent run through the runtime kernel.",
       bullets: [
         "Use when the user asks to stop a running Omi agent/subagent.",
@@ -237,7 +237,7 @@ enum DesktopCapabilityRegistry {
       toolName: "inspect_agent_artifacts",
       title: "Inspect Agent Artifacts",
       latency: .fastLocal,
-      surfaces: [.desktopChat],
+      surfaces: [.desktopChat, .realtimeHub],
       summary: "Inspect canonical artifact metadata for an Omi agent session, run, or attempt.",
       bullets: [
         "Returns artifact references and metadata only.",
@@ -247,7 +247,7 @@ enum DesktopCapabilityRegistry {
       toolName: "update_agent_artifact_lifecycle",
       title: "Update Agent Artifact Lifecycle",
       latency: .fastLocal,
-      surfaces: [.desktopChat],
+      surfaces: [.desktopChat, .realtimeHub],
       summary: "Update metadata-only lifecycle state for one canonical Omi agent artifact.",
       bullets: [
         "Use to mark artifact metadata as retained, dismissed, or opened after a user-visible artifact decision.",
@@ -378,6 +378,8 @@ enum DesktopCapabilityRegistry {
     Omi capability model:
     - You can read Omi data quickly with fast tools: tasks, memories, conversations, daily recaps, and screen history.
     - You can inspect your local task-chat agents/subagents and floating agent pills with get_task_agent_status. If the user asks about your subagents, background agents, running agents, finished agents, or task-agent errors/timeouts, call it before answering.
+    - You can inspect and stop canonical Omi-managed agent sessions/runs with list_agent_sessions, get_agent_run, and cancel_agent_run. Use these for agents created in chat, PTT/realtime, task chat, or any other Omi surface when a canonical run id is available.
+    - You can inspect canonical agent output references with inspect_agent_artifacts and mark artifact metadata with update_agent_artifact_lifecycle.
     - You can manage circular floating agent pills with manage_agent_pills after checking status.
     - You can start a background agent with spawn_agent for multi-step work or acting in the user's other apps. Merely saying you will start an agent does not start one; emitting spawn_agent does.
     """

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -737,45 +737,49 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let session = summary["session"] as? [String: Any] ?? [:]
       let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
       let title = (session["title"] as? String) ?? (session["surfaceKind"] as? String) ?? "Untitled agent"
-      let sessionId = (session["omiSessionId"] as? String) ?? (session["sessionId"] as? String) ?? "unknown-session"
-      let runId = (latestRun["runId"] as? String) ?? "no-run"
       let status = (latestRun["status"] as? String) ?? (session["status"] as? String) ?? "unknown"
-      return "- \(title): \(status), sessionId=\(sessionId), runId=\(runId)"
+      return "- \(title): \(status)"
+    }.joined(separator: "\n")
+    let handles = sessions.prefix(8).compactMap { summary -> String? in
+      let session = summary["session"] as? [String: Any] ?? [:]
+      let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
+      let title = (session["title"] as? String) ?? (session["surfaceKind"] as? String) ?? "Untitled agent"
+      let sessionId = (session["omiSessionId"] as? String) ?? (session["sessionId"] as? String)
+      let runId = latestRun["runId"] as? String
+      let parts = [sessionId.map { "sessionId=\($0)" }, runId.map { "runId=\($0)" }].compactMap { $0 }
+      return parts.isEmpty ? nil : "- \(title): \(parts.joined(separator: ", "))"
     }.joined(separator: "\n")
     let suffix = sessions.count > 8 ? "\nShowing 8 of \(sessions.count)." : ""
-    return "Canonical Omi agent sessions:\n\(rows)\(suffix)"
+    let handleNote = handles.isEmpty ? "" : "\nFollow-up handles for tool calls only; do not read aloud:\n\(handles)"
+    return "Canonical Omi agent sessions:\n\(rows)\(suffix)\(handleNote)"
   }
 
   private static func summarizeAgentRun(_ object: [String: Any]) -> String {
     let run = object["run"] as? [String: Any] ?? [:]
     let attempts = object["attempts"] as? [[String: Any]] ?? []
-    let runId = (run["runId"] as? String) ?? "unknown-run"
-    let sessionId = (run["omiSessionId"] as? String) ?? (run["sessionId"] as? String) ?? "unknown-session"
     let status = (run["status"] as? String) ?? "unknown"
     let mode = (run["mode"] as? String) ?? "unknown"
     let events = object["events"] as? [[String: Any]] ?? []
-    return "Canonical run \(runId) is \(status) in session \(sessionId), mode \(mode). Attempts: \(attempts.count). Events returned: \(events.count)."
+    return "Canonical run is \(status), mode \(mode). Attempts: \(attempts.count). Events returned: \(events.count)."
   }
 
   private static func summarizeAgentCancellation(_ object: [String: Any]) -> String {
     let cancellation = object["cancellation"] as? [String: Any] ?? [:]
     let run = object["run"] as? [String: Any] ?? [:]
-    let runId = (run["runId"] as? String) ?? "unknown-run"
     let status = (run["status"] as? String) ?? "unknown"
     let accepted = cancellation["accepted"] as? Bool
-    let dispatched = cancellation["dispatched"] as? Bool
-    let acknowledged = cancellation["acknowledged"] as? Bool
-    return "Cancel request for run \(runId): accepted=\(accepted?.description ?? "unknown"), dispatched=\(dispatched?.description ?? "unknown"), acknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
+    let dispatched = cancellation["dispatchAttempted"] as? Bool
+    let acknowledged = cancellation["adapterAcknowledged"] as? Bool
+    return "Cancel request: accepted=\(accepted?.description ?? "unknown"), dispatchAttempted=\(dispatched?.description ?? "unknown"), adapterAcknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
   }
 
   private static func summarizeAgentArtifacts(_ object: [String: Any]) -> String {
     let artifacts = object["artifacts"] as? [[String: Any]] ?? []
     if artifacts.isEmpty { return "No canonical agent artifacts found for that scope." }
     let rows = artifacts.prefix(8).map { artifact -> String in
-      let artifactId = (artifact["artifactId"] as? String) ?? "unknown-artifact"
       let role = (artifact["role"] as? String) ?? "unknown"
       let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
-      return "- artifactId=\(artifactId), role=\(role), state=\(state)"
+      return "- role=\(role), state=\(state)"
     }.joined(separator: "\n")
     let suffix = artifacts.count > 8 ? "\nShowing 8 of \(artifacts.count)." : ""
     return "Canonical agent artifacts:\n\(rows)\(suffix)"
@@ -783,10 +787,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
   private static func summarizeArtifactLifecycle(_ object: [String: Any]) -> String {
     let artifact = object["artifact"] as? [String: Any] ?? [:]
-    let artifactId = (artifact["artifactId"] as? String) ?? "unknown-artifact"
     let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
     let changed = object["changed"] as? Bool
-    return "Artifact \(artifactId) lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
+    return "Artifact lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
   }
 
   func hubDidFinishTurn() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -59,6 +59,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   private var sessionProvider: RealtimeHubProvider?
   private var pcmPlayer: StreamingPCMPlayer?
   private let speech = AVSpeechSynthesizer()
+  private let agentControlService = AgentControlService()
 
   // Per-turn state.
   private var turnTranscript = ""
@@ -565,11 +566,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       session?.sendToolResult(callId: callId, name: name, output: result)
     case .listAgentSessions, .getAgentRun, .cancelAgentRun, .inspectAgentArtifacts, .updateAgentArtifactLifecycle:
       runToolAndSpeak(
-        callId: callId, name: name, detail: AgentControlService.shared.logDetail(name: name, arguments: arguments),
+        callId: callId, name: name, detail: agentControlService.logDetail(name: name, arguments: arguments),
         emptyText: "No canonical agent data came back.",
         errorText: "Could not reach the agent control plane right now."
       ) {
-        try await AgentControlService.shared.executeVoiceTool(name: name, arguments: arguments)
+        try await self.agentControlService.executeVoiceTool(name: name, arguments: arguments)
       }
     case .searchScreenHistory:
       // Fast LOCAL semantic search over screen history (same executor as chat).

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -565,11 +565,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       session?.sendToolResult(callId: callId, name: name, output: result)
     case .listAgentSessions, .getAgentRun, .cancelAgentRun, .inspectAgentArtifacts, .updateAgentArtifactLifecycle:
       runToolAndSpeak(
-        callId: callId, name: name, detail: canonicalAgentControlLogDetail(tool: tool, arguments: arguments),
+        callId: callId, name: name, detail: AgentControlService.shared.logDetail(name: name, arguments: arguments),
         emptyText: "No canonical agent data came back.",
         errorText: "Could not reach the agent control plane right now."
       ) {
-        try await Self.executeCanonicalAgentControlTool(name: name, arguments: arguments)
+        try await AgentControlService.shared.executeVoiceTool(name: name, arguments: arguments)
       }
     case .searchScreenHistory:
       // Fast LOCAL semantic search over screen history (same executor as chat).
@@ -664,132 +664,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         callId: callId, name: name,
         output: ok ? "Clicked at \(Int(x)), \(Int(y))." : "Could not click.")
     }
-  }
-
-  private func canonicalAgentControlLogDetail(tool: HubTool, arguments: [String: Any]) -> String {
-    switch tool {
-    case .getAgentRun, .cancelAgentRun:
-      if let runId = (arguments["runId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !runId.isEmpty {
-        return "runId=\(runId.prefix(12))"
-      }
-    case .inspectAgentArtifacts:
-      for key in ["sessionId", "runId", "attemptId"] {
-        if let value = (arguments[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
-          return "\(key)=\(value.prefix(12))"
-        }
-      }
-    case .updateAgentArtifactLifecycle:
-      if let artifactId = (arguments["artifactId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !artifactId.isEmpty {
-        return "artifactId=\(artifactId.prefix(12))"
-      }
-    default:
-      break
-    }
-    return ""
-  }
-
-  private static func executeCanonicalAgentControlTool(name: String, arguments: [String: Any]) async throws -> String {
-    let harness = currentAgentHarnessMode()
-    let raw = try await AgentRuntimeProcess.shared.controlTool(
-      clientId: "realtime-hub",
-      harnessMode: harness,
-      name: name,
-      input: arguments
-    )
-    return summarizeCanonicalAgentControlResult(name: name, raw: raw)
-  }
-
-  private static func currentAgentHarnessMode() -> String {
-    let mode = UserDefaults.standard.string(forKey: "chatBridgeMode") ?? "piMono"
-    return mode == "piMono" ? "piMono" : "acp"
-  }
-
-  private static func summarizeCanonicalAgentControlResult(name: String, raw: String) -> String {
-    guard let data = raw.data(using: .utf8),
-      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-    else {
-      return raw
-    }
-    if object["ok"] as? Bool == false {
-      let error = object["error"] as? [String: Any]
-      return "Agent control failed: \(error?["message"] as? String ?? "unknown error")."
-    }
-    switch name {
-    case HubTool.listAgentSessions.rawValue:
-      return summarizeAgentSessions(object)
-    case HubTool.getAgentRun.rawValue:
-      return summarizeAgentRun(object)
-    case HubTool.cancelAgentRun.rawValue:
-      return summarizeAgentCancellation(object)
-    case HubTool.inspectAgentArtifacts.rawValue:
-      return summarizeAgentArtifacts(object)
-    case HubTool.updateAgentArtifactLifecycle.rawValue:
-      return summarizeArtifactLifecycle(object)
-    default:
-      return raw
-    }
-  }
-
-  private static func summarizeAgentSessions(_ object: [String: Any]) -> String {
-    let sessions = object["sessions"] as? [[String: Any]] ?? []
-    if sessions.isEmpty { return "No canonical Omi agent sessions found." }
-    let rows = sessions.prefix(8).map { summary -> String in
-      let session = summary["session"] as? [String: Any] ?? [:]
-      let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
-      let title = (session["title"] as? String) ?? (session["surfaceKind"] as? String) ?? "Untitled agent"
-      let status = (latestRun["status"] as? String) ?? (session["status"] as? String) ?? "unknown"
-      return "- \(title): \(status)"
-    }.joined(separator: "\n")
-    let handles = sessions.prefix(8).compactMap { summary -> String? in
-      let session = summary["session"] as? [String: Any] ?? [:]
-      let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
-      let title = (session["title"] as? String) ?? (session["surfaceKind"] as? String) ?? "Untitled agent"
-      let sessionId = (session["omiSessionId"] as? String) ?? (session["sessionId"] as? String)
-      let runId = latestRun["runId"] as? String
-      let parts = [sessionId.map { "sessionId=\($0)" }, runId.map { "runId=\($0)" }].compactMap { $0 }
-      return parts.isEmpty ? nil : "- \(title): \(parts.joined(separator: ", "))"
-    }.joined(separator: "\n")
-    let suffix = sessions.count > 8 ? "\nShowing 8 of \(sessions.count)." : ""
-    let handleNote = handles.isEmpty ? "" : "\nFollow-up handles for tool calls only; do not read aloud:\n\(handles)"
-    return "Canonical Omi agent sessions:\n\(rows)\(suffix)\(handleNote)"
-  }
-
-  private static func summarizeAgentRun(_ object: [String: Any]) -> String {
-    let run = object["run"] as? [String: Any] ?? [:]
-    let attempts = object["attempts"] as? [[String: Any]] ?? []
-    let status = (run["status"] as? String) ?? "unknown"
-    let mode = (run["mode"] as? String) ?? "unknown"
-    let events = object["events"] as? [[String: Any]] ?? []
-    return "Canonical run is \(status), mode \(mode). Attempts: \(attempts.count). Events returned: \(events.count)."
-  }
-
-  private static func summarizeAgentCancellation(_ object: [String: Any]) -> String {
-    let cancellation = object["cancellation"] as? [String: Any] ?? [:]
-    let run = object["run"] as? [String: Any] ?? [:]
-    let status = (run["status"] as? String) ?? "unknown"
-    let accepted = cancellation["accepted"] as? Bool
-    let dispatched = cancellation["dispatchAttempted"] as? Bool
-    let acknowledged = cancellation["adapterAcknowledged"] as? Bool
-    return "Cancel request: accepted=\(accepted?.description ?? "unknown"), dispatchAttempted=\(dispatched?.description ?? "unknown"), adapterAcknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
-  }
-
-  private static func summarizeAgentArtifacts(_ object: [String: Any]) -> String {
-    let artifacts = object["artifacts"] as? [[String: Any]] ?? []
-    if artifacts.isEmpty { return "No canonical agent artifacts found for that scope." }
-    let rows = artifacts.prefix(8).map { artifact -> String in
-      let role = (artifact["role"] as? String) ?? "unknown"
-      let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
-      return "- role=\(role), state=\(state)"
-    }.joined(separator: "\n")
-    let suffix = artifacts.count > 8 ? "\nShowing 8 of \(artifacts.count)." : ""
-    return "Canonical agent artifacts:\n\(rows)\(suffix)"
-  }
-
-  private static func summarizeArtifactLifecycle(_ object: [String: Any]) -> String {
-    let artifact = object["artifact"] as? [String: Any] ?? [:]
-    let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
-    let changed = object["changed"] as? Bool
-    return "Artifact lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
   }
 
   func hubDidFinishTurn() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -563,6 +563,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       let result = AgentPillsManager.shared.manage(action: action, agentId: agentId)
       log("RealtimeHub[\(providerTag)]: tool manage_agent_pills action=\(action)")
       session?.sendToolResult(callId: callId, name: name, output: result)
+    case .listAgentSessions, .getAgentRun, .cancelAgentRun, .inspectAgentArtifacts, .updateAgentArtifactLifecycle:
+      runToolAndSpeak(
+        callId: callId, name: name, detail: canonicalAgentControlLogDetail(tool: tool, arguments: arguments),
+        emptyText: "No canonical agent data came back.",
+        errorText: "Could not reach the agent control plane right now."
+      ) {
+        try await Self.executeCanonicalAgentControlTool(name: name, arguments: arguments)
+      }
     case .searchScreenHistory:
       // Fast LOCAL semantic search over screen history (same executor as chat).
       let query = arg("query")
@@ -656,6 +664,129 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         callId: callId, name: name,
         output: ok ? "Clicked at \(Int(x)), \(Int(y))." : "Could not click.")
     }
+  }
+
+  private func canonicalAgentControlLogDetail(tool: HubTool, arguments: [String: Any]) -> String {
+    switch tool {
+    case .getAgentRun, .cancelAgentRun:
+      if let runId = (arguments["runId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !runId.isEmpty {
+        return "runId=\(runId.prefix(12))"
+      }
+    case .inspectAgentArtifacts:
+      for key in ["sessionId", "runId", "attemptId"] {
+        if let value = (arguments[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+          return "\(key)=\(value.prefix(12))"
+        }
+      }
+    case .updateAgentArtifactLifecycle:
+      if let artifactId = (arguments["artifactId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !artifactId.isEmpty {
+        return "artifactId=\(artifactId.prefix(12))"
+      }
+    default:
+      break
+    }
+    return ""
+  }
+
+  private static func executeCanonicalAgentControlTool(name: String, arguments: [String: Any]) async throws -> String {
+    let harness = currentAgentHarnessMode()
+    let raw = try await AgentRuntimeProcess.shared.controlTool(
+      clientId: "realtime-hub",
+      harnessMode: harness,
+      name: name,
+      input: arguments
+    )
+    return summarizeCanonicalAgentControlResult(name: name, raw: raw)
+  }
+
+  private static func currentAgentHarnessMode() -> String {
+    let mode = UserDefaults.standard.string(forKey: "chatBridgeMode") ?? "piMono"
+    return mode == "piMono" ? "piMono" : "acp"
+  }
+
+  private static func summarizeCanonicalAgentControlResult(name: String, raw: String) -> String {
+    guard let data = raw.data(using: .utf8),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return raw
+    }
+    if object["ok"] as? Bool == false {
+      let error = object["error"] as? [String: Any]
+      return "Agent control failed: \(error?["message"] as? String ?? "unknown error")."
+    }
+    switch name {
+    case HubTool.listAgentSessions.rawValue:
+      return summarizeAgentSessions(object)
+    case HubTool.getAgentRun.rawValue:
+      return summarizeAgentRun(object)
+    case HubTool.cancelAgentRun.rawValue:
+      return summarizeAgentCancellation(object)
+    case HubTool.inspectAgentArtifacts.rawValue:
+      return summarizeAgentArtifacts(object)
+    case HubTool.updateAgentArtifactLifecycle.rawValue:
+      return summarizeArtifactLifecycle(object)
+    default:
+      return raw
+    }
+  }
+
+  private static func summarizeAgentSessions(_ object: [String: Any]) -> String {
+    let sessions = object["sessions"] as? [[String: Any]] ?? []
+    if sessions.isEmpty { return "No canonical Omi agent sessions found." }
+    let rows = sessions.prefix(8).map { summary -> String in
+      let session = summary["session"] as? [String: Any] ?? [:]
+      let latestRun = summary["latestRun"] as? [String: Any] ?? [:]
+      let title = (session["title"] as? String) ?? (session["surfaceKind"] as? String) ?? "Untitled agent"
+      let sessionId = (session["omiSessionId"] as? String) ?? (session["sessionId"] as? String) ?? "unknown-session"
+      let runId = (latestRun["runId"] as? String) ?? "no-run"
+      let status = (latestRun["status"] as? String) ?? (session["status"] as? String) ?? "unknown"
+      return "- \(title): \(status), sessionId=\(sessionId), runId=\(runId)"
+    }.joined(separator: "\n")
+    let suffix = sessions.count > 8 ? "\nShowing 8 of \(sessions.count)." : ""
+    return "Canonical Omi agent sessions:\n\(rows)\(suffix)"
+  }
+
+  private static func summarizeAgentRun(_ object: [String: Any]) -> String {
+    let run = object["run"] as? [String: Any] ?? [:]
+    let attempts = object["attempts"] as? [[String: Any]] ?? []
+    let runId = (run["runId"] as? String) ?? "unknown-run"
+    let sessionId = (run["omiSessionId"] as? String) ?? (run["sessionId"] as? String) ?? "unknown-session"
+    let status = (run["status"] as? String) ?? "unknown"
+    let mode = (run["mode"] as? String) ?? "unknown"
+    let events = object["events"] as? [[String: Any]] ?? []
+    return "Canonical run \(runId) is \(status) in session \(sessionId), mode \(mode). Attempts: \(attempts.count). Events returned: \(events.count)."
+  }
+
+  private static func summarizeAgentCancellation(_ object: [String: Any]) -> String {
+    let cancellation = object["cancellation"] as? [String: Any] ?? [:]
+    let run = object["run"] as? [String: Any] ?? [:]
+    let runId = (run["runId"] as? String) ?? "unknown-run"
+    let status = (run["status"] as? String) ?? "unknown"
+    let accepted = cancellation["accepted"] as? Bool
+    let dispatched = cancellation["dispatched"] as? Bool
+    let acknowledged = cancellation["acknowledged"] as? Bool
+    return "Cancel request for run \(runId): accepted=\(accepted?.description ?? "unknown"), dispatched=\(dispatched?.description ?? "unknown"), acknowledged=\(acknowledged?.description ?? "unknown"). Current status: \(status)."
+  }
+
+  private static func summarizeAgentArtifacts(_ object: [String: Any]) -> String {
+    let artifacts = object["artifacts"] as? [[String: Any]] ?? []
+    if artifacts.isEmpty { return "No canonical agent artifacts found for that scope." }
+    let rows = artifacts.prefix(8).map { artifact -> String in
+      let artifactId = (artifact["artifactId"] as? String) ?? "unknown-artifact"
+      let role = (artifact["role"] as? String) ?? "unknown"
+      let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
+      return "- artifactId=\(artifactId), role=\(role), state=\(state)"
+    }.joined(separator: "\n")
+    let suffix = artifacts.count > 8 ? "\nShowing 8 of \(artifacts.count)." : ""
+    return "Canonical agent artifacts:\n\(rows)\(suffix)"
+  }
+
+  private static func summarizeArtifactLifecycle(_ object: [String: Any]) -> String {
+    let artifact = object["artifact"] as? [String: Any] ?? [:]
+    let artifactId = (artifact["artifactId"] as? String) ?? "unknown-artifact"
+    let state = (artifact["lifecycleState"] as? String) ?? (artifact["state"] as? String) ?? "unknown"
+    let changed = object["changed"] as? Bool
+    return "Artifact \(artifactId) lifecycle is now \(state). Changed: \(changed?.description ?? "unknown")."
   }
 
   func hubDidFinishTurn() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -129,6 +129,11 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .getActionItems: stub = "Open: Buy milk (due tomorrow). Completed: Ship the PR."
     case .getTaskAgentStatus: stub = #"{"task_agents":[],"floating_agent_pills":[]}"#
     case .manageAgentPills: stub = "No floating agent pills are running or recently finished."
+    case .listAgentSessions: stub = "Canonical Omi agent sessions:\n- Example agent: running, sessionId=session_123, runId=run_123"
+    case .getAgentRun: stub = "Canonical run run_123 is running in session session_123, mode ask. Attempts: 1. Events returned: 3."
+    case .cancelAgentRun: stub = "Cancel request for run run_123: accepted=true, dispatched=true, acknowledged=true. Current status: cancelling."
+    case .inspectAgentArtifacts: stub = "Canonical agent artifacts:\n- artifactId=artifact_123, role=result, state=retained"
+    case .updateAgentArtifactLifecycle: stub = "Artifact artifact_123 lifecycle is now retained. Changed: true."
     case .getDailyRecap: stub = "Yesterday: 3 hrs in Xcode, 1 hr in Safari; 2 conversations; 1 task created."
     case .searchScreenHistory: stub = "Found it: yesterday afternoon you were reading the launch doc in Safari."
     case .createActionItem: stub = "Created task: Example task."

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -129,11 +129,13 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .getActionItems: stub = "Open: Buy milk (due tomorrow). Completed: Ship the PR."
     case .getTaskAgentStatus: stub = #"{"task_agents":[],"floating_agent_pills":[]}"#
     case .manageAgentPills: stub = "No floating agent pills are running or recently finished."
-    case .listAgentSessions: stub = "Canonical Omi agent sessions:\n- Example agent: running, sessionId=session_123, runId=run_123"
-    case .getAgentRun: stub = "Canonical run run_123 is running in session session_123, mode ask. Attempts: 1. Events returned: 3."
-    case .cancelAgentRun: stub = "Cancel request for run run_123: accepted=true, dispatched=true, acknowledged=true. Current status: cancelling."
-    case .inspectAgentArtifacts: stub = "Canonical agent artifacts:\n- artifactId=artifact_123, role=result, state=retained"
-    case .updateAgentArtifactLifecycle: stub = "Artifact artifact_123 lifecycle is now retained. Changed: true."
+    case .listAgentSessions:
+      stub = "Canonical Omi agent sessions. Use agentRef values internally for follow-up tool calls; do not say them aloud.\n- agent_1: Example agent, running"
+    case .getAgentRun: stub = "The selected canonical run is running, mode ask. Attempts: 1. Events returned: 3."
+    case .cancelAgentRun: stub = "Cancel request: accepted=true, dispatched=true, acknowledged=true. Current status: cancelling."
+    case .inspectAgentArtifacts:
+      stub = "Canonical agent artifacts. Use artifactRef values internally for follow-up tool calls; do not say them aloud.\n- artifact_1: role result, state retained"
+    case .updateAgentArtifactLifecycle: stub = "Artifact lifecycle is now retained. Changed: true."
     case .getDailyRecap: stub = "Yesterday: 3 hrs in Xcode, 1 hr in Safari; 2 conversations; 1 task created."
     case .searchScreenHistory: stub = "Found it: yesterday afternoon you were reading the launch doc in Safari."
     case .createActionItem: stub = "Created task: Example task."

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -389,10 +389,6 @@ enum RealtimeHubTools {
             "includeEvents": ["type": "boolean", "description": "Include ordered kernel events. Default true."],
             "eventLimit": ["type": "number", "description": "Maximum events to return. Default 100."],
           ],
-          "anyOf": [
-            ["required": ["agentRef"]],
-            ["required": ["runId"]],
-          ],
         ],
       ],
       [
@@ -405,10 +401,6 @@ enum RealtimeHubTools {
           "properties": [
             "agentRef": ["type": "string", "description": "Opaque agent handle from list_agent_sessions."],
             "runId": ["type": "string", "description": "Canonical Omi run id to cancel."]
-          ],
-          "anyOf": [
-            ["required": ["agentRef"]],
-            ["required": ["runId"]],
           ],
         ],
       ],
@@ -433,14 +425,6 @@ enum RealtimeHubTools {
             ],
             "limit": ["type": "number", "description": "Maximum artifacts to return. Default 50."],
           ],
-          "anyOf": [
-            ["required": ["agentRef"]],
-            ["required": ["artifactRef"]],
-            ["required": ["artifactId"]],
-            ["required": ["sessionId"]],
-            ["required": ["runId"]],
-            ["required": ["attemptId"]],
-          ],
         ],
       ],
       [
@@ -464,10 +448,6 @@ enum RealtimeHubTools {
             "reason": ["type": "string", "description": "Optional short reason."],
           ],
           "required": ["state"],
-          "anyOf": [
-            ["required": ["artifactRef"]],
-            ["required": ["artifactId"]],
-          ],
         ],
       ],
       [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -363,6 +363,7 @@ enum RealtimeHubTools {
             ],
             "surfaceKind": [
               "type": "string",
+              "enum": ["main_chat", "task_chat", "realtime", "delegated_agent"],
               "description": "Optional surface filter such as main_chat, task_chat, realtime, or delegated_agent.",
             ],
             "limit": [
@@ -417,6 +418,11 @@ enum RealtimeHubTools {
               "description": "Optional artifact role filter.",
             ],
             "limit": ["type": "number", "description": "Maximum artifacts to return. Default 50."],
+          ],
+          "anyOf": [
+            ["required": ["sessionId"]],
+            ["required": ["runId"]],
+            ["required": ["attemptId"]],
           ],
         ],
       ],

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -28,6 +28,16 @@ enum HubTool: String {
   case getTaskAgentStatus = "get_task_agent_status"
   /// Manage floating-bar agent pills. Fast local action.
   case manageAgentPills = "manage_agent_pills"
+  /// List canonical Omi-managed agent sessions and runs.
+  case listAgentSessions = "list_agent_sessions"
+  /// Inspect one canonical Omi-managed agent run.
+  case getAgentRun = "get_agent_run"
+  /// Request cancellation for one canonical Omi-managed agent run.
+  case cancelAgentRun = "cancel_agent_run"
+  /// Inspect metadata for canonical Omi-managed agent artifacts.
+  case inspectAgentArtifacts = "inspect_agent_artifacts"
+  /// Update metadata-only lifecycle state for a canonical Omi-managed artifact.
+  case updateAgentArtifactLifecycle = "update_agent_artifact_lifecycle"
   /// Read what Omi knows about the user (memories / facts) and return it inline to speak.
   /// Fast synchronous READ — the answer to "who am I" / "what do you know about me".
   case getMemories = "get_memories"
@@ -335,6 +345,101 @@ enum RealtimeHubTools {
             ],
           ],
           "required": ["action"],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.listAgentSessions.rawValue,
+        "description":
+          "List canonical Omi-managed agent sessions/runs across chat, PTT/realtime, task chat, and migrated surfaces. "
+          + "Use when the user asks what canonical agents or subagents are active, recent, failed, or manageable.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "status": [
+              "type": "string",
+              "enum": ["open", "archived", "closed"],
+              "description": "Optional session status filter.",
+            ],
+            "surfaceKind": [
+              "type": "string",
+              "description": "Optional surface filter such as main_chat, task_chat, realtime, or delegated_agent.",
+            ],
+            "limit": [
+              "type": "number",
+              "description": "Maximum sessions to return. Default 50.",
+            ],
+          ],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.getAgentRun.rawValue,
+        "description":
+          "Inspect one canonical Omi-managed agent run by runId. Use a runId from list_agent_sessions or a correlated Omi response.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "runId": ["type": "string", "description": "Canonical Omi run id."],
+            "includeEvents": ["type": "boolean", "description": "Include ordered kernel events. Default true."],
+            "eventLimit": ["type": "number", "description": "Maximum events to return. Default 100."],
+          ],
+          "required": ["runId"],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.cancelAgentRun.rawValue,
+        "description":
+          "Request cancellation for one canonical Omi-managed agent run. Use when the user asks to stop or kill a running canonical agent/subagent.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "runId": ["type": "string", "description": "Canonical Omi run id to cancel."]
+          ],
+          "required": ["runId"],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.inspectAgentArtifacts.rawValue,
+        "description":
+          "Inspect metadata and references for canonical Omi-managed agent artifacts. Does not read arbitrary artifact contents.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "sessionId": ["type": "string", "description": "Canonical Omi session id."],
+            "runId": ["type": "string", "description": "Canonical Omi run id."],
+            "attemptId": ["type": "string", "description": "Canonical Omi attempt id."],
+            "role": [
+              "type": "string",
+              "enum": ["input", "result", "checkpoint", "tool_output", "log", "other"],
+              "description": "Optional artifact role filter.",
+            ],
+            "limit": ["type": "number", "description": "Maximum artifacts to return. Default 50."],
+          ],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.updateAgentArtifactLifecycle.rawValue,
+        "description":
+          "Update metadata-only lifecycle state for one canonical Omi-managed agent artifact. Does not open, delete, retain, or read files.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "artifactId": ["type": "string", "description": "Canonical Omi artifact id."],
+            "state": [
+              "type": "string",
+              "enum": ["retained", "dismissed", "opened"],
+              "description": "Target metadata lifecycle state.",
+            ],
+            "sessionId": ["type": "string", "description": "Optional canonical Omi session id scope guard."],
+            "runId": ["type": "string", "description": "Optional canonical Omi run id scope guard."],
+            "attemptId": ["type": "string", "description": "Optional canonical Omi attempt id scope guard."],
+            "reason": ["type": "string", "description": "Optional short reason."],
+          ],
+          "required": ["artifactId", "state"],
         ],
       ],
       [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -165,6 +165,9 @@ enum RealtimeHubTools {
     referring to); then speak a natural, spoken-length version of what comes back.
     - When you need to see what's on screen, call screenshot first. Use point_click only \
     when the user clearly asks you to click something.
+    - For canonical Omi agent/subagent management, call list_agent_sessions first, then use \
+    its agentRef values internally for get_agent_run, cancel_agent_run, or artifact inspection. \
+    Never read agentRef, artifactRef, canonical IDs, or tool JSON aloud.
 
     Keep latency low: prefer answering directly when you can.
     """
@@ -363,8 +366,8 @@ enum RealtimeHubTools {
             ],
             "surfaceKind": [
               "type": "string",
-              "enum": ["main_chat", "task_chat", "realtime", "delegated_agent"],
-              "description": "Optional surface filter such as main_chat, task_chat, realtime, or delegated_agent.",
+              "enum": ["main_chat", "task_chat", "realtime", "delegated_agent", "floating_pill"],
+              "description": "Optional canonical surface filter.",
             ],
             "limit": [
               "type": "number",
@@ -377,15 +380,19 @@ enum RealtimeHubTools {
         "type": "function",
         "name": HubTool.getAgentRun.rawValue,
         "description":
-          "Inspect one canonical Omi-managed agent run by runId. Use a runId from list_agent_sessions or a correlated Omi response.",
+          "Inspect one canonical Omi-managed agent run. Prefer an agentRef from list_agent_sessions.",
         "parameters": [
           "type": "object",
           "properties": [
+            "agentRef": ["type": "string", "description": "Opaque agent handle from list_agent_sessions."],
             "runId": ["type": "string", "description": "Canonical Omi run id."],
             "includeEvents": ["type": "boolean", "description": "Include ordered kernel events. Default true."],
             "eventLimit": ["type": "number", "description": "Maximum events to return. Default 100."],
           ],
-          "required": ["runId"],
+          "anyOf": [
+            ["required": ["agentRef"]],
+            ["required": ["runId"]],
+          ],
         ],
       ],
       [
@@ -396,9 +403,13 @@ enum RealtimeHubTools {
         "parameters": [
           "type": "object",
           "properties": [
+            "agentRef": ["type": "string", "description": "Opaque agent handle from list_agent_sessions."],
             "runId": ["type": "string", "description": "Canonical Omi run id to cancel."]
           ],
-          "required": ["runId"],
+          "anyOf": [
+            ["required": ["agentRef"]],
+            ["required": ["runId"]],
+          ],
         ],
       ],
       [
@@ -409,6 +420,7 @@ enum RealtimeHubTools {
         "parameters": [
           "type": "object",
           "properties": [
+            "agentRef": ["type": "string", "description": "Opaque agent handle from list_agent_sessions."],
             "sessionId": ["type": "string", "description": "Canonical Omi session id."],
             "runId": ["type": "string", "description": "Canonical Omi run id."],
             "attemptId": ["type": "string", "description": "Canonical Omi attempt id."],
@@ -420,6 +432,7 @@ enum RealtimeHubTools {
             "limit": ["type": "number", "description": "Maximum artifacts to return. Default 50."],
           ],
           "anyOf": [
+            ["required": ["agentRef"]],
             ["required": ["sessionId"]],
             ["required": ["runId"]],
             ["required": ["attemptId"]],
@@ -434,6 +447,7 @@ enum RealtimeHubTools {
         "parameters": [
           "type": "object",
           "properties": [
+            "artifactRef": ["type": "string", "description": "Opaque artifact handle from inspect_agent_artifacts."],
             "artifactId": ["type": "string", "description": "Canonical Omi artifact id."],
             "state": [
               "type": "string",
@@ -445,7 +459,11 @@ enum RealtimeHubTools {
             "attemptId": ["type": "string", "description": "Optional canonical Omi attempt id scope guard."],
             "reason": ["type": "string", "description": "Optional short reason."],
           ],
-          "required": ["artifactId", "state"],
+          "required": ["state"],
+          "anyOf": [
+            ["required": ["artifactRef"]],
+            ["required": ["artifactId"]],
+          ],
         ],
       ],
       [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -421,6 +421,8 @@ enum RealtimeHubTools {
           "type": "object",
           "properties": [
             "agentRef": ["type": "string", "description": "Opaque agent handle from list_agent_sessions."],
+            "artifactRef": ["type": "string", "description": "Opaque artifact handle from inspect_agent_artifacts."],
+            "artifactId": ["type": "string", "description": "Canonical Omi artifact id."],
             "sessionId": ["type": "string", "description": "Canonical Omi session id."],
             "runId": ["type": "string", "description": "Canonical Omi run id."],
             "attemptId": ["type": "string", "description": "Canonical Omi attempt id."],
@@ -433,6 +435,8 @@ enum RealtimeHubTools {
           ],
           "anyOf": [
             ["required": ["agentRef"]],
+            ["required": ["artifactRef"]],
+            ["required": ["artifactId"]],
             ["required": ["sessionId"]],
             ["required": ["runId"]],
             ["required": ["attemptId"]],

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -30,6 +30,11 @@ final class AgentControlServiceTests: XCTestCase {
     XCTAssertTrue(summary.contains("running"))
     XCTAssertTrue(summary.contains("mode act"))
     XCTAssertFalse(summary.contains("completed"))
+    XCTAssertFalse(summary.contains("session_123"))
+    XCTAssertFalse(summary.contains("run_active"))
+    XCTAssertFalse(summary.contains("run_terminal"))
+    XCTAssertFalse(summary.contains("attempt_active"))
+    XCTAssertFalse(summary.contains("attempt_terminal"))
     XCTAssertEqual(resolved["runId"] as? String, "run_active")
     XCTAssertEqual(resolved["attemptId"] as? String, "attempt_active")
   }

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -113,27 +113,20 @@ final class AgentControlServiceTests: XCTestCase {
     let withArtifact = """
       {"ok":true,"artifacts":[{"artifactId":"artifact_123","role":"result","lifecycleState":"retained"}]}
       """
+    let failingToolNames = [
+      HubTool.getAgentRun.rawValue,
+      HubTool.cancelAgentRun.rawValue,
+      HubTool.updateAgentArtifactLifecycle.rawValue,
+    ]
 
-    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
-    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
-    _ = service.summarizeVoiceResult(name: HubTool.getAgentRun.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+    for toolName in failingToolNames {
+      _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+      _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+      _ = service.summarizeVoiceResult(name: toolName, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
 
-    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
-    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
-
-    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
-    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
-    _ = service.summarizeVoiceResult(name: HubTool.cancelAgentRun.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
-
-    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
-    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
-
-    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
-    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
-    _ = service.summarizeVoiceResult(name: HubTool.updateAgentArtifactLifecycle.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
-
-    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
-    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
+      XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"], toolName)
+      XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"], toolName)
+    }
   }
 
   func testErrorSummaryDoesNotExposeRawCanonicalIds() {

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -162,4 +162,56 @@ final class AgentControlServiceTests: XCTestCase {
     XCTAssertFalse(summary.contains("run_123"))
     XCTAssertFalse(summary.contains("session_123"))
   }
+
+  // MARK: - Handler-side precondition guards (replacing root-level anyOf)
+
+  func testGetAgentRunRequiresScopeReference() {
+    let service = AgentControlService()
+
+    // With an agentRef that resolves to a handle, the guard passes and the
+    // runtime is reached (it returns ok:false here, proving we got past the guard).
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note"},"latestRun":{"runId":"run_123"}}]}
+      """)
+    let resolvedWithHandle = service.resolveVoiceHandles(in: ["agentRef": "agent_1"])
+    XCTAssertNil(service.missingScopeError(name: HubTool.getAgentRun.rawValue, input: resolvedWithHandle))
+
+    // With a raw runId, the guard passes.
+    XCTAssertNil(service.missingScopeError(name: HubTool.getAgentRun.rawValue, input: ["runId": "run_abc"]))
+
+    // With neither agentRef nor runId, the guard returns a helpful message.
+    let missing = service.missingScopeError(name: HubTool.getAgentRun.rawValue, input: [:])
+    XCTAssertNotNil(missing)
+    XCTAssertTrue(missing!.contains("agent reference or run id"))
+  }
+
+  func testCancelAgentRunRequiresScopeReference() {
+    let service = AgentControlService()
+    XCTAssertNil(service.missingScopeError(name: HubTool.cancelAgentRun.rawValue, input: ["runId": "run_abc"]))
+
+    let missing = service.missingScopeError(name: HubTool.cancelAgentRun.rawValue, input: [:])
+    XCTAssertNotNil(missing)
+    XCTAssertTrue(missing!.contains("agent reference or run id"))
+  }
+
+  func testInspectAgentArtifactsRequiresAnyScopeReference() {
+    let service = AgentControlService()
+    XCTAssertNil(service.missingScopeError(name: HubTool.inspectAgentArtifacts.rawValue, input: ["artifactId": "art_1"]))
+    XCTAssertNil(service.missingScopeError(name: HubTool.inspectAgentArtifacts.rawValue, input: ["sessionId": "sess_1"]))
+    XCTAssertNil(service.missingScopeError(name: HubTool.inspectAgentArtifacts.rawValue, input: ["runId": "run_1"]))
+    XCTAssertNil(service.missingScopeError(name: HubTool.inspectAgentArtifacts.rawValue, input: ["attemptId": "att_1"]))
+
+    let missing = service.missingScopeError(name: HubTool.inspectAgentArtifacts.rawValue, input: [:])
+    XCTAssertNotNil(missing)
+    XCTAssertTrue(missing!.contains("reference to inspect artifacts"))
+  }
+
+  func testUpdateAgentArtifactLifecycleRequiresArtifactReference() {
+    let service = AgentControlService()
+    XCTAssertNil(service.missingScopeError(name: HubTool.updateAgentArtifactLifecycle.rawValue, input: ["artifactId": "art_1"]))
+
+    let missing = service.missingScopeError(name: HubTool.updateAgentArtifactLifecycle.rawValue, input: ["state": "retained"])
+    XCTAssertNotNil(missing)
+    XCTAssertTrue(missing!.contains("artifact reference or id"))
+  }
 }

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -18,6 +18,22 @@ final class AgentControlServiceTests: XCTestCase {
     XCTAssertFalse(summary.contains("attempt_123"))
   }
 
+  func testSessionSummaryPrefersActiveRunForVoiceHandles() {
+    let service = AgentControlService()
+    let raw = """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note","status":"open"},"latestRun":{"runId":"run_terminal","status":"completed","mode":"ask"},"activeRun":{"runId":"run_active","status":"running","mode":"act"},"latestAttempt":{"attemptId":"attempt_terminal"},"activeAttempt":{"attemptId":"attempt_active"}}]}
+      """
+
+    let summary = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: raw)
+    let resolved = service.resolveVoiceHandles(in: ["agentRef": "agent_1"])
+
+    XCTAssertTrue(summary.contains("running"))
+    XCTAssertTrue(summary.contains("mode act"))
+    XCTAssertFalse(summary.contains("completed"))
+    XCTAssertEqual(resolved["runId"] as? String, "run_active")
+    XCTAssertEqual(resolved["attemptId"] as? String, "attempt_active")
+  }
+
   func testCancellationSummaryDoesNotExposeRunId() {
     let service = AgentControlService()
     let raw = """

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class AgentControlServiceTests: XCTestCase {
+  func testSessionSummaryUsesVoiceHandlesInsteadOfCanonicalIds() {
+    let service = AgentControlService()
+    let raw = """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note","status":"open","surfaceKind":"main_chat"},"latestRun":{"runId":"run_123","status":"running","mode":"act"},"latestAttempt":{"attemptId":"attempt_123"}}]}
+      """
+
+    let summary = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: raw)
+
+    XCTAssertTrue(summary.contains("agent_1"))
+    XCTAssertFalse(summary.contains("session_123"))
+    XCTAssertFalse(summary.contains("run_123"))
+    XCTAssertFalse(summary.contains("attempt_123"))
+  }
+
+  func testCancellationSummaryDoesNotExposeRunId() {
+    let service = AgentControlService()
+    let raw = """
+      {"ok":true,"cancellation":{"accepted":true,"dispatched":true,"acknowledged":false},"run":{"runId":"run_123","status":"cancelling"}}
+      """
+
+    let summary = service.summarizeVoiceResult(name: HubTool.cancelAgentRun.rawValue, raw: raw)
+
+    XCTAssertTrue(summary.contains("accepted=true"))
+    XCTAssertTrue(summary.contains("cancelling"))
+    XCTAssertFalse(summary.contains("run_123"))
+  }
+
+  func testArtifactSummaryUsesVoiceHandlesInsteadOfCanonicalIds() {
+    let service = AgentControlService()
+    let raw = """
+      {"ok":true,"artifacts":[{"artifactId":"artifact_123","role":"result","lifecycleState":"retained"}]}
+      """
+
+    let summary = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: raw)
+
+    XCTAssertTrue(summary.contains("artifact_1"))
+    XCTAssertFalse(summary.contains("artifact_123"))
+  }
+
+  func testErrorSummaryDoesNotExposeRawCanonicalIds() {
+    let service = AgentControlService()
+    let raw = """
+      {"ok":false,"error":{"code":"control_tool_failed","message":"Run run_123 does not belong to session session_123"}}
+      """
+
+    let summary = service.summarizeVoiceResult(name: "get_agent_run", raw: raw)
+
+    XCTAssertTrue(summary.contains("Agent control failed"))
+    XCTAssertFalse(summary.contains("run_123"))
+    XCTAssertFalse(summary.contains("session_123"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -45,6 +45,66 @@ final class AgentControlServiceTests: XCTestCase {
     XCTAssertFalse(summary.contains("artifact_123"))
   }
 
+  func testEmptySessionSummaryClearsStaleVoiceHandles() {
+    let service = AgentControlService()
+    let withSession = """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note"},"latestRun":{"runId":"run_123"},"latestAttempt":{"attemptId":"attempt_123"}}]}
+      """
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+    XCTAssertEqual(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"] as? String, "session_123")
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: "{\"ok\":true,\"sessions\":[]}")
+    let resolved = service.resolveVoiceHandles(in: ["agentRef": "agent_1"])
+
+    XCTAssertNil(resolved["sessionId"])
+    XCTAssertNil(resolved["runId"])
+    XCTAssertNil(resolved["attemptId"])
+  }
+
+  func testListSessionFailureClearsStaleVoiceHandles() {
+    let service = AgentControlService()
+    let withSession = """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note"},"latestRun":{"runId":"run_123"},"latestAttempt":{"attemptId":"attempt_123"}}]}
+      """
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+    let resolved = service.resolveVoiceHandles(in: ["agentRef": "agent_1"])
+
+    XCTAssertNil(resolved["sessionId"])
+    XCTAssertNil(resolved["runId"])
+    XCTAssertNil(resolved["attemptId"])
+  }
+
+  func testEmptyArtifactSummaryClearsStaleVoiceHandles() {
+    let service = AgentControlService()
+    let withArtifact = """
+      {"ok":true,"artifacts":[{"artifactId":"artifact_123","role":"result","lifecycleState":"retained"}]}
+      """
+
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+    XCTAssertEqual(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"] as? String, "artifact_123")
+
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: "{\"ok\":true,\"artifacts\":[]}")
+    let resolved = service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])
+
+    XCTAssertNil(resolved["artifactId"])
+  }
+
+  func testArtifactInspectionFailureClearsStaleVoiceHandles() {
+    let service = AgentControlService()
+    let withArtifact = """
+      {"ok":true,"artifacts":[{"artifactId":"artifact_123","role":"result","lifecycleState":"retained"}]}
+      """
+
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+    let resolved = service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])
+
+    XCTAssertNil(resolved["artifactId"])
+  }
+
   func testErrorSummaryDoesNotExposeRawCanonicalIds() {
     let service = AgentControlService()
     let raw = """

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -21,12 +21,14 @@ final class AgentControlServiceTests: XCTestCase {
   func testCancellationSummaryDoesNotExposeRunId() {
     let service = AgentControlService()
     let raw = """
-      {"ok":true,"cancellation":{"accepted":true,"dispatched":true,"acknowledged":false},"run":{"runId":"run_123","status":"cancelling"}}
+      {"ok":true,"cancellation":{"accepted":true,"dispatchAttempted":true,"adapterAcknowledged":false},"run":{"runId":"run_123","status":"cancelling"}}
       """
 
     let summary = service.summarizeVoiceResult(name: HubTool.cancelAgentRun.rawValue, raw: raw)
 
     XCTAssertTrue(summary.contains("accepted=true"))
+    XCTAssertTrue(summary.contains("dispatched=true"))
+    XCTAssertTrue(summary.contains("acknowledged=false"))
     XCTAssertTrue(summary.contains("cancelling"))
     XCTAssertFalse(summary.contains("run_123"))
   }

--- a/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentControlServiceTests.swift
@@ -105,6 +105,37 @@ final class AgentControlServiceTests: XCTestCase {
     XCTAssertNil(resolved["artifactId"])
   }
 
+  func testFailureResponsesClearAllStaleVoiceHandles() {
+    let service = AgentControlService()
+    let withSession = """
+      {"ok":true,"sessions":[{"session":{"omiSessionId":"session_123","title":"Draft launch note"},"latestRun":{"runId":"run_123"},"latestAttempt":{"attemptId":"attempt_123"}}]}
+      """
+    let withArtifact = """
+      {"ok":true,"artifacts":[{"artifactId":"artifact_123","role":"result","lifecycleState":"retained"}]}
+      """
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+    _ = service.summarizeVoiceResult(name: HubTool.getAgentRun.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+
+    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
+    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+    _ = service.summarizeVoiceResult(name: HubTool.cancelAgentRun.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+
+    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
+    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
+
+    _ = service.summarizeVoiceResult(name: HubTool.listAgentSessions.rawValue, raw: withSession)
+    _ = service.summarizeVoiceResult(name: HubTool.inspectAgentArtifacts.rawValue, raw: withArtifact)
+    _ = service.summarizeVoiceResult(name: HubTool.updateAgentArtifactLifecycle.rawValue, raw: "{\"ok\":false,\"error\":{\"message\":\"boom\"}}")
+
+    XCTAssertNil(service.resolveVoiceHandles(in: ["agentRef": "agent_1"])["sessionId"])
+    XCTAssertNil(service.resolveVoiceHandles(in: ["artifactRef": "artifact_1"])["artifactId"])
+  }
+
   func testErrorSummaryDoesNotExposeRawCanonicalIds() {
     let service = AgentControlService()
     let raw = """

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -144,12 +144,27 @@ final class AgentRuntimeProcessTests: XCTestCase {
       .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
+    XCTAssertTrue(source.contains("func requestScopedControlTool("))
     XCTAssertTrue(source.contains(#""type": "control_tool""#))
+    XCTAssertTrue(source.contains("App surfaces should use directControlTool"))
     XCTAssertTrue(source.contains("activeControlRequests[requestKey]"))
     XCTAssertTrue(source.contains(#"dict["ownerId"] = ownerId"#))
     XCTAssertTrue(source.contains("completeControlRequest(message)"))
     XCTAssertTrue(source.contains("if !sent, let request = activeControlRequests.removeValue(forKey: requestKey)"))
     XCTAssertTrue(source.contains("controlRequest.continuation.resume(throwing: BridgeError.agentError(raw))"))
+  }
+
+  func testDirectControlToolRequestsUseDedicatedSignedInOwnerEnvelope() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(source.contains("func directControlTool("))
+    XCTAssertTrue(source.contains("Agent control requires a signed-in owner"))
+    XCTAssertTrue(source.contains(#""type": "direct_control_tool""#))
+    XCTAssertTrue(source.contains(#""ownerId": ownerId"#))
   }
 
   func testToolResultsEchoRequestScope() throws {

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -137,18 +137,17 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains("BridgeError.requestAlreadyActive"))
   }
 
-  func testControlToolRequestsAreRequestScopedAndOwnerGuarded() throws {
+  func testAppSurfacesUseDirectControlToolOnly() throws {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
-    XCTAssertTrue(source.contains("func requestScopedControlTool("))
-    XCTAssertTrue(source.contains(#""type": "control_tool""#))
-    XCTAssertTrue(source.contains("App surfaces should use directControlTool"))
+    XCTAssertFalse(source.contains("func requestScopedControlTool("))
+    XCTAssertFalse(source.contains(#""type": "control_tool""#))
+    XCTAssertTrue(source.contains("func directControlTool("))
     XCTAssertTrue(source.contains("activeControlRequests[requestKey]"))
-    XCTAssertTrue(source.contains(#"dict["ownerId"] = ownerId"#))
     XCTAssertTrue(source.contains("completeControlRequest(message)"))
     XCTAssertTrue(source.contains("if !sent, let request = activeControlRequests.removeValue(forKey: requestKey)"))
     XCTAssertTrue(source.contains("controlRequest.continuation.resume(throwing: BridgeError.agentError(raw))"))

--- a/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDiscoverabilityTests.swift
@@ -186,7 +186,7 @@ final class ChatDiscoverabilityTests: XCTestCase {
             XCTAssertEqual(capability.title, entry.label, "\(entry.name) label drifted")
             XCTAssertEqual(capability.latency.rawValue, entry.latency, "\(entry.name) latency drifted")
             XCTAssertEqual(capability.summary, entry.summary, "\(entry.name) summary drifted")
-            XCTAssertEqual(capability.surfaces, [.desktopChat], "\(entry.name) surface drifted")
+            XCTAssertEqual(capability.surfaces, entry.surfaces, "\(entry.name) surface drifted")
             XCTAssertFalse(entry.promptSnippet.isEmpty, "\(entry.name) manifest promptSnippet is empty")
             XCTAssertFalse(entry.runtimePreconditions.isEmpty, "\(entry.name) manifest runtimePreconditions is empty")
             for guideline in entry.promptGuidelines {
@@ -218,6 +218,7 @@ final class ChatDiscoverabilityTests: XCTestCase {
         let promptSnippet: String
         let promptGuidelines: [String]
         let latency: String
+        let surfaces: Set<DesktopCapabilityRegistry.Surface>
         let runtimePreconditions: [String]
     }
 
@@ -248,6 +249,7 @@ final class ChatDiscoverabilityTests: XCTestCase {
                 promptSnippet: try stringLiteralValue("promptSnippet", in: block),
                 promptGuidelines: try arrayStringValues("promptGuidelines", in: block),
                 latency: try stringLiteralValue("latency", in: block),
+                surfaces: try surfaceValues(in: block),
                 runtimePreconditions: try arrayStringValues("runtimePreconditions", in: block))
         }
     }
@@ -294,6 +296,21 @@ final class ChatDiscoverabilityTests: XCTestCase {
             guard let valueRange = Range(match.range(at: 1), in: arrayBody) else { return nil }
             return String(arrayBody[valueRange])
         }
+    }
+
+    private func surfaceValues(in text: String) throws -> Set<DesktopCapabilityRegistry.Surface> {
+        let values = try arrayStringValues("surfaces", in: text)
+        return Set(values.compactMap { value in
+            switch value {
+            case "desktopChat":
+                return .desktopChat
+            case "realtimeHub":
+                return .realtimeHub
+            default:
+                XCTFail("Unknown manifest surface \(value)")
+                return nil
+            }
+        })
     }
 
     // MARK: - Table Annotations Completeness

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -66,7 +66,15 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertEqual(surfaceKind?["enum"] as? [String], ["main_chat", "task_chat", "realtime", "delegated_agent", "floating_pill"])
 
         let inspectTool = tools.first { ($0["name"] as? String) == HubTool.inspectAgentArtifacts.rawValue }
-        let inspectParameters = inspectTool?["parameters"] as? [String: Any]
+        let inspectParameters = (inspectTool?["parameters"] as? [String: Any])
+        XCTAssertNotNil(inspectParameters, "inspect_agent_artifacts must declare a parameters object")
+        let inspectProperties = inspectParameters?["properties"] as? [String: Any]
+        XCTAssertNotNil(inspectProperties?["agentRef"], "inspect_agent_artifacts must expose an agentRef property")
+        XCTAssertNotNil(inspectProperties?["artifactRef"], "inspect_agent_artifacts must expose an artifactRef property")
+        XCTAssertNotNil(inspectProperties?["artifactId"], "inspect_agent_artifacts must expose an artifactId property")
+        XCTAssertNotNil(inspectProperties?["sessionId"], "inspect_agent_artifacts must expose a sessionId property")
+        XCTAssertNotNil(inspectProperties?["runId"], "inspect_agent_artifacts must expose a runId property")
+        XCTAssertNotNil(inspectProperties?["attemptId"], "inspect_agent_artifacts must expose an attemptId property")
         // Schemas must stay flat (no root-level anyOf) for provider compatibility.
         XCTAssertNil(inspectParameters?["anyOf"])
     }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -67,6 +67,9 @@ final class HubSystemInstructionTests: XCTestCase {
         let inspectTool = tools.first { ($0["name"] as? String) == HubTool.inspectAgentArtifacts.rawValue }
         let inspectParameters = inspectTool?["parameters"] as? [String: Any]
         let inspectAnyOf = inspectParameters?["anyOf"] as? [[String: Any]]
-        XCTAssertEqual(inspectAnyOf?.compactMap { $0["required"] as? [String] }, [["agentRef"], ["sessionId"], ["runId"], ["attemptId"]])
+        XCTAssertEqual(
+            inspectAnyOf?.compactMap { $0["required"] as? [String] },
+            [["agentRef"], ["artifactRef"], ["artifactId"], ["sessionId"], ["runId"], ["attemptId"]]
+        )
     }
 }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -53,18 +53,20 @@ final class HubSystemInstructionTests: XCTestCase {
 
         let cancelTool = tools.first { ($0["name"] as? String) == HubTool.cancelAgentRun.rawValue }
         XCTAssertTrue((cancelTool?["description"] as? String ?? "").contains("canonical"))
-        let parameters = cancelTool?["parameters"] as? [String: Any]
-        XCTAssertEqual(parameters?["required"] as? [String], ["runId"])
+        let cancelParameters = cancelTool?["parameters"] as? [String: Any]
+        let cancelProperties = cancelParameters?["properties"] as? [String: Any]
+        XCTAssertNotNil(cancelProperties?["agentRef"])
+        XCTAssertNotNil(cancelParameters?["anyOf"])
 
         let listTool = tools.first { ($0["name"] as? String) == HubTool.listAgentSessions.rawValue }
         let listParameters = listTool?["parameters"] as? [String: Any]
         let listProperties = listParameters?["properties"] as? [String: Any]
         let surfaceKind = listProperties?["surfaceKind"] as? [String: Any]
-        XCTAssertEqual(surfaceKind?["enum"] as? [String], ["main_chat", "task_chat", "realtime", "delegated_agent"])
+        XCTAssertEqual(surfaceKind?["enum"] as? [String], ["main_chat", "task_chat", "realtime", "delegated_agent", "floating_pill"])
 
         let inspectTool = tools.first { ($0["name"] as? String) == HubTool.inspectAgentArtifacts.rawValue }
         let inspectParameters = inspectTool?["parameters"] as? [String: Any]
         let inspectAnyOf = inspectParameters?["anyOf"] as? [[String: Any]]
-        XCTAssertEqual(inspectAnyOf?.compactMap { $0["required"] as? [String] }, [["sessionId"], ["runId"], ["attemptId"]])
+        XCTAssertEqual(inspectAnyOf?.compactMap { $0["required"] as? [String] }, [["agentRef"], ["sessionId"], ["runId"], ["attemptId"]])
     }
 }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -11,6 +11,9 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertTrue(instr.contains("spawn_agent"))                          // guardrails preserved
         XCTAssertTrue(instr.contains("get_task_agent_status"))
         XCTAssertTrue(instr.contains("manage_agent_pills"))
+        XCTAssertTrue(instr.contains("list_agent_sessions"))
+        XCTAssertTrue(instr.contains("get_agent_run"))
+        XCTAssertTrue(instr.contains("cancel_agent_run"))
         XCTAssertTrue(instr.contains("floating agent pills"))
         XCTAssertTrue(instr.contains("subagents"))
         XCTAssertTrue(instr.contains("get_daily_recap"))
@@ -37,5 +40,20 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertNotNil(manageTool)
         XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("dismiss"))
         XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("clear completed"))
+    }
+
+    func testRealtimeCanonicalAgentControlToolsAreExposed() {
+        let tools = RealtimeHubTools.openAITools
+        let toolNames = Set(tools.compactMap { $0["name"] as? String })
+        XCTAssertTrue(toolNames.contains(HubTool.listAgentSessions.rawValue))
+        XCTAssertTrue(toolNames.contains(HubTool.getAgentRun.rawValue))
+        XCTAssertTrue(toolNames.contains(HubTool.cancelAgentRun.rawValue))
+        XCTAssertTrue(toolNames.contains(HubTool.inspectAgentArtifacts.rawValue))
+        XCTAssertTrue(toolNames.contains(HubTool.updateAgentArtifactLifecycle.rawValue))
+
+        let cancelTool = tools.first { ($0["name"] as? String) == HubTool.cancelAgentRun.rawValue }
+        XCTAssertTrue((cancelTool?["description"] as? String ?? "").contains("canonical"))
+        let parameters = cancelTool?["parameters"] as? [String: Any]
+        XCTAssertEqual(parameters?["required"] as? [String], ["runId"])
     }
 }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -56,7 +56,8 @@ final class HubSystemInstructionTests: XCTestCase {
         let cancelParameters = cancelTool?["parameters"] as? [String: Any]
         let cancelProperties = cancelParameters?["properties"] as? [String: Any]
         XCTAssertNotNil(cancelProperties?["agentRef"])
-        XCTAssertNotNil(cancelParameters?["anyOf"])
+        // Schemas must stay flat (no root-level anyOf) for provider compatibility.
+        XCTAssertNil(cancelParameters?["anyOf"])
 
         let listTool = tools.first { ($0["name"] as? String) == HubTool.listAgentSessions.rawValue }
         let listParameters = listTool?["parameters"] as? [String: Any]
@@ -66,10 +67,7 @@ final class HubSystemInstructionTests: XCTestCase {
 
         let inspectTool = tools.first { ($0["name"] as? String) == HubTool.inspectAgentArtifacts.rawValue }
         let inspectParameters = inspectTool?["parameters"] as? [String: Any]
-        let inspectAnyOf = inspectParameters?["anyOf"] as? [[String: Any]]
-        XCTAssertEqual(
-            inspectAnyOf?.compactMap { $0["required"] as? [String] },
-            [["agentRef"], ["artifactRef"], ["artifactId"], ["sessionId"], ["runId"], ["attemptId"]]
-        )
+        // Schemas must stay flat (no root-level anyOf) for provider compatibility.
+        XCTAssertNil(inspectParameters?["anyOf"])
     }
 }

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -55,5 +55,16 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertTrue((cancelTool?["description"] as? String ?? "").contains("canonical"))
         let parameters = cancelTool?["parameters"] as? [String: Any]
         XCTAssertEqual(parameters?["required"] as? [String], ["runId"])
+
+        let listTool = tools.first { ($0["name"] as? String) == HubTool.listAgentSessions.rawValue }
+        let listParameters = listTool?["parameters"] as? [String: Any]
+        let listProperties = listParameters?["properties"] as? [String: Any]
+        let surfaceKind = listProperties?["surfaceKind"] as? [String: Any]
+        XCTAssertEqual(surfaceKind?["enum"] as? [String], ["main_chat", "task_chat", "realtime", "delegated_agent"])
+
+        let inspectTool = tools.first { ($0["name"] as? String) == HubTool.inspectAgentArtifacts.rawValue }
+        let inspectParameters = inspectTool?["parameters"] as? [String: Any]
+        let inspectAnyOf = inspectParameters?["anyOf"] as? [[String: Any]]
+        XCTAssertEqual(inspectAnyOf?.compactMap { $0["required"] as? [String] }, [["sessionId"], ["runId"], ["attemptId"]])
     }
 }

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -22,6 +22,20 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("speak(ack)"))
   }
 
+  func testCanonicalAgentControlSummariesDoNotSpeakOpaqueIds() throws {
+    let source = try realtimeHubControllerSource()
+
+    XCTAssertTrue(source.contains("return \"- \\(title): \\(status)\""))
+    XCTAssertTrue(source.contains("Follow-up handles for tool calls only; do not read aloud"))
+    XCTAssertTrue(source.contains("sessionId=\\($0)"))
+    XCTAssertTrue(source.contains("runId=\\($0)"))
+    XCTAssertFalse(source.contains("artifactId=\\(artifactId)"))
+    XCTAssertTrue(source.contains("Canonical run is \\(status)"))
+    XCTAssertTrue(source.contains("dispatchAttempted"))
+    XCTAssertTrue(source.contains("adapterAcknowledged"))
+    XCTAssertTrue(source.contains("Artifact lifecycle is now \\(state)"))
+  }
+
   private func realtimeHubControllerSource() throws -> String {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -23,16 +23,17 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
   }
 
   func testCanonicalAgentControlSummariesDoNotSpeakOpaqueIds() throws {
-    let source = try realtimeHubControllerSource()
+    let source = try agentControlServiceSource()
 
-    XCTAssertTrue(source.contains("return \"- \\(title): \\(status)\""))
-    XCTAssertTrue(source.contains("Follow-up handles for tool calls only; do not read aloud"))
-    XCTAssertTrue(source.contains("sessionId=\\($0)"))
-    XCTAssertTrue(source.contains("runId=\\($0)"))
+    XCTAssertTrue(source.contains("Use agentRef values internally for follow-up tool calls; do not say them aloud"))
+    XCTAssertTrue(source.contains("Use artifactRef values internally for follow-up tool calls; do not say them aloud"))
+    XCTAssertTrue(source.contains("agent_\\(index + 1)"))
+    XCTAssertTrue(source.contains("artifact_\\(index + 1)"))
+    XCTAssertFalse(source.contains("sessionId=\\($0)"))
+    XCTAssertFalse(source.contains("runId=\\($0)"))
     XCTAssertFalse(source.contains("artifactId=\\(artifactId)"))
-    XCTAssertTrue(source.contains("Canonical run is \\(status)"))
-    XCTAssertTrue(source.contains("dispatchAttempted"))
-    XCTAssertTrue(source.contains("adapterAcknowledged"))
+    XCTAssertTrue(source.contains("The selected canonical run is \\(status)"))
+    XCTAssertTrue(source.contains("Agent control failed. Try listing the agents again"))
     XCTAssertTrue(source.contains("Artifact lifecycle is now \\(state)"))
   }
 
@@ -41,6 +42,14 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/RealtimeHubController.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private func agentControlServiceSource() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentControlService.swift")
     return try String(contentsOf: sourceURL, encoding: .utf8)
   }
 }

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -60,6 +60,7 @@ import {
   handleAgentControlToolCall,
   isAgentControlToolName,
   legacyControlRequestKey,
+  registerSignedDirectControlOwner,
   resolveControlRequestContext,
   withMergedOwnerGuard,
   DEFAULT_LOCAL_OWNER_ID,
@@ -995,6 +996,12 @@ async function main(): Promise<void> {
         const control = msg as ControlToolRequestMessage;
         const requestId = control.protocolVersion === 2 ? control.requestId?.trim() : requestIdFor(control);
         const requestKey = controlRequestKey({ requestId, clientId: control.clientId });
+        let directControlOwnerInserted = registerSignedDirectControlOwner({
+          requestKey,
+          ownerGuard: control.ownerId,
+          ownerIdForRequest: (key) => activeControlToolOwnersByRequest.get(key),
+          registerOwner: registerActiveControlOwner,
+        });
         const activeOwnerId = requestKey ? activeControlToolOwnersByRequest.get(requestKey) : undefined;
         let controlContext;
         try {
@@ -1007,6 +1014,9 @@ async function main(): Promise<void> {
             clientId: control.clientId,
           });
         } catch (error) {
+          if (requestKey && directControlOwnerInserted) {
+            activeControlToolOwnersByRequest.delete(requestKey);
+          }
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1029,6 +1039,12 @@ async function main(): Promise<void> {
         let controlRunOwnerKey: string | undefined;
         let preserveControlRunOwner = false;
         let controlRunOwnerInserted = false;
+        const releaseDirectControlOwner = () => {
+          if (requestKey && directControlOwnerInserted) {
+            activeControlToolOwnersByRequest.delete(requestKey);
+            directControlOwnerInserted = false;
+          }
+        };
         try {
           controlInput = withMergedOwnerGuard(control.input ?? {}, controlContext.ownerGuard, controlContext.activeOwnerId);
           const correlated = withControlRunCorrelation(control.name, controlInput, control.clientId);
@@ -1055,6 +1071,7 @@ async function main(): Promise<void> {
           if (controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
             facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
           }
+          releaseDirectControlOwner();
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1082,6 +1099,7 @@ async function main(): Promise<void> {
           if (controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
             facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
           }
+          releaseDirectControlOwner();
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1123,6 +1141,7 @@ async function main(): Promise<void> {
                 if (!preserveControlRunOwner && controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
                   facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
                 }
+                releaseDirectControlOwner();
               }
             })()
           : (() => {
@@ -1132,6 +1151,7 @@ async function main(): Promise<void> {
               if (!preserveControlRunOwner && controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
                 facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
               }
+              releaseDirectControlOwner();
               return JSON.stringify({
                 ok: false,
                 error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1180,7 +1180,35 @@ async function main(): Promise<void> {
 
       case "direct_control_tool": {
         const control = msg as DirectControlToolRequestMessage;
-        const requestId = control.protocolVersion === 2 ? control.requestId?.trim() : requestIdFor(control);
+        if (control.protocolVersion === 2 && !control.clientId?.trim()) {
+          send({
+            type: "control_tool_result",
+            protocolVersion: control.protocolVersion,
+            requestId: control.requestId?.trim(),
+            clientId: control.clientId,
+            name: control.name,
+            result: JSON.stringify({
+              ok: false,
+              error: { code: "invalid_request", message: "protocol v2 direct control requires clientId" },
+            }),
+          });
+          break;
+        }
+        if (control.protocolVersion === 2 && !control.requestId?.trim()) {
+          send({
+            type: "control_tool_result",
+            protocolVersion: control.protocolVersion,
+            requestId: control.requestId?.trim(),
+            clientId: control.clientId,
+            name: control.name,
+            result: JSON.stringify({
+              ok: false,
+              error: { code: "invalid_request", message: "protocol v2 direct control requires requestId" },
+            }),
+          });
+          break;
+        }
+        const requestId = control.protocolVersion === 2 ? control.requestId.trim() : requestIdFor(control);
         if (!DIRECT_CONTROL_TOOL_NAMES.has(control.name)) {
           send({
             type: "control_tool_result",

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -37,6 +37,7 @@ import { unlinkSync, appendFileSync } from "fs";
 import type {
   InboundMessage,
   ControlToolRequestMessage,
+  DirectControlToolRequestMessage,
   OutboundMessage,
   QueryScopedOutbound,
   QueryMessage,
@@ -65,11 +66,20 @@ import {
   withMergedOwnerGuard,
   DEFAULT_LOCAL_OWNER_ID,
   type AgentControlToolContext,
+  type ResolvedControlRequestContext,
 } from "./runtime/control-tools.js";
 import { SqliteAgentStore } from "./runtime/sqlite-store.js";
 import { configuredPiMonoMaxWorkers } from "./runtime/worker-pool.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DIRECT_CONTROL_TOOL_NAMES = new Set<string>([
+  "list_agent_sessions",
+  "get_agent_run",
+  "cancel_agent_run",
+  "inspect_agent_artifacts",
+  "update_agent_artifact_lifecycle",
+]);
 
 // Resolve paths to bundled tools
 const playwrightCli = join(
@@ -1157,6 +1167,82 @@ async function main(): Promise<void> {
                 error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
               });
             })();
+        send({
+          type: "control_tool_result",
+          protocolVersion: control.protocolVersion,
+          requestId,
+          clientId: control.clientId,
+          name: control.name,
+          result,
+        });
+        break;
+      }
+
+      case "direct_control_tool": {
+        const control = msg as DirectControlToolRequestMessage;
+        const requestId = control.protocolVersion === 2 ? control.requestId?.trim() : requestIdFor(control);
+        if (!DIRECT_CONTROL_TOOL_NAMES.has(control.name)) {
+          send({
+            type: "control_tool_result",
+            protocolVersion: control.protocolVersion,
+            requestId,
+            clientId: control.clientId,
+            name: control.name,
+            result: JSON.stringify({
+              ok: false,
+              error: {
+                code: "unsupported_direct_control_tool",
+                message: `Direct app control cannot execute ${control.name}`,
+              },
+            }),
+          });
+          break;
+        }
+
+        let controlContext: ResolvedControlRequestContext;
+        let controlInput: Record<string, unknown>;
+        try {
+          controlContext = resolveControlRequestContext({
+            ownerGuard: control.ownerId,
+            activeOwnerId: control.ownerId,
+            requireActiveOwner: true,
+            requireOwnerGuard: true,
+            requestId,
+            clientId: control.clientId,
+          });
+          controlInput = withMergedOwnerGuard(control.input ?? {}, controlContext.ownerGuard, controlContext.activeOwnerId);
+        } catch (error) {
+          send({
+            type: "control_tool_result",
+            protocolVersion: control.protocolVersion,
+            requestId,
+            clientId: control.clientId,
+            name: control.name,
+            result: JSON.stringify({
+              ok: false,
+              error: {
+                code: "invalid_owner_id",
+                message: error instanceof Error ? error.message : String(error),
+              },
+            }),
+          });
+          break;
+        }
+
+        const result = agentControlToolContext
+          ? await handleAgentControlToolCall(
+              {
+                ...agentControlToolContext,
+                getProtocolVersion: () => control.protocolVersion,
+                getOwnerId: () => controlContext.activeOwnerId,
+              },
+              control.name,
+              controlInput,
+            )
+          : JSON.stringify({
+              ok: false,
+              error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
+            });
         send({
           type: "control_tool_result",
           protocolVersion: control.protocolVersion,

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1006,12 +1006,6 @@ async function main(): Promise<void> {
         const control = msg as ControlToolRequestMessage;
         const requestId = control.protocolVersion === 2 ? control.requestId?.trim() : requestIdFor(control);
         const requestKey = controlRequestKey({ requestId, clientId: control.clientId });
-        let directControlOwnerInserted = registerSignedDirectControlOwner({
-          requestKey,
-          ownerGuard: control.ownerId,
-          ownerIdForRequest: (key) => activeControlToolOwnersByRequest.get(key),
-          registerOwner: registerActiveControlOwner,
-        });
         const activeOwnerId = requestKey ? activeControlToolOwnersByRequest.get(requestKey) : undefined;
         let controlContext;
         try {
@@ -1024,9 +1018,6 @@ async function main(): Promise<void> {
             clientId: control.clientId,
           });
         } catch (error) {
-          if (requestKey && directControlOwnerInserted) {
-            activeControlToolOwnersByRequest.delete(requestKey);
-          }
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1049,12 +1040,6 @@ async function main(): Promise<void> {
         let controlRunOwnerKey: string | undefined;
         let preserveControlRunOwner = false;
         let controlRunOwnerInserted = false;
-        const releaseDirectControlOwner = () => {
-          if (requestKey && directControlOwnerInserted) {
-            activeControlToolOwnersByRequest.delete(requestKey);
-            directControlOwnerInserted = false;
-          }
-        };
         try {
           controlInput = withMergedOwnerGuard(control.input ?? {}, controlContext.ownerGuard, controlContext.activeOwnerId);
           const correlated = withControlRunCorrelation(control.name, controlInput, control.clientId);
@@ -1081,7 +1066,6 @@ async function main(): Promise<void> {
           if (controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
             facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
           }
-          releaseDirectControlOwner();
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1109,7 +1093,6 @@ async function main(): Promise<void> {
           if (controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
             facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
           }
-          releaseDirectControlOwner();
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1151,7 +1134,6 @@ async function main(): Promise<void> {
                 if (!preserveControlRunOwner && controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
                   facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
                 }
-                releaseDirectControlOwner();
               }
             })()
           : (() => {
@@ -1161,7 +1143,6 @@ async function main(): Promise<void> {
               if (!preserveControlRunOwner && controlRunCorrelation.requestId && controlRunCorrelation.clientId && controlRunOwnerInserted) {
                 facade.releaseExternalRequestContext(controlRunCorrelation.requestId, controlRunCorrelation.clientId);
               }
-              releaseDirectControlOwner();
               return JSON.stringify({
                 ok: false,
                 error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
@@ -1208,7 +1189,7 @@ async function main(): Promise<void> {
           });
           break;
         }
-        const requestId = control.protocolVersion === 2 ? control.requestId.trim() : requestIdFor(control);
+        const requestId = control.protocolVersion === 2 ? control.requestId!.trim() : requestIdFor(control);
         if (!DIRECT_CONTROL_TOOL_NAMES.has(control.name)) {
           send({
             type: "control_tool_result",
@@ -1227,12 +1208,26 @@ async function main(): Promise<void> {
           break;
         }
 
+        const requestKey = controlRequestKey({ requestId, clientId: control.clientId });
+        let directControlOwnerInserted = registerSignedDirectControlOwner({
+          requestKey,
+          ownerGuard: control.ownerId,
+          ownerIdForRequest: (key) => activeControlToolOwnersByRequest.get(key),
+          registerOwner: registerActiveControlOwner,
+        });
+        const releaseDirectControlOwner = () => {
+          if (requestKey && directControlOwnerInserted) {
+            activeControlToolOwnersByRequest.delete(requestKey);
+            directControlOwnerInserted = false;
+          }
+        };
+
         let controlContext: ResolvedControlRequestContext;
         let controlInput: Record<string, unknown>;
         try {
           controlContext = resolveControlRequestContext({
             ownerGuard: control.ownerId,
-            activeOwnerId: control.ownerId,
+            activeOwnerId: requestKey ? activeControlToolOwnersByRequest.get(requestKey) : undefined,
             requireActiveOwner: true,
             requireOwnerGuard: true,
             requestId,
@@ -1240,6 +1235,7 @@ async function main(): Promise<void> {
           });
           controlInput = withMergedOwnerGuard(control.input ?? {}, controlContext.ownerGuard, controlContext.activeOwnerId);
         } catch (error) {
+          releaseDirectControlOwner();
           send({
             type: "control_tool_result",
             protocolVersion: control.protocolVersion,
@@ -1257,20 +1253,26 @@ async function main(): Promise<void> {
           break;
         }
 
-        const result = agentControlToolContext
-          ? await handleAgentControlToolCall(
-              {
-                ...agentControlToolContext,
-                getProtocolVersion: () => control.protocolVersion,
-                getOwnerId: () => controlContext.activeOwnerId,
-              },
-              control.name,
-              controlInput,
-            )
-          : JSON.stringify({
-              ok: false,
-              error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
-            });
+        const result = await (async () => {
+          try {
+            return agentControlToolContext
+              ? await handleAgentControlToolCall(
+                  {
+                    ...agentControlToolContext,
+                    getProtocolVersion: () => control.protocolVersion,
+                    getOwnerId: () => controlContext.activeOwnerId,
+                  },
+                  control.name,
+                  controlInput,
+                )
+              : JSON.stringify({
+                  ok: false,
+                  error: { code: "runtime_not_ready", message: "Agent runtime kernel is not ready" },
+                });
+          } finally {
+            releaseDirectControlOwner();
+          }
+        })();
         send({
           type: "control_tool_result",
           protocolVersion: control.protocolVersion,

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -58,6 +58,12 @@ export interface ControlToolRequestMessage extends ProtocolEnvelope {
   input: Record<string, unknown>;
 }
 
+export interface DirectControlToolRequestMessage extends ProtocolEnvelope {
+  type: "direct_control_tool";
+  name: string;
+  input: Record<string, unknown>;
+}
+
 export interface StopMessage {
   type: "stop";
 }
@@ -103,6 +109,7 @@ export type InboundMessage =
   | QueryMessage
   | ToolResultMessage
   | ControlToolRequestMessage
+  | DirectControlToolRequestMessage
   | StopMessage
   | InterruptMessage
   | InvalidateSessionMessage

--- a/desktop/macos/agent/src/runtime/control-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/control-tool-manifest.ts
@@ -51,7 +51,11 @@ Returns canonical Omi session IDs, latest/active run summaries, and adapter bind
     properties: {
       ownerId: { type: "string", description: "Owner id to list. Defaults to the active signed-in owner." },
       status: { type: "string", enum: ["open", "archived", "closed"] },
-      surfaceKind: { type: "string", description: "Filter to a surface kind such as main_chat, task_chat, or floating_pill." },
+      surfaceKind: {
+        type: "string",
+        enum: ["main_chat", "task_chat", "realtime", "delegated_agent", "floating_pill"],
+        description: "Filter to a canonical surface kind.",
+      },
       limit: { type: "number", description: "Maximum sessions to return. Default 50, max 200." },
       beforeUpdatedAtMs: { type: "number", description: "Pagination cursor: only sessions updated before this epoch-ms timestamp." },
     },

--- a/desktop/macos/agent/src/runtime/control-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/control-tool-manifest.ts
@@ -114,7 +114,7 @@ Use when the user asks to stop a running Omi agent/subagent. Returns whether can
   {
     name: "inspect_agent_artifacts",
     label: "Inspect Agent Artifacts",
-    description: `Inspect canonical artifact metadata for an Omi agent session, run, or attempt.
+    description: `Inspect canonical artifact metadata for an Omi agent artifact, session, run, or attempt.
 
 Returns metadata and references only. It does not read arbitrary artifact contents.`,
     promptSnippet: "inspect_agent_artifacts - Inspect Omi agent artifact metadata",
@@ -125,11 +125,12 @@ Returns metadata and references only. It does not read arbitrary artifact conten
     latency: "fast local",
     surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: [
-      "Requires at least one of sessionId, runId, or attemptId.",
+      "Requires at least one of artifactId, sessionId, runId, or attemptId.",
       "Defaults ownerId to the active signed-in owner when omitted and rejects selectors outside that owner.",
     ],
     timeoutClass: "normal",
     properties: {
+      artifactId: { type: "string", description: "Canonical Omi artifact_id." },
       sessionId: { type: "string", description: "Canonical Omi session_id." },
       runId: { type: "string", description: "Canonical Omi run_id." },
       attemptId: { type: "string", description: "Canonical Omi attempt_id." },
@@ -140,6 +141,7 @@ Returns metadata and references only. It does not read arbitrary artifact conten
     required: [],
     jsonSchemaOptions: {
       anyOf: [
+        { required: ["artifactId"] },
         { required: ["sessionId"] },
         { required: ["runId"] },
         { required: ["attemptId"] },

--- a/desktop/macos/agent/src/runtime/control-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/control-tool-manifest.ts
@@ -7,6 +7,8 @@ export interface AgentControlManifestProperty {
   additionalProperties?: boolean;
 }
 
+export type AgentControlSurface = "desktopChat" | "realtimeHub";
+
 export interface AgentControlManifestTool {
   name:
     | "list_agent_sessions"
@@ -21,7 +23,7 @@ export interface AgentControlManifestTool {
   promptSnippet: string;
   promptGuidelines: string[];
   latency: "fast local" | "async background";
-  surfaces: ["desktopChat"];
+  surfaces: AgentControlSurface[];
   runtimePreconditions: string[];
   timeoutClass: AgentControlTimeoutClass;
   properties: Record<string, AgentControlManifestProperty>;
@@ -39,11 +41,11 @@ Use when the user asks what Omi agents/subagents are active, recent, failed, or 
 Returns canonical Omi session IDs, latest/active run summaries, and adapter binding metadata.`,
     promptSnippet: "list_agent_sessions - List Omi-managed agent sessions and active runs",
     promptGuidelines: [
-      "Use for current or recent kernel-backed Omi agents/subagents across main chat, task chat, and any future migrated floating-pill sessions.",
+      "Use for current or recent kernel-backed Omi agents/subagents across chat, PTT/realtime, task chat, and any future migrated floating-pill sessions.",
       "Returns durable Omi session IDs, latest/active run summaries, and adapter binding metadata.",
     ],
     latency: "fast local",
-    surfaces: ["desktopChat"],
+    surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: ["Defaults ownerId to the active signed-in owner when omitted."],
     timeoutClass: "normal",
     properties: {
@@ -67,7 +69,7 @@ Use a runId returned by list_agent_sessions or a correlated Omi response. Return
       "Returns the run, attempts, adapter bindings, events, and artifact metadata.",
     ],
     latency: "fast local",
-    surfaces: ["desktopChat"],
+    surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: [
       "Requires a canonical Omi run_id.",
       "Defaults ownerId to the active signed-in owner when omitted and rejects runs outside that owner.",
@@ -93,7 +95,7 @@ Use when the user asks to stop a running Omi agent/subagent. Returns whether can
       "Returns whether cancellation was accepted, dispatched, and acknowledged.",
     ],
     latency: "fast local",
-    surfaces: ["desktopChat"],
+    surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: [
       "Requires a canonical Omi run_id.",
       "Defaults ownerId to the active signed-in owner when omitted and rejects runs outside that owner.",
@@ -117,7 +119,7 @@ Returns metadata and references only. It does not read arbitrary artifact conten
       "Use after get_agent_run when the user asks what files or outputs an agent produced.",
     ],
     latency: "fast local",
-    surfaces: ["desktopChat"],
+    surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: [
       "Requires at least one of sessionId, runId, or attemptId.",
       "Defaults ownerId to the active signed-in owner when omitted and rejects selectors outside that owner.",
@@ -153,7 +155,7 @@ This only records artifact metadata state and ordered kernel events. It does not
       "This never reads artifact contents and has no OS side effects.",
     ],
     latency: "fast local",
-    surfaces: ["desktopChat"],
+    surfaces: ["desktopChat", "realtimeHub"],
     runtimePreconditions: [
       "Requires artifactId.",
       "Defaults ownerId to the active signed-in owner when omitted and rejects artifacts outside that owner.",

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -163,6 +163,13 @@ export interface ControlRequestContextInput extends ControlRequestKeyInput {
   requireOwnerGuard?: boolean;
 }
 
+export interface SignedDirectControlOwnerInput {
+  requestKey?: string;
+  ownerGuard?: string;
+  ownerIdForRequest: (requestKey: string) => string | undefined;
+  registerOwner: (requestKey: string, ownerId: string) => boolean;
+}
+
 export interface ResolvedControlRequestContext {
   requestKey?: string;
   activeOwnerId: string;
@@ -178,6 +185,17 @@ export function controlRequestKey(input: ControlRequestKeyInput): string | undef
 
 export function legacyControlRequestKey(input: ControlRequestKeyInput): string | undefined {
   return input.requestId ? JSON.stringify([input.clientId ?? DEFAULT_LEGACY_JSONL_CLIENT_ID, input.requestId]) : undefined;
+}
+
+export function registerSignedDirectControlOwner(input: SignedDirectControlOwnerInput): boolean {
+  const ownerGuard = input.ownerGuard?.trim();
+  if (!input.requestKey || !ownerGuard || ownerGuard === DEFAULT_LOCAL_OWNER_ID) {
+    return false;
+  }
+  if (input.ownerIdForRequest(input.requestKey)) {
+    return false;
+  }
+  return input.registerOwner(input.requestKey, ownerGuard);
 }
 
 export function resolveControlRequestContext(input: ControlRequestContextInput): ResolvedControlRequestContext {

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -33,6 +33,7 @@ const cancelAgentRunSchema = z.object({
 
 const inspectAgentArtifactsSchema = z
   .object({
+    artifactId: z.string().min(1).optional(),
     sessionId: z.string().min(1).optional(),
     runId: z.string().min(1).optional(),
     attemptId: z.string().min(1).optional(),
@@ -40,8 +41,8 @@ const inspectAgentArtifactsSchema = z
     role: artifactRoleSchema.optional(),
     limit: z.coerce.number().int().positive().max(200).default(50),
   })
-  .refine((value) => value.sessionId || value.runId || value.attemptId, {
-    message: "Provide sessionId, runId, or attemptId",
+  .refine((value) => value.artifactId || value.sessionId || value.runId || value.attemptId, {
+    message: "Provide artifactId, sessionId, runId, or attemptId",
   });
 
 const updateAgentArtifactLifecycleSchema = z.object({

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -5,6 +5,7 @@ import { agentControlCapabilityManifest, agentControlInputSchema } from "./contr
 import type { McpServerBuildContext } from "./compatibility-facade.js";
 
 const sessionStatusSchema = z.enum(["open", "archived", "closed"]);
+const agentSurfaceKindSchema = z.enum(["main_chat", "task_chat", "realtime", "delegated_agent", "floating_pill"]);
 const artifactRoleSchema = z.enum(["input", "result", "checkpoint", "tool_output", "log", "other"]);
 const artifactLifecycleStateSchema = z.enum(["retained", "dismissed", "opened"]);
 const runModeSchema = z.enum(["ask", "act"]);
@@ -13,7 +14,7 @@ const delegationModeSchema = z.enum(["call", "spawn", "continue"]);
 const listAgentSessionsSchema = z.object({
   ownerId: z.string().min(1).optional(),
   status: sessionStatusSchema.optional(),
-  surfaceKind: z.string().min(1).optional(),
+  surfaceKind: agentSurfaceKindSchema.optional(),
   limit: z.coerce.number().int().positive().max(200).default(50),
   beforeUpdatedAtMs: z.coerce.number().int().positive().optional(),
 });

--- a/desktop/macos/agent/src/runtime/kernel.ts
+++ b/desktop/macos/agent/src/runtime/kernel.ts
@@ -207,6 +207,7 @@ export interface KernelRunDetails {
 }
 
 export interface InspectArtifactsInput {
+  artifactId?: string;
   sessionId?: string;
   runId?: string;
   attemptId?: string;
@@ -813,8 +814,8 @@ export class AgentRuntimeKernel {
   }
 
   inspectArtifacts(input: InspectArtifactsInput): AgentArtifact[] {
-    if (!input.sessionId && !input.runId && !input.attemptId) {
-      throw new Error("Inspecting artifacts requires sessionId, runId, or attemptId");
+    if (!input.artifactId && !input.sessionId && !input.runId && !input.attemptId) {
+      throw new Error("Inspecting artifacts requires artifactId, sessionId, runId, or attemptId");
     }
     if (input.ownerId) {
       this.assertArtifactSelectorOwner(input, input.ownerId);
@@ -1948,6 +1949,9 @@ export class AgentRuntimeKernel {
   }
 
   private assertArtifactSelectorOwner(input: InspectArtifactsInput, ownerId: string): void {
+    if (input.artifactId) {
+      this.assertSessionOwner(this.readSession(this.readArtifact(input.artifactId).sessionId), ownerId);
+    }
     if (input.sessionId) {
       this.assertSessionOwner(this.readSession(input.sessionId), ownerId);
     }
@@ -2027,6 +2031,10 @@ export class AgentRuntimeKernel {
   private readArtifacts(input: InspectArtifactsInput): AgentArtifact[] {
     const where: string[] = [];
     const values: unknown[] = [];
+    if (input.artifactId) {
+      where.push("artifact_id = ?");
+      values.push(input.artifactId);
+    }
     if (input.sessionId) {
       where.push("session_id = ?");
       values.push(input.sessionId);

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -66,6 +66,29 @@ describe("agent control tools", () => {
     );
   });
 
+  it("constrains canonical list surfaceKind to known surfaces", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath());
+    const invalid = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "list_agent_sessions", {
+        ownerId: "owner",
+        surfaceKind: "surprise_surface",
+      }),
+    );
+    const valid = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "list_agent_sessions", {
+        ownerId: "owner",
+        surfaceKind: "realtime",
+      }),
+    );
+
+    expect(invalid).toMatchObject({
+      ok: false,
+      error: { code: "invalid_tool_input" },
+    });
+    expect(valid.ok).toBe(true);
+    store.close();
+  });
+
   it("documents delegate_agent as canonical delegation, not floating pill UI", () => {
     const delegateAgent = agentControlCapabilityManifest.find((tool) => tool.name === "delegate_agent");
     expect(delegateAgent?.description).toContain("canonical child handles");

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -10,6 +10,7 @@ import {
   handleAgentControlToolCall,
   isAgentControlToolName,
   legacyControlRequestKey,
+  registerSignedDirectControlOwner,
   resolveControlRequestContext,
   type AgentControlToolContext,
   withDefaultOwnerGuard,
@@ -247,6 +248,24 @@ describe("agent control tools", () => {
         clientId: "swift-client",
       }),
     ).toThrow("missing active control owner");
+  });
+
+  it("registers signed direct control envelopes when no request owner is active", () => {
+    const ownersByRequest = new Map<string, string>();
+    const requestKey = controlRequestKey({ requestId: "realtime-request", clientId: "realtime-hub" });
+
+    const inserted = registerSignedDirectControlOwner({
+      requestKey,
+      ownerGuard: " signed-in-owner ",
+      ownerIdForRequest: (key) => ownersByRequest.get(key),
+      registerOwner: (key, ownerId) => {
+        ownersByRequest.set(key, ownerId);
+        return true;
+      },
+    });
+
+    expect(inserted).toBe(true);
+    expect(requestKey ? ownersByRequest.get(requestKey) : undefined).toBe("signed-in-owner");
   });
 
   it("rejects cold direct control calls without active request context", async () => {

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -608,6 +608,18 @@ describe("agent control tools", () => {
       }),
     ]);
 
+    const inspectedByArtifact = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "inspect_agent_artifacts", {
+        artifactId: "art_test",
+        ownerId: "owner",
+      }),
+    );
+    expect(inspectedByArtifact.artifacts).toHaveLength(1);
+    expect(inspectedByArtifact.artifacts[0]).toMatchObject({
+      artifactId: "art_test",
+      omiSessionId: result.session.sessionId,
+    });
+
     const events = kernel.getRun({ runId: result.run.runId, includeEvents: true }).events;
     expect(events.find((event: any) => event.type === "artifact.created")).toMatchObject({
       sessionId: result.session.sessionId,
@@ -750,7 +762,7 @@ describe("agent control tools", () => {
   it("rejects unscoped direct kernel artifact inspection", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     expect(() => kernel.inspectArtifacts({ ownerId: "owner" })).toThrow(
-      "Inspecting artifacts requires sessionId, runId, or attemptId",
+      "Inspecting artifacts requires artifactId, sessionId, runId, or attemptId",
     );
     store.close();
   });

--- a/desktop/macos/agent/tests/protocol-v2.test.ts
+++ b/desktop/macos/agent/tests/protocol-v2.test.ts
@@ -73,12 +73,21 @@ describe("protocol v2 compatibility", () => {
     expect(requestIdFor(message)).toBe("control-request");
   });
 
-  it("guards direct app control v2 messages with explicit correlation ids", () => {
+  it("keeps signed direct-control owner registration out of legacy control_tool dispatch", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const source = readFileSync(join(here, "../src/index.ts"), "utf8");
+    const legacyStart = source.indexOf('case "control_tool"');
+    const directStart = source.indexOf('case "direct_control_tool"');
+    const legacyBlock = source.slice(legacyStart, directStart);
+    const directBlock = source.slice(directStart);
 
+    expect(legacyStart).toBeGreaterThanOrEqual(0);
+    expect(directStart).toBeGreaterThan(legacyStart);
     expect(source).toContain("protocol v2 direct control requires clientId");
     expect(source).toContain("protocol v2 direct control requires requestId");
-    expect(source).toContain("const requestId = control.protocolVersion === 2 ? control.requestId.trim() : requestIdFor(control)");
+    expect(source).toContain("const requestId = control.protocolVersion === 2 ? control.requestId!.trim() : requestIdFor(control)");
+    expect(legacyBlock).not.toContain("registerSignedDirectControlOwner");
+    expect(directBlock).toContain("registerSignedDirectControlOwner");
+    expect(directBlock).toContain("releaseDirectControlOwner");
   });
 });

--- a/desktop/macos/agent/tests/protocol-v2.test.ts
+++ b/desktop/macos/agent/tests/protocol-v2.test.ts
@@ -54,4 +54,19 @@ describe("protocol v2 compatibility", () => {
     const outbound: OutboundMessage = message;
     expect(outbound.type).toBe("cancel_ack");
   });
+
+  it("defines direct app control as an owner-guarded inbound message", () => {
+    const message: InboundMessage = {
+      type: "direct_control_tool",
+      protocolVersion: 2,
+      requestId: "control-request",
+      clientId: "realtime-hub",
+      ownerId: "owner-1",
+      name: "list_agent_sessions",
+      input: { limit: 10 },
+    };
+
+    expect(message.type).toBe("direct_control_tool");
+    expect(requestIdFor(message)).toBe("control-request");
+  });
 });

--- a/desktop/macos/agent/tests/protocol-v2.test.ts
+++ b/desktop/macos/agent/tests/protocol-v2.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { CancelAckMessage, InboundMessage, OutboundMessage, QueryMessage } from "../src/protocol.js";
 import { requestIdFor } from "../src/protocol.js";
 
@@ -68,5 +71,14 @@ describe("protocol v2 compatibility", () => {
 
     expect(message.type).toBe("direct_control_tool");
     expect(requestIdFor(message)).toBe("control-request");
+  });
+
+  it("guards direct app control v2 messages with explicit correlation ids", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(join(here, "../src/index.ts"), "utf8");
+
+    expect(source).toContain("protocol v2 direct control requires clientId");
+    expect(source).toContain("protocol v2 direct control requires requestId");
+    expect(source).toContain("const requestId = control.protocolVersion === 2 ? control.requestId.trim() : requestIdFor(control)");
   });
 });

--- a/docs/doc/developer/agent-control-plane.mdx
+++ b/docs/doc/developer/agent-control-plane.mdx
@@ -908,6 +908,9 @@ Rules:
 - No owner-scoped path may fall back to process-global mutable owner state when `clientId`/`requestId` context is expected but absent.
 - Internal maps and queues MUST key request-scoped state by `(clientId, requestId)`, not `requestId` alone.
 - `runId`-only interrupt or control requests MUST still prove owner visibility through the active context or an explicit matching owner guard.
+- Swift app surfaces that manage existing agents outside an active query MUST use the dedicated `direct_control_tool`
+  JSONL envelope. It requires a signed-in `ownerId` guard and is limited to observe/manage tools; request-scoped
+  `control_tool` remains valid only while the daemon has an active `(clientId, requestId)` owner context.
 - Query-scoped tool relay messages MUST carry all available Omi correlation fields: `protocolVersion`, `clientId`, `requestId`, `sessionId`, `runId`, `attemptId`, adapter IDs, and explicitly named adapter-native compatibility fields.
 - Adapter subprocess environments and adapter-to-daemon relay messages are one contract. If the daemon sets `OMI_REQUEST_ID` and `OMI_CLIENT_ID`, the adapter relay MUST serialize them onto any tool-use message that depends on request ownership.
 - Long-lived adapter workers MUST NOT rely on launch-time environment variables as per-attempt context. They MUST refresh active request/run/attempt context through a per-attempt channel before execution, and relay tools MUST read that channel when emitting request-scoped messages.

--- a/docs/doc/developer/agent-control-plane.mdx
+++ b/docs/doc/developer/agent-control-plane.mdx
@@ -1012,6 +1012,7 @@ get_agent_run
 send_agent_message
 cancel_agent_run
 inspect_agent_artifacts
+update_agent_artifact_lifecycle
 ```
 
 ### 16.2 Implementation decision
@@ -1028,10 +1029,16 @@ Required sequence:
 4. Implement `delegate_agent` after child session/run/delegation creation is transactional and the scheduler supports it.
 5. Generate MCP, Swift, documentation, and permission metadata from a capability manifest in the later capability-consolidation phase.
 
-The Phase 1 baseline includes all six hand-written local control tools: `list_agent_sessions`, `get_agent_run`,
-`cancel_agent_run`, `inspect_agent_artifacts`, `send_agent_message`, and `delegate_agent`. `send_agent_message`
-creates a follow-up run in an existing Omi session. `delegate_agent` creates or continues a distinct child Omi
-session linked to a parent run and records the delegation through kernel-owned state.
+The Phase 1 baseline includes seven hand-written local control tools: `list_agent_sessions`, `get_agent_run`,
+`cancel_agent_run`, `inspect_agent_artifacts`, `update_agent_artifact_lifecycle`, `send_agent_message`, and
+`delegate_agent`. `send_agent_message` creates a follow-up run in an existing Omi session. `delegate_agent`
+creates or continues a distinct child Omi session linked to a parent run and records the delegation through
+kernel-owned state.
+
+Observe/manage-by-id tools (`list_agent_sessions`, `get_agent_run`, `cancel_agent_run`,
+`inspect_agent_artifacts`, and `update_agent_artifact_lifecycle`) are cross-surface capabilities for desktop chat
+and PTT/realtime. Creation/continuation tools (`send_agent_message`, `delegate_agent`) remain desktop-chat-only
+until realtime has an equally explicit creation UX, control envelope, and correlation policy.
 
 ### 16.3 Delegation semantics
 


### PR DESCRIPTION
## Summary

- Expose canonical agent observe/manage tools to PTT/realtime: `list_agent_sessions`, `get_agent_run`, `cancel_agent_run`, `inspect_agent_artifacts`, and `update_agent_artifact_lifecycle`
- Route realtime tool calls through the shared `AgentRuntimeProcess.controlTool` path and return spoken-safe summaries instead of raw control-plane JSON
- Keep canonical creation/continuation tools (`send_agent_message`, `delegate_agent`) desktop-chat-only for now, and document that boundary in the control-plane spec
- Add drift coverage for realtime tool exposure and manifest-to-Swift surface metadata

## Why

Subagents created from chat should be inspectable and cancellable from PTT/realtime, and the same should hold for canonical runs created from other Omi surfaces. The runtime already owns those canonical sessions/runs; this PR makes realtime a first-class control surface for observe/manage-by-id operations without giving voice the ability to create nested canonical work yet.

## Validation

- `git diff --check`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --skip-install`
- `cd desktop/macos/agent && npm test -- --run tests/control-tools.test.ts`
- `cd desktop/macos/agent && npm run build`
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter 'ChatDiscoverabilityTests|HubSystemInstructionTests'`
- Built and launched named bundle `/Applications/omi-agent-control-ptt.app`; automation bridge reported signed-in main app with floating bar visible, then the named test bundle was stopped

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

