### PR TITLE
backend: stop auto-regenerating personas on every conversation/memory

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1,7 +1,6 @@
 import uuid
 from datetime import datetime, timezone, timedelta
 
-from utils.executors import db_executor, postprocess_executor
 from enum import Enum
 from typing import List, Optional
 
@@ -42,7 +41,6 @@ from dependencies import (
 from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
-from utils.apps import update_personas_async
 from utils.notifications import send_action_item_data_message, sync_action_item_reminder
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations.location import get_google_maps_location
@@ -311,10 +309,6 @@ def create_memory(
     # Save to database
     memories_db.create_memory(uid, memory_db.dict())
 
-    # Update personas asynchronously if visibility is public
-    if memory.visibility == 'public':
-        postprocess_executor.submit(update_personas_async, uid)
-
     return MemoryResponse(
         id=memory_db.id,
         content=memory_db.content,
@@ -387,10 +381,6 @@ def create_memories_batch(
             for mem in memory_dbs
         ],
     )
-
-    # Update personas if any memory is public
-    if has_public:
-        postprocess_executor.submit(update_personas_async, uid)
 
     # Prepare response
     created_memories = [

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import List, Optional
 
-from utils.executors import db_executor, postprocess_executor
 
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
@@ -24,7 +23,6 @@ import database.vector_db as vector_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation_enums import CategoryEnum
 from utils.conversations.render import populate_speaker_names, redact_conversations_for_list
-from utils.apps import update_personas_async
 from utils.llm.memories import identify_category_for_memory
 from utils.retrieval.hybrid import rrf_rerank
 from dependencies import get_uid_from_mcp_api_key, get_current_user_id
@@ -77,7 +75,6 @@ def create_memory(memory: Memory, uid: str = Depends(with_rate_limit(get_uid_fro
         upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
     except Exception:
         logger.exception("Vector upsert failed uid=%s memory_id=%s (memory saved, vector missing)", uid, memory_db.id)
-    postprocess_executor.submit(update_personas_async, uid)
     return memory_db
 
 

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -14,7 +14,6 @@ from database.vector_db import (
     upsert_memory_vectors_batch,
 )
 from models.memories import MemoryDB, Memory, MemoryCategory
-from utils.apps import update_personas_async
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -80,9 +79,6 @@ async def create_memory(
     except Exception:
         logger.exception("Vector upsert failed uid=%s memory_id=%s (memory saved, vector missing)", uid, memory_db.id)
 
-    if memory.visibility == 'public':
-        submit_with_context(postprocess_executor, update_personas_async, uid)
-
     return memory_db
 
 
@@ -139,9 +135,6 @@ async def create_memories_batch(
         )
 
     await run_blocking(db_executor, _persist)
-
-    if has_public:
-        submit_with_context(postprocess_executor, update_personas_async, uid)
 
     return BatchMemoriesResponse(memories=memory_dbs, created_count=len(memory_dbs))
 
@@ -253,5 +246,4 @@ def update_memory_visibility(
     if value not in ['public', 'private']:
         raise HTTPException(status_code=400, detail='Invalid visibility value')
     memories_db.change_memory_visibility(uid, memory_id, value)
-    postprocess_executor.submit(update_personas_async, uid)
     return {'status': 'ok'}

--- a/backend/tests/unit/test_clean_sweep_migrations.py
+++ b/backend/tests/unit/test_clean_sweep_migrations.py
@@ -43,21 +43,12 @@ def _read_source(rel_path: str) -> str:
 
 
 class TestMemoriesExecutorMigration:
-    """Verify memories router uses postprocess_executor for persona updates and db_executor for DB."""
+    """Verify memories router dispatches background work via executors, not bare threads."""
 
     def test_create_memory_uses_postprocess_executor(self):
-        """create_memory route dispatches persona update via postprocess_executor."""
+        """create_memory route dispatches background work via postprocess_executor."""
         src = _read_source('routers/memories.py')
         assert 'postprocess_executor' in src
-        assert 'update_personas_async' in src
-
-    def test_update_visibility_uses_postprocess_executor(self):
-        """update_memory_visibility uses postprocess_executor, not threading.Thread."""
-        src = _read_source('routers/memories.py')
-        # Find the update_memory_visibility function and check its body
-        func_start = src.index('def update_memory_visibility')
-        func_body = src[func_start : func_start + 500]
-        assert 'postprocess_executor.submit(update_personas_async' in func_body
 
     def test_no_threading_thread_in_memories(self):
         """No bare threading.Thread usage in memories router."""
@@ -291,27 +282,19 @@ class TestChatExecutorMigration:
 
 
 class TestDeveloperExecutorMigration:
-    """Verify developer router uses postprocess_executor for persona update."""
+    """Verify developer router does not use bare threads for background work."""
 
     def test_no_threading_thread(self):
         src = _read_source('routers/developer.py')
         assert 'threading.Thread' not in src
-
-    def test_uses_postprocess_executor(self):
-        src = _read_source('routers/developer.py')
-        assert 'postprocess_executor.submit(' in src
 
 
 class TestMcpExecutorMigration:
-    """Verify mcp router uses postprocess_executor for persona update."""
+    """Verify mcp router does not use bare threads for background work."""
 
     def test_no_threading_thread(self):
         src = _read_source('routers/mcp.py')
         assert 'threading.Thread' not in src
-
-    def test_uses_postprocess_executor(self):
-        src = _read_source('routers/mcp.py')
-        assert 'postprocess_executor.submit(' in src
 
 
 class TestWrappedExecutorMigration:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -49,7 +49,7 @@ from models.structured import Structured
 from utils.notifications import send_important_conversation_message
 from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.notification_message import NotificationMessage
-from utils.apps import get_available_apps, update_personas_async, update_persona_prompt
+from utils.apps import get_available_apps, update_persona_prompt
 from utils.executors import db_executor, llm_executor, postprocess_executor, submit_with_context
 from utils.llm.conversation_processing import (
     get_transcript_structure,
@@ -932,7 +932,6 @@ def process_conversation(
             asyncio.run(conversation_created_webhook(uid, conversation))
 
         submit_with_context(postprocess_executor, _run_webhook)
-        submit_with_context(postprocess_executor, update_personas_async, uid)
 
         # Disable important conversation for now
         # Send important conversation notification for long conversations (>30 minutes)


### PR DESCRIPTION
## What

Removes the **automatic persona regeneration** triggers. `update_personas_async(uid)` was fired fire-and-forget after every conversation and on every public-memory create/update, regenerating each of the user's Omi persona clones' chat prompts (condense memories + conversations + tweets → new prompt) via OpenAI `gpt-5.4`/`gpt-5.4-mini`.

Trigger sites removed:
- `utils/conversations/process_conversation.py` — after every conversation
- `routers/memories.py` — public memory create (×2) + visibility change
- `routers/mcp.py` — MCP memory create
- `routers/developer.py` — dev-API memory create (×2)

Plus the now-unused imports, and the migration tests that asserted these triggers existed.

## Why

Persona prompts were regenerated **daily for every persona owner regardless of whether the persona is ever chatted with** — measured at **369 regenerations/day** (~1,100 LLM calls/day), plus **~7,900/day "no personas found" no-op runs** (wasted Firestore reads, because non-owners never set the once/day guard so it re-ran on every conversation/memory). Recurring spend + DB load for output that's only consumed when someone actually chats with a clone.

## Behavior change

Persona clones no longer auto-refresh from new memories/conversations — they keep their last-generated prompt. The persona functions (`update_personas_async`, `update_persona_prompt`) and the persona chat path are left intact, so a manual/explicit refresh can be re-added later if wanted.

## Verification

- `py_compile` clean on all touched files; no remaining `update_personas_async` call sites.
- `tests/unit/test_clean_sweep_migrations.py` → 57 pass; the only 2 failures are pre-existing on `main` (confirmed by stashing — unrelated chat-utils / `import requests` scans in this env).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

