### PR TITLE
fix(backend): expose ffmpeg libs to diarizer

### DIFF
--- a/backend/diarizer/Dockerfile
+++ b/backend/diarizer/Dockerfile
@@ -11,10 +11,10 @@ FROM gcr.io/based-hardware-dev/python:3.11-slim-forky
 
 WORKDIR /app
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"
-ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/x86_64-linux-gnu"
 
 # Install CUDA Runtime 13.2 Update 1 only; the pod runs inference and does not need build tools like nvcc.
-RUN apt-get update && apt-get -y install build-essential ffmpeg curl unzip wget && \ 
+RUN apt-get update && apt-get -y install build-essential ffmpeg curl unzip wget && \
 wget https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda-repo-debian13-13-2-local_13.2.1-595.58.03-1_amd64.deb && \
 dpkg -i cuda-repo-debian13-13-2-local_13.2.1-595.58.03-1_amd64.deb && \
 cp /var/cuda-repo-debian13-13-2-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \

--- a/backend/tests/unit/test_diarizer_dockerfile.py
+++ b/backend/tests/unit/test_diarizer_dockerfile.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_diarizer_runtime_library_path_includes_ffmpeg_libs():
+    dockerfile = Path(__file__).resolve().parents[2] / 'diarizer' / 'Dockerfile'
+    contents = dockerfile.read_text()
+
+    assert '/usr/local/nvidia/lib' in contents
+    assert '/usr/local/nvidia/lib64' in contents
+    assert '/usr/lib/x86_64-linux-gnu' in contents
+
+
+def test_diarizer_dockerfile_has_no_backslash_space_continuations():
+    dockerfile = Path(__file__).resolve().parents[2] / 'diarizer' / 'Dockerfile'
+
+    for line in dockerfile.read_text().splitlines():
+        assert not line.endswith('\\ ')


### PR DESCRIPTION
## What changed

- Added `/usr/lib/x86_64-linux-gnu` to the diarizer container `LD_LIBRARY_PATH`.
- Fixed the existing backslash-space continuation in the Dockerfile install step.
- Added a small unit test that checks the Dockerfile keeps the ffmpeg shared library path and avoids that fragile continuation form.

## Why

#7181 points out that torchcodec warns at pod startup because it cannot find the apt-installed ffmpeg shared libraries after the Forky base image bump. The Dockerfile installs `ffmpeg`, but the runtime library path only included NVIDIA paths. Adding Debian's library directory gives the dynamic linker the path where `libavutil.so.*` and the related ffmpeg libs are installed.

## Checks

- `python -m pytest backend/tests/unit/test_diarizer_dockerfile.py`
- `python -m black --check backend/tests/unit/test_diarizer_dockerfile.py`
- `git diff --check`

Addresses #7181.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

