### PR TITLE
fix(omiGlass): apply BLE_TX_POWER so the device is reliably discoverable

### DIFF
--- a/omiGlass/firmware/src/app.cpp
+++ b/omiGlass/firmware/src/app.cpp
@@ -588,6 +588,10 @@ void configure_ble()
 {
     Serial.println("Initializing BLE...");
     BLEDevice::init(BLE_DEVICE_NAME);
+    // Apply the configured BLE TX power. Previously BLE_TX_POWER was defined but
+    // never applied, so the radio advertised at a weak default and the device was
+    // frequently undiscoverable by phones even at close range.
+    BLEDevice::setPower(BLE_TX_POWER);
     BLEServer *server = BLEDevice::createServer();
     server->setCallbacks(new ServerHandler());
 

--- a/omiGlass/firmware/src/config.h
+++ b/omiGlass/firmware/src/config.h
@@ -78,7 +78,7 @@ typedef enum {
 #define BLE_MTU_SIZE 517            // Maximum MTU for efficiency
 #define BLE_CHUNK_SIZE 500          // Safe chunk size for photo transfer
 #define BLE_PHOTO_TRANSFER_DELAY 3  // Fast transfer for connection stability
-#define BLE_TX_POWER ESP_PWR_LVL_N0 // Low power for 6+ hour battery life
+#define BLE_TX_POWER ESP_PWR_LVL_P9 // Max TX power for reliable discovery/range (applied in configure_ble)
 
 // Power-optimized BLE Advertising - Longer intervals for power savings
 #define BLE_ADV_MIN_INTERVAL 0x0140  // 200ms minimum (was 160ms)


### PR DESCRIPTION
BLE_TX_POWER was defined in config.h but never applied, so the BLE radio advertised at a weak default level. On assembled glasses this made the device frequently undiscoverable by phones / BLE centrals even at close range (a likely cause of reports that omiGlass BLE is flaky/unreliable).

Call BLEDevice::setPower(BLE_TX_POWER) in configure_ble() and raise the default to ESP_PWR_LVL_P9. After this, the device advertises at ~-40 dBm at close range and connects + streams photos reliably.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

