### PR TITLE
Fix Stripe checkout entitlement race

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -725,9 +725,18 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                 )
                 return {"status": "success"}
 
-            # Check if user already has an active subscription to prevent duplicates
+            # Check if user already has an active *paid* subscription to prevent duplicates.
+            # Stripe sends customer.subscription.created while Checkout subscriptions are still
+            # incomplete; our subscription event handler represents those as Basic with a Stripe
+            # subscription id. Do not treat that transient Basic record as a duplicate checkout,
+            # otherwise checkout.session.completed returns before persisting the real paid
+            # subscription/customer id and later stale incomplete_expired events can clobber access.
             existing_subscription = await run_blocking(db_executor, users_db.get_user_valid_subscription, uid)
-            if existing_subscription and existing_subscription.stripe_subscription_id:
+            if (
+                existing_subscription
+                and existing_subscription.stripe_subscription_id
+                and is_paid_plan(existing_subscription.plan)
+            ):
                 # If user already has a Stripe subscription, verify it's not the same one
                 if existing_subscription.stripe_subscription_id == session.get('subscription'):
                     logger.warning(f"Duplicate webhook event for existing subscription: {session.get('subscription')}")
@@ -833,6 +842,9 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                         new_subscription = active_paid
                 try:
                     if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
+                        customer_id = subscription_obj.get('customer')
+                        if customer_id:
+                            await run_blocking(db_executor, users_db.set_stripe_customer_id, uid, customer_id)
                         await run_blocking(db_executor, conversations_db.unlock_all_conversations, uid)
                         await run_blocking(db_executor, memories_db.unlock_all_memories, uid)
                         await run_blocking(db_executor, action_items_db.unlock_all_action_items, uid)

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -831,6 +831,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                 # active paid subscription — they canceled one sub and started
                 # another near-simultaneously, possibly on a new Stripe customer —
                 # don't overwrite their plan with basic. Adopt the active paid sub.
+                adopted_active_paid = False
                 if not is_paid_plan(new_subscription.plan):
                     event_sub_id = subscription_obj.get('id')
                     active_paid = await run_blocking(stripe_executor, find_active_paid_subscription_for_user, uid)
@@ -840,11 +841,22 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                             f"a different active paid sub {active_paid.stripe_subscription_id} exists."
                         )
                         new_subscription = active_paid
+                        adopted_active_paid = True
                 try:
                     if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
-                        customer_id = subscription_obj.get('customer')
-                        if customer_id:
-                            await run_blocking(db_executor, users_db.set_stripe_customer_id, uid, customer_id)
+                        # Only persist the customer id from the incoming event when we
+                        # did NOT adopt a different active paid subscription. When the
+                        # stale-downgrade guard adopted active_paid, the event's
+                        # subscription_obj['customer'] belongs to the canceled/stale
+                        # subscription (possibly a different Stripe customer), so
+                        # writing it would clobber the correct customer id that
+                        # find_active_paid_subscription_for_user used to locate
+                        # active_paid — a later reconciliation could then query the
+                        # wrong customer and miss the paid sub.
+                        if not adopted_active_paid:
+                            customer_id = subscription_obj.get('customer')
+                            if customer_id:
+                                await run_blocking(db_executor, users_db.set_stripe_customer_id, uid, customer_id)
                         await run_blocking(db_executor, conversations_db.unlock_all_conversations, uid)
                         await run_blocking(db_executor, memories_db.unlock_all_memories, uid)
                         await run_blocking(db_executor, action_items_db.unlock_all_action_items, uid)

--- a/backend/scripts/support/find_stripe_entitlement_mismatches.py
+++ b/backend/scripts/support/find_stripe_entitlement_mismatches.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Find users whose Firestore entitlement does not match active Stripe subs.
+
+This is a support/audit script for Stripe webhook eventual-consistency races.
+It treats Stripe active/trialing subscriptions with `metadata.uid` and a known paid
+price id as source-of-truth, then compares against `users/{uid}` in Firestore.
+
+Usage:
+  STRIPE_API_KEY=sk_live_... python scripts/support/find_stripe_entitlement_mismatches.py \
+    --project based-hardware --output /tmp/stripe-entitlement-mismatches.json
+
+The script is read-only. It does not repair users.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from google.cloud import firestore
+
+# Keep in sync with backend/utils/subscription.py and production Cloud Run env.
+# Env vars override these defaults when present.
+DEFAULT_PRICE_TO_PLAN = {
+    # Current Operator
+    "price_1TMxVM1F8wnoWYvw9uaoYX7V": "operator",
+    "price_1TMxVM1F8wnoWYvwNfXdF6LW": "operator",
+    # Current Architect / legacy Pro
+    "price_1TAfBB1F8wnoWYvw8XBFM1dX": "architect",
+    "price_1TLFac1F8wnoWYvwtPxZhtzE": "architect",
+    # Current/legacy Neo / Unlimited
+    "price_1RtJPm1F8wnoWYvwhVJ38kLb": "unlimited",
+    "price_1RtJQ71F8wnoWYvwKMPaGlGY": "unlimited",
+    "price_1TNIHd1F8wnoWYvwkIrekcQZ": "unlimited",
+    "price_1TNIHd1F8wnoWYvwlKywJ8TO": "unlimited",
+}
+
+ENV_PRICE_PLAN_KEYS = {
+    "STRIPE_OPERATOR_MONTHLY_PRICE_ID": "operator",
+    "STRIPE_OPERATOR_ANNUAL_PRICE_ID": "operator",
+    "STRIPE_ARCHITECT_MONTHLY_PRICE_ID": "architect",
+    "STRIPE_ARCHITECT_ANNUAL_PRICE_ID": "architect",
+    "STRIPE_PRO_MONTHLY_PRICE_ID": "architect",
+    "STRIPE_PRO_ANNUAL_PRICE_ID": "architect",
+    "STRIPE_UNLIMITED_MONTHLY_PRICE_ID": "unlimited",
+    "STRIPE_UNLIMITED_ANNUAL_PRICE_ID": "unlimited",
+    "STRIPE_NEO_MONTHLY_PRICE_ID": "unlimited",
+    "STRIPE_NEO_ANNUAL_PRICE_ID": "unlimited",
+}
+
+PAID_PLANS = {"unlimited", "operator", "architect"}
+
+
+@dataclass
+class StripeSub:
+    uid: str
+    stripe_subscription_id: str
+    stripe_customer_id: str
+    stripe_status: str
+    expected_plan: str
+    price_id: str
+    current_period_start: int | None
+    current_period_end: int | None
+    cancel_at_period_end: bool
+    customer_email: str | None = None
+
+
+@dataclass
+class Mismatch:
+    uid: str
+    reason: str
+    expected_plan: str
+    stripe_subscription_id: str
+    stripe_customer_id: str
+    price_id: str
+    customer_email: str | None
+    firestore_plan: str | None
+    firestore_status: str | None
+    firestore_subscription_id: str | None
+    firestore_customer_id: str | None
+    firestore_exists: bool
+
+
+def stripe_get(api_key: str, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = f"https://api.stripe.com/v1/{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params, doseq=True)
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 support script, fixed host
+        return json.load(resp)
+
+
+def price_to_plan_map() -> dict[str, str]:
+    mapping = dict(DEFAULT_PRICE_TO_PLAN)
+    for env_key, plan in ENV_PRICE_PLAN_KEYS.items():
+        price_id = os.getenv(env_key)
+        if price_id:
+            mapping[price_id] = plan
+    return mapping
+
+
+def iter_stripe_subscriptions(api_key: str, statuses: list[str]) -> list[dict[str, Any]]:
+    subscriptions: list[dict[str, Any]] = []
+    for status in statuses:
+        params: dict[str, Any] = {"status": status, "limit": 100, "expand[]": "data.customer"}
+        while True:
+            page = stripe_get(api_key, "subscriptions", params)
+            data = page.get("data", [])
+            subscriptions.extend(data)
+            if not page.get("has_more"):
+                break
+            params["starting_after"] = data[-1]["id"]
+            # Be gentle with Stripe when paging large accounts.
+            time.sleep(0.05)
+    return subscriptions
+
+
+def build_stripe_source_of_truth(
+    api_key: str, statuses: list[str]
+) -> tuple[dict[str, StripeSub], list[dict[str, Any]]]:
+    plan_by_price = price_to_plan_map()
+    by_uid: dict[str, StripeSub] = {}
+    skipped: list[dict[str, Any]] = []
+
+    for sub in iter_stripe_subscriptions(api_key, statuses):
+        metadata = sub.get("metadata") or {}
+        uid = metadata.get("uid")
+        items = (sub.get("items") or {}).get("data") or []
+        price_id = items[0].get("price", {}).get("id") if items else None
+        expected_plan = plan_by_price.get(price_id or "")
+        if not uid or not expected_plan:
+            skipped.append(
+                {
+                    "subscription_id": sub.get("id"),
+                    "status": sub.get("status"),
+                    "uid": uid,
+                    "price_id": price_id,
+                    "reason": "missing_uid_or_unknown_price",
+                }
+            )
+            continue
+
+        customer = sub.get("customer")
+        if isinstance(customer, dict):
+            customer_id = customer.get("id")
+            customer_email = customer.get("email")
+        else:
+            customer_id = customer
+            customer_email = None
+
+        candidate = StripeSub(
+            uid=uid,
+            stripe_subscription_id=sub["id"],
+            stripe_customer_id=customer_id or "",
+            stripe_status=sub.get("status", ""),
+            expected_plan=expected_plan,
+            price_id=price_id or "",
+            current_period_start=sub.get("current_period_start"),
+            current_period_end=sub.get("current_period_end"),
+            cancel_at_period_end=bool(sub.get("cancel_at_period_end", False)),
+            customer_email=customer_email,
+        )
+
+        # If Stripe somehow has multiple active paid subs for a uid, keep the one
+        # with the furthest period end and let the mismatch report surface the ids.
+        existing = by_uid.get(uid)
+        if not existing or (candidate.current_period_end or 0) > (existing.current_period_end or 0):
+            by_uid[uid] = candidate
+
+    return by_uid, skipped
+
+
+def compare_firestore(project: str, stripe_by_uid: dict[str, StripeSub]) -> list[Mismatch]:
+    db = firestore.Client(project=project)
+    mismatches: list[Mismatch] = []
+
+    for uid, stripe_sub in sorted(stripe_by_uid.items()):
+        snap = db.collection("users").document(uid).get()
+        if not snap.exists:
+            mismatches.append(
+                Mismatch(
+                    uid=uid,
+                    reason="firestore_user_missing",
+                    expected_plan=stripe_sub.expected_plan,
+                    stripe_subscription_id=stripe_sub.stripe_subscription_id,
+                    stripe_customer_id=stripe_sub.stripe_customer_id,
+                    price_id=stripe_sub.price_id,
+                    customer_email=stripe_sub.customer_email,
+                    firestore_plan=None,
+                    firestore_status=None,
+                    firestore_subscription_id=None,
+                    firestore_customer_id=None,
+                    firestore_exists=False,
+                )
+            )
+            continue
+
+        data = snap.to_dict() or {}
+        fs_sub = data.get("subscription") or {}
+        fs_plan = fs_sub.get("plan")
+        fs_status = fs_sub.get("status")
+        fs_sub_id = fs_sub.get("stripe_subscription_id")
+        fs_customer_id = data.get("stripe_customer_id")
+
+        reasons = []
+        if fs_plan != stripe_sub.expected_plan:
+            reasons.append(f"plan:{fs_plan}->{stripe_sub.expected_plan}")
+        if fs_status != "active":
+            reasons.append(f"status:{fs_status}->active")
+        if fs_sub_id != stripe_sub.stripe_subscription_id:
+            reasons.append(f"subscription_id:{fs_sub_id}->{stripe_sub.stripe_subscription_id}")
+        if fs_customer_id != stripe_sub.stripe_customer_id:
+            reasons.append(f"customer_id:{fs_customer_id}->{stripe_sub.stripe_customer_id}")
+        if fs_plan not in PAID_PLANS:
+            reasons.append("firestore_not_paid")
+
+        if reasons:
+            mismatches.append(
+                Mismatch(
+                    uid=uid,
+                    reason=", ".join(reasons),
+                    expected_plan=stripe_sub.expected_plan,
+                    stripe_subscription_id=stripe_sub.stripe_subscription_id,
+                    stripe_customer_id=stripe_sub.stripe_customer_id,
+                    price_id=stripe_sub.price_id,
+                    customer_email=stripe_sub.customer_email,
+                    firestore_plan=fs_plan,
+                    firestore_status=fs_status,
+                    firestore_subscription_id=fs_sub_id,
+                    firestore_customer_id=fs_customer_id,
+                    firestore_exists=True,
+                )
+            )
+
+    return mismatches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=os.getenv("GOOGLE_CLOUD_PROJECT", "based-hardware"))
+    parser.add_argument(
+        "--statuses", nargs="+", default=["active", "trialing"], help="Stripe subscription statuses to scan"
+    )
+    parser.add_argument("--output", help="Optional JSON output path")
+    parser.add_argument(
+        "--include-skipped", action="store_true", help="Include skipped Stripe subs with no uid/unknown price in output"
+    )
+    args = parser.parse_args()
+
+    api_key = os.getenv("STRIPE_API_KEY")
+    if not api_key:
+        print("STRIPE_API_KEY is required", file=sys.stderr)
+        return 2
+
+    stripe_by_uid, skipped = build_stripe_source_of_truth(api_key, args.statuses)
+    mismatches = compare_firestore(args.project, stripe_by_uid)
+
+    result = {
+        "project": args.project,
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+        "stripe_statuses": args.statuses,
+        "stripe_paid_uid_count": len(stripe_by_uid),
+        "mismatch_count": len(mismatches),
+        "mismatches": [asdict(m) for m in mismatches],
+    }
+    if args.include_skipped:
+        result["skipped"] = skipped
+
+    text = json.dumps(result, indent=2, sort_keys=True)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(text + "\n")
+    print(text)
+    return 1 if mismatches else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -8,6 +8,7 @@ credentials and Python 3.10+, so we extract and test the function logic directly
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -171,6 +172,67 @@ class TestStripeWebhookDuplicateAndCustomerSourceLevel:
         sub_idx = source.find("'customer.subscription.updated'")
         assert sub_idx != -1, "customer.subscription handler not found"
         next_idx = source.find("subscription_schedule.completed", sub_idx)
+        assert next_idx != -1, "subscription_schedule handler not found after customer.subscription handler"
         block = source[sub_idx:next_idx]
         assert 'users_db.set_stripe_customer_id' in block
         assert "subscription_obj.get('customer')" in block
+
+    def test_stale_downgrade_guard_does_not_clobber_customer_id(self):
+        """When the active-paid adoption guard fires, the event's customer id
+        must not be persisted, because it belongs to the stale/canceled sub
+        (possibly a different Stripe customer) and would break later
+        reconciliation via find_active_paid_subscription_for_user."""
+        source = self._read_source()
+        # Anchor to the subscription event handler block to avoid matching an
+        # earlier set_stripe_customer_id in the checkout.session.completed path.
+        sub_idx = source.find("'customer.subscription.updated'")
+        assert sub_idx != -1, "customer.subscription handler not found"
+        handler_block = source[sub_idx:]
+        set_customer_idx = handler_block.find("users_db.set_stripe_customer_id")
+        assert set_customer_idx != -1, "set_stripe_customer_id call not found in subscription handler"
+        # The guard flag must precede the set_stripe_customer_id call
+        guard_idx = handler_block.find("adopted_active_paid = False")
+        assert guard_idx != -1, "adopted_active_paid flag not found"
+        assert guard_idx < set_customer_idx, "guard flag must precede customer id write"
+        # The write must be gated on NOT adopting active_paid
+        guard_block = handler_block[max(0, set_customer_idx - 400) : set_customer_idx]
+        assert "not adopted_active_paid" in guard_block, "customer id write must be gated on not adopted_active_paid"
+
+
+class TestStripeEntitlementMismatchScannerDrift:
+    """Guard against price→plan mapping drift between the standalone support
+    scanner and the backend subscription mapping.
+
+    find_stripe_entitlement_mismatches.py cannot import the backend chain
+    (Firestore/Google Cloud deps), so it keeps its own DEFAULT_PRICE_TO_PLAN.
+    If it drifts from backend/utils/subscription.py LEGACY_PRICE_MAP, the
+    scanner silently skips active paid subscriptions and under-reports
+    entitlement mismatches. This test catches that drift.
+    """
+
+    SUPPORT_FILE = Path(__file__).resolve().parents[2] / "scripts" / "support" / "find_stripe_entitlement_mismatches.py"
+    SUBSCRIPTION_FILE = Path(__file__).resolve().parents[2] / "utils" / "subscription.py"
+
+    def _extract_price_ids(self, source: str, start_marker: str) -> set:
+        """Extract quoted price_ IDs between start_marker and the closing brace."""
+        start = source.find(start_marker)
+        assert start != -1, f"{start_marker} not found"
+        end = source.find("\n}", start)
+        block = source[start:end]
+        return set(re.findall(r"['\"](price_[A-Za-z0-9]+)['\"]", block))
+
+    def test_support_scanner_legacy_price_ids_match_backend(self):
+        """Every legacy price id in the backend LEGACY_PRICE_MAP must appear in
+        the support scanner's DEFAULT_PRICE_TO_PLAN so the scanner never silently
+        skips a known paid price."""
+        support_src = self.SUPPORT_FILE.read_text(encoding="utf-8")
+        sub_src = self.SUBSCRIPTION_FILE.read_text(encoding="utf-8")
+
+        backend_legacy = self._extract_price_ids(sub_src, "LEGACY_PRICE_MAP = {")
+        support_default = self._extract_price_ids(support_src, "DEFAULT_PRICE_TO_PLAN = {")
+
+        missing = backend_legacy - support_default
+        assert not missing, (
+            f"Support scanner is missing legacy price IDs that the backend knows about: {missing}. "
+            "Add them to DEFAULT_PRICE_TO_PLAN to avoid under-reporting entitlement mismatches."
+        )

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -140,3 +140,37 @@ class TestBuildSubscriptionFromStripeObject:
         """Result always includes current_period_end."""
         result = self.fn(_make_stripe_sub())
         assert result.current_period_end == 1700000000
+
+
+class TestStripeWebhookDuplicateAndCustomerSourceLevel:
+    """Regression coverage for duplicate checkout + stale downgrade race.
+
+    Scenario seen in prod: Stripe emits customer.subscription.created with
+    status=incomplete before checkout.session.completed. The created event stored
+    a Basic subscription with the same Stripe sub id, so checkout completion was
+    treated as a duplicate and returned before storing stripe_customer_id. One
+    day later, the first failed Checkout's incomplete_expired event downgraded
+    the user because the active paid sub lived on a second customer and could not
+    be discovered from Firestore.
+    """
+
+    PAYMENT_SOURCE_FILE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+
+    def _read_source(self):
+        return self.PAYMENT_SOURCE_FILE.read_text(encoding="utf-8")
+
+    def test_checkout_duplicate_return_only_applies_to_paid_existing_subscription(self):
+        source = self._read_source()
+        duplicate_idx = source.find('Duplicate webhook event for existing subscription')
+        assert duplicate_idx != -1, "duplicate checkout guard not found"
+        guard_block = source[max(0, duplicate_idx - 600) : duplicate_idx]
+        assert 'is_paid_plan(existing_subscription.plan)' in guard_block
+
+    def test_subscription_events_persist_customer_id_for_uid_metadata_path(self):
+        source = self._read_source()
+        sub_idx = source.find("'customer.subscription.updated'")
+        assert sub_idx != -1, "customer.subscription handler not found"
+        next_idx = source.find("subscription_schedule.completed", sub_idx)
+        block = source[sub_idx:next_idx]
+        assert 'users_db.set_stripe_customer_id' in block
+        assert "subscription_obj.get('customer')" in block


### PR DESCRIPTION
## Summary
- Prevent `checkout.session.completed` from being treated as duplicate when the existing stored subscription is only a transient Basic record from an incomplete Stripe subscription event
- Persist `stripe_customer_id` from active paid `customer.subscription.*` webhook events so stale downgrade protection can find active paid subs later
- Add regression coverage for the duplicate-checkout/stale-downgrade race that left a paying Operator user on Basic
- Add a read-only support scanner for Stripe-vs-Firestore entitlement mismatches: `backend/scripts/support/find_stripe_entitlement_mismatches.py`

## Test Plan
- `uv run --with pytest --with pydantic --with fastapi --with stripe --with firebase-admin --with google-cloud-firestore python -m pytest tests/unit/test_fair_use_upgrade.py tests/unit/test_stripe_webhook_behavioral.py -q`
- `uv run --with google-cloud-firestore python -m py_compile scripts/support/find_stripe_entitlement_mismatches.py`

## Support validation
Ran the new scanner against production with `STRIPE_API_KEY` from GCP Secret Manager. Results are intentionally not pasted here because they include customer emails; local artifact: `/tmp/stripe-entitlement-mismatches.json`.
