### PR TITLE
fix audio player crash when switching samples rapidly

### DIFF
--- a/app/lib/providers/user_speech_samples_provider.dart
+++ b/app/lib/providers/user_speech_samples_provider.dart
@@ -71,12 +71,17 @@ class UserSpeechSamplesProvider extends BaseProvider {
         isPlaying = true;
       }
     } else {
-      _audioPlayer.stop();
-      await _audioPlayer.setUrl(samplesUrl[index]);
-      currentPlayingIndex = index;
-      isPlaying = true;
-      notifyListeners();
-      await _audioPlayer.play();
+      try {
+        await _audioPlayer.stop();
+        await _audioPlayer.setUrl(samplesUrl[index]);
+        currentPlayingIndex = index;
+        isPlaying = true;
+        notifyListeners();
+        await _audioPlayer.play();
+      } catch (e) {
+        currentPlayingIndex = null;
+        isPlaying = false;
+      }
     }
     notifyListeners();
   }


### PR DESCRIPTION
## Problem

`AudioPlayer._setPlatformActive.checkInterruption` throws `PlatformException(abort, Loading interrupted, null, null)` when the user taps a different speech sample before the previous one finishes loading.

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/29616078761c6481ae288fc65b3f12b5?time=7d&types=crash&sessionEventKey=6A3CEE98036E000221C18E913C895809_2233701407585464823

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: PlatformException(abort, Loading interrupted, null, null)
       at AudioPlayer._setPlatformActive.checkInterruption(just_audio.dart:1331)
       at AudioPlayer._setPlatformActive.setPlatform(just_audio.dart:1442)
```

## Root Cause

In `UserSpeechSamplesProvider.playPause()`, `stop()` was not awaited before calling `setUrl()`. This caused just_audio's internal interruption counter to increment mid-stop; when `setUrl()` then called `checkInterruption()` it detected the mismatch and threw an unhandled `PlatformException`.

## Fix

- Await `_audioPlayer.stop()` before `setUrl()` so the player is fully stopped before loading the next track.
- Wrap the stop/load/play sequence in try-catch so any interruption exception is caught instead of propagating uncaught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

