### PR TITLE
fix crash in ConversationProvider updateSpecificGroupedConvo

### DIFF
--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -131,7 +131,9 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void updateSpecificGroupedConvo(ServerConversation convo, DateTime date, int idx) {
-    groupedConversations[date]![idx] = convo;
+    final group = groupedConversations[date];
+    if (group == null || idx < 0 || idx >= group.length) return;
+    group[idx] = convo;
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary

- Guard against null date bucket (`groupedConversations[date]` returning null) and out-of-bounds index in `updateSpecificGroupedConvo`
- Fixes `RangeError (length): Invalid value: Not in inclusive range 0..4: 5` and `Null check operator used on a null value` crashes

## Crash

**ConversationProvider.updateSpecificGroupedConvo**
`io.flutter.plugins.firebase.crashlytics.FlutterError - RangeError (length): Invalid value: Not in inclusive range 0..4: 5`

`package:omi/providers/conversation_provider.dart:84`

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/618bed11b6f592b9b7f785b0ed8c7e88?time=7d&types=crash&sessionEventKey=6A390A1603200001282557267E2993ED_2232607659511955038

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
       at ConversationProvider.updateSpecificGroupedConvo(conversation_provider.dart:134)
       at ConversationProvider.updateSearchedConvoDetails(conversation_provider.dart:128)
       at _ConversationDetailPageState.initState.<fn>(page.dart:219)
```

## Test plan

- [ ] Open a conversation detail page — no crash on init
- [ ] Confirm grouped conversations update correctly after viewing a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

