### PR TITLE
[codex] Extract listen pusher session

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -4,7 +4,6 @@ import io
 import json
 import logging
 import os
-import random
 import audioop
 import struct
 import time
@@ -38,8 +37,6 @@ else:
 from fastapi import APIRouter, Depends
 from fastapi.websockets import WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
-from websockets.exceptions import ConnectionClosed
-
 from firebase_admin.auth import InvalidIdTokenError
 
 from utils.speaker_assignment import (
@@ -83,7 +80,7 @@ from utils.conversations.process_conversation import retrieve_in_progress_conver
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists, get_user_has_speech_profile
-from utils.pusher import connect_to_trigger_pusher, PusherCircuitBreakerOpen, get_circuit_breaker, CircuitState
+from utils.pusher import PusherCircuitBreakerOpen
 from utils.request_validation import ImageChunkEnvelope
 from utils.speaker_identification import detect_speaker_from_text
 from utils.stt.streaming import (
@@ -128,10 +125,8 @@ from utils.aac import AACDecoder
 from utils.audio import AudioRingBuffer
 from utils.metrics import (
     BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS,
-    PUSHER_CIRCUIT_BREAKER_REJECTIONS,
-    PUSHER_CIRCUIT_BREAKER_STATE,
-    PUSHER_SESSION_DEGRADED,
 )
+from utils.listen_pusher_session import ListenPusherSession, ListenPusherSessionConfig, ListenPusherSessionDeps
 from utils.stt.speaker_embedding import (
     extract_embedding_from_bytes,
     compare_embeddings,
@@ -171,19 +166,6 @@ FREEMIUM_THRESHOLD_SECONDS = 180  # 3 minutes remaining - notify user
 
 TARGET_SAMPLE_RATE = 16000
 
-
-# Per-session pusher reconnect state machine
-class PusherReconnectState(str, Enum):
-    CONNECTED = 'connected'
-    RECONNECT_BACKOFF = 'reconnect_backoff'
-    DEGRADED = 'degraded'
-    HALF_OPEN_PROBE = 'half_open_probe'
-
-
-PUSHER_MAX_RECONNECT_ATTEMPTS = 6
-PUSHER_DEGRADED_COOLDOWN = 60.0  # seconds before probing from DEGRADED
-PUSHER_RECONNECT_BASE_DELAY = 1.0  # seconds
-PUSHER_RECONNECT_MAX_DELAY = 60.0  # seconds
 
 WS_RECEIVE_TIMEOUT = 300.0  # seconds — no-data timeout on client WebSocket receive
 BG_DRAIN_TIMEOUT = 30.0  # seconds — grace period for bg tasks to drain after disconnect
@@ -1137,549 +1119,6 @@ async def _stream_handler(
 
     # Pusher
     #
-    def create_pusher_task_handler():
-        nonlocal websocket_active
-        nonlocal current_conversation_id
-
-        pusher_ws = None
-        pusher_connect_lock = asyncio.Lock()
-        pusher_connected = False
-
-        # Per-session reconnect state machine
-        reconnect_state = PusherReconnectState.CONNECTED
-        reconnect_attempts = 0
-        reconnect_task = None  # single task per session
-        degraded_since: float = 0.0
-
-        # Transcript (bounded to prevent memory growth when pusher is down)
-        segment_buffers: deque = deque(maxlen=MAX_SEGMENT_BUFFER_SIZE)
-
-        last_synced_conversation_id = None
-
-        # Conversation processing — maps conversation_id to {sent_at, retries}
-        PENDING_REQUEST_TIMEOUT = 120  # seconds before retrying a pending request
-        MAX_RETRIES_PER_REQUEST = 3
-        pending_conversation_requests: Dict[str, dict] = {}
-        pending_request_event = asyncio.Event()
-
-        # Speaker-sample extraction requests buffered while pusher is disconnected,
-        # replayed on reconnect (#6060). Bounded to avoid unbounded growth during
-        # long outages; oldest is dropped when full.
-        pending_speaker_sample_requests: deque = deque(maxlen=MAX_PENDING_SPEAKER_SAMPLE_REQUESTS)
-
-        def transcript_send(segments):
-            nonlocal segment_buffers
-            segment_buffers.extend(segments)
-
-        async def request_conversation_processing(conversation_id: str):
-            """Request pusher to process a conversation."""
-            nonlocal pusher_ws, pusher_connected, pending_conversation_requests, pending_request_event
-            if not pusher_connected or not pusher_ws:
-                logger.info(f"Pusher not connected for {conversation_id}, will retry on reconnect {uid} {session_id}")
-                # Track as pending so it gets retried on reconnect
-                if conversation_id not in pending_conversation_requests:
-                    pending_conversation_requests[conversation_id] = {'sent_at': time.time(), 'retries': 0}
-                    pending_request_event.set()
-                return False
-            # Prevent unbounded growth of pending requests
-            if len(pending_conversation_requests) >= MAX_PENDING_REQUESTS:
-                oldest_id = min(
-                    pending_conversation_requests, key=lambda k: pending_conversation_requests[k]['sent_at']
-                )
-                logger.info(
-                    f"Too many pending requests, dropping {oldest_id} to add {conversation_id} {uid} {session_id}"
-                )
-                del pending_conversation_requests[oldest_id]
-            try:
-                pending_conversation_requests[conversation_id] = {
-                    'sent_at': time.time(),
-                    'retries': pending_conversation_requests.get(conversation_id, {}).get('retries', 0),
-                }
-                pending_request_event.set()  # Signal the receiver
-                data = bytearray()
-                data.extend(struct.pack("I", 104))
-                # Forward BYOK keys to pusher so process_conversation routes LLM
-                # calls through the user's keys. Empty dict when user isn't BYOK
-                # — pusher then uses its env keys (unchanged behavior).
-                payload = {
-                    "conversation_id": conversation_id,
-                    "language": language,
-                    "byok_keys": get_byok_keys(),
-                }
-                data.extend(bytes(json.dumps(payload), "utf-8"))
-                await pusher_ws.send(data)
-                logger.info(f"Sent process_conversation request to pusher: {conversation_id} {uid} {session_id}")
-                return True
-            except Exception as e:
-                logger.error(f"Failed to send process_conversation request: {e} {uid} {session_id}")
-                return False
-
-        async def _transcript_flush(auto_reconnect: bool = True):
-            nonlocal pusher_ws
-            nonlocal pusher_connected
-            if pusher_connected and pusher_ws and len(segment_buffers) > 0:
-                try:
-                    # 102|data
-                    data = bytearray()
-                    data.extend(struct.pack("I", 102))
-                    data.extend(
-                        bytes(
-                            json.dumps({"segments": list(segment_buffers), "memory_id": current_conversation_id}),
-                            "utf-8",
-                        )
-                    )
-                    segment_buffers.clear()  # reset
-                    await pusher_ws.send(data)
-                except ConnectionClosed as e:
-                    logger.error(f"Pusher transcripts Connection closed: {e} {uid} {session_id}")
-                    _mark_disconnected()
-                except Exception as e:
-                    logger.error(f"Pusher transcripts failed: {e} {uid} {session_id}")
-
-        async def transcript_consume():
-            nonlocal websocket_active
-            while websocket_active:
-                await asyncio.sleep(1)
-                if len(segment_buffers) > 0:
-                    await _transcript_flush(auto_reconnect=True)
-
-        # Audio bytes (bounded to prevent memory growth when pusher is down)
-        # Using deque of chunks for O(1) trimming instead of O(n) bytearray slice
-        audio_chunks: deque = deque()  # deque of bytes objects
-        audio_total_size = 0  # Track total size for O(1) limit check
-        audio_buffer_last_received: float = None  # Track when last audio was received
-        audio_bytes_enabled = (
-            bool(get_audio_bytes_webhook_seconds(uid)) or is_audio_bytes_app_enabled(uid) or private_cloud_sync_enabled
-        )
-
-        def audio_bytes_send(audio_bytes: bytes, received_at: float):
-            nonlocal audio_chunks, audio_total_size, audio_buffer_last_received
-            chunk = audio_bytes
-            # Trim oversized incoming chunk
-            if len(chunk) > MAX_AUDIO_BUFFER_SIZE:
-                chunk = chunk[-MAX_AUDIO_BUFFER_SIZE:]
-            # Drop oldest chunks to make room - O(1) per chunk
-            while audio_total_size + len(chunk) > MAX_AUDIO_BUFFER_SIZE and audio_chunks:
-                old = audio_chunks.popleft()
-                audio_total_size -= len(old)
-            audio_chunks.append(chunk)
-            audio_total_size += len(chunk)
-            audio_buffer_last_received = received_at
-
-        async def _audio_bytes_flush(auto_reconnect: bool = True):
-            nonlocal audio_chunks, audio_total_size
-            nonlocal audio_buffer_last_received
-            nonlocal pusher_ws
-            nonlocal pusher_connected
-            nonlocal last_synced_conversation_id
-
-            # Send conversation ID
-            if (
-                pusher_ws
-                and current_conversation_id
-                and (last_synced_conversation_id is None or current_conversation_id != last_synced_conversation_id)
-            ):
-                try:
-                    # 103|conversation_id
-                    data = bytearray()
-                    data.extend(struct.pack("I", 103))
-                    data.extend(bytes(current_conversation_id, "utf-8"))
-                    await pusher_ws.send(data)
-                    last_synced_conversation_id = current_conversation_id
-                except ConnectionClosed as e:
-                    logger.error(f"Pusher audio_bytes Connection closed: {e} {uid} {session_id}")
-                    _mark_disconnected()
-                except Exception as e:
-                    logger.error(f"Failed to send conversation_id to pusher: {e} {uid} {session_id}")
-
-            # Send audio bytes
-            if pusher_connected and pusher_ws and audio_total_size > 0:
-                try:
-                    # Calculate buffer start time:
-                    # buffer_start = last_received_time - buffer_duration
-                    # buffer_duration = buffer_length_bytes / (rate * 2 bytes per sample)
-                    # Multi-channel audio is resampled to TARGET_SAMPLE_RATE before reaching the pusher
-                    effective_rate = TARGET_SAMPLE_RATE if is_multi_channel else sample_rate
-                    buffer_duration_seconds = audio_total_size / (effective_rate * 2)
-                    buffer_start_time = (audio_buffer_last_received or time.time()) - buffer_duration_seconds
-
-                    # Join chunks into contiguous bytes for sending
-                    audio_data = b''.join(audio_chunks)
-
-                    # 101|timestamp(8 bytes double)|audio_data
-                    data = bytearray()
-                    data.extend(struct.pack("I", 101))
-                    data.extend(struct.pack("d", buffer_start_time))
-                    data.extend(audio_data)
-                    # Reset buffer
-                    audio_chunks.clear()
-                    audio_total_size = 0
-                    del audio_data  # Free immediately
-                    await pusher_ws.send(data)
-                except ConnectionClosed as e:
-                    logger.error(f"Pusher audio_bytes Connection closed: {e} {uid} {session_id}")
-                    _mark_disconnected()
-                except Exception as e:
-                    logger.error(f"Pusher audio_bytes failed: {e} {uid} {session_id}")
-
-        async def audio_bytes_consume():
-            nonlocal websocket_active
-            nonlocal audio_chunks, audio_total_size
-            nonlocal pusher_ws
-            nonlocal pusher_connected
-            while websocket_active:
-                await asyncio.sleep(1)
-                if audio_total_size > 0:
-                    await _audio_bytes_flush(auto_reconnect=True)
-
-        async def pusher_receive():
-            """Receive and handle messages from pusher, with timeout-based retry for pending requests."""
-            nonlocal websocket_active, pusher_ws, pusher_connected, pending_conversation_requests, pending_request_event
-            while websocket_active:
-                # Wait efficiently until there's work to do
-                if not pending_conversation_requests:
-                    pending_request_event.clear()
-                    try:
-                        await asyncio.wait_for(pending_request_event.wait(), timeout=5.0)
-                    except asyncio.TimeoutError:
-                        continue  # Check websocket_active
-
-                if not pusher_connected or not pusher_ws:
-                    await asyncio.sleep(0.5)
-                    continue
-
-                try:
-                    msg = await asyncio.wait_for(pusher_ws.recv(), timeout=5.0)
-                    if not msg or len(msg) < 4:
-                        continue
-                    header_type = struct.unpack('<I', msg[:4])[0]
-
-                    # Conversation processed response
-                    if header_type == 201:
-                        result = json.loads(msg[4:].decode("utf-8"))
-                        conversation_id = result.get("conversation_id")
-                        pending_conversation_requests.pop(conversation_id, None)
-
-                        if "error" in result:
-                            logger.error(f"Conversation processing failed: {result['error']} {uid} {session_id}")
-                            continue
-
-                        if result.get("success"):
-                            logger.info(f"Conversation processed by pusher: {conversation_id} {uid} {session_id}")
-                            on_conversation_processed(conversation_id)
-
-                except asyncio.TimeoutError:
-                    pass  # Fall through to retry check below
-                except asyncio.CancelledError:
-                    break
-                except ConnectionClosed as e:
-                    logger.error(f"Pusher receive connection closed: {e} {uid} {session_id}")
-                    _mark_disconnected()
-                except Exception as e:
-                    logger.error(f"Pusher receive error: {e} {uid} {session_id}")
-                    await asyncio.sleep(0.5)
-
-                # Retry timed-out pending requests (handles silent WS death)
-                now = time.time()
-                timed_out = [
-                    cid
-                    for cid, info in list(pending_conversation_requests.items())
-                    if now - info['sent_at'] > PENDING_REQUEST_TIMEOUT
-                ]
-                for cid in timed_out:
-                    info = pending_conversation_requests.get(cid)
-                    if not info:
-                        continue
-                    if info['retries'] >= MAX_RETRIES_PER_REQUEST:
-                        logger.warning(
-                            f"Conversation {cid} retry limit reached, keeping buffered for pusher recovery {uid} {session_id}"
-                        )
-                        # Don't drop — conversation is marked processing in Firestore,
-                        # cleanup_processing_conversations() will pick it up on next session (#6061)
-                        info['sent_at'] = now  # Reset timeout to avoid tight retry loop
-                        continue
-                    info['retries'] += 1
-                    logger.warning(
-                        f"Retrying process_conversation for {cid} (attempt {info['retries']}/{MAX_RETRIES_PER_REQUEST}) {uid} {session_id}"
-                    )
-                    await request_conversation_processing(cid)
-
-        async def _flush():
-            await _audio_bytes_flush(auto_reconnect=False)
-            await _transcript_flush(auto_reconnect=False)
-
-        def _mark_disconnected():
-            """Signal pusher disconnection — sets state and ensures reconnect loop is running."""
-            nonlocal pusher_connected, reconnect_state, reconnect_task
-            if not pusher_connected:
-                return  # already marked
-            pusher_connected = False
-            if reconnect_state == PusherReconnectState.CONNECTED:
-                reconnect_state = PusherReconnectState.RECONNECT_BACKOFF
-                logger.info(f"Pusher disconnected, entering RECONNECT_BACKOFF {uid} {session_id}")
-            # Ensure reconnect loop is running (single task per session)
-            if reconnect_task is None or reconnect_task.done():
-                reconnect_task = asyncio.create_task(_pusher_reconnect_loop())
-
-        async def _pusher_reconnect_loop():
-            """Single reconnect loop per session — replaces 3 scattered auto-reconnect calls.
-
-            State machine:
-            RECONNECT_BACKOFF → (6 failures) → DEGRADED → (60s) → HALF_OPEN_PROBE → success → CONNECTED
-                                                                                   → failure → DEGRADED
-            """
-            nonlocal reconnect_state, reconnect_attempts, degraded_since, pusher_connected
-            logger.info(f"Pusher reconnect loop started {uid} {session_id}")
-            PUSHER_SESSION_DEGRADED.inc()
-            try:
-                while websocket_active and not pusher_connected:
-                    if reconnect_state == PusherReconnectState.RECONNECT_BACKOFF:
-                        if reconnect_attempts >= PUSHER_MAX_RECONNECT_ATTEMPTS:
-                            reconnect_state = PusherReconnectState.DEGRADED
-                            degraded_since = time.monotonic()
-                            reconnect_attempts = 0
-                            logger.warning(
-                                f"Pusher reconnect exhausted ({PUSHER_MAX_RECONNECT_ATTEMPTS} attempts), "
-                                f"entering DEGRADED mode {uid} {session_id}"
-                            )
-                            # Keep pending conversations buffered — will resend when pusher recovers (#6061)
-                            if pending_conversation_requests:
-                                logger.info(
-                                    f"Keeping {len(pending_conversation_requests)} conversations buffered for pusher recovery {uid} {session_id}"
-                                )
-                            continue
-
-                        # Exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s (capped at 60s)
-                        delay = min(
-                            PUSHER_RECONNECT_BASE_DELAY * (2**reconnect_attempts),
-                            PUSHER_RECONNECT_MAX_DELAY,
-                        )
-                        # Add jitter (±25%)
-                        delay *= 0.75 + random.random() * 0.5
-                        logger.info(
-                            f"Pusher reconnect attempt {reconnect_attempts + 1}/{PUSHER_MAX_RECONNECT_ATTEMPTS}, "
-                            f"waiting {delay:.1f}s {uid} {session_id}"
-                        )
-                        if await wait_for_event(shutdown_event, delay):
-                            break
-
-                        try:
-                            await connect()
-                            if pusher_connected:
-                                reconnect_state = PusherReconnectState.CONNECTED
-                                reconnect_attempts = 0
-                                logger.info(f"Pusher reconnected successfully {uid} {session_id}")
-                                break
-                        except PusherCircuitBreakerOpen:
-                            PUSHER_CIRCUIT_BREAKER_REJECTIONS.inc()
-                            # Circuit breaker is open — skip to degraded immediately
-                            reconnect_state = PusherReconnectState.DEGRADED
-                            degraded_since = time.monotonic()
-                            reconnect_attempts = 0
-                            logger.warning(f"Circuit breaker open, skipping to DEGRADED {uid} {session_id}")
-                            # Keep pending conversations buffered — will resend when pusher recovers (#6061)
-                            continue
-                        except Exception:
-                            pass  # _connect already logged the error
-
-                        reconnect_attempts += 1
-
-                    elif reconnect_state == PusherReconnectState.DEGRADED:
-                        # Wait for cooldown before probing
-                        elapsed = time.monotonic() - degraded_since
-                        remaining = PUSHER_DEGRADED_COOLDOWN - elapsed
-                        if remaining > 0:
-                            if await wait_for_event(shutdown_event, min(remaining, 5.0)):
-                                break
-                            continue
-                        # Cooldown elapsed — try a single probe
-                        reconnect_state = PusherReconnectState.HALF_OPEN_PROBE
-                        logger.info(f"Pusher DEGRADED cooldown elapsed, probing {uid} {session_id}")
-
-                    elif reconnect_state == PusherReconnectState.HALF_OPEN_PROBE:
-                        try:
-                            await connect()
-                            if pusher_connected:
-                                reconnect_state = PusherReconnectState.CONNECTED
-                                reconnect_attempts = 0
-                                logger.info(f"Pusher probe succeeded, back to CONNECTED {uid} {session_id}")
-                                break
-                        except PusherCircuitBreakerOpen:
-                            PUSHER_CIRCUIT_BREAKER_REJECTIONS.inc()
-                            pass
-                        except Exception:
-                            pass
-                        # Probe failed — back to DEGRADED
-                        reconnect_state = PusherReconnectState.DEGRADED
-                        degraded_since = time.monotonic()
-                        logger.warning(f"Pusher probe failed, back to DEGRADED {uid} {session_id}")
-
-                    else:
-                        # Shouldn't happen, but guard against
-                        break
-            finally:
-                PUSHER_SESSION_DEGRADED.dec()
-                logger.info(f"Pusher reconnect loop ended (state={reconnect_state.value}) {uid} {session_id}")
-
-        async def connect():
-            nonlocal pusher_connected
-            nonlocal pusher_connect_lock
-            nonlocal pusher_ws
-            async with pusher_connect_lock:
-                if pusher_connected:
-                    return
-                # drain
-                if pusher_ws:
-                    try:
-                        await pusher_ws.close()
-                        pusher_ws = None
-                    except Exception as e:
-                        logger.error(f"Pusher draining failed: {e} {uid} {session_id}")
-                # connect (PusherCircuitBreakerOpen propagates to caller)
-                await _connect()
-
-        async def _connect():
-            nonlocal pusher_ws
-            nonlocal pusher_connected
-            nonlocal current_conversation_id
-            nonlocal reconnect_state, reconnect_attempts
-
-            try:
-                pusher_sample_rate = TARGET_SAMPLE_RATE if is_multi_channel else sample_rate
-                pusher_ws = await connect_to_trigger_pusher(
-                    uid, pusher_sample_rate, retries=5, is_active=lambda: websocket_active
-                )
-                if pusher_ws is None:
-                    # Session ended during connection attempt
-                    return
-                pusher_connected = True
-                reconnect_state = PusherReconnectState.CONNECTED
-                reconnect_attempts = 0
-                # Re-send any pending conversation requests after reconnect
-                if pending_conversation_requests:
-                    logger.info(
-                        f"Reconnected to pusher, re-sending {len(pending_conversation_requests)} pending requests {uid} {session_id}"
-                    )
-                    for cid in list(pending_conversation_requests.keys()):
-                        pending_conversation_requests[cid]['sent_at'] = time.time()
-                        await request_conversation_processing(cid)
-                # Re-send any speaker sample requests buffered while disconnected (#6060)
-                if pending_speaker_sample_requests:
-                    buffered = list(pending_speaker_sample_requests)
-                    pending_speaker_sample_requests.clear()
-                    logger.info(
-                        f"Reconnected to pusher, re-sending {len(buffered)} pending speaker sample requests {uid} {session_id}"
-                    )
-                    for person_id, conv_id, segment_ids in buffered:
-                        await send_speaker_sample_request(person_id, conv_id, segment_ids)
-            except PusherCircuitBreakerOpen:
-                raise  # Let caller handle circuit breaker
-            except Exception as e:
-                logger.error(f"Exception in connect: {e} {uid} {session_id}")
-
-        async def close(code: int = 1000):
-            nonlocal reconnect_task
-            # Cancel reconnect loop if running
-            if reconnect_task and not reconnect_task.done():
-                reconnect_task.cancel()
-                try:
-                    await reconnect_task
-                except asyncio.CancelledError:
-                    pass
-                reconnect_task = None
-            await _flush()
-            if pusher_ws:
-                await pusher_ws.close(code)
-
-        def is_degraded():
-            return reconnect_state in (PusherReconnectState.DEGRADED, PusherReconnectState.HALF_OPEN_PROBE)
-
-        async def send_speaker_sample_request(
-            person_id: str,
-            conv_id: str,
-            segment_ids: List[str],
-        ):
-            """Send speaker sample extraction request to pusher with segment IDs."""
-            nonlocal pusher_ws, pusher_connected
-            if not pusher_connected or not pusher_ws:
-                # Buffer instead of dropping so the request survives a transient
-                # pusher disconnect and is replayed on reconnect (#6060).
-                pending_speaker_sample_requests.append((person_id, conv_id, segment_ids))
-                logger.warning(
-                    f"Pusher not connected, buffered speaker sample request: person={person_id}, "
-                    f"{len(segment_ids)} segments ({len(pending_speaker_sample_requests)} pending) {uid} {session_id}"
-                )
-                return
-            try:
-                data = bytearray()
-                data.extend(struct.pack("I", 105))
-                data.extend(
-                    bytes(
-                        json.dumps(
-                            {
-                                "person_id": person_id,
-                                "conversation_id": conv_id,
-                                "segment_ids": segment_ids,
-                            }
-                        ),
-                        "utf-8",
-                    )
-                )
-                await pusher_ws.send(data)
-                logger.info(
-                    f"Sent speaker sample request to pusher: person={person_id}, {len(segment_ids)} segments {uid} {session_id}"
-                )
-            except Exception as e:
-                logger.error(f"Failed to send speaker sample request: {e} {uid} {session_id}")
-
-        def is_connected():
-            return pusher_connected
-
-        async def pusher_heartbeat():
-            """Send periodic data-frame heartbeats to reset the GKE ILB idle timer.
-
-            The GKE Internal Load Balancer counts only data frames for its idle
-            timeout (default 30 s). WebSocket control frames (ping/pong) are
-            ignored. During user silence most connections carry zero data frames,
-            causing the ILB to kill the connection. This task sends a minimal
-            4-byte data frame (header type 100) every 20 s to keep the link alive.
-            """
-            nonlocal pusher_ws, pusher_connected, websocket_active
-            while websocket_active:
-                if await wait_for_event(shutdown_event, 20):
-                    break
-                if pusher_connected and pusher_ws:
-                    try:
-                        await pusher_ws.send(struct.pack("I", 100))
-                    except ConnectionClosed:
-                        _mark_disconnected()
-                    except Exception as e:
-                        logger.error(f"Pusher heartbeat send failed: {e} {uid} {session_id}")
-
-        def start_degraded():
-            """Enter degraded mode and start reconnect loop after initial connect failure."""
-            nonlocal reconnect_state, reconnect_task, degraded_since
-            reconnect_state = PusherReconnectState.DEGRADED
-            degraded_since = time.monotonic()
-            if reconnect_task is None or reconnect_task.done():
-                reconnect_task = asyncio.create_task(_pusher_reconnect_loop())
-
-        return (
-            connect,
-            close,
-            transcript_send,
-            transcript_consume,
-            audio_bytes_send if audio_bytes_enabled else None,
-            audio_bytes_consume if audio_bytes_enabled else None,
-            request_conversation_processing,
-            pusher_receive,
-            is_connected,
-            is_degraded,
-            start_degraded,
-            send_speaker_sample_request,
-            pusher_heartbeat,
-        )
-
     transcript_send = None
     transcript_consume = None
     audio_bytes_send = None
@@ -2761,21 +2200,48 @@ async def _stream_handler(
         # Init pusher
         pusher_tasks = []
         if PUSHER_ENABLED:
-            (
-                pusher_connect,
-                pusher_close,
-                transcript_send,
-                transcript_consume,
-                audio_bytes_send,
-                audio_bytes_consume,
-                request_conversation_processing,
-                pusher_receive,
-                pusher_is_connected,
-                pusher_is_degraded,
-                pusher_start_degraded,
-                send_speaker_sample_request,
-                pusher_heartbeat,
-            ) = create_pusher_task_handler()
+            pusher_session = ListenPusherSession(
+                ListenPusherSessionConfig(
+                    uid=uid,
+                    session_id=session_id,
+                    sample_rate=sample_rate,
+                    is_multi_channel=is_multi_channel,
+                    language=language,
+                    audio_bytes_enabled=(
+                        bool(get_audio_bytes_webhook_seconds(uid))
+                        or is_audio_bytes_app_enabled(uid)
+                        or private_cloud_sync_enabled
+                    ),
+                    max_segment_buffer_size=MAX_SEGMENT_BUFFER_SIZE,
+                    max_audio_buffer_size=MAX_AUDIO_BUFFER_SIZE,
+                    max_pending_requests=MAX_PENDING_REQUESTS,
+                    max_pending_speaker_sample_requests=MAX_PENDING_SPEAKER_SAMPLE_REQUESTS,
+                ),
+                ListenPusherSessionDeps(
+                    get_current_conversation_id=lambda: current_conversation_id,
+                    is_active=lambda: websocket_active,
+                    shutdown_event=shutdown_event,
+                    get_byok_keys=get_byok_keys,
+                    on_conversation_processed=on_conversation_processed,
+                    wait_for_event=wait_for_event,
+                ),
+            )
+
+            pusher_connect = pusher_session.connect
+            pusher_close = pusher_session.close
+            transcript_send = pusher_session.transcript_send
+            transcript_consume = pusher_session.transcript_consume
+            audio_bytes_send = pusher_session.audio_bytes_send if pusher_session.config.audio_bytes_enabled else None
+            audio_bytes_consume = (
+                pusher_session.audio_bytes_consume if pusher_session.config.audio_bytes_enabled else None
+            )
+            request_conversation_processing = pusher_session.request_conversation_processing
+            pusher_receive = pusher_session.pusher_receive
+            pusher_is_connected = pusher_session.is_connected
+            pusher_is_degraded = pusher_session.is_degraded
+            pusher_start_degraded = pusher_session.start_degraded
+            send_speaker_sample_request = pusher_session.send_speaker_sample_request
+            pusher_heartbeat = pusher_session.pusher_heartbeat
 
             # Pusher connection — graceful degradation instead of 1011 hard close
             try:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -87,6 +87,7 @@ pytest tests/unit/test_file_upload_endpoint_security.py -v
 pytest tests/unit/test_auth_redirect_uri.py -v
 pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_pusher_conversation_retry.py -v
+pytest tests/unit/utils/test_listen_pusher_session.py -v
 pytest tests/unit/test_listen_fallback_removal.py -v
 pytest tests/unit/test_desktop_updates.py -v
 pytest tests/unit/test_translation_optimization.py -v

--- a/backend/tests/unit/test_pusher_conversation_retry.py
+++ b/backend/tests/unit/test_pusher_conversation_retry.py
@@ -19,6 +19,12 @@ install_websockets_stub()
 
 from websockets.exceptions import ConnectionClosed
 
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 # ---------------------------------------------------------------------------
 # Helpers: mirror the real pending request tracking from transcribe.py
 # ---------------------------------------------------------------------------
@@ -88,7 +94,7 @@ def _handle_type_201_response(pending_requests: dict, conversation_id: str):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_tracks_pending_on_success():
     """Successful send adds conversation to pending with timestamp."""
     pending = {}
@@ -103,7 +109,7 @@ async def test_request_tracks_pending_on_success():
     assert pending["conv-1"]["sent_at"] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_tracks_pending_when_disconnected():
     """When pusher is disconnected, conversation is tracked for retry on reconnect."""
     pending = {}
@@ -117,7 +123,7 @@ async def test_request_tracks_pending_when_disconnected():
     assert event.is_set(), "Should signal the receiver"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_does_not_overwrite_retry_count_when_disconnected():
     """Re-requesting a conversation that's already pending doesn't reset retry count."""
     pending = {"conv-1": {"sent_at": time.time() - 100, "retries": 2}}
@@ -129,7 +135,7 @@ async def test_request_does_not_overwrite_retry_count_when_disconnected():
     assert pending["conv-1"]["retries"] == 2, "Should not reset retry count"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_preserves_retry_count_on_resend():
     """Re-sending a pending request preserves its retry count."""
     pending = {"conv-1": {"sent_at": time.time() - 200, "retries": 2}}
@@ -142,7 +148,7 @@ async def test_request_preserves_retry_count_on_resend():
     assert pending["conv-1"]["retries"] == 2, "Retry count should be preserved"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_drops_oldest_on_overflow():
     """When pending requests hit MAX, drops the oldest."""
     pending = {}
@@ -162,7 +168,7 @@ async def test_request_drops_oldest_on_overflow():
     assert len(pending) == MAX_PENDING_REQUESTS
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_request_send_failure_keeps_pending():
     """If WS send raises, conversation stays in pending for retry."""
     pending = {}
@@ -271,7 +277,7 @@ def test_type_201_unknown_id_is_safe():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_resends_all_pending():
     """After reconnect, all pending requests are re-sent."""
     mock_ws = AsyncMock()
@@ -294,7 +300,7 @@ async def test_reconnect_resends_all_pending():
         assert header == 104
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_preserves_retry_counts():
     """Re-sending on reconnect preserves existing retry counts."""
     mock_ws = AsyncMock()

--- a/backend/tests/unit/utils/test_listen_pusher_session.py
+++ b/backend/tests/unit/utils/test_listen_pusher_session.py
@@ -46,6 +46,11 @@ def response_201(conversation_id: str, success=True):
     return struct.pack("<I", 201) + payload
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 def make_session(
     *,
     ws=None,
@@ -101,7 +106,7 @@ def make_session(
     return session
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_frame_payloads_and_order():
     ws = FakePusherWebSocket()
     session = make_session(ws=ws)
@@ -144,7 +149,7 @@ async def test_frame_payloads_and_order():
     }
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pending_conversation_and_speaker_sample_replay_uses_target_rate_for_multi_channel():
     ws = FakePusherWebSocket()
     connect_calls = []
@@ -165,6 +170,23 @@ async def test_pending_conversation_and_speaker_sample_replay_uses_target_rate_f
     assert list(session.pending_speaker_sample_requests) == []
 
 
+@pytest.mark.anyio
+async def test_disconnected_conversation_buffer_respects_max_pending_requests():
+    now = {"value": 1000.0}
+    session = make_session(
+        config_overrides={"max_pending_requests": 2},
+        deps_overrides={"now": lambda: now["value"]},
+    )
+
+    assert await session.request_conversation_processing("conv-1") is False
+    now["value"] += 1
+    assert await session.request_conversation_processing("conv-2") is False
+    now["value"] += 1
+    assert await session.request_conversation_processing("conv-3") is False
+
+    assert list(session.pending_conversation_requests.keys()) == ["conv-2", "conv-3"]
+
+
 def test_bounded_audio_and_transcript_buffers():
     session = make_session(config_overrides={"max_segment_buffer_size": 2, "max_audio_buffer_size": 5})
 
@@ -181,7 +203,7 @@ def test_bounded_audio_and_transcript_buffers():
     assert session.audio_total_size == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_incoming_201_invokes_callback_and_removes_pending_request():
     active_ref = {"active": True}
     ws = FakePusherWebSocket(incoming=[response_201("conv-1")])
@@ -196,7 +218,7 @@ async def test_incoming_201_invokes_callback_and_removes_pending_request():
     assert session.callbacks == ["conv-1"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_disconnected_starts_single_reconnect_loop():
     session = make_session()
     session.pusher_ws = FakePusherWebSocket()
@@ -212,7 +234,7 @@ async def test_mark_disconnected_starts_single_reconnect_loop():
         await first_task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_close_cancels_reconnect_flushes_buffers_and_closes_socket():
     ws = FakePusherWebSocket()
     session = make_session(ws=ws)

--- a/backend/tests/unit/utils/test_listen_pusher_session.py
+++ b/backend/tests/unit/utils/test_listen_pusher_session.py
@@ -1,0 +1,231 @@
+import asyncio
+import json
+import struct
+
+import pytest
+
+from utils.listen_pusher_session import (
+    TARGET_SAMPLE_RATE,
+    ListenPusherSession,
+    ListenPusherSessionConfig,
+    ListenPusherSessionDeps,
+)
+
+
+class FakePusherWebSocket:
+    def __init__(self, incoming=None):
+        self.sent = []
+        self.incoming = list(incoming or [])
+        self.closed_codes = []
+        self.on_recv = None
+
+    async def send(self, data):
+        self.sent.append(bytes(data))
+
+    async def recv(self):
+        if self.on_recv:
+            self.on_recv()
+        if self.incoming:
+            return self.incoming.pop(0)
+        await asyncio.sleep(10)
+
+    async def close(self, code=1000):
+        self.closed_codes.append(code)
+
+
+def frame_type(frame: bytes) -> int:
+    return struct.unpack("I", frame[:4])[0]
+
+
+def frame_json(frame: bytes):
+    return json.loads(frame[4:].decode("utf-8"))
+
+
+def response_201(conversation_id: str, success=True):
+    payload = json.dumps({"conversation_id": conversation_id, "success": success}).encode("utf-8")
+    return struct.pack("<I", 201) + payload
+
+
+def make_session(
+    *,
+    ws=None,
+    current_conversation_id="conv-1",
+    active_ref=None,
+    config_overrides=None,
+    deps_overrides=None,
+    connect_calls=None,
+):
+    active_ref = active_ref if active_ref is not None else {"active": True}
+    config_values = {
+        "uid": "uid-1",
+        "session_id": "session-1",
+        "sample_rate": 8000,
+        "is_multi_channel": False,
+        "language": "en",
+        "audio_bytes_enabled": True,
+        "max_segment_buffer_size": 3,
+        "max_audio_buffer_size": 8,
+        "max_pending_requests": 3,
+        "max_pending_speaker_sample_requests": 2,
+    }
+    if config_overrides:
+        config_values.update(config_overrides)
+
+    async def connect_to_pusher(uid, sample_rate, retries=5, is_active=None):
+        if connect_calls is not None:
+            connect_calls.append((uid, sample_rate, retries, is_active))
+        return ws or FakePusherWebSocket()
+
+    async def wait_for_event(event, timeout):
+        return False
+
+    callbacks = []
+    deps_values = {
+        "get_current_conversation_id": lambda: current_conversation_id,
+        "is_active": lambda: active_ref["active"],
+        "shutdown_event": asyncio.Event(),
+        "get_byok_keys": lambda: {"openai": "key"},
+        "on_conversation_processed": callbacks.append,
+        "wait_for_event": wait_for_event,
+        "connect_to_pusher": connect_to_pusher,
+        "sleep": asyncio.sleep,
+        "random": lambda: 0.5,
+        "now": lambda: 1000.0,
+        "monotonic": lambda: 2000.0,
+    }
+    if deps_overrides:
+        deps_values.update(deps_overrides)
+
+    session = ListenPusherSession(ListenPusherSessionConfig(**config_values), ListenPusherSessionDeps(**deps_values))
+    session.callbacks = callbacks
+    return session
+
+
+@pytest.mark.asyncio
+async def test_frame_payloads_and_order():
+    ws = FakePusherWebSocket()
+    session = make_session(ws=ws)
+    await session.connect()
+
+    session.audio_bytes_send(b"abcd", received_at=100.0)
+    await session._audio_bytes_flush()
+    session.transcript_send([{"id": "seg-1", "text": "hello"}])
+    await session._transcript_flush()
+    await session.request_conversation_processing("conv-1")
+    await session.send_speaker_sample_request("person-1", "conv-1", ["seg-1"])
+
+    active_ref = {"active": True}
+
+    async def wait_for_event(event, timeout):
+        if active_ref["active"]:
+            active_ref["active"] = False
+            return False
+        return True
+
+    session.deps.wait_for_event = wait_for_event
+    session.deps.is_active = lambda: active_ref["active"]
+    await session.pusher_heartbeat()
+
+    assert [frame_type(frame) for frame in ws.sent] == [103, 101, 102, 104, 105, 100]
+    assert ws.sent[0][4:].decode("utf-8") == "conv-1"
+    timestamp = struct.unpack("d", ws.sent[1][4:12])[0]
+    assert timestamp == 100.0 - (4 / (8000 * 2))
+    assert ws.sent[1][12:] == b"abcd"
+    assert frame_json(ws.sent[2]) == {"segments": [{"id": "seg-1", "text": "hello"}], "memory_id": "conv-1"}
+    assert frame_json(ws.sent[3]) == {
+        "conversation_id": "conv-1",
+        "language": "en",
+        "byok_keys": {"openai": "key"},
+    }
+    assert frame_json(ws.sent[4]) == {
+        "person_id": "person-1",
+        "conversation_id": "conv-1",
+        "segment_ids": ["seg-1"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_pending_conversation_and_speaker_sample_replay_uses_target_rate_for_multi_channel():
+    ws = FakePusherWebSocket()
+    connect_calls = []
+    session = make_session(
+        ws=ws,
+        config_overrides={"is_multi_channel": True, "sample_rate": 44100},
+        connect_calls=connect_calls,
+    )
+
+    assert await session.request_conversation_processing("conv-pending") is False
+    await session.send_speaker_sample_request("person-1", "conv-pending", ["seg-1", "seg-2"])
+    await session.connect()
+
+    assert connect_calls[0][1] == TARGET_SAMPLE_RATE
+    assert [frame_type(frame) for frame in ws.sent] == [104, 105]
+    assert frame_json(ws.sent[0])["conversation_id"] == "conv-pending"
+    assert frame_json(ws.sent[1])["segment_ids"] == ["seg-1", "seg-2"]
+    assert list(session.pending_speaker_sample_requests) == []
+
+
+def test_bounded_audio_and_transcript_buffers():
+    session = make_session(config_overrides={"max_segment_buffer_size": 2, "max_audio_buffer_size": 5})
+
+    session.transcript_send([{"id": "seg-1"}, {"id": "seg-2"}, {"id": "seg-3"}])
+    assert list(session.segment_buffers) == [{"id": "seg-2"}, {"id": "seg-3"}]
+
+    session.audio_bytes_send(b"abc", received_at=1.0)
+    session.audio_bytes_send(b"def", received_at=2.0)
+    assert b"".join(session.audio_chunks) == b"def"
+    assert session.audio_total_size == 3
+
+    session.audio_bytes_send(b"123456789", received_at=3.0)
+    assert b"".join(session.audio_chunks) == b"56789"
+    assert session.audio_total_size == 5
+
+
+@pytest.mark.asyncio
+async def test_incoming_201_invokes_callback_and_removes_pending_request():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[response_201("conv-1")])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1")
+
+    await session.pusher_receive()
+
+    assert session.pending_conversation_requests == {}
+    assert session.callbacks == ["conv-1"]
+
+
+@pytest.mark.asyncio
+async def test_mark_disconnected_starts_single_reconnect_loop():
+    session = make_session()
+    session.pusher_ws = FakePusherWebSocket()
+    session.pusher_connected = True
+
+    session._mark_disconnected()
+    first_task = session.reconnect_task
+    session._mark_disconnected()
+
+    assert session.reconnect_task is first_task
+    first_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_reconnect_flushes_buffers_and_closes_socket():
+    ws = FakePusherWebSocket()
+    session = make_session(ws=ws)
+    await session.connect()
+    session.transcript_send([{"id": "seg-1"}])
+    session.audio_bytes_send(b"abc", received_at=100.0)
+
+    async def sleepy_reconnect():
+        await asyncio.sleep(10)
+
+    session.reconnect_task = asyncio.create_task(sleepy_reconnect())
+    await session.close(code=1001)
+
+    assert session.reconnect_task is None
+    assert [frame_type(frame) for frame in ws.sent] == [103, 101, 102]
+    assert ws.closed_codes == [1001]

--- a/backend/utils/listen_pusher_session.py
+++ b/backend/utils/listen_pusher_session.py
@@ -94,17 +94,9 @@ class ListenPusherSession:
     def transcript_send(self, segments):
         self.segment_buffers.extend(segments)
 
-    async def request_conversation_processing(self, conversation_id: str):
-        """Request pusher to process a conversation."""
-        if not self.pusher_connected or not self.pusher_ws:
-            logger.info(
-                f"Pusher not connected for {conversation_id}, will retry on reconnect {self.uid} {self.session_id}"
-            )
-            if conversation_id not in self.pending_conversation_requests:
-                self.pending_conversation_requests[conversation_id] = {'sent_at': self.deps.now(), 'retries': 0}
-                self.pending_request_event.set()
-            return False
-        if len(self.pending_conversation_requests) >= self.config.max_pending_requests:
+    def _buffer_pending_conversation_request(self, conversation_id: str):
+        existing = self.pending_conversation_requests.get(conversation_id)
+        if existing is None and len(self.pending_conversation_requests) >= self.config.max_pending_requests:
             oldest_id = min(
                 self.pending_conversation_requests,
                 key=lambda k: self.pending_conversation_requests[k]['sent_at'],
@@ -113,12 +105,23 @@ class ListenPusherSession:
                 f"Too many pending requests, dropping {oldest_id} to add {conversation_id} {self.uid} {self.session_id}"
             )
             del self.pending_conversation_requests[oldest_id]
+            existing = None
+        self.pending_conversation_requests[conversation_id] = {
+            'sent_at': self.deps.now(),
+            'retries': (existing or {}).get('retries', 0),
+        }
+        self.pending_request_event.set()
+
+    async def request_conversation_processing(self, conversation_id: str):
+        """Request pusher to process a conversation."""
+        if not self.pusher_connected or not self.pusher_ws:
+            logger.info(
+                f"Pusher not connected for {conversation_id}, will retry on reconnect {self.uid} {self.session_id}"
+            )
+            self._buffer_pending_conversation_request(conversation_id)
+            return False
         try:
-            self.pending_conversation_requests[conversation_id] = {
-                'sent_at': self.deps.now(),
-                'retries': self.pending_conversation_requests.get(conversation_id, {}).get('retries', 0),
-            }
-            self.pending_request_event.set()
+            self._buffer_pending_conversation_request(conversation_id)
             data = bytearray()
             data.extend(struct.pack("I", 104))
             payload = {

--- a/backend/utils/listen_pusher_session.py
+++ b/backend/utils/listen_pusher_session.py
@@ -1,0 +1,507 @@
+import asyncio
+import json
+import logging
+import random
+import struct
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Dict, List, Optional
+
+from websockets.exceptions import ConnectionClosed
+
+from utils.metrics import PUSHER_CIRCUIT_BREAKER_REJECTIONS, PUSHER_SESSION_DEGRADED
+from utils.pusher import PusherCircuitBreakerOpen, connect_to_trigger_pusher
+
+logger = logging.getLogger(__name__)
+
+TARGET_SAMPLE_RATE = 16000
+
+
+class PusherReconnectState(str, Enum):
+    CONNECTED = 'connected'
+    RECONNECT_BACKOFF = 'reconnect_backoff'
+    DEGRADED = 'degraded'
+    HALF_OPEN_PROBE = 'half_open_probe'
+
+
+PUSHER_MAX_RECONNECT_ATTEMPTS = 6
+PUSHER_DEGRADED_COOLDOWN = 60.0
+PUSHER_RECONNECT_BASE_DELAY = 1.0
+PUSHER_RECONNECT_MAX_DELAY = 60.0
+PENDING_REQUEST_TIMEOUT = 120
+MAX_RETRIES_PER_REQUEST = 3
+
+
+@dataclass
+class ListenPusherSessionConfig:
+    uid: str
+    session_id: str
+    sample_rate: int
+    is_multi_channel: bool
+    language: str
+    audio_bytes_enabled: bool
+    max_segment_buffer_size: int
+    max_audio_buffer_size: int
+    max_pending_requests: int
+    max_pending_speaker_sample_requests: int
+
+
+@dataclass
+class ListenPusherSessionDeps:
+    get_current_conversation_id: Callable[[], Optional[str]]
+    is_active: Callable[[], bool]
+    shutdown_event: asyncio.Event
+    get_byok_keys: Callable[[], dict]
+    on_conversation_processed: Callable[[str], None]
+    wait_for_event: Callable[[asyncio.Event, float], Awaitable[bool]]
+    connect_to_pusher: Callable[..., Awaitable[object]] = connect_to_trigger_pusher
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
+    random: Callable[[], float] = random.random
+    now: Callable[[], float] = time.time
+    monotonic: Callable[[], float] = time.monotonic
+
+
+class ListenPusherSession:
+    def __init__(self, config: ListenPusherSessionConfig, deps: ListenPusherSessionDeps):
+        self.config = config
+        self.deps = deps
+        self.pusher_ws = None
+        self.pusher_connect_lock = asyncio.Lock()
+        self.pusher_connected = False
+        self.reconnect_state = PusherReconnectState.CONNECTED
+        self.reconnect_attempts = 0
+        self.reconnect_task = None
+        self.degraded_since: float = 0.0
+        self.segment_buffers: deque = deque(maxlen=config.max_segment_buffer_size)
+        self.last_synced_conversation_id = None
+        self.pending_conversation_requests: Dict[str, dict] = {}
+        self.pending_request_event = asyncio.Event()
+        self.pending_speaker_sample_requests: deque = deque(maxlen=config.max_pending_speaker_sample_requests)
+        self.audio_chunks: deque = deque()
+        self.audio_total_size = 0
+        self.audio_buffer_last_received: Optional[float] = None
+
+    @property
+    def uid(self):
+        return self.config.uid
+
+    @property
+    def session_id(self):
+        return self.config.session_id
+
+    def transcript_send(self, segments):
+        self.segment_buffers.extend(segments)
+
+    async def request_conversation_processing(self, conversation_id: str):
+        """Request pusher to process a conversation."""
+        if not self.pusher_connected or not self.pusher_ws:
+            logger.info(
+                f"Pusher not connected for {conversation_id}, will retry on reconnect {self.uid} {self.session_id}"
+            )
+            if conversation_id not in self.pending_conversation_requests:
+                self.pending_conversation_requests[conversation_id] = {'sent_at': self.deps.now(), 'retries': 0}
+                self.pending_request_event.set()
+            return False
+        if len(self.pending_conversation_requests) >= self.config.max_pending_requests:
+            oldest_id = min(
+                self.pending_conversation_requests,
+                key=lambda k: self.pending_conversation_requests[k]['sent_at'],
+            )
+            logger.info(
+                f"Too many pending requests, dropping {oldest_id} to add {conversation_id} {self.uid} {self.session_id}"
+            )
+            del self.pending_conversation_requests[oldest_id]
+        try:
+            self.pending_conversation_requests[conversation_id] = {
+                'sent_at': self.deps.now(),
+                'retries': self.pending_conversation_requests.get(conversation_id, {}).get('retries', 0),
+            }
+            self.pending_request_event.set()
+            data = bytearray()
+            data.extend(struct.pack("I", 104))
+            payload = {
+                "conversation_id": conversation_id,
+                "language": self.config.language,
+                "byok_keys": self.deps.get_byok_keys(),
+            }
+            data.extend(bytes(json.dumps(payload), "utf-8"))
+            await self.pusher_ws.send(data)
+            logger.info(f"Sent process_conversation request to pusher: {conversation_id} {self.uid} {self.session_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to send process_conversation request: {e} {self.uid} {self.session_id}")
+            return False
+
+    async def _transcript_flush(self, auto_reconnect: bool = True):
+        if self.pusher_connected and self.pusher_ws and len(self.segment_buffers) > 0:
+            try:
+                data = bytearray()
+                data.extend(struct.pack("I", 102))
+                data.extend(
+                    bytes(
+                        json.dumps(
+                            {
+                                "segments": list(self.segment_buffers),
+                                "memory_id": self.deps.get_current_conversation_id(),
+                            }
+                        ),
+                        "utf-8",
+                    )
+                )
+                self.segment_buffers.clear()
+                await self.pusher_ws.send(data)
+            except ConnectionClosed as e:
+                logger.error(f"Pusher transcripts Connection closed: {e} {self.uid} {self.session_id}")
+                self._mark_disconnected()
+            except Exception as e:
+                logger.error(f"Pusher transcripts failed: {e} {self.uid} {self.session_id}")
+
+    async def transcript_consume(self):
+        while self.deps.is_active():
+            await self.deps.sleep(1)
+            if len(self.segment_buffers) > 0:
+                await self._transcript_flush(auto_reconnect=True)
+
+    def audio_bytes_send(self, audio_bytes: bytes, received_at: float):
+        chunk = audio_bytes
+        if len(chunk) > self.config.max_audio_buffer_size:
+            chunk = chunk[-self.config.max_audio_buffer_size :]
+        while self.audio_total_size + len(chunk) > self.config.max_audio_buffer_size and self.audio_chunks:
+            old = self.audio_chunks.popleft()
+            self.audio_total_size -= len(old)
+        self.audio_chunks.append(chunk)
+        self.audio_total_size += len(chunk)
+        self.audio_buffer_last_received = received_at
+
+    async def _audio_bytes_flush(self, auto_reconnect: bool = True):
+        current_conversation_id = self.deps.get_current_conversation_id()
+        if (
+            self.pusher_ws
+            and current_conversation_id
+            and (
+                self.last_synced_conversation_id is None or current_conversation_id != self.last_synced_conversation_id
+            )
+        ):
+            try:
+                data = bytearray()
+                data.extend(struct.pack("I", 103))
+                data.extend(bytes(current_conversation_id, "utf-8"))
+                await self.pusher_ws.send(data)
+                self.last_synced_conversation_id = current_conversation_id
+            except ConnectionClosed as e:
+                logger.error(f"Pusher audio_bytes Connection closed: {e} {self.uid} {self.session_id}")
+                self._mark_disconnected()
+            except Exception as e:
+                logger.error(f"Failed to send conversation_id to pusher: {e} {self.uid} {self.session_id}")
+
+        if self.pusher_connected and self.pusher_ws and self.audio_total_size > 0:
+            try:
+                effective_rate = TARGET_SAMPLE_RATE if self.config.is_multi_channel else self.config.sample_rate
+                buffer_duration_seconds = self.audio_total_size / (effective_rate * 2)
+                buffer_start_time = (self.audio_buffer_last_received or self.deps.now()) - buffer_duration_seconds
+                audio_data = b''.join(self.audio_chunks)
+                data = bytearray()
+                data.extend(struct.pack("I", 101))
+                data.extend(struct.pack("d", buffer_start_time))
+                data.extend(audio_data)
+                self.audio_chunks.clear()
+                self.audio_total_size = 0
+                del audio_data
+                await self.pusher_ws.send(data)
+            except ConnectionClosed as e:
+                logger.error(f"Pusher audio_bytes Connection closed: {e} {self.uid} {self.session_id}")
+                self._mark_disconnected()
+            except Exception as e:
+                logger.error(f"Pusher audio_bytes failed: {e} {self.uid} {self.session_id}")
+
+    async def audio_bytes_consume(self):
+        while self.deps.is_active():
+            await self.deps.sleep(1)
+            if self.audio_total_size > 0:
+                await self._audio_bytes_flush(auto_reconnect=True)
+
+    async def pusher_receive(self):
+        """Receive and handle messages from pusher, with timeout-based retry for pending requests."""
+        while self.deps.is_active():
+            if not self.pending_conversation_requests:
+                self.pending_request_event.clear()
+                try:
+                    await asyncio.wait_for(self.pending_request_event.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    continue
+
+            if not self.pusher_connected or not self.pusher_ws:
+                await self.deps.sleep(0.5)
+                continue
+
+            try:
+                msg = await asyncio.wait_for(self.pusher_ws.recv(), timeout=5.0)
+                if not msg or len(msg) < 4:
+                    continue
+                header_type = struct.unpack('<I', msg[:4])[0]
+
+                if header_type == 201:
+                    result = json.loads(msg[4:].decode("utf-8"))
+                    conversation_id = result.get("conversation_id")
+                    self.pending_conversation_requests.pop(conversation_id, None)
+
+                    if "error" in result:
+                        logger.error(f"Conversation processing failed: {result['error']} {self.uid} {self.session_id}")
+                        continue
+
+                    if result.get("success"):
+                        logger.info(f"Conversation processed by pusher: {conversation_id} {self.uid} {self.session_id}")
+                        self.deps.on_conversation_processed(conversation_id)
+
+            except asyncio.TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                break
+            except ConnectionClosed as e:
+                logger.error(f"Pusher receive connection closed: {e} {self.uid} {self.session_id}")
+                self._mark_disconnected()
+            except Exception as e:
+                logger.error(f"Pusher receive error: {e} {self.uid} {self.session_id}")
+                await self.deps.sleep(0.5)
+
+            now = self.deps.now()
+            timed_out = [
+                cid
+                for cid, info in list(self.pending_conversation_requests.items())
+                if now - info['sent_at'] > PENDING_REQUEST_TIMEOUT
+            ]
+            for cid in timed_out:
+                info = self.pending_conversation_requests.get(cid)
+                if not info:
+                    continue
+                if info['retries'] >= MAX_RETRIES_PER_REQUEST:
+                    logger.warning(
+                        f"Conversation {cid} retry limit reached, keeping buffered for pusher recovery {self.uid} {self.session_id}"
+                    )
+                    info['sent_at'] = now
+                    continue
+                info['retries'] += 1
+                logger.warning(
+                    f"Retrying process_conversation for {cid} (attempt {info['retries']}/{MAX_RETRIES_PER_REQUEST}) {self.uid} {self.session_id}"
+                )
+                await self.request_conversation_processing(cid)
+
+    async def _flush(self):
+        await self._audio_bytes_flush(auto_reconnect=False)
+        await self._transcript_flush(auto_reconnect=False)
+
+    def _mark_disconnected(self):
+        """Signal pusher disconnection and ensure one reconnect loop is running."""
+        if not self.pusher_connected:
+            return
+        self.pusher_connected = False
+        if self.reconnect_state == PusherReconnectState.CONNECTED:
+            self.reconnect_state = PusherReconnectState.RECONNECT_BACKOFF
+            logger.info(f"Pusher disconnected, entering RECONNECT_BACKOFF {self.uid} {self.session_id}")
+        if self.reconnect_task is None or self.reconnect_task.done():
+            self.reconnect_task = asyncio.create_task(self._pusher_reconnect_loop())
+
+    async def _pusher_reconnect_loop(self):
+        """Single reconnect loop per session."""
+        logger.info(f"Pusher reconnect loop started {self.uid} {self.session_id}")
+        PUSHER_SESSION_DEGRADED.inc()
+        try:
+            while self.deps.is_active() and not self.pusher_connected:
+                if self.reconnect_state == PusherReconnectState.RECONNECT_BACKOFF:
+                    if self.reconnect_attempts >= PUSHER_MAX_RECONNECT_ATTEMPTS:
+                        self.reconnect_state = PusherReconnectState.DEGRADED
+                        self.degraded_since = self.deps.monotonic()
+                        self.reconnect_attempts = 0
+                        logger.warning(
+                            f"Pusher reconnect exhausted ({PUSHER_MAX_RECONNECT_ATTEMPTS} attempts), "
+                            f"entering DEGRADED mode {self.uid} {self.session_id}"
+                        )
+                        if self.pending_conversation_requests:
+                            logger.info(
+                                f"Keeping {len(self.pending_conversation_requests)} conversations buffered for pusher recovery {self.uid} {self.session_id}"
+                            )
+                        continue
+
+                    delay = min(
+                        PUSHER_RECONNECT_BASE_DELAY * (2**self.reconnect_attempts),
+                        PUSHER_RECONNECT_MAX_DELAY,
+                    )
+                    delay *= 0.75 + self.deps.random() * 0.5
+                    logger.info(
+                        f"Pusher reconnect attempt {self.reconnect_attempts + 1}/{PUSHER_MAX_RECONNECT_ATTEMPTS}, "
+                        f"waiting {delay:.1f}s {self.uid} {self.session_id}"
+                    )
+                    if await self.deps.wait_for_event(self.deps.shutdown_event, delay):
+                        break
+
+                    try:
+                        await self.connect()
+                        if self.pusher_connected:
+                            self.reconnect_state = PusherReconnectState.CONNECTED
+                            self.reconnect_attempts = 0
+                            logger.info(f"Pusher reconnected successfully {self.uid} {self.session_id}")
+                            break
+                    except PusherCircuitBreakerOpen:
+                        PUSHER_CIRCUIT_BREAKER_REJECTIONS.inc()
+                        self.reconnect_state = PusherReconnectState.DEGRADED
+                        self.degraded_since = self.deps.monotonic()
+                        self.reconnect_attempts = 0
+                        logger.warning(f"Circuit breaker open, skipping to DEGRADED {self.uid} {self.session_id}")
+                        continue
+                    except Exception:
+                        pass
+
+                    self.reconnect_attempts += 1
+
+                elif self.reconnect_state == PusherReconnectState.DEGRADED:
+                    elapsed = self.deps.monotonic() - self.degraded_since
+                    remaining = PUSHER_DEGRADED_COOLDOWN - elapsed
+                    if remaining > 0:
+                        if await self.deps.wait_for_event(self.deps.shutdown_event, min(remaining, 5.0)):
+                            break
+                        continue
+                    self.reconnect_state = PusherReconnectState.HALF_OPEN_PROBE
+                    logger.info(f"Pusher DEGRADED cooldown elapsed, probing {self.uid} {self.session_id}")
+
+                elif self.reconnect_state == PusherReconnectState.HALF_OPEN_PROBE:
+                    try:
+                        await self.connect()
+                        if self.pusher_connected:
+                            self.reconnect_state = PusherReconnectState.CONNECTED
+                            self.reconnect_attempts = 0
+                            logger.info(f"Pusher probe succeeded, back to CONNECTED {self.uid} {self.session_id}")
+                            break
+                    except PusherCircuitBreakerOpen:
+                        PUSHER_CIRCUIT_BREAKER_REJECTIONS.inc()
+                    except Exception:
+                        pass
+                    self.reconnect_state = PusherReconnectState.DEGRADED
+                    self.degraded_since = self.deps.monotonic()
+                    logger.warning(f"Pusher probe failed, back to DEGRADED {self.uid} {self.session_id}")
+
+                else:
+                    break
+        finally:
+            PUSHER_SESSION_DEGRADED.dec()
+            logger.info(
+                f"Pusher reconnect loop ended (state={self.reconnect_state.value}) {self.uid} {self.session_id}"
+            )
+
+    async def connect(self):
+        async with self.pusher_connect_lock:
+            if self.pusher_connected:
+                return
+            if self.pusher_ws:
+                try:
+                    await self.pusher_ws.close()
+                    self.pusher_ws = None
+                except Exception as e:
+                    logger.error(f"Pusher draining failed: {e} {self.uid} {self.session_id}")
+            await self._connect()
+
+    async def _connect(self):
+        try:
+            pusher_sample_rate = TARGET_SAMPLE_RATE if self.config.is_multi_channel else self.config.sample_rate
+            self.pusher_ws = await self.deps.connect_to_pusher(
+                self.uid, pusher_sample_rate, retries=5, is_active=self.deps.is_active
+            )
+            if self.pusher_ws is None:
+                return
+            self.pusher_connected = True
+            self.reconnect_state = PusherReconnectState.CONNECTED
+            self.reconnect_attempts = 0
+            if self.pending_conversation_requests:
+                logger.info(
+                    f"Reconnected to pusher, re-sending {len(self.pending_conversation_requests)} pending requests {self.uid} {self.session_id}"
+                )
+                for cid in list(self.pending_conversation_requests.keys()):
+                    self.pending_conversation_requests[cid]['sent_at'] = self.deps.now()
+                    await self.request_conversation_processing(cid)
+            if self.pending_speaker_sample_requests:
+                buffered = list(self.pending_speaker_sample_requests)
+                self.pending_speaker_sample_requests.clear()
+                logger.info(
+                    f"Reconnected to pusher, re-sending {len(buffered)} pending speaker sample requests {self.uid} {self.session_id}"
+                )
+                for person_id, conv_id, segment_ids in buffered:
+                    await self.send_speaker_sample_request(person_id, conv_id, segment_ids)
+        except PusherCircuitBreakerOpen:
+            raise
+        except Exception as e:
+            logger.error(f"Exception in connect: {e} {self.uid} {self.session_id}")
+
+    async def close(self, code: int = 1000):
+        if self.reconnect_task and not self.reconnect_task.done():
+            self.reconnect_task.cancel()
+            try:
+                await self.reconnect_task
+            except asyncio.CancelledError:
+                pass
+            self.reconnect_task = None
+        await self._flush()
+        if self.pusher_ws:
+            await self.pusher_ws.close(code)
+
+    def is_degraded(self):
+        return self.reconnect_state in (PusherReconnectState.DEGRADED, PusherReconnectState.HALF_OPEN_PROBE)
+
+    async def send_speaker_sample_request(
+        self,
+        person_id: str,
+        conv_id: str,
+        segment_ids: List[str],
+    ):
+        """Send speaker sample extraction request to pusher with segment IDs."""
+        if not self.pusher_connected or not self.pusher_ws:
+            self.pending_speaker_sample_requests.append((person_id, conv_id, segment_ids))
+            logger.warning(
+                f"Pusher not connected, buffered speaker sample request: person={person_id}, "
+                f"{len(segment_ids)} segments ({len(self.pending_speaker_sample_requests)} pending) {self.uid} {self.session_id}"
+            )
+            return
+        try:
+            data = bytearray()
+            data.extend(struct.pack("I", 105))
+            data.extend(
+                bytes(
+                    json.dumps(
+                        {
+                            "person_id": person_id,
+                            "conversation_id": conv_id,
+                            "segment_ids": segment_ids,
+                        }
+                    ),
+                    "utf-8",
+                )
+            )
+            await self.pusher_ws.send(data)
+            logger.info(
+                f"Sent speaker sample request to pusher: person={person_id}, {len(segment_ids)} segments {self.uid} {self.session_id}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to send speaker sample request: {e} {self.uid} {self.session_id}")
+
+    def is_connected(self):
+        return self.pusher_connected
+
+    async def pusher_heartbeat(self):
+        """Send periodic data-frame heartbeats to reset the GKE ILB idle timer."""
+        while self.deps.is_active():
+            if await self.deps.wait_for_event(self.deps.shutdown_event, 20):
+                break
+            if self.pusher_connected and self.pusher_ws:
+                try:
+                    await self.pusher_ws.send(struct.pack("I", 100))
+                except ConnectionClosed:
+                    self._mark_disconnected()
+                except Exception as e:
+                    logger.error(f"Pusher heartbeat send failed: {e} {self.uid} {self.session_id}")
+
+    def start_degraded(self):
+        """Enter degraded mode and start reconnect loop after initial connect failure."""
+        self.reconnect_state = PusherReconnectState.DEGRADED
+        self.degraded_since = self.deps.monotonic()
+        if self.reconnect_task is None or self.reconnect_task.done():
+            self.reconnect_task = asyncio.create_task(self._pusher_reconnect_loop())


### PR DESCRIPTION
## Summary
- Extracted the listen pusher bridge from transcribe.py into ListenPusherSession with explicit config/deps dataclasses.
- Preserved pusher frame formats, pending replay, reconnect/degraded behavior, and router-level pusher gating/task scheduling.
- Added focused fake-websocket unit coverage for frames, replay, buffers, 201 handling, reconnect-loop creation, and close flushing.

## Validation
- python -m compileall -f backend/routers/transcribe.py backend/utils/listen_pusher_session.py
- python -m pytest backend/tests/unit/utils/test_listen_pusher_session.py -q
- python backend/scripts/scan_async_blockers.py (exit 0; reports existing async-blocker findings)
- backend/.venv/bin/python -m pytest testing/e2e/test_listen_stt.py -q
- backend/.venv/bin/python -m pytest testing/e2e/test_boundary_contract_compatibility.py -q

Note: backend/testing/e2e/run.sh is blocked on this macOS host by missing GNU timeout, so the two requested e2e files were run directly through backend/.venv/bin/python after syncing backend deps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

