### PR TITLE
fix(backend): warn on executor queue buildup

### DIFF
--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -321,16 +321,40 @@ async def test_log_executor_health_warns_above_threshold(caplog):
 
 
 @pytest.mark.asyncio
+async def test_log_executor_health_warns_above_queue_depth_threshold(caplog):
+    """log_executor_health must warn when queued work grows even if active workers are below threshold."""
+    queued_metrics = [
+        {'name': 'test-pool', 'max_workers': 8, 'active_count': 2, 'queue_depth': 11, 'utilization_pct': 25.0},
+    ]
+    with patch('utils.executors.get_executor_metrics', return_value=queued_metrics):
+        with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
+            with caplog.at_level(logging.WARNING, logger='utils.executors'):
+                try:
+                    await log_executor_health(
+                        interval_seconds=1,
+                        utilization_threshold_pct=70.0,
+                        queue_depth_threshold=10,
+                    )
+                except asyncio.CancelledError:
+                    pass
+    assert any('executor_pool_health' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_log_executor_health_silent_below_threshold(caplog):
     """log_executor_health must not log when all pools are below the threshold."""
     idle_metrics = [
-        {'name': 'test-pool', 'max_workers': 8, 'active_count': 1, 'queue_depth': 0, 'utilization_pct': 12.5},
+        {'name': 'test-pool', 'max_workers': 8, 'active_count': 1, 'queue_depth': 9, 'utilization_pct': 12.5},
     ]
     with patch('utils.executors.get_executor_metrics', return_value=idle_metrics):
         with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
             with caplog.at_level(logging.WARNING, logger='utils.executors'):
                 try:
-                    await log_executor_health(interval_seconds=1, utilization_threshold_pct=70.0)
+                    await log_executor_health(
+                        interval_seconds=1,
+                        utilization_threshold_pct=70.0,
+                        queue_depth_threshold=10,
+                    )
                 except asyncio.CancelledError:
                     pass
     assert not any('executor_pool_health' in r.message for r in caplog.records)
@@ -338,15 +362,19 @@ async def test_log_executor_health_silent_below_threshold(caplog):
 
 @pytest.mark.asyncio
 async def test_log_executor_health_silent_at_exact_threshold(caplog):
-    """Utilization at exactly the threshold (70.0) must NOT trigger a warning (> not >=)."""
+    """Metrics at exactly their thresholds must NOT trigger a warning (> not >=)."""
     at_threshold_metrics = [
-        {'name': 'test-pool', 'max_workers': 10, 'active_count': 7, 'queue_depth': 0, 'utilization_pct': 70.0},
+        {'name': 'test-pool', 'max_workers': 10, 'active_count': 7, 'queue_depth': 10, 'utilization_pct': 70.0},
     ]
     with patch('utils.executors.get_executor_metrics', return_value=at_threshold_metrics):
         with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
             with caplog.at_level(logging.WARNING, logger='utils.executors'):
                 try:
-                    await log_executor_health(interval_seconds=1, utilization_threshold_pct=70.0)
+                    await log_executor_health(
+                        interval_seconds=1,
+                        utilization_threshold_pct=70.0,
+                        queue_depth_threshold=10,
+                    )
                 except asyncio.CancelledError:
                     pass
     assert not any('executor_pool_health' in r.message for r in caplog.records)

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -108,15 +108,23 @@ def get_executor_metrics() -> list:
     return metrics
 
 
-async def log_executor_health(interval_seconds: int = 60, utilization_threshold_pct: float = 70.0):
-    """Periodically log pool metrics when any pool exceeds the utilization threshold."""
+async def log_executor_health(
+    interval_seconds: int = 60,
+    utilization_threshold_pct: float = 70.0,
+    queue_depth_threshold: int = 100,
+):
+    """Periodically log pool metrics when any pool exceeds a health threshold."""
     while True:
         await asyncio.sleep(interval_seconds)
         try:
             metrics = get_executor_metrics()
-            saturated = [p for p in metrics if p['utilization_pct'] > utilization_threshold_pct]
-            if saturated:
-                logger.warning('executor_pool_health: %s', saturated)
+            unhealthy = [
+                p
+                for p in metrics
+                if p['utilization_pct'] > utilization_threshold_pct or p['queue_depth'] > queue_depth_threshold
+            ]
+            if unhealthy:
+                logger.warning('executor_pool_health: %s', unhealthy)
         except Exception:
             pass
 


### PR DESCRIPTION
## What changed

- Added a `queue_depth_threshold` to `log_executor_health`.
- Kept the existing utilization warning behavior, but now the same health log also fires when queued work grows past the threshold.
- Added unit coverage for queue-depth warnings, below-threshold silence, and exact-threshold behavior.

## Why

#6753 calls out that the executor queues are unbounded, so saturation can show up as queued work before it shows up as obvious request failures. This does not change submission behavior or introduce backpressure yet. It makes the existing executor health loop surface queue buildup so the team can see when a pool is falling behind.

I kept this as an observability slice rather than mixing in bounded submission or pool splitting.

## Checks

- `python -m pytest backend/tests/unit/test_executors.py`
- `python -m black --check backend/utils/executors.py backend/tests/unit/test_executors.py`
- `git diff --check`

Addresses part of #6753.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

