### PR TITLE
[codex] Extract user data services

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from google.cloud import firestore
@@ -271,8 +271,51 @@ def get_pending_deletion_wipes(limit: int = 100) -> list[dict]:
     deploy/restart before the in-process cleanup_executor future started, or that
     failed and need re-enqueueing.
     """
-    docs = db.collection('account_deletions').where('wipe_status', 'in', ['pending', 'failed']).limit(limit).stream()
+    docs = (
+        db.collection('account_deletions')
+        .where('wipe_status', 'in', ['pending', 'failed', 'retrying'])
+        .limit(limit)
+        .stream()
+    )
     return [doc.to_dict() | {'uid': doc.id} for doc in docs]
+
+
+@transactional
+def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
+    """Atomically claim a wipe for re-enqueueing inside a Firestore transaction.
+
+    Transitions ``wipe_status`` from ``pending``/``failed``/``retrying`` (stale)
+    to ``retrying`` so concurrent workers cannot re-enqueue the same wipe. If the
+    wipe is already ``retrying`` and not yet stale, the claim is refused (another
+    worker owns it).
+    """
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return None
+    data = snapshot.to_dict()
+    status = data.get('wipe_status')
+    if status in ('pending', 'failed'):
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': datetime.now(timezone.utc)})
+        return snapshot.id
+    if status == 'retrying':
+        claimed_at = data.get('wipe_claimed_at')
+        if claimed_at and claimed_at < datetime.now(timezone.utc) - stale_after:
+            # Stale claim (worker probably crashed). Re-claim it.
+            transaction.update(doc_ref, {'wipe_claimed_at': datetime.now(timezone.utc)})
+            return snapshot.id
+    return None
+
+
+def claim_deletion_wipe(uid: str, stale_after: timedelta = timedelta(minutes=10)) -> str | None:
+    """Attempt to claim a pending/failed/stale wipe for re-enqueueing.
+
+    Returns the uid if claimed (caller should enqueue the wipe), or ``None`` if
+    another worker already owns a non-stale claim. This prevents the same wipe
+    from being re-enqueued concurrently by multiple workers or scheduler runs.
+    """
+    doc_ref = db.collection('account_deletions').document(uid)
+    transaction = db.transaction()
+    return _claim_deletion_wipe_txn(transaction, doc_ref, stale_after)
 
 
 def create_person(uid: str, data: dict):

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -248,6 +248,23 @@ def mark_user_deletion_wipe_started(uid: str):
     )
 
 
+def mark_user_deletion_wipe_intent(uid: str):
+    """Persist a non-actionable deletion intent *before* auth deletion.
+
+    Written BEFORE ``auth.delete_account()`` succeeds. The reconciler does not
+    query for ``'deleting_auth'`` records, so a crash or deploy between this
+    write and the confirmed auth deletion leaves a benign record that cannot
+    trigger a data wipe for a user whose Firebase account still exists.
+
+    Call ``mark_user_deletion_wipe_started`` to transition the marker to the
+    actionable ``'pending'`` state once auth deletion is confirmed.
+    """
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'deleting_auth', 'wipe_intent_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
 def mark_user_deletion_wipe_completed(uid: str):
     """Mark the background data wipe as finished."""
     db.collection('account_deletions').document(uid).set(

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -272,52 +272,6 @@ def mark_user_deletion_wipe_running(uid: str):
     )
 
 
-@transactional
-def _claim_running_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
-    """Atomically transition a wipe to ``running`` before the worker executes.
-
-    Only transitions from actionable states (``pending``, ``failed``,
-    ``retrying``, or stale ``running`` where the previous worker crashed). A
-    fresh ``running`` record means another worker is actively executing and is
-    refused; ``completed``, ``cancelled``, and ``deleting_auth`` are terminal
-    or pre-actionable and are also refused.
-
-    This transactional guard prevents concurrent execution of the same wipe
-    even when the reconciler re-enqueues it: only one worker successfully
-    transitions to ``running``; all others skip.
-    """
-    snapshot = doc_ref.get(transaction=transaction)
-    if not snapshot.exists:
-        return None
-    data = snapshot.to_dict()
-    status = data.get('wipe_status')
-    now = datetime.now(timezone.utc)
-    if status in ('pending', 'failed', 'retrying'):
-        transaction.update(doc_ref, {'wipe_status': 'running', 'wipe_running_at': now})
-        return snapshot.id
-    if status == 'running':
-        running_at = data.get('wipe_running_at')
-        if running_at and running_at < now - stale_after:
-            # Stale running — previous worker crashed mid-execution. Re-claim.
-            transaction.update(doc_ref, {'wipe_running_at': now})
-            return snapshot.id
-        return None  # Another worker is actively running this wipe.
-    return None  # completed, cancelled, deleting_auth — skip.
-
-
-def claim_running_wipe(uid: str, stale_after: timedelta = timedelta(minutes=10)) -> str | None:
-    """Attempt to transition a wipe to ``running`` before executing it.
-
-    Returns the uid if claimed (caller should proceed with the wipe), or
-    ``None`` if another worker is already running it or the wipe is in a
-    terminal/pre-actionable state. This prevents concurrent execution of the
-    same wipe by multiple workers or overlapping scheduler runs.
-    """
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
-    return _claim_running_wipe_txn(transaction, doc_ref, stale_after)
-
-
 def mark_user_deletion_wipe_intent(uid: str):
     """Persist a non-actionable deletion intent *before* auth deletion.
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -280,36 +280,38 @@ def cancel_user_deletion_wipe(uid: str):
 def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timedelta(minutes=10)) -> list[dict]:
     """Return account_deletions documents whose wipe needs retry.
 
-    Queries ``failed`` records and ``pending`` records older than ``stale_after``
-    (always actionable), then adds stale ``retrying`` claims (worker probably
-    crashed) only if room remains under ``limit``. Fresh ``pending`` markers from
-    in-progress deletions are excluded so the reconciler doesn't double-enqueue a
-    wipe that is still running.
+    Queries ``failed`` records (always actionable), stale ``pending`` records
+    (queued more than ``stale_after`` ago), and stale ``retrying`` claims
+    (worker probably crashed). Fresh ``pending`` markers from in-progress
+    deletions are excluded so the reconciler doesn't double-enqueue a wipe
+    that is still running.
+
+    All queries are single-field equality filters on ``wipe_status`` to avoid
+    requiring Firestore composite indexes. Age filtering is done in Python.
     """
     stale_cutoff = datetime.now(timezone.utc) - stale_after
+    budget = limit
 
-    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').limit(limit).stream()
+    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').limit(budget).stream()
     result = [doc.to_dict() | {'uid': doc.id} for doc in failed_docs]
 
     if len(result) < limit:
-        stale_pending_docs = (
-            db.collection('account_deletions')
-            .where('wipe_status', '==', 'pending')
-            .where('wipe_queued_at', '<', stale_cutoff)
-            .limit(limit - len(result))
-            .stream()
-        )
-        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_pending_docs)
+        budget = limit - len(result)
+        pending_docs = db.collection('account_deletions').where('wipe_status', '==', 'pending').limit(budget).stream()
+        for doc in pending_docs:
+            data = doc.to_dict()
+            queued_at = data.get('wipe_queued_at')
+            if queued_at and queued_at < stale_cutoff:
+                result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
-        stale_retrying_docs = (
-            db.collection('account_deletions')
-            .where('wipe_status', '==', 'retrying')
-            .where('wipe_claimed_at', '<', stale_cutoff)
-            .limit(limit - len(result))
-            .stream()
-        )
-        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_retrying_docs)
+        budget = limit - len(result)
+        retrying_docs = db.collection('account_deletions').where('wipe_status', '==', 'retrying').limit(budget).stream()
+        for doc in retrying_docs:
+            data = doc.to_dict()
+            claimed_at = data.get('wipe_claimed_at')
+            if claimed_at and claimed_at < stale_cutoff:
+                result.append(data | {'uid': doc.id})
 
     return result
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -264,27 +264,52 @@ def mark_user_deletion_wipe_failed(uid: str):
     )
 
 
+def cancel_user_deletion_wipe(uid: str):
+    """Cancel a pending deletion-wipe marker.
+
+    Called when the Firebase auth deletion fails after the marker was already
+    persisted. Without this, the reconciliation worker would later wipe the
+    user's data even though their Firebase account still exists.
+    """
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'cancelled', 'wipe_cancelled_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
 def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timedelta(minutes=10)) -> list[dict]:
     """Return account_deletions documents whose wipe needs retry.
 
-    Queries ``pending``/``failed`` records first (always actionable), then adds
-    stale ``retrying`` claims (worker probably crashed) only if room remains
-    under ``limit``. Non-stale ``retrying`` claims are excluded so they cannot
-    crowd out actionable work under backlog.
+    Queries ``failed`` records and ``pending`` records older than ``stale_after``
+    (always actionable), then adds stale ``retrying`` claims (worker probably
+    crashed) only if room remains under ``limit``. Fresh ``pending`` markers from
+    in-progress deletions are excluded so the reconciler doesn't double-enqueue a
+    wipe that is still running.
     """
-    docs = db.collection('account_deletions').where('wipe_status', 'in', ['pending', 'failed']).limit(limit).stream()
-    result = [doc.to_dict() | {'uid': doc.id} for doc in docs]
+    stale_cutoff = datetime.now(timezone.utc) - stale_after
+
+    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').limit(limit).stream()
+    result = [doc.to_dict() | {'uid': doc.id} for doc in failed_docs]
 
     if len(result) < limit:
-        stale_cutoff = datetime.now(timezone.utc) - stale_after
-        stale_docs = (
+        stale_pending_docs = (
+            db.collection('account_deletions')
+            .where('wipe_status', '==', 'pending')
+            .where('wipe_queued_at', '<', stale_cutoff)
+            .limit(limit - len(result))
+            .stream()
+        )
+        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_pending_docs)
+
+    if len(result) < limit:
+        stale_retrying_docs = (
             db.collection('account_deletions')
             .where('wipe_status', '==', 'retrying')
             .where('wipe_claimed_at', '<', stale_cutoff)
             .limit(limit - len(result))
             .stream()
         )
-        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_docs)
+        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_retrying_docs)
 
     return result
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -224,13 +224,16 @@ def clear_byok_active(uid: str):
 
 def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: Optional[str] = None):
     # Stored in a top-level collection so it survives the user record being deleted.
+    # Use merge=True so a retried delete request does not erase a durable wipe marker
+    # (pending/failed/retrying/deleting_auth) already written to the same document.
     db.collection('account_deletions').document(uid).set(
         {
             'uid': uid,
             'reason': reason or '',
             'reason_details': reason_details or '',
             'timestamp': datetime.now(timezone.utc),
-        }
+        },
+        merge=True,
     )
 
 
@@ -403,7 +406,10 @@ def get_pending_deletion_wipes(
                 break
             data = doc.to_dict()
             claimed_at = data.get('wipe_claimed_at')
-            if claimed_at and claimed_at < stale_cutoff:
+            # Use the longer ``running_stale_after`` window so a queued-but-
+            # not-yet-running retrying claim is not returned as a candidate
+            # before the executor future has had a chance to start.
+            if claimed_at and claimed_at < running_cutoff:
                 result.append(data | {'uid': doc.id})
 
     return result
@@ -464,7 +470,13 @@ def _claim_deletion_wipe_txn(
         return snapshot.id
     if status == 'retrying':
         claimed_at = data.get('wipe_claimed_at')
-        if claimed_at and claimed_at < now - stale_after:
+        # Use the longer ``running_stale_after`` window (not ``stale_after``)
+        # because a retrying wipe was just claimed by the reconciler and
+        # enqueued. If the executor backlog is full, the future may sit queued
+        # beyond ``stale_after`` (10 min) without transitioning to ``running``.
+        # Using the short window would let the periodic reconciler enqueue
+        # another copy every pass, causing duplicate wipes to race.
+        if claimed_at and claimed_at < now - running_stale_after:
             # Stale claim (worker probably crashed). Re-claim it.
             transaction.update(doc_ref, {'wipe_claimed_at': now})
             return snapshot.id

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -256,6 +256,25 @@ def mark_user_deletion_wipe_completed(uid: str):
     )
 
 
+def mark_user_deletion_wipe_failed(uid: str):
+    """Mark the background data wipe as failed so a reconciliation worker can retry."""
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'failed', 'wipe_failed_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
+def get_pending_deletion_wipes(limit: int = 100) -> list[dict]:
+    """Return account_deletions documents whose wipe is pending or failed (needs retry).
+
+    A reconciliation worker calls this to find wipes that were cancelled by a
+    deploy/restart before the in-process cleanup_executor future started, or that
+    failed and need re-enqueueing.
+    """
+    docs = db.collection('account_deletions').where('wipe_status', 'in', ['pending', 'failed']).limit(limit).stream()
+    return [doc.to_dict() | {'uid': doc.id} for doc in docs]
+
+
 def create_person(uid: str, data: dict):
     people_ref = db.collection('users').document(uid).collection('people')
     people_ref.document(data['id']).set(data)

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -234,6 +234,28 @@ def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: 
     )
 
 
+def mark_user_deletion_wipe_started(uid: str):
+    """Mark that the background data wipe has been queued but not yet completed.
+
+    Persisted in the top-level ``account_deletions`` collection so it survives a
+    deploy or pod restart. A reconciliation worker can query for documents where
+    ``wipe_status == 'pending'`` and re-enqueue incomplete wipes, ensuring the
+    in-process ``cleanup_executor`` backlog is not silently lost.
+    """
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'pending', 'wipe_queued_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
+def mark_user_deletion_wipe_completed(uid: str):
+    """Mark the background data wipe as finished."""
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'completed', 'wipe_completed_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
 def create_person(uid: str, data: dict):
     people_ref = db.collection('users').document(uid).collection('people')
     people_ref.document(data['id']).set(data)

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -251,10 +251,11 @@ def mark_user_deletion_wipe_started(uid: str):
 def mark_user_deletion_wipe_intent(uid: str):
     """Persist a non-actionable deletion intent *before* auth deletion.
 
-    Written BEFORE ``auth.delete_account()`` succeeds. The reconciler does not
-    query for ``'deleting_auth'`` records, so a crash or deploy between this
-    write and the confirmed auth deletion leaves a benign record that cannot
-    trigger a data wipe for a user whose Firebase account still exists.
+    Written BEFORE ``auth.delete_account()`` succeeds. The reconciler only
+    recovers stale ``'deleting_auth'`` records *after* verifying the Firebase
+    auth user is actually gone, so a crash between this write and the confirmed
+    auth deletion cannot trigger a premature data wipe for a user whose Firebase
+    account still exists.
 
     Call ``mark_user_deletion_wipe_started`` to transition the marker to the
     actionable ``'pending'`` state once auth deletion is confirmed.
@@ -298,10 +299,16 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
     """Return account_deletions documents whose wipe needs retry.
 
     Queries ``failed`` records (always actionable), stale ``pending`` records
-    (queued more than ``stale_after`` ago), and stale ``retrying`` claims
-    (worker probably crashed). Fresh ``pending`` markers from in-progress
-    deletions are excluded so the reconciler doesn't double-enqueue a wipe
-    that is still running.
+    (queued more than ``stale_after`` ago), stale ``deleting_auth`` records
+    (intent written but never transitioned to ``pending`` — usually a crash
+    after ``auth.delete_account()`` succeeded), and stale ``retrying`` claims
+    (worker probably crashed). Fresh ``pending`` and ``deleting_auth`` markers
+    from in-progress deletions are excluded so the reconciler doesn't
+    double-enqueue a wipe that is still running.
+
+    The caller is responsible for verifying the Firebase auth user is actually
+    gone before recovering a ``deleting_auth`` record — this function returns
+    candidates, and ``claim_deletion_wipe`` also age-guards inside a transaction.
 
     All queries are single-field equality filters on ``wipe_status`` to avoid
     requiring Firestore composite indexes. Age filtering is done in Python.
@@ -328,6 +335,21 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
                 result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
+        # Over-fetch all 'deleting_auth' docs and age-filter in Python. A stale
+        # 'deleting_auth' record (intent written but never transitioned to
+        # 'pending') usually means a crash/deploy after auth.delete_account()
+        # succeeded. The reconciler verifies the Firebase user is gone before
+        # recovering these — see reconcile_pending_deletion_wipes.
+        deleting_auth_docs = db.collection('account_deletions').where('wipe_status', '==', 'deleting_auth').stream()
+        for doc in deleting_auth_docs:
+            if len(result) >= limit:
+                break
+            data = doc.to_dict()
+            intent_at = data.get('wipe_intent_at')
+            if intent_at and intent_at < stale_cutoff:
+                result.append(data | {'uid': doc.id})
+
+    if len(result) < limit:
         retrying_docs = db.collection('account_deletions').where('wipe_status', '==', 'retrying').stream()
         for doc in retrying_docs:
             if len(result) >= limit:
@@ -344,12 +366,13 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
 def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
     """Atomically claim a wipe for re-enqueueing inside a Firestore transaction.
 
-    Transitions ``wipe_status`` from ``failed``, stale ``pending``, or stale
+    Transitions ``wipe_status`` from ``failed``, stale ``pending``, stale
+    ``deleting_auth`` (auth user verified gone by caller), or stale
     ``retrying`` to ``retrying`` so concurrent workers cannot re-enqueue the same
-    wipe. Fresh ``pending`` markers (recently queued by an in-progress deletion)
-    are left untouched to avoid wiping data before Firebase auth deletion
-    succeeds. ``retrying`` claims that are not yet stale are also refused (another
-    worker owns them).
+    wipe. Fresh ``pending`` and fresh ``deleting_auth`` markers (recently written
+    by an in-progress deletion) are left untouched to avoid wiping data before
+    Firebase auth deletion succeeds. ``retrying`` claims that are not yet stale
+    are also refused (another worker owns them).
     """
     snapshot = doc_ref.get(transaction=transaction)
     if not snapshot.exists:
@@ -357,6 +380,15 @@ def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> st
     data = snapshot.to_dict()
     status = data.get('wipe_status')
     now = datetime.now(timezone.utc)
+    if status == 'deleting_auth':
+        # Recoverable only after the caller verified the Firebase auth user is
+        # gone. Re-validate the age inside the transaction so a fresh intent
+        # from an in-progress deletion is never claimed prematurely.
+        intent_at = data.get('wipe_intent_at')
+        if intent_at and intent_at >= now - stale_after:
+            return None
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
+        return snapshot.id
     if status == 'pending':
         # Re-validate the pending marker age *inside* the transaction. The
         # reconciler query may have returned a stale record that was since

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -320,24 +320,37 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
 def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
     """Atomically claim a wipe for re-enqueueing inside a Firestore transaction.
 
-    Transitions ``wipe_status`` from ``pending``/``failed``/``retrying`` (stale)
-    to ``retrying`` so concurrent workers cannot re-enqueue the same wipe. If the
-    wipe is already ``retrying`` and not yet stale, the claim is refused (another
-    worker owns it).
+    Transitions ``wipe_status`` from ``failed``, stale ``pending``, or stale
+    ``retrying`` to ``retrying`` so concurrent workers cannot re-enqueue the same
+    wipe. Fresh ``pending`` markers (recently queued by an in-progress deletion)
+    are left untouched to avoid wiping data before Firebase auth deletion
+    succeeds. ``retrying`` claims that are not yet stale are also refused (another
+    worker owns them).
     """
     snapshot = doc_ref.get(transaction=transaction)
     if not snapshot.exists:
         return None
     data = snapshot.to_dict()
     status = data.get('wipe_status')
-    if status in ('pending', 'failed'):
-        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': datetime.now(timezone.utc)})
+    now = datetime.now(timezone.utc)
+    if status == 'pending':
+        # Re-validate the pending marker age *inside* the transaction. The
+        # reconciler query may have returned a stale record that was since
+        # refreshed by a new delete request; claiming a fresh marker could
+        # enqueue a wipe before Firebase auth deletion has succeeded.
+        queued_at = data.get('wipe_queued_at')
+        if queued_at and queued_at >= now - stale_after:
+            return None
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
+        return snapshot.id
+    if status == 'failed':
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
         return snapshot.id
     if status == 'retrying':
         claimed_at = data.get('wipe_claimed_at')
-        if claimed_at and claimed_at < datetime.now(timezone.utc) - stale_after:
+        if claimed_at and claimed_at < now - stale_after:
             # Stale claim (worker probably crashed). Re-claim it.
-            transaction.update(doc_ref, {'wipe_claimed_at': datetime.now(timezone.utc)})
+            transaction.update(doc_ref, {'wipe_claimed_at': now})
             return snapshot.id
     return None
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -241,11 +241,81 @@ def mark_user_deletion_wipe_started(uid: str):
     deploy or pod restart. A reconciliation worker can query for documents where
     ``wipe_status == 'pending'`` and re-enqueue incomplete wipes, ensuring the
     in-process ``cleanup_executor`` backlog is not silently lost.
+
+    The worker transitions the marker to ``'running'`` (via
+    ``mark_user_deletion_wipe_running``) as soon as it actually starts
+    executing, so the reconciler can distinguish a genuinely orphaned queued
+    wipe from one that is actively executing but slow.
     """
     db.collection('account_deletions').document(uid).set(
         {'wipe_status': 'pending', 'wipe_queued_at': datetime.now(timezone.utc)},
         merge=True,
     )
+
+
+def mark_user_deletion_wipe_running(uid: str):
+    """Transition a queued wipe marker to ``running`` once the worker starts.
+
+    Called by ``background_wipe_user_data`` at the top of the executor future.
+    This lets the reconciler distinguish a genuinely orphaned ``pending`` wipe
+    (queued in the executor backlog but never picked up — safe to re-enqueue)
+    from a ``running`` wipe (actively executing — only recovered if the claim
+    is stale, i.e. the worker probably crashed).
+
+    Without this, a slow but live wipe could be reclaimed as orphaned after
+    ``stale_after`` (default 10 min) and re-enqueued concurrently, leading to
+    duplicate work where a later failure overwrites a successful completion.
+    """
+    db.collection('account_deletions').document(uid).set(
+        {'wipe_status': 'running', 'wipe_running_at': datetime.now(timezone.utc)},
+        merge=True,
+    )
+
+
+@transactional
+def _claim_running_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
+    """Atomically transition a wipe to ``running`` before the worker executes.
+
+    Only transitions from actionable states (``pending``, ``failed``,
+    ``retrying``, or stale ``running`` where the previous worker crashed). A
+    fresh ``running`` record means another worker is actively executing and is
+    refused; ``completed``, ``cancelled``, and ``deleting_auth`` are terminal
+    or pre-actionable and are also refused.
+
+    This transactional guard prevents concurrent execution of the same wipe
+    even when the reconciler re-enqueues it: only one worker successfully
+    transitions to ``running``; all others skip.
+    """
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return None
+    data = snapshot.to_dict()
+    status = data.get('wipe_status')
+    now = datetime.now(timezone.utc)
+    if status in ('pending', 'failed', 'retrying'):
+        transaction.update(doc_ref, {'wipe_status': 'running', 'wipe_running_at': now})
+        return snapshot.id
+    if status == 'running':
+        running_at = data.get('wipe_running_at')
+        if running_at and running_at < now - stale_after:
+            # Stale running — previous worker crashed mid-execution. Re-claim.
+            transaction.update(doc_ref, {'wipe_running_at': now})
+            return snapshot.id
+        return None  # Another worker is actively running this wipe.
+    return None  # completed, cancelled, deleting_auth — skip.
+
+
+def claim_running_wipe(uid: str, stale_after: timedelta = timedelta(minutes=10)) -> str | None:
+    """Attempt to transition a wipe to ``running`` before executing it.
+
+    Returns the uid if claimed (caller should proceed with the wipe), or
+    ``None`` if another worker is already running it or the wipe is in a
+    terminal/pre-actionable state. This prevents concurrent execution of the
+    same wipe by multiple workers or overlapping scheduler runs.
+    """
+    doc_ref = db.collection('account_deletions').document(uid)
+    transaction = db.transaction()
+    return _claim_running_wipe_txn(transaction, doc_ref, stale_after)
 
 
 def mark_user_deletion_wipe_intent(uid: str):
@@ -295,16 +365,22 @@ def cancel_user_deletion_wipe(uid: str):
     )
 
 
-def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timedelta(minutes=10)) -> list[dict]:
+def get_pending_deletion_wipes(
+    limit: int = 100,
+    stale_after: timedelta = timedelta(minutes=10),
+    running_stale_after: timedelta = timedelta(minutes=30),
+) -> list[dict]:
     """Return account_deletions documents whose wipe needs retry.
 
     Queries ``failed`` records (always actionable), stale ``pending`` records
     (queued more than ``stale_after`` ago), stale ``deleting_auth`` records
     (intent written but never transitioned to ``pending`` — usually a crash
-    after ``auth.delete_account()`` succeeded), and stale ``retrying`` claims
-    (worker probably crashed). Fresh ``pending`` and ``deleting_auth`` markers
-    from in-progress deletions are excluded so the reconciler doesn't
-    double-enqueue a wipe that is still running.
+    after ``auth.delete_account()`` succeeded), stale ``running`` records (worker
+    started but hasn't finished within ``running_stale_after`` — probably
+    crashed), and stale ``retrying`` claims (worker probably crashed). Fresh
+    ``pending``, ``deleting_auth``, and ``running`` markers from in-progress
+    deletions are excluded so the reconciler doesn't double-enqueue a wipe that
+    is still running.
 
     The caller is responsible for verifying the Firebase auth user is actually
     gone before recovering a ``deleting_auth`` record — this function returns
@@ -314,6 +390,7 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
     requiring Firestore composite indexes. Age filtering is done in Python.
     """
     stale_cutoff = datetime.now(timezone.utc) - stale_after
+    running_cutoff = datetime.now(timezone.utc) - running_stale_after
     budget = limit
 
     failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').limit(budget).stream()
@@ -332,6 +409,22 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
             data = doc.to_dict()
             queued_at = data.get('wipe_queued_at')
             if queued_at and queued_at < stale_cutoff:
+                result.append(data | {'uid': doc.id})
+
+    if len(result) < limit:
+        # Recover stale ``running`` markers — the worker started but hasn't
+        # finished within ``running_stale_after``. This is much longer than the
+        # ``pending`` stale window because a legitimately slow wipe (queued
+        # behind other cleanup jobs) can take several minutes; we only want to
+        # reclaim a ``running`` marker when the worker has almost certainly
+        # crashed or the pod was killed mid-execution.
+        running_docs = db.collection('account_deletions').where('wipe_status', '==', 'running').stream()
+        for doc in running_docs:
+            if len(result) >= limit:
+                break
+            data = doc.to_dict()
+            running_at = data.get('wipe_running_at')
+            if running_at and running_at < running_cutoff:
                 result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
@@ -363,16 +456,19 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
 
 
 @transactional
-def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> str | None:
+def _claim_deletion_wipe_txn(
+    transaction, doc_ref, stale_after: timedelta, running_stale_after: timedelta
+) -> str | None:
     """Atomically claim a wipe for re-enqueueing inside a Firestore transaction.
 
     Transitions ``wipe_status`` from ``failed``, stale ``pending``, stale
-    ``deleting_auth`` (auth user verified gone by caller), or stale
-    ``retrying`` to ``retrying`` so concurrent workers cannot re-enqueue the same
-    wipe. Fresh ``pending`` and fresh ``deleting_auth`` markers (recently written
-    by an in-progress deletion) are left untouched to avoid wiping data before
-    Firebase auth deletion succeeds. ``retrying`` claims that are not yet stale
-    are also refused (another worker owns them).
+    ``deleting_auth`` (auth user verified gone by caller), stale ``running``
+    (worker crashed mid-execution), or stale ``retrying`` to ``retrying`` so
+    concurrent workers cannot re-enqueue the same wipe. Fresh ``pending``,
+    ``deleting_auth``, and ``running`` markers (recently written by an
+    in-progress deletion) are left untouched to avoid wiping data before
+    Firebase auth deletion succeeds or interrupting a live worker. ``retrying``
+    claims that are not yet stale are also refused (another worker owns them).
     """
     snapshot = doc_ref.get(transaction=transaction)
     if not snapshot.exists:
@@ -399,6 +495,16 @@ def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> st
             return None
         transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
         return snapshot.id
+    if status == 'running':
+        # A ``running`` marker means the worker started executing. Only reclaim
+        # it if it's stale beyond ``running_stale_after`` — the worker almost
+        # certainly crashed or the pod was killed mid-execution. A fresh or
+        # moderately recent ``running`` marker belongs to a live worker.
+        running_at = data.get('wipe_running_at')
+        if running_at and running_at >= now - running_stale_after:
+            return None
+        transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
+        return snapshot.id
     if status == 'failed':
         transaction.update(doc_ref, {'wipe_status': 'retrying', 'wipe_claimed_at': now})
         return snapshot.id
@@ -411,7 +517,11 @@ def _claim_deletion_wipe_txn(transaction, doc_ref, stale_after: timedelta) -> st
     return None
 
 
-def claim_deletion_wipe(uid: str, stale_after: timedelta = timedelta(minutes=10)) -> str | None:
+def claim_deletion_wipe(
+    uid: str,
+    stale_after: timedelta = timedelta(minutes=10),
+    running_stale_after: timedelta = timedelta(minutes=30),
+) -> str | None:
     """Attempt to claim a pending/failed/stale wipe for re-enqueueing.
 
     Returns the uid if claimed (caller should enqueue the wipe), or ``None`` if
@@ -420,7 +530,7 @@ def claim_deletion_wipe(uid: str, stale_after: timedelta = timedelta(minutes=10)
     """
     doc_ref = db.collection('account_deletions').document(uid)
     transaction = db.transaction()
-    return _claim_deletion_wipe_txn(transaction, doc_ref, stale_after)
+    return _claim_deletion_wipe_txn(transaction, doc_ref, stale_after, running_stale_after)
 
 
 def create_person(uid: str, data: dict):

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -264,20 +264,29 @@ def mark_user_deletion_wipe_failed(uid: str):
     )
 
 
-def get_pending_deletion_wipes(limit: int = 100) -> list[dict]:
-    """Return account_deletions documents whose wipe is pending or failed (needs retry).
+def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timedelta(minutes=10)) -> list[dict]:
+    """Return account_deletions documents whose wipe needs retry.
 
-    A reconciliation worker calls this to find wipes that were cancelled by a
-    deploy/restart before the in-process cleanup_executor future started, or that
-    failed and need re-enqueueing.
+    Queries ``pending``/``failed`` records first (always actionable), then adds
+    stale ``retrying`` claims (worker probably crashed) only if room remains
+    under ``limit``. Non-stale ``retrying`` claims are excluded so they cannot
+    crowd out actionable work under backlog.
     """
-    docs = (
-        db.collection('account_deletions')
-        .where('wipe_status', 'in', ['pending', 'failed', 'retrying'])
-        .limit(limit)
-        .stream()
-    )
-    return [doc.to_dict() | {'uid': doc.id} for doc in docs]
+    docs = db.collection('account_deletions').where('wipe_status', 'in', ['pending', 'failed']).limit(limit).stream()
+    result = [doc.to_dict() | {'uid': doc.id} for doc in docs]
+
+    if len(result) < limit:
+        stale_cutoff = datetime.now(timezone.utc) - stale_after
+        stale_docs = (
+            db.collection('account_deletions')
+            .where('wipe_status', '==', 'retrying')
+            .where('wipe_claimed_at', '<', stale_cutoff)
+            .limit(limit - len(result))
+            .stream()
+        )
+        result.extend(doc.to_dict() | {'uid': doc.id} for doc in stale_docs)
+
+    return result
 
 
 @transactional

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -313,18 +313,25 @@ def get_pending_deletion_wipes(limit: int = 100, stale_after: timedelta = timede
     result = [doc.to_dict() | {'uid': doc.id} for doc in failed_docs]
 
     if len(result) < limit:
-        budget = limit - len(result)
-        pending_docs = db.collection('account_deletions').where('wipe_status', '==', 'pending').limit(budget).stream()
+        # Over-fetch *all* pending docs and age-filter in Python. A tight
+        # ``.limit(budget)`` would cap the query before stale records beyond the
+        # first page of fresh pending docs, leaving them permanently unqueued.
+        # The ``account_deletions`` collection only holds deletion events so
+        # the full scan is bounded.
+        pending_docs = db.collection('account_deletions').where('wipe_status', '==', 'pending').stream()
         for doc in pending_docs:
+            if len(result) >= limit:
+                break
             data = doc.to_dict()
             queued_at = data.get('wipe_queued_at')
             if queued_at and queued_at < stale_cutoff:
                 result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
-        budget = limit - len(result)
-        retrying_docs = db.collection('account_deletions').where('wipe_status', '==', 'retrying').limit(budget).stream()
+        retrying_docs = db.collection('account_deletions').where('wipe_status', '==', 'retrying').stream()
         for doc in retrying_docs:
+            if len(result) >= limit:
+                break
             data = doc.to_dict()
             claimed_at = data.get('wipe_claimed_at')
             if claimed_at and claimed_at < stale_cutoff:

--- a/backend/main.py
+++ b/backend/main.py
@@ -185,6 +185,9 @@ async def startup_event():
         run_blocking(db_executor, _drain_pending_deletion_wipes),
         name='startup_deletion_wipe_reconcile',
     )
+    # Periodic reconciliation ensures stale retrying claims (worker crashed) and
+    # new pending/failed wipes are retried without requiring a restart.
+    start_background_task(_periodic_deletion_wipe_reconcile(), name='periodic_deletion_wipe_reconcile')
 
 
 def _drain_pending_deletion_wipes():
@@ -195,6 +198,22 @@ def _drain_pending_deletion_wipes():
             logger.info(f"Startup deletion-wipe reconciliation: {result}")
     except Exception as e:
         logger.error(f"Startup deletion-wipe reconciliation failed: {e}")
+
+
+async def _periodic_deletion_wipe_reconcile(interval_seconds: int = 300):
+    """Periodically reconcile orphaned or failed account-deletion wipes.
+
+    Runs every 5 minutes (default) so stale retrying claims and new
+    pending/failed wipes are retried without requiring a restart.
+    """
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            result = await run_blocking(db_executor, reconcile_pending_deletion_wipes)
+            if result.get('requeued'):
+                logger.info(f"Periodic deletion-wipe reconciliation: {result}")
+        except Exception as e:
+            logger.error(f"Periodic deletion-wipe reconciliation failed: {e}")
 
 
 @app.on_event("shutdown")

--- a/backend/main.py
+++ b/backend/main.py
@@ -67,7 +67,13 @@ from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
 from utils.subscription import validate_stripe_price_ids
 from utils.http_client import close_all_clients
-from utils.executors import drain_background_tasks, log_executor_health, run_blocking, db_executor
+from utils.executors import (
+    drain_background_tasks,
+    log_executor_health,
+    run_blocking,
+    db_executor,
+    start_background_task,
+)
 from services.users.account_deletion import reconcile_pending_deletion_wipes
 
 # Log LangSmith tracing status at startup
@@ -175,7 +181,10 @@ async def startup_event():
     asyncio.create_task(log_executor_health())
     # Drain account-deletion wipes orphaned by a previous deploy/restart. Offloaded
     # to db_executor so the blocking Firestore queries don't stall event-loop startup.
-    asyncio.create_task(run_blocking(db_executor, _drain_pending_deletion_wipes))
+    start_background_task(
+        run_blocking(db_executor, _drain_pending_deletion_wipes),
+        name='startup_deletion_wipe_reconcile',
+    )
 
 
 def _drain_pending_deletion_wipes():

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 load_dotenv()  # No-op if .env doesn't exist (production); loads local dev secrets otherwise
 
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 import firebase_admin
 from fastapi import FastAPI
@@ -66,7 +67,8 @@ from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
 from utils.subscription import validate_stripe_price_ids
 from utils.http_client import close_all_clients
-from utils.executors import drain_background_tasks, log_executor_health
+from utils.executors import drain_background_tasks, log_executor_health, run_blocking, db_executor
+from services.users.account_deletion import reconcile_pending_deletion_wipes
 
 # Log LangSmith tracing status at startup
 log_langsmith_status()
@@ -171,6 +173,19 @@ app.add_middleware(BYOKMiddleware)
 @app.on_event("startup")
 async def startup_event():
     asyncio.create_task(log_executor_health())
+    # Drain account-deletion wipes orphaned by a previous deploy/restart. Offloaded
+    # to db_executor so the blocking Firestore queries don't stall event-loop startup.
+    asyncio.create_task(run_blocking(db_executor, _drain_pending_deletion_wipes))
+
+
+def _drain_pending_deletion_wipes():
+    """Best-effort reconciliation of pending/failed account-deletion wipes on startup."""
+    try:
+        result = reconcile_pending_deletion_wipes()
+        if result.get('requeued'):
+            logger.info(f"Startup deletion-wipe reconciliation: {result}")
+    except Exception as e:
+        logger.error(f"Startup deletion-wipe reconciliation failed: {e}")
 
 
 @app.on_event("shutdown")

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -22,6 +22,7 @@ from database import (
     users as users_db,
 )
 from services.users.data_export import iter_user_data_export
+from services.users.account_deletion import start_account_deletion
 from database.app_review_config import should_hide_subscription_ui
 from database.webhook_health import record_dev_webhook_success
 from database.conversations import get_in_progress_conversation, get_conversation
@@ -145,8 +146,6 @@ def delete_account(
     request: DeleteAccountRequest = DeleteAccountRequest(),
     uid: str = Depends(auth.get_current_user_uid),
 ):
-    from services.users.account_deletion import start_account_deletion
-
     try:
         return start_account_deletion(uid, reason=request.reason, reason_details=request.reason_details)
     except Exception as e:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,6 +1,6 @@
-import json
+from __future__ import annotations
+
 import re
-import threading
 import uuid
 from typing import List, Dict, Any, Union, Optional
 import hashlib
@@ -21,6 +21,7 @@ from database import (
     llm_usage as llm_usage_db,
     users as users_db,
 )
+from services.users import iter_user_data_export, start_account_deletion
 from database.app_review_config import should_hide_subscription_ui
 from database.webhook_health import record_dev_webhook_success
 from database.conversations import get_in_progress_conversation, get_conversation
@@ -91,7 +92,6 @@ from utils.subscription import (
 from database import user_usage as user_usage_db
 from utils import stripe as stripe_utils
 from utils.log_sanitizer import sanitize
-from utils.twilio_service import delete_user_caller_ids
 from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
@@ -103,19 +103,7 @@ from utils.other.storage import (
     delete_user_person_speech_samples,
     delete_user_person_speech_sample,
 )
-from database.conversations import get_conversation_ids
-from database.memories import get_memory_ids
-from database.action_items import get_action_item_ids
-from database.screen_activity import get_screen_activity_ids
-from database.vector_db import (
-    delete_conversation_vectors_batch,
-    delete_transcript_chunk_vectors_batch,
-    delete_memory_vectors_batch,
-    delete_action_item_vectors_batch,
-    delete_screen_activity_vectors,
-)
 from utils.webhooks import webhook_first_time_setup
-from database.action_items import get_action_items as get_standalone_action_items
 from utils.byok import has_byok_keys, invalidate_byok_state_cache
 import logging
 
@@ -152,121 +140,13 @@ class DeleteAccountRequest(BaseModel):
     reason_details: Optional[str] = None
 
 
-def _purge_derived_user_data(uid: str):
-    """Best-effort purge of a user's data that lives OUTSIDE Firestore — Pinecone vectors and GCS
-    recordings — run before the Firestore wipe removes the IDs we need to enumerate (#5088).
-
-    Each backend is isolated in its own try/except so one failure (or a slow external call) never
-    blocks the others or the subsequent Firestore deletion. IDs are read via lightweight IDs-only
-    queries (no decryption).
-
-    Scope: conversation (ns1), memory (ns2), action-item (ns4), screen-activity (ns3) and
-    transcript-chunk (ns_tchunks) vectors,
-    plus conversation recordings. Known follow-ups NOT covered here: X-post vectors (no delete helper
-    yet), speech-profile / person-sample / private-cloud-sync / chat-upload GCS blobs, and the
-    externally-indexed Typesense collection.
-    """
-    try:
-        conversation_ids = get_conversation_ids(uid)
-        if conversation_ids:
-            delete_conversation_vectors_batch(uid, conversation_ids)
-    except Exception as e:
-        logger.error(f'delete_account purge conversation vectors failed for {uid}: {sanitize(str(e))}')
-
-    try:
-        conversation_ids = get_conversation_ids(uid)
-        if conversation_ids:
-            delete_transcript_chunk_vectors_batch(uid, conversation_ids)
-    except Exception as e:
-        logger.error(f'delete_account purge transcript chunk vectors failed for {uid}: {sanitize(str(e))}')
-
-    try:
-        memory_ids = get_memory_ids(uid)
-        if memory_ids:
-            delete_memory_vectors_batch(uid, memory_ids)
-    except Exception as e:
-        logger.error(f'delete_account purge memory vectors failed for {uid}: {sanitize(str(e))}')
-
-    try:
-        action_item_ids = get_action_item_ids(uid)
-        if action_item_ids:
-            delete_action_item_vectors_batch(uid, action_item_ids)
-    except Exception as e:
-        logger.error(f'delete_account purge action item vectors failed for {uid}: {sanitize(str(e))}')
-
-    try:
-        screen_activity_ids = get_screen_activity_ids(uid)
-        if screen_activity_ids:
-            delete_screen_activity_vectors(uid, screen_activity_ids)
-    except Exception as e:
-        logger.error(f'delete_account purge screen activity vectors failed for {uid}: {sanitize(str(e))}')
-
-    try:
-        delete_all_conversation_recordings(uid)
-    except Exception as e:
-        logger.error(f'delete_account purge recordings failed for {uid}: {sanitize(str(e))}')
-
-
-def _background_wipe_user_data(uid: str):
-    try:
-        # Twilio caller IDs first, while the phone_numbers subcollection still
-        # carries the twilio_sid metadata. delete_user_caller_ids is best-effort
-        # — Twilio errors are logged inside and never propagate, so a momentary
-        # Twilio outage cannot leave the user half-deleted in Firestore.
-        delete_user_caller_ids(uid)
-        # Purge external stores (Pinecone vectors, GCS recordings) BEFORE the Firestore wipe, which
-        # removes the IDs we enumerate. Best-effort + isolated so it never blocks the Firestore wipe.
-        _purge_derived_user_data(uid)
-        delete_user_data(uid)
-        logger.info(f'delete_account background wipe complete for {uid}')
-    except Exception as e:
-        logger.error(f'delete_account background wipe failed for {uid}: {sanitize(str(e))}')
-
-
 @router.delete('/v1/users/delete-account', tags=['v1'])
 def delete_account(
     request: DeleteAccountRequest = DeleteAccountRequest(),
     uid: str = Depends(auth.get_current_user_uid),
 ):
     try:
-        # 1. Persist deletion feedback first (top-level collection survives wipe).
-        if request.reason or request.reason_details:
-            try:
-                users_db.set_user_deletion_feedback(uid, request.reason, request.reason_details)
-            except Exception as e:
-                logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
-
-        # 1.5 Cancel any active paid Stripe subscription before wiping the account, so the user
-        #     isn't billed after deletion (they lose all access and can't self-serve a cancel).
-        #     Read the subscription while the user doc still exists. Best-effort: a Stripe hiccup
-        #     must never block account deletion, but log loudly so support can clean up manually.
-        try:
-            sub = users_db.get_user_subscription(uid)
-            if sub and sub.stripe_subscription_id:
-                canceled = stripe_utils.cancel_subscription(sub.stripe_subscription_id)
-                if not canceled:
-                    logger.error(f'delete_account stripe cancel returned None for {uid}')
-        except Exception as e:
-            # cancel_subscription swallows its own Stripe errors (returns None), so this only
-            # fires on the subscription lookup (e.g. a Firestore read error).
-            logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
-
-        # 2. Revoke Firebase auth immediately so tokens are useless and the
-        #    account cannot be logged back into while the data wipe runs.
-        try:
-            auth.delete_account(uid)
-        except Exception as e:
-            err = str(e).upper()
-            if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
-                logger.info(f'delete_account firebase user already gone for {uid}')
-            else:
-                raise
-
-        # 3. Wipe Firestore subcollections in the background — can take minutes
-        #    for heavy users and would otherwise time out at the load balancer.
-        threading.Thread(target=_background_wipe_user_data, args=(uid,), daemon=True).start()
-
-        return {'status': 'ok', 'message': 'Account deletion started'}
+        return start_account_deletion(uid, reason=request.reason, reason_details=request.reason_details)
     except Exception as e:
         logger.info(f'delete_account {sanitize(str(e))}')
         raise HTTPException(status_code=500, detail='Could not delete account. Please try again.')
@@ -1646,55 +1526,11 @@ def get_llm_top_features(
     return llm_usage_db.get_top_features(uid, days=days, limit=limit)
 
 
-def _json_default(obj):
-    if isinstance(obj, datetime):
-        return obj.isoformat()
-    raise TypeError(f"Type {type(obj)} not serializable")
-
-
 @router.get('/v1/users/export', tags=['v1'])
 def export_all_user_data(uid: str = Depends(auth.get_current_user_uid)):
     """Export all user data for GDPR/CCPA compliance. Streams response to avoid timeouts."""
-
-    def generate():
-        profile = get_user_profile(uid)
-        memories_list = memories_db.get_memories(uid, limit=10000, offset=0)
-        people = get_people(uid)
-        action_items = get_standalone_action_items(uid, limit=10000, offset=0)
-
-        # Stream pretty-printed JSON, yielding conversations and messages one at a time
-        yield '{\n'
-        yield '  "profile": ' + json.dumps(profile if profile else {}, default=_json_default, indent=2) + ',\n'
-
-        # Stream conversations via generator (batched internally, never all in memory)
-        # Note: locked conversations are intentionally included in GDPR/CCPA exports per Art. 15
-        yield '  "conversations": [\n'
-        first = True
-        for conv in conversations_db.iter_all_conversations(uid, include_discarded=True):
-            if not first:
-                yield ',\n'
-            first = False
-            yield '    ' + json.dumps(conv, default=_json_default, indent=4)
-        yield '\n  ],\n'
-
-        yield '  "memories": ' + json.dumps(memories_list, default=_json_default, indent=2) + ',\n'
-        yield '  "people": ' + json.dumps(people, default=_json_default, indent=2) + ',\n'
-        yield '  "action_items": ' + json.dumps(action_items, default=_json_default, indent=2) + ',\n'
-
-        # Stream chat messages via generator (batched internally, never all in memory)
-        yield '  "chat_messages": [\n'
-        first = True
-        for msg in chat_db.iter_all_messages(uid):
-            if not first:
-                yield ',\n'
-            first = False
-            yield '    ' + json.dumps(msg, default=_json_default, indent=4)
-        yield '\n  ]\n'
-
-        yield '}\n'
-
     return StreamingResponse(
-        generate(),
+        iter_user_data_export(uid),
         media_type='application/json',
         headers={'Content-Disposition': 'attachment; filename="omi-export.json"'},
     )

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -21,7 +21,7 @@ from database import (
     llm_usage as llm_usage_db,
     users as users_db,
 )
-from services.users import iter_user_data_export, start_account_deletion
+from services.users.data_export import iter_user_data_export
 from database.app_review_config import should_hide_subscription_ui
 from database.webhook_health import record_dev_webhook_success
 from database.conversations import get_in_progress_conversation, get_conversation
@@ -145,6 +145,8 @@ def delete_account(
     request: DeleteAccountRequest = DeleteAccountRequest(),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    from services.users.account_deletion import start_account_deletion
+
     try:
         return start_account_deletion(uid, reason=request.reason, reason_details=request.reason_details)
     except Exception as e:

--- a/backend/services/users/__init__.py
+++ b/backend/services/users/__init__.py
@@ -1,0 +1,9 @@
+from .account_deletion import background_wipe_user_data, purge_derived_user_data, start_account_deletion
+from .data_export import iter_user_data_export
+
+__all__ = [
+    'background_wipe_user_data',
+    'iter_user_data_export',
+    'purge_derived_user_data',
+    'start_account_deletion',
+]

--- a/backend/services/users/__init__.py
+++ b/backend/services/users/__init__.py
@@ -1,9 +1,5 @@
-from .account_deletion import background_wipe_user_data, purge_derived_user_data, start_account_deletion
-from .data_export import iter_user_data_export
+"""User service modules.
 
-__all__ = [
-    'background_wipe_user_data',
-    'iter_user_data_export',
-    'purge_derived_user_data',
-    'start_account_deletion',
-]
+Keep this package initializer dependency-free so importing one user service does
+not pull unrelated integrations such as Stripe.
+"""

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -143,6 +143,12 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         except Exception as e:
             logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
 
+    # Persist the pending-deletion marker FIRST, before any irreversible action
+    # (Stripe cancel, Firebase user delete). Retry transient Firestore failures.
+    # If the marker cannot be written, do NOT proceed — without it, a deploy/restart
+    # that cancels the queued wipe leaves no recovery path for the user's data.
+    _persist_wipe_marker_with_retry(uid)
+
     try:
         sub = users_db.get_user_subscription(uid)
         if sub and sub.stripe_subscription_id:
@@ -151,12 +157,6 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
                 logger.error(f'delete_account stripe cancel returned None for {uid}')
     except Exception as e:
         logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
-
-    # Persist the pending-deletion marker BEFORE the irreversible Firebase user
-    # deletion. Retry transient Firestore failures. If the marker cannot be
-    # written, do NOT proceed — without it, a deploy/restart that cancels the
-    # queued wipe leaves no recovery path for the user's Firestore/GCS/vector data.
-    _persist_wipe_marker_with_retry(uid)
 
     try:
         auth.delete_account(uid)

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -76,6 +76,13 @@ def background_wipe_user_data(uid: str):
         logger.info(f'delete_account background wipe complete for {uid}')
     except Exception as e:
         logger.error(f'delete_account background wipe failed for {uid}: {sanitize(str(e))}')
+    finally:
+        # Persist final status so a reconciliation worker can distinguish completed
+        # wipes from those cancelled by a deploy/restart before they started.
+        try:
+            users_db.mark_user_deletion_wipe_completed(uid)
+        except Exception as e:
+            logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
 
 
 def start_account_deletion(uid: str, reason: str | None = None, reason_details: str | None = None) -> dict[str, str]:
@@ -102,6 +109,14 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
             logger.info(f'delete_account firebase user already gone for {uid}')
         else:
             raise
+
+    # Persist a pending-deletion marker before enqueueing so a deploy/restart that
+    # cancels the queued wipe future can be reconciled (the marker survives in
+    # Firestore; a worker can query for `wipe_status == 'pending'`).
+    try:
+        users_db.mark_user_deletion_wipe_started(uid)
+    except Exception as e:
+        logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -76,9 +76,13 @@ def background_wipe_user_data(uid: str):
         logger.info(f'delete_account background wipe complete for {uid}')
     except Exception as e:
         logger.error(f'delete_account background wipe failed for {uid}: {sanitize(str(e))}')
-    finally:
-        # Persist final status so a reconciliation worker can distinguish completed
-        # wipes from those cancelled by a deploy/restart before they started.
+        # Mark the wipe as failed so a reconciliation worker can retry. Do NOT mark
+        # completed — that would hide a partial wipe from the recovery path.
+        try:
+            users_db.mark_user_deletion_wipe_failed(uid)
+        except Exception as persist_err:
+            logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(persist_err))}')
+    else:
         try:
             users_db.mark_user_deletion_wipe_completed(uid)
         except Exception as e:
@@ -121,3 +125,34 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 
     return {'status': 'ok', 'message': 'Account deletion started'}
+
+
+def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
+    """Re-enqueue account-deletion wipes that were cancelled or failed.
+
+    Called by a periodic worker (cron, Cloud Scheduler, or startup hook) to drain
+    the ``wipe_status in ('pending', 'failed')`` backlog left behind when a deploy
+    or restart cancels in-process ``cleanup_executor`` futures before they start.
+
+    Returns a summary dict with counts of re-enqueued and skipped wipes.
+    """
+    requeued = 0
+    skipped = 0
+    try:
+        pending = users_db.get_pending_deletion_wipes(limit=limit)
+    except Exception as e:
+        logger.error(f'delete_account reconciliation query failed: {sanitize(str(e))}')
+        return {'requeued': 0, 'skipped': 0, 'error': 1}
+
+    for record in pending:
+        uid = record.get('uid')
+        if not uid:
+            skipped += 1
+            continue
+        submit_with_context(cleanup_executor, background_wipe_user_data, uid)
+        requeued += 1
+        logger.info(f'delete_account reconciliation re-enqueued wipe for {uid}')
+
+    if requeued:
+        logger.info(f'delete_account reconciliation: re-enqueued {requeued}, skipped {skipped}')
+    return {'requeued': requeued, 'skipped': skipped}

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import threading
+
+from database import users as users_db
+from database.action_items import get_action_item_ids
+from database.conversations import get_conversation_ids
+from database.memories import get_memory_ids
+from database.screen_activity import get_screen_activity_ids
+from database.vector_db import (
+    delete_action_item_vectors_batch,
+    delete_conversation_vectors_batch,
+    delete_memory_vectors_batch,
+    delete_screen_activity_vectors,
+    delete_transcript_chunk_vectors_batch,
+)
+from utils import stripe as stripe_utils
+from utils.log_sanitizer import sanitize
+from utils.other import endpoints as auth
+from utils.other.storage import delete_all_conversation_recordings
+from utils.twilio_service import delete_user_caller_ids
+
+logger = logging.getLogger(__name__)
+
+
+def purge_derived_user_data(uid: str):
+    """Best-effort purge of a user's derived data outside Firestore."""
+    try:
+        conversation_ids = get_conversation_ids(uid)
+        if conversation_ids:
+            delete_conversation_vectors_batch(uid, conversation_ids)
+    except Exception as e:
+        logger.error(f'delete_account purge conversation vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        conversation_ids = get_conversation_ids(uid)
+        if conversation_ids:
+            delete_transcript_chunk_vectors_batch(uid, conversation_ids)
+    except Exception as e:
+        logger.error(f'delete_account purge transcript chunk vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        memory_ids = get_memory_ids(uid)
+        if memory_ids:
+            delete_memory_vectors_batch(uid, memory_ids)
+    except Exception as e:
+        logger.error(f'delete_account purge memory vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        action_item_ids = get_action_item_ids(uid)
+        if action_item_ids:
+            delete_action_item_vectors_batch(uid, action_item_ids)
+    except Exception as e:
+        logger.error(f'delete_account purge action item vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        screen_activity_ids = get_screen_activity_ids(uid)
+        if screen_activity_ids:
+            delete_screen_activity_vectors(uid, screen_activity_ids)
+    except Exception as e:
+        logger.error(f'delete_account purge screen activity vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        delete_all_conversation_recordings(uid)
+    except Exception as e:
+        logger.error(f'delete_account purge recordings failed for {uid}: {sanitize(str(e))}')
+
+
+def background_wipe_user_data(uid: str):
+    try:
+        # Twilio caller IDs first, while the phone_numbers subcollection still carries twilio_sid metadata.
+        delete_user_caller_ids(uid)
+        purge_derived_user_data(uid)
+        users_db.delete_user_data(uid)
+        logger.info(f'delete_account background wipe complete for {uid}')
+    except Exception as e:
+        logger.error(f'delete_account background wipe failed for {uid}: {sanitize(str(e))}')
+
+
+def start_account_deletion(uid: str, reason: str | None = None, reason_details: str | None = None) -> dict[str, str]:
+    if reason or reason_details:
+        try:
+            users_db.set_user_deletion_feedback(uid, reason, reason_details)
+        except Exception as e:
+            logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
+
+    try:
+        sub = users_db.get_user_subscription(uid)
+        if sub and sub.stripe_subscription_id:
+            canceled = stripe_utils.cancel_subscription(sub.stripe_subscription_id)
+            if not canceled:
+                logger.error(f'delete_account stripe cancel returned None for {uid}')
+    except Exception as e:
+        logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        auth.delete_account(uid)
+    except Exception as e:
+        err = str(e).upper()
+        if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
+            logger.info(f'delete_account firebase user already gone for {uid}')
+        else:
+            raise
+
+    threading.Thread(target=background_wipe_user_data, args=(uid,), daemon=True).start()
+
+    return {'status': 'ok', 'message': 'Account deletion started'}

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -140,6 +140,13 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
             logger.info(f'delete_account firebase user already gone for {uid}')
         else:
+            # Auth deletion failed — cancel the pending marker so the
+            # reconciliation worker doesn't wipe data for a user whose
+            # Firebase account still exists.
+            try:
+                users_db.cancel_user_deletion_wipe(uid)
+            except Exception as cancel_err:
+                logger.error(f'delete_account marker cancel failed for {uid}: {sanitize(str(cancel_err))}')
             raise
 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import time
 from database import users as users_db
 from database.action_items import get_action_item_ids
 from database.conversations import get_conversation_ids
@@ -89,6 +90,27 @@ def background_wipe_user_data(uid: str):
             logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
 
 
+def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
+    """Persist the pending-deletion marker, retrying transient Firestore failures.
+
+    Raises on persistent failure so the caller can surface the error to the user
+    rather than proceeding to the irreversible Firebase user deletion without a
+    durable recovery marker.
+    """
+    last_err = None
+    for attempt in range(max_attempts):
+        try:
+            users_db.mark_user_deletion_wipe_started(uid)
+            return
+        except Exception as e:
+            last_err = e
+            if attempt < max_attempts - 1:
+                time.sleep(retry_delay * (attempt + 1))
+    raise Exception(
+        f'Failed to persist deletion-wipe marker after {max_attempts} attempts for {uid}: {sanitize(str(last_err))}'
+    )
+
+
 def start_account_deletion(uid: str, reason: str | None = None, reason_details: str | None = None) -> dict[str, str]:
     if reason or reason_details:
         try:
@@ -105,6 +127,12 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
     except Exception as e:
         logger.error(f'delete_account subscription lookup failed for {uid}: {sanitize(str(e))}')
 
+    # Persist the pending-deletion marker BEFORE the irreversible Firebase user
+    # deletion. Retry transient Firestore failures. If the marker cannot be
+    # written, do NOT proceed — without it, a deploy/restart that cancels the
+    # queued wipe leaves no recovery path for the user's Firestore/GCS/vector data.
+    _persist_wipe_marker_with_retry(uid)
+
     try:
         auth.delete_account(uid)
     except Exception as e:
@@ -113,14 +141,6 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
             logger.info(f'delete_account firebase user already gone for {uid}')
         else:
             raise
-
-    # Persist a pending-deletion marker before enqueueing so a deploy/restart that
-    # cancels the queued wipe future can be reconciled (the marker survives in
-    # Firestore; a worker can query for `wipe_status == 'pending'`).
-    try:
-        users_db.mark_user_deletion_wipe_started(uid)
-    except Exception as e:
-        logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -93,10 +93,11 @@ def background_wipe_user_data(uid: str):
 def _persist_wipe_intent_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
     """Persist the non-actionable deletion intent, retrying transient Firestore failures.
 
-    Writes ``wipe_status='deleting_auth'`` which the reconciler does NOT query
-    for. A crash or deploy between this write and ``auth.delete_account()``
-    therefore leaves a benign record that cannot trigger a premature data wipe
-    for a user whose Firebase account still exists.
+    Writes ``wipe_status='deleting_auth'`` which the reconciler only recovers
+    *after* verifying the Firebase auth user is actually gone. A crash or deploy
+    between this write and ``auth.delete_account()`` therefore leaves a benign
+    record that cannot trigger a premature data wipe for a user whose Firebase
+    account still exists.
 
     Raises on persistent failure so the caller can surface the error to the user
     rather than proceeding to the irreversible Firebase user deletion without a
@@ -122,9 +123,10 @@ def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay
     Called only after ``auth.delete_account()`` has succeeded (or the user was
     already gone). On persistent Firestore failure, logs a critical error rather
     than raising — the Firebase user is already deleted, so raising would
-    surface a misleading error. The background wipe may not be queued, but no
-    dangerous state is possible (the marker remains ``'deleting_auth'``, which
-    the reconciler ignores).
+    surface a misleading error. The background wipe may not be queued
+    immediately, but a stale ``'deleting_auth'`` marker is now recoverable:
+    ``reconcile_pending_deletion_wipes`` will verify the auth user is gone and
+    re-enqueue the wipe.
     """
     last_err = None
     for attempt in range(max_attempts):
@@ -174,11 +176,12 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
             logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
 
     # Phase 1 — persist a NON-ACTIONABLE intent ('deleting_auth') before any
-    # irreversible action. The reconciler never queries for 'deleting_auth', so
-    # a crash/deploy between this write and the confirmed auth deletion cannot
-    # trigger a premature data wipe for a user whose Firebase account still
-    # exists. Retry transient Firestore failures; if the intent cannot be
-    # written, do NOT proceed.
+    # irreversible action. The reconciler only recovers stale 'deleting_auth'
+    # records after verifying the Firebase auth user is gone, so a crash/deploy
+    # between this write and the confirmed auth deletion cannot trigger a
+    # premature data wipe for a user whose Firebase account still exists. Retry
+    # transient Firestore failures; if the intent cannot be written, do NOT
+    # proceed.
     _persist_wipe_intent_with_retry(uid)
 
     try:
@@ -199,7 +202,8 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         else:
             # Auth deletion failed — cancel the intent so the record doesn't
             # linger in 'deleting_auth'. This is cosmetic cleanup, not a safety
-            # requirement: the reconciler never acts on 'deleting_auth'.
+            # requirement: the reconciler verifies the auth user is gone before
+            # recovering any 'deleting_auth' record.
             _cancel_wipe_marker_with_retry(uid)
             raise
 
@@ -213,6 +217,26 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
     return {'status': 'ok', 'message': 'Account deletion started'}
 
 
+def _is_auth_user_gone(uid: str) -> bool:
+    """Check whether the Firebase auth user for ``uid`` no longer exists.
+
+    Returns ``True`` if the user was already deleted (``USER_NOT_FOUND`` or
+    equivalent). Returns ``False`` on any other error — fail safe so a transient
+    Firebase outage does not trigger a data wipe for a user whose auth account
+    may still exist.
+    """
+    try:
+        auth.get_user(uid)
+        return False
+    except Exception as e:
+        err = str(e).upper()
+        if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
+            return True
+        # Indeterminate — do NOT treat as gone.
+        logger.warning(f'delete_account auth-user-gone check indeterminate for {uid}: {sanitize(str(e))}')
+        return False
+
+
 def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
     """Re-enqueue account-deletion wipes that were cancelled or failed.
 
@@ -220,6 +244,13 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
     the ``wipe_status in ('pending', 'failed', 'retrying')`` backlog left behind
     when a deploy or restart cancels in-process ``cleanup_executor`` futures
     before they start.
+
+    Also recovers stale ``'deleting_auth'`` records — markers where the deletion
+    intent was written but never transitioned to ``'pending'`` (usually a crash
+    or deploy after ``auth.delete_account()`` succeeded). For these records, the
+    Firebase auth user is verified gone *before* claiming and re-enqueueing, so a
+    transient Firebase outage or a record left by an in-progress deletion cannot
+    trigger a premature data wipe for a user whose auth account still exists.
 
     Each wipe is atomically claimed via a Firestore transaction before
     re-enqueueing, so concurrent workers or overlapping scheduler runs cannot
@@ -240,6 +271,17 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
         if not uid:
             skipped += 1
             continue
+        # P1 recovery: a 'deleting_auth' record means the intent was written but
+        # the marker was never transitioned to 'pending'. Verify the Firebase
+        # auth user is actually gone before claiming it, so we never wipe data
+        # for a user whose auth account may still exist.
+        if record.get('wipe_status') == 'deleting_auth':
+            if not _is_auth_user_gone(uid):
+                skipped += 1
+                logger.info(
+                    f'delete_account reconciliation skipping deleting_auth record for {uid} — auth user still exists'
+                )
+                continue
         # Atomically claim the wipe to prevent concurrent re-enqueueing by
         # multiple workers. If the claim fails, another worker owns it.
         try:

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -131,8 +131,13 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
     """Re-enqueue account-deletion wipes that were cancelled or failed.
 
     Called by a periodic worker (cron, Cloud Scheduler, or startup hook) to drain
-    the ``wipe_status in ('pending', 'failed')`` backlog left behind when a deploy
-    or restart cancels in-process ``cleanup_executor`` futures before they start.
+    the ``wipe_status in ('pending', 'failed', 'retrying')`` backlog left behind
+    when a deploy or restart cancels in-process ``cleanup_executor`` futures
+    before they start.
+
+    Each wipe is atomically claimed via a Firestore transaction before
+    re-enqueueing, so concurrent workers or overlapping scheduler runs cannot
+    double-enqueue the same wipe.
 
     Returns a summary dict with counts of re-enqueued and skipped wipes.
     """
@@ -147,6 +152,17 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
     for record in pending:
         uid = record.get('uid')
         if not uid:
+            skipped += 1
+            continue
+        # Atomically claim the wipe to prevent concurrent re-enqueueing by
+        # multiple workers. If the claim fails, another worker owns it.
+        try:
+            claimed_uid = users_db.claim_deletion_wipe(uid)
+        except Exception as e:
+            logger.error(f'delete_account reconciliation claim failed for {uid}: {sanitize(str(e))}')
+            skipped += 1
+            continue
+        if claimed_uid is None:
             skipped += 1
             continue
         submit_with_context(cleanup_executor, background_wipe_user_data, uid)

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 
 from database import users as users_db
 from database.action_items import get_action_item_ids
@@ -16,6 +15,7 @@ from database.vector_db import (
     delete_transcript_chunk_vectors_batch,
 )
 from utils import stripe as stripe_utils
+from utils.executors import postprocess_executor, submit_with_context
 from utils.log_sanitizer import sanitize
 from utils.other import endpoints as auth
 from utils.other.storage import delete_all_conversation_recordings
@@ -103,6 +103,6 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         else:
             raise
 
-    threading.Thread(target=background_wipe_user_data, args=(uid,), daemon=True).start()
+    submit_with_context(postprocess_executor, background_wipe_user_data, uid)
 
     return {'status': 'ok', 'message': 'Account deletion started'}

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -111,6 +111,31 @@ def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay
     )
 
 
+def _cancel_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
+    """Cancel the pending-deletion marker, retrying transient Firestore failures.
+
+    Used when auth.delete_account() fails after the marker was already persisted.
+    Escalates to a critical log (not an exception) if cancellation ultimately
+    fails — the auth error still propagates to the caller, and the stale marker
+    will age out naturally (pending → stale → retried by reconciler, by which
+    point the auth user may be re-deleted).
+    """
+    last_err = None
+    for attempt in range(max_attempts):
+        try:
+            users_db.cancel_user_deletion_wipe(uid)
+            return
+        except Exception as e:
+            last_err = e
+            if attempt < max_attempts - 1:
+                time.sleep(retry_delay * (attempt + 1))
+    logger.critical(
+        f'delete_account marker CANCEL failed after {max_attempts} attempts for {uid}: '
+        f'{sanitize(str(last_err))} — manual intervention may be needed to prevent '
+        f'unwanted data wipe by the reconciliation worker.'
+    )
+
+
 def start_account_deletion(uid: str, reason: str | None = None, reason_details: str | None = None) -> dict[str, str]:
     if reason or reason_details:
         try:
@@ -142,11 +167,8 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         else:
             # Auth deletion failed — cancel the pending marker so the
             # reconciliation worker doesn't wipe data for a user whose
-            # Firebase account still exists.
-            try:
-                users_db.cancel_user_deletion_wipe(uid)
-            except Exception as cancel_err:
-                logger.error(f'delete_account marker cancel failed for {uid}: {sanitize(str(cancel_err))}')
+            # Firebase account still exists. Retry transient Firestore failures.
+            _cancel_wipe_marker_with_retry(uid)
             raise
 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -90,12 +90,41 @@ def background_wipe_user_data(uid: str):
             logger.error(f'delete_account wipe status persist failed for {uid}: {sanitize(str(e))}')
 
 
-def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
-    """Persist the pending-deletion marker, retrying transient Firestore failures.
+def _persist_wipe_intent_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
+    """Persist the non-actionable deletion intent, retrying transient Firestore failures.
+
+    Writes ``wipe_status='deleting_auth'`` which the reconciler does NOT query
+    for. A crash or deploy between this write and ``auth.delete_account()``
+    therefore leaves a benign record that cannot trigger a premature data wipe
+    for a user whose Firebase account still exists.
 
     Raises on persistent failure so the caller can surface the error to the user
     rather than proceeding to the irreversible Firebase user deletion without a
     durable recovery marker.
+    """
+    last_err = None
+    for attempt in range(max_attempts):
+        try:
+            users_db.mark_user_deletion_wipe_intent(uid)
+            return
+        except Exception as e:
+            last_err = e
+            if attempt < max_attempts - 1:
+                time.sleep(retry_delay * (attempt + 1))
+    raise Exception(
+        f'Failed to persist deletion-wipe intent after {max_attempts} attempts for {uid}: {sanitize(str(last_err))}'
+    )
+
+
+def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay: float = 0.5):
+    """Transition the marker to the actionable ``'pending'`` state after auth deletion is confirmed.
+
+    Called only after ``auth.delete_account()`` has succeeded (or the user was
+    already gone). On persistent Firestore failure, logs a critical error rather
+    than raising — the Firebase user is already deleted, so raising would
+    surface a misleading error. The background wipe may not be queued, but no
+    dangerous state is possible (the marker remains ``'deleting_auth'``, which
+    the reconciler ignores).
     """
     last_err = None
     for attempt in range(max_attempts):
@@ -106,8 +135,9 @@ def _persist_wipe_marker_with_retry(uid: str, max_attempts: int = 3, retry_delay
             last_err = e
             if attempt < max_attempts - 1:
                 time.sleep(retry_delay * (attempt + 1))
-    raise Exception(
-        f'Failed to persist deletion-wipe marker after {max_attempts} attempts for {uid}: {sanitize(str(last_err))}'
+    logger.critical(
+        f'delete_account marker transition to pending failed after {max_attempts} attempts for {uid}: '
+        f'{sanitize(str(last_err))} — Firebase user already deleted, wipe may need manual re-queue.'
     )
 
 
@@ -143,11 +173,13 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         except Exception as e:
             logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
 
-    # Persist the pending-deletion marker FIRST, before any irreversible action
-    # (Stripe cancel, Firebase user delete). Retry transient Firestore failures.
-    # If the marker cannot be written, do NOT proceed — without it, a deploy/restart
-    # that cancels the queued wipe leaves no recovery path for the user's data.
-    _persist_wipe_marker_with_retry(uid)
+    # Phase 1 — persist a NON-ACTIONABLE intent ('deleting_auth') before any
+    # irreversible action. The reconciler never queries for 'deleting_auth', so
+    # a crash/deploy between this write and the confirmed auth deletion cannot
+    # trigger a premature data wipe for a user whose Firebase account still
+    # exists. Retry transient Firestore failures; if the intent cannot be
+    # written, do NOT proceed.
+    _persist_wipe_intent_with_retry(uid)
 
     try:
         sub = users_db.get_user_subscription(uid)
@@ -165,11 +197,16 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
             logger.info(f'delete_account firebase user already gone for {uid}')
         else:
-            # Auth deletion failed — cancel the pending marker so the
-            # reconciliation worker doesn't wipe data for a user whose
-            # Firebase account still exists. Retry transient Firestore failures.
+            # Auth deletion failed — cancel the intent so the record doesn't
+            # linger in 'deleting_auth'. This is cosmetic cleanup, not a safety
+            # requirement: the reconciler never acts on 'deleting_auth'.
             _cancel_wipe_marker_with_retry(uid)
             raise
+
+    # Phase 2 — auth deletion confirmed. Transition the marker to the
+    # actionable 'pending' state so the reconciler can recover the wipe if
+    # the queued executor future is lost to a deploy/restart.
+    _persist_wipe_marker_with_retry(uid)
 
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -15,7 +15,7 @@ from database.vector_db import (
     delete_transcript_chunk_vectors_batch,
 )
 from utils import stripe as stripe_utils
-from utils.executors import postprocess_executor, submit_with_context
+from utils.executors import cleanup_executor, submit_with_context
 from utils.log_sanitizer import sanitize
 from utils.other import endpoints as auth
 from utils.other.storage import delete_all_conversation_recordings
@@ -103,6 +103,6 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         else:
             raise
 
-    submit_with_context(postprocess_executor, background_wipe_user_data, uid)
+    submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 
     return {'status': 'ok', 'message': 'Account deletion started'}

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -70,6 +70,14 @@ def purge_derived_user_data(uid: str):
 
 def background_wipe_user_data(uid: str):
     try:
+        # Transition to ``running`` so the reconciler can distinguish a
+        # genuinely orphaned ``pending`` marker (queued but never started)
+        # from a wipe that is actively executing. Without this, a slow wipe
+        # could be duplicate-claimed after the short ``pending`` stale window.
+        try:
+            users_db.mark_user_deletion_wipe_running(uid)
+        except Exception as e:
+            logger.warning(f'delete_account marker transition to running failed for {uid}: {sanitize(str(e))}')
         # Twilio caller IDs first, while the phone_numbers subcollection still carries twilio_sid metadata.
         delete_user_caller_ids(uid)
         purge_derived_user_data(uid)

--- a/backend/services/users/data_export.py
+++ b/backend/services/users/data_export.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Iterator
+
+from database import chat as chat_db
+from database import conversations as conversations_db
+from database import memories as memories_db
+from database.action_items import get_action_items as get_standalone_action_items
+from database.users import get_people, get_user_profile
+
+
+def _json_default(obj):
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+def iter_user_data_export(uid: str) -> Iterator[str]:
+    profile = get_user_profile(uid)
+    memories_list = memories_db.get_memories(uid, limit=10000, offset=0)
+    people = get_people(uid)
+    action_items = get_standalone_action_items(uid, limit=10000, offset=0)
+
+    yield '{\n'
+    yield '  "profile": ' + json.dumps(profile if profile else {}, default=_json_default, indent=2) + ',\n'
+
+    yield '  "conversations": [\n'
+    first = True
+    for conv in conversations_db.iter_all_conversations(uid, include_discarded=True):
+        if not first:
+            yield ',\n'
+        first = False
+        yield '    ' + json.dumps(conv, default=_json_default, indent=4)
+    yield '\n  ],\n'
+
+    yield '  "memories": ' + json.dumps(memories_list, default=_json_default, indent=2) + ',\n'
+    yield '  "people": ' + json.dumps(people, default=_json_default, indent=2) + ',\n'
+    yield '  "action_items": ' + json.dumps(action_items, default=_json_default, indent=2) + ',\n'
+
+    yield '  "chat_messages": [\n'
+    first = True
+    for msg in chat_db.iter_all_messages(uid):
+        if not first:
+            yield ',\n'
+        first = False
+        yield '    ' + json.dumps(msg, default=_json_default, indent=4)
+    yield '\n  ]\n'
+
+    yield '}\n'

--- a/backend/services/users/data_export.py
+++ b/backend/services/users/data_export.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Iterator
+from typing import Callable, Iterable, Iterator
 
 from database import chat as chat_db
 from database import conversations as conversations_db
@@ -17,13 +17,33 @@ def _json_default(obj):
     raise TypeError(f"Type {type(obj)} not serializable")
 
 
-def iter_user_data_export(uid: str) -> Iterator[str]:
-    profile = get_user_profile(uid)
-    memories_list = memories_db.get_memories(uid, limit=10000, offset=0)
-    people = get_people(uid)
-    action_items = get_standalone_action_items(uid, limit=10000, offset=0)
+def _iter_paginated(fetch_page: Callable[[int, int], list[dict]], *, batch_size: int = 1000) -> Iterator[dict]:
+    offset = 0
+    while True:
+        page = fetch_page(batch_size, offset)
+        if not page:
+            break
+        yield from page
+        if len(page) < batch_size:
+            break
+        offset += batch_size
 
+
+def _yield_json_array(items: Iterable[dict]) -> Iterator[str]:
+    yield '[\n'
+    first = True
+    for item in items:
+        if not first:
+            yield ',\n'
+        first = False
+        yield '    ' + json.dumps(item, default=_json_default, indent=4)
+    yield '\n  ]'
+
+
+def iter_user_data_export(uid: str) -> Iterator[str]:
     yield '{\n'
+
+    profile = get_user_profile(uid)
     yield '  "profile": ' + json.dumps(profile if profile else {}, default=_json_default, indent=2) + ',\n'
 
     yield '  "conversations": [\n'
@@ -35,9 +55,20 @@ def iter_user_data_export(uid: str) -> Iterator[str]:
         yield '    ' + json.dumps(conv, default=_json_default, indent=4)
     yield '\n  ],\n'
 
-    yield '  "memories": ' + json.dumps(memories_list, default=_json_default, indent=2) + ',\n'
+    yield '  "memories": '
+    yield from _yield_json_array(
+        _iter_paginated(lambda limit, offset: memories_db.get_non_filtered_memories(uid, limit=limit, offset=offset))
+    )
+    yield ',\n'
+
+    people = get_people(uid)
     yield '  "people": ' + json.dumps(people, default=_json_default, indent=2) + ',\n'
-    yield '  "action_items": ' + json.dumps(action_items, default=_json_default, indent=2) + ',\n'
+
+    yield '  "action_items": '
+    yield from _yield_json_array(
+        _iter_paginated(lambda limit, offset: get_standalone_action_items(uid, limit=limit, offset=offset))
+    )
+    yield ',\n'
 
     yield '  "chat_messages": [\n'
     first = True

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -211,6 +211,7 @@ pytest tests/unit/test_delete_account_stripe_cancel.py -v
 pytest tests/unit/test_delete_account_purge_storage.py -v
 pytest tests/services/users/test_account_deletion.py -v
 pytest tests/services/users/test_data_export.py -v
+pytest tests/routers/test_users.py -v
 pytest tests/unit/test_apps_review_reply_validation.py -v
 pytest tests/unit/test_apps_create_app_json.py -v
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -209,6 +209,7 @@ pytest tests/unit/test_conversation_events_bounds.py -v
 pytest tests/unit/test_conversation_hybrid_search.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v
 pytest tests/unit/test_delete_account_purge_storage.py -v
+pytest tests/unit/test_claim_deletion_wipe_txn.py -v
 pytest tests/services/users/test_account_deletion.py -v
 pytest tests/services/users/test_data_export.py -v
 pytest tests/routers/test_users.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -209,6 +209,8 @@ pytest tests/unit/test_conversation_events_bounds.py -v
 pytest tests/unit/test_conversation_hybrid_search.py -v
 pytest tests/unit/test_delete_account_stripe_cancel.py -v
 pytest tests/unit/test_delete_account_purge_storage.py -v
+pytest tests/services/users/test_account_deletion.py -v
+pytest tests/services/users/test_data_export.py -v
 pytest tests/unit/test_apps_review_reply_validation.py -v
 pytest tests/unit/test_apps_create_app_json.py -v
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,7 +6,6 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
     'ENCRYPTION_SECRET',
     'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -112,23 +112,14 @@ for _pkg_name, _attr in (
     if _pkg is not None and hasattr(_pkg, _attr):
         delattr(_pkg, _attr)
 
-
-@pytest.fixture(autouse=True, scope='module')
-def _restore_endpoints_shim():
-    yield
-    if _prior_endpoints is None:
-        sys.modules.pop('utils.other.endpoints', None)
-    else:
-        sys.modules['utils.other.endpoints'] = _prior_endpoints
-    if _prior_routers_users is None:
-        sys.modules.pop('routers.users', None)
-    else:
-        sys.modules['routers.users'] = _prior_routers_users
-    for _svc_name, _prior in _prior_service_modules.items():
-        if _prior is None:
-            sys.modules.pop(_svc_name, None)
-        else:
-            sys.modules[_svc_name] = _prior
+# Restore utils.other.endpoints immediately too — pytest collects later test
+# modules before any module-scoped fixture teardown runs, so the shim would
+# persist in sys.modules during that window.  users_router already holds the
+# reference it needs; the shim is no longer required after import.
+if _prior_endpoints is None:
+    sys.modules.pop('utils.other.endpoints', None)
+else:
+    sys.modules['utils.other.endpoints'] = _prior_endpoints
 
 
 def _account_deletion_module(start_account_deletion):

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -84,6 +84,14 @@ for _module_name, _module in list(sys.modules.items()):
     if isinstance(_module, _AutoMockModule):
         del sys.modules[_module_name]
 
+# Pop ``routers.users`` and the service modules it transitively imported under
+# the stub finder. Without this, later test modules in a full ``pytest tests``
+# run reuse the mock-backed router/service symbols instead of the real module.
+_prior_routers_users = sys.modules.get('routers.users')
+sys.modules.pop('routers.users', None)
+for _svc_name in ('services.users', 'services.users.account_deletion'):
+    sys.modules.pop(_svc_name, None)
+
 
 @pytest.fixture(autouse=True, scope='module')
 def _restore_endpoints_shim():
@@ -92,6 +100,12 @@ def _restore_endpoints_shim():
         sys.modules.pop('utils.other.endpoints', None)
     else:
         sys.modules['utils.other.endpoints'] = _prior_endpoints
+    # Also restore or pop routers.users so the stub-loaded version doesn't
+    # leak into later test modules.
+    if _prior_routers_users is None:
+        sys.modules.pop('routers.users', None)
+    else:
+        sys.modules['routers.users'] = _prior_routers_users
 
 
 def _account_deletion_module(start_account_deletion):

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -66,12 +66,21 @@ _endpoints.with_rate_limit = lambda dependency, _policy: dependency
 _endpoints.delete_account = MagicMock()
 _endpoints.get_user = MagicMock()
 
-# Save the prior entry so it can be restored after the test module finishes —
-# otherwise this minimal shim leaks into sys.modules and can be reused by later
-# test modules (e.g. ones expecting the real _enforce_rate_limit), making
-# results depend on collection order.
+# Save prior sys.modules entries BEFORE any stubbed import runs so the
+# module-scoped teardown restores the real modules (not the stub-loaded
+# versions) — otherwise the mock-backed shim leaks into later test modules.
 _prior_endpoints = sys.modules.get('utils.other.endpoints')
 sys.modules['utils.other.endpoints'] = _endpoints
+
+_prior_routers_users = sys.modules.get('routers.users')
+_prior_service_modules = {
+    name: sys.modules.get(name)
+    for name in (
+        'services.users',
+        'services.users.account_deletion',
+        'services.users.data_export',
+    )
+}
 
 import firebase_admin.auth as _fa_auth  # noqa: E402
 
@@ -85,12 +94,23 @@ for _module_name, _module in list(sys.modules.items()):
         del sys.modules[_module_name]
 
 # Pop ``routers.users`` and the service modules it transitively imported under
-# the stub finder. Without this, later test modules in a full ``pytest tests``
-# run reuse the mock-backed router/service symbols instead of the real module.
-_prior_routers_users = sys.modules.get('routers.users')
+# the stub finder so later test modules in a full ``pytest tests`` run re-import
+# the real modules instead of reusing mock-backed symbols.
 sys.modules.pop('routers.users', None)
-for _svc_name in ('services.users', 'services.users.account_deletion'):
+for _svc_name in _prior_service_modules:
     sys.modules.pop(_svc_name, None)
+# Clear parent package attributes so ``from routers import users`` and
+# ``from services.users import ...`` don't resolve to stub-loaded modules via
+# attribute lookup on the already-imported package objects.
+for _pkg_name, _attr in (
+    ('routers', 'users'),
+    ('services', 'users'),
+    ('services.users', 'account_deletion'),
+    ('services.users', 'data_export'),
+):
+    _pkg = sys.modules.get(_pkg_name)
+    if _pkg is not None and hasattr(_pkg, _attr):
+        delattr(_pkg, _attr)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -100,12 +120,15 @@ def _restore_endpoints_shim():
         sys.modules.pop('utils.other.endpoints', None)
     else:
         sys.modules['utils.other.endpoints'] = _prior_endpoints
-    # Also restore or pop routers.users so the stub-loaded version doesn't
-    # leak into later test modules.
     if _prior_routers_users is None:
         sys.modules.pop('routers.users', None)
     else:
         sys.modules['routers.users'] = _prior_routers_users
+    for _svc_name, _prior in _prior_service_modules.items():
+        if _prior is None:
+            sys.modules.pop(_svc_name, None)
+        else:
+            sys.modules[_svc_name] = _prior
 
 
 def _account_deletion_module(start_account_deletion):

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -3,7 +3,7 @@ import importlib.abc
 import importlib.machinery
 import sys
 import types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -67,35 +67,46 @@ _endpoints.delete_account = MagicMock()
 _endpoints.get_user = MagicMock()
 sys.modules['utils.other.endpoints'] = _endpoints
 
-_services_users = types.ModuleType('services.users')
-_services_users.iter_user_data_export = MagicMock(return_value=iter(['{"ok": true}\n']))
-_services_users.start_account_deletion = MagicMock(return_value={'status': 'ok', 'message': 'Account deletion started'})
-sys.modules['services.users'] = _services_users
-
 import firebase_admin.auth as _fa_auth  # noqa: E402
 
 _fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
 
 from routers import users as users_router  # noqa: E402
 
+sys.meta_path.remove(_finder)
+for _module_name, _module in list(sys.modules.items()):
+    if isinstance(_module, _AutoMockModule):
+        del sys.modules[_module_name]
+
+
+def _account_deletion_module(start_account_deletion):
+    module = types.ModuleType('services.users.account_deletion')
+    module.start_account_deletion = start_account_deletion
+    return module
+
 
 def test_delete_account_delegates_to_service():
-    users_router.start_account_deletion = MagicMock(
-        return_value={'status': 'ok', 'message': 'Account deletion started'}
-    )
+    start_account_deletion = MagicMock(return_value={'status': 'ok', 'message': 'Account deletion started'})
     request = users_router.DeleteAccountRequest(reason='reason', reason_details='details')
 
-    result = users_router.delete_account(request=request, uid='uid1')
+    with patch.dict(
+        sys.modules,
+        {'services.users.account_deletion': _account_deletion_module(start_account_deletion)},
+    ):
+        result = users_router.delete_account(request=request, uid='uid1')
 
     assert result == {'status': 'ok', 'message': 'Account deletion started'}
-    users_router.start_account_deletion.assert_called_once_with('uid1', reason='reason', reason_details='details')
+    start_account_deletion.assert_called_once_with('uid1', reason='reason', reason_details='details')
 
 
 def test_delete_account_maps_unexpected_service_error_to_500():
-    users_router.start_account_deletion = MagicMock(side_effect=Exception('boom'))
-
-    with pytest.raises(HTTPException) as exc:
-        users_router.delete_account(request=users_router.DeleteAccountRequest(), uid='uid1')
+    start_account_deletion = MagicMock(side_effect=Exception('boom'))
+    with patch.dict(
+        sys.modules,
+        {'services.users.account_deletion': _account_deletion_module(start_account_deletion)},
+    ):
+        with pytest.raises(HTTPException) as exc:
+            users_router.delete_account(request=users_router.DeleteAccountRequest(), uid='uid1')
 
     assert exc.value.status_code == 500
     assert exc.value.detail == 'Could not delete account. Please try again.'

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -65,6 +65,12 @@ _endpoints.get_current_user_uid = lambda: 'uid1'
 _endpoints.with_rate_limit = lambda dependency, _policy: dependency
 _endpoints.delete_account = MagicMock()
 _endpoints.get_user = MagicMock()
+
+# Save the prior entry so it can be restored after the test module finishes —
+# otherwise this minimal shim leaks into sys.modules and can be reused by later
+# test modules (e.g. ones expecting the real _enforce_rate_limit), making
+# results depend on collection order.
+_prior_endpoints = sys.modules.get('utils.other.endpoints')
 sys.modules['utils.other.endpoints'] = _endpoints
 
 import firebase_admin.auth as _fa_auth  # noqa: E402
@@ -77,6 +83,15 @@ sys.meta_path.remove(_finder)
 for _module_name, _module in list(sys.modules.items()):
     if isinstance(_module, _AutoMockModule):
         del sys.modules[_module_name]
+
+
+@pytest.fixture(autouse=True, scope='module')
+def _restore_endpoints_shim():
+    yield
+    if _prior_endpoints is None:
+        sys.modules.pop('utils.other.endpoints', None)
+    else:
+        sys.modules['utils.other.endpoints'] = _prior_endpoints
 
 
 def _account_deletion_module(start_account_deletion):

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -89,10 +89,7 @@ def test_delete_account_delegates_to_service():
     start_account_deletion = MagicMock(return_value={'status': 'ok', 'message': 'Account deletion started'})
     request = users_router.DeleteAccountRequest(reason='reason', reason_details='details')
 
-    with patch.dict(
-        sys.modules,
-        {'services.users.account_deletion': _account_deletion_module(start_account_deletion)},
-    ):
+    with patch.object(users_router, 'start_account_deletion', start_account_deletion):
         result = users_router.delete_account(request=request, uid='uid1')
 
     assert result == {'status': 'ok', 'message': 'Account deletion started'}
@@ -101,10 +98,7 @@ def test_delete_account_delegates_to_service():
 
 def test_delete_account_maps_unexpected_service_error_to_500():
     start_account_deletion = MagicMock(side_effect=Exception('boom'))
-    with patch.dict(
-        sys.modules,
-        {'services.users.account_deletion': _account_deletion_module(start_account_deletion)},
-    ):
+    with patch.object(users_router, 'start_account_deletion', start_account_deletion):
         with pytest.raises(HTTPException) as exc:
             users_router.delete_account(request=users_router.DeleteAccountRequest(), uid='uid1')
 

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -1,0 +1,119 @@
+import asyncio
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+
+class _AutoMockModule(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_STUB_PREFIXES = (
+    'database',
+    'firebase_admin',
+    'google.cloud',
+    'google.api_core',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'pytz',
+    'twilio',
+    'utils',
+)
+
+
+def _should_stub(name: str) -> bool:
+    if name in {'utils.other.endpoints', 'services.users'}:
+        return False
+    return any(name == prefix or name.startswith(prefix + '.') for prefix in _STUB_PREFIXES)
+
+
+class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _should_stub(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMockModule(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _StubFinder()
+sys.meta_path.insert(0, _finder)
+
+_endpoints = types.ModuleType('utils.other.endpoints')
+_endpoints.get_current_user_uid = lambda: 'uid1'
+_endpoints.with_rate_limit = lambda dependency, _policy: dependency
+_endpoints.delete_account = MagicMock()
+_endpoints.get_user = MagicMock()
+sys.modules['utils.other.endpoints'] = _endpoints
+
+_services_users = types.ModuleType('services.users')
+_services_users.iter_user_data_export = MagicMock(return_value=iter(['{"ok": true}\n']))
+_services_users.start_account_deletion = MagicMock(return_value={'status': 'ok', 'message': 'Account deletion started'})
+sys.modules['services.users'] = _services_users
+
+import firebase_admin.auth as _fa_auth  # noqa: E402
+
+_fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+from routers import users as users_router  # noqa: E402
+
+
+def test_delete_account_delegates_to_service():
+    users_router.start_account_deletion = MagicMock(
+        return_value={'status': 'ok', 'message': 'Account deletion started'}
+    )
+    request = users_router.DeleteAccountRequest(reason='reason', reason_details='details')
+
+    result = users_router.delete_account(request=request, uid='uid1')
+
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    users_router.start_account_deletion.assert_called_once_with('uid1', reason='reason', reason_details='details')
+
+
+def test_delete_account_maps_unexpected_service_error_to_500():
+    users_router.start_account_deletion = MagicMock(side_effect=Exception('boom'))
+
+    with pytest.raises(HTTPException) as exc:
+        users_router.delete_account(request=users_router.DeleteAccountRequest(), uid='uid1')
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == 'Could not delete account. Please try again.'
+
+
+def test_export_all_user_data_keeps_streaming_headers():
+    users_router.iter_user_data_export = MagicMock(return_value=iter(['{"ok": true}\n']))
+
+    response = users_router.export_all_user_data(uid='uid1')
+
+    assert response.media_type == 'application/json'
+    assert response.headers['content-disposition'] == 'attachment; filename="omi-export.json"'
+    users_router.iter_user_data_export.assert_called_once_with('uid1')
+
+    async def _consume():
+        parts = []
+        async for chunk in response.body_iterator:
+            parts.append(chunk)
+        return ''.join(parts)
+
+    assert asyncio.run(_consume()) == '{"ok": true}\n'

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -84,9 +84,9 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
     assert result == {'status': 'ok', 'message': 'Account deletion started'}
     assert calls == [
         ('feedback', 'uid1', 'unused', 'details'),
+        ('wipe_started', 'uid1'),
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
-        ('wipe_started', 'uid1'),
         ('auth', 'uid1'),
         ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -49,10 +49,9 @@ sys.meta_path.insert(0, _StubFinder())
 from services.users import account_deletion  # noqa: E402
 
 
-def test_start_account_deletion_preserves_order_and_starts_background_thread(monkeypatch):
+def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(monkeypatch):
     calls = []
     sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
-    thread = MagicMock()
 
     monkeypatch.setattr(
         account_deletion.users_db,
@@ -69,11 +68,11 @@ def test_start_account_deletion_preserves_order_and_starts_background_thread(mon
     )
     monkeypatch.setattr(account_deletion.auth, 'delete_account', lambda uid: calls.append(('auth', uid)))
 
-    def fake_thread(target, args, daemon):
-        calls.append(('thread', target, args, daemon))
-        return thread
-
-    monkeypatch.setattr(account_deletion.threading, 'Thread', fake_thread)
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda executor, target, uid: calls.append(('enqueue', executor, target, uid)),
+    )
 
     result = account_deletion.start_account_deletion('uid1', reason='unused', reason_details='details')
 
@@ -83,13 +82,11 @@ def test_start_account_deletion_preserves_order_and_starts_background_thread(mon
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
         ('auth', 'uid1'),
-        ('thread', account_deletion.background_wipe_user_data, ('uid1',), True),
+        ('enqueue', account_deletion.postprocess_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
-    thread.start.assert_called_once_with()
 
 
 def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
-    thread = MagicMock()
     monkeypatch.setattr(
         account_deletion.users_db, 'set_user_deletion_feedback', MagicMock(side_effect=Exception('db down'))
     )
@@ -98,19 +95,23 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
     )
     monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock())
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('USER_NOT_FOUND')))
-    monkeypatch.setattr(account_deletion.threading, 'Thread', MagicMock(return_value=thread))
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
 
     result = account_deletion.start_account_deletion('uid1', reason='reason')
 
     assert result['status'] == 'ok'
     account_deletion.stripe_utils.cancel_subscription.assert_not_called()
-    thread.start.assert_called_once_with()
+    submit.assert_called_once_with(
+        account_deletion.postprocess_executor, account_deletion.background_wipe_user_data, 'uid1'
+    )
 
 
 def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
-    monkeypatch.setattr(account_deletion.threading, 'Thread', MagicMock())
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
 
     try:
         account_deletion.start_account_deletion('uid1')
@@ -119,7 +120,7 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
     else:
         raise AssertionError('expected firebase error to propagate')
 
-    account_deletion.threading.Thread.assert_not_called()
+    submit.assert_not_called()
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -86,20 +86,21 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
         ('feedback', 'uid1', 'unused', 'details'),
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
-        ('auth', 'uid1'),
         ('wipe_started', 'uid1'),
+        ('auth', 'uid1'),
         ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
 
 
 def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
+    """Stripe/feedback failures are tolerated, but marker write must succeed."""
     monkeypatch.setattr(
         account_deletion.users_db, 'set_user_deletion_feedback', MagicMock(side_effect=Exception('db down'))
     )
     monkeypatch.setattr(
         account_deletion.users_db,
         'mark_user_deletion_wipe_started',
-        MagicMock(side_effect=Exception('marker down')),
+        MagicMock(),
     )
     monkeypatch.setattr(
         account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
@@ -108,6 +109,7 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('USER_NOT_FOUND')))
     submit = MagicMock()
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
     result = account_deletion.start_account_deletion('uid1', reason='reason')
 
@@ -118,12 +120,36 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
     )
 
 
+def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
+    """If the durable marker cannot be written, the deletion must NOT proceed."""
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(side_effect=Exception('firestore down'))
+    )
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert 'marker' in str(exc).lower() or 'deletion-wipe' in str(exc).lower()
+    else:
+        raise AssertionError('expected marker failure to raise')
+
+    # Firebase user must NOT be deleted if the marker failed.
+    account_deletion.auth.delete_account.assert_not_called()
+    submit.assert_not_called()
+
+
 def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
+    """Firebase errors propagate. The marker IS written first (before auth.delete_account)."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
     submit = MagicMock()
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
     try:
         account_deletion.start_account_deletion('uid1')
@@ -133,7 +159,8 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
         raise AssertionError('expected firebase error to propagate')
 
     submit.assert_not_called()
-    account_deletion.users_db.mark_user_deletion_wipe_started.assert_not_called()
+    # Marker is written BEFORE Firebase deletion, so it IS called even when Firebase fails.
+    account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1')
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -143,9 +143,11 @@ def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
 
 
 def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
-    """Firebase errors propagate. The marker IS written first (before auth.delete_account)."""
+    """Firebase errors propagate. The marker IS written first, then cancelled on failure."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+    cancel_wipe = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'cancel_user_deletion_wipe', cancel_wipe)
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
     submit = MagicMock()
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
@@ -159,8 +161,10 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
         raise AssertionError('expected firebase error to propagate')
 
     submit.assert_not_called()
-    # Marker is written BEFORE Firebase deletion, so it IS called even when Firebase fails.
+    # Marker is written BEFORE Firebase deletion, so it IS called.
     account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1')
+    # On Firebase failure, the marker is cancelled so reconciliation won't wipe data.
+    cancel_wipe.assert_called_once_with('uid1')
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -32,12 +32,16 @@ def _should_stub(name: str) -> bool:
 
 
 class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def __init__(self):
+        self._created: set[str] = set()
+
     def find_spec(self, name, path=None, target=None):
         if _should_stub(name):
             return importlib.machinery.ModuleSpec(name, self, is_package=True)
         return None
 
     def create_module(self, spec):
+        self._created.add(spec.name)
         return _AutoMockModule(spec.name)
 
     def exec_module(self, module):
@@ -49,12 +53,13 @@ sys.meta_path.insert(0, _finder)
 try:
     from services.users import account_deletion  # noqa: E402
 finally:
-    # Remove the meta-path finder and clear stubbed modules so they don't
-    # leak into sys.modules and interfere with other tests collected in the
-    # same pytest process (e.g. utils.executors resolving to a MagicMock).
+    # Remove the meta-path finder and clear *only* the modules that the
+    # stub finder actually created. Broadly deleting every module matching
+    # _STUB_PREFIXES (database, utils, …) would also evict real project
+    # modules imported by other tests collected in the same pytest process.
     sys.meta_path.remove(_finder)
-    for _name in [n for n in sys.modules if _should_stub(n)]:
-        del sys.modules[_name]
+    for _name in list(_finder._created):
+        sys.modules.pop(_name, None)
 
 
 def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(monkeypatch):
@@ -65,6 +70,11 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
         account_deletion.users_db,
         'set_user_deletion_feedback',
         lambda uid, reason, details: calls.append(('feedback', uid, reason, details)),
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'mark_user_deletion_wipe_intent',
+        lambda uid: calls.append(('wipe_intent', uid)),
     )
     monkeypatch.setattr(
         account_deletion.users_db,
@@ -92,10 +102,11 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
     assert result == {'status': 'ok', 'message': 'Account deletion started'}
     assert calls == [
         ('feedback', 'uid1', 'unused', 'details'),
-        ('wipe_started', 'uid1'),
+        ('wipe_intent', 'uid1'),
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
         ('auth', 'uid1'),
+        ('wipe_started', 'uid1'),
         ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
 
@@ -129,9 +140,9 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
 
 
 def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
-    """If the durable marker cannot be written, the deletion must NOT proceed."""
+    """If the durable intent cannot be written, the deletion must NOT proceed."""
     monkeypatch.setattr(
-        account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(side_effect=Exception('firestore down'))
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(side_effect=Exception('firestore down'))
     )
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
     monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
@@ -141,19 +152,21 @@ def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
     try:
         account_deletion.start_account_deletion('uid1')
     except Exception as exc:
-        assert 'marker' in str(exc).lower() or 'deletion-wipe' in str(exc).lower()
+        assert 'intent' in str(exc).lower() or 'deletion-wipe' in str(exc).lower()
     else:
-        raise AssertionError('expected marker failure to raise')
+        raise AssertionError('expected intent failure to raise')
 
-    # Firebase user must NOT be deleted if the marker failed.
+    # Firebase user must NOT be deleted if the intent failed.
     account_deletion.auth.delete_account.assert_not_called()
     submit.assert_not_called()
 
 
 def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
-    """Firebase errors propagate. The marker IS written first, then cancelled on failure."""
+    """Firebase errors propagate. The intent IS written first, then cancelled on failure; Phase 2 is never reached."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock())
+    mark_started = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', mark_started)
     cancel_wipe = MagicMock()
     monkeypatch.setattr(account_deletion.users_db, 'cancel_user_deletion_wipe', cancel_wipe)
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
@@ -169,10 +182,41 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
         raise AssertionError('expected firebase error to propagate')
 
     submit.assert_not_called()
-    # Marker is written BEFORE Firebase deletion, so it IS called.
-    account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1')
-    # On Firebase failure, the marker is cancelled so reconciliation won't wipe data.
+    # Phase 1 intent IS written BEFORE Firebase deletion.
+    account_deletion.users_db.mark_user_deletion_wipe_intent.assert_called_once_with('uid1')
+    # On Firebase failure, the intent is cancelled so the record doesn't linger.
     cancel_wipe.assert_called_once_with('uid1')
+    # Phase 2 (transition to 'pending') is never reached on auth failure.
+    mark_started.assert_not_called()
+
+
+def test_start_account_deletion_writes_intent_before_pending(monkeypatch):
+    """P1 safety: the non-actionable 'deleting_auth' intent is written before
+    auth deletion, and the actionable 'pending' marker is written only after
+    auth deletion is confirmed.
+
+    This verifies the two-phase ordering that prevents a crash between the
+    intent write and auth deletion from leaving an actionable 'pending' marker
+    that the reconciler could prematurely act on.
+    """
+    call_log = []
+    intent_mock = MagicMock(side_effect=lambda uid: call_log.append('intent'))
+    started_mock = MagicMock(side_effect=lambda uid: call_log.append('started'))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', intent_mock)
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', started_mock)
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(
+        account_deletion.auth, 'delete_account', MagicMock(side_effect=lambda uid: call_log.append('auth'))
+    )
+    monkeypatch.setattr(account_deletion, 'submit_with_context', MagicMock())
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+
+    account_deletion.start_account_deletion('uid1')
+
+    # Intent is written before auth, started is written after auth.
+    assert call_log == ['intent', 'auth', 'started']
+    intent_mock.assert_called_once_with('uid1')
+    started_mock.assert_called_once_with('uid1')
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -228,6 +228,9 @@ def test_start_account_deletion_writes_intent_before_pending(monkeypatch):
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):
     calls = []
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_running', lambda uid: calls.append(('running', uid))
+    )
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', lambda uid: calls.append(('twilio', uid)))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', lambda uid: calls.append(('purge', uid)))
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', lambda uid: calls.append(('firestore', uid)))
@@ -237,10 +240,17 @@ def test_background_wipe_user_data_preserves_order(monkeypatch):
 
     account_deletion.background_wipe_user_data('uid1')
 
-    assert calls == [('twilio', 'uid1'), ('purge', 'uid1'), ('firestore', 'uid1'), ('wipe_done', 'uid1')]
+    assert calls == [
+        ('running', 'uid1'),
+        ('twilio', 'uid1'),
+        ('purge', 'uid1'),
+        ('firestore', 'uid1'),
+        ('wipe_done', 'uid1'),
+    ]
 
 
 def test_background_wipe_user_data_swallows_failures(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock())
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock(side_effect=Exception('twilio down')))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
@@ -254,6 +264,22 @@ def test_background_wipe_user_data_swallows_failures(monkeypatch):
     # On failure, mark as failed (not completed) so a reconciliation worker can retry.
     account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
     account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
+
+
+def test_background_wipe_continues_when_running_marker_persist_fails(monkeypatch):
+    """A failure to transition to ``running`` is non-fial — the wipe still runs."""
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock(side_effect=Exception('firestore down'))
+    )
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock())
+    monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
+
+    # Should not raise — the wipe proceeds even if the running marker can't be written.
+    account_deletion.background_wipe_user_data('uid1')
+
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_called_once_with('uid1')
 
 
 def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -60,6 +60,13 @@ finally:
     sys.meta_path.remove(_finder)
     for _name in list(_finder._created):
         sys.modules.pop(_name, None)
+    # The imported service module itself was loaded against the MagicMock
+    # stubs (its globals hold MagicMock objects for users_db, stripe_utils,
+    # etc.). Pop it — along with its parent packages — so a later test that
+    # imports the real service reloads it with production dependencies
+    # instead of reusing this mock-backed copy.
+    for _svc_name in ('services.users.account_deletion', 'services.users', 'services'):
+        sys.modules.pop(_svc_name, None)
 
 
 def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -154,15 +154,16 @@ def test_background_wipe_user_data_swallows_failures(monkeypatch):
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock(side_effect=Exception('twilio down')))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
 
     account_deletion.background_wipe_user_data('uid1')
 
     account_deletion.purge_derived_user_data.assert_not_called()
     account_deletion.users_db.delete_user_data.assert_not_called()
-    # wipe-completed is persisted in finally even when the wipe itself fails,
-    # so a reconciliation worker doesn't re-enqueue a wipe that already ran.
-    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_called_once_with('uid1')
+    # On failure, mark as failed (not completed) so a reconciliation worker can retry.
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
 
 
 def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(monkeypatch):
@@ -251,3 +252,52 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     account_deletion.delete_action_item_vectors_batch.assert_called_once_with('uid1', ['a1'])
     account_deletion.delete_screen_activity_vectors.assert_called_once_with('uid1', ['s1'])
     account_deletion.delete_all_conversation_recordings.assert_called_once_with('uid1')
+
+
+def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):
+    pending = [{'uid': 'uid1', 'wipe_status': 'pending'}, {'uid': 'uid2', 'wipe_status': 'failed'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    enqueued = []
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda executor, target, uid: enqueued.append((executor, target, uid)),
+    )
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 2, 'skipped': 0}
+    assert len(enqueued) == 2
+    assert enqueued[0] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1')
+    assert enqueued[1] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid2')
+
+
+def test_reconcile_pending_deletion_wipes_skips_missing_uid(monkeypatch):
+    pending = [{'uid': 'uid1'}, {'wipe_status': 'pending'}]  # second record has no uid
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    enqueued = []
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda executor, target, uid: enqueued.append(uid),
+    )
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 1, 'skipped': 1}
+    assert enqueued == ['uid1']
+
+
+def test_reconcile_pending_deletion_wipes_handles_query_error(monkeypatch):
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'get_pending_deletion_wipes',
+        MagicMock(side_effect=Exception('firestore down')),
+    )
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 0, 'skipped': 0, 'error': 1}
+    submit.assert_not_called()

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -427,3 +427,79 @@ def test_reconcile_pending_deletion_wipes_handles_query_error(monkeypatch):
 
     assert result == {'requeued': 0, 'skipped': 0, 'error': 1}
     submit.assert_not_called()
+
+
+def test_reconcile_recovers_deleting_auth_when_user_gone(monkeypatch):
+    """Stale 'deleting_auth' record with Firebase user deleted → recovered."""
+    pending = [{'uid': 'uid1', 'wipe_status': 'deleting_auth'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
+    monkeypatch.setattr(account_deletion.auth, 'get_user', MagicMock(side_effect=Exception('USER_NOT_FOUND')))
+    enqueued = []
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda executor, target, uid: enqueued.append(uid),
+    )
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 1, 'skipped': 0}
+    assert enqueued == ['uid1']
+
+
+def test_reconcile_skips_deleting_auth_when_user_exists(monkeypatch):
+    """Stale 'deleting_auth' record but Firebase user still exists → skipped."""
+    pending = [{'uid': 'uid1', 'wipe_status': 'deleting_auth'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    # get_user succeeds → user exists
+    monkeypatch.setattr(account_deletion.auth, 'get_user', MagicMock(return_value=object()))
+    claim = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', claim)
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 0, 'skipped': 1}
+    claim.assert_not_called()
+    submit.assert_not_called()
+
+
+def test_reconcile_skips_deleting_auth_on_indeterminate_error(monkeypatch):
+    """Stale 'deleting_auth' with indeterminate Firebase error → skipped (fail safe)."""
+    pending = [{'uid': 'uid1', 'wipe_status': 'deleting_auth'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    # Indeterminate error — not USER_NOT_FOUND
+    monkeypatch.setattr(account_deletion.auth, 'get_user', MagicMock(side_effect=Exception('internal error')))
+    claim = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', claim)
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 0, 'skipped': 1}
+    claim.assert_not_called()
+    submit.assert_not_called()
+
+
+def test_is_auth_user_gone_returns_true_for_user_not_found(monpatch=None):
+    """_is_auth_user_gone returns True when Firebase reports USER_NOT_FOUND."""
+    # Direct unit test of the helper.
+    original_get_user = account_deletion.auth.get_user
+    account_deletion.auth.get_user = MagicMock(side_effect=Exception('USER_NOT_FOUND'))
+    try:
+        assert account_deletion._is_auth_user_gone('uid1') is True
+    finally:
+        account_deletion.auth.get_user = original_get_user
+
+
+def test_is_auth_user_gone_returns_false_for_indeterminate_error(monkeypatch=None):
+    """_is_auth_user_gone returns False (fail safe) on non-USER_NOT_FOUND errors."""
+    original_get_user = account_deletion.auth.get_user
+    account_deletion.auth.get_user = MagicMock(side_effect=Exception('internal error'))
+    try:
+        assert account_deletion._is_auth_user_gone('uid1') is False
+    finally:
+        account_deletion.auth.get_user = original_get_user

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -267,7 +267,7 @@ def test_background_wipe_user_data_swallows_failures(monkeypatch):
 
 
 def test_background_wipe_continues_when_running_marker_persist_fails(monkeypatch):
-    """A failure to transition to ``running`` is non-fial — the wipe still runs."""
+    """A failure to transition to ``running`` is non-fatal — the wipe still runs."""
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock(side_effect=Exception('firestore down'))
     )

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -59,6 +59,11 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
         lambda uid, reason, details: calls.append(('feedback', uid, reason, details)),
     )
     monkeypatch.setattr(
+        account_deletion.users_db,
+        'mark_user_deletion_wipe_started',
+        lambda uid: calls.append(('wipe_started', uid)),
+    )
+    monkeypatch.setattr(
         account_deletion.users_db, 'get_user_subscription', lambda uid: calls.append(('sub', uid)) or sub
     )
     monkeypatch.setattr(
@@ -82,6 +87,7 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
         ('auth', 'uid1'),
+        ('wipe_started', 'uid1'),
         ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
 
@@ -89,6 +95,11 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
 def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
     monkeypatch.setattr(
         account_deletion.users_db, 'set_user_deletion_feedback', MagicMock(side_effect=Exception('db down'))
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'mark_user_deletion_wipe_started',
+        MagicMock(side_effect=Exception('marker down')),
     )
     monkeypatch.setattr(
         account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
@@ -109,6 +120,7 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
 
 def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
     submit = MagicMock()
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
@@ -121,6 +133,7 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
         raise AssertionError('expected firebase error to propagate')
 
     submit.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_started.assert_not_called()
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):
@@ -128,21 +141,28 @@ def test_background_wipe_user_data_preserves_order(monkeypatch):
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', lambda uid: calls.append(('twilio', uid)))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', lambda uid: calls.append(('purge', uid)))
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', lambda uid: calls.append(('firestore', uid)))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_completed', lambda uid: calls.append(('wipe_done', uid))
+    )
 
     account_deletion.background_wipe_user_data('uid1')
 
-    assert calls == [('twilio', 'uid1'), ('purge', 'uid1'), ('firestore', 'uid1')]
+    assert calls == [('twilio', 'uid1'), ('purge', 'uid1'), ('firestore', 'uid1'), ('wipe_done', 'uid1')]
 
 
 def test_background_wipe_user_data_swallows_failures(monkeypatch):
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock(side_effect=Exception('twilio down')))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
 
     account_deletion.background_wipe_user_data('uid1')
 
     account_deletion.purge_derived_user_data.assert_not_called()
     account_deletion.users_db.delete_user_data.assert_not_called()
+    # wipe-completed is persisted in finally even when the wipe itself fails,
+    # so a reconciliation worker doesn't re-enqueue a wipe that already ran.
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_called_once_with('uid1')
 
 
 def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -44,9 +44,17 @@ class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
-sys.meta_path.insert(0, _StubFinder())
-
-from services.users import account_deletion  # noqa: E402
+_finder = _StubFinder()
+sys.meta_path.insert(0, _finder)
+try:
+    from services.users import account_deletion  # noqa: E402
+finally:
+    # Remove the meta-path finder and clear stubbed modules so they don't
+    # leak into sys.modules and interfere with other tests collected in the
+    # same pytest process (e.g. utils.executors resolving to a MagicMock).
+    sys.meta_path.remove(_finder)
+    for _name in [n for n in sys.modules if _should_stub(n)]:
+        del sys.modules[_name]
 
 
 def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(monkeypatch):

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -1,0 +1,232 @@
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class _AutoMockModule(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_STUB_PREFIXES = (
+    'database',
+    'firebase_admin',
+    'google.cloud',
+    'google.api_core',
+    'pinecone',
+    'typesense',
+    'utils',
+)
+
+
+def _should_stub(name: str) -> bool:
+    return any(name == prefix or name.startswith(prefix + '.') for prefix in _STUB_PREFIXES)
+
+
+class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _should_stub(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMockModule(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+sys.meta_path.insert(0, _StubFinder())
+
+from services.users import account_deletion  # noqa: E402
+
+
+def test_start_account_deletion_preserves_order_and_starts_background_thread(monkeypatch):
+    calls = []
+    sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
+    thread = MagicMock()
+
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'set_user_deletion_feedback',
+        lambda uid, reason, details: calls.append(('feedback', uid, reason, details)),
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db, 'get_user_subscription', lambda uid: calls.append(('sub', uid)) or sub
+    )
+    monkeypatch.setattr(
+        account_deletion.stripe_utils,
+        'cancel_subscription',
+        lambda sub_id: calls.append(('stripe', sub_id)) or object(),
+    )
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', lambda uid: calls.append(('auth', uid)))
+
+    def fake_thread(target, args, daemon):
+        calls.append(('thread', target, args, daemon))
+        return thread
+
+    monkeypatch.setattr(account_deletion.threading, 'Thread', fake_thread)
+
+    result = account_deletion.start_account_deletion('uid1', reason='unused', reason_details='details')
+
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    assert calls == [
+        ('feedback', 'uid1', 'unused', 'details'),
+        ('sub', 'uid1'),
+        ('stripe', 'sub_123'),
+        ('auth', 'uid1'),
+        ('thread', account_deletion.background_wipe_user_data, ('uid1',), True),
+    ]
+    thread.start.assert_called_once_with()
+
+
+def test_start_account_deletion_tolerates_best_effort_failures_and_missing_firebase_user(monkeypatch):
+    thread = MagicMock()
+    monkeypatch.setattr(
+        account_deletion.users_db, 'set_user_deletion_feedback', MagicMock(side_effect=Exception('db down'))
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
+    )
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock())
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('USER_NOT_FOUND')))
+    monkeypatch.setattr(account_deletion.threading, 'Thread', MagicMock(return_value=thread))
+
+    result = account_deletion.start_account_deletion('uid1', reason='reason')
+
+    assert result['status'] == 'ok'
+    account_deletion.stripe_utils.cancel_subscription.assert_not_called()
+    thread.start.assert_called_once_with()
+
+
+def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock(side_effect=Exception('permission denied')))
+    monkeypatch.setattr(account_deletion.threading, 'Thread', MagicMock())
+
+    try:
+        account_deletion.start_account_deletion('uid1')
+    except Exception as exc:
+        assert str(exc) == 'permission denied'
+    else:
+        raise AssertionError('expected firebase error to propagate')
+
+    account_deletion.threading.Thread.assert_not_called()
+
+
+def test_background_wipe_user_data_preserves_order(monkeypatch):
+    calls = []
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', lambda uid: calls.append(('twilio', uid)))
+    monkeypatch.setattr(account_deletion, 'purge_derived_user_data', lambda uid: calls.append(('purge', uid)))
+    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', lambda uid: calls.append(('firestore', uid)))
+
+    account_deletion.background_wipe_user_data('uid1')
+
+    assert calls == [('twilio', 'uid1'), ('purge', 'uid1'), ('firestore', 'uid1')]
+
+
+def test_background_wipe_user_data_swallows_failures(monkeypatch):
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock(side_effect=Exception('twilio down')))
+    monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+
+    account_deletion.background_wipe_user_data('uid1')
+
+    account_deletion.purge_derived_user_data.assert_not_called()
+    account_deletion.users_db.delete_user_data.assert_not_called()
+
+
+def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(monkeypatch):
+    calls = []
+    conversation_calls = iter([['c1'], ['c2']])
+    monkeypatch.setattr(
+        account_deletion,
+        'get_conversation_ids',
+        lambda uid: calls.append(('get_conversations', uid)) or next(conversation_calls),
+    )
+    monkeypatch.setattr(account_deletion, 'get_memory_ids', lambda uid: calls.append(('get_memories', uid)) or ['m1'])
+    monkeypatch.setattr(
+        account_deletion, 'get_action_item_ids', lambda uid: calls.append(('get_actions', uid)) or ['a1']
+    )
+    monkeypatch.setattr(
+        account_deletion, 'get_screen_activity_ids', lambda uid: calls.append(('get_screen', uid)) or ['s1']
+    )
+    monkeypatch.setattr(
+        account_deletion,
+        'delete_conversation_vectors_batch',
+        lambda uid, ids: calls.append(('delete_conversation_vectors', uid, ids)),
+    )
+    monkeypatch.setattr(
+        account_deletion,
+        'delete_transcript_chunk_vectors_batch',
+        lambda uid, ids: calls.append(('delete_transcript_vectors', uid, ids)),
+    )
+    monkeypatch.setattr(
+        account_deletion,
+        'delete_memory_vectors_batch',
+        lambda uid, ids: calls.append(('delete_memory_vectors', uid, ids)),
+    )
+    monkeypatch.setattr(
+        account_deletion,
+        'delete_action_item_vectors_batch',
+        lambda uid, ids: calls.append(('delete_action_vectors', uid, ids)),
+    )
+    monkeypatch.setattr(
+        account_deletion,
+        'delete_screen_activity_vectors',
+        lambda uid, ids: calls.append(('delete_screen_vectors', uid, ids)),
+    )
+    monkeypatch.setattr(
+        account_deletion, 'delete_all_conversation_recordings', lambda uid: calls.append(('recordings', uid))
+    )
+
+    account_deletion.purge_derived_user_data('uid1')
+
+    assert calls == [
+        ('get_conversations', 'uid1'),
+        ('delete_conversation_vectors', 'uid1', ['c1']),
+        ('get_conversations', 'uid1'),
+        ('delete_transcript_vectors', 'uid1', ['c2']),
+        ('get_memories', 'uid1'),
+        ('delete_memory_vectors', 'uid1', ['m1']),
+        ('get_actions', 'uid1'),
+        ('delete_action_vectors', 'uid1', ['a1']),
+        ('get_screen', 'uid1'),
+        ('delete_screen_vectors', 'uid1', ['s1']),
+        ('recordings', 'uid1'),
+    ]
+
+
+def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
+    monkeypatch.setattr(account_deletion, 'get_conversation_ids', MagicMock(side_effect=Exception('read down')))
+    monkeypatch.setattr(account_deletion, 'delete_conversation_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_transcript_chunk_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'get_memory_ids', MagicMock(return_value=['m1']))
+    monkeypatch.setattr(
+        account_deletion, 'delete_memory_vectors_batch', MagicMock(side_effect=Exception('pinecone down'))
+    )
+    monkeypatch.setattr(account_deletion, 'get_action_item_ids', MagicMock(return_value=['a1']))
+    monkeypatch.setattr(account_deletion, 'delete_action_item_vectors_batch', MagicMock())
+    monkeypatch.setattr(account_deletion, 'get_screen_activity_ids', MagicMock(return_value=['s1']))
+    monkeypatch.setattr(account_deletion, 'delete_screen_activity_vectors', MagicMock())
+    monkeypatch.setattr(
+        account_deletion, 'delete_all_conversation_recordings', MagicMock(side_effect=Exception('gcs down'))
+    )
+
+    account_deletion.purge_derived_user_data('uid1')
+
+    assert account_deletion.get_conversation_ids.call_count == 2
+    account_deletion.delete_conversation_vectors_batch.assert_not_called()
+    account_deletion.delete_transcript_chunk_vectors_batch.assert_not_called()
+    account_deletion.delete_memory_vectors_batch.assert_called_once_with('uid1', ['m1'])
+    account_deletion.delete_action_item_vectors_batch.assert_called_once_with('uid1', ['a1'])
+    account_deletion.delete_screen_activity_vectors.assert_called_once_with('uid1', ['s1'])
+    account_deletion.delete_all_conversation_recordings.assert_called_once_with('uid1')

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -257,6 +257,7 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
 def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):
     pending = [{'uid': 'uid1', 'wipe_status': 'pending'}, {'uid': 'uid2', 'wipe_status': 'failed'}]
     monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
     enqueued = []
     monkeypatch.setattr(
         account_deletion,
@@ -272,9 +273,51 @@ def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):
     assert enqueued[1] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid2')
 
 
+def test_reconcile_pending_deletion_wipes_skips_already_claimed(monkeypatch):
+    """Wipes already claimed by another worker are skipped (no double-enqueue)."""
+    pending = [{'uid': 'uid1', 'wipe_status': 'pending'}, {'uid': 'uid2', 'wipe_status': 'failed'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    # uid1 claimable, uid2 already claimed by another worker.
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'claim_deletion_wipe',
+        lambda uid: uid if uid == 'uid1' else None,
+    )
+    enqueued = []
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda executor, target, uid: enqueued.append(uid),
+    )
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 1, 'skipped': 1}
+    assert enqueued == ['uid1']
+
+
+def test_reconcile_pending_deletion_wipes_skips_claim_exception(monkeypatch):
+    """Claim exceptions are logged and skipped, not propagated."""
+    pending = [{'uid': 'uid1', 'wipe_status': 'pending'}]
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'claim_deletion_wipe',
+        MagicMock(side_effect=Exception('txn conflict')),
+    )
+    submit = MagicMock()
+    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert result == {'requeued': 0, 'skipped': 1}
+    submit.assert_not_called()
+
+
 def test_reconcile_pending_deletion_wipes_skips_missing_uid(monkeypatch):
     pending = [{'uid': 'uid1'}, {'wipe_status': 'pending'}]  # second record has no uid
     monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
     enqueued = []
     monkeypatch.setattr(
         account_deletion,

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -82,7 +82,7 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
         ('sub', 'uid1'),
         ('stripe', 'sub_123'),
         ('auth', 'uid1'),
-        ('enqueue', account_deletion.postprocess_executor, account_deletion.background_wipe_user_data, 'uid1'),
+        ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
 
 
@@ -103,7 +103,7 @@ def test_start_account_deletion_tolerates_best_effort_failures_and_missing_fireb
     assert result['status'] == 'ok'
     account_deletion.stripe_utils.cancel_subscription.assert_not_called()
     submit.assert_called_once_with(
-        account_deletion.postprocess_executor, account_deletion.background_wipe_user_data, 'uid1'
+        account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'
     )
 
 

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -46,9 +46,17 @@ class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         pass
 
 
-sys.meta_path.insert(0, _StubFinder())
-
-from services.users import data_export  # noqa: E402
+_finder = _StubFinder()
+sys.meta_path.insert(0, _finder)
+try:
+    from services.users import data_export  # noqa: E402
+finally:
+    # Remove the meta-path finder and clear stubbed modules so they don't
+    # leak into sys.modules and interfere with other tests collected in the
+    # same pytest process (e.g. utils.executors resolving to a MagicMock).
+    sys.meta_path.remove(_finder)
+    for _name in [n for n in sys.modules if _should_stub(n)]:
+        del sys.modules[_name]
 
 
 def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -62,6 +62,13 @@ finally:
     sys.meta_path.remove(_finder)
     for _name in list(_finder._created):
         sys.modules.pop(_name, None)
+    # The imported service module itself was loaded against the MagicMock
+    # stubs (its globals hold MagicMock objects for database, utils, etc.).
+    # Pop it — along with its parent packages — so a later test that imports
+    # the real service reloads it with production dependencies instead of
+    # reusing this mock-backed copy.
+    for _svc_name in ('services.users.data_export', 'services.users', 'services'):
+        sys.modules.pop(_svc_name, None)
 
 
 def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -1,0 +1,96 @@
+import importlib.abc
+import importlib.machinery
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+
+class _AutoMockModule(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_STUB_PREFIXES = (
+    'database',
+    'firebase_admin',
+    'google.cloud',
+    'google.api_core',
+    'pinecone',
+    'typesense',
+    'utils',
+)
+
+
+def _should_stub(name: str) -> bool:
+    return any(name == prefix or name.startswith(prefix + '.') for prefix in _STUB_PREFIXES)
+
+
+class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _should_stub(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMockModule(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+sys.meta_path.insert(0, _StubFinder())
+
+from services.users import data_export  # noqa: E402
+
+
+def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):
+    now = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value={'created_at': now}))
+    monkeypatch.setattr(data_export.memories_db, 'get_memories', MagicMock(return_value=[{'id': 'mem1'}]))
+    monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[{'id': 'person1'}]))
+    monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[{'id': 'task1'}]))
+    monkeypatch.setattr(
+        data_export.conversations_db,
+        'iter_all_conversations',
+        MagicMock(return_value=iter([{'id': 'conv1', 'is_locked': True}, {'id': 'conv2'}])),
+    )
+    monkeypatch.setattr(
+        data_export.chat_db, 'iter_all_messages', MagicMock(return_value=iter([{'id': 'msg1', 'created_at': now}]))
+    )
+
+    body = ''.join(data_export.iter_user_data_export('uid1'))
+    payload = json.loads(body)
+
+    assert payload == {
+        'profile': {'created_at': '2026-01-02T03:04:05+00:00'},
+        'conversations': [{'id': 'conv1', 'is_locked': True}, {'id': 'conv2'}],
+        'memories': [{'id': 'mem1'}],
+        'people': [{'id': 'person1'}],
+        'action_items': [{'id': 'task1'}],
+        'chat_messages': [{'id': 'msg1', 'created_at': '2026-01-02T03:04:05+00:00'}],
+    }
+    data_export.memories_db.get_memories.assert_called_once_with('uid1', limit=10000, offset=0)
+    data_export.get_standalone_action_items.assert_called_once_with('uid1', limit=10000, offset=0)
+    data_export.conversations_db.iter_all_conversations.assert_called_once_with('uid1', include_discarded=True)
+    data_export.chat_db.iter_all_messages.assert_called_once_with('uid1')
+
+
+def test_iter_user_data_export_uses_empty_profile_object(monkeypatch):
+    monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value=None))
+    monkeypatch.setattr(data_export.memories_db, 'get_memories', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export.conversations_db, 'iter_all_conversations', MagicMock(return_value=iter([])))
+    monkeypatch.setattr(data_export.chat_db, 'iter_all_messages', MagicMock(return_value=iter([])))
+
+    payload = json.loads(''.join(data_export.iter_user_data_export('uid1')))
+
+    assert payload['profile'] == {}

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -34,12 +34,16 @@ def _should_stub(name: str) -> bool:
 
 
 class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def __init__(self):
+        self._created: set[str] = set()
+
     def find_spec(self, name, path=None, target=None):
         if _should_stub(name):
             return importlib.machinery.ModuleSpec(name, self, is_package=True)
         return None
 
     def create_module(self, spec):
+        self._created.add(spec.name)
         return _AutoMockModule(spec.name)
 
     def exec_module(self, module):
@@ -51,12 +55,13 @@ sys.meta_path.insert(0, _finder)
 try:
     from services.users import data_export  # noqa: E402
 finally:
-    # Remove the meta-path finder and clear stubbed modules so they don't
-    # leak into sys.modules and interfere with other tests collected in the
-    # same pytest process (e.g. utils.executors resolving to a MagicMock).
+    # Remove the meta-path finder and clear *only* the modules that the
+    # stub finder actually created. Broadly deleting every module matching
+    # _STUB_PREFIXES (database, utils, …) would also evict real project
+    # modules imported by other tests collected in the same pytest process.
     sys.meta_path.remove(_finder)
-    for _name in [n for n in sys.modules if _should_stub(n)]:
-        del sys.modules[_name]
+    for _name in list(_finder._created):
+        sys.modules.pop(_name, None)
 
 
 def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -4,7 +4,7 @@ import json
 import sys
 import types
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 
 class _AutoMockModule(types.ModuleType):
@@ -54,7 +54,7 @@ from services.users import data_export  # noqa: E402
 def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):
     now = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value={'created_at': now}))
-    monkeypatch.setattr(data_export.memories_db, 'get_memories', MagicMock(return_value=[{'id': 'mem1'}]))
+    monkeypatch.setattr(data_export.memories_db, 'get_non_filtered_memories', MagicMock(return_value=[{'id': 'mem1'}]))
     monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[{'id': 'person1'}]))
     monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[{'id': 'task1'}]))
     monkeypatch.setattr(
@@ -77,15 +77,15 @@ def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):
         'action_items': [{'id': 'task1'}],
         'chat_messages': [{'id': 'msg1', 'created_at': '2026-01-02T03:04:05+00:00'}],
     }
-    data_export.memories_db.get_memories.assert_called_once_with('uid1', limit=10000, offset=0)
-    data_export.get_standalone_action_items.assert_called_once_with('uid1', limit=10000, offset=0)
+    data_export.memories_db.get_non_filtered_memories.assert_called_once_with('uid1', limit=1000, offset=0)
+    data_export.get_standalone_action_items.assert_called_once_with('uid1', limit=1000, offset=0)
     data_export.conversations_db.iter_all_conversations.assert_called_once_with('uid1', include_discarded=True)
     data_export.chat_db.iter_all_messages.assert_called_once_with('uid1')
 
 
 def test_iter_user_data_export_uses_empty_profile_object(monkeypatch):
     monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value=None))
-    monkeypatch.setattr(data_export.memories_db, 'get_memories', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export.memories_db, 'get_non_filtered_memories', MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[]))
     monkeypatch.setattr(data_export.conversations_db, 'iter_all_conversations', MagicMock(return_value=iter([])))
@@ -94,3 +94,53 @@ def test_iter_user_data_export_uses_empty_profile_object(monkeypatch):
     payload = json.loads(''.join(data_export.iter_user_data_export('uid1')))
 
     assert payload['profile'] == {}
+
+
+def test_iter_user_data_export_yields_before_heavy_reads(monkeypatch):
+    get_profile = MagicMock(return_value={})
+    monkeypatch.setattr(data_export, 'get_user_profile', get_profile)
+    monkeypatch.setattr(data_export.memories_db, 'get_non_filtered_memories', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export.conversations_db, 'iter_all_conversations', MagicMock(return_value=iter([])))
+    monkeypatch.setattr(data_export.chat_db, 'iter_all_messages', MagicMock(return_value=iter([])))
+
+    chunks = data_export.iter_user_data_export('uid1')
+
+    assert next(chunks) == '{\n'
+    get_profile.assert_not_called()
+
+
+def test_iter_user_data_export_paginates_complete_collections(monkeypatch):
+    monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value={}))
+    monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export.conversations_db, 'iter_all_conversations', MagicMock(return_value=iter([])))
+    monkeypatch.setattr(data_export.chat_db, 'iter_all_messages', MagicMock(return_value=iter([])))
+
+    memory_pages = [
+        [{'id': f'mem-{i}'} for i in range(1000)],
+        [{'id': 'mem-1000'}],
+    ]
+    action_item_pages = [
+        [{'id': f'task-{i}'} for i in range(1000)],
+        [{'id': 'task-1000'}],
+    ]
+    get_non_filtered_memories = MagicMock(side_effect=memory_pages)
+    get_action_items = MagicMock(side_effect=action_item_pages)
+    monkeypatch.setattr(data_export.memories_db, 'get_non_filtered_memories', get_non_filtered_memories)
+    monkeypatch.setattr(data_export, 'get_standalone_action_items', get_action_items)
+
+    payload = json.loads(''.join(data_export.iter_user_data_export('uid1')))
+
+    assert len(payload['memories']) == 1001
+    assert payload['memories'][-1] == {'id': 'mem-1000'}
+    assert len(payload['action_items']) == 1001
+    assert payload['action_items'][-1] == {'id': 'task-1000'}
+    assert get_non_filtered_memories.call_args_list == [
+        call('uid1', limit=1000, offset=0),
+        call('uid1', limit=1000, offset=1000),
+    ]
+    assert get_action_items.call_args_list == [
+        call('uid1', limit=1000, offset=0),
+        call('uid1', limit=1000, offset=1000),
+    ]

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -17,8 +17,6 @@ import types
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 os.environ.setdefault('ENCRYPTION_SECRET', 'test-secret-for-ci')
 
 # ---------------------------------------------------------------------------
@@ -69,26 +67,20 @@ if 'database.users' not in _STUB_PRIORS:
 
 from database import users as users_db  # noqa: E402
 
-
-@pytest.fixture(autouse=True, scope='module')
-def _restore_sys_modules():
-    """Restore sys.modules entries this module stubbed.
-
-    After all tests in this module finish, each stubbed name is either removed
-    (if it was absent before) or restored to its prior object, so the stubs do
-    not leak into later test modules in a multi-file pytest run.  We also clear
-    the parent ``database`` package attribute so ``from database import users``
-    doesn't resolve to the half-stubbed module via attribute lookup.
-    """
-    yield
-    for _name, _prior in _STUB_PRIORS.items():
-        if _prior is None:
-            sys.modules.pop(_name, None)
-        else:
-            sys.modules[_name] = _prior
-    _db_pkg = sys.modules.get('database')
-    if _db_pkg is not None and hasattr(_db_pkg, 'users'):
-        delattr(_db_pkg, 'users')
+# Restore all stubbed sys.modules entries IMMEDIATELY after capturing the
+# users_db reference. pytest imports/collects later test modules before any
+# module-scoped fixture teardown runs, so if we waited for fixture teardown
+# the half-stubbed entries (database._client, database.redis_db, etc.) would
+# still be in sys.modules while later tests are collected, causing them to
+# bind MagicMock-backed helpers instead of their own stubs or the real modules.
+for _name, _prior in _STUB_PRIORS.items():
+    if _prior is None:
+        sys.modules.pop(_name, None)
+    else:
+        sys.modules[_name] = _prior
+_db_pkg = sys.modules.get('database')
+if _db_pkg is not None and hasattr(_db_pkg, 'users'):
+    delattr(_db_pkg, 'users')
 
 
 def _make_snapshot(data):

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -61,6 +61,12 @@ _utils_sub = types.ModuleType('utils.subscription')
 setattr(_utils_sub, 'get_default_basic_subscription', MagicMock())
 _install_stub('utils.subscription', _utils_sub)
 
+# database.users is imported against the stubs above, so record its prior
+# sys.modules entry now; the autouse fixture below restores/removes it so the
+# half-stubbed module does not leak into other unit-test modules.
+if 'database.users' not in _STUB_PRIORS:
+    _STUB_PRIORS['database.users'] = sys.modules.get('database.users')
+
 from database import users as users_db  # noqa: E402
 
 

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -17,33 +17,67 @@ import types
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
+import pytest
+
 os.environ.setdefault('ENCRYPTION_SECRET', 'test-secret-for-ci')
+
+# ---------------------------------------------------------------------------
+# Module stubbing with cleanup
+# ---------------------------------------------------------------------------
+# The real ``database.users`` module cannot be imported without Firestore
+# credentials, so we install lightweight stubs for its transitive imports.
+# We track every entry we touch so an autouse fixture can restore sys.modules
+# after this module's tests finish — preventing the stubs from leaking into
+# other unit tests in a multi-file pytest run (e.g. test_rate_limiting.py
+# expects the real database.redis_db.check_rate_limit).
+_STUB_PRIORS: dict[str, 'types.ModuleType | None'] = {}
+
+
+def _install_stub(name, mod):
+    """Install *mod* under *name*, remembering the prior sys.modules entry."""
+    if name not in _STUB_PRIORS:
+        _STUB_PRIORS[name] = sys.modules.get(name)
+    sys.modules[name] = mod
+
 
 # Stub database._client so firestore.Client() is never called at import time.
 # We only need this for module load; the transaction function under test does
 # not use the db singleton at all (it receives doc_ref as an argument).
-if 'database._client' not in sys.modules:
-    _fake_client_mod = types.ModuleType('database._client')
-    setattr(_fake_client_mod, 'db', MagicMock())
-    setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
-    sys.modules['database._client'] = _fake_client_mod
+_fake_client_mod = types.ModuleType('database._client')
+setattr(_fake_client_mod, 'db', MagicMock())
+setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
+_install_stub('database._client', _fake_client_mod)
 
 # Stub database.firestore_cache and database.redis_db since database/users.py
 # imports from them at module level, and they transitively require real clients.
 for _mod_name in ('database.firestore_cache', 'database.redis_db'):
-    if _mod_name not in sys.modules:
-        _mod = types.ModuleType(_mod_name)
-        for _attr in ('CachePolicy', 'get_or_fetch', 'invalidate', 'try_acquire_user_platform_write_lock'):
-            setattr(_mod, _attr, MagicMock())
-        sys.modules[_mod_name] = _mod
+    _mod = types.ModuleType(_mod_name)
+    for _attr in ('CachePolicy', 'get_or_fetch', 'invalidate', 'try_acquire_user_platform_write_lock'):
+        setattr(_mod, _attr, MagicMock())
+    _install_stub(_mod_name, _mod)
 
 # Stub utils.subscription (imported at module level for get_default_basic_subscription)
-if 'utils.subscription' not in sys.modules:
-    _utils_sub = types.ModuleType('utils.subscription')
-    setattr(_utils_sub, 'get_default_basic_subscription', MagicMock())
-    sys.modules['utils.subscription'] = _utils_sub
+_utils_sub = types.ModuleType('utils.subscription')
+setattr(_utils_sub, 'get_default_basic_subscription', MagicMock())
+_install_stub('utils.subscription', _utils_sub)
 
 from database import users as users_db  # noqa: E402
+
+
+@pytest.fixture(autouse=True, scope='module')
+def _restore_sys_modules():
+    """Restore sys.modules entries this module stubbed.
+
+    After all tests in this module finish, each stubbed name is either removed
+    (if it was absent before) or restored to its prior object, so the stubs do
+    not leak into later test modules in a multi-file pytest run.
+    """
+    yield
+    for _name, _prior in _STUB_PRIORS.items():
+        if _prior is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _prior
 
 
 def _make_snapshot(data):

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -15,7 +15,7 @@ import os
 import sys
 import types
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -210,3 +210,106 @@ def test_claim_txn_returns_none_for_unknown_status():
     result, updates = _run_claim(data)
     assert result is None
     assert len(updates) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_pending_deletion_wipes: over-fetch regression test (review P2)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDocSnapshot:
+    def __init__(self, data):
+        self._data = data
+        self.id = data.get('uid')
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeCollection:
+    """Minimal Firestore collection mock that streams a list of doc dicts."""
+
+    def __init__(self, docs_by_status):
+        # docs_by_status: {'pending': [...], 'failed': [...], 'retrying': [...]}
+        self._docs_by_status = docs_by_status
+        self._status = None
+
+    def where(self, field, op, value):
+        # Only equality filters are used in get_pending_deletion_wipes.
+        assert op == '=='
+        self._status = value
+        return self
+
+    def limit(self, n):
+        # Should no longer be called for age-filtered queries after the fix.
+        # Record it but still return all docs so the test is robust.
+        return self
+
+    def stream(self):
+        for data in self._docs_by_status.get(self._status, []):
+            yield _FakeDocSnapshot(data)
+
+
+def test_get_pending_deletion_wipes_finds_stale_after_fresh_window():
+    """P2: stale pending docs beyond a fresh window must not be skipped.
+
+    Before the fix, ``.limit(budget)`` capped the query before the age filter,
+    so a page of fresh ``pending`` docs hid stale records that needed recovery.
+    After the fix the query over-fetches all docs of each status and ages them
+    in Python, breaking as soon as ``limit`` actionable records are collected.
+    """
+    now = datetime.now(timezone.utc)
+    stale_after = timedelta(minutes=10)
+
+    docs_by_status = {
+        'failed': [],
+        'pending': [
+            # Fresh pending docs come first — these would fill a tight limit.
+            {'uid': 'fresh1', 'wipe_status': 'pending', 'wipe_queued_at': now - timedelta(seconds=30)},
+            {'uid': 'fresh2', 'wipe_status': 'pending', 'wipe_queued_at': now - timedelta(seconds=60)},
+            # Stale pending doc beyond the fresh window — must be returned.
+            {'uid': 'stale1', 'wipe_status': 'pending', 'wipe_queued_at': now - timedelta(minutes=15)},
+        ],
+        'retrying': [],
+    }
+
+    fake_collection = _FakeCollection(docs_by_status)
+    fake_db = types.SimpleNamespace()
+    fake_db.collection = lambda name: fake_collection
+
+    with patch.object(users_db, 'db', fake_db):
+        result = users_db.get_pending_deletion_wipes(limit=100, stale_after=stale_after)
+
+    uids = [r['uid'] for r in result]
+    assert 'stale1' in uids, 'stale pending record must be found past the fresh window'
+    assert 'fresh1' not in uids
+    assert 'fresh2' not in uids
+
+
+def test_get_pending_deletion_wipes_respects_limit_with_over_fetch():
+    """The limit is still honoured even when over-fetching: only ``limit``
+    actionable records are returned (failed first, then stale pending)."""
+    now = datetime.now(timezone.utc)
+    stale_after = timedelta(minutes=10)
+
+    docs_by_status = {
+        'failed': [
+            {'uid': 'fail1', 'wipe_status': 'failed'},
+            {'uid': 'fail2', 'wipe_status': 'failed'},
+        ],
+        'pending': [
+            {'uid': 'stale1', 'wipe_status': 'pending', 'wipe_queued_at': now - timedelta(minutes=15)},
+        ],
+        'retrying': [],
+    }
+
+    fake_collection = _FakeCollection(docs_by_status)
+    fake_db = types.SimpleNamespace()
+    fake_db.collection = lambda name: fake_collection
+
+    with patch.object(users_db, 'db', fake_db):
+        result = users_db.get_pending_deletion_wipes(limit=2, stale_after=stale_after)
+
+    uids = {r['uid'] for r in result}
+    assert uids == {'fail1', 'fail2'}
+    assert len(result) == 2

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -1,0 +1,178 @@
+"""Unit tests for the _claim_deletion_wipe_txn transaction logic.
+
+Tests the P1 race-condition fix: a fresh ``pending`` marker (recently
+re-queued by a retrying delete request) must NOT be claimed inside the
+transaction, because Firebase auth deletion may not have succeeded yet.
+
+The real ``database.users`` module cannot be imported without Firestore
+credentials (``_client.py`` calls ``firestore.Client()`` at module level),
+so we stub only ``database._client`` before importing. Everything else in
+``database.users`` is real Python that operates on the passed-in
+transaction/doc_ref objects.
+"""
+
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'test-secret-for-ci')
+
+# Stub database._client so firestore.Client() is never called at import time.
+# We only need this for module load; the transaction function under test does
+# not use the db singleton at all (it receives doc_ref as an argument).
+if 'database._client' not in sys.modules:
+    _fake_client_mod = types.ModuleType('database._client')
+    setattr(_fake_client_mod, 'db', MagicMock())
+    setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
+    sys.modules['database._client'] = _fake_client_mod
+
+# Stub database.firestore_cache and database.redis_db since database/users.py
+# imports from them at module level, and they transitively require real clients.
+for _mod_name in ('database.firestore_cache', 'database.redis_db'):
+    if _mod_name not in sys.modules:
+        _mod = types.ModuleType(_mod_name)
+        for _attr in ('CachePolicy', 'get_or_fetch', 'invalidate', 'try_acquire_user_platform_write_lock'):
+            setattr(_mod, _attr, MagicMock())
+        sys.modules[_mod_name] = _mod
+
+# Stub utils.subscription (imported at module level for get_default_basic_subscription)
+if 'utils.subscription' not in sys.modules:
+    _utils_sub = types.ModuleType('utils.subscription')
+    setattr(_utils_sub, 'get_default_basic_subscription', MagicMock())
+    sys.modules['utils.subscription'] = _utils_sub
+
+from database import users as users_db  # noqa: E402
+
+
+def _make_snapshot(data):
+    """Create a minimal mock snapshot object."""
+    snap = types.SimpleNamespace()
+    snap.exists = data is not None
+    snap.to_dict = lambda: data
+    snap.id = data.get('uid') if data else None
+    return snap
+
+
+def _make_txn():
+    """Create a mock transaction that records update calls."""
+    updates = []
+    txn = types.SimpleNamespace()
+    txn._updates = updates
+    txn.update = lambda ref, fields: updates.append((ref, fields))
+    return txn
+
+
+def _run_claim(data, stale_after=timedelta(minutes=10)):
+    """Run the claim transaction with given doc data, return (result, updates).
+
+    The @transactional decorator wraps the raw function in a _Transactional
+    object. We access the raw function via .to_wrap and call it directly with
+    lightweight mocks, avoiding the need for a real Firestore transaction.
+    """
+    txn = _make_txn()
+    txn_obj = users_db._claim_deletion_wipe_txn
+    raw_fn = getattr(txn_obj, 'to_wrap', txn_obj)
+    snapshot = _make_snapshot(data)
+
+    class FakeDocRef:
+        def get(self, transaction=None):
+            return snapshot
+
+    result = raw_fn(txn, FakeDocRef(), stale_after)
+    return result, txn._updates
+
+
+def test_claim_txn_skips_fresh_pending_marker():
+    """P1: a fresh pending marker (recently queued) must NOT be claimed.
+
+    This is the exact race condition flagged in the review: the reconciler
+    query returns a stale pending record, but by the time the transaction
+    runs a new delete request has refreshed wipe_queued_at. Claiming it
+    would enqueue a wipe before Firebase auth deletion has succeeded.
+    """
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'pending',
+        'wipe_queued_at': now - timedelta(seconds=30),  # fresh: only 30s old
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0  # no transaction.update called
+
+
+def test_claim_txn_claims_stale_pending_marker():
+    """A stale pending marker (older than stale_after) IS claimed."""
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'pending',
+        'wipe_queued_at': now - timedelta(minutes=15),  # stale: 15min old
+    }
+    result, updates = _run_claim(data)
+    assert result == 'uid1'
+    assert len(updates) == 1
+    assert updates[0][1]['wipe_status'] == 'retrying'
+    assert 'wipe_claimed_at' in updates[0][1]
+
+
+def test_claim_txn_claims_failed_marker():
+    """A failed marker is always claimable regardless of age."""
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'failed',
+        'wipe_failed_at': now - timedelta(seconds=5),  # recent failure
+    }
+    result, updates = _run_claim(data)
+    assert result == 'uid1'
+    assert updates[0][1]['wipe_status'] == 'retrying'
+
+
+def test_claim_txn_skips_fresh_retrying_claim():
+    """A retrying claim that is not stale is refused."""
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'retrying',
+        'wipe_claimed_at': now - timedelta(seconds=30),  # fresh claim
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0
+
+
+def test_claim_txn_reclaims_stale_retrying_claim():
+    """A retrying claim older than stale_after is re-claimed."""
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'retrying',
+        'wipe_claimed_at': now - timedelta(minutes=15),  # stale claim
+    }
+    result, updates = _run_claim(data)
+    assert result == 'uid1'
+    # Only updates wipe_claimed_at (doesn't re-set wipe_status, already retrying)
+    assert 'wipe_status' not in updates[0][1]
+    assert 'wipe_claimed_at' in updates[0][1]
+
+
+def test_claim_txn_returns_none_for_missing_doc():
+    """A non-existent document returns None."""
+    result, updates = _run_claim(None)
+    assert result is None
+    assert len(updates) == 0
+
+
+def test_claim_txn_returns_none_for_unknown_status():
+    """An unknown status (e.g. 'completed', 'cancelled') returns None."""
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'completed',
+        'wipe_completed_at': datetime.now(timezone.utc),
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -104,7 +104,7 @@ def _make_txn():
     return txn
 
 
-def _run_claim(data, stale_after=timedelta(minutes=10)):
+def _run_claim(data, stale_after=timedelta(minutes=10), running_stale_after=timedelta(minutes=30)):
     """Run the claim transaction with given doc data, return (result, updates).
 
     The @transactional decorator wraps the raw function in a _Transactional
@@ -120,7 +120,7 @@ def _run_claim(data, stale_after=timedelta(minutes=10)):
         def get(self, transaction=None):
             return snapshot
 
-    result = raw_fn(txn, FakeDocRef(), stale_after)
+    result = raw_fn(txn, FakeDocRef(), stale_after, running_stale_after)
     return result, txn._updates
 
 
@@ -212,6 +212,63 @@ def test_claim_txn_returns_none_for_unknown_status():
         'uid': 'uid1',
         'wipe_status': 'completed',
         'wipe_completed_at': datetime.now(timezone.utc),
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0
+
+
+# ---------------------------------------------------------------------------
+# running state tests (review P2: don't reclaim live wipes solely by age)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_txn_skips_fresh_running_marker():
+    """A fresh ``running`` marker belongs to a live worker — must NOT be claimed.
+
+    This is the core fix for the review concern: a slow but live wipe should
+    not be duplicate-claimed just because it has been running for a while.
+    The ``running`` stale window (default 30 min) is much longer than the
+    ``pending`` stale window (10 min).
+    """
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'running',
+        'wipe_running_at': now - timedelta(minutes=12),  # 12 min: stale for pending, fresh for running
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0
+
+
+def test_claim_txn_claims_stale_running_marker():
+    """A ``running`` marker older than ``running_stale_after`` IS claimed.
+
+    The worker almost certainly crashed or the pod was killed mid-execution.
+    """
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'running',
+        'wipe_running_at': now - timedelta(minutes=45),  # 45 min: stale even for running window
+    }
+    result, updates = _run_claim(data)
+    assert result == 'uid1'
+    assert updates[0][1]['wipe_status'] == 'retrying'
+
+
+def test_claim_txn_skips_running_marker_near_stale_boundary():
+    """A ``running`` marker just under the stale boundary is NOT claimed.
+
+    Uses 29 min to avoid sub-second timing flakiness with the default
+    30 min ``running_stale_after``.
+    """
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'running',
+        'wipe_running_at': now - timedelta(minutes=29),  # 29 min: just under 30 min boundary
     }
     result, updates = _run_claim(data)
     assert result is None
@@ -319,3 +376,35 @@ def test_get_pending_deletion_wipes_respects_limit_with_over_fetch():
     uids = {r['uid'] for r in result}
     assert uids == {'fail1', 'fail2'}
     assert len(result) == 2
+
+
+def test_get_pending_deletion_wipes_includes_stale_running():
+    """Stale ``running`` records (worker crashed mid-execution) are recovered.
+
+    A ``running`` marker older than ``running_stale_after`` (default 30 min)
+    is included so the reconciler can re-enqueue a wipe whose worker died.
+    """
+    now = datetime.now(timezone.utc)
+
+    docs_by_status = {
+        'failed': [],
+        'pending': [],
+        'running': [
+            # Fresh running — worker is live, should NOT be recovered.
+            {'uid': 'live1', 'wipe_status': 'running', 'wipe_running_at': now - timedelta(minutes=12)},
+            # Stale running — worker probably crashed, SHOULD be recovered.
+            {'uid': 'crashed1', 'wipe_status': 'running', 'wipe_running_at': now - timedelta(minutes=45)},
+        ],
+        'retrying': [],
+    }
+
+    fake_collection = _FakeCollection(docs_by_status)
+    fake_db = types.SimpleNamespace()
+    fake_db.collection = lambda name: fake_collection
+
+    with patch.object(users_db, 'db', fake_db):
+        result = users_db.get_pending_deletion_wipes(limit=100)
+
+    uids = [r['uid'] for r in result]
+    assert 'crashed1' in uids, 'stale running record must be recovered'
+    assert 'live1' not in uids, 'fresh running record must not be recovered'

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -76,7 +76,9 @@ def _restore_sys_modules():
 
     After all tests in this module finish, each stubbed name is either removed
     (if it was absent before) or restored to its prior object, so the stubs do
-    not leak into later test modules in a multi-file pytest run.
+    not leak into later test modules in a multi-file pytest run.  We also clear
+    the parent ``database`` package attribute so ``from database import users``
+    doesn't resolve to the half-stubbed module via attribute lookup.
     """
     yield
     for _name, _prior in _STUB_PRIORS.items():
@@ -84,6 +86,9 @@ def _restore_sys_modules():
             sys.modules.pop(_name, None)
         else:
             sys.modules[_name] = _prior
+    _db_pkg = sys.modules.get('database')
+    if _db_pkg is not None and hasattr(_db_pkg, 'users'):
+        delattr(_db_pkg, 'users')
 
 
 def _make_snapshot(data):

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -184,13 +184,36 @@ def test_claim_txn_skips_fresh_retrying_claim():
     assert len(updates) == 0
 
 
-def test_claim_txn_reclaims_stale_retrying_claim():
-    """A retrying claim older than stale_after is re-claimed."""
+def test_claim_txn_skips_queued_retrying_claim():
+    """A retrying claim that is stale for ``stale_after`` (10 min) but fresh
+    for ``running_stale_after`` (30 min) is NOT re-claimed.
+
+    This is the review fix: a queued-but-not-yet-running retrying claim
+    should not be re-enqueued by the periodic reconciler.
+    """
     now = datetime.now(timezone.utc)
     data = {
         'uid': 'uid1',
         'wipe_status': 'retrying',
-        'wipe_claimed_at': now - timedelta(minutes=15),  # stale claim
+        'wipe_claimed_at': now - timedelta(minutes=15),  # stale for 10 min, fresh for 30 min
+    }
+    result, updates = _run_claim(data)
+    assert result is None
+    assert len(updates) == 0
+
+
+def test_claim_txn_reclaims_stale_retrying_claim():
+    """A retrying claim older than ``running_stale_after`` (30 min) is re-claimed.
+
+    The longer window is used because a retrying wipe was just claimed and
+    enqueued; if the executor backlog is full the future may sit queued
+    beyond the 10-min ``stale_after`` without transitioning to ``running``.
+    """
+    now = datetime.now(timezone.utc)
+    data = {
+        'uid': 'uid1',
+        'wipe_status': 'retrying',
+        'wipe_claimed_at': now - timedelta(minutes=45),  # stale: 45min > 30min running_stale_after
     }
     result, updates = _run_claim(data)
     assert result == 'uid1'

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -100,7 +100,7 @@ try:
     import firebase_admin.auth as _fa_auth  # stubbed
 
     _fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
-    from routers import users as users_router  # noqa: E402  (heavy import; deps stubbed above)
+    from services.users import account_deletion as users_service  # noqa: E402  (deps stubbed above)
 finally:
     if _finder in sys.meta_path:
         sys.meta_path.remove(_finder)
@@ -109,7 +109,7 @@ finally:
 
 
 def _purge_patches(**overrides):
-    """Patch every purge collaborator on the users router. overrides set return_value/side_effect."""
+    """Patch every purge collaborator on the users service. overrides set return_value/side_effect."""
     enumerators = {
         'get_conversation_ids': ['c1', 'c2'],
         'get_memory_ids': ['m1'],
@@ -120,17 +120,22 @@ def _purge_patches(**overrides):
     # create=True: some collaborators are pulled into users.py via `from database.users import *`,
     # which doesn't bind names on the stubbed module, so the attribute may not pre-exist here.
     for name, ids in enumerators.items():
-        patchers[name] = patch.object(users_router, name, create=True, **(overrides.get(name) or {'return_value': ids}))
+        patchers[name] = patch.object(
+            users_service, name, create=True, **(overrides.get(name) or {'return_value': ids})
+        )
     for name in (
         'delete_conversation_vectors_batch',
+        'delete_transcript_chunk_vectors_batch',
         'delete_memory_vectors_batch',
         'delete_action_item_vectors_batch',
         'delete_screen_activity_vectors',
         'delete_all_conversation_recordings',
-        'delete_user_data',
         'delete_user_caller_ids',
     ):
-        patchers[name] = patch.object(users_router, name, create=True, **(overrides.get(name) or {}))
+        patchers[name] = patch.object(users_service, name, create=True, **(overrides.get(name) or {}))
+    patchers['delete_user_data'] = patch.object(
+        users_service.users_db, 'delete_user_data', create=True, **(overrides.get('delete_user_data') or {})
+    )
     started = {name: p.start() for name, p in patchers.items()}
     return patchers, started
 
@@ -143,7 +148,7 @@ def _stop(patchers):
 def test_purge_runs_all_backends_before_firestore_wipe():
     patchers, m = _purge_patches()
     try:
-        users_router._background_wipe_user_data('uid1')
+        users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
 
@@ -165,16 +170,16 @@ def test_id_enumeration_happens_before_firestore_wipe():
         delete_user_data={'side_effect': lambda uid: order.append('wipe')},
     )
     try:
-        users_router._background_wipe_user_data('uid1')
+        users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
-    assert order == ['enumerate', 'wipe'], order
+    assert order == ['enumerate', 'enumerate', 'wipe'], order
 
 
 def test_pinecone_failure_does_not_block_recordings_or_firestore_wipe():
     patchers, m = _purge_patches(delete_conversation_vectors_batch={'side_effect': Exception('pinecone down')})
     try:
-        users_router._background_wipe_user_data('uid1')
+        users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
     # one backend failing must not stop the rest or the Firestore wipe
@@ -186,7 +191,7 @@ def test_pinecone_failure_does_not_block_recordings_or_firestore_wipe():
 def test_gcs_failure_does_not_block_firestore_wipe():
     patchers, m = _purge_patches(delete_all_conversation_recordings={'side_effect': Exception('gcs down')})
     try:
-        users_router._background_wipe_user_data('uid1')
+        users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
     m['delete_all_conversation_recordings'].assert_called_once_with('uid1')  # purge was wired + attempted
@@ -196,7 +201,7 @@ def test_gcs_failure_does_not_block_firestore_wipe():
 def test_enumeration_failure_is_isolated():
     patchers, m = _purge_patches(get_conversation_ids={'side_effect': Exception('firestore read error')})
     try:
-        users_router._background_wipe_user_data('uid1')
+        users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
     # conversation enumeration blew up, but the other backends + the wipe still run

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -125,29 +125,35 @@ def test_paid_user_subscription_is_canceled_before_wipe():
     ) as cancel, patch.object(
         users_service.auth, 'delete_account'
     ) as fb_delete, patch.object(
-        users_service.threading, 'Thread'
-    ) as thread:
+        users_service, 'submit_with_context'
+    ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
     get_sub.assert_called_once_with('uid1')
     cancel.assert_called_once_with('sub_123')
     fb_delete.assert_called_once()  # deletion still proceeds
-    thread.return_value.start.assert_called_once_with()
+    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'
 
 
 def test_free_user_does_not_call_stripe():
     with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub(None)), patch.object(
         users_service.stripe_utils, 'cancel_subscription'
-    ) as cancel, patch.object(users_service.auth, 'delete_account'), patch.object(users_service.threading, 'Thread'):
+    ) as cancel, patch.object(users_service.auth, 'delete_account'), patch.object(
+        users_service, 'submit_with_context'
+    ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
     cancel.assert_not_called()
+    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'
 
 
 def test_stripe_error_does_not_block_deletion():
     with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
         users_service.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
-    ), patch.object(users_service.auth, 'delete_account') as fb_delete, patch.object(users_service.threading, 'Thread'):
+    ), patch.object(users_service.auth, 'delete_account') as fb_delete, patch.object(
+        users_service, 'submit_with_context'
+    ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
     fb_delete.assert_called_once()  # best-effort: Stripe failure must not abort deletion
+    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -103,7 +103,7 @@ try:
     import firebase_admin.auth as _fa_auth  # stubbed
 
     _fa_auth.InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
-    from routers import users as users_router  # noqa: E402  (heavy import; deps stubbed above)
+    from services.users import account_deletion as users_service  # noqa: E402  (deps stubbed above)
 finally:
     if _finder in sys.meta_path:
         sys.meta_path.remove(_finder)
@@ -119,38 +119,35 @@ def _sub(stripe_subscription_id):
 
 def test_paid_user_subscription_is_canceled_before_wipe():
     with patch.object(
-        users_router.users_db, 'get_user_subscription', return_value=_sub('sub_123')
+        users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')
     ) as get_sub, patch.object(
-        users_router.stripe_utils, 'cancel_subscription', return_value=MagicMock()
+        users_service.stripe_utils, 'cancel_subscription', return_value=MagicMock()
     ) as cancel, patch.object(
-        users_router.auth, 'delete_account'
+        users_service.auth, 'delete_account'
     ) as fb_delete, patch.object(
-        users_router, '_background_wipe_user_data'
-    ):
-        resp = users_router.delete_account(uid='uid1')
+        users_service.threading, 'Thread'
+    ) as thread:
+        resp = users_service.start_account_deletion(uid='uid1')
     get_sub.assert_called_once_with('uid1')
     cancel.assert_called_once_with('sub_123')
     fb_delete.assert_called_once()  # deletion still proceeds
+    thread.return_value.start.assert_called_once_with()
     assert resp['status'] == 'ok'
 
 
 def test_free_user_does_not_call_stripe():
-    with patch.object(users_router.users_db, 'get_user_subscription', return_value=_sub(None)), patch.object(
-        users_router.stripe_utils, 'cancel_subscription'
-    ) as cancel, patch.object(users_router.auth, 'delete_account'), patch.object(
-        users_router, '_background_wipe_user_data'
-    ):
-        resp = users_router.delete_account(uid='uid1')
+    with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub(None)), patch.object(
+        users_service.stripe_utils, 'cancel_subscription'
+    ) as cancel, patch.object(users_service.auth, 'delete_account'), patch.object(users_service.threading, 'Thread'):
+        resp = users_service.start_account_deletion(uid='uid1')
     cancel.assert_not_called()
     assert resp['status'] == 'ok'
 
 
 def test_stripe_error_does_not_block_deletion():
-    with patch.object(users_router.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
-        users_router.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
-    ), patch.object(users_router.auth, 'delete_account') as fb_delete, patch.object(
-        users_router, '_background_wipe_user_data'
-    ):
-        resp = users_router.delete_account(uid='uid1')
+    with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
+        users_service.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
+    ), patch.object(users_service.auth, 'delete_account') as fb_delete, patch.object(users_service.threading, 'Thread'):
+        resp = users_service.start_account_deletion(uid='uid1')
     fb_delete.assert_called_once()  # best-effort: Stripe failure must not abort deletion
     assert resp['status'] == 'ok'

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -131,7 +131,7 @@ def test_paid_user_subscription_is_canceled_before_wipe():
     get_sub.assert_called_once_with('uid1')
     cancel.assert_called_once_with('sub_123')
     fb_delete.assert_called_once()  # deletion still proceeds
-    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
+    submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'
 
 
@@ -143,7 +143,7 @@ def test_free_user_does_not_call_stripe():
     ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
     cancel.assert_not_called()
-    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
+    submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'
 
 
@@ -155,5 +155,5 @@ def test_stripe_error_does_not_block_deletion():
     ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
     fb_delete.assert_called_once()  # best-effort: Stripe failure must not abort deletion
-    submit.assert_called_once_with(users_service.postprocess_executor, users_service.background_wipe_user_data, 'uid1')
+    submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'

--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -176,7 +176,7 @@ def test_get_executor_metrics_returns_all_pools():
     metrics = get_executor_metrics()
     assert len(metrics) == len(_ALL_EXECUTORS)
     names = {m['name'] for m in metrics}
-    expected = {'critical', 'db', 'llm', 'stripe', 'sync', 'postprocess', 'storage'}
+    expected = {'critical', 'db', 'llm', 'stripe', 'sync', 'postprocess', 'cleanup', 'storage'}
     assert names == expected
 
 

--- a/backend/tests/unit/test_llm_usage_endpoints.py
+++ b/backend/tests/unit/test_llm_usage_endpoints.py
@@ -164,6 +164,10 @@ cache_mod.get_memory_cache = MagicMock(return_value=None)
 users_mod = sys.modules["database.users"]
 users_mod.get_user_transcription_preferences = MagicMock()
 users_mod.set_user_transcription_preferences = MagicMock()
+# Export-service helpers are imported at module level by services.users.data_export,
+# which is eagerly loaded when routers.users imports services.users.
+users_mod.get_people = MagicMock(return_value=[])
+users_mod.get_user_profile = MagicMock(return_value={})
 users_mod.__all__ = []
 
 llm_usage_mod = _install_stub("database.llm_usage")

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -921,21 +921,21 @@ class TestUsersLockEnforcement:
         locked_conv = _make_conversation(locked=True)
         unlocked_conv = _make_conversation(locked=False, conversation_id='conv-2')
         conversations_db.iter_all_conversations = MagicMock(return_value=iter([locked_conv, unlocked_conv]))
-        memories_db.get_memories = MagicMock(return_value=[])
+        memories_db.get_non_filtered_memories = MagicMock(return_value=[])
         chat_db.iter_all_messages = MagicMock(return_value=iter([]))
 
-        # These functions are imported via 'from database.users import *' so they live
-        # in the routers.users namespace. Use create=True since the wildcard import
-        # may not have populated them in the stub environment.
-        # Patches must stay active during body consumption since generate() is lazy.
-        with patch('routers.users.get_user_profile', return_value={'name': 'Test'}, create=True):
-            with patch('routers.users.get_people', return_value=[], create=True):
-                with patch('routers.users.get_standalone_action_items', return_value=[], create=True):
+        # The export generator lives in services.users.data_export, which binds
+        # these helpers at module level. Patch the service-level symbols so the
+        # stub environment returns controlled data instead of MagicMock defaults.
+        # Patches must stay active during body consumption since the generator is lazy.
+        with patch('services.users.data_export.get_user_profile', return_value={'name': 'Test'}):
+            with patch('services.users.data_export.get_people', return_value=[]):
+                with patch('services.users.data_export.get_standalone_action_items', return_value=[]):
                     from routers.users import export_all_user_data
 
                     response = export_all_user_data(uid='test-uid')
 
-                    # Consume body inside patches — generate() is a lazy generator.
+                    # Consume body inside patches — the generator is lazy.
                     # StreamingResponse wraps sync generators as async iterators,
                     # so iterate the underlying generator directly.
                     import asyncio

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -11,6 +11,9 @@ Provides shared executors with strict separation (bulkhead pattern):
 - sync_executor: sync pipeline VAD/STT/segment processing.
 - postprocess_executor: best-effort post-processing (memories, trends, vectors,
   action items, goals, conversation processing, webhook delivery).
+- cleanup_executor: long-running account-deletion wipes (vectors, recordings,
+  Firestore subcollections). Bulkheaded so bursts of account deletions cannot
+  starve normal post-processing.
 - storage_executor: audio file precaching, GCS operations.
 
 These replace ad-hoc ThreadPoolExecutor creation throughout the codebase,
@@ -61,6 +64,7 @@ llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=6, thread_nam
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
 sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=16, thread_name_prefix="sync")
 postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=24, thread_name_prefix="postproc")
+cleanup_executor = MonitoredThreadPoolExecutor(name="cleanup", max_workers=4, thread_name_prefix="cleanup")
 storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=128, thread_name_prefix="storage")
 
 _ALL_EXECUTORS = [
@@ -70,6 +74,7 @@ _ALL_EXECUTORS = [
     stripe_executor,
     sync_executor,
     postprocess_executor,
+    cleanup_executor,
     storage_executor,
 ]
 


### PR DESCRIPTION
## Summary
- Extract account deletion orchestration from `backend/routers/users.py` into `backend/services/users/account_deletion.py`.
- Extract GDPR/CCPA user export generation into `backend/services/users/data_export.py` while keeping router response headers unchanged.
- Add focused service/router tests and retarget stale delete-account unit tests to the new service boundary.

## Validation
- `python -m pytest -q backend/tests/services/users/test_account_deletion.py backend/tests/services/users/test_data_export.py backend/tests/routers/test_users.py`
- `python -m pytest -q backend/tests/routers -k users`
- `python -m pytest -q backend/tests/unit/test_delete_account_stripe_cancel.py backend/tests/unit/test_delete_account_purge_storage.py`
- `python -m compileall backend/routers/users.py backend/services/users/account_deletion.py backend/services/users/data_export.py`
- `black --line-length 120 --skip-string-normalization` on changed Python files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

