### PR TITLE
fix(app): preserve custom STT segment metadata

### DIFF
--- a/app/lib/models/stt_response_schema.dart
+++ b/app/lib/models/stt_response_schema.dart
@@ -1,11 +1,14 @@
-/// Minimal schema for parsing STT responses into TranscriptSegments
-/// Only contains fields required by backend: text, start, end, speaker
+/// Schema for parsing STT responses into backend TranscriptSegment payloads.
 class SttResponseSchema {
   final String? segmentsPath;
   final String segmentsTextField;
   final String? segmentsStartField;
   final String? segmentsEndField;
   final String? segmentsSpeakerField;
+  final String? segmentsSpeakerIdField;
+  final String? segmentsIsUserField;
+  final String? segmentsPersonIdField;
+  final String? segmentsTranslationsField;
   final String? textPath;
   final double defaultSegmentDuration;
 
@@ -15,6 +18,10 @@ class SttResponseSchema {
     this.segmentsStartField = 'start',
     this.segmentsEndField = 'end',
     this.segmentsSpeakerField,
+    this.segmentsSpeakerIdField,
+    this.segmentsIsUserField,
+    this.segmentsPersonIdField,
+    this.segmentsTranslationsField,
     this.textPath = 'text',
     this.defaultSegmentDuration = 5.0,
   });
@@ -117,6 +124,10 @@ class SttResponseSchema {
       segmentsStartField: json['segments_start_field'] as String?,
       segmentsEndField: json['segments_end_field'] as String?,
       segmentsSpeakerField: json['segments_speaker_field'] as String?,
+      segmentsSpeakerIdField: json['segments_speaker_id_field'] as String?,
+      segmentsIsUserField: json['segments_is_user_field'] as String?,
+      segmentsPersonIdField: json['segments_person_id_field'] as String?,
+      segmentsTranslationsField: json['segments_translations_field'] as String?,
       textPath: json['text_path'] as String?,
       defaultSegmentDuration: (json['default_segment_duration'] as num?)?.toDouble() ?? 5.0,
     );
@@ -128,6 +139,10 @@ class SttResponseSchema {
     'segments_start_field': segmentsStartField,
     'segments_end_field': segmentsEndField,
     'segments_speaker_field': segmentsSpeakerField,
+    'segments_speaker_id_field': segmentsSpeakerIdField,
+    'segments_is_user_field': segmentsIsUserField,
+    'segments_person_id_field': segmentsPersonIdField,
+    'segments_translations_field': segmentsTranslationsField,
     'text_path': textPath,
     'default_segment_duration': defaultSegmentDuration,
   };

--- a/app/lib/models/stt_response_schema.dart
+++ b/app/lib/models/stt_response_schema.dart
@@ -134,18 +134,18 @@ class SttResponseSchema {
   }
 
   Map<String, dynamic> toJson() => {
-    'segments_path': segmentsPath,
-    'segments_text_field': segmentsTextField,
-    'segments_start_field': segmentsStartField,
-    'segments_end_field': segmentsEndField,
-    'segments_speaker_field': segmentsSpeakerField,
-    'segments_speaker_id_field': segmentsSpeakerIdField,
-    'segments_is_user_field': segmentsIsUserField,
-    'segments_person_id_field': segmentsPersonIdField,
-    'segments_translations_field': segmentsTranslationsField,
-    'text_path': textPath,
-    'default_segment_duration': defaultSegmentDuration,
-  };
+        'segments_path': segmentsPath,
+        'segments_text_field': segmentsTextField,
+        'segments_start_field': segmentsStartField,
+        'segments_end_field': segmentsEndField,
+        'segments_speaker_field': segmentsSpeakerField,
+        'segments_speaker_id_field': segmentsSpeakerIdField,
+        'segments_is_user_field': segmentsIsUserField,
+        'segments_person_id_field': segmentsPersonIdField,
+        'segments_translations_field': segmentsTranslationsField,
+        'text_path': textPath,
+        'default_segment_duration': defaultSegmentDuration,
+      };
 }
 
 class JsonPathNavigator {

--- a/app/lib/models/stt_result.dart
+++ b/app/lib/models/stt_result.dart
@@ -149,9 +149,8 @@ class SttTranscriptionResult {
 
           final speakerValue = _schemaValue(seg, schema.segmentsSpeakerField, 'speaker');
           final speakerIdValue = _schemaValue(seg, schema.segmentsSpeakerIdField, 'speaker_id');
-          final speakerId = speakerIdValue != null
-              ? _extractSpeakerId(speakerIdValue)
-              : _extractSpeakerId(speakerValue);
+          final speakerId =
+              speakerIdValue != null ? _extractSpeakerId(speakerIdValue) : _extractSpeakerId(speakerValue);
           final speaker = _extractSpeakerLabel(speakerValue, speakerId);
           final isUser = _extractBool(_schemaValue(seg, schema.segmentsIsUserField, 'is_user'));
           final personId = _extractNullableString(_schemaValue(seg, schema.segmentsPersonIdField, 'person_id'));

--- a/app/lib/models/stt_result.dart
+++ b/app/lib/models/stt_result.dart
@@ -26,14 +26,76 @@ int _extractSpeakerId(dynamic value) {
   return 0;
 }
 
+String _extractSpeakerLabel(dynamic value, int speakerId) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+  return 'SPEAKER_$speakerId';
+}
+
+bool _extractBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    final normalized = value.trim().toLowerCase();
+    if (normalized == 'true' || normalized == '1' || normalized == 'yes') return true;
+    if (normalized == 'false' || normalized == '0' || normalized == 'no') return false;
+  }
+  return false;
+}
+
+String? _extractNullableString(dynamic value) {
+  if (value == null) return null;
+  final text = value.toString().trim();
+  return text.isEmpty ? null : text;
+}
+
+List<dynamic>? _extractTranslations(dynamic value) {
+  if (value is List) return value;
+  return null;
+}
+
+dynamic _schemaValue(dynamic json, String? configuredPath, String fallbackPath) {
+  if (configuredPath != null) {
+    return JsonPathNavigator.getValue(json, configuredPath);
+  }
+  return JsonPathNavigator.getValue(json, fallbackPath);
+}
+
 /// A single segment of transcribed text with timing - matches backend TranscriptSegment
 class SttSegment {
   final String text;
   final double start;
   final double end;
+  final String speaker;
   final int speakerId;
+  final bool isUser;
+  final String? personId;
+  final List<dynamic>? translations;
 
-  SttSegment({required this.text, required this.start, required this.end, this.speakerId = 0});
+  SttSegment({
+    required this.text,
+    required this.start,
+    required this.end,
+    String? speaker,
+    this.speakerId = 0,
+    this.isUser = false,
+    this.personId,
+    this.translations,
+  }) : speaker = speaker ?? 'SPEAKER_$speakerId';
+
+  Map<String, dynamic> toTranscriptSegmentJson() {
+    return {
+      'text': text.trim(),
+      'speaker': speaker,
+      'speaker_id': speakerId,
+      'is_user': isUser,
+      'start': start,
+      'end': end,
+      'person_id': personId,
+      if (translations != null) 'translations': translations,
+    };
+  }
 }
 
 class SttTranscriptionResult {
@@ -85,12 +147,30 @@ class SttTranscriptionResult {
             }
           }
 
-          // Extract speaker ID from speaker field
-          final speakerValue = schema.segmentsSpeakerField != null
-              ? JsonPathNavigator.getValue(seg, schema.segmentsSpeakerField)
-              : null;
+          final speakerValue = _schemaValue(seg, schema.segmentsSpeakerField, 'speaker');
+          final speakerIdValue = _schemaValue(seg, schema.segmentsSpeakerIdField, 'speaker_id');
+          final speakerId = speakerIdValue != null
+              ? _extractSpeakerId(speakerIdValue)
+              : _extractSpeakerId(speakerValue);
+          final speaker = _extractSpeakerLabel(speakerValue, speakerId);
+          final isUser = _extractBool(_schemaValue(seg, schema.segmentsIsUserField, 'is_user'));
+          final personId = _extractNullableString(_schemaValue(seg, schema.segmentsPersonIdField, 'person_id'));
+          final translations = _extractTranslations(
+            _schemaValue(seg, schema.segmentsTranslationsField, 'translations'),
+          );
 
-          segments.add(SttSegment(text: text, start: start, end: end, speakerId: _extractSpeakerId(speakerValue)));
+          segments.add(
+            SttSegment(
+              text: text,
+              start: start,
+              end: end,
+              speaker: speaker,
+              speakerId: speakerId,
+              isUser: isUser,
+              personId: personId,
+              translations: translations,
+            ),
+          );
         }
       }
     }

--- a/app/lib/models/stt_result.dart
+++ b/app/lib/models/stt_result.dart
@@ -191,3 +191,32 @@ class SttTranscriptionResult {
     return SttTranscriptionResult(segments: segments, rawText: rawText);
   }
 }
+
+List<Map<String, dynamic>> mergeTranscriptSegmentsBySpeaker(Iterable<SttSegment> sourceSegments) {
+  final segments = <Map<String, dynamic>>[];
+
+  for (final segment in sourceSegments) {
+    if (segment.text.trim().isEmpty) continue;
+
+    final segmentJson = segment.toTranscriptSegmentJson();
+    final hasTranslations = segment.translations != null && segment.translations!.isNotEmpty;
+    final lastTranslations = segments.isNotEmpty ? segments.last['translations'] : null;
+    final lastHasTranslations = lastTranslations is List && lastTranslations.isNotEmpty;
+
+    if (segments.isEmpty ||
+        segments.last['speaker'] != segmentJson['speaker'] ||
+        segments.last['speaker_id'] != segmentJson['speaker_id'] ||
+        segments.last['is_user'] != segmentJson['is_user'] ||
+        segments.last['person_id'] != segmentJson['person_id'] ||
+        lastHasTranslations ||
+        hasTranslations) {
+      segments.add(segmentJson);
+    } else {
+      final last = segments.last;
+      last['text'] = '${last['text']} ${segment.text.trim()}';
+      last['end'] = segment.end;
+    }
+  }
+
+  return segments;
+}

--- a/app/lib/services/sockets/pure_polling.dart
+++ b/app/lib/services/sockets/pure_polling.dart
@@ -154,10 +154,8 @@ class PurePollingSocket implements IPureSocket {
         if (result.segments.isNotEmpty) {
           _audioOffsetSeconds = result.segments.last.end;
         }
-        final segmentsJson = result.segments
-            .where((s) => s.text.trim().isNotEmpty)
-            .map((s) => s.toTranscriptSegmentJson())
-            .toList();
+        final segmentsJson =
+            result.segments.where((s) => s.text.trim().isNotEmpty).map((s) => s.toTranscriptSegmentJson()).toList();
         if (segmentsJson.isNotEmpty) {
           onMessage(jsonEncode(segmentsJson));
         }

--- a/app/lib/services/sockets/pure_polling.dart
+++ b/app/lib/services/sockets/pure_polling.dart
@@ -156,16 +156,7 @@ class PurePollingSocket implements IPureSocket {
         }
         final segmentsJson = result.segments
             .where((s) => s.text.trim().isNotEmpty)
-            .map(
-              (s) => {
-                'text': s.text.trim(),
-                'speaker': 'SPEAKER_${s.speakerId}',
-                'speaker_id': s.speakerId,
-                'is_user': false,
-                'start': s.start,
-                'end': s.end,
-              },
-            )
+            .map((s) => s.toTranscriptSegmentJson())
             .toList();
         if (segmentsJson.isNotEmpty) {
           onMessage(jsonEncode(segmentsJson));

--- a/app/lib/services/sockets/pure_streaming_stt.dart
+++ b/app/lib/services/sockets/pure_streaming_stt.dart
@@ -530,19 +530,19 @@ class PureStreamingSttSocket implements IPureSocket {
         for (final segment in result.segments) {
           if (segment.text.trim().isEmpty) continue;
 
-          final speakerId = segment.speakerId;
-          final speaker = 'SPEAKER_$speakerId';
+          final segmentJson = segment.toTranscriptSegmentJson();
+          final speaker = segmentJson['speaker'];
+          final hasTranslations = segment.translations != null && segment.translations!.isNotEmpty;
+          final lastTranslations = segments.isNotEmpty ? segments.last['translations'] : null;
+          final lastHasTranslations = lastTranslations is List && lastTranslations.isNotEmpty;
 
-          if (segments.isEmpty || segments.last['speaker'] != speaker) {
-            segments.add({
-              'text': segment.text.trim(),
-              'speaker': speaker,
-              'speaker_id': speakerId,
-              'is_user': false,
-              'start': segment.start,
-              'end': segment.end,
-              'person_id': null,
-            });
+          if (segments.isEmpty ||
+              segments.last['speaker'] != speaker ||
+              segments.last['is_user'] != segmentJson['is_user'] ||
+              segments.last['person_id'] != segmentJson['person_id'] ||
+              lastHasTranslations ||
+              hasTranslations) {
+            segments.add(segmentJson);
           } else {
             final last = segments.last;
             last['text'] = '${last['text']} ${segment.text.trim()}';

--- a/app/lib/services/sockets/pure_streaming_stt.dart
+++ b/app/lib/services/sockets/pure_streaming_stt.dart
@@ -526,29 +526,7 @@ class PureStreamingSttSocket implements IPureSocket {
         }
 
         // Aggregate words by speaker (matching backend TranscriptSegment format)
-        final segments = <Map<String, dynamic>>[];
-        for (final segment in result.segments) {
-          if (segment.text.trim().isEmpty) continue;
-
-          final segmentJson = segment.toTranscriptSegmentJson();
-          final speaker = segmentJson['speaker'];
-          final hasTranslations = segment.translations != null && segment.translations!.isNotEmpty;
-          final lastTranslations = segments.isNotEmpty ? segments.last['translations'] : null;
-          final lastHasTranslations = lastTranslations is List && lastTranslations.isNotEmpty;
-
-          if (segments.isEmpty ||
-              segments.last['speaker'] != speaker ||
-              segments.last['is_user'] != segmentJson['is_user'] ||
-              segments.last['person_id'] != segmentJson['person_id'] ||
-              lastHasTranslations ||
-              hasTranslations) {
-            segments.add(segmentJson);
-          } else {
-            final last = segments.last;
-            last['text'] = '${last['text']} ${segment.text.trim()}';
-            last['end'] = segment.end;
-          }
-        }
+        final segments = mergeTranscriptSegmentsBySpeaker(result.segments);
 
         if (segments.isNotEmpty) {
           onMessage(jsonEncode(segments));

--- a/app/test/unit/stt_result_test.dart
+++ b/app/test/unit/stt_result_test.dart
@@ -94,5 +94,19 @@ void main() {
       expect(segment.speakerId, 3);
       expect(segment.speaker, 'SPEAKER_3');
     });
+
+    test('merges adjacent transcript segments only when speaker identity matches', () {
+      final merged = mergeTranscriptSegmentsBySpeaker([
+        SttSegment(text: 'same', start: 0, end: 1, speaker: 'Participant', speakerId: 1),
+        SttSegment(text: 'speaker', start: 1, end: 2, speaker: 'Participant', speakerId: 1),
+        SttSegment(text: 'different id', start: 2, end: 3, speaker: 'Participant', speakerId: 2),
+      ]);
+
+      expect(merged, hasLength(2));
+      expect(merged.first['text'], 'same speaker');
+      expect(merged.first['speaker_id'], 1);
+      expect(merged.last['text'], 'different id');
+      expect(merged.last['speaker_id'], 2);
+    });
   });
 }

--- a/app/test/unit/stt_result_test.dart
+++ b/app/test/unit/stt_result_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/models/stt_response_schema.dart';
+import 'package:omi/models/stt_result.dart';
+
+void main() {
+  group('SttTranscriptionResult', () {
+    test('preserves TranscriptSegment-compatible metadata by default', () {
+      final result = SttTranscriptionResult.fromJsonWithSchema({
+        'segments': [
+          {
+            'text': 'hello',
+            'speaker': 'SPEAKER_00',
+            'speaker_id': 0,
+            'is_user': true,
+            'person_id': 'user-person',
+            'start': 0.0,
+            'end': 1.0,
+            'translations': [
+              {'lang': 'es', 'text': 'hola'},
+            ],
+          },
+          {
+            'text': 'there',
+            'speaker': 'SPEAKER_01',
+            'speaker_id': 1,
+            'is_user': false,
+            'person_id': 'other-person',
+            'start': 1.0,
+            'end': 2.0,
+          },
+        ],
+      }, const SttResponseSchema());
+
+      expect(result.segments, hasLength(2));
+
+      final first = result.segments.first.toTranscriptSegmentJson();
+      expect(first['speaker'], 'SPEAKER_00');
+      expect(first['speaker_id'], 0);
+      expect(first['is_user'], true);
+      expect(first['person_id'], 'user-person');
+      expect(first['translations'], [
+        {'lang': 'es', 'text': 'hola'},
+      ]);
+
+      final second = result.segments.last.toTranscriptSegmentJson();
+      expect(second['speaker'], 'SPEAKER_01');
+      expect(second['speaker_id'], 1);
+      expect(second['is_user'], false);
+      expect(second['person_id'], 'other-person');
+    });
+
+    test('supports explicit metadata field mappings', () {
+      final result = SttTranscriptionResult.fromJsonWithSchema(
+        {
+          'items': [
+            {
+              'word': 'mapped',
+              'times': {'start': 4.0, 'end': 5.5},
+              'speaker_meta': {'label': 'SPEAKER_07', 'id': 7},
+              'owner': {'is_user': 'true', 'person': 'person-7'},
+            },
+          ],
+        },
+        const SttResponseSchema(
+          segmentsPath: 'items',
+          segmentsTextField: 'word',
+          segmentsStartField: 'times.start',
+          segmentsEndField: 'times.end',
+          segmentsSpeakerField: 'speaker_meta.label',
+          segmentsSpeakerIdField: 'speaker_meta.id',
+          segmentsIsUserField: 'owner.is_user',
+          segmentsPersonIdField: 'owner.person',
+        ),
+      );
+
+      final segment = result.segments.single;
+      expect(segment.text, 'mapped');
+      expect(segment.start, 4.0);
+      expect(segment.end, 5.5);
+      expect(segment.speaker, 'SPEAKER_07');
+      expect(segment.speakerId, 7);
+      expect(segment.isUser, true);
+      expect(segment.personId, 'person-7');
+    });
+
+    test('derives speaker label from speaker id when no label is present', () {
+      final result = SttTranscriptionResult.fromJsonWithSchema({
+        'segments': [
+          {'text': 'numbered', 'speaker_id': 3, 'start': 1.0, 'end': 2.0},
+        ],
+      }, const SttResponseSchema());
+
+      final segment = result.segments.single;
+      expect(segment.speakerId, 3);
+      expect(segment.speaker, 'SPEAKER_3');
+    });
+  });
+}


### PR DESCRIPTION
Just a note before I proceed, I know the last batch of PRs probably came across as noisy. Sorry about that. I am going to keep these more focused and better tested instead of sending a bunch of tiny one-off changes.

## Summary

Custom STT providers can return segment objects that already match the backend transcript shape, including `speaker`, `speaker_id`, `is_user`, `person_id`, and `translations`.

The app parser was only carrying text, timing, and a derived speaker id. The socket forwarding code then rebuilt every segment with `is_user: false` and no `person_id`, so caller-provided speaker ownership metadata was lost before it reached `/v4/listen`.

Closes #7982.

## Root cause

`SttTranscriptionResult.fromJsonWithSchema` only extracted the configured speaker field and collapsed the rest of the per-segment metadata. `PureStreamingSttSocket` and `PurePollingSocket` then rebuilt backend payloads manually, which overwrote `is_user` and dropped `person_id` and `translations`.

## Change

- Add optional schema fields for `speaker_id`, `is_user`, `person_id`, and `translations`.
- Preserve TranscriptSegment-compatible fields by default when the provider already returns them.
- Forward parsed segments through a shared `toTranscriptSegmentJson()` payload builder.
- Keep streaming aggregation from merging across different user/person metadata or translated segments.
- Add unit coverage for native TranscriptSegment-shaped responses and explicit schema field mappings.

## Test plan

- `git diff --check`
- `dart format --output=none --set-exit-if-changed app/test/unit/stt_result_test.dart`

I could not run `flutter test` locally because this environment does not have the Flutter SDK on PATH. `dart test` fails during package resolution because `flutter_test` is SDK-provided.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

