### PR TITLE
Guard Stripe entitlement downgrades from stale subscription events

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1224,6 +1224,23 @@ def get_user_subscription(uid: str) -> Subscription:
     return default_subscription
 
 
+def get_existing_user_subscription(uid: str) -> Optional[Subscription]:
+    """Gets the user's stored subscription without creating a default record."""
+    user_ref = db.collection('users').document(uid)
+    user_doc = user_ref.get(['subscription'])
+    if not user_doc.exists:
+        return None
+
+    user_data = user_doc.to_dict()
+    if 'subscription' not in user_data:
+        return None
+
+    sub_data = user_data['subscription']
+    if sub_data.get('plan') == 'free':
+        sub_data['plan'] = PlanType.basic.value
+    return Subscription(**sub_data)
+
+
 def get_user_training_data_opt_in(uid: str) -> Optional[dict]:
     """Get user's training data opt-in status."""
     user_ref = db.collection('users').document(uid)

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -140,7 +140,15 @@ def _has_current_paid_subscription_for_different_stripe_sub(
         return False
     if current_subscription.status != SubscriptionStatus.active or not is_paid_plan(current_subscription.plan):
         return False
-    if current_subscription.current_period_end and current_subscription.current_period_end < (now or int(time.time())):
+    # Require a valid, unexpired period end before preserving paid access.
+    # A missing or zero current_period_end means the stored paid row is not
+    # provably valid, so we do NOT let it shield a downgrade from a stale
+    # inactive event. This mirrors reconcile_basic_plan_with_stripe, which
+    # only treats a paid subscription as usable when current_period_end is
+    # present and still in the future.
+    if not current_subscription.current_period_end:
+        return False
+    if current_subscription.current_period_end < (now or int(time.time())):
         return False
     return True
 
@@ -1163,8 +1171,7 @@ def get_paypal_payment_details_endpoint(uid: str = Depends(auth.get_current_user
 @router.get("/v1/payments/success", response_class=HTMLResponse)
 def stripe_success(session_id: str = Query(...)):
     # The subscription is updated via webhook. This page is just for user feedback.
-    return HTMLResponse(
-        content="""
+    return HTMLResponse(content="""
         <html>
             <head><title>Success</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1172,14 +1179,12 @@ def stripe_success(session_id: str = Query(...)):
                 <p>Your subscription is now active. You can close this window and return to the app.</p>
             </body>
         </html>
-    """
-    )
+    """)
 
 
 @router.get("/v1/payments/cancel", response_class=HTMLResponse)
 def stripe_cancel():
-    return HTMLResponse(
-        content="""
+    return HTMLResponse(content="""
         <html>
             <head><title>Cancelled</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1187,8 +1192,7 @@ def stripe_cancel():
                 <p>Your payment process was cancelled. You can return to the app.</p>
             </body>
         </html>
-    """
-    )
+    """)
 
 
 @router.post('/v1/payments/customer-portal')
@@ -1221,8 +1225,7 @@ def create_customer_portal_endpoint(uid: str = Depends(auth.get_current_user_uid
 
 @router.get("/v1/payments/portal-return", response_class=HTMLResponse)
 def portal_return():
-    return HTMLResponse(
-        content="""
+    return HTMLResponse(content="""
         <html>
             <head><title>Portal Complete</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1230,8 +1233,7 @@ def portal_return():
                 <p>Your payment settings have been updated. You can close this window and return to the app.</p>
             </body>
         </html>
-    """
-    )
+    """)
 
 
 @router.get("/v1/payment-methods/status")

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -130,6 +130,21 @@ def _build_subscription_from_stripe_object(stripe_sub: dict) -> Subscription | N
     )
 
 
+def _has_current_paid_subscription_for_different_stripe_sub(
+    current_subscription: Subscription | None, event_subscription_id: str | None, now: int | None = None
+) -> bool:
+    """True when a stale inactive event should not overwrite stored paid access."""
+    if not current_subscription or not event_subscription_id:
+        return False
+    if current_subscription.stripe_subscription_id == event_subscription_id:
+        return False
+    if current_subscription.status != SubscriptionStatus.active or not is_paid_plan(current_subscription.plan):
+        return False
+    if current_subscription.current_period_end and current_subscription.current_period_end < (now or int(time.time())):
+        return False
+    return True
+
+
 def _update_subscription_from_session(uid: str, session: stripe.checkout.Session):
     customer_id = session.get('customer')
     subscription_id = session.get('subscription')
@@ -834,6 +849,13 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                 adopted_active_paid = False
                 if not is_paid_plan(new_subscription.plan):
                     event_sub_id = subscription_obj.get('id')
+                    current_subscription = await run_blocking(db_executor, users_db.get_existing_user_subscription, uid)
+                    if _has_current_paid_subscription_for_different_stripe_sub(current_subscription, event_sub_id):
+                        logger.info(
+                            f"Ignoring downgrade from {event['type']} (sub {event_sub_id}) for user {uid}: "
+                            f"stored paid sub {current_subscription.stripe_subscription_id} is still valid."
+                        )
+                        return {"status": "success"}
                     active_paid = await run_blocking(stripe_executor, find_active_paid_subscription_for_user, uid)
                     if active_paid and active_paid.stripe_subscription_id != event_sub_id:
                         logger.info(
@@ -1141,7 +1163,8 @@ def get_paypal_payment_details_endpoint(uid: str = Depends(auth.get_current_user
 @router.get("/v1/payments/success", response_class=HTMLResponse)
 def stripe_success(session_id: str = Query(...)):
     # The subscription is updated via webhook. This page is just for user feedback.
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Success</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1149,12 +1172,14 @@ def stripe_success(session_id: str = Query(...)):
                 <p>Your subscription is now active. You can close this window and return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.get("/v1/payments/cancel", response_class=HTMLResponse)
 def stripe_cancel():
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Cancelled</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1162,7 +1187,8 @@ def stripe_cancel():
                 <p>Your payment process was cancelled. You can return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.post('/v1/payments/customer-portal')
@@ -1195,7 +1221,8 @@ def create_customer_portal_endpoint(uid: str = Depends(auth.get_current_user_uid
 
 @router.get("/v1/payments/portal-return", response_class=HTMLResponse)
 def portal_return():
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Portal Complete</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1203,7 +1230,8 @@ def portal_return():
                 <p>Your payment settings have been updated. You can close this window and return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.get("/v1/payment-methods/status")

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -45,6 +45,24 @@ def _get_build_subscription_fn():
     return namespace['_build_subscription_from_stripe_object'], namespace
 
 
+def _get_current_paid_guard_fn():
+    source = (Path(__file__).resolve().parents[2] / "routers" / "payment.py").read_text(encoding="utf-8")
+    func_start = source.index('def _has_current_paid_subscription_for_different_stripe_sub')
+    next_func = source.index('\ndef ', func_start + 1)
+    func_source = source[func_start:next_func]
+    func_source = func_source.replace('Subscription | None', 'object')
+    func_source = func_source.replace('str | None', 'object')
+    func_source = func_source.replace('int | None', 'object')
+
+    namespace = {
+        'SubscriptionStatus': SubscriptionStatus,
+        'is_paid_plan': lambda plan: plan in {PlanType.unlimited, PlanType.architect, PlanType.operator},
+        'time': MagicMock(time=MagicMock(return_value=1_700_000_000)),
+    }
+    exec(compile(func_source, '<payment.py>', 'exec'), namespace)
+    return namespace['_has_current_paid_subscription_for_different_stripe_sub']
+
+
 # ── Behavioral tests for _build_subscription_from_stripe_object ─────────────
 
 
@@ -197,6 +215,64 @@ class TestStripeWebhookDuplicateAndCustomerSourceLevel:
         # The write must be gated on NOT adopting active_paid
         guard_block = handler_block[max(0, set_customer_idx - 400) : set_customer_idx]
         assert "not adopted_active_paid" in guard_block, "customer id write must be gated on not adopted_active_paid"
+
+
+class TestStripeSubscriptionEventPrecedence:
+    PAYMENT_SOURCE_FILE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+    USERS_SOURCE_FILE = Path(__file__).resolve().parents[2] / "database" / "users.py"
+
+    def setup_method(self):
+        self.fn = _get_current_paid_guard_fn()
+
+    def test_inactive_event_cannot_clobber_different_current_paid_subscription(self):
+        current = Subscription(
+            plan=PlanType.operator,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id="sub_current_paid",
+            current_period_end=1_800_000_000,
+        )
+
+        assert self.fn(current, "sub_old_inactive", now=1_700_000_000) is True
+
+    def test_matching_subscription_event_can_update_current_subscription(self):
+        current = Subscription(
+            plan=PlanType.operator,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id="sub_current_paid",
+            current_period_end=1_800_000_000,
+        )
+
+        assert self.fn(current, "sub_current_paid", now=1_700_000_000) is False
+
+    def test_expired_paid_subscription_does_not_block_inactive_event(self):
+        current = Subscription(
+            plan=PlanType.operator,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id="sub_expired_paid",
+            current_period_end=1_600_000_000,
+        )
+
+        assert self.fn(current, "sub_old_inactive", now=1_700_000_000) is False
+
+    def test_webhook_uses_non_creating_subscription_read_for_stale_downgrade_guard(self):
+        source = self.PAYMENT_SOURCE_FILE.read_text(encoding="utf-8")
+        sub_idx = source.find("'customer.subscription.updated'")
+        assert sub_idx != -1, "customer.subscription handler not found"
+        next_idx = source.find("subscription_schedule.completed", sub_idx)
+        assert next_idx != -1, "subscription_schedule handler end marker not found"
+        block = source[sub_idx:next_idx]
+
+        assert 'get_existing_user_subscription' in block
+        assert 'get_user_subscription' not in block
+
+    def test_existing_subscription_read_does_not_create_default_subscription(self):
+        source = self.USERS_SOURCE_FILE.read_text(encoding="utf-8")
+        func_start = source.index('def get_existing_user_subscription')
+        next_func = source.index('\ndef ', func_start + 1)
+        func_body = source[func_start:next_func]
+
+        assert '.set(' not in func_body
+        assert 'get_default_basic_subscription' not in func_body
 
 
 class TestStripeEntitlementMismatchScannerDrift:

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -254,6 +254,32 @@ class TestStripeSubscriptionEventPrecedence:
 
         assert self.fn(current, "sub_old_inactive", now=1_700_000_000) is False
 
+    def test_missing_period_end_does_not_preserve_paid_access(self):
+        """A paid subscription with a missing/zero current_period_end is not
+        provably valid, so it must not shield a downgrade from a stale inactive
+        event (Codex P2). Without the guard, the truthiness check would skip the
+        expiration test and the helper would incorrectly return True."""
+        current = Subscription(
+            plan=PlanType.operator,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id="sub_no_period_end",
+            current_period_end=None,
+        )
+
+        assert self.fn(current, "sub_old_inactive", now=1_700_000_000) is False
+
+    def test_zero_period_end_does_not_preserve_paid_access(self):
+        """A zero current_period_end is equivalent to missing and must not be
+        treated as a valid unexpired period."""
+        current = Subscription(
+            plan=PlanType.operator,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id="sub_zero_period_end",
+            current_period_end=0,
+        )
+
+        assert self.fn(current, "sub_old_inactive", now=1_700_000_000) is False
+
     def test_webhook_uses_non_creating_subscription_read_for_stale_downgrade_guard(self):
         source = self.PAYMENT_SOURCE_FILE.read_text(encoding="utf-8")
         sub_idx = source.find("'customer.subscription.updated'")

--- a/backend/tests/unit/test_stripe_webhook_none_guard.py
+++ b/backend/tests/unit/test_stripe_webhook_none_guard.py
@@ -148,7 +148,8 @@ def test_customer_subscription_logs_none_subscription():
     """customer.subscription.* handler must log when _build_subscription_from_stripe_object returns None."""
     source = _read_source()
     handler_start = source.index("'customer.subscription.updated'")
-    handler_section = source[handler_start : handler_start + 4000]
+    handler_end = source.index("subscription_schedule.completed", handler_start)
+    handler_section = source[handler_start:handler_end]
 
     # Must log unknown price ID when subscription build fails
     assert (
@@ -185,7 +186,8 @@ def test_checkout_path_checks_user_exists_before_processing():
     source = _read_source()
     # Find the regular user subscription branch within checkout handler
     branch_start = source.index("# Regular user subscription")
-    branch_section = source[branch_start : branch_start + 1500]
+    branch_end = source.index("await run_blocking(stripe_executor, _update_subscription_from_session", branch_start)
+    branch_section = source[branch_start:branch_end]
 
     # Must have user existence check before get_user_valid_subscription
     assert 'get_user_profile' in branch_section, (


### PR DESCRIPTION
## Summary
- Add a non-creating Firestore subscription read for webhook reconciliation so stale-event checks do not resurrect missing user docs.
- Prevent inactive/basic `customer.subscription.*` events for an old Stripe subscription from overwriting a different still-valid paid subscription already stored for the user.
- Add regression coverage for the event-precedence rule and stabilize nearby source-window webhook tests.

Fixes #8417

## Test Plan
- `python -m pytest backend/tests/unit/test_stripe_webhook_behavioral.py backend/tests/unit/test_stripe_webhook_none_guard.py -q`
- `git diff --check origin/main..HEAD`
- `python backend/scripts/scan_async_blockers.py` (no new `backend/routers/payment.py` findings; reports existing blockers elsewhere)

## Notes
- `cd backend && ./test-preflight.sh` is blocked in this shell because the `python3` environment reports `pytest not installed`; the active `python` interpreter runs the focused pytest suite successfully.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

