### PR TITLE
fix(app): make analytics fail open

### DIFF
--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -309,7 +309,7 @@ class AnalyticsManager {
     }
     var retryLater = false;
     var flushAgain = false;
-    Duration? retryDelay;
+    var retryDelay = _retryDelays.last;
     _flushInProgress = true;
     try {
       final adapter = _adapter;

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/memory.dart';
@@ -15,6 +19,20 @@ class AnalyticsManager {
   static final SharedPreferencesUtil _preferences = SharedPreferencesUtil();
   static final Map<String, DateTime> _pendingTimedEvents = {};
   static const Duration _pendingTimedEventTtl = Duration(hours: 1);
+  static const Duration _initTimeout = Duration(seconds: 2);
+  static const int _maxQueuedEvents = 200;
+  static const int _flushBatchSize = 20;
+  static const int _maxDeliveryAttempts = 3;
+  static const List<Duration> _retryDelays = [
+    Duration(seconds: 1),
+    Duration(seconds: 5),
+    Duration(seconds: 30),
+  ];
+  static final List<_QueuedAnalyticsEvent> _queuedEvents = [];
+  static bool _flushScheduled = false;
+  static bool _flushInProgress = false;
+  static Timer? _retryTimer;
+  static int _droppedEvents = 0;
 
   /// Inject the analytics adapter at boot. Must be called before [init].
   /// Calling without ever configuring leaves every method as a no-op, which
@@ -25,15 +43,42 @@ class AnalyticsManager {
     _adapter = adapter;
   }
 
-  static Future<void> init() async {
+  static Future<void> init({Duration timeout = _initTimeout}) async {
     _initStarted = true;
     if (_adapter == null && Env.posthogApiKey != null) {
       _adapter = PostHogAnalyticsAdapter(apiKey: Env.posthogApiKey!);
     }
     final adapter = _adapter;
     if (adapter == null) return;
-    await PlatformService.executeIfSupportedAsync(PlatformService.isAnalyticsSupported, adapter.init);
-    await _loadPersonPropertyCache();
+    try {
+      await PlatformService.executeIfSupportedAsync(PlatformService.isAnalyticsSupported, adapter.init)
+          .timeout(timeout);
+      await _loadPersonPropertyCache();
+      _scheduleFlush();
+    } catch (_) {}
+  }
+
+  static Future<void> flushPending({bool force = false}) => _flushQueuedEvents(force: force);
+
+  @visibleForTesting
+  static int get queuedEventCountForTesting => _queuedEvents.length;
+
+  @visibleForTesting
+  static int get droppedEventCountForTesting => _droppedEvents;
+
+  @visibleForTesting
+  static void resetForTesting() {
+    _adapter = null;
+    _initStarted = false;
+    _pendingTimedEvents.clear();
+    _lastSentPersonProperty.clear();
+    _personPropertyCacheLoaded = false;
+    _queuedEvents.clear();
+    _flushScheduled = false;
+    _flushInProgress = false;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _droppedEvents = 0;
   }
 
   factory AnalyticsManager() {
@@ -102,11 +147,13 @@ class AnalyticsManager {
           pending[cacheKey] = serialized;
         });
         if (fresh.isEmpty) return;
-        adapter.identify(userId: uid, userProperties: fresh);
-        pending.forEach((cacheKey, serialized) {
-          _lastSentPersonProperty[cacheKey] = serialized;
-          _persistPersonPropertyCacheEntry(cacheKey, serialized);
-        });
+        try {
+          adapter.identify(userId: uid, userProperties: fresh);
+          pending.forEach((cacheKey, serialized) {
+            _lastSentPersonProperty[cacheKey] = serialized;
+            _persistPersonPropertyCacheEntry(cacheKey, serialized);
+          });
+        } catch (_) {}
       });
 
   static const String _personPropertyCachePrefix = '_ph_lastset_';
@@ -158,7 +205,9 @@ class AnalyticsManager {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
       final adapter = _adapter;
       if (adapter == null) return;
-      adapter.enable();
+      try {
+        adapter.enable();
+      } catch (_) {}
       identify();
     });
   }
@@ -167,9 +216,11 @@ class AnalyticsManager {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
       final adapter = _adapter;
       if (adapter == null) return;
-      adapter.disable();
-      adapter.reset();
-      _clearPersonPropertyCache();
+      try {
+        adapter.disable();
+        adapter.reset();
+      } catch (_) {}
+      unawaited(_clearPersonPropertyCache());
     });
   }
 
@@ -179,7 +230,11 @@ class AnalyticsManager {
       if (adapter == null) return;
       final uid = _preferences.uid;
       if (uid.isEmpty) return;
-      adapter.identify(userId: uid);
+      try {
+        adapter.identify(userId: uid);
+      } catch (_) {
+        return;
+      }
       _instance.setPeopleValues();
       setNameAndEmail();
     });
@@ -189,9 +244,13 @@ class AnalyticsManager {
     PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
       final adapter = _adapter;
       if (adapter == null) return;
-      _clearPersonPropertyCache();
-      adapter.alias(newUserId: newUid);
-      adapter.identify(userId: newUid);
+      unawaited(_clearPersonPropertyCache());
+      try {
+        adapter.alias(newUserId: newUid);
+        adapter.identify(userId: newUid);
+      } catch (_) {
+        return;
+      }
       setNameAndEmail();
     });
   }
@@ -216,8 +275,90 @@ class AnalyticsManager {
         if (start != null) {
           props['\$duration'] = DateTime.now().difference(start).inMilliseconds / 1000.0;
         }
-        adapter.track(eventName: eventName, properties: props);
+        _enqueueEvent(_QueuedAnalyticsEvent(eventName: eventName, properties: props));
       });
+
+  static void _enqueueEvent(_QueuedAnalyticsEvent event) {
+    while (_queuedEvents.length >= _maxQueuedEvents) {
+      _queuedEvents.removeAt(0);
+      _droppedEvents++;
+    }
+    _queuedEvents.add(event);
+    _scheduleFlush();
+  }
+
+  static void _scheduleFlush() {
+    if (_flushScheduled || _flushInProgress || (_retryTimer?.isActive ?? false)) return;
+    _flushScheduled = true;
+    unawaited(Future<void>.microtask(() async {
+      _flushScheduled = false;
+      await _flushQueuedEvents();
+    }));
+  }
+
+  static Future<void> _flushQueuedEvents({bool force = false}) async {
+    if (_flushInProgress) return;
+    if (force) {
+      _retryTimer?.cancel();
+      _retryTimer = null;
+    } else if (_retryTimer?.isActive ?? false) {
+      return;
+    }
+    var retryLater = false;
+    var flushAgain = false;
+    Duration? retryDelay;
+    _flushInProgress = true;
+    try {
+      final adapter = _adapter;
+      if (adapter == null || !adapter.isInitialized) {
+        retryLater = _queuedEvents.isNotEmpty;
+        retryDelay = _retryDelays.last;
+        return;
+      }
+
+      var delivered = 0;
+      while (_queuedEvents.isNotEmpty && delivered < _flushBatchSize) {
+        final event = _queuedEvents.removeAt(0);
+        try {
+          adapter.track(eventName: event.eventName, properties: event.properties);
+          delivered++;
+        } catch (_) {
+          final retriedEvent = event.nextAttempt();
+          _requeueOrDrop(retriedEvent);
+          retryLater = _queuedEvents.isNotEmpty;
+          retryDelay = _retryDelayForAttempt(retriedEvent.attempts);
+          return;
+        }
+      }
+      flushAgain = _queuedEvents.isNotEmpty;
+    } finally {
+      _flushInProgress = false;
+      if (retryLater) {
+        _scheduleRetry(retryDelay);
+      } else if (flushAgain) {
+        _scheduleFlush();
+      }
+    }
+  }
+
+  static void _requeueOrDrop(_QueuedAnalyticsEvent event) {
+    if (event.attempts >= _maxDeliveryAttempts) {
+      _droppedEvents++;
+      return;
+    }
+    _queuedEvents.insert(0, event);
+  }
+
+  static Duration _retryDelayForAttempt(int attempts) {
+    final delayIndex = attempts >= _retryDelays.length ? _retryDelays.length - 1 : attempts;
+    return _retryDelays[delayIndex];
+  }
+
+  static void _scheduleRetry([Duration? delay]) {
+    if (_retryTimer?.isActive ?? false) return;
+    final attempts = _queuedEvents.isEmpty ? 0 : _queuedEvents.first.attempts;
+    _retryTimer = Timer(delay ?? _retryDelayForAttempt(attempts), _scheduleFlush);
+  }
 
   void startTimingEvent(String eventName) =>
       PlatformService.executeIfSupported(PlatformService.isAnalyticsSupported, () {
@@ -1765,4 +1906,22 @@ class AnalyticsManager {
     }
     return value.toString();
   }
+}
+
+class _QueuedAnalyticsEvent {
+  const _QueuedAnalyticsEvent({
+    required this.eventName,
+    required this.properties,
+    this.attempts = 0,
+  });
+
+  final String eventName;
+  final Map<String, Object> properties;
+  final int attempts;
+
+  _QueuedAnalyticsEvent nextAttempt() => _QueuedAnalyticsEvent(
+        eventName: eventName,
+        properties: properties,
+        attempts: attempts + 1,
+      );
 }

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -329,7 +329,7 @@ class AnalyticsManager {
           final retriedEvent = event.nextAttempt();
           _requeueOrDrop(retriedEvent);
           retryLater = _queuedEvents.isNotEmpty;
-          retryDelay = _retryDelayForAttempt(retriedEvent.attempts);
+          retryDelay = _retryDelayForAttempt(event.attempts);
           return;
         }
       }
@@ -353,15 +353,14 @@ class AnalyticsManager {
   }
 
   static Duration _retryDelayForAttempt(int attempts) {
-    final delayIndex = attempts <= 1 ? 0 : attempts - 1;
+    final delayIndex = attempts <= 0 ? 0 : attempts;
     if (delayIndex >= _retryDelays.length) return _retryDelays.last;
     return _retryDelays[delayIndex];
   }
 
-  static void _scheduleRetry([Duration? delay]) {
+  static void _scheduleRetry(Duration delay) {
     if (_retryTimer?.isActive ?? false) return;
-    final attempts = _queuedEvents.isEmpty ? 0 : _queuedEvents.first.attempts;
-    _retryTimer = Timer(delay ?? _retryDelayForAttempt(attempts), _scheduleFlush);
+    _retryTimer = Timer(delay, _scheduleFlush);
   }
 
   void startTimingEvent(String eventName) =>

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -67,6 +67,9 @@ class AnalyticsManager {
   static int get droppedEventCountForTesting => _droppedEvents;
 
   @visibleForTesting
+  static Duration retryDelayForTesting(int attempts) => _retryDelayForAttempt(attempts);
+
+  @visibleForTesting
   static void resetForTesting() {
     _adapter = null;
     _initStarted = false;
@@ -350,7 +353,8 @@ class AnalyticsManager {
   }
 
   static Duration _retryDelayForAttempt(int attempts) {
-    final delayIndex = attempts >= _retryDelays.length ? _retryDelays.length - 1 : attempts;
+    final delayIndex = attempts <= 1 ? 0 : attempts - 1;
+    if (delayIndex >= _retryDelays.length) return _retryDelays.last;
     return _retryDelays[delayIndex];
   }
 

--- a/app/lib/utils/platform/platform_manager.dart
+++ b/app/lib/utils/platform/platform_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -32,7 +33,7 @@ class PlatformManager {
   static Future<void> initializeServices() async {
     _instance._packageInfo = await PackageInfo.fromPlatform();
     _instance._deviceIdHash = await _instance._getDeviceIdHash();
-    await AnalyticsManager.init();
+    unawaited(AnalyticsManager.init());
     await IntercomManager.instance.initIntercom();
   }
 

--- a/app/test/unit/analytics_manager_fail_open_test.dart
+++ b/app/test/unit/analytics_manager_fail_open_test.dart
@@ -64,6 +64,13 @@ void main() {
     expect(AnalyticsManager.queuedEventCountForTesting, 0);
   });
 
+  test('retry delay sequence starts with the first backoff slot', () {
+    expect(AnalyticsManager.retryDelayForTesting(1), const Duration(seconds: 1));
+    expect(AnalyticsManager.retryDelayForTesting(2), const Duration(seconds: 5));
+    expect(AnalyticsManager.retryDelayForTesting(3), const Duration(seconds: 30));
+    expect(AnalyticsManager.retryDelayForTesting(4), const Duration(seconds: 30));
+  });
+
   test('queue is bounded and drops oldest events under pressure', () {
     final adapter = _FakeAnalyticsAdapter();
     AnalyticsManager.configure(adapter);

--- a/app/test/unit/analytics_manager_fail_open_test.dart
+++ b/app/test/unit/analytics_manager_fail_open_test.dart
@@ -65,8 +65,9 @@ void main() {
   });
 
   test('retry delay sequence starts with the first backoff slot', () {
-    expect(AnalyticsManager.retryDelayForTesting(1), const Duration(seconds: 1));
-    expect(AnalyticsManager.retryDelayForTesting(2), const Duration(seconds: 5));
+    expect(AnalyticsManager.retryDelayForTesting(0), const Duration(seconds: 1));
+    expect(AnalyticsManager.retryDelayForTesting(1), const Duration(seconds: 5));
+    expect(AnalyticsManager.retryDelayForTesting(2), const Duration(seconds: 30));
     expect(AnalyticsManager.retryDelayForTesting(3), const Duration(seconds: 30));
     expect(AnalyticsManager.retryDelayForTesting(4), const Duration(seconds: 30));
   });

--- a/app/test/unit/analytics_manager_fail_open_test.dart
+++ b/app/test/unit/analytics_manager_fail_open_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/utils/analytics/analytics_adapter.dart';
+import 'package:omi/utils/analytics/analytics_manager.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    AnalyticsManager.resetForTesting();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  tearDown(AnalyticsManager.resetForTesting);
+
+  test('init returns when the analytics SDK hangs', () async {
+    final adapter = _FakeAnalyticsAdapter(hangInit: true);
+    AnalyticsManager.configure(adapter);
+
+    final elapsed = Stopwatch()..start();
+    await AnalyticsManager.init(timeout: const Duration(milliseconds: 10));
+    elapsed.stop();
+
+    expect(adapter.isInitialized, isFalse);
+    expect(elapsed.elapsed, lessThan(const Duration(milliseconds: 250)));
+  });
+
+  test('track queues events and flushes them after init', () async {
+    final adapter = _FakeAnalyticsAdapter();
+    AnalyticsManager.configure(adapter);
+
+    AnalyticsManager().track('Queued Event', properties: {'count': 1, 'ignored': null});
+    expect(adapter.events, isEmpty);
+    expect(AnalyticsManager.queuedEventCountForTesting, 1);
+
+    await AnalyticsManager.init();
+    await AnalyticsManager.flushPending(force: true);
+
+    expect(adapter.events, hasLength(1));
+    expect(adapter.events.single.eventName, 'Queued Event');
+    expect(adapter.events.single.properties, {'count': 1});
+    expect(AnalyticsManager.queuedEventCountForTesting, 0);
+  });
+
+  test('track retries adapter failures without throwing through the caller', () async {
+    final adapter = _FakeAnalyticsAdapter(trackFailuresBeforeSuccess: 1);
+    AnalyticsManager.configure(adapter);
+    await AnalyticsManager.init();
+
+    AnalyticsManager().track('Retry Event');
+    await AnalyticsManager.flushPending(force: true);
+
+    expect(adapter.events, isEmpty);
+    expect(AnalyticsManager.queuedEventCountForTesting, 1);
+
+    await AnalyticsManager.flushPending(force: true);
+
+    expect(adapter.events, hasLength(1));
+    expect(adapter.events.single.eventName, 'Retry Event');
+    expect(AnalyticsManager.queuedEventCountForTesting, 0);
+  });
+
+  test('queue is bounded and drops oldest events under pressure', () {
+    final adapter = _FakeAnalyticsAdapter();
+    AnalyticsManager.configure(adapter);
+
+    for (var i = 0; i < 205; i++) {
+      AnalyticsManager().track('Queued Event $i');
+    }
+
+    expect(AnalyticsManager.queuedEventCountForTesting, 200);
+    expect(AnalyticsManager.droppedEventCountForTesting, 5);
+  });
+}
+
+class _FakeAnalyticsAdapter implements AnalyticsAdapter {
+  _FakeAnalyticsAdapter({
+    this.hangInit = false,
+    this.trackFailuresBeforeSuccess = 0,
+  });
+
+  final bool hangInit;
+  int trackFailuresBeforeSuccess;
+  final List<_RecordedEvent> events = [];
+  bool _initialized = false;
+
+  @override
+  bool get isInitialized => _initialized;
+
+  @override
+  Future<void> init() async {
+    if (hangInit) {
+      await Completer<void>().future;
+    }
+    _initialized = true;
+  }
+
+  @override
+  void identify({required String userId, Map<String, Object>? userProperties}) {}
+
+  @override
+  void alias({required String newUserId}) {}
+
+  @override
+  void track({required String eventName, Map<String, Object>? properties}) {
+    if (trackFailuresBeforeSuccess > 0) {
+      trackFailuresBeforeSuccess--;
+      throw StateError('analytics unavailable');
+    }
+    events.add(_RecordedEvent(eventName, properties ?? const {}));
+  }
+
+  @override
+  void enable() {}
+
+  @override
+  void disable() {}
+
+  @override
+  void reset() {}
+}
+
+class _RecordedEvent {
+  const _RecordedEvent(this.eventName, this.properties);
+
+  final String eventName;
+  final Map<String, Object> properties;
+}


### PR DESCRIPTION
## What changed

This issue still applies even though the app has moved from `MixpanelManager` to the `AnalyticsManager` and PostHog adapter path.

- Start analytics init in the background from `PlatformManager.initializeServices()` so app boot is not waiting on the analytics SDK.
- Add a timeout and local catch around analytics init.
- Route `track()` through a bounded in-memory queue instead of calling the SDK inline from feature code.
- Drain queued events in small batches, retry failed sends with backoff, and drop oldest events when the queue is full.
- Wrap identify, alias, opt in/out, and user property calls so SDK errors stay inside analytics.
- Add tests with a fake adapter for a hung init, queued delivery after init, one retry after a thrown track call, retry delay ordering, and queue pressure.

## Why

Analytics should be best effort. If PostHog hangs, throws, or is not initialized yet, startup and user-facing callbacks should keep going.

## Notes

I did not wire lifecycle pause/terminate flushing in this PR because the current lifecycle hook lives in `app/lib/main.dart`, which already has another open PR touching it. This keeps the change away from that overlap. A follow-up can add lifecycle flush once that file is clear.

Addresses #5275.

## Checks

- `flutter test test/unit/analytics_manager_fail_open_test.dart` with Flutter 3.35.7: 5 tests passed.
- `git diff --check`
- GitHub `Lint & Format Check` is the source of truth for formatting on Linux. Local Windows `dart format --set-exit-if-changed` kept rewriting `app/lib/utils/analytics/analytics_manager.dart` after formatting, but the formatted diff is clean.
