### PR TITLE
fix phone call null check crash in startCall

### DIFF
--- a/app/lib/providers/phone_call_provider.dart
+++ b/app/lib/providers/phone_call_provider.dart
@@ -193,7 +193,8 @@ class PhoneCallProvider extends ChangeNotifier {
     _lastError = null;
     _callState = PhoneCallState.connecting;
     _remoteNumber = phoneNumber;
-    _currentCallId = DateTime.now().millisecondsSinceEpoch.toString();
+    final callId = DateTime.now().millisecondsSinceEpoch.toString();
+    _currentCallId = callId;
     _transcriptSegments.clear();
     _isMuted = false;
     _isSpeakerOn = false;
@@ -236,7 +237,7 @@ class PhoneCallProvider extends ChangeNotifier {
     // Make the call via native layer
     var callStarted = await _nativeService.makeCall(
       phoneNumber: phoneNumber,
-      callId: _currentCallId!,
+      callId: callId,
       contactName: _contactName,
     );
 


### PR DESCRIPTION
## PhoneCallProvider.startCall
**FlutterError - Null check operator used on a null value**

`package:omi/providers/phone_call_provider.dart:207`

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/c3a640240d0e5d0dfe67c8fb1cea1dd7?time=7d&types=crash&sessionEventKey=abc8257014d14a3dbbf0fabc81a7cb0d_2232987816919466335

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 PhoneCallProvider.startCall + 239 (phone_call_provider.dart:239)
1  ???                            0x0 _PhoneCallsPageState._makeCall + 122 (phone_calls_page.dart:122)
```

## Root Cause

`startCall` set `_currentCallId` at the top of the method, then performed three `await` calls before using it with `!`:

```dart
_currentCallId = DateTime.now().millisecondsSinceEpoch.toString();
// ...
await Permission.microphone.request()   // await 1
await api.getPhoneCallToken()           // await 2
await _nativeService.initialize(...)    // await 3

callId: _currentCallId!,  // ← crash here if _currentCallId was nulled during awaits
```

During any of those awaits, the native layer can fire a call-state event that triggers `_onCallEnded`, which schedules a `Future.delayed(2s)` that sets `_currentCallId = null`. If that timer fires before execution resumes, the `!` crashes.

## Fix

Capture `callId` into a local variable immediately when assigned and use it for the `makeCall` invocation. Local variables are not affected by concurrent async mutations to instance fields.

```dart
final callId = DateTime.now().millisecondsSinceEpoch.toString();
_currentCallId = callId;
// ...
callId: callId,  // safe — local variable can't be nulled externally
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

