### PR TITLE
[codex] Clear stale offline sync rate limits

### DIFF
--- a/app/lib/pages/settings/fair_use_page.dart
+++ b/app/lib/pages/settings/fair_use_page.dart
@@ -29,6 +29,11 @@ class _FairUsePageState extends State<FairUsePage> {
     });
     try {
       final result = await getFairUseStatus();
+      // Reconcile the rate-limit cooldown regardless of whether the widget is
+      // still mounted — this only touches the SyncRateLimiter singleton and
+      // must not be skipped if the user navigates away before the response
+      // returns (otherwise a stale cooldown is never cleared).
+      reconcileSyncRateLimitWithFairUseStatus(result);
       if (mounted) {
         if (result == null) {
           setState(() {
@@ -36,7 +41,6 @@ class _FairUsePageState extends State<FairUsePage> {
             _isLoading = false;
           });
         } else {
-          reconcileSyncRateLimitWithFairUseStatus(result);
           setState(() {
             _status = result;
             _isLoading = false;

--- a/app/lib/pages/settings/fair_use_page.dart
+++ b/app/lib/pages/settings/fair_use_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class FairUsePage extends StatefulWidget {
@@ -35,6 +36,7 @@ class _FairUsePageState extends State<FairUsePage> {
             _isLoading = false;
           });
         } else {
+          reconcileSyncRateLimitWithFairUseStatus(result);
           setState(() {
             _status = result;
             _isLoading = false;

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -20,6 +20,7 @@ import 'package:omi/pages/settings/fair_use_page.dart';
 import 'package:omi/pages/settings/transcription_settings_page.dart';
 import 'package:omi/pages/settings/widgets/plans_sheet.dart';
 import 'package:omi/providers/usage_provider.dart';
+import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class UsagePage extends StatefulWidget {
@@ -46,6 +47,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     try {
       final result = await getFairUseStatus();
       if (mounted && result != null) {
+        reconcileSyncRateLimitWithFairUseStatus(result);
         setState(() => _fairUseStatus = result);
       }
     } catch (_) {
@@ -317,8 +319,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       ),
       body: Consumer<UsageProvider>(
         builder: (context, provider, child) {
-          final hasAnyData =
-              provider.todayUsage != null ||
+          final hasAnyData = provider.todayUsage != null ||
               provider.monthlyUsage != null ||
               provider.yearlyUsage != null ||
               provider.allTimeUsage != null;
@@ -1148,8 +1149,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                 builder: (context) {
                   final minutesUsed = (subscription.transcriptionSecondsUsed / 60).round();
                   final minutesLimit = (subscription.transcriptionSecondsLimit / 60).round();
-                  final percentage = (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit)
-                      .clamp(0.0, 1.0);
+                  final percentage =
+                      (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit).clamp(0.0, 1.0);
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -46,8 +46,9 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
   Future<void> _loadFairUseStatus() async {
     try {
       final result = await getFairUseStatus();
+      // Reconcile the rate-limit cooldown regardless of widget mount state.
+      reconcileSyncRateLimitWithFairUseStatus(result);
       if (mounted && result != null) {
-        reconcileSyncRateLimitWithFairUseStatus(result);
         setState(() => _fairUseStatus = result);
       }
     } catch (_) {

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -5,7 +5,6 @@ import 'package:omi/backend/http/api/payment.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/models/subscription.dart';
 import 'package:omi/models/user_usage.dart';
-import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/utils/logger.dart';
 
 class UsageProvider with ChangeNotifier {
@@ -121,7 +120,6 @@ class UsageProvider with ChangeNotifier {
       _subscription = await getUserSubscription();
       if (_subscription != null) {
         PlatformManager.instance.analytics.setSubscriptionTier(_subscription!.subscription.plan.name);
-        reconcileSyncRateLimitWithSubscription(_subscription);
       }
     } catch (e) {
       _error = 'Failed to load subscription data. Please try again later.';

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -5,6 +5,7 @@ import 'package:omi/backend/http/api/payment.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/models/subscription.dart';
 import 'package:omi/models/user_usage.dart';
+import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/utils/logger.dart';
 
 class UsageProvider with ChangeNotifier {
@@ -120,6 +121,7 @@ class UsageProvider with ChangeNotifier {
       _subscription = await getUserSubscription();
       if (_subscription != null) {
         PlatformManager.instance.analytics.setSubscriptionTier(_subscription!.subscription.plan.name);
+        reconcileSyncRateLimitWithSubscription(_subscription);
       }
     } catch (e) {
       _error = 'Failed to load subscription data. Please try again later.';

--- a/app/lib/services/wals/sync_rate_limit_reconciliation.dart
+++ b/app/lib/services/wals/sync_rate_limit_reconciliation.dart
@@ -1,26 +1,21 @@
-import 'package:omi/models/subscription.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
-
-bool shouldClearSyncRateLimitForPlan(Subscription subscription) {
-  if (subscription.status != SubscriptionStatus.active) return false;
-  return subscription.plan == PlanType.unlimited ||
-      subscription.plan == PlanType.operator ||
-      subscription.plan == PlanType.architect;
-}
 
 bool shouldClearSyncRateLimitForFairUseStatus(Map<String, dynamic>? status) {
   return status?['stage'] == 'none';
 }
 
-void reconcileSyncRateLimitWithSubscription(UserSubscriptionResponse? subscription) {
-  if (subscription == null) return;
-  if (shouldClearSyncRateLimitForPlan(subscription.subscription)) {
-    SyncRateLimiter.instance.clear();
-  }
-}
-
+/// Reconcile the persisted fair-use rate-limit cooldown against the latest
+/// server-reported fair-use status. When the server says `stage: none` the
+/// fair-use restriction has been lifted, so we clear the persisted HTTP-429
+/// backoff — but only the persisted state, not an active backend-busy
+/// cooldown (see [SyncRateLimiter.clearRateLimit]).
+///
+/// Note: a paid subscription alone is NOT sufficient to clear the cooldown.
+/// The backend preserves abuse-derived restrict/throttle states even for
+/// paid users (`backend/utils/fair_use.py`), so we rely on the fair-use
+/// status endpoint as the authoritative signal.
 void reconcileSyncRateLimitWithFairUseStatus(Map<String, dynamic>? status) {
   if (shouldClearSyncRateLimitForFairUseStatus(status)) {
-    SyncRateLimiter.instance.clear();
+    SyncRateLimiter.instance.clearRateLimit();
   }
 }

--- a/app/lib/services/wals/sync_rate_limit_reconciliation.dart
+++ b/app/lib/services/wals/sync_rate_limit_reconciliation.dart
@@ -1,0 +1,26 @@
+import 'package:omi/models/subscription.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+
+bool shouldClearSyncRateLimitForPlan(Subscription subscription) {
+  if (subscription.status != SubscriptionStatus.active) return false;
+  return subscription.plan == PlanType.unlimited ||
+      subscription.plan == PlanType.operator ||
+      subscription.plan == PlanType.architect;
+}
+
+bool shouldClearSyncRateLimitForFairUseStatus(Map<String, dynamic>? status) {
+  return status?['stage'] == 'none';
+}
+
+void reconcileSyncRateLimitWithSubscription(UserSubscriptionResponse? subscription) {
+  if (subscription == null) return;
+  if (shouldClearSyncRateLimitForPlan(subscription.subscription)) {
+    SyncRateLimiter.instance.clear();
+  }
+}
+
+void reconcileSyncRateLimitWithFairUseStatus(Map<String, dynamic>? status) {
+  if (shouldClearSyncRateLimitForFairUseStatus(status)) {
+    SyncRateLimiter.instance.clear();
+  }
+}

--- a/app/lib/services/wals/sync_rate_limiter.dart
+++ b/app/lib/services/wals/sync_rate_limiter.dart
@@ -103,4 +103,14 @@ class SyncRateLimiter extends ChangeNotifier {
     SharedPreferencesUtil().saveString(_prefKeyReason, '');
     notifyListeners();
   }
+
+  /// Clear only the persisted fair-use rate-limit cooldown (HTTP 429),
+  /// preserving any active in-memory backend-busy cooldown. Used when a
+  /// fair-use status refresh confirms the restriction was lifted but the
+  /// backend may still be saturated and should keep its own backoff.
+  void clearRateLimit() {
+    SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
+    SharedPreferencesUtil().saveString(_prefKeyReason, '');
+    notifyListeners();
+  }
 }

--- a/app/test/unit/sync_rate_limit_reconciliation_test.dart
+++ b/app/test/unit/sync_rate_limit_reconciliation_test.dart
@@ -30,8 +30,10 @@ void main() {
 
   test('clears persisted rate limit but preserves backendBusy cooldown', () {
     // Set both a persisted rate-limit and an in-memory backendBusy cooldown.
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backendBusy);
+    // Use a longer backendBusy cooldown so `reason` reports it as the
+    // dominant deadline (matching `until`'s max-based pick).
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.rateLimit);
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.backendBusy);
     expect(SyncRateLimiter.instance.isLimited, isTrue);
     expect(SyncRateLimiter.instance.reason, RateLimitReason.backendBusy);
 
@@ -53,8 +55,8 @@ void main() {
 
   group('clearRateLimit', () {
     test('only clears persisted rate-limit state, preserves backendBusy', () {
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
-      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backendBusy);
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.rateLimit);
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.backendBusy);
 
       SyncRateLimiter.instance.clearRateLimit();
 

--- a/app/test/unit/sync_rate_limit_reconciliation_test.dart
+++ b/app/test/unit/sync_rate_limit_reconciliation_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/models/subscription.dart';
+import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+UserSubscriptionResponse _subscriptionResponse({
+  required PlanType plan,
+  SubscriptionStatus status = SubscriptionStatus.active,
+}) {
+  return UserSubscriptionResponse(
+    subscription: Subscription(plan: plan, status: status),
+    transcriptionSecondsUsed: 0,
+    transcriptionSecondsLimit: 0,
+    wordsTranscribedUsed: 0,
+    wordsTranscribedLimit: 0,
+    insightsGainedUsed: 0,
+    insightsGainedLimit: 0,
+  );
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+  });
+
+  test('clears stale rate limit when subscription refresh confirms active operator plan', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+
+    reconcileSyncRateLimitWithSubscription(_subscriptionResponse(plan: PlanType.operator));
+
+    expect(SyncRateLimiter.instance.isLimited, isFalse);
+  });
+
+  test('keeps active rate limit for basic subscription', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithSubscription(_subscriptionResponse(plan: PlanType.basic));
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+
+  test('keeps active rate limit for inactive paid subscription', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithSubscription(
+      _subscriptionResponse(plan: PlanType.operator, status: SubscriptionStatus.inactive),
+    );
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+
+  test('clears stale rate limit when fair-use status is unrestricted', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+
+    reconcileSyncRateLimitWithFairUseStatus({'stage': 'none'});
+
+    expect(SyncRateLimiter.instance.isLimited, isFalse);
+  });
+
+  test('keeps active rate limit when fair-use status is still restricted', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithFairUseStatus({'stage': 'restrict'});
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+}

--- a/app/test/unit/sync_rate_limit_reconciliation_test.dart
+++ b/app/test/unit/sync_rate_limit_reconciliation_test.dart
@@ -1,57 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/preferences.dart';
-import 'package:omi/models/subscription.dart';
 import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-UserSubscriptionResponse _subscriptionResponse({
-  required PlanType plan,
-  SubscriptionStatus status = SubscriptionStatus.active,
-}) {
-  return UserSubscriptionResponse(
-    subscription: Subscription(plan: plan, status: status),
-    transcriptionSecondsUsed: 0,
-    transcriptionSecondsLimit: 0,
-    wordsTranscribedUsed: 0,
-    wordsTranscribedLimit: 0,
-    insightsGainedUsed: 0,
-    insightsGainedLimit: 0,
-  );
-}
 
 void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
     SyncRateLimiter.instance.clear();
-  });
-
-  test('clears stale rate limit when subscription refresh confirms active operator plan', () {
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
-    expect(SyncRateLimiter.instance.isLimited, isTrue);
-
-    reconcileSyncRateLimitWithSubscription(_subscriptionResponse(plan: PlanType.operator));
-
-    expect(SyncRateLimiter.instance.isLimited, isFalse);
-  });
-
-  test('keeps active rate limit for basic subscription', () {
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
-
-    reconcileSyncRateLimitWithSubscription(_subscriptionResponse(plan: PlanType.basic));
-
-    expect(SyncRateLimiter.instance.isLimited, isTrue);
-  });
-
-  test('keeps active rate limit for inactive paid subscription', () {
-    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
-
-    reconcileSyncRateLimitWithSubscription(
-      _subscriptionResponse(plan: PlanType.operator, status: SubscriptionStatus.inactive),
-    );
-
-    expect(SyncRateLimiter.instance.isLimited, isTrue);
   });
 
   test('clears stale rate limit when fair-use status is unrestricted', () {
@@ -69,5 +26,48 @@ void main() {
     reconcileSyncRateLimitWithFairUseStatus({'stage': 'restrict'});
 
     expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+
+  test('clears persisted rate limit but preserves backendBusy cooldown', () {
+    // Set both a persisted rate-limit and an in-memory backendBusy cooldown.
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backendBusy);
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+    expect(SyncRateLimiter.instance.reason, RateLimitReason.backendBusy);
+
+    // A fair-use status refresh with stage: none should only clear the
+    // persisted rate-limit, not the backendBusy cooldown.
+    reconcileSyncRateLimitWithFairUseStatus({'stage': 'none'});
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue, reason: 'backendBusy cooldown should still be active');
+    expect(SyncRateLimiter.instance.reason, RateLimitReason.backendBusy);
+  });
+
+  test('null fair-use status does not clear the cooldown', () {
+    SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600);
+
+    reconcileSyncRateLimitWithFairUseStatus(null);
+
+    expect(SyncRateLimiter.instance.isLimited, isTrue);
+  });
+
+  group('clearRateLimit', () {
+    test('only clears persisted rate-limit state, preserves backendBusy', () {
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backendBusy);
+
+      SyncRateLimiter.instance.clearRateLimit();
+
+      expect(SyncRateLimiter.instance.isLimited, isTrue);
+      expect(SyncRateLimiter.instance.reason, RateLimitReason.backendBusy);
+    });
+
+    test('clears all when only persisted rate-limit was active', () {
+      SyncRateLimiter.instance.markLimited(retryAfterSeconds: 3600, reason: RateLimitReason.rateLimit);
+
+      SyncRateLimiter.instance.clearRateLimit();
+
+      expect(SyncRateLimiter.instance.isLimited, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- clear persisted offline sync rate-limit state when subscription refresh confirms an active paid plan
- clear the same stale cooldown when fair-use status refresh returns `stage: none`
- add focused unit coverage for paid, basic, inactive paid, unrestricted, and still-restricted reconciliation cases

Fixes #8420.

## Validation
- `/Users/dazheng/fvm/versions/3.38.10/bin/flutter test --no-pub test/unit/sync_rate_limit_reconciliation_test.dart`

## Notes
- `.fvmrc` currently points at Flutter 3.24.1, but `app/pubspec.lock` requires Flutter >=3.38.0. I used Flutter 3.38.10 for validation without changing repo config.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

