### PR TITLE
fix(backend): retry developer webhook delivery with backoff

### DIFF
--- a/backend/testing/e2e/conftest.py
+++ b/backend/testing/e2e/conftest.py
@@ -90,6 +90,7 @@ def _set_e2e_env():
     os.environ["BUCKET_APP_THUMBNAILS"] = "app-thumbnails"
     os.environ["BUCKET_CHAT_FILES"] = "chat-files"
     os.environ["BUCKET_DESKTOP_UPDATES"] = "desktop-updates"
+    os.environ["DEV_WEBHOOK_RETRY_DELAYS"] = "0,0,0"
     # Disable Stripe validation so startup doesn't fail.
     os.environ["STRIPE_SECRET_KEY"] = ""
     os.environ["ADMIN_KEY"] = ""

--- a/backend/tests/unit/test_webhook_auto_disable.py
+++ b/backend/tests/unit/test_webhook_auto_disable.py
@@ -320,6 +320,59 @@ class TestDevWebhookHealthTracking:
 class TestDevWebhookAutoDisable:
     """Test developer webhook auto-disable integration in webhooks.py."""
 
+    def test_append_query_params_preserves_existing_query(self):
+        from utils.webhooks import _append_query_params
+
+        result = _append_query_params(
+            "https://example.com/webhook?token=abc&uid=stale",
+            {"uid": "uid-1", "sample_rate": 16000},
+        )
+
+        assert result == "https://example.com/webhook?token=abc&uid=uid-1&sample_rate=16000"
+
+    def test_retry_delays_can_be_overridden_by_env(self, monkeypatch):
+        from utils.webhooks import _get_dev_webhook_retry_delays
+
+        monkeypatch.setenv("DEV_WEBHOOK_RETRY_DELAYS", "0,0.25,1")
+
+        assert _get_dev_webhook_retry_delays() == (0.0, 0.25, 1.0)
+
+    @pytest.mark.asyncio
+    async def test_post_dev_webhook_retries_until_success(self):
+        from utils.webhooks import _post_dev_webhook
+
+        responses = [MagicMock(status_code=500), MagicMock(status_code=502), MagicMock(status_code=200)]
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=responses)
+
+        mock_sem = AsyncMock()
+        mock_sem.__aenter__ = AsyncMock()
+        mock_sem.__aexit__ = AsyncMock()
+
+        sleep_calls = []
+
+        async def fake_sleep(delay):
+            sleep_calls.append(delay)
+
+        with (
+            patch("utils.webhooks.get_webhook_client", return_value=mock_client),
+            patch("utils.webhooks.get_webhook_semaphore", return_value=mock_sem),
+            patch("utils.webhooks.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            response = await _post_dev_webhook(
+                "test_webhook",
+                "https://example.com/webhook",
+                json={"hello": "world"},
+                retry_delays=(0.1, 0.2),
+            )
+
+        assert response.status_code == 200
+        assert mock_client.post.await_count == 3
+        assert sleep_calls == [0.1, 0.2]
+        idempotency_keys = [call.kwargs["headers"]["Idempotency-Key"] for call in mock_client.post.await_args_list]
+        assert len(set(idempotency_keys)) == 1
+        assert idempotency_keys[0]
+
     @pytest.mark.asyncio
     async def test_dev_webhook_disabled_on_threshold(self):
         """When failure threshold exceeded, disable_user_webhook_db should be called."""
@@ -340,6 +393,7 @@ class TestDevWebhookAutoDisable:
             patch("utils.webhooks.record_dev_webhook_failure", return_value=True) as mock_fail,
             patch("utils.webhooks.disable_user_webhook_db") as mock_disable,
             patch("utils.webhooks.send_notification") as mock_notify,
+            patch("utils.webhooks._DEV_WEBHOOK_RETRY_DELAYS", ()),
         ):
             await realtime_transcript_webhook("uid-1", [{"text": "hello"}])
             mock_fail.assert_called_once()
@@ -388,12 +442,54 @@ class TestDevWebhookAutoDisable:
             patch("utils.webhooks.get_webhook_client", return_value=mock_client),
             patch("utils.webhooks.get_webhook_circuit_breaker", return_value=mock_cb),
             patch("utils.webhooks.record_dev_webhook_failure", return_value=False) as mock_fail,
+            patch("utils.webhooks._DEV_WEBHOOK_RETRY_DELAYS", ()),
         ):
             await realtime_transcript_webhook("uid-1", [{"text": "hello"}])
             mock_fail.assert_called_once()
             args = mock_fail.call_args[0]
             assert args[2] == 0
             assert args[3] == 'ConnectionError'
+
+    @pytest.mark.asyncio
+    async def test_realtime_transcript_retry_success_records_success_only(self):
+        from utils.webhooks import realtime_transcript_webhook
+
+        first_response = MagicMock()
+        first_response.status_code = 500
+        second_response = MagicMock()
+        second_response.status_code = 200
+        second_response.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[first_response, second_response])
+
+        mock_cb = MagicMock()
+        mock_cb.allow_request.return_value = True
+
+        mock_sem = AsyncMock()
+        mock_sem.__aenter__ = AsyncMock()
+        mock_sem.__aexit__ = AsyncMock()
+
+        sleep_calls = []
+
+        async def fake_sleep(delay):
+            sleep_calls.append(delay)
+
+        with (
+            patch("utils.webhooks.get_webhook_client", return_value=mock_client),
+            patch("utils.webhooks.get_webhook_circuit_breaker", return_value=mock_cb),
+            patch("utils.webhooks.get_webhook_semaphore", return_value=mock_sem),
+            patch("utils.webhooks.record_dev_webhook_success") as mock_success,
+            patch("utils.webhooks.record_dev_webhook_failure") as mock_fail,
+            patch("utils.webhooks._DEV_WEBHOOK_RETRY_DELAYS", (0.01,)),
+            patch("utils.webhooks.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await realtime_transcript_webhook("uid-1", [{"text": "hello"}])
+
+        assert mock_client.post.await_count == 2
+        assert sleep_calls == [0.01]
+        mock_success.assert_called_once()
+        mock_fail.assert_not_called()
 
 
 class TestDisableAppInFirestore:
@@ -2005,6 +2101,7 @@ class TestDevWebhookIntegrationPaths:
             patch("utils.webhooks.get_webhook_client", return_value=mock_client),
             patch("utils.webhooks.get_webhook_circuit_breaker", return_value=mock_cb),
             patch("utils.webhooks.get_webhook_semaphore", return_value=mock_sem),
+            patch("utils.webhooks._DEV_WEBHOOK_RETRY_DELAYS", ()),
         ):
             mock_memory = MagicMock()
             mock_memory.is_locked = False
@@ -2041,6 +2138,7 @@ class TestDevWebhookIntegrationPaths:
             patch("utils.webhooks.get_webhook_client", return_value=mock_client),
             patch("utils.webhooks.get_webhook_circuit_breaker", return_value=mock_cb),
             patch("utils.webhooks.get_webhook_semaphore", return_value=mock_sem),
+            patch("utils.webhooks._DEV_WEBHOOK_RETRY_DELAYS", ()),
         ):
             mock_memory = MagicMock()
             mock_memory.is_locked = False

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
+import os
+import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from database.redis_db import (
     get_user_webhook_db,
@@ -23,10 +26,95 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
+
+
+def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
+    raw_delays = os.getenv('DEV_WEBHOOK_RETRY_DELAYS')
+    if raw_delays is None:
+        return _DEV_WEBHOOK_RETRY_DELAYS
+    try:
+        return tuple(float(delay.strip()) for delay in raw_delays.split(',') if delay.strip())
+    except ValueError:
+        logger.warning(f'Invalid DEV_WEBHOOK_RETRY_DELAYS={raw_delays!r}; using default schedule')
+        return _DEV_WEBHOOK_RETRY_DELAYS
+
+
+def _append_query_params(url: str, params: dict) -> str:
+    parts = urlsplit(url)
+    param_keys = {key for key, value in params.items() if value is not None}
+    query_items = [
+        (key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if key not in param_keys
+    ]
+    query_items.extend((key, str(value)) for key, value in params.items() if value is not None)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query_items), parts.fragment))
+
+
+async def _post_dev_webhook(
+    webhook_name: str,
+    webhook_url: str,
+    *,
+    retry_delays: Optional[tuple[float, ...]] = None,
+    idempotency_key: Optional[str] = None,
+    **request_kwargs,
+):
+    if retry_delays is None:
+        retry_delays = _get_dev_webhook_retry_delays()
+
+    headers = dict(request_kwargs.pop('headers', {}) or {})
+    headers.setdefault('Idempotency-Key', idempotency_key or str(uuid.uuid4()))
+    request_kwargs['headers'] = headers
+
+    client = get_webhook_client()
+    attempts = len(retry_delays) + 1
+    last_response = None
+    last_exception = None
+
+    for attempt_index in range(attempts):
+        attempt_number = attempt_index + 1
+        failure_reason = None
+        try:
+            async with get_webhook_semaphore():
+                response = await client.post(webhook_url, **request_kwargs)
+            last_response = response
+            last_exception = None
+            if 200 <= response.status_code < 300:
+                logger.info(
+                    f'{webhook_name}: delivery succeeded status={response.status_code} '
+                    f'attempt={attempt_number}/{attempts} url={webhook_url}'
+                )
+                return response
+            failure_reason = f'HTTP {response.status_code}'
+        except Exception as e:
+            last_response = None
+            last_exception = e
+            failure_reason = type(e).__name__
+
+        if attempt_index < len(retry_delays):
+            delay = retry_delays[attempt_index]
+            logger.warning(
+                f'{webhook_name}: delivery failed reason={failure_reason} '
+                f'attempt={attempt_number}/{attempts}; retrying in {delay:g}s'
+            )
+            await asyncio.sleep(delay)
+
+    if last_response is not None:
+        logger.error(
+            f'{webhook_name}: delivery failed status={last_response.status_code} attempts={attempts} url={webhook_url}'
+        )
+        return last_response
+
+    if last_exception is None:
+        raise RuntimeError(f'{webhook_name}: delivery failed without a response or exception')
+    logger.error(f'{webhook_name}: delivery failed error={type(last_exception).__name__} attempts={attempts}')
+    raise last_exception
+
 
 async def _handle_dev_webhook_disable(uid: str, wtype: str, should_disable: bool):
     if should_disable:
-        logger.warning(f'Dev webhook auto-disabled: uid={uid} type={wtype} after {100} consecutive failures')
+        logger.warning(
+            f'Dev webhook auto-disabled: uid={uid} type={wtype} after {_DEV_FAILURE_THRESHOLD} consecutive failures'
+        )
         await run_blocking(db_executor, disable_user_webhook_db, uid, wtype)
         wtype_str = wtype.value if hasattr(wtype, 'value') else str(wtype)
         await run_blocking(
@@ -56,21 +144,19 @@ async def conversation_created_webhook(uid, memory: Conversation):
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.memory_created)
         if not webhook_url:
             return
-        webhook_url += f'?uid={uid}'
+        webhook_url = _append_query_params(webhook_url, {'uid': uid})
         cb = get_webhook_circuit_breaker(webhook_url)
         if not cb.allow_request():
             logger.info(f'memory_created_webhook: circuit breaker open for {webhook_url[:80]}')
             return
         try:
             payload = await run_blocking(db_executor, _build_conversation_webhook_payload_sync, uid, memory)
-            async with get_webhook_semaphore():
-                client = get_webhook_client()
-                response = await client.post(
-                    webhook_url,
-                    json=payload,
-                    headers={'Content-Type': 'application/json'},
-                )
-            logger.info(f'memory_created_webhook: {webhook_url} {response.status_code}')
+            response = await _post_dev_webhook(
+                'memory_created_webhook',
+                webhook_url,
+                json=payload,
+                headers={'Content-Type': 'application/json'},
+            )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
                 await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.memory_created)
@@ -109,25 +195,23 @@ async def day_summary_webhook(uid, summary: str, summary_json: Optional[dict] = 
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.day_summary)
         if not webhook_url:
             return
-        webhook_url += f'?uid={uid}'
+        webhook_url = _append_query_params(webhook_url, {'uid': uid})
         cb = get_webhook_circuit_breaker(webhook_url)
         if not cb.allow_request():
             logger.info(f'day_summary_webhook: circuit breaker open for {webhook_url[:80]}')
             return
         try:
-            async with get_webhook_semaphore():
-                client = get_webhook_client()
-                response = await client.post(
-                    webhook_url,
-                    json={
-                        'summary': summary,
-                        'summary_json': summary_json,
-                        'uid': uid,
-                        'created_at': datetime.now(timezone.utc).isoformat(),
-                    },
-                    headers={'Content-Type': 'application/json'},
-                )
-            logger.info(f'day_summary_webhook: {webhook_url} {response.status_code}')
+            response = await _post_dev_webhook(
+                'day_summary_webhook',
+                webhook_url,
+                json={
+                    'summary': summary,
+                    'summary_json': summary_json,
+                    'uid': uid,
+                    'created_at': datetime.now(timezone.utc).isoformat(),
+                },
+                headers={'Content-Type': 'application/json'},
+            )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
                 await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.day_summary)
@@ -161,20 +245,18 @@ async def realtime_transcript_webhook(uid, segments: List[dict]):
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.realtime_transcript)
         if not webhook_url:
             return
-        webhook_url += f'?uid={uid}'
+        webhook_url = _append_query_params(webhook_url, {'uid': uid})
         cb = get_webhook_circuit_breaker(webhook_url)
         if not cb.allow_request():
             logger.info(f'realtime_transcript_webhook: circuit breaker open for {webhook_url[:80]}')
             return
         try:
-            async with get_webhook_semaphore():
-                client = get_webhook_client()
-                response = await client.post(
-                    webhook_url,
-                    json={'segments': segments, 'session_id': uid},
-                    headers={'Content-Type': 'application/json'},
-                )
-            logger.info(f'realtime_transcript_webhook: {webhook_url} {response.status_code}')
+            response = await _post_dev_webhook(
+                'realtime_transcript_webhook',
+                webhook_url,
+                json={'segments': segments, 'session_id': uid},
+                headers={'Content-Type': 'application/json'},
+            )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
                 await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.realtime_transcript)
@@ -238,18 +320,18 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         webhook_url = webhook_url.split(',')[0]
         if not webhook_url:
             return
-        webhook_url += f'?sample_rate={sample_rate}&uid={uid}'
+        webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
         cb = get_webhook_circuit_breaker(webhook_url)
         if not cb.allow_request():
             logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
             return
         try:
-            async with get_webhook_semaphore():
-                client = get_webhook_client()
-                response = await client.post(
-                    webhook_url, content=bytes(data), headers={'Content-Type': 'application/octet-stream'}
-                )
-            logger.info(f'send_audio_bytes_developer_webhook: {webhook_url} {response.status_code}')
+            response = await _post_dev_webhook(
+                'send_audio_bytes_developer_webhook',
+                webhook_url,
+                content=bytes(data),
+                headers={'Content-Type': 'application/octet-stream'},
+            )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
                 await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)


### PR DESCRIPTION
## Summary
- add retry/backoff around developer webhook delivery before recording the final health state
- send one Idempotency-Key header across all retry attempts for a delivery
- log success, retry, and final failure status for each developer webhook path
- preserve existing webhook query params when adding uid and sample_rate

Part of #5488. This covers the retry/backoff and delivery logging slice. It does not add the dead-letter queue or developer dashboard.

## Test plan
- python -m pytest backend/tests/unit/test_webhook_auto_disable.py::TestDevWebhookAutoDisable backend/tests/unit/test_webhook_auto_disable.py::TestDevWebhookIntegrationPaths -q
- python -m pytest backend/tests/unit/test_webhook_auto_disable.py -q
- python -m black --check --line-length 120 --skip-string-normalization backend/utils/webhooks.py backend/tests/unit/test_webhook_auto_disable.py backend/testing/e2e/conftest.py