### PR TITLE
backend: stop running trends extraction on every conversation

### DIFF
--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -17,7 +17,6 @@ import database.conversations as conversations_db
 import database.notifications as notification_db
 import database.users as users_db
 import database.tasks as tasks_db
-import database.trends as trends_db
 import database.action_items as action_items_db
 import database.folders as folders_db
 import database.calendar_meetings as calendar_db
@@ -49,7 +48,6 @@ from models.other import Person
 from models.structured import Structured
 from utils.notifications import send_important_conversation_message
 from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
-from models.trend import Trend
 from models.notification_message import NotificationMessage
 from utils.apps import get_available_apps, update_personas_async, update_persona_prompt
 from utils.executors import db_executor, llm_executor, postprocess_executor, submit_with_context
@@ -66,7 +64,6 @@ from utils.analytics import record_usage
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llm.memories import extract_memories_from_text, new_memories_extractor
 from utils.llm.external_integrations import summarize_experience_text
-from utils.llm.trends import trends_extractor
 from utils.llm.goals import extract_and_update_goal_progress
 from utils.llm.chat import (
     retrieve_metadata_from_text,
@@ -585,13 +582,6 @@ def send_new_memories_notification(user_id: str, memories: [MemoryDB]):
     send_notification(user_id, "omi" + ' says', message, NotificationMessage.get_message_as_dict(ai_message))
 
 
-def _extract_trends(uid: str, conversation: Conversation):
-    with track_usage(uid, Features.TRENDS):
-        extracted_items = trends_extractor(uid, conversation.transcript_segments, conversation.get_person_ids())
-        parsed = [Trend(category=item.category, topics=[item.topic], type=item.type) for item in extracted_items]
-        trends_db.save_trends(conversation.id, parsed)
-
-
 def _save_action_items(uid: str, conversation: Conversation):
     """
     Save action items from a conversation to the dedicated action_items collection.
@@ -912,7 +902,6 @@ def process_conversation(
             if TRANSCRIPT_CHUNK_INDEXING_ENABLED:
                 submit_with_context(postprocess_executor, save_transcript_chunk_vectors, uid, conversation)
         submit_with_context(postprocess_executor, _extract_memories, uid, conversation)
-        submit_with_context(postprocess_executor, _extract_trends, uid, conversation)
         submit_with_context(postprocess_executor, _save_action_items, uid, conversation)
         submit_with_context(postprocess_executor, _update_goal_progress, uid, conversation)
 


### PR DESCRIPTION
## What

Removes the per-conversation **trends extraction** from the conversation post-processing pipeline.

`_extract_trends` was fired fire-and-forget on **every non-discarded conversation** (`process_conversation.py`), making one LLM call each (`trends_extractor` → `get_llm('trends')`) and writing to the global `trends` Firestore collection.

## Why

The output is effectively unused. The only consumer anywhere is the web **Dreamforce** event page (`web/frontend/src/app/dreamforce/page.tsx` → `GET /v1/trends`); the mobile app, main web app, and desktop never read it. Dreamforce is past, so this is an LLM call per conversation feeding a dead surface.

At current volume (~16.5k conversations/day) that's **~0.5M LLM calls/month** (~2,535 input tokens each), i.e. roughly **$130–510/month** depending on whether it resolves to gemini-2.5-flash-lite or gpt-4.1-mini — pure waste.

## Change

- Remove the `submit_with_context(..., _extract_trends, ...)` trigger from `process_conversation`.
- Remove the now-orphaned `_extract_trends` function and its now-unused imports (`database.trends`, `models.trend.Trend`, `utils.llm.trends.trends_extractor`).

Independent of memories / action-items / goals (those are untouched). The `/v1/trends` endpoint, `trends_extractor`, and the `trends` collection are left in place — they just no longer get fed on every conversation.

## Verification

- `python -m py_compile` passes; no remaining `trends`/`Trend` references in `process_conversation.py`.
- Pure removal of a fire-and-forget call + dead code; no behavior change to other extractors.
- (Local pytest is blocked by an env mismatch — system pydantic v1 on py3.12 — so CI / hermetic E2E validates the suite.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

