### PR TITLE
fix WAL file crash on corrupted JSON at startup

### DIFF
--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -39,7 +39,13 @@ class WalFileManager {
       return [];
     }
 
-    final jsonData = jsonDecode(content);
+    dynamic jsonData;
+    try {
+      jsonData = jsonDecode(content);
+    } on FormatException catch (e) {
+      Logger.debug('WAL file is corrupted ($e), trying backup');
+      return await _loadFromBackup();
+    }
     if (jsonData is! Map<String, dynamic> || jsonData['wals'] is! List) {
       Logger.debug('Invalid WAL file format, returning empty list');
       return [];
@@ -95,7 +101,13 @@ class WalFileManager {
       return [];
     }
 
-    final jsonData = jsonDecode(content);
+    dynamic jsonData;
+    try {
+      jsonData = jsonDecode(content);
+    } on FormatException catch (e) {
+      Logger.debug('WAL backup file is also corrupted ($e), returning empty list');
+      return [];
+    }
     if (jsonData is! Map<String, dynamic> || jsonData['wals'] is! List) {
       return [];
     }


### PR DESCRIPTION
## Problem

`WalFileManager.loadWals` crashes on startup when the WAL file exists but contains corrupted or non-JSON content.

Crashlytics: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/29616078761c6481ae288fc65b3f12b5

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: FormatException: Unexpected character (at character 1)

^

       at .jsonDecode(dart:convert)
       at WalFileManager.loadWals(wal_file_manager.dart:42)
       at LocalWalSyncImpl._initializeWals(local_wal_sync.dart:103)
```

## Root Cause

`jsonDecode(content)` in `loadWals()` (and in `_loadFromBackup()`) had no try-catch. If the WAL file is corrupted (e.g. truncated mid-write, filesystem error), the `FormatException` propagated uncaught through `_initializeWals` and crashed the app on every subsequent launch.

## Fix

- Wrap `jsonDecode` in `loadWals()` with a `FormatException` catch that falls back to the backup file.
- Wrap `jsonDecode` in `_loadFromBackup()` with a `FormatException` catch that returns an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

