### PR TITLE
Fix/4480 Add speaker-filtered conversation search

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -520,6 +520,7 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
   int? page,
   int? limit,
   bool includeDiscarded = true,
+  String? speakerId,
 }) async {
   Logger.debug(Env.apiBaseUrl);
   var response = await makeApiCall(
@@ -531,6 +532,7 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
       'page': page ?? 1,
       'per_page': limit ?? 10,
       'include_discarded': includeDiscarded,
+      if (speakerId != null) 'speaker_id': speakerId,
     }),
   );
   if (response == null) return (<ServerConversation>[], 0, 0);

--- a/app/lib/pages/conversations/widgets/search_widget.dart
+++ b/app/lib/pages/conversations/widgets/search_widget.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/home_provider.dart';
+import 'package:omi/pages/conversations/widgets/speaker_filter_sheet.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/debouncer.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
@@ -59,7 +60,7 @@ class _SearchWidgetState extends State<SearchWidget> {
 
     // Hide search bar if focus is lost and there's no search query
     if (!_homeProvider!.isConvoSearchFieldFocused &&
-        _convoProvider!.previousQuery.isEmpty &&
+        !_convoProvider!.hasActiveSearch &&
         _homeProvider!.showConvoSearchBar) {
       _homeProvider!.hideConvoSearchBar();
     }
@@ -201,8 +202,9 @@ class _SearchWidgetState extends State<SearchWidget> {
                           await provider.searchConversations(""); // clear
                           searchController.clear();
                           setShowClearButton();
-                          // Hide search bar when search is cleared
-                          homeProvider.hideConvoSearchBar();
+                          if (!provider.hasActiveSearch) {
+                            homeProvider.hideConvoSearchBar();
+                          }
                           PlatformManager.instance.analytics.searchQueryCleared();
                         },
                         child: const Icon(Icons.close, color: Colors.white),
@@ -212,6 +214,30 @@ class _SearchWidgetState extends State<SearchWidget> {
               ),
               style: const TextStyle(color: Colors.white),
             ),
+          ),
+          const SizedBox(width: 8),
+          Consumer<ConversationProvider>(
+            builder: (context, convoProvider, _) {
+              final isActive = convoProvider.selectedSpeakerId != null;
+              return Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: isActive ? Colors.deepPurple.withValues(alpha: 0.5) : const Color(0xFF1F1F25),
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: IconButton(
+                  key: const Key('conversation_speaker_filter'),
+                  padding: EdgeInsets.zero,
+                  tooltip: context.l10n.phoneSpeaker,
+                  icon: Icon(Icons.person_search, size: 20, color: isActive ? Colors.white : Colors.white70),
+                  onPressed: () async {
+                    HapticFeedback.mediumImpact();
+                    await showSpeakerFilterSheet(context);
+                  },
+                ),
+              );
+            },
           ),
           const SizedBox(width: 8),
           // Calendar button - same height as search bar (48px)

--- a/app/lib/pages/conversations/widgets/speaker_filter_sheet.dart
+++ b/app/lib/pages/conversations/widgets/speaker_filter_sheet.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/schema/person.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/providers/people_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+typedef SpeakerSelected = Future<void> Function(String? speakerId);
+
+Future<void> showSpeakerFilterSheet(BuildContext context) async {
+  final conversationProvider = context.read<ConversationProvider>();
+  final people = context.read<PeopleProvider>().people;
+
+  await showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: const Color(0xFF1F1F25),
+    showDragHandle: true,
+    builder: (sheetContext) {
+      return SpeakerFilterSheet(
+        people: people,
+        selectedSpeakerId: conversationProvider.selectedSpeakerId,
+        title: context.l10n.phoneSpeaker,
+        allLabel: context.l10n.all,
+        userLabel: context.l10n.speakerLabelYou,
+        onSelected: (speakerId) async {
+          Navigator.of(sheetContext).pop();
+          await conversationProvider.setSpeakerFilter(speakerId);
+        },
+      );
+    },
+  );
+}
+
+class SpeakerFilterSheet extends StatelessWidget {
+  const SpeakerFilterSheet({
+    super.key,
+    required this.people,
+    required this.selectedSpeakerId,
+    required this.title,
+    required this.allLabel,
+    required this.userLabel,
+    required this.onSelected,
+  });
+
+  final List<Person> people;
+  final String? selectedSpeakerId;
+  final String title;
+  final String allLabel;
+  final String userLabel;
+  final SpeakerSelected onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.7),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+            ),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  _speakerTile(
+                    key: const Key('speaker_filter_all'),
+                    name: allLabel,
+                    speakerId: null,
+                    icon: Icons.people_outline,
+                  ),
+                  _speakerTile(
+                    key: const Key('speaker_filter_user'),
+                    name: userLabel,
+                    speakerId: 'user',
+                    icon: Icons.person_outline,
+                  ),
+                  for (final person in people)
+                    _speakerTile(
+                      key: Key('speaker_filter_${person.id}'),
+                      name: person.name,
+                      speakerId: person.id,
+                      icon: Icons.person_outline,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _speakerTile({
+    required Key key,
+    required String name,
+    required String? speakerId,
+    required IconData icon,
+  }) {
+    final selected = speakerId == selectedSpeakerId;
+    return ListTile(
+      key: key,
+      leading: Icon(icon),
+      title: Text(name),
+      trailing: selected ? const Icon(Icons.check, color: Colors.deepPurpleAccent) : null,
+      onTap: () async {
+        await onSelected(speakerId);
+      },
+    );
+  }
+}

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -26,6 +26,7 @@ class ConversationProvider extends ChangeNotifier {
   bool hasDailySummaries = false; // whether user has any daily summaries
   DateTime? selectedDate;
   String? selectedFolderId;
+  String? selectedSpeakerId;
 
   String previousQuery = '';
   int totalSearchPages = 1;
@@ -68,6 +69,7 @@ class ConversationProvider extends ChangeNotifier {
   // The empty-state widget should defer to a pending auto-retry so the user
   // doesn't see "No conversations yet" in the gap between backoff attempts.
   bool get isAwaitingInitialFetchRetry => _initialFetchRetryTimer?.isActive ?? false;
+  bool get hasActiveSearch => previousQuery.isNotEmpty || selectedSpeakerId != null;
 
   ConversationProvider() {
     _setupMergeListener();
@@ -103,6 +105,7 @@ class ConversationProvider extends ChangeNotifier {
     hasDailySummaries = false;
     selectedDate = null;
     selectedFolderId = null;
+    selectedSpeakerId = null;
     previousQuery = '';
     totalSearchPages = 1;
     currentSearchPage = 1;
@@ -136,7 +139,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<void> searchConversations(String query, {bool showShimmer = false}) async {
-    if (query.isEmpty) {
+    if (query.isEmpty && selectedSpeakerId == null) {
       previousQuery = "";
       currentSearchPage = 0;
       totalSearchPages = 0;
@@ -152,7 +155,11 @@ class ConversationProvider extends ChangeNotifier {
     }
 
     previousQuery = query;
-    var (convos, current, total) = await searchConversationsServer(query, includeDiscarded: showDiscardedConversations);
+    var (convos, current, total) = await searchConversationsServer(
+      query,
+      includeDiscarded: showDiscardedConversations,
+      speakerId: selectedSpeakerId,
+    );
     convos.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     searchedConversations = convos;
     currentSearchPage = current;
@@ -168,6 +175,11 @@ class ConversationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setSpeakerFilter(String? speakerId) async {
+    selectedSpeakerId = speakerId;
+    await searchConversations(previousQuery, showShimmer: true);
+  }
+
   Future<void> searchMoreConversations() async {
     if (totalSearchPages < currentSearchPage + 1) {
       return;
@@ -177,6 +189,7 @@ class ConversationProvider extends ChangeNotifier {
       previousQuery,
       page: currentSearchPage + 1,
       includeDiscarded: showDiscardedConversations,
+      speakerId: selectedSpeakerId,
     );
     searchedConversations.addAll(newConvos);
     searchedConversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
@@ -223,7 +236,7 @@ class ConversationProvider extends ChangeNotifier {
     groupedConversations = {};
     notifyListeners();
 
-    if (previousQuery.isNotEmpty) {
+    if (hasActiveSearch) {
       searchConversations(previousQuery, showShimmer: true);
     } else {
       fetchConversations();
@@ -240,7 +253,7 @@ class ConversationProvider extends ChangeNotifier {
     groupedConversations = {};
     notifyListeners();
 
-    if (previousQuery.isNotEmpty) {
+    if (hasActiveSearch) {
       searchConversations(previousQuery, showShimmer: true);
     } else {
       fetchConversations();
@@ -255,7 +268,7 @@ class ConversationProvider extends ChangeNotifier {
     groupedConversations = {};
     notifyListeners();
 
-    if (previousQuery.isNotEmpty) {
+    if (hasActiveSearch) {
       searchConversations(previousQuery, showShimmer: true);
     } else {
       fetchConversations();
@@ -522,6 +535,7 @@ class ConversationProvider extends ChangeNotifier {
     selectedDate = date;
 
     // Clear search when applying date filter
+    selectedSpeakerId = null;
     previousQuery = "";
     currentSearchPage = 0;
     totalSearchPages = 0;
@@ -538,6 +552,7 @@ class ConversationProvider extends ChangeNotifier {
     selectedDate = null;
 
     // Clear search when clearing date filter
+    selectedSpeakerId = null;
     previousQuery = "";
     currentSearchPage = 0;
     totalSearchPages = 0;
@@ -587,7 +602,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void groupConversationsByDate() {
-    if (previousQuery.isNotEmpty) {
+    if (hasActiveSearch) {
       _groupSearchConvosByDateWithoutNotify();
     } else {
       _groupConversationsByDateWithoutNotify();
@@ -726,7 +741,7 @@ class ConversationProvider extends ChangeNotifier {
       }
     }
     conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
-    if (previousQuery.isNotEmpty) {
+    if (hasActiveSearch) {
       int si = searchedConversations.indexWhere((element) => element.id == conversation.id);
       if (si != -1) {
         searchedConversations[si] = conversation;

--- a/app/test/widgets/speaker_filter_sheet_test.dart
+++ b/app/test/widgets/speaker_filter_sheet_test.dart
@@ -56,6 +56,22 @@ void main() {
     expect(selected, 'person-1');
   });
 
+  testWidgets('returns user sentinel when you option is selected', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      buildSheet(
+        onSelected: (speakerId) async {
+          selected = speakerId;
+        },
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('speaker_filter_user')));
+    await tester.pump();
+
+    expect(selected, 'user');
+  });
+
   testWidgets('returns null when all speakers is selected', (tester) async {
     String? selected = 'person-1';
     await tester.pumpWidget(

--- a/app/test/widgets/speaker_filter_sheet_test.dart
+++ b/app/test/widgets/speaker_filter_sheet_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/person.dart';
+import 'package:omi/pages/conversations/widgets/speaker_filter_sheet.dart';
+
+void main() {
+  final person = Person(
+    id: 'person-1',
+    name: 'Alex',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  Widget buildSheet({
+    String? selectedSpeakerId,
+    required SpeakerSelected onSelected,
+  }) {
+    return MaterialApp(
+      theme: ThemeData.dark(),
+      home: Scaffold(
+        body: SpeakerFilterSheet(
+          people: [person],
+          selectedSpeakerId: selectedSpeakerId,
+          title: 'Speaker',
+          allLabel: 'All',
+          userLabel: 'You',
+          onSelected: onSelected,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders all, user, and named speaker options', (tester) async {
+    await tester.pumpWidget(buildSheet(onSelected: (_) async {}));
+
+    expect(find.byKey(const Key('speaker_filter_all')), findsOneWidget);
+    expect(find.byKey(const Key('speaker_filter_user')), findsOneWidget);
+    expect(find.byKey(const Key('speaker_filter_person-1')), findsOneWidget);
+    expect(find.text('Alex'), findsOneWidget);
+  });
+
+  testWidgets('returns the selected speaker id', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      buildSheet(
+        onSelected: (speakerId) async {
+          selected = speakerId;
+        },
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('speaker_filter_person-1')));
+    await tester.pump();
+
+    expect(selected, 'person-1');
+  });
+
+  testWidgets('returns null when all speakers is selected', (tester) async {
+    String? selected = 'person-1';
+    await tester.pumpWidget(
+      buildSheet(
+        selectedSpeakerId: 'person-1',
+        onSelected: (speakerId) async {
+          selected = speakerId;
+        },
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('speaker_filter_all')));
+    await tester.pump();
+
+    expect(selected, isNull);
+  });
+}

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -261,12 +261,13 @@ class UpdateActionItemDescriptionRequest(BaseModel):
 
 
 class SearchRequest(BaseModel):
-    query: str
+    query: str = ''
     page: Optional[int] = 1
     per_page: Optional[int] = 10
     include_discarded: Optional[bool] = True
     start_date: Optional[str] = None  # ISO format datetime string
     end_date: Optional[str] = None  # ISO format datetime string
+    speaker_id: Optional[str] = None
 
 
 class TestPromptRequest(BaseModel):

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -853,6 +853,11 @@ def search_conversations_endpoint(
     search_request: SearchRequest,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "conversations:search")),
 ):
+    if search_request.speaker_id and search_request.speaker_id != 'user':
+        person = users_db.get_person(uid, search_request.speaker_id)
+        if person is None:
+            raise HTTPException(status_code=404, detail="Speaker not found")
+
     # Convert ISO datetime strings to Unix timestamps if provided
     start_timestamp = None
     end_timestamp = None
@@ -877,6 +882,7 @@ def search_conversations_endpoint(
         include_discarded=search_request.include_discarded,
         start_date=start_timestamp,
         end_date=end_timestamp,
+        speaker_id=search_request.speaker_id,
     )
 
 

--- a/backend/tests/unit/test_conversation_hybrid_search.py
+++ b/backend/tests/unit/test_conversation_hybrid_search.py
@@ -76,7 +76,11 @@ _restore_real_backend_package("utils")
 _restore_real_backend_package("utils.conversations")
 
 import utils.conversations.search as search_module
-from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
+from utils.conversations.search import (
+    keyword_search_conversation_ids,
+    merge_conversation_search_ids,
+    search_conversations,
+)
 
 
 class TestMergeConversationSearchIds:
@@ -129,6 +133,51 @@ class TestKeywordSearchConversationIds:
                 start_date=100,
                 end_date=200,
             )
+
+
+class TestSpeakerFilteredConversationSearch:
+    def _search_mock(self):
+        search = MagicMock(return_value={'hits': []})
+        collection = MagicMock()
+        collection.documents.search = search
+        return search, {'conversations': collection}
+
+    def test_named_speaker_filter_combines_with_existing_filters(self):
+        search, collections = self._search_mock()
+        with patch.object(search_module.client, 'collections', collections, create=True):
+            search_conversations(
+                uid='uid1',
+                query='launch',
+                include_discarded=False,
+                start_date=100,
+                end_date=200,
+                speaker_id='person-1',
+            )
+
+        params = search.call_args.args[0]
+        assert params['q'] == 'launch'
+        assert params['filter_by'] == (
+            'userId:=uid1 && discarded:=false && created_at:>=100 && created_at:<=200 '
+            '&& transcript_segments.person_id:=person-1'
+        )
+
+    def test_user_speaker_filter_uses_is_user_field(self):
+        search, collections = self._search_mock()
+        with patch.object(search_module.client, 'collections', collections, create=True):
+            search_conversations(uid='uid1', query='', speaker_id='user')
+
+        params = search.call_args.args[0]
+        assert params['q'] == '*'
+        assert params['filter_by'] == 'userId:=uid1 && transcript_segments.is_user:=true'
+
+    def test_search_without_speaker_keeps_existing_filter_behavior(self):
+        search, collections = self._search_mock()
+        with patch.object(search_module.client, 'collections', collections, create=True):
+            search_conversations(uid='uid1', query='planning')
+
+        params = search.call_args.args[0]
+        assert params['q'] == 'planning'
+        assert params['filter_by'] == 'userId:=uid1'
 
 
 class TestCallSitesUseHybridSearch:

--- a/backend/tests/unit/test_conversation_hybrid_search.py
+++ b/backend/tests/unit/test_conversation_hybrid_search.py
@@ -121,6 +121,12 @@ class TestKeywordSearchConversationIds:
             mock_search.side_effect = Exception('typesense unreachable')
             assert keyword_search_conversation_ids('uid1', 'Steph') == []
 
+    def test_empty_query_returns_no_keyword_hits(self):
+        with patch.object(search_module, 'search_conversations') as mock_search:
+            assert keyword_search_conversation_ids('uid1', '   ') == []
+
+        mock_search.assert_not_called()
+
     def test_passes_filters_and_excludes_discarded(self):
         with patch.object(search_module, 'search_conversations') as mock_search:
             mock_search.return_value = {'items': []}
@@ -169,6 +175,14 @@ class TestSpeakerFilteredConversationSearch:
         params = search.call_args.args[0]
         assert params['q'] == '*'
         assert params['filter_by'] == 'userId:=uid1 && transcript_segments.is_user:=true'
+
+    def test_empty_query_without_structured_filter_returns_empty_without_wildcard_search(self):
+        search, collections = self._search_mock()
+        with patch.object(search_module.client, 'collections', collections, create=True):
+            results = search_conversations(uid='uid1', query='   ')
+
+        assert results == {'items': [], 'total_pages': 1, 'current_page': 1, 'per_page': 10}
+        search.assert_not_called()
 
     def test_search_without_speaker_keeps_existing_filter_behavior(self):
         search, collections = self._search_mock()

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -60,6 +60,7 @@ _stubs = [
     'utils.conversations.calendar_linking',
     'utils.conversations.calendar_utils',
     'utils.conversations.location',
+    'utils.executors',
     'utils.llm.conversation_processing',
     'utils.speaker_identification',
     'utils.app_integrations',
@@ -189,3 +190,38 @@ def test_valid_date_is_accepted_and_calls_search():
         )
         assert resp.status_code == 200
         assert mock_search.called
+
+
+def test_named_speaker_is_validated_and_forwarded():
+    with (
+        patch.object(conv.users_db, 'get_person', return_value={'id': 'person-1'}) as mock_get_person,
+        patch.object(conv, 'search_conversations', return_value={'items': []}) as mock_search,
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': '', 'speaker_id': 'person-1'})
+
+    assert resp.status_code == 200
+    mock_get_person.assert_called_once_with('test-uid', 'person-1')
+    assert mock_search.call_args.kwargs['speaker_id'] == 'person-1'
+
+
+def test_unknown_speaker_returns_404():
+    with patch.object(conv.users_db, 'get_person', return_value=None):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': '', 'speaker_id': 'missing'})
+
+    assert resp.status_code == 404
+    assert resp.json()['detail'] == 'Speaker not found'
+
+
+def test_user_speaker_does_not_require_person_record():
+    with (
+        patch.object(conv.users_db, 'get_person') as mock_get_person,
+        patch.object(conv, 'search_conversations', return_value={'items': []}) as mock_search,
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': '', 'speaker_id': 'user'})
+
+    assert resp.status_code == 200
+    mock_get_person.assert_not_called()
+    assert mock_search.call_args.kwargs['speaker_id'] == 'user'

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -25,9 +25,9 @@ def search_conversations(
     include_discarded: bool = True,
     start_date: int = None,
     end_date: int = None,
+    speaker_id: str = None,
 ) -> Dict:
     try:
-
         filter_by = f'userId:={uid}'
         if not include_discarded:
             filter_by = filter_by + ' && discarded:=false'
@@ -38,8 +38,13 @@ def search_conversations(
         if end_date is not None:
             filter_by = filter_by + f' && created_at:<={end_date}'
 
+        if speaker_id == 'user':
+            filter_by = filter_by + ' && transcript_segments.is_user:=true'
+        elif speaker_id:
+            filter_by = filter_by + f' && transcript_segments.person_id:={speaker_id}'
+
         search_parameters = {
-            'q': query,
+            'q': query.strip() or '*',
             'query_by': 'structured.overview, structured.title',
             'filter_by': filter_by,
             'sort_by': 'created_at:desc',

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -28,6 +28,16 @@ def search_conversations(
     speaker_id: str = None,
 ) -> Dict:
     try:
+        stripped_query = query.strip() if query else ''
+        has_filter_only_browse = bool(speaker_id) or start_date is not None or end_date is not None
+        if not stripped_query and not has_filter_only_browse:
+            return {
+                'items': [],
+                'total_pages': page,
+                'current_page': page,
+                'per_page': per_page,
+            }
+
         filter_by = f'userId:={uid}'
         if not include_discarded:
             filter_by = filter_by + ' && discarded:=false'
@@ -44,7 +54,7 @@ def search_conversations(
             filter_by = filter_by + f' && transcript_segments.person_id:={speaker_id}'
 
         search_parameters = {
-            'q': query.strip() or '*',
+            'q': stripped_query or '*',
             'query_by': 'structured.overview, structured.title',
             'filter_by': filter_by,
             'sort_by': 'created_at:desc',
@@ -99,6 +109,9 @@ def keyword_search_conversation_ids(
 
     Fail-open: any search error returns [] so callers can fall back to vector-only results.
     """
+    if not query.strip():
+        return []
+
     try:
         results = search_conversations(
             uid=uid,


### PR DESCRIPTION
### OVERVIEW

This PR adds the first scoped part of Smart Search: searching/filtering conversations by speaker.

The issue originally mentioned multiple future search dimensions such as speaker, sentiment, tasks, and questions. Based on the maintainer clarification, this PR focuses only on speaker search first, while keeping the design open for sentiment and other AI filters later.

## Problem

Omi already supports conversation search, but users cannot narrow results by who said something.

That makes queries like these difficult:

- “What did David say about the launch?”
- “Show me conversations where I spoke about pricing.”
- “Find memories involving a specific person.”

The existing search flow was mostly query-based. It did not expose speaker metadata as a structured filter through the backend or app search UI.

## Approach

This PR extends the existing conversation search pipeline instead of creating a separate search endpoint.

The new flow is:

1. The app lets the user choose a speaker from the search UI.
2. The selected speaker is stored in `ConversationProvider`.
3. The app sends an optional `speaker_id` field to the existing conversation search API.
4. The backend validates the speaker when needed.
5. The Typesense search filter is extended with speaker-specific transcript segment filters.
6. Search can now work with both:
   - a text query + speaker filter
   - speaker filter only

## Backend Changes

### Search request model

Added an optional `speaker_id` field to the conversation search request.

Also made `query` default to an empty string so speaker-only search is possible.

This allows the app to ask:

```json
{
  "query": "",
  "speaker_id": "person-id"
}
```
instead of requiring a text query every time.

## Speaker ownership validation

For named speakers, the backend checks that the person exists for the current user before searching.

If the speaker does not exist, the endpoint returns `404`.

The special speaker value `user` is treated separately because it represents the user's own speech, not a saved person record.

## Typesense filtering

The existing Typesense search helper now accepts an optional speaker filter:

- `speaker_id == "user"` filters on user transcript segments.
- Any other `speaker_id` filters on matching person transcript segments.

When no text query is provided, the backend uses a wildcard query so the user can browse all conversations for that speaker.

## App Changes

### API client

The conversation search API client now accepts an optional `speakerId` and includes it in the request body only when selected.

### Conversation provider

`ConversationProvider` now tracks the selected speaker filter.

It also has a `hasActiveSearch` concept so the app understands that search is active when either:

- there is a text query, or
- a speaker filter is selected

This prevents speaker-only search from being treated like an empty/inactive search.

### Speaker filter UI

Added a speaker filter bottom sheet to the conversation search UI.

It includes:

- `All`
- `You`
- saved people from `PeopleProvider`

Selecting an option updates the provider and reruns the conversation search with the selected speaker.

The UI uses existing localized strings where possible instead of adding new hardcoded labels.

## Design Choices

### Reused the existing search endpoint

I chose to extend the existing conversation search endpoint rather than add a new speaker-specific endpoint.

This keeps the app/backend contract simpler and lets future filters compose through the same search flow.

### Structured filter instead of semantic prompt matching

Speaker search should be exact and reliable, so this PR uses structured transcript segment metadata rather than inferring speakers from the semantic query.

Semantic search is still used for the text query, but speaker identity is handled as a filter.

### `user` as a special speaker value

The user's own speech is not stored as a normal saved person, so the app/backend use `user` as a sentinel value.

This keeps the API simple while still supporting “show me what I said” searches.

### Speaker-only search support

The search request now supports an empty query with a speaker filter.

This matters because users may want to simply browse conversations involving a person without typing a keyword.

### Scoped to speaker search only

I intentionally did not add sentiment, task, or question filters in this PR.

Those are useful future features, but speaker search was confirmed as the priority. Keeping this PR focused makes it easier to review and reduces the chance of mixing several search behaviors at once.

## Tests Added

### Backend search helper tests

Added coverage for speaker-filtered Typesense search behavior:

- named speaker filters are added correctly
- user speaker filters use the user transcript segment field
- speaker-only search uses wildcard search
- existing search behavior remains unchanged when no speaker is selected

These tests protect the core retrieval behavior.

### Backend endpoint tests

Added endpoint-level tests for speaker validation and request forwarding:

- valid named speaker is validated and forwarded to search
- unknown speaker returns `404`
- `user` speaker does not require person lookup
- selected speaker is passed through to the search helper

These tests make sure the API boundary behaves correctly, not just the lower-level search helper.

### Flutter widget test

Added coverage for the new speaker filter sheet:

- renders `All`, `You`, and `saved people`
- selecting a saved person returns that person's ID
- selecting `All` clears the speaker filter

This protects the main UI behavior added in this PR.

## Testing

Backend targeted tests:

```bash
cd backend
python -m pytest tests/unit/test_conversation_hybrid_search.py tests/unit/test_conversation_search_date_validation.py -q
```
Flutter widget test:

```bash
cd app
fvm flutter test test/widgets/speaker_filter_sheet_test.dart
```
## Future Scope

This PR sets up the structure for additional Smart Search filters, but does not implement them yet.
Possible follow-ups:
- sentiment filtering.
- task/question filters.
- combining speaker + sentiment + date filters in the UI.
- showing speaker result counts.
- supporting unknown/unlabeled speaker groups.
- improving ranking when both semantic query and speaker filter are active.
- adding richer “what did X say about Y?” memory retrieval flows.

## Notes
This PR is intentionally focused on the first confirmed search dimension: speaker search.
It keeps the implementation close to the existing conversation search architecture while making the API and provider state flexible enough for future filters.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

