### PR TITLE
[codex] Add LLM gateway chat extraction pilot

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -116,7 +116,20 @@ jobs:
               ./backend/charts/llm-gateway \
               -f ./backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml \
               --set "image.tag=${GITHUB_SHA::7}"
-            kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s
+            if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s; then
+              echo "=== llm-gateway deployment ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend describe deploy/${{ vars.ENV }}-omi-llm-gateway || true
+              echo "=== llm-gateway pods ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend get pods -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway -o wide || true
+              kubectl -n ${{ vars.ENV }}-omi-backend describe pods -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway || true
+              echo "=== llm-gateway logs ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend logs -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway --tail=200 || true
+              echo "=== backend ExternalSecret status ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend describe externalsecret/${{ vars.ENV }}-omi-backend-external-secret || true
+              echo "=== backend secret key presence ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data}' | python -c 'import json,sys; print("\\n".join(sorted(json.load(sys.stdin).keys())))' || true
+              exit 1
+            fi
           else
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
           fi

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -66,6 +66,21 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Bootstrap LLM Gateway dev service token
+        if: env.SERVICE == 'llm-gateway' && github.event.inputs.environment == 'development'
+        run: |
+          SECRET_NAME="OMI_LLM_GATEWAY_SERVICE_TOKEN"
+          if gcloud secrets describe "$SECRET_NAME" --project="${{ vars.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
+            echo "$SECRET_NAME already exists in ${{ vars.GCP_PROJECT_ID }}."
+            exit 0
+          fi
+
+          echo "Creating $SECRET_NAME in ${{ vars.GCP_PROJECT_ID }}."
+          openssl rand -base64 48 | gcloud secrets create "$SECRET_NAME" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --replication-policy="automatic" \
+            --data-file=- >/dev/null
+
       - name: Login to GCR
         run: gcloud auth configure-docker
 

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -73,7 +73,7 @@ jobs:
           if gcloud secrets describe "$SECRET_NAME" --project="${{ vars.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
             if [[ "${{ github.event.inputs.release_version }}" == "rotate-dev-token" ]]; then
               echo "Rotating $SECRET_NAME in ${{ vars.GCP_PROJECT_ID }}."
-              openssl rand -base64 48 | gcloud secrets versions add "$SECRET_NAME" \
+              openssl rand -base64 48 | tr -d '\n' | gcloud secrets versions add "$SECRET_NAME" \
                 --project="${{ vars.GCP_PROJECT_ID }}" \
                 --data-file=- >/dev/null
               exit 0
@@ -86,7 +86,7 @@ jobs:
           # Tolerate a concurrent create from another workflow run losing the
           # check-then-create race (ALREADY_EXISTS); the secret existing is the
           # desired end state regardless of which run created it.
-          openssl rand -base64 48 | gcloud secrets create "$SECRET_NAME" \
+          openssl rand -base64 48 | tr -d '\n' | gcloud secrets create "$SECRET_NAME" \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --replication-policy="automatic" \
             --data-file=- >/dev/null || {

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -76,10 +76,20 @@ jobs:
           fi
 
           echo "Creating $SECRET_NAME in ${{ vars.GCP_PROJECT_ID }}."
+          # Tolerate a concurrent create from another workflow run losing the
+          # check-then-create race (ALREADY_EXISTS); the secret existing is the
+          # desired end state regardless of which run created it.
           openssl rand -base64 48 | gcloud secrets create "$SECRET_NAME" \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --replication-policy="automatic" \
-            --data-file=- >/dev/null
+            --data-file=- >/dev/null || {
+              if gcloud secrets describe "$SECRET_NAME" --project="${{ vars.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
+                echo "$SECRET_NAME now exists (created concurrently by another run)."
+                exit 0
+              fi
+              echo "Failed to create or find $SECRET_NAME." >&2
+              exit 1
+            }
 
       - name: Login to GCR
         run: gcloud auth configure-docker
@@ -155,7 +165,7 @@ jobs:
       - name: Smoke LLM Gateway
         if: env.SERVICE == 'llm-gateway'
         run: |
-          SMOKE_POD="llm-gateway-smoke-${GITHUB_RUN_ID}"
+          SMOKE_POD="llm-gateway-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}"
           cleanup() {
             kubectl -n ${{ vars.ENV }}-omi-backend delete pod "$SMOKE_POD" --ignore-not-found=true
           }

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -188,7 +188,7 @@ jobs:
             containers:
               - name: smoke
                 image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
-                command: ["sh", "-c", "python scripts/smoke-llm-gateway.py --url \"\$SMOKE_URL\" --token \"\$SMOKE_TOKEN\""]
+                command: ["sh", "-c", "python scripts/smoke-llm-gateway.py --url \"\$SMOKE_URL\" --token \"\$SMOKE_TOKEN\" --check-metrics --metrics-token \"\$METRICS_SECRET\""]
                 env:
                   - name: SMOKE_URL
                     value: http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080
@@ -197,6 +197,11 @@ jobs:
                       secretKeyRef:
                         name: ${{ vars.ENV }}-omi-backend-secrets
                         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+                  - name: METRICS_SECRET
+                    valueFrom:
+                      secretKeyRef:
+                        name: ${{ vars.ENV }}-omi-backend-secrets
+                        key: METRICS_SECRET
           EOF
 
           for _ in {1..120}; do

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -19,9 +19,13 @@ on:
         description: 'Release version (optional)'
         required: false
         default: ''
+      service:
+        description: 'Service to deploy'
+        required: false
+        default: 'pusher'
 
 env:
-  SERVICE: pusher
+  SERVICE: ${{ github.event.inputs.service || 'pusher' }}
   REGION: us-central1
 
 jobs:
@@ -37,6 +41,10 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.environment }}" != "development" && "${{ github.event.inputs.environment }}" != "prod" ]]; then
             echo "Invalid environment: ${{ github.event.inputs.environment }}. Must be 'development' or 'prod'."
+            exit 1
+          fi
+          if [[ "${{ env.SERVICE }}" != "pusher" && "${{ env.SERVICE }}" != "llm-gateway" ]]; then
+            echo "Invalid service: ${{ env.SERVICE }}. Must be 'pusher' or 'llm-gateway'."
             exit 1
           fi
 
@@ -69,7 +77,11 @@ jobs:
 
       - name: Build and Push Docker image
         run: |
-          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/pusher/Dockerfile .
+          if [[ "${{ env.SERVICE }}" == "llm-gateway" ]]; then
+            docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/Dockerfile .
+          else
+            docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/pusher/Dockerfile .
+          fi
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
 
       # - name: Deploy to Cloud Run
@@ -89,7 +101,36 @@ jobs:
 
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
-          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+          if [[ "${{ env.SERVICE }}" == "llm-gateway" ]]; then
+            python backend/scripts/validate-llm-gateway-env.py \
+              backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+              backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml
+            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
+              ./backend/charts/backend-secrets \
+              -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
+            kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
+              ${{ vars.ENV }}-omi-backend-external-secret \
+              force-sync="$(date +%s)" --overwrite
+            sleep 10
+            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-llm-gateway \
+              ./backend/charts/llm-gateway \
+              -f ./backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml \
+              --set "image.tag=${GITHUB_SHA::7}"
+            kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s
+          else
+            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+          fi
+
+      - name: Smoke LLM Gateway
+        if: env.SERVICE == 'llm-gateway'
+        run: |
+          TOKEN="$(kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data.OMI_LLM_GATEWAY_SERVICE_TOKEN}' | base64 -d)"
+          kubectl -n ${{ vars.ENV }}-omi-backend run "llm-gateway-smoke-${GITHUB_RUN_ID}" \
+            --rm -i --restart=Never \
+            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
+            --env "SMOKE_URL=http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080" \
+            --env "SMOKE_TOKEN=$TOKEN" \
+            --command -- sh -c 'python scripts/smoke-llm-gateway.py --url "$SMOKE_URL" --token "$SMOKE_TOKEN"'
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -207,6 +207,11 @@ jobs:
           for _ in {1..120}; do
             PHASE="$(kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
             if [[ "$PHASE" == "Succeeded" ]]; then
+              echo "=== llm-gateway smoke pod ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o wide || true
+              kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o jsonpath='{.status.phase}{"\n"}{range .status.containerStatuses[*]}{.name}{" ready="}{.ready}{" state="}{.state.terminated.reason}{" exit="}{.state.terminated.exitCode}{"\n"}{end}' || true
+              echo "=== llm-gateway smoke logs ==="
+              kubectl -n ${{ vars.ENV }}-omi-backend logs "$SMOKE_POD" || true
               exit 0
             fi
             if [[ "$PHASE" == "Failed" ]]; then

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -137,8 +137,11 @@ jobs:
               echo "=== llm-gateway pods ==="
               kubectl -n ${{ vars.ENV }}-omi-backend get pods -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway -o wide || true
               kubectl -n ${{ vars.ENV }}-omi-backend describe pods -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway || true
-              echo "=== llm-gateway logs ==="
-              kubectl -n ${{ vars.ENV }}-omi-backend logs -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-llm-gateway --tail=200 || true
+              # NOTE: raw `kubectl logs` is intentionally omitted here because the gateway is an
+              # OpenAI-compatible service that processes chat content and service tokens — its
+              # runtime logs may leak sensitive payloads into CI output. Use `gcloud compute ssh`,
+              # `kubectl logs` interactively from an authenticated operator shell, or structured
+              # error reporting instead of dumping raw logs in CI.
               echo "=== backend ExternalSecret status ==="
               kubectl -n ${{ vars.ENV }}-omi-backend describe externalsecret/${{ vars.ENV }}-omi-backend-external-secret || true
               echo "=== backend secret key presence ==="

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -71,6 +71,13 @@ jobs:
         run: |
           SECRET_NAME="OMI_LLM_GATEWAY_SERVICE_TOKEN"
           if gcloud secrets describe "$SECRET_NAME" --project="${{ vars.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
+            if [[ "${{ github.event.inputs.release_version }}" == "rotate-dev-token" ]]; then
+              echo "Rotating $SECRET_NAME in ${{ vars.GCP_PROJECT_ID }}."
+              openssl rand -base64 48 | gcloud secrets versions add "$SECRET_NAME" \
+                --project="${{ vars.GCP_PROJECT_ID }}" \
+                --data-file=- >/dev/null
+              exit 0
+            fi
             echo "$SECRET_NAME already exists in ${{ vars.GCP_PROJECT_ID }}."
             exit 0
           fi
@@ -171,18 +178,41 @@ jobs:
           }
           trap cleanup EXIT
 
-          TOKEN="$(kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data.OMI_LLM_GATEWAY_SERVICE_TOKEN}' | base64 -d)"
-          kubectl -n ${{ vars.ENV }}-omi-backend run "$SMOKE_POD" \
-            --restart=Never \
-            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
-            --env "SMOKE_URL=http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080" \
-            --env "SMOKE_TOKEN=$TOKEN" \
-            --command -- sh -c 'python scripts/smoke-llm-gateway.py --url "$SMOKE_URL" --token "$SMOKE_TOKEN"'
+          cat <<EOF | kubectl -n ${{ vars.ENV }}-omi-backend apply -f -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: $SMOKE_POD
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: smoke
+                image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
+                command: ["sh", "-c", "python scripts/smoke-llm-gateway.py --url \"\$SMOKE_URL\" --token \"\$SMOKE_TOKEN\""]
+                env:
+                  - name: SMOKE_URL
+                    value: http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080
+                  - name: SMOKE_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: ${{ vars.ENV }}-omi-backend-secrets
+                        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+          EOF
 
-          kubectl -n ${{ vars.ENV }}-omi-backend wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$SMOKE_POD" --timeout=120s && exit 0
+          for _ in {1..120}; do
+            PHASE="$(kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+            if [[ "$PHASE" == "Succeeded" ]]; then
+              exit 0
+            fi
+            if [[ "$PHASE" == "Failed" ]]; then
+              break
+            fi
+            sleep 1
+          done
 
           echo "=== llm-gateway smoke pod ==="
-          kubectl -n ${{ vars.ENV }}-omi-backend describe pod "$SMOKE_POD" || true
+          kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o wide || true
+          kubectl -n ${{ vars.ENV }}-omi-backend get pod "$SMOKE_POD" -o jsonpath='{.status.phase}{"\n"}{range .status.containerStatuses[*]}{.name}{" ready="}{.ready}{" state="}{.state.terminated.reason}{" exit="}{.state.terminated.exitCode}{"\n"}{end}' || true
           echo "=== llm-gateway smoke logs ==="
           kubectl -n ${{ vars.ENV }}-omi-backend logs "$SMOKE_POD" || true
           exit 1

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -152,13 +152,27 @@ jobs:
       - name: Smoke LLM Gateway
         if: env.SERVICE == 'llm-gateway'
         run: |
+          SMOKE_POD="llm-gateway-smoke-${GITHUB_RUN_ID}"
+          cleanup() {
+            kubectl -n ${{ vars.ENV }}-omi-backend delete pod "$SMOKE_POD" --ignore-not-found=true
+          }
+          trap cleanup EXIT
+
           TOKEN="$(kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data.OMI_LLM_GATEWAY_SERVICE_TOKEN}' | base64 -d)"
-          kubectl -n ${{ vars.ENV }}-omi-backend run "llm-gateway-smoke-${GITHUB_RUN_ID}" \
-            --rm -i --restart=Never \
+          kubectl -n ${{ vars.ENV }}-omi-backend run "$SMOKE_POD" \
+            --restart=Never \
             --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
             --env "SMOKE_URL=http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080" \
             --env "SMOKE_TOKEN=$TOKEN" \
             --command -- sh -c 'python scripts/smoke-llm-gateway.py --url "$SMOKE_URL" --token "$SMOKE_TOKEN"'
+
+          kubectl -n ${{ vars.ENV }}-omi-backend wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$SMOKE_POD" --timeout=120s && exit 0
+
+          echo "=== llm-gateway smoke pod ==="
+          kubectl -n ${{ vars.ENV }}-omi-backend describe pod "$SMOKE_POD" || true
+          echo "=== llm-gateway smoke logs ==="
+          kubectl -n ${{ vars.ENV }}-omi-backend logs "$SMOKE_POD" || true
+          exit 1
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -1,0 +1,111 @@
+name: Deploy LLM Gateway to GKE
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select the environment to deploy to'
+        required: true
+        default: 'development'
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        default: 'main'
+
+env:
+  SERVICE: llm-gateway
+  REGION: us-central1
+
+jobs:
+  deploy:
+    environment: ${{ github.event.inputs.environment }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Environment Input
+        run: |
+          if [[ "${{ github.event.inputs.environment }}" != "development" && "${{ github.event.inputs.environment }}" != "prod" ]]; then
+            echo "Invalid environment: ${{ github.event.inputs.environment }}. Must be 'development' or 'prod'."
+            exit 1
+          fi
+
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Google Auth
+        id: auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Login to GCR
+        run: gcloud auth configure-docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Google Service Account
+        run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Validate gateway env wiring
+        run: |
+          python backend/scripts/validate-llm-gateway-env.py \
+            backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml
+
+      - name: Build and Push Docker image
+        run: |
+          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/Dockerfile .
+          docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Upgrade backend-secrets Helm chart
+        run: |
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
+            ./backend/charts/backend-secrets \
+            -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
+          kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
+            ${{ vars.ENV }}-omi-backend-external-secret \
+            force-sync="$(date +%s)" --overwrite
+          sleep 10
+
+      - name: Deploy LLM Gateway to GKE cluster using Helm
+        run: |
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-llm-gateway \
+            ./backend/charts/llm-gateway \
+            -f ./backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml \
+            --set "image.tag=${GITHUB_SHA::7}"
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s
+
+      - name: Smoke LLM Gateway
+        run: |
+          TOKEN="$(kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data.OMI_LLM_GATEWAY_SERVICE_TOKEN}' | base64 -d)"
+          kubectl -n ${{ vars.ENV }}-omi-backend run "llm-gateway-smoke-${GITHUB_RUN_ID}" \
+            --rm -i --restart=Never \
+            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
+            --env "SMOKE_URL=http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080" \
+            --env "SMOKE_TOKEN=$TOKEN" \
+            --command -- sh -c 'python scripts/smoke-llm-gateway.py --url "$SMOKE_URL" --token "$SMOKE_TOKEN"'
+
+      - name: Show Output
+        run: echo "LLM Gateway deployed to ${{ github.event.inputs.environment }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ backend (main.py)
   ├── ws ──► pusher (pusher/)
   ├── ──────► diarizer (diarizer/)
   ├── ──────► vad (modal/)
-  └── ──────► deepgram (self-hosted or cloud)
+  ├── ──────► deepgram (self-hosted or cloud)
+  └── ──────► llm-gateway (llm_gateway/main.py)
 
 pusher
   ├── ──────► diarizer (diarizer/)
@@ -84,9 +85,10 @@ backend-sync (main.py, Cloud Run)
 notifications-job (modal/job.py)  [cron]
 ```
 
-Helm charts: `backend/charts/{backend-listen,pusher,diarizer,vad,deepgram-self-hosted,agent-proxy}/`
+Helm charts: `backend/charts/{backend-listen,pusher,diarizer,vad,deepgram-self-hosted,agent-proxy,llm-gateway}/`
 
 - **backend** (`main.py`) — REST API. Streams audio to pusher via WebSocket (`utils/pusher.py`). Calls diarizer for speaker embeddings (`utils/stt/speaker_embedding.py`). Calls vad for voice activity detection and speaker identification (`utils/stt/vad.py`, `utils/stt/speech_profile.py`). Calls deepgram for STT (`utils/stt/streaming.py`).
+- **llm-gateway** (`llm_gateway/main.py`) — Internal FastAPI service for Omi-managed LLM auto lanes. Called by backend with service auth for `omi:auto:*` chat-completions routes; not exposed to clients.
 - **pusher** (`pusher/main.py`) — Receives audio via binary WebSocket protocol. Calls diarizer and deepgram for speaker sample extraction (`utils/speaker_identification.py` → `utils/speaker_sample.py`).
 - **agent-proxy** (`agent-proxy/main.py`) — GKE. WebSocket proxy at `wss://agent.omi.me/v1/agent/ws`. Validates Firebase ID token, looks up `agentVm` in Firestore, proxies bidirectionally to VM's `ws://<ip>:8080/ws`.
 - **diarizer** (`diarizer/main.py`) — GPU. Speaker embeddings at `/v2/embedding`. Called by backend and pusher (`HOSTED_SPEAKER_EMBEDDING_API_URL`).

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -82,6 +82,7 @@ backend/
                           #   - Batches + uploads audio to private cloud storage (60s batches, 3 retries)
                           #   - Queues speaker sample extraction (120s age minimum)
                           #   - 5 concurrent background tasks per WebSocket connection
+  llm_gateway/            # Subservice: internal Omi-managed LLM auto-lane gateway
   diarizer/              # Subservice: speaker audio analysis (separate Docker, GPU/CUDA)
                           #   - POST /v1/diarization — speaker boundary detection (pyannote/speaker-diarization)
                           #   - POST /v1/embedding — speaker vector extraction (pyannote/embedding)

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -106,6 +106,13 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: OPENAI_API_KEY
+  - name: OMI_LLM_GATEWAY_URL
+    value: "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080"
+  - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: GOOGLE_MAPS_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -98,6 +98,13 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: OPENAI_API_KEY
+  - name: OMI_LLM_GATEWAY_URL
+    value: "http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080"
+  - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: FAL_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -24,6 +24,8 @@ externalSecret:
       remoteKey: FAL_KEY
     - secretKey: OPENAI_API_KEY
       remoteKey: OPENAI_API_KEY
+    - secretKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
+      remoteKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
     - secretKey: GOOGLE_MAPS_API_KEY
       remoteKey: GOOGLE_MAPS_API_KEY
     - secretKey: GITHUB_TOKEN

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -20,6 +20,8 @@ externalSecret:
       remoteKey: GITHUB_TOKEN
     - secretKey: OPENAI_API_KEY
       remoteKey: OPENAI_API_KEY
+    - secretKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
+      remoteKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
     - secretKey: FAL_KEY
       remoteKey: FAL_KEY
     - secretKey: GROQ_API_KEY

--- a/backend/charts/llm-gateway/Chart.yaml
+++ b/backend/charts/llm-gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: llm-gateway
+description: Internal Omi LLM Gateway service
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -9,6 +9,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
 serviceAccount:
   create: true
   automount: true

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -69,22 +69,9 @@ livenessProbe:
   timeoutSeconds: 5
 
 readinessProbe:
-  exec:
-    command:
-      - python
-      - -c
-      - |
-        import os
-        import urllib.request
-
-        request = urllib.request.Request(
-            'http://127.0.0.1:8080/ready',
-            headers={
-                'Authorization': f"Bearer {os.environ['OMI_LLM_GATEWAY_SERVICE_TOKEN']}",
-                'X-Omi-Service-Caller': 'backend',
-            },
-        )
-        urllib.request.urlopen(request, timeout=4).read()
+  httpGet:
+    path: /health
+    port: 8080
   failureThreshold: 3
   periodSeconds: 10
   timeoutSeconds: 5

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -1,0 +1,93 @@
+replicaCount: 1
+
+image:
+  repository: gcr.io/based-hardware-dev/llm-gateway
+  pullPolicy: Always
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/metrics"
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+env:
+  - name: OMI_LLM_GATEWAY_PROD
+    value: "true"
+  - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+  - name: LLM_GATEWAY_ALLOWED_CALLERS
+    value: "backend"
+  - name: OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: OPENAI_API_KEY
+  - name: METRICS_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: METRICS_SECRET
+  - name: DD_SERVICE
+    value: "llm-gateway"
+  - name: DD_ENV
+    value: "dev"
+  - name: DD_TRACE_ENABLED
+    value: "false"
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  failureThreshold: 3
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - 'curl -fsS -H "Authorization: Bearer ${OMI_LLM_GATEWAY_SERVICE_TOKEN}" -H "X-Omi-Service-Caller: backend" http://127.0.0.1:8080/ready >/dev/null'
+  failureThreshold: 3
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  failureThreshold: 30
+  periodSeconds: 5
+
+autoscaling:
+  enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -62,6 +62,8 @@ env:
     value: "dev"
   - name: DD_TRACE_ENABLED
     value: "false"
+  - name: LLM_GATEWAY_EXPOSE_PROVIDER_ERROR_DETAILS
+    value: "true"
 
 resources:
   requests:

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -71,9 +71,20 @@ livenessProbe:
 readinessProbe:
   exec:
     command:
-      - sh
+      - python
       - -c
-      - 'curl -fsS -H "Authorization: Bearer ${OMI_LLM_GATEWAY_SERVICE_TOKEN}" -H "X-Omi-Service-Caller: backend" http://127.0.0.1:8080/ready >/dev/null'
+      - |
+        import os
+        import urllib.request
+
+        request = urllib.request.Request(
+            'http://127.0.0.1:8080/ready',
+            headers={
+                'Authorization': f"Bearer {os.environ['OMI_LLM_GATEWAY_SERVICE_TOKEN']}",
+                'X-Omi-Service-Caller': 'backend',
+            },
+        )
+        urllib.request.urlopen(request, timeout=4).read()
   failureThreshold: 3
   periodSeconds: 10
   timeoutSeconds: 5

--- a/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
@@ -9,6 +9,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
 serviceAccount:
   create: true
   automount: true

--- a/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
@@ -69,22 +69,9 @@ livenessProbe:
   timeoutSeconds: 5
 
 readinessProbe:
-  exec:
-    command:
-      - python
-      - -c
-      - |
-        import os
-        import urllib.request
-
-        request = urllib.request.Request(
-            'http://127.0.0.1:8080/ready',
-            headers={
-                'Authorization': f"Bearer {os.environ['OMI_LLM_GATEWAY_SERVICE_TOKEN']}",
-                'X-Omi-Service-Caller': 'backend',
-            },
-        )
-        urllib.request.urlopen(request, timeout=4).read()
+  httpGet:
+    path: /health
+    port: 8080
   failureThreshold: 3
   periodSeconds: 10
   timeoutSeconds: 5

--- a/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
@@ -1,0 +1,105 @@
+replicaCount: 2
+
+image:
+  repository: gcr.io/based-hardware/llm-gateway
+  pullPolicy: Always
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/metrics"
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+env:
+  - name: OMI_LLM_GATEWAY_PROD
+    value: "true"
+  - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+  - name: LLM_GATEWAY_ALLOWED_CALLERS
+    value: "backend"
+  - name: OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: OPENAI_API_KEY
+  - name: METRICS_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: METRICS_SECRET
+  - name: DD_SERVICE
+    value: "llm-gateway"
+  - name: DD_ENV
+    value: "prod"
+  - name: DD_TRACE_ENABLED
+    value: "true"
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 2
+    memory: 2Gi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  failureThreshold: 3
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - 'curl -fsS -H "Authorization: Bearer ${OMI_LLM_GATEWAY_SERVICE_TOKEN}" -H "X-Omi-Service-Caller: backend" http://127.0.0.1:8080/ready >/dev/null'
+  failureThreshold: 3
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  failureThreshold: 30
+  periodSeconds: 5
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70
+
+nodeSelector: {}
+tolerations: []
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - prod

--- a/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
@@ -71,9 +71,20 @@ livenessProbe:
 readinessProbe:
   exec:
     command:
-      - sh
+      - python
       - -c
-      - 'curl -fsS -H "Authorization: Bearer ${OMI_LLM_GATEWAY_SERVICE_TOKEN}" -H "X-Omi-Service-Caller: backend" http://127.0.0.1:8080/ready >/dev/null'
+      - |
+        import os
+        import urllib.request
+
+        request = urllib.request.Request(
+            'http://127.0.0.1:8080/ready',
+            headers={
+                'Authorization': f"Bearer {os.environ['OMI_LLM_GATEWAY_SERVICE_TOKEN']}",
+                'X-Omi-Service-Caller': 'backend',
+            },
+        )
+        urllib.request.urlopen(request, timeout=4).read()
   failureThreshold: 3
   periodSeconds: 10
   timeoutSeconds: 5

--- a/backend/charts/llm-gateway/templates/_helpers.tpl
+++ b/backend/charts/llm-gateway/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "llm-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "llm-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "llm-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "llm-gateway.labels" -}}
+helm.sh/chart: {{ include "llm-gateway.chart" . }}
+{{ include "llm-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "llm-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "llm-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "llm-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "llm-gateway.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/backend/charts/llm-gateway/templates/deployment.yaml
+++ b/backend/charts/llm-gateway/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "llm-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "llm-gateway.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "llm-gateway.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uvicorn"]
+          args: ["llm_gateway.main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/backend/charts/llm-gateway/templates/deployment.yaml
+++ b/backend/charts/llm-gateway/templates/deployment.yaml
@@ -28,12 +28,20 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "llm-gateway.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["uvicorn"]
-          args: ["llm_gateway.main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]
+          args: ["llm_gateway.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.service.port }}", "--loop", "uvloop"]
           env:
             {{- toYaml .Values.env | nindent 12 }}
           ports:

--- a/backend/charts/llm-gateway/templates/hpa.yaml
+++ b/backend/charts/llm-gateway/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "llm-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/backend/charts/llm-gateway/templates/service.yaml
+++ b/backend/charts/llm-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "llm-gateway.selectorLabels" . | nindent 4 }}

--- a/backend/charts/llm-gateway/templates/serviceaccount.yaml
+++ b/backend/charts/llm-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "llm-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/backend/llm_gateway/__init__.py
+++ b/backend/llm_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Omi LLM Gateway service package."""

--- a/backend/llm_gateway/config/feature_bundles.yaml
+++ b/backend/llm_gateway/config/feature_bundles.yaml
@@ -1,0 +1,12 @@
+feature_bundles:
+  - feature: memories
+    lane_id: omi:auto:chat-structured
+    prompt_version: memory_extraction.v17
+    parser_version: memory_schema.v9
+    eval_suite: memory_precision_recall.v5
+    promotion_gates:
+      schema_valid_rate: ">= 99.5%"
+      precision_regression: none
+      recall_delta: ">= 0"
+      p95_latency_ms: "<= LKG + 10%"
+      cost_per_success: "<= LKG + 15%"

--- a/backend/llm_gateway/config/feature_bundles.yaml
+++ b/backend/llm_gateway/config/feature_bundles.yaml
@@ -1,12 +1,12 @@
 feature_bundles:
-  - feature: memories
+  - feature: chat_extraction.requires_context
     lane_id: omi:auto:chat-structured
-    prompt_version: memory_extraction.v17
-    parser_version: memory_schema.v9
-    eval_suite: memory_precision_recall.v5
+    prompt_version: chat_extraction.requires_context.v1
+    parser_version: RequiresContext.v1
+    eval_suite: chat_extraction_requires_context.v1
     promotion_gates:
       schema_valid_rate: ">= 99.5%"
-      precision_regression: none
-      recall_delta: ">= 0"
+      classification_agreement_delta: ">= 0"
+      false_negative_regression: none
       p95_latency_ms: "<= LKG + 10%"
       cost_per_success: "<= LKG + 15%"

--- a/backend/llm_gateway/config/lanes.yaml
+++ b/backend/llm_gateway/config/lanes.yaml
@@ -21,6 +21,7 @@ lanes:
         - byok_auth
         - byok_quota
         - byok_rate_limit
+        - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
         - invalid_config

--- a/backend/llm_gateway/config/lanes.yaml
+++ b/backend/llm_gateway/config/lanes.yaml
@@ -1,0 +1,28 @@
+lanes:
+  - lane_id: omi:auto:chat-structured
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.60
+      latency: 0.20
+      cost: 0.20
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.chat_structured.2026_06_27.001
+    last_known_good: route.chat_structured.2026_06_20.001

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -56,12 +56,16 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:95f52d92ff3f104784ad84573ce278ce282a46f32c8abc31a5a051fcb89c6cbe
+    artifact_digest: sha256:8fc0aab6f81dacfcaf227010f57d8d67303caf8b5836d6ee078aee5e6c6e01e5
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
+    # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so
+    # that while the pilot's active route is shadow-only, serving this route is a
+    # no-user-visible behavior match instead of silently swapping gpt-4.1-mini
+    # for gpt-4o-mini and changing classifier behavior for 100% of pilot calls.
     primary:
       provider: openai
-      model: gpt-4o-mini
+      model: gpt-4.1-mini
     fallbacks: []
     timeouts:
       request_ms: 9000

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:839aef96e888b7e77b2a3176f7fb667120905cfead593ad2fb3376b0e58974b5
+    artifact_digest: sha256:c4c393fc3e915b2ecc41d4ef4cce5abd30c6439076814f55e29578eab6232e31
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -8,7 +8,7 @@ route_artifacts:
       model: gpt-4.1-mini
     fallbacks:
       - provider: openai
-        model: gpt-4o-mini
+        model: gpt-4.1-mini
     timeouts:
       request_ms: 8000
     retry:
@@ -20,7 +20,7 @@ route_artifacts:
       tools: false
     evidence:
       benchmark_snapshot: bench.omi.chat_structured.2026_06_27
-      eval_report: eval.memory_extraction.2026_06_27
+      eval_report: eval.chat_extraction_requires_context.2026_06_27
       benchmark_source: omi_eval
       dev_only: false
     rollout:
@@ -56,7 +56,7 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:8fc0aab6f81dacfcaf227010f57d8d67303caf8b5836d6ee078aee5e6c6e01e5
+    artifact_digest: sha256:1d46ec82568f2d523da23e1df4b0956cfe876cc6ece9d05dbfb7e0edc7eda74b
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so
@@ -78,7 +78,7 @@ route_artifacts:
       tools: false
     evidence:
       benchmark_snapshot: bench.omi.chat_structured.2026_06_20
-      eval_report: eval.memory_extraction.2026_06_20
+      eval_report: eval.chat_extraction_requires_context.2026_06_20
       benchmark_source: omi_eval
       dev_only: false
     rollout:

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,0 +1,106 @@
+route_artifacts:
+  - route_artifact_id: route.chat_structured.2026_06_27.001
+    artifact_digest: sha256:8d1b53535185ef6e2c29f85b9a7229233c362ede45628629922d1bd34cbe5df0
+    lane_id: omi:auto:chat-structured
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks:
+      - provider: openai
+        model: gpt-4o-mini
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.chat_structured.2026_06_27
+      eval_report: eval.memory_extraction.2026_06_27
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    fallback_policy:
+      fallback_on:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_on:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+
+  - route_artifact_id: route.chat_structured.2026_06_20.001
+    artifact_digest: sha256:c2abd48765e9863ef8b5a19e98c48d9997e3f28030b7232f77a2c4ea4af797af
+    lane_id: omi:auto:chat-structured
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4o-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 9000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.chat_structured.2026_06_20
+      eval_report: eval.memory_extraction.2026_06_20
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: active
+      percent: 100
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    fallback_policy:
+      fallback_on:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_on:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:8d1b53535185ef6e2c29f85b9a7229233c362ede45628629922d1bd34cbe5df0
+    artifact_digest: sha256:839aef96e888b7e77b2a3176f7fb667120905cfead593ad2fb3376b0e58974b5
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -37,6 +37,7 @@ route_artifacts:
         - byok_auth
         - byok_quota
         - byok_rate_limit
+        - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
         - invalid_config
@@ -49,12 +50,13 @@ route_artifacts:
         - byok_auth
         - byok_quota
         - byok_rate_limit
+        - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:c2abd48765e9863ef8b5a19e98c48d9997e3f28030b7232f77a2c4ea4af797af
+    artifact_digest: sha256:95f52d92ff3f104784ad84573ce278ce282a46f32c8abc31a5a051fcb89c6cbe
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -89,6 +91,7 @@ route_artifacts:
         - byok_auth
         - byok_quota
         - byok_rate_limit
+        - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
         - invalid_config
@@ -101,6 +104,7 @@ route_artifacts:
         - byok_auth
         - byok_quota
         - byok_rate_limit
+        - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
         - invalid_config

--- a/backend/llm_gateway/gateway/__init__.py
+++ b/backend/llm_gateway/gateway/__init__.py
@@ -1,0 +1,5 @@
+"""Gateway routing config and validation helpers."""
+
+from llm_gateway.gateway.config_loader import ConfigValidationError, GatewayConfig, load_gateway_config
+
+__all__ = ['ConfigValidationError', 'GatewayConfig', 'load_gateway_config']

--- a/backend/llm_gateway/gateway/auth.py
+++ b/backend/llm_gateway/gateway/auth.py
@@ -5,7 +5,7 @@ import os
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from llm_gateway.gateway.schemas import StrictBaseModel
 
@@ -58,11 +58,14 @@ def require_service_auth(request: Request) -> ServiceCaller:
     if caller_name is None or not caller_name.strip():
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='missing service caller')
 
-    caller = ServiceCaller(
-        name=caller_name,
-        user_uid=request.headers.get(USER_UID_HEADER),
-        tenant_id=request.headers.get(TENANT_ID_HEADER),
-    )
+    try:
+        caller = ServiceCaller(
+            name=caller_name,
+            user_uid=request.headers.get(USER_UID_HEADER),
+            tenant_id=request.headers.get(TENANT_ID_HEADER),
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='invalid service caller') from exc
     if caller.name not in allowed_service_callers():
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='service caller is not allowed')
 

--- a/backend/llm_gateway/gateway/auth.py
+++ b/backend/llm_gateway/gateway/auth.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request, status
+from pydantic import Field, field_validator
+
+from llm_gateway.gateway.schemas import StrictBaseModel
+
+SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
+ALLOWED_CALLERS_ENV_VAR = 'LLM_GATEWAY_ALLOWED_CALLERS'
+DEFAULT_ALLOWED_CALLERS = frozenset({'backend', 'pusher'})
+
+AUTHORIZATION_HEADER = 'authorization'
+CALLER_HEADER = 'x-omi-service-caller'
+USER_UID_HEADER = 'x-omi-user-uid'
+TENANT_ID_HEADER = 'x-omi-tenant-id'
+
+
+class ServiceCaller(StrictBaseModel):
+    name: str = Field(min_length=1, max_length=64, pattern=r'^[a-z][a-z0-9_-]*$')
+    user_uid: str | None = Field(default=None, min_length=1, max_length=256)
+    tenant_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator('name', mode='before')
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @field_validator('user_uid', 'tenant_id', mode='before')
+    @classmethod
+    def normalize_optional_header(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+
+def require_service_auth(request: Request) -> ServiceCaller:
+    expected_token = _configured_service_token()
+    if expected_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='llm gateway service auth is not configured',
+        )
+
+    supplied_token = _extract_bearer_token(request.headers.get(AUTHORIZATION_HEADER))
+    if supplied_token is None or not hmac.compare_digest(supplied_token, expected_token):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='invalid service authentication',
+            headers={'WWW-Authenticate': 'Bearer'},
+        )
+
+    caller_name = request.headers.get(CALLER_HEADER)
+    if caller_name is None or not caller_name.strip():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='missing service caller')
+
+    caller = ServiceCaller(
+        name=caller_name,
+        user_uid=request.headers.get(USER_UID_HEADER),
+        tenant_id=request.headers.get(TENANT_ID_HEADER),
+    )
+    if caller.name not in allowed_service_callers():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='service caller is not allowed')
+
+    return caller
+
+
+ServiceAuthDependency = Annotated[ServiceCaller, Depends(require_service_auth)]
+
+
+def allowed_service_callers() -> frozenset[str]:
+    configured = os.getenv(ALLOWED_CALLERS_ENV_VAR)
+    if configured is None or not configured.strip():
+        return DEFAULT_ALLOWED_CALLERS
+    callers = frozenset(item.strip().lower() for item in configured.split(',') if item.strip())
+    return callers or DEFAULT_ALLOWED_CALLERS
+
+
+def _configured_service_token() -> str | None:
+    token = os.getenv(SERVICE_TOKEN_ENV_VAR)
+    if token is None:
+        return None
+    stripped = token.strip()
+    return stripped or None
+
+
+def _extract_bearer_token(authorization: str | None) -> str | None:
+    if authorization is None:
+        return None
+    scheme, separator, token = authorization.strip().partition(' ')
+    if separator != ' ' or scheme.lower() != 'bearer':
+        return None
+    stripped = token.strip()
+    return stripped or None

--- a/backend/llm_gateway/gateway/auth.py
+++ b/backend/llm_gateway/gateway/auth.py
@@ -9,7 +9,11 @@ from pydantic import Field, ValidationError, field_validator
 
 from llm_gateway.gateway.schemas import StrictBaseModel
 
-SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
+PRIMARY_SERVICE_TOKEN_ENV_VAR = 'OMI_LLM_GATEWAY_SERVICE_TOKEN'
+LEGACY_SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
+# Kept for backwards compatibility with code/tests that reference the old name.
+SERVICE_TOKEN_ENV_VAR = LEGACY_SERVICE_TOKEN_ENV_VAR
+SERVICE_TOKEN_ENV_VARS = (PRIMARY_SERVICE_TOKEN_ENV_VAR, LEGACY_SERVICE_TOKEN_ENV_VAR)
 ALLOWED_CALLERS_ENV_VAR = 'LLM_GATEWAY_ALLOWED_CALLERS'
 DEFAULT_ALLOWED_CALLERS = frozenset({'backend', 'pusher'})
 
@@ -84,11 +88,16 @@ def allowed_service_callers() -> frozenset[str]:
 
 
 def _configured_service_token() -> str | None:
-    token = os.getenv(SERVICE_TOKEN_ENV_VAR)
-    if token is None:
-        return None
-    stripped = token.strip()
-    return stripped or None
+    # Match the client precedence (utils.llm.gateway_client): the OMI_ prefixed
+    # env var wins; the bare name is kept as a legacy fallback so local dev and
+    # token rotation work even when the two disagree.
+    for env_var in SERVICE_TOKEN_ENV_VARS:
+        token = os.getenv(env_var)
+        if token is not None:
+            stripped = token.strip()
+            if stripped:
+                return stripped
+    return None
 
 
 def _extract_bearer_token(authorization: str | None) -> str | None:

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+
+from llm_gateway.gateway.schemas import FeatureBundle, LaneConfig, RouteArtifact
+
+DEFAULT_CONFIG_DIR = Path(__file__).resolve().parents[1] / 'config'
+PROD_ENV_VAR = 'OMI_LLM_GATEWAY_PROD'
+
+
+class ConfigValidationError(ValueError):
+    pass
+
+
+class GatewayConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    lanes: dict[str, LaneConfig]
+    route_artifacts: dict[str, RouteArtifact]
+    feature_bundles: dict[str, FeatureBundle]
+
+
+def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool | None = None) -> GatewayConfig:
+    resolved_config_dir = Path(config_dir) if config_dir is not None else DEFAULT_CONFIG_DIR
+    resolved_prod_mode = _resolve_prod_mode(prod_mode)
+
+    lane_items = _load_config_list(resolved_config_dir / 'lanes.yaml', 'lanes')
+    artifact_items = _load_config_list(resolved_config_dir / 'route_artifacts.yaml', 'route_artifacts')
+    bundle_items = _load_config_list(resolved_config_dir / 'feature_bundles.yaml', 'feature_bundles')
+
+    lanes = _parse_lanes(lane_items)
+    route_artifacts = _parse_route_artifacts(artifact_items, prod_mode=resolved_prod_mode)
+    feature_bundles = _parse_feature_bundles(bundle_items)
+
+    _validate_lane_routes(lanes, route_artifacts)
+    _validate_feature_bundles(feature_bundles, lanes)
+
+    return GatewayConfig(lanes=lanes, route_artifacts=route_artifacts, feature_bundles=feature_bundles)
+
+
+def _resolve_prod_mode(prod_mode: bool | None) -> bool:
+    if prod_mode is not None:
+        return prod_mode
+    return os.getenv(PROD_ENV_VAR, '').strip().lower() in {'1', 'true', 'yes'}
+
+
+def _load_config_list(path: Path, top_level_key: str) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise ConfigValidationError(f'missing gateway config file: {path}')
+
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = yaml.safe_load(handle)
+
+    if loaded is None:
+        return []
+    if isinstance(loaded, list):
+        items = loaded
+    elif isinstance(loaded, dict) and top_level_key in loaded:
+        items = loaded[top_level_key]
+    else:
+        raise ConfigValidationError(f'{path} must contain a list or top-level {top_level_key} list')
+
+    if not isinstance(items, list):
+        raise ConfigValidationError(f'{path} {top_level_key} must be a list')
+    for item in items:
+        if not isinstance(item, dict):
+            raise ConfigValidationError(f'{path} {top_level_key} entries must be mappings')
+    return items
+
+
+def _parse_lanes(items: list[dict[str, Any]]) -> dict[str, LaneConfig]:
+    lanes: dict[str, LaneConfig] = {}
+    for item in items:
+        lane = LaneConfig.model_validate(item)
+        if lane.lane_id in lanes:
+            raise ConfigValidationError(f'duplicate lane_id: {lane.lane_id}')
+        lanes[lane.lane_id] = lane
+    return lanes
+
+
+def _parse_route_artifacts(items: list[dict[str, Any]], *, prod_mode: bool) -> dict[str, RouteArtifact]:
+    route_artifacts: dict[str, RouteArtifact] = {}
+    for item in items:
+        artifact = RouteArtifact.model_validate(item)
+        if artifact.route_artifact_id in route_artifacts:
+            raise ConfigValidationError(f'duplicate route_artifact_id: {artifact.route_artifact_id}')
+        if artifact.artifact_digest is not None and artifact.artifact_digest != artifact.content_digest:
+            raise ConfigValidationError(
+                f'artifact_digest mismatch for {artifact.route_artifact_id}: '
+                f'expected {artifact.content_digest}, got {artifact.artifact_digest}'
+            )
+        if prod_mode and not artifact.evidence.is_prod_eligible():
+            raise ConfigValidationError(f'route artifact {artifact.route_artifact_id} uses dev-only benchmark evidence')
+        route_artifacts[artifact.route_artifact_id] = artifact
+    return route_artifacts
+
+
+def _parse_feature_bundles(items: list[dict[str, Any]]) -> dict[str, FeatureBundle]:
+    feature_bundles: dict[str, FeatureBundle] = {}
+    for item in items:
+        bundle = FeatureBundle.model_validate(item)
+        if bundle.feature in feature_bundles:
+            raise ConfigValidationError(f'duplicate feature bundle: {bundle.feature}')
+        feature_bundles[bundle.feature] = bundle
+    return feature_bundles
+
+
+def _validate_lane_routes(lanes: dict[str, LaneConfig], route_artifacts: dict[str, RouteArtifact]) -> None:
+    for lane in lanes.values():
+        active = _route_for_lane_pointer(lane, 'active_route', lane.active_route, route_artifacts)
+        last_known_good = _route_for_lane_pointer(lane, 'last_known_good', lane.last_known_good, route_artifacts)
+        _validate_route_matches_lane(lane, active, 'active_route')
+        _validate_route_matches_lane(lane, last_known_good, 'last_known_good')
+
+
+def _route_for_lane_pointer(
+    lane: LaneConfig,
+    pointer_name: str,
+    route_artifact_id: str,
+    route_artifacts: dict[str, RouteArtifact],
+) -> RouteArtifact:
+    artifact = route_artifacts.get(route_artifact_id)
+    if artifact is None:
+        raise ConfigValidationError(f'lane {lane.lane_id} {pointer_name} route not found: {route_artifact_id}')
+    return artifact
+
+
+def _validate_route_matches_lane(lane: LaneConfig, artifact: RouteArtifact, pointer_name: str) -> None:
+    prefix = f'lane {lane.lane_id} {pointer_name} {artifact.route_artifact_id}'
+    if artifact.lane_id != lane.lane_id:
+        raise ConfigValidationError(f'{prefix} lane_id mismatch: {artifact.lane_id}')
+    if artifact.surface != lane.surface:
+        raise ConfigValidationError(f'{prefix} surface mismatch: {artifact.surface}')
+    if artifact.capabilities.structured_output != lane.capabilities.structured_output:
+        raise ConfigValidationError(f'{prefix} structured_output mismatch')
+    if artifact.capabilities != lane.capabilities:
+        raise ConfigValidationError(f'{prefix} capabilities mismatch')
+    if artifact.credential_policy.mode != lane.credential_policy.mode:
+        raise ConfigValidationError(f'{prefix} credential mode mismatch: {artifact.credential_policy.mode}')
+
+
+def _validate_feature_bundles(feature_bundles: dict[str, FeatureBundle], lanes: dict[str, LaneConfig]) -> None:
+    for bundle in feature_bundles.values():
+        if bundle.lane_id not in lanes:
+            raise ConfigValidationError(f'feature bundle {bundle.feature} references unknown lane: {bundle.lane_id}')

--- a/backend/llm_gateway/gateway/credentials.py
+++ b/backend/llm_gateway/gateway/credentials.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping
+
+from pydantic import Field, field_validator
+
+from llm_gateway.gateway.auth import ServiceCaller
+from llm_gateway.gateway.schemas import CredentialMode, CredentialPolicy, FailureClass, StrictBaseModel
+
+BYOK_UNSUPPORTED_PROVIDER_FAILURE = FailureClass.BYOK_UNSUPPORTED_PROVIDER.value
+
+BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES = frozenset(
+    {
+        FailureClass.MISSING_BYOK_KEY.value,
+        FailureClass.BYOK_AUTH.value,
+        FailureClass.BYOK_QUOTA.value,
+        FailureClass.BYOK_RATE_LIMIT.value,
+        BYOK_UNSUPPORTED_PROVIDER_FAILURE,
+    }
+)
+
+
+class CredentialSource(str, Enum):
+    OMI_MANAGED = 'omi_managed'
+    SERVICE_FORWARDED_BYOK = 'service_forwarded_byok'
+    INTERNAL_KEY_REFERENCE = 'internal_key_reference'
+
+
+class ProviderKeyPresence(StrictBaseModel):
+    provider: str = Field(min_length=1, max_length=64, pattern=r'^[a-z][a-z0-9_-]*$')
+    present: bool
+    key_ref: str | None = Field(default=None, min_length=1, max_length=256)
+
+    @field_validator('provider', mode='before')
+    @classmethod
+    def normalize_provider(cls, value: str) -> str:
+        return value.strip().lower()
+
+
+class CredentialContext(StrictBaseModel):
+    mode: CredentialMode
+    source: CredentialSource
+    caller: ServiceCaller
+    provider_keys: dict[str, ProviderKeyPresence] = Field(default_factory=dict)
+
+    def has_provider_key(self, provider: str) -> bool:
+        key_presence = self.provider_keys.get(provider.strip().lower())
+        return key_presence.present if key_presence is not None else False
+
+    def safe_model_dump(self) -> dict:
+        return self.model_dump(mode='json')
+
+
+def build_omi_managed_credential_context(caller: ServiceCaller) -> CredentialContext:
+    return CredentialContext(mode=CredentialMode.OMI_PAID, source=CredentialSource.OMI_MANAGED, caller=caller)
+
+
+def build_byok_credential_context(
+    caller: ServiceCaller,
+    provider_keys: Mapping[str, str | None],
+    *,
+    key_refs: Mapping[str, str | None] | None = None,
+) -> CredentialContext:
+    presences: dict[str, ProviderKeyPresence] = {}
+    normalized_key_refs = _normalize_optional_mapping(key_refs)
+    for provider, raw_key in provider_keys.items():
+        normalized_provider = provider.strip().lower()
+        key_ref = normalized_key_refs.get(normalized_provider)
+        presences[normalized_provider] = ProviderKeyPresence(
+            provider=normalized_provider,
+            present=bool(raw_key.strip()) if raw_key is not None else False,
+            key_ref=key_ref,
+        )
+
+    return CredentialContext(
+        mode=CredentialMode.BYOK,
+        source=CredentialSource.SERVICE_FORWARDED_BYOK,
+        caller=caller,
+        provider_keys=presences,
+    )
+
+
+def build_key_reference_credential_context(
+    caller: ServiceCaller,
+    key_refs: Mapping[str, str | None],
+) -> CredentialContext:
+    presences: dict[str, ProviderKeyPresence] = {}
+    for provider, key_ref in key_refs.items():
+        normalized_provider = provider.strip().lower()
+        presences[normalized_provider] = ProviderKeyPresence(
+            provider=normalized_provider,
+            present=bool(key_ref),
+            key_ref=key_ref,
+        )
+
+    return CredentialContext(
+        mode=CredentialMode.BYOK,
+        source=CredentialSource.INTERNAL_KEY_REFERENCE,
+        caller=caller,
+        provider_keys=presences,
+    )
+
+
+def is_byok_failure_class(failure_class: FailureClass | str) -> bool:
+    return _failure_class_value(failure_class) in BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES
+
+
+def is_fallback_eligible_by_default(
+    failure_class: FailureClass | str,
+    credential_policy: CredentialPolicy,
+) -> bool:
+    failure_value = _failure_class_value(failure_class)
+    if credential_policy.mode == CredentialMode.BYOK and failure_value in BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES:
+        return False
+    if failure_value in {_failure_class_value(item) for item in credential_policy.never_fallback_failure_classes}:
+        return False
+    return failure_value in {_failure_class_value(item) for item in credential_policy.fallback_eligible_failure_classes}
+
+
+def _failure_class_value(failure_class: FailureClass | str) -> str:
+    if isinstance(failure_class, FailureClass):
+        return failure_class.value
+    return failure_class
+
+
+def _normalize_optional_mapping(values: Mapping[str, str | None] | None) -> dict[str, str | None]:
+    if values is None:
+        return {}
+    return {key.strip().lower(): value for key, value in values.items()}

--- a/backend/llm_gateway/gateway/credentials.py
+++ b/backend/llm_gateway/gateway/credentials.py
@@ -88,10 +88,14 @@ def build_key_reference_credential_context(
     presences: dict[str, ProviderKeyPresence] = {}
     for provider, key_ref in key_refs.items():
         normalized_provider = provider.strip().lower()
+        stripped_key_ref = key_ref.strip() if isinstance(key_ref, str) else key_ref
+        # Whitespace-only refs are treated as absent so they do not pass
+        # BYOK key-availability checks.
+        normalized_key_ref = stripped_key_ref or None
         presences[normalized_provider] = ProviderKeyPresence(
             provider=normalized_provider,
-            present=bool(key_ref),
-            key_ref=key_ref,
+            present=bool(normalized_key_ref),
+            key_ref=normalized_key_ref,
         )
 
     return CredentialContext(

--- a/backend/llm_gateway/gateway/errors.py
+++ b/backend/llm_gateway/gateway/errors.py
@@ -12,6 +12,7 @@ class GatewayErrorCode(str, Enum):
     CAPABILITY_NOT_SUPPORTED = 'capability_not_supported'
     INVALID_ROUTE_CONFIG = 'invalid_route_config'
     CREDENTIAL_FAILURE = 'credential_failure'
+    PROVIDER_FAILURE = 'provider_failure'
 
 
 class GatewayError(Exception):
@@ -78,6 +79,16 @@ class GatewayCredentialFailureError(GatewayError):
         super().__init__(
             message,
             code=GatewayErrorCode.CREDENTIAL_FAILURE,
+            failure_class=failure_class,
+            param=param,
+        )
+
+
+class GatewayProviderFailureError(GatewayError):
+    def __init__(self, message: str, *, failure_class: FailureClass, param: str | None = None) -> None:
+        super().__init__(
+            message,
+            code=GatewayErrorCode.PROVIDER_FAILURE,
             failure_class=failure_class,
             param=param,
         )

--- a/backend/llm_gateway/gateway/errors.py
+++ b/backend/llm_gateway/gateway/errors.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from llm_gateway.gateway.schemas import FailureClass
+
+
+class GatewayErrorCode(str, Enum):
+    INVALID_REQUEST = 'invalid_request'
+    MODEL_NOT_FOUND = 'model_not_found'
+    UNSUPPORTED_MODEL = 'unsupported_model'
+    CAPABILITY_NOT_SUPPORTED = 'capability_not_supported'
+    INVALID_ROUTE_CONFIG = 'invalid_route_config'
+    CREDENTIAL_FAILURE = 'credential_failure'
+
+
+class GatewayError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: GatewayErrorCode,
+        failure_class: FailureClass | None = None,
+        param: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.failure_class = failure_class
+        self.param = param
+
+    def to_error_dict(self) -> dict[str, str | None]:
+        return {
+            'message': self.message,
+            'code': self.code.value,
+            'failure_class': self.failure_class.value if self.failure_class is not None else None,
+            'param': self.param,
+        }
+
+
+class GatewayInvalidRequestError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = None) -> None:
+        super().__init__(message, code=GatewayErrorCode.INVALID_REQUEST, param=param)
+
+
+class GatewayModelNotFoundError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = 'model') -> None:
+        super().__init__(message, code=GatewayErrorCode.MODEL_NOT_FOUND, param=param)
+
+
+class GatewayUnsupportedModelError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = 'model') -> None:
+        super().__init__(message, code=GatewayErrorCode.UNSUPPORTED_MODEL, param=param)
+
+
+class GatewayCapabilityMismatchError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = None) -> None:
+        super().__init__(
+            message,
+            code=GatewayErrorCode.CAPABILITY_NOT_SUPPORTED,
+            failure_class=FailureClass.CAPABILITY_MISMATCH,
+            param=param,
+        )
+
+
+class GatewayInvalidRouteConfigError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = None) -> None:
+        super().__init__(
+            message,
+            code=GatewayErrorCode.INVALID_ROUTE_CONFIG,
+            failure_class=FailureClass.INVALID_CONFIG,
+            param=param,
+        )
+
+
+class GatewayCredentialFailureError(GatewayError):
+    def __init__(self, message: str, *, failure_class: FailureClass, param: str | None = None) -> None:
+        super().__init__(
+            message,
+            code=GatewayErrorCode.CREDENTIAL_FAILURE,
+            failure_class=failure_class,
+            param=param,
+        )

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -14,7 +14,7 @@ from llm_gateway.gateway.errors import (
 )
 from llm_gateway.gateway.providers import ChatCompletionProvider, ProviderFailure
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
-from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RouteArtifact
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutStage, RouteArtifact
 
 
 @dataclass(frozen=True)
@@ -48,22 +48,34 @@ async def execute_chat_completion(
     credential_context: CredentialContext,
     provider_registry: ProviderRegistry,
 ) -> ExecutorResult:
-    _validate_credential_mode(resolved_route.active_route, credential_context)
+    serving_route = _select_serving_route(resolved_route)
+    serving_is_lkg = serving_route is resolved_route.last_known_good_route
+    _validate_credential_mode(serving_route, credential_context)
 
     first_failure: FailureClass | None = None
     last_error: GatewayError | None = None
     try:
         return await _execute_route(
             resolved_route,
-            resolved_route.active_route,
+            serving_route,
             credential_context,
             provider_registry,
-            is_lkg=False,
+            is_lkg=serving_is_lkg,
             fallback_reason=None,
         )
     except GatewayError as exc:
         first_failure = exc.failure_class
         last_error = exc
+
+    # When the active route is in shadow/disabled rollout the LKG is already
+    # the serving route — there is no separate LKG fallback to try.
+    if serving_is_lkg:
+        if last_error is not None:
+            raise last_error
+        raise GatewayProviderFailureError(
+            'provider request failed',
+            failure_class=FailureClass.INVALID_CONFIG,
+        )
 
     if first_failure is not None and select_lkg_route_for_failure(resolved_route, first_failure) is not None:
         try:
@@ -84,6 +96,24 @@ async def execute_chat_completion(
         'provider request failed',
         failure_class=FailureClass.INVALID_CONFIG,
     )
+
+
+def _select_serving_route(resolved_route: ResolvedRoute) -> RouteArtifact:
+    """Return the route that should receive live traffic.
+
+    When the active route is in shadow or disabled rollout, traffic falls
+    back to the last-known-good route until the active route is promoted.
+    """
+    if _is_route_eligible_to_serve(resolved_route.active_route):
+        return resolved_route.active_route
+    return resolved_route.last_known_good_route
+
+
+def _is_route_eligible_to_serve(route: RouteArtifact) -> bool:
+    """Whether a route should receive live traffic based on rollout stage."""
+    if route.rollout.stage in (RolloutStage.SHADOW, RolloutStage.DISABLED):
+        return False
+    return route.rollout.percent > 0
 
 
 async def _execute_route(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -18,6 +19,9 @@ from llm_gateway.gateway.providers import ChatCompletionProvider, ProviderFailur
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
 from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutStage, RouteArtifact
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest
+from utils.log_sanitizer import sanitize
+
+EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR = 'LLM_GATEWAY_EXPOSE_PROVIDER_ERROR_DETAILS'
 
 
 @dataclass(frozen=True)
@@ -299,24 +303,30 @@ def _unsupported_provider_error(
 def _map_provider_failure(exc: ProviderFailure, credential_context: CredentialContext) -> GatewayError:
     failure_class = exc.failure_class
     if failure_class == FailureClass.INVALID_CONFIG:
-        return GatewayInvalidRouteConfigError(_safe_failure_message(failure_class), param='provider')
+        return GatewayInvalidRouteConfigError(_safe_failure_message(failure_class, exc.safe_message), param='provider')
     if failure_class == FailureClass.CAPABILITY_MISMATCH:
-        return GatewayCapabilityMismatchError(_safe_failure_message(failure_class), param='provider')
+        return GatewayCapabilityMismatchError(_safe_failure_message(failure_class, exc.safe_message), param='provider')
     if credential_context.mode == CredentialMode.BYOK or is_byok_failure_class(failure_class):
         return GatewayCredentialFailureError(
-            _safe_failure_message(failure_class),
+            _safe_failure_message(failure_class, exc.safe_message),
             failure_class=failure_class,
             param='provider',
         )
     return GatewayProviderFailureError(
-        _safe_failure_message(failure_class),
+        _safe_failure_message(failure_class, exc.safe_message),
         failure_class=failure_class,
         param='provider',
     )
 
 
-def _safe_failure_message(failure_class: FailureClass) -> str:
+def _safe_failure_message(failure_class: FailureClass, provider_message: str | None = None) -> str:
+    if _expose_provider_error_details() and provider_message and provider_message != 'provider request failed':
+        return sanitize(provider_message)
     return f'provider request failed: {failure_class.value}'
+
+
+def _expose_provider_error_details() -> bool:
+    return os.getenv(EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR, '').strip().lower() == 'true'
 
 
 def _can_try_next_provider(route: RouteArtifact, failure_class: FailureClass | None) -> bool:

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -15,6 +17,7 @@ from llm_gateway.gateway.errors import (
 from llm_gateway.gateway.providers import ChatCompletionProvider, ProviderFailure
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
 from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutStage, RouteArtifact
+from llm_gateway.gateway.validator import ValidatedChatCompletionRequest
 
 
 @dataclass(frozen=True)
@@ -103,17 +106,46 @@ def _select_serving_route(resolved_route: ResolvedRoute) -> RouteArtifact:
 
     When the active route is in shadow or disabled rollout, traffic falls
     back to the last-known-good route until the active route is promoted.
+
+    For canary (partial) rollouts the active route only receives the
+    configured percentage of traffic via deterministic per-request
+    sampling; the remainder is served by the last-known-good route.
     """
-    if _is_route_eligible_to_serve(resolved_route.active_route):
+    if _is_route_eligible_to_serve(resolved_route.active_route, resolved_route.validated_request):
         return resolved_route.active_route
     return resolved_route.last_known_good_route
 
 
-def _is_route_eligible_to_serve(route: RouteArtifact) -> bool:
-    """Whether a route should receive live traffic based on rollout stage."""
+def _is_route_eligible_to_serve(route: RouteArtifact, validated_request: ValidatedChatCompletionRequest) -> bool:
+    """Whether a route should receive live traffic based on rollout stage and percent."""
     if route.rollout.stage in (RolloutStage.SHADOW, RolloutStage.DISABLED):
         return False
+    if route.rollout.stage == RolloutStage.CANARY and route.rollout.percent < 100.0:
+        return _canary_sample(route, validated_request)
     return route.rollout.percent > 0
+
+
+def _canary_sample(route: RouteArtifact, validated_request: ValidatedChatCompletionRequest) -> bool:
+    """Deterministically decide whether a single request is served by a canary route.
+
+    A stable hash of the request messages (plus the route artifact id so
+    different canary routes in the same lane diverge) is mapped into the
+    [0, 100) range and compared against the configured rollout percentage.
+    This keeps the same request consistently on the same lane across
+    retries, while distributing traffic proportionally over many requests.
+    """
+    payload = json.dumps(
+        {
+            'route_artifact_id': route.route_artifact_id,
+            'messages': list(validated_request.messages),
+        },
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+    )
+    digest = hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    bucket = int(digest[:8], 16) % 10000 / 100.0
+    return bucket < route.rollout.percent
 
 
 async def _execute_route(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from llm_gateway.gateway.credentials import CredentialContext, is_byok_failure_class
+from llm_gateway.gateway.errors import (
+    GatewayCapabilityMismatchError,
+    GatewayCredentialFailureError,
+    GatewayError,
+    GatewayInvalidRouteConfigError,
+    GatewayProviderFailureError,
+)
+from llm_gateway.gateway.providers import ChatCompletionProvider, ProviderFailure
+from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RouteArtifact
+
+
+@dataclass(frozen=True)
+class ExecutorResult:
+    response: dict[str, Any]
+    lane_id: str
+    selected_route_artifact_id: str
+    selected_provider: str
+    selected_model: str
+    fallback_used: bool
+    fallback_reason: FailureClass | None
+    used_lkg: bool
+
+
+class ProviderRegistry:
+    def __init__(self, providers: Mapping[str, ChatCompletionProvider] | None = None) -> None:
+        self._providers = {provider.strip().lower(): client for provider, client in (providers or {}).items()}
+
+    def provider_for(self, provider: str) -> ChatCompletionProvider | None:
+        return self._providers.get(provider.strip().lower())
+
+
+async def execute_chat_completion(
+    resolved_route: ResolvedRoute,
+    credential_context: CredentialContext,
+    provider_registry: ProviderRegistry,
+) -> ExecutorResult:
+    _validate_credential_mode(resolved_route.active_route, credential_context)
+
+    first_failure: FailureClass | None = None
+    last_error: GatewayError | None = None
+    try:
+        return await _execute_route(
+            resolved_route,
+            resolved_route.active_route,
+            credential_context,
+            provider_registry,
+            is_lkg=False,
+            fallback_reason=None,
+        )
+    except GatewayError as exc:
+        first_failure = exc.failure_class
+        last_error = exc
+
+    if first_failure is not None and select_lkg_route_for_failure(resolved_route, first_failure) is not None:
+        try:
+            return await _execute_route(
+                resolved_route,
+                resolved_route.last_known_good_route,
+                credential_context,
+                provider_registry,
+                is_lkg=True,
+                fallback_reason=first_failure,
+            )
+        except GatewayError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    raise GatewayProviderFailureError(
+        'provider request failed',
+        failure_class=FailureClass.INVALID_CONFIG,
+    )
+
+
+async def _execute_route(
+    resolved_route: ResolvedRoute,
+    route: RouteArtifact,
+    credential_context: CredentialContext,
+    provider_registry: ProviderRegistry,
+    *,
+    is_lkg: bool,
+    fallback_reason: FailureClass | None,
+) -> ExecutorResult:
+    refs = [route.primary, *route.fallbacks]
+    last_error: GatewayError | None = None
+    current_fallback_reason = fallback_reason
+
+    for index, provider_ref in enumerate(refs):
+        provider = provider_registry.provider_for(provider_ref.provider)
+        if provider is None:
+            error = _unsupported_provider_error(provider_ref, credential_context)
+        elif route.credential_policy.mode == CredentialMode.BYOK and not credential_context.has_provider_key(
+            provider_ref.provider
+        ):
+            error = GatewayCredentialFailureError(
+                f'BYOK key is required for provider {provider_ref.provider}',
+                failure_class=FailureClass.MISSING_BYOK_KEY,
+                param='credentials',
+            )
+        else:
+            try:
+                provider_response = await provider.create_chat_completion(
+                    _provider_request(resolved_route, provider_ref),
+                    provider_ref=provider_ref,
+                    credentials=credential_context,
+                    timeout_ms=route.timeouts.request_ms,
+                )
+                return _executor_result(
+                    provider_response,
+                    resolved_route=resolved_route,
+                    route=route,
+                    provider_ref=provider_ref,
+                    fallback_used=index > 0 or is_lkg,
+                    fallback_reason=current_fallback_reason,
+                    used_lkg=is_lkg,
+                )
+            except ProviderFailure as exc:
+                error = _map_provider_failure(exc, credential_context)
+
+        last_error = error
+        if index == len(refs) - 1 or not _can_try_next_provider(route, error.failure_class):
+            raise error
+        current_fallback_reason = error.failure_class
+
+    if last_error is not None:
+        raise last_error
+    raise GatewayInvalidRouteConfigError(f'route {route.route_artifact_id} has no provider refs')
+
+
+def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
+    return {
+        'model': provider_ref.model,
+        'messages': list(resolved_route.validated_request.messages),
+        'response_format': dict(resolved_route.validated_request.response_format),
+        'stream': False,
+    }
+
+
+def _executor_result(
+    provider_response: Mapping[str, Any],
+    *,
+    resolved_route: ResolvedRoute,
+    route: RouteArtifact,
+    provider_ref: ProviderRef,
+    fallback_used: bool,
+    fallback_reason: FailureClass | None,
+    used_lkg: bool,
+) -> ExecutorResult:
+    response = dict(provider_response)
+    response['model'] = resolved_route.validated_request.model
+    return ExecutorResult(
+        response=response,
+        lane_id=resolved_route.lane.lane_id,
+        selected_route_artifact_id=route.route_artifact_id,
+        selected_provider=provider_ref.provider,
+        selected_model=provider_ref.model,
+        fallback_used=fallback_used,
+        fallback_reason=fallback_reason,
+        used_lkg=used_lkg,
+    )
+
+
+def _validate_credential_mode(route: RouteArtifact, credential_context: CredentialContext) -> None:
+    if route.credential_policy.mode != credential_context.mode:
+        raise GatewayInvalidRouteConfigError(
+            f'route {route.route_artifact_id} credential mode does not match request context'
+        )
+
+
+def _unsupported_provider_error(
+    provider_ref: ProviderRef,
+    credential_context: CredentialContext,
+) -> GatewayCredentialFailureError | GatewayInvalidRouteConfigError:
+    if credential_context.mode == CredentialMode.BYOK:
+        return GatewayCredentialFailureError(
+            f'BYOK provider is not supported for this route: {provider_ref.provider}',
+            failure_class=FailureClass.BYOK_UNSUPPORTED_PROVIDER,
+            param='provider',
+        )
+    return GatewayInvalidRouteConfigError(f'provider is not supported for this route: {provider_ref.provider}')
+
+
+def _map_provider_failure(exc: ProviderFailure, credential_context: CredentialContext) -> GatewayError:
+    failure_class = exc.failure_class
+    if failure_class == FailureClass.INVALID_CONFIG:
+        return GatewayInvalidRouteConfigError(_safe_failure_message(failure_class), param='provider')
+    if failure_class == FailureClass.CAPABILITY_MISMATCH:
+        return GatewayCapabilityMismatchError(_safe_failure_message(failure_class), param='provider')
+    if credential_context.mode == CredentialMode.BYOK or is_byok_failure_class(failure_class):
+        return GatewayCredentialFailureError(
+            _safe_failure_message(failure_class),
+            failure_class=failure_class,
+            param='provider',
+        )
+    return GatewayProviderFailureError(
+        _safe_failure_message(failure_class),
+        failure_class=failure_class,
+        param='provider',
+    )
+
+
+def _safe_failure_message(failure_class: FailureClass) -> str:
+    return f'provider request failed: {failure_class.value}'
+
+
+def _can_try_next_provider(route: RouteArtifact, failure_class: FailureClass | None) -> bool:
+    if failure_class is None:
+        return False
+    return is_lkg_eligible(route, failure_class)

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -15,13 +15,16 @@ from llm_gateway.gateway.errors import (
     GatewayInvalidRouteConfigError,
     GatewayProviderFailureError,
 )
-from llm_gateway.gateway.providers import ChatCompletionProvider, ProviderFailure
+from llm_gateway.gateway.providers import (
+    ChatCompletionProvider,
+    EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR,
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    ProviderFailure,
+)
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
 from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutStage, RouteArtifact
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest
 from utils.log_sanitizer import sanitize
-
-EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR = 'LLM_GATEWAY_EXPOSE_PROVIDER_ERROR_DETAILS'
 
 
 @dataclass(frozen=True)
@@ -320,7 +323,7 @@ def _map_provider_failure(exc: ProviderFailure, credential_context: CredentialCo
 
 
 def _safe_failure_message(failure_class: FailureClass, provider_message: str | None = None) -> str:
-    if _expose_provider_error_details() and provider_message and provider_message != 'provider request failed':
+    if _expose_provider_error_details() and provider_message and provider_message != GENERIC_PROVIDER_FAILURE_MESSAGE:
         return sanitize(provider_message)
     return f'provider request failed: {failure_class.value}'
 

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -148,6 +148,15 @@ def _canary_sample(route: RouteArtifact, validated_request: ValidatedChatComplet
     return bucket < route.rollout.percent
 
 
+RETRYABLE_PROVIDER_FAILURE_CLASSES = frozenset(
+    {
+        FailureClass.TIMEOUT_BEFORE_OUTPUT,
+        FailureClass.PROVIDER_429_OMI_PAID,
+        FailureClass.PROVIDER_5XX_OMI_PAID,
+    }
+)
+
+
 async def _execute_route(
     resolved_route: ResolvedRoute,
     route: RouteArtifact,
@@ -227,6 +236,8 @@ async def _attempt_provider(
             return response, None
         except ProviderFailure as exc:
             error = _map_provider_failure(exc, credential_context)
+            if error.failure_class not in RETRYABLE_PROVIDER_FAILURE_CLASSES:
+                return None, error
     return None, error
 
 

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -36,6 +36,12 @@ class ProviderRegistry:
     def provider_for(self, provider: str) -> ChatCompletionProvider | None:
         return self._providers.get(provider.strip().lower())
 
+    async def aclose(self) -> None:
+        for provider in self._providers.values():
+            close = getattr(provider, 'aclose', None)
+            if close is not None:
+                await close()
+
 
 async def execute_chat_completion(
     resolved_route: ResolvedRoute,
@@ -136,12 +142,14 @@ async def _execute_route(
 
 
 def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
-    return {
+    provider_request = {
         'model': provider_ref.model,
         'messages': list(resolved_route.validated_request.messages),
         'response_format': dict(resolved_route.validated_request.response_format),
         'stream': False,
     }
+    provider_request.update(dict(resolved_route.validated_request.forwarded_params))
+    return provider_request
 
 
 def _executor_result(

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -112,15 +112,16 @@ async def _execute_route(
                 param='credentials',
             )
         else:
-            try:
-                provider_response = await provider.create_chat_completion(
-                    _provider_request(resolved_route, provider_ref),
-                    provider_ref=provider_ref,
-                    credentials=credential_context,
-                    timeout_ms=route.timeouts.request_ms,
-                )
+            response, error = await _attempt_provider(
+                resolved_route,
+                route,
+                provider,
+                provider_ref,
+                credential_context,
+            )
+            if error is None:
                 return _executor_result(
-                    provider_response,
+                    response,  # type: ignore[arg-type]
                     resolved_route=resolved_route,
                     route=route,
                     provider_ref=provider_ref,
@@ -128,8 +129,6 @@ async def _execute_route(
                     fallback_reason=current_fallback_reason,
                     used_lkg=is_lkg,
                 )
-            except ProviderFailure as exc:
-                error = _map_provider_failure(exc, credential_context)
 
         last_error = error
         if index == len(refs) - 1 or not _can_try_next_provider(route, error.failure_class):
@@ -139,6 +138,34 @@ async def _execute_route(
     if last_error is not None:
         raise last_error
     raise GatewayInvalidRouteConfigError(f'route {route.route_artifact_id} has no provider refs')
+
+
+async def _attempt_provider(
+    resolved_route: ResolvedRoute,
+    route: RouteArtifact,
+    provider: ChatCompletionProvider,
+    provider_ref: ProviderRef,
+    credential_context: CredentialContext,
+) -> tuple[Mapping[str, Any] | None, GatewayError | None]:
+    """Try a single provider up to ``route.retry.max_attempts`` times.
+
+    Returns ``(response, None)`` on success, or ``(None, error)`` if all
+    attempts fail.
+    """
+    max_attempts = max(route.retry.max_attempts, 1)
+    error: GatewayError | None = None
+    for _attempt in range(max_attempts):
+        try:
+            response = await provider.create_chat_completion(
+                _provider_request(resolved_route, provider_ref),
+                provider_ref=provider_ref,
+                credentials=credential_context,
+                timeout_ms=route.timeouts.request_ms,
+            )
+            return response, None
+        except ProviderFailure as exc:
+            error = _map_provider_failure(exc, credential_context)
+    return None, error
 
 
 def _provider_request(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:

--- a/backend/llm_gateway/gateway/metrics.py
+++ b/backend/llm_gateway/gateway/metrics.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import time
+from prometheus_client import Counter, Histogram
+
+from llm_gateway.gateway.errors import GatewayError
+from llm_gateway.gateway.executor import ExecutorResult
+
+REQUEST_LATENCY_SECONDS = Histogram(
+    'llm_gateway_request_latency_seconds',
+    'LLM gateway request latency by route selection and outcome',
+    [
+        'lane_id',
+        'route_artifact_id',
+        'provider',
+        'model',
+        'used_lkg',
+        'fallback_used',
+        'fallback_reason',
+        'outcome',
+        'error_class',
+    ],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 40),
+)
+
+REQUESTS_TOTAL = Counter(
+    'llm_gateway_requests_total',
+    'LLM gateway requests by route selection and outcome',
+    [
+        'lane_id',
+        'route_artifact_id',
+        'provider',
+        'model',
+        'used_lkg',
+        'fallback_used',
+        'fallback_reason',
+        'outcome',
+        'error_class',
+    ],
+)
+
+
+def observe_success(started_at: float, result: ExecutorResult) -> None:
+    labels = _result_labels(result, outcome='success', error_class='none')
+    REQUESTS_TOTAL.labels(**labels).inc()
+    REQUEST_LATENCY_SECONDS.labels(**labels).observe(time.monotonic() - started_at)
+
+
+def observe_error(
+    started_at: float,
+    *,
+    lane_id: str,
+    route_artifact_id: str,
+    error: GatewayError,
+) -> None:
+    labels = {
+        'lane_id': _bounded(lane_id),
+        'route_artifact_id': _bounded(route_artifact_id),
+        'provider': 'none',
+        'model': 'none',
+        'used_lkg': 'false',
+        'fallback_used': 'false',
+        'fallback_reason': _bounded(error.failure_class.value if error.failure_class is not None else 'none'),
+        'outcome': 'error',
+        'error_class': _bounded(error.code.value),
+    }
+    REQUESTS_TOTAL.labels(**labels).inc()
+    REQUEST_LATENCY_SECONDS.labels(**labels).observe(time.monotonic() - started_at)
+
+
+def time_request() -> float:
+    return time.monotonic()
+
+
+def _result_labels(result: ExecutorResult, *, outcome: str, error_class: str) -> dict[str, str]:
+    return {
+        'lane_id': _bounded(result.lane_id),
+        'route_artifact_id': _bounded(result.selected_route_artifact_id),
+        'provider': _bounded(result.selected_provider),
+        'model': _bounded(result.selected_model),
+        'used_lkg': _bool_label(result.used_lkg),
+        'fallback_used': _bool_label(result.fallback_used),
+        'fallback_reason': _bounded(result.fallback_reason.value if result.fallback_reason is not None else 'none'),
+        'outcome': _bounded(outcome),
+        'error_class': _bounded(error_class),
+    }
+
+
+def _bounded(value: str) -> str:
+    normalized = value.strip().lower().replace(' ', '_')
+    return normalized[:128] if normalized else 'unknown'
+
+
+def _bool_label(value: bool) -> str:
+    return 'true' if value else 'false'

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -30,7 +30,7 @@ class ChatCompletionProvider(Protocol):
     ) -> Mapping[str, Any]: ...
 
 
-@dataclass(frozen=True)
+@dataclass
 class ProviderFailure(Exception):
     failure_class: FailureClass
     safe_message: str = 'provider request failed'

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from llm_gateway.gateway.credentials import CredentialContext
+from llm_gateway.gateway.schemas import FailureClass, ProviderRef
+
+
+class ChatCompletionProvider(Protocol):
+    async def create_chat_completion(
+        self,
+        request: Mapping[str, Any],
+        *,
+        provider_ref: ProviderRef,
+        credentials: CredentialContext,
+        timeout_ms: int,
+    ) -> Mapping[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class ProviderFailure(Exception):
+    failure_class: FailureClass
+    safe_message: str = 'provider request failed'
+
+    def __str__(self) -> str:
+        return self.safe_message
+
+
+class FakeChatCompletionProvider:
+    def __init__(self, outcomes: list[Mapping[str, Any] | ProviderFailure] | None = None) -> None:
+        self._outcomes: deque[Mapping[str, Any] | ProviderFailure] = deque(outcomes or [])
+        self.calls: list[FakeProviderCall] = []
+
+    async def create_chat_completion(
+        self,
+        request: Mapping[str, Any],
+        *,
+        provider_ref: ProviderRef,
+        credentials: CredentialContext,
+        timeout_ms: int,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            FakeProviderCall(
+                provider=provider_ref.provider,
+                model=provider_ref.model,
+                request=dict(request),
+                credential_mode=credentials.mode.value,
+                timeout_ms=timeout_ms,
+            )
+        )
+        if not self._outcomes:
+            return _default_fake_response(provider_ref)
+
+        outcome = self._outcomes.popleft()
+        if isinstance(outcome, ProviderFailure):
+            raise outcome
+        return outcome
+
+
+@dataclass(frozen=True)
+class FakeProviderCall:
+    provider: str
+    model: str
+    request: dict[str, Any]
+    credential_mode: str
+    timeout_ms: int
+
+
+def fake_success_response(provider_ref: ProviderRef, *, content: str = '{"answer":"ok"}') -> dict[str, Any]:
+    return {
+        'id': 'chatcmpl_fake',
+        'object': 'chat.completion',
+        'created': 1782522000,
+        'model': provider_ref.model,
+        'choices': [
+            {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': content},
+                'finish_reason': 'stop',
+            }
+        ],
+    }
+
+
+def _default_fake_response(provider_ref: ProviderRef) -> dict[str, Any]:
+    return fake_success_response(provider_ref)

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass
+import os
 from typing import Any, Protocol
 
+import httpx
+
 from llm_gateway.gateway.credentials import CredentialContext
-from llm_gateway.gateway.schemas import FailureClass, ProviderRef
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef
+
+OPENAI_API_KEY_ENV_VAR = 'OPENAI_API_KEY'
+OPENAI_BASE_URL_ENV_VAR = 'OPENAI_BASE_URL'
+DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 
 
 class ChatCompletionProvider(Protocol):
@@ -27,6 +34,66 @@ class ProviderFailure(Exception):
 
     def __str__(self) -> str:
         return self.safe_message
+
+
+class OpenAICompatibleChatCompletionProvider:
+    def __init__(
+        self,
+        *,
+        api_key_env: str = OPENAI_API_KEY_ENV_VAR,
+        base_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key_env = api_key_env
+        self._base_url = (base_url or os.getenv(OPENAI_BASE_URL_ENV_VAR, DEFAULT_OPENAI_BASE_URL)).rstrip('/')
+        self._http_client = http_client or httpx.AsyncClient()
+
+    async def create_chat_completion(
+        self,
+        request: Mapping[str, Any],
+        *,
+        provider_ref: ProviderRef,
+        credentials: CredentialContext,
+        timeout_ms: int,
+    ) -> Mapping[str, Any]:
+        if credentials.mode == CredentialMode.BYOK:
+            raise ProviderFailure(FailureClass.BYOK_UNSUPPORTED_PROVIDER)
+
+        api_key = os.getenv(self._api_key_env, '').strip()
+        if not api_key:
+            raise ProviderFailure(FailureClass.INVALID_CONFIG)
+
+        try:
+            response = await self._http_client.post(
+                f'{self._base_url}/chat/completions',
+                json=dict(request),
+                headers={
+                    'Authorization': f'Bearer {api_key}',
+                    'Content-Type': 'application/json',
+                },
+                timeout=timeout_ms / 1000.0,
+            )
+        except httpx.TimeoutException as exc:
+            raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
+        except httpx.HTTPError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+
+        if response.status_code in {401, 403}:
+            raise ProviderFailure(FailureClass.INVALID_CONFIG)
+        if response.status_code == 429:
+            raise ProviderFailure(FailureClass.PROVIDER_429_OMI_PAID)
+        if response.status_code >= 500:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        if response.status_code >= 400:
+            raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+
+        try:
+            parsed = response.json()
+        except ValueError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+        if not isinstance(parsed, Mapping):
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        return parsed
 
 
 class FakeChatCompletionProvider:

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass
+import json
 import os
 from typing import Any, Protocol
 
@@ -14,6 +15,8 @@ from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRe
 OPENAI_API_KEY_ENV_VAR = 'OPENAI_API_KEY'
 OPENAI_BASE_URL_ENV_VAR = 'OPENAI_BASE_URL'
 DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
+DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_RESPONSE_BYTES_ENV_VAR = 'OPENAI_MAX_RESPONSE_BYTES'
 
 
 class ChatCompletionProvider(Protocol):
@@ -47,6 +50,7 @@ class OpenAICompatibleChatCompletionProvider:
         self._api_key_env = api_key_env
         self._base_url = (base_url or os.getenv(OPENAI_BASE_URL_ENV_VAR, DEFAULT_OPENAI_BASE_URL)).rstrip('/')
         self._http_client = http_client or httpx.AsyncClient()
+        self._owns_http_client = http_client is None
 
     async def create_chat_completion(
         self,
@@ -64,7 +68,8 @@ class OpenAICompatibleChatCompletionProvider:
             raise ProviderFailure(FailureClass.INVALID_CONFIG)
 
         try:
-            response = await self._http_client.post(
+            async with self._http_client.stream(
+                'POST',
                 f'{self._base_url}/chat/completions',
                 json=dict(request),
                 headers={
@@ -72,28 +77,22 @@ class OpenAICompatibleChatCompletionProvider:
                     'Content-Type': 'application/json',
                 },
                 timeout=timeout_ms / 1000.0,
-            )
+            ) as response:
+                _raise_for_status(response.status_code)
+                parsed = _parse_limited_json_response(
+                    await _read_limited_response(response, max_bytes=_configured_max_response_bytes())
+                )
         except httpx.TimeoutException as exc:
             raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
         except httpx.HTTPError as exc:
             raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
 
-        if response.status_code in {401, 403}:
-            raise ProviderFailure(FailureClass.INVALID_CONFIG)
-        if response.status_code == 429:
-            raise ProviderFailure(FailureClass.PROVIDER_429_OMI_PAID)
-        if response.status_code >= 500:
-            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
-        if response.status_code >= 400:
-            raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
-
-        try:
-            parsed = response.json()
-        except ValueError as exc:
-            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
-        if not isinstance(parsed, Mapping):
-            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        _validate_chat_completion_response_shape(parsed)
         return parsed
+
+    async def aclose(self) -> None:
+        if self._owns_http_client:
+            await self._http_client.aclose()
 
 
 class FakeChatCompletionProvider:
@@ -154,3 +153,72 @@ def fake_success_response(provider_ref: ProviderRef, *, content: str = '{"answer
 
 def _default_fake_response(provider_ref: ProviderRef) -> dict[str, Any]:
     return fake_success_response(provider_ref)
+
+
+def _raise_for_status(status_code: int) -> None:
+    if status_code in {401, 403}:
+        raise ProviderFailure(FailureClass.INVALID_CONFIG)
+    if status_code == 429:
+        raise ProviderFailure(FailureClass.PROVIDER_429_OMI_PAID)
+    if status_code >= 500:
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    if status_code >= 400:
+        raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+
+
+async def _read_limited_response(response: httpx.Response, *, max_bytes: int) -> bytes:
+    content_length = response.headers.get('content-length')
+    if content_length is not None:
+        try:
+            if int(content_length) > max_bytes:
+                raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        except ValueError as exc:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        total += len(chunk)
+        if total > max_bytes:
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        chunks.append(chunk)
+    return b''.join(chunks)
+
+
+def _parse_limited_json_response(body: bytes) -> Mapping[str, Any]:
+    try:
+        parsed = json.loads(body)
+    except ValueError as exc:
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID) from exc
+    if not isinstance(parsed, Mapping):
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    return parsed
+
+
+def _validate_chat_completion_response_shape(response: Mapping[str, Any]) -> None:
+    if response.get('object') != 'chat.completion':
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    if not isinstance(response.get('id'), str) or not response['id']:
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    if not isinstance(response.get('model'), str) or not response['model']:
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    choices = response.get('choices')
+    if not isinstance(choices, list) or not choices:
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+    for choice in choices:
+        if not isinstance(choice, Mapping):
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        message = choice.get('message')
+        if not isinstance(message, Mapping) or message.get('role') != 'assistant':
+            raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+
+
+def _configured_max_response_bytes() -> int:
+    configured = os.getenv(MAX_RESPONSE_BYTES_ENV_VAR, '').strip()
+    if not configured:
+        return DEFAULT_MAX_RESPONSE_BYTES
+    try:
+        value = int(configured)
+    except ValueError as exc:
+        raise ProviderFailure(FailureClass.INVALID_CONFIG) from exc
+    return value if value > 0 else DEFAULT_MAX_RESPONSE_BYTES

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -11,12 +11,14 @@ import httpx
 
 from llm_gateway.gateway.credentials import CredentialContext
 from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef
+from utils.log_sanitizer import sanitize
 
 OPENAI_API_KEY_ENV_VAR = 'OPENAI_API_KEY'
 OPENAI_BASE_URL_ENV_VAR = 'OPENAI_BASE_URL'
 DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 MAX_RESPONSE_BYTES_ENV_VAR = 'OPENAI_MAX_RESPONSE_BYTES'
+PROVIDER_ERROR_DETAIL_BYTES = 1000
 
 
 class ChatCompletionProvider(Protocol):
@@ -78,10 +80,9 @@ class OpenAICompatibleChatCompletionProvider:
                 },
                 timeout=timeout_ms / 1000.0,
             ) as response:
-                _raise_for_status(response.status_code)
-                parsed = _parse_limited_json_response(
-                    await _read_limited_response(response, max_bytes=_configured_max_response_bytes())
-                )
+                body = await _read_limited_response(response, max_bytes=_configured_max_response_bytes())
+                _raise_for_status(response.status_code, body)
+                parsed = _parse_limited_json_response(body)
         except httpx.TimeoutException as exc:
             raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
         except httpx.HTTPError as exc:
@@ -155,17 +156,28 @@ def _default_fake_response(provider_ref: ProviderRef) -> dict[str, Any]:
     return fake_success_response(provider_ref)
 
 
-def _raise_for_status(status_code: int) -> None:
+def _raise_for_status(status_code: int, body: bytes = b'') -> None:
     if status_code in {401, 403}:
-        raise ProviderFailure(FailureClass.INVALID_CONFIG)
+        raise ProviderFailure(FailureClass.INVALID_CONFIG, safe_message=_provider_error_message(status_code, body))
     if status_code == 408:
-        raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT)
+        raise ProviderFailure(
+            FailureClass.TIMEOUT_BEFORE_OUTPUT, safe_message=_provider_error_message(status_code, body)
+        )
     if status_code == 429:
-        raise ProviderFailure(FailureClass.PROVIDER_429_OMI_PAID)
+        raise ProviderFailure(
+            FailureClass.PROVIDER_429_OMI_PAID, safe_message=_provider_error_message(status_code, body)
+        )
     if status_code >= 500:
-        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        raise ProviderFailure(
+            FailureClass.PROVIDER_5XX_OMI_PAID, safe_message=_provider_error_message(status_code, body)
+        )
     if status_code >= 400:
-        raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+        raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH, safe_message=_provider_error_message(status_code, body))
+
+
+def _provider_error_message(status_code: int, body: bytes) -> str:
+    preview = body.decode('utf-8', errors='replace')[:PROVIDER_ERROR_DETAIL_BYTES]
+    return f'provider request failed: status={status_code} body={sanitize(preview)}'
 
 
 async def _read_limited_response(response: httpx.Response, *, max_bytes: int) -> bytes:

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -158,6 +158,8 @@ def _default_fake_response(provider_ref: ProviderRef) -> dict[str, Any]:
 def _raise_for_status(status_code: int) -> None:
     if status_code in {401, 403}:
         raise ProviderFailure(FailureClass.INVALID_CONFIG)
+    if status_code == 408:
+        raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT)
     if status_code == 429:
         raise ProviderFailure(FailureClass.PROVIDER_429_OMI_PAID)
     if status_code >= 500:

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -19,6 +19,8 @@ DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 MAX_RESPONSE_BYTES_ENV_VAR = 'OPENAI_MAX_RESPONSE_BYTES'
 PROVIDER_ERROR_DETAIL_BYTES = 1000
+EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR = 'LLM_GATEWAY_EXPOSE_PROVIDER_ERROR_DETAILS'
+GENERIC_PROVIDER_FAILURE_MESSAGE = 'provider request failed'
 
 
 class ChatCompletionProvider(Protocol):
@@ -35,7 +37,7 @@ class ChatCompletionProvider(Protocol):
 @dataclass
 class ProviderFailure(Exception):
     failure_class: FailureClass
-    safe_message: str = 'provider request failed'
+    safe_message: str = GENERIC_PROVIDER_FAILURE_MESSAGE
 
     def __str__(self) -> str:
         return self.safe_message
@@ -80,8 +82,16 @@ class OpenAICompatibleChatCompletionProvider:
                 },
                 timeout=timeout_ms / 1000.0,
             ) as response:
+                status_code = response.status_code
+                if status_code >= 400:
+                    # On error responses, read only a small bounded preview so
+                    # that a large/invalid-content-length body cannot reclassify
+                    # the status-specific failure class (e.g. 401 -> 5XX). The
+                    # body is never surfaced unless LLM_GATEWAY_EXPOSE_PROVIDER_ERROR_DETAILS
+                    # is explicitly enabled.
+                    error_preview = await _read_bounded_preview(response, max_bytes=PROVIDER_ERROR_DETAIL_BYTES)
+                    _raise_for_status(status_code, error_preview)
                 body = await _read_limited_response(response, max_bytes=_configured_max_response_bytes())
-                _raise_for_status(response.status_code, body)
                 parsed = _parse_limited_json_response(body)
         except httpx.TimeoutException as exc:
             raise ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT) from exc
@@ -176,8 +186,14 @@ def _raise_for_status(status_code: int, body: bytes = b'') -> None:
 
 
 def _provider_error_message(status_code: int, body: bytes) -> str:
+    if not _expose_provider_error_details():
+        return GENERIC_PROVIDER_FAILURE_MESSAGE
     preview = body.decode('utf-8', errors='replace')[:PROVIDER_ERROR_DETAIL_BYTES]
     return f'provider request failed: status={status_code} body={sanitize(preview)}'
+
+
+def _expose_provider_error_details() -> bool:
+    return os.getenv(EXPOSE_PROVIDER_ERROR_DETAILS_ENV_VAR, '').strip().lower() == 'true'
 
 
 async def _read_limited_response(response: httpx.Response, *, max_bytes: int) -> bytes:
@@ -196,6 +212,28 @@ async def _read_limited_response(response: httpx.Response, *, max_bytes: int) ->
         if total > max_bytes:
             raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
         chunks.append(chunk)
+    return b''.join(chunks)
+
+
+async def _read_bounded_preview(response: httpx.Response, *, max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` of the response body, truncating silently.
+
+    Unlike :func:`_read_limited_response`, an oversized body never raises a
+    failure class — the preview is simply truncated. This keeps status-specific
+    classification (401/403/429/4xx) intact regardless of body size, so a
+    large error response from the provider is not reclassified as a generic 5xx.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        remaining = max_bytes - total
+        if remaining <= 0:
+            break
+        if len(chunk) > remaining:
+            chunks.append(chunk[:remaining])
+            break
+        chunks.append(chunk)
+        total += len(chunk)
     return b''.join(chunks)
 
 

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from llm_gateway.gateway.config_loader import GatewayConfig
+from llm_gateway.gateway.credentials import is_byok_failure_class
+from llm_gateway.gateway.errors import (
+    GatewayCapabilityMismatchError,
+    GatewayInvalidRouteConfigError,
+    GatewayModelNotFoundError,
+    GatewayUnsupportedModelError,
+)
+from llm_gateway.gateway.schemas import FailureClass, LaneConfig, RouteArtifact, Surface
+from llm_gateway.gateway.validator import ValidatedChatCompletionRequest, validate_chat_completion_request
+
+SUPPORTED_AUTO_LANE_IDS = frozenset({'omi:auto:chat-structured'})
+AUTO_LANE_PREFIX = 'omi:auto:'
+NEVER_LKG_FAILURE_CLASSES = frozenset(
+    {
+        FailureClass.CAPABILITY_MISMATCH,
+        FailureClass.INVALID_CONFIG,
+        FailureClass.BYOK_AUTH,
+        FailureClass.BYOK_QUOTA,
+        FailureClass.BYOK_RATE_LIMIT,
+        FailureClass.BYOK_UNSUPPORTED_PROVIDER,
+        FailureClass.MISSING_BYOK_KEY,
+    }
+)
+
+
+@dataclass(frozen=True)
+class ResolvedRoute:
+    lane: LaneConfig
+    active_route: RouteArtifact
+    last_known_good_route: RouteArtifact
+    validated_request: ValidatedChatCompletionRequest
+
+
+def is_auto_lane_id(model: str) -> bool:
+    return isinstance(model, str) and model.startswith(AUTO_LANE_PREFIX)
+
+
+def resolve_chat_completion_route(
+    config: GatewayConfig,
+    request: Mapping[str, Any],
+) -> ResolvedRoute:
+    model = request.get('model') if isinstance(request, Mapping) else None
+    if not isinstance(model, str) or not model.strip():
+        raise GatewayModelNotFoundError('model is required')
+
+    lane = resolve_lane(config, model.strip())
+    validated_request = validate_chat_completion_request(request, lane)
+    active_route = _route_by_id(config, lane.active_route, pointer_name='active_route')
+    lkg_route = _route_by_id(config, lane.last_known_good, pointer_name='last_known_good')
+
+    _validate_route_matches_lane(lane, active_route, pointer_name='active_route')
+    _validate_route_matches_lane(lane, lkg_route, pointer_name='last_known_good')
+
+    return ResolvedRoute(
+        lane=lane,
+        active_route=active_route,
+        last_known_good_route=lkg_route,
+        validated_request=validated_request,
+    )
+
+
+def resolve_lane(config: GatewayConfig, model: str) -> LaneConfig:
+    if not is_auto_lane_id(model):
+        raise GatewayUnsupportedModelError(
+            f'provider model names are not direct routes in gateway v1: {model}',
+        )
+
+    if model not in SUPPORTED_AUTO_LANE_IDS:
+        raise GatewayModelNotFoundError(f'auto lane not found: {model}')
+
+    lane = config.lanes.get(model)
+    if lane is None:
+        raise GatewayModelNotFoundError(f'auto lane not configured: {model}')
+    if lane.surface != Surface.OPENAI_CHAT_COMPLETIONS:
+        raise GatewayCapabilityMismatchError(f'unsupported lane surface: {lane.surface.value}', param='model')
+    return lane
+
+
+def select_lkg_route_for_failure(
+    resolved_route: ResolvedRoute, failure_class: FailureClass | str
+) -> RouteArtifact | None:
+    if is_lkg_eligible(resolved_route.active_route, failure_class):
+        return resolved_route.last_known_good_route
+    return None
+
+
+def is_lkg_eligible(active_route: RouteArtifact, failure_class: FailureClass | str) -> bool:
+    normalized_failure_class = _normalize_failure_class(failure_class)
+    if normalized_failure_class in NEVER_LKG_FAILURE_CLASSES or is_byok_failure_class(normalized_failure_class):
+        return False
+    if normalized_failure_class in set(active_route.fallback_policy.never_fallback_on):
+        return False
+    return normalized_failure_class in set(active_route.fallback_policy.fallback_on)
+
+
+def _route_by_id(config: GatewayConfig, route_artifact_id: str, *, pointer_name: str) -> RouteArtifact:
+    route = config.route_artifacts.get(route_artifact_id)
+    if route is None:
+        raise GatewayInvalidRouteConfigError(f'{pointer_name} route not configured: {route_artifact_id}')
+    return route
+
+
+def _validate_route_matches_lane(lane: LaneConfig, route: RouteArtifact, *, pointer_name: str) -> None:
+    prefix = f'{pointer_name} {route.route_artifact_id}'
+    if route.lane_id != lane.lane_id:
+        raise GatewayInvalidRouteConfigError(f'{prefix} lane_id mismatch: {route.lane_id}')
+    if route.surface != lane.surface:
+        raise GatewayInvalidRouteConfigError(f'{prefix} surface mismatch: {route.surface.value}')
+    if route.capabilities != lane.capabilities:
+        raise GatewayInvalidRouteConfigError(f'{prefix} capabilities mismatch')
+    if route.credential_policy.mode != lane.credential_policy.mode:
+        raise GatewayInvalidRouteConfigError(f'{prefix} credential mode mismatch: {route.credential_policy.mode.value}')
+
+
+def _normalize_failure_class(failure_class: FailureClass | str) -> FailureClass:
+    if isinstance(failure_class, FailureClass):
+        return failure_class
+    try:
+        return FailureClass(failure_class)
+    except ValueError as exc:
+        raise GatewayInvalidRouteConfigError(f'unknown failure class: {failure_class}') from exc

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -7,6 +7,7 @@ from llm_gateway.gateway.config_loader import GatewayConfig
 from llm_gateway.gateway.credentials import is_byok_failure_class
 from llm_gateway.gateway.errors import (
     GatewayCapabilityMismatchError,
+    GatewayInvalidRequestError,
     GatewayInvalidRouteConfigError,
     GatewayModelNotFoundError,
     GatewayUnsupportedModelError,
@@ -47,7 +48,7 @@ def resolve_chat_completion_route(
 ) -> ResolvedRoute:
     model = request.get('model') if isinstance(request, Mapping) else None
     if not isinstance(model, str) or not model.strip():
-        raise GatewayModelNotFoundError('model is required')
+        raise GatewayInvalidRequestError('model is required', param='model')
 
     lane = resolve_lane(config, model.strip())
     validated_request = validate_chat_completion_request(request, lane)

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import hashlib
 import json
 from enum import Enum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 
 class StrictBaseModel(BaseModel):
     model_config = ConfigDict(extra='forbid')
+
+
+# Shared type alias for lane_id so the pattern lives in exactly one place.
+LaneId = Annotated[str, Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')]
 
 
 class Surface(str, Enum):
@@ -134,7 +138,7 @@ class FallbackPolicy(StrictBaseModel):
 
 
 class LaneConfig(StrictBaseModel):
-    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    lane_id: LaneId
     surface: Surface
     capabilities: Capabilities
     objective: Objective
@@ -145,7 +149,7 @@ class LaneConfig(StrictBaseModel):
 
 class RouteArtifact(StrictBaseModel):
     route_artifact_id: str = Field(min_length=1)
-    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    lane_id: LaneId
     surface: Surface
     primary: ProviderRef
     fallbacks: list[ProviderRef] = Field(default_factory=list)
@@ -173,7 +177,7 @@ class RouteArtifact(StrictBaseModel):
 
 class FeatureBundle(StrictBaseModel):
     feature: str = Field(min_length=1)
-    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    lane_id: LaneId
     prompt_version: str = Field(min_length=1)
     parser_version: str = Field(min_length=1)
     eval_suite: str = Field(min_length=1)

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -95,6 +95,14 @@ class RolloutPolicy(StrictBaseModel):
     stage: RolloutStage
     percent: float = Field(default=0.0, ge=0.0, le=100.0)
 
+    @model_validator(mode='after')
+    def validate_stage_percent(self):
+        if self.stage == RolloutStage.ACTIVE and self.percent != 100.0:
+            raise ValueError('active rollout stage must use percent 100')
+        if self.stage in (RolloutStage.SHADOW, RolloutStage.DISABLED) and self.percent != 0.0:
+            raise ValueError(f'{self.stage.value} rollout stage must use percent 0')
+        return self
+
 
 class Evidence(StrictBaseModel):
     benchmark_snapshot: str = Field(min_length=1)

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -41,6 +41,7 @@ class FailureClass(str, Enum):
     BYOK_AUTH = 'byok_auth'
     BYOK_QUOTA = 'byok_quota'
     BYOK_RATE_LIMIT = 'byok_rate_limit'
+    BYOK_UNSUPPORTED_PROVIDER = 'byok_unsupported_provider'
     MISSING_BYOK_KEY = 'missing_byok_key'
     CAPABILITY_MISMATCH = 'capability_mismatch'
     INVALID_CONFIG = 'invalid_config'

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+
+
+class StrictBaseModel(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+
+class Surface(str, Enum):
+    OPENAI_CHAT_COMPLETIONS = 'openai.chat_completions'
+
+
+class StructuredOutputMode(str, Enum):
+    NONE = 'none'
+    JSON_OBJECT = 'json_object'
+    JSON_SCHEMA = 'json_schema'
+
+
+class CredentialMode(str, Enum):
+    OMI_PAID = 'omi_paid'
+    BYOK = 'byok'
+
+
+class RolloutStage(str, Enum):
+    DISABLED = 'disabled'
+    SHADOW = 'shadow'
+    CANARY = 'canary'
+    ACTIVE = 'active'
+
+
+class FailureClass(str, Enum):
+    TIMEOUT_BEFORE_OUTPUT = 'timeout_before_output'
+    PROVIDER_429_OMI_PAID = 'provider_429_omi_paid'
+    PROVIDER_5XX_OMI_PAID = 'provider_5xx_omi_paid'
+    BYOK_AUTH = 'byok_auth'
+    BYOK_QUOTA = 'byok_quota'
+    BYOK_RATE_LIMIT = 'byok_rate_limit'
+    MISSING_BYOK_KEY = 'missing_byok_key'
+    CAPABILITY_MISMATCH = 'capability_mismatch'
+    INVALID_CONFIG = 'invalid_config'
+
+
+class BenchmarkSource(str, Enum):
+    OMI_EVAL = 'omi_eval'
+    EXTERNAL_BENCHMARK = 'external_benchmark'
+    MOCK = 'mock'
+    DEV_FIXTURE = 'dev_fixture'
+
+
+class Capabilities(StrictBaseModel):
+    text_input: bool
+    streaming: bool
+    structured_output: StructuredOutputMode
+    tools: bool
+
+
+class Objective(StrictBaseModel):
+    quality: float = Field(ge=0.0, le=1.0)
+    latency: float = Field(ge=0.0, le=1.0)
+    cost: float = Field(ge=0.0, le=1.0)
+
+    @model_validator(mode='after')
+    def validate_weights(self):
+        total = self.quality + self.latency + self.cost
+        if abs(total - 1.0) > 0.0001:
+            raise ValueError('objective weights must sum to 1.0')
+        return self
+
+
+class ProviderRef(StrictBaseModel):
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+
+
+class TimeoutPolicy(StrictBaseModel):
+    request_ms: int = Field(gt=0)
+
+
+class RetryPolicy(StrictBaseModel):
+    max_attempts: int = Field(ge=1)
+
+
+class RolloutPolicy(StrictBaseModel):
+    stage: RolloutStage
+    percent: float = Field(default=0.0, ge=0.0, le=100.0)
+
+
+class Evidence(StrictBaseModel):
+    benchmark_snapshot: str = Field(min_length=1)
+    eval_report: str = Field(min_length=1)
+    benchmark_source: BenchmarkSource
+    dev_only: bool = False
+
+    def is_prod_eligible(self) -> bool:
+        return not self.dev_only and self.benchmark_source not in {
+            BenchmarkSource.MOCK,
+            BenchmarkSource.DEV_FIXTURE,
+        }
+
+
+class CredentialPolicy(StrictBaseModel):
+    mode: CredentialMode
+    allow_byok_to_omi_paid_fallback: bool = False
+    fallback_eligible_failure_classes: list[FailureClass] = Field(default_factory=list)
+    never_fallback_failure_classes: list[FailureClass] = Field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_failure_class_sets(self):
+        overlap = set(self.fallback_eligible_failure_classes) & set(self.never_fallback_failure_classes)
+        if overlap:
+            names = ', '.join(sorted(overlap))
+            raise ValueError(f'credential fallback class sets overlap: {names}')
+        return self
+
+
+class FallbackPolicy(StrictBaseModel):
+    fallback_on: list[FailureClass] = Field(default_factory=list)
+    never_fallback_on: list[FailureClass] = Field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_failure_class_sets(self):
+        overlap = set(self.fallback_on) & set(self.never_fallback_on)
+        if overlap:
+            names = ', '.join(sorted(overlap))
+            raise ValueError(f'fallback_on and never_fallback_on overlap: {names}')
+        return self
+
+
+class LaneConfig(StrictBaseModel):
+    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    surface: Surface
+    capabilities: Capabilities
+    objective: Objective
+    credential_policy: CredentialPolicy
+    active_route: str = Field(min_length=1)
+    last_known_good: str = Field(min_length=1)
+
+
+class RouteArtifact(StrictBaseModel):
+    route_artifact_id: str = Field(min_length=1)
+    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    surface: Surface
+    primary: ProviderRef
+    fallbacks: list[ProviderRef] = Field(default_factory=list)
+    timeouts: TimeoutPolicy
+    retry: RetryPolicy
+    capabilities: Capabilities
+    evidence: Evidence
+    rollout: RolloutPolicy
+    credential_policy: CredentialPolicy
+    fallback_policy: FallbackPolicy
+    artifact_digest: str | None = None
+
+    @field_validator('artifact_digest')
+    @classmethod
+    def validate_artifact_digest(cls, value: str | None) -> str | None:
+        if value is not None and not value.startswith('sha256:'):
+            raise ValueError('artifact_digest must use sha256:<hex> format')
+        return value
+
+    @computed_field
+    @property
+    def content_digest(self) -> str:
+        return compute_route_artifact_digest(self)
+
+
+class FeatureBundle(StrictBaseModel):
+    feature: str = Field(min_length=1)
+    lane_id: str = Field(pattern=r'^omi:auto:[a-z0-9][a-z0-9-]*$')
+    prompt_version: str = Field(min_length=1)
+    parser_version: str = Field(min_length=1)
+    eval_suite: str = Field(min_length=1)
+    promotion_gates: dict[str, str] = Field(default_factory=dict)
+
+
+def compute_route_artifact_digest(artifact: RouteArtifact | dict[str, Any]) -> str:
+    if isinstance(artifact, RouteArtifact):
+        payload = artifact.model_dump(mode='json', exclude={'artifact_digest', 'content_digest'}, exclude_none=True)
+    else:
+        payload = dict(artifact)
+        payload.pop('artifact_digest', None)
+        payload.pop('content_digest', None)
+    canonical = json.dumps(payload, sort_keys=True, separators=(',', ':'), ensure_ascii=True)
+    return f'sha256:{hashlib.sha256(canonical.encode("utf-8")).hexdigest()}'
+
+
+ConfigFileName = Literal['lanes.yaml', 'route_artifacts.yaml', 'feature_bundles.yaml']

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from llm_gateway.gateway.errors import GatewayCapabilityMismatchError, GatewayInvalidRequestError
+from llm_gateway.gateway.schemas import LaneConfig, StructuredOutputMode
+
+
+@dataclass(frozen=True)
+class ValidatedChatCompletionRequest:
+    model: str
+    messages: tuple[Mapping[str, Any], ...]
+    response_format: Mapping[str, Any]
+
+
+def validate_chat_completion_request(
+    request: Mapping[str, Any],
+    lane: LaneConfig,
+) -> ValidatedChatCompletionRequest:
+    if not isinstance(request, Mapping):
+        raise GatewayInvalidRequestError('request body must be an object')
+
+    model = request.get('model')
+    if not isinstance(model, str) or not model.strip():
+        raise GatewayInvalidRequestError('model is required', param='model')
+
+    if request.get('stream') is True:
+        raise GatewayCapabilityMismatchError('streaming is not supported for this lane', param='stream')
+    if 'tools' in request:
+        raise GatewayCapabilityMismatchError('tools are not supported for this lane', param='tools')
+    if 'tool_choice' in request and request.get('tool_choice') not in (None, 'none'):
+        raise GatewayCapabilityMismatchError('tool_choice is not supported for this lane', param='tool_choice')
+
+    messages = _validate_messages(request.get('messages'))
+    response_format = _validate_response_format(request.get('response_format'), lane)
+
+    return ValidatedChatCompletionRequest(
+        model=model.strip(),
+        messages=tuple(messages),
+        response_format=response_format,
+    )
+
+
+def _validate_messages(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise GatewayInvalidRequestError('messages must be a non-empty list', param='messages')
+
+    validated: list[Mapping[str, Any]] = []
+    for index, message in enumerate(value):
+        param = f'messages[{index}]'
+        if not isinstance(message, Mapping):
+            raise GatewayInvalidRequestError('each message must be an object', param=param)
+        role = message.get('role')
+        if not isinstance(role, str) or not role:
+            raise GatewayInvalidRequestError('message role is required', param=f'{param}.role')
+        if 'content' not in message:
+            raise GatewayInvalidRequestError('message content is required', param=f'{param}.content')
+        _validate_text_content(message.get('content'), param=f'{param}.content')
+        validated.append(message)
+    return validated
+
+
+def _validate_text_content(content: Any, *, param: str) -> None:
+    if isinstance(content, str):
+        return
+
+    if isinstance(content, list) and content and all(_is_text_content_part(part) for part in content):
+        return
+
+    raise GatewayCapabilityMismatchError('only text message content is supported for this lane', param=param)
+
+
+def _is_text_content_part(part: Any) -> bool:
+    return isinstance(part, Mapping) and part.get('type') == 'text' and isinstance(part.get('text'), str)
+
+
+def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise GatewayInvalidRequestError('response_format with json_schema is required', param='response_format')
+
+    response_format_type = value.get('type')
+    if response_format_type != StructuredOutputMode.JSON_SCHEMA.value:
+        raise GatewayCapabilityMismatchError(
+            'only json_schema structured output is supported for this lane',
+            param='response_format.type',
+        )
+
+    if lane.capabilities.structured_output != StructuredOutputMode.JSON_SCHEMA:
+        raise GatewayCapabilityMismatchError(
+            'lane does not support json_schema structured output', param='response_format'
+        )
+
+    json_schema = value.get('json_schema')
+    if not isinstance(json_schema, Mapping):
+        raise GatewayInvalidRequestError(
+            'response_format.json_schema must be an object', param='response_format.json_schema'
+        )
+    schema = json_schema.get('schema')
+    if not isinstance(schema, Mapping):
+        raise GatewayInvalidRequestError(
+            'response_format.json_schema.schema must be an object',
+            param='response_format.json_schema.schema',
+        )
+
+    return value

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -16,6 +16,7 @@ class ValidatedChatCompletionRequest:
 
 
 CONTROL_PARAMS = frozenset({'model', 'messages', 'response_format', 'stream', 'tools', 'tool_choice'})
+GATEWAY_LOCAL_PARAMS = frozenset({'metadata'})
 FORWARDED_CHAT_COMPLETION_PARAMS = frozenset(
     {
         'frequency_penalty',
@@ -23,7 +24,6 @@ FORWARDED_CHAT_COMPLETION_PARAMS = frozenset(
         'logprobs',
         'max_completion_tokens',
         'max_tokens',
-        'metadata',
         'n',
         'presence_penalty',
         'seed',
@@ -136,7 +136,7 @@ def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any]
 
 
 def _validate_forwarded_params(request: Mapping[str, Any]) -> Mapping[str, Any]:
-    unsupported = sorted(set(request.keys()) - CONTROL_PARAMS - FORWARDED_CHAT_COMPLETION_PARAMS)
+    unsupported = sorted(set(request.keys()) - CONTROL_PARAMS - GATEWAY_LOCAL_PARAMS - FORWARDED_CHAT_COMPLETION_PARAMS)
     if unsupported:
         raise GatewayInvalidRequestError(
             f'unsupported chat completion parameter: {unsupported[0]}',

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -120,6 +120,11 @@ def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any]
         raise GatewayInvalidRequestError(
             'response_format.json_schema must be an object', param='response_format.json_schema'
         )
+    name = json_schema.get('name')
+    if not isinstance(name, str) or not name.strip():
+        raise GatewayInvalidRequestError(
+            'response_format.json_schema.name is required', param='response_format.json_schema.name'
+        )
     schema = json_schema.get('schema')
     if not isinstance(schema, Mapping):
         raise GatewayInvalidRequestError(

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -12,6 +12,28 @@ class ValidatedChatCompletionRequest:
     model: str
     messages: tuple[Mapping[str, Any], ...]
     response_format: Mapping[str, Any]
+    forwarded_params: Mapping[str, Any]
+
+
+CONTROL_PARAMS = frozenset({'model', 'messages', 'response_format', 'stream', 'tools', 'tool_choice'})
+FORWARDED_CHAT_COMPLETION_PARAMS = frozenset(
+    {
+        'frequency_penalty',
+        'logit_bias',
+        'logprobs',
+        'max_completion_tokens',
+        'max_tokens',
+        'metadata',
+        'n',
+        'presence_penalty',
+        'seed',
+        'stop',
+        'temperature',
+        'top_logprobs',
+        'top_p',
+        'user',
+    }
+)
 
 
 def validate_chat_completion_request(
@@ -34,11 +56,13 @@ def validate_chat_completion_request(
 
     messages = _validate_messages(request.get('messages'))
     response_format = _validate_response_format(request.get('response_format'), lane)
+    forwarded_params = _validate_forwarded_params(request)
 
     return ValidatedChatCompletionRequest(
         model=model.strip(),
         messages=tuple(messages),
         response_format=response_format,
+        forwarded_params=forwarded_params,
     )
 
 
@@ -104,3 +128,13 @@ def _validate_response_format(value: Any, lane: LaneConfig) -> Mapping[str, Any]
         )
 
     return value
+
+
+def _validate_forwarded_params(request: Mapping[str, Any]) -> Mapping[str, Any]:
+    unsupported = sorted(set(request.keys()) - CONTROL_PARAMS - FORWARDED_CHAT_COMPLETION_PARAMS)
+    if unsupported:
+        raise GatewayInvalidRequestError(
+            f'unsupported chat completion parameter: {unsupported[0]}',
+            param=unsupported[0],
+        )
+    return {key: request[key] for key in FORWARDED_CHAT_COMPLETION_PARAMS if key in request}

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,7 +1,19 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
+from llm_gateway.routers.dependencies import close_provider_registry
 from llm_gateway.routers import health, openai_compatible
 
-app = FastAPI(title='Omi LLM Gateway')
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        yield
+    finally:
+        await close_provider_registry()
+
+
+app = FastAPI(title='Omi LLM Gateway', lifespan=lifespan)
 app.include_router(health.router)
 app.include_router(openai_compatible.router)

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from llm_gateway.routers.dependencies import close_provider_registry
-from llm_gateway.routers import health, openai_compatible
+from llm_gateway.routers import health, metrics, openai_compatible
 
 
 @asynccontextmanager
@@ -17,3 +17,4 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title='Omi LLM Gateway', lifespan=lifespan)
 app.include_router(health.router)
 app.include_router(openai_compatible.router)
+app.include_router(metrics.router)

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
-from llm_gateway.routers import health
+from llm_gateway.routers import health, openai_compatible
 
 app = FastAPI(title='Omi LLM Gateway')
 app.include_router(health.router)
+app.include_router(openai_compatible.router)

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+
+from llm_gateway.routers import health
+
+app = FastAPI(title='Omi LLM Gateway')
+app.include_router(health.router)

--- a/backend/llm_gateway/routers/__init__.py
+++ b/backend/llm_gateway/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Routers for the Omi LLM Gateway service."""

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.executor import ProviderRegistry
+
+
+@lru_cache(maxsize=1)
+def get_gateway_config() -> GatewayConfig:
+    return load_gateway_config(prod_mode=True)
+
+
+def get_provider_registry() -> ProviderRegistry:
+    return ProviderRegistry()

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
 from llm_gateway.gateway.executor import ProviderRegistry
+from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
 
 
 @lru_cache(maxsize=1)
@@ -12,4 +13,4 @@ def get_gateway_config() -> GatewayConfig:
 
 
 def get_provider_registry() -> ProviderRegistry:
-    return ProviderRegistry()
+    return ProviderRegistry({'openai': OpenAICompatibleChatCompletionProvider()})

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -12,5 +12,11 @@ def get_gateway_config() -> GatewayConfig:
     return load_gateway_config(prod_mode=True)
 
 
+@lru_cache(maxsize=1)
 def get_provider_registry() -> ProviderRegistry:
     return ProviderRegistry({'openai': OpenAICompatibleChatCompletionProvider()})
+
+
+async def close_provider_registry() -> None:
+    await get_provider_registry().aclose()
+    get_provider_registry.cache_clear()

--- a/backend/llm_gateway/routers/health.py
+++ b/backend/llm_gateway/routers/health.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
+
+from llm_gateway.gateway.auth import ServiceAuthDependency
+from llm_gateway.gateway.config_loader import ConfigValidationError
+from llm_gateway.routers.dependencies import get_gateway_config
 
 router = APIRouter()
 
@@ -6,3 +10,20 @@ router = APIRouter()
 @router.get('/health')
 def get_health():
     return {'status': 'healthy'}
+
+
+@router.get('/ready')
+def get_ready(caller: ServiceAuthDependency):
+    try:
+        config = get_gateway_config()
+    except ConfigValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='llm gateway config is invalid',
+        ) from exc
+
+    return {
+        'status': 'ready',
+        'lanes': sorted(config.lanes.keys()),
+        'route_artifact_count': len(config.route_artifacts),
+    }

--- a/backend/llm_gateway/routers/health.py
+++ b/backend/llm_gateway/routers/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get('/health')
+def get_health():
+    return {'status': 'healthy'}

--- a/backend/llm_gateway/routers/health.py
+++ b/backend/llm_gateway/routers/health.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException, status
+from pydantic import ValidationError
 
 from llm_gateway.gateway.auth import ServiceAuthDependency
 from llm_gateway.gateway.config_loader import ConfigValidationError
@@ -16,7 +17,7 @@ def get_health():
 def get_ready(caller: ServiceAuthDependency):
     try:
         config = get_gateway_config()
-    except ConfigValidationError as exc:
+    except (ConfigValidationError, ValidationError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='llm gateway config is invalid',

--- a/backend/llm_gateway/routers/metrics.py
+++ b/backend/llm_gateway/routers/metrics.py
@@ -1,0 +1,19 @@
+import hmac
+import os
+
+from fastapi import APIRouter, HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from utils.metrics import metrics_response
+
+router = APIRouter()
+_bearer = HTTPBearer(auto_error=False)
+
+
+@router.get('/metrics')
+def metrics(credentials: HTTPAuthorizationCredentials = Security(_bearer)):
+    expected = os.environ.get('METRICS_SECRET', '')
+    token = credentials.credentials if credentials else ''
+    if not expected or not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401)
+    return metrics_response()

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from functools import lru_cache
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from llm_gateway.gateway.auth import ServiceAuthDependency
-from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.config_loader import GatewayConfig
 from llm_gateway.gateway.credentials import build_omi_managed_credential_context
 from llm_gateway.gateway.errors import (
     GatewayError,
@@ -16,17 +15,9 @@ from llm_gateway.gateway.errors import (
 )
 from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
+from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
 
 router = APIRouter()
-
-
-@lru_cache(maxsize=1)
-def get_gateway_config() -> GatewayConfig:
-    return load_gateway_config(prod_mode=True)
-
-
-def get_provider_registry() -> ProviderRegistry:
-    return ProviderRegistry()
 
 
 @router.post('/v1/chat/completions')

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -53,12 +53,31 @@ def _error_response(exc: GatewayError) -> JSONResponse:
         content={
             'error': {
                 'message': exc.message,
-                'type': exc.code.value,
+                'type': _error_type_for_code(exc.code),
                 'param': exc.param,
                 'code': exc.code.value,
             }
         },
     )
+
+
+def _error_type_for_code(code: GatewayErrorCode) -> str:
+    """Map an internal error code to an OpenAI API error category.
+
+    OpenAI distinguishes ``type`` (a broad error category) from ``code`` (the
+    specific identifier). Without this distinction clients that categorize
+    errors by ``type`` cannot classify them correctly.
+    """
+    if code == GatewayErrorCode.CREDENTIAL_FAILURE:
+        return 'authentication_error'
+    if code in {
+        GatewayErrorCode.INVALID_REQUEST,
+        GatewayErrorCode.INVALID_ROUTE_CONFIG,
+        GatewayErrorCode.UNSUPPORTED_MODEL,
+        GatewayErrorCode.CAPABILITY_NOT_SUPPORTED,
+    }:
+        return 'invalid_request_error'
+    return 'api_error'
 
 
 def _status_code_for_error(exc: GatewayError) -> int:

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from llm_gateway.gateway.auth import ServiceAuthDependency
+from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.credentials import build_omi_managed_credential_context
+from llm_gateway.gateway.errors import (
+    GatewayError,
+    GatewayErrorCode,
+    GatewayInvalidRequestError,
+)
+from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
+from llm_gateway.gateway.resolver import resolve_chat_completion_route
+
+router = APIRouter()
+
+
+@lru_cache(maxsize=1)
+def get_gateway_config() -> GatewayConfig:
+    return load_gateway_config(prod_mode=True)
+
+
+def get_provider_registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+@router.post('/v1/chat/completions')
+async def create_chat_completion(
+    request: Request,
+    caller: ServiceAuthDependency,
+    config: GatewayConfig = Depends(get_gateway_config),
+    provider_registry: ProviderRegistry = Depends(get_provider_registry),
+):
+    try:
+        request_body = await _request_json(request)
+        resolved_route = resolve_chat_completion_route(config, request_body)
+        credentials = build_omi_managed_credential_context(caller)
+        result = await execute_chat_completion(resolved_route, credentials, provider_registry)
+        return JSONResponse(content=result.response)
+    except GatewayError as exc:
+        return _error_response(exc)
+
+
+async def _request_json(request: Request) -> dict[str, Any]:
+    try:
+        body = await request.json()
+    except ValueError as exc:
+        raise GatewayInvalidRequestError('request body must be valid JSON') from exc
+    if not isinstance(body, dict):
+        raise GatewayInvalidRequestError('request body must be an object')
+    return body
+
+
+def _error_response(exc: GatewayError) -> JSONResponse:
+    return JSONResponse(
+        status_code=_status_code_for_error(exc),
+        content={
+            'error': {
+                'message': exc.message,
+                'type': exc.code.value,
+                'param': exc.param,
+                'code': exc.code.value,
+            }
+        },
+    )
+
+
+def _status_code_for_error(exc: GatewayError) -> int:
+    if exc.code == GatewayErrorCode.MODEL_NOT_FOUND:
+        return 404
+    if exc.code in {
+        GatewayErrorCode.INVALID_REQUEST,
+        GatewayErrorCode.UNSUPPORTED_MODEL,
+        GatewayErrorCode.CAPABILITY_NOT_SUPPORTED,
+    }:
+        return 400
+    if exc.code == GatewayErrorCode.CREDENTIAL_FAILURE:
+        return 401
+    if exc.code == GatewayErrorCode.INVALID_ROUTE_CONFIG:
+        return 503
+    if exc.code == GatewayErrorCode.PROVIDER_FAILURE:
+        return 502
+    return 500

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -35,17 +35,27 @@ async def create_chat_completion(
         resolved_route = resolve_chat_completion_route(config, request_body)
         credentials = build_omi_managed_credential_context(caller)
         result = await execute_chat_completion(resolved_route, credentials, provider_registry)
-        observe_success(started_at, result)
+        _safe_observe(lambda: observe_success(started_at, result))
         return JSONResponse(content=result.response)
     except GatewayError as exc:
         if resolved_route is not None:
-            observe_error(
-                started_at,
-                lane_id=resolved_route.lane.lane_id,
-                route_artifact_id=resolved_route.active_route.route_artifact_id,
-                error=exc,
+            _safe_observe(
+                lambda: observe_error(
+                    started_at,
+                    lane_id=resolved_route.lane.lane_id,
+                    route_artifact_id=resolved_route.active_route.route_artifact_id,
+                    error=exc,
+                )
             )
         return _error_response(exc)
+
+
+def _safe_observe(fn: Any) -> None:
+    """Emit metrics without risking request-handling failures."""
+    try:
+        fn()
+    except Exception:
+        pass
 
 
 async def _request_json(request: Request) -> dict[str, Any]:

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -14,6 +14,7 @@ from llm_gateway.gateway.errors import (
     GatewayInvalidRequestError,
 )
 from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
+from llm_gateway.gateway.metrics import observe_error, observe_success, time_request
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
 
@@ -27,13 +28,23 @@ async def create_chat_completion(
     config: GatewayConfig = Depends(get_gateway_config),
     provider_registry: ProviderRegistry = Depends(get_provider_registry),
 ):
+    started_at = time_request()
+    resolved_route = None
     try:
         request_body = await _request_json(request)
         resolved_route = resolve_chat_completion_route(config, request_body)
         credentials = build_omi_managed_credential_context(caller)
         result = await execute_chat_completion(resolved_route, credentials, provider_registry)
+        observe_success(started_at, result)
         return JSONResponse(content=result.response)
     except GatewayError as exc:
+        if resolved_route is not None:
+            observe_error(
+                started_at,
+                lane_id=resolved_route.lane.lane_id,
+                route_artifact_id=resolved_route.active_route.route_artifact_id,
+                error=exc,
+            )
         return _error_response(exc)
 
 

--- a/backend/scripts/dev-serve-llm-gateway.sh
+++ b/backend/scripts/dev-serve-llm-gateway.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run the local LLM gateway as a separate FastAPI process.
+#
+#   cd backend && ./scripts/dev-serve-llm-gateway.sh [extra uvicorn args]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../../scripts/dev-instance.sh"
+cd "$BACKEND_DIR"
+
+LLM_GATEWAY_PORT="${LLM_GATEWAY_PORT:-$((PYTHON_PORT + 1000))}"
+PIDFILE="$OMI_DEV_DIR/llm-gateway.pid"
+
+if [ -f "$PIDFILE" ]; then
+  OLD="$(cat "$PIDFILE" 2>/dev/null || true)"
+  if [ -n "$OLD" ] && kill -0 "$OLD" 2>/dev/null; then
+    echo "dev-serve-llm-gateway: stopping our old gateway (pid $OLD, port $LLM_GATEWAY_PORT)"
+    kill "$OLD" 2>/dev/null || true
+    sleep 0.5
+  fi
+  rm -f "$PIDFILE"
+fi
+
+HOLDER="$(lsof -ti tcp:"$LLM_GATEWAY_PORT" -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+if [ -n "$HOLDER" ]; then
+  echo "ERROR: LLM gateway port $LLM_GATEWAY_PORT (instance '$OMI_INSTANCE') is in use by pid $HOLDER:"
+  echo "  $(ps -o command= -p "$HOLDER" 2>/dev/null)"
+  echo "  Stop it, or run with LLM_GATEWAY_PORT=<free> / OMI_INSTANCE=<name>."
+  exit 1
+fi
+
+for v in .venv venv; do
+  [ -f "$v/bin/activate" ] && { source "$v/bin/activate"; break; }
+done
+
+echo "dev-serve-llm-gateway: instance='$OMI_INSTANCE' -> http://127.0.0.1:$LLM_GATEWAY_PORT"
+echo $$ > "$PIDFILE"
+exec python3 -m uvicorn llm_gateway.main:app --host 0.0.0.0 --port "$LLM_GATEWAY_PORT" "$@"

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 
 import httpx
@@ -15,12 +16,21 @@ def main() -> int:
         required=True,
         help='Base URL, for example http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080',
     )
-    parser.add_argument('--token', required=True, help='Service bearer token')
+    parser.add_argument(
+        '--token',
+        default=None,
+        help='Service bearer token (default: read from OMI_LLM_GATEWAY_SERVICE_TOKEN env var)',
+    )
     args = parser.parse_args()
+
+    token = args.token or os.environ.get('OMI_LLM_GATEWAY_SERVICE_TOKEN')
+    if not token:
+        print('ERROR: provide --token or set OMI_LLM_GATEWAY_SERVICE_TOKEN env var')
+        return 2
 
     base_url = args.url.rstrip('/')
     headers = {
-        'Authorization': f'Bearer {args.token}',
+        'Authorization': f'Bearer {token}',
         'X-Omi-Service-Caller': 'backend',
         'Content-Type': 'application/json',
     }
@@ -52,7 +62,7 @@ def main() -> int:
         response.raise_for_status()
         body = response.json()
 
-    content = body.get('choices', [{}])[0].get('message', {}).get('content')
+    content = (body.get('choices') or [{}])[0].get('message', {}).get('content')
     if not isinstance(content, str):
         print('ERROR: response did not contain choices[0].message.content')
         return 1

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -9,6 +9,15 @@ import sys
 import httpx
 
 
+def _raise_for_status(response: httpx.Response, label: str) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError:
+        print(f'ERROR: {label} returned HTTP {response.status_code}')
+        print(response.text[:1000])
+        raise
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Smoke test the internal Omi LLM Gateway.')
     parser.add_argument(
@@ -57,9 +66,9 @@ def main() -> int:
 
     with httpx.Client(timeout=20.0) as client:
         ready = client.get(f'{base_url}/ready', headers=headers)
-        ready.raise_for_status()
+        _raise_for_status(ready, '/ready')
         response = client.post(f'{base_url}/v1/chat/completions', headers=headers, json=payload)
-        response.raise_for_status()
+        _raise_for_status(response, '/v1/chat/completions')
         body = response.json()
 
     content = (body.get('choices') or [{}])[0].get('message', {}).get('content')

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Smoke test the internal Omi LLM Gateway.')
+    parser.add_argument(
+        '--url',
+        required=True,
+        help='Base URL, for example http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080',
+    )
+    parser.add_argument('--token', required=True, help='Service bearer token')
+    args = parser.parse_args()
+
+    base_url = args.url.rstrip('/')
+    headers = {
+        'Authorization': f'Bearer {args.token}',
+        'X-Omi-Service-Caller': 'backend',
+        'Content-Type': 'application/json',
+    }
+    payload = {
+        'model': 'omi:auto:chat-structured',
+        'messages': [
+            {'role': 'user', 'content': 'Question: should this use prior conversation context? Answer false.'}
+        ],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'RequiresContext',
+                'strict': True,
+                'schema': {
+                    'type': 'object',
+                    'properties': {'requires_context': {'type': 'boolean'}},
+                    'required': ['requires_context'],
+                    'additionalProperties': False,
+                },
+            },
+        },
+        'metadata': {'omi_feature': 'chat_extraction.requires_context.smoke'},
+    }
+
+    with httpx.Client(timeout=20.0) as client:
+        ready = client.get(f'{base_url}/ready', headers=headers)
+        ready.raise_for_status()
+        response = client.post(f'{base_url}/v1/chat/completions', headers=headers, json=payload)
+        response.raise_for_status()
+        body = response.json()
+
+    content = body.get('choices', [{}])[0].get('message', {}).get('content')
+    if not isinstance(content, str):
+        print('ERROR: response did not contain choices[0].message.content')
+        return 1
+    try:
+        decoded = json.loads(content)
+    except ValueError:
+        print('ERROR: response content was not JSON')
+        return 1
+    if not isinstance(decoded.get('requires_context'), bool):
+        print('ERROR: response JSON did not contain boolean requires_context')
+        return 1
+    print('LLM gateway smoke passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -40,6 +40,36 @@ def _get_ready(client: httpx.Client, url: str, headers: dict[str, str]) -> httpx
     return client.get(f'{url}/ready', headers=headers)
 
 
+def _assert_success_metric(client: httpx.Client, url: str, metrics_token: str) -> None:
+    headers = {'Authorization': f'Bearer {metrics_token}'}
+    for attempt in range(1, 11):
+        response = client.get(f'{url}/metrics', headers=headers)
+        _raise_for_status(response, '/metrics')
+        metric_line = _find_success_request_metric(response.text)
+        if metric_line is not None:
+            print(f'LLM gateway success metric observed: {metric_line}')
+            return
+        if attempt < 10:
+            time.sleep(2)
+    print('ERROR: llm_gateway_requests_total success metric was not observed')
+    raise RuntimeError('llm gateway success metric missing')
+
+
+def _find_success_request_metric(metrics_text: str) -> str | None:
+    for line in metrics_text.splitlines():
+        if not line.startswith('llm_gateway_requests_total{'):
+            continue
+        if 'lane_id="omi:auto:chat-structured"' not in line or 'outcome="success"' not in line:
+            continue
+        try:
+            value = float(line.rsplit(' ', 1)[-1])
+        except ValueError:
+            continue
+        if value > 0:
+            return line
+    return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Smoke test the internal Omi LLM Gateway.')
     parser.add_argument(
@@ -51,6 +81,16 @@ def main() -> int:
         '--token',
         default=None,
         help='Service bearer token (default: read from OMI_LLM_GATEWAY_SERVICE_TOKEN env var)',
+    )
+    parser.add_argument(
+        '--check-metrics',
+        action='store_true',
+        help='Verify llm_gateway_requests_total increments after the smoke request',
+    )
+    parser.add_argument(
+        '--metrics-token',
+        default=None,
+        help='Metrics bearer token (default: read from METRICS_SECRET env var)',
     )
     args = parser.parse_args()
 
@@ -91,6 +131,12 @@ def main() -> int:
         response = client.post(f'{base_url}/v1/chat/completions', headers=headers, json=payload)
         _raise_for_status(response, '/v1/chat/completions')
         body = response.json()
+        if args.check_metrics:
+            metrics_token = (args.metrics_token or os.environ.get('METRICS_SECRET') or '').strip()
+            if not metrics_token:
+                print('ERROR: provide --metrics-token or set METRICS_SECRET env var when --check-metrics is used')
+                return 2
+            _assert_success_metric(client, base_url, metrics_token)
 
     content = (body.get('choices') or [{}])[0].get('message', {}).get('content')
     if not isinstance(content, str):

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import sys
+import time
 
 import httpx
 
@@ -16,6 +17,27 @@ def _raise_for_status(response: httpx.Response, label: str) -> None:
         print(f'ERROR: {label} returned HTTP {response.status_code}')
         print(response.text[:1000])
         raise
+
+
+def _get_ready(client: httpx.Client, url: str, headers: dict[str, str]) -> httpx.Response:
+    last_error: Exception | None = None
+    for attempt in range(1, 31):
+        try:
+            ready = client.get(f'{url}/ready', headers=headers)
+            if ready.status_code < 500:
+                _raise_for_status(ready, '/ready')
+                return ready
+            last_error = httpx.HTTPStatusError(
+                f'/ready returned HTTP {ready.status_code}',
+                request=ready.request,
+                response=ready,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+            last_error = exc
+        if attempt < 30:
+            time.sleep(2)
+    print(f'ERROR: /ready did not become available: {last_error}')
+    return client.get(f'{url}/ready', headers=headers)
 
 
 def main() -> int:
@@ -65,8 +87,7 @@ def main() -> int:
     }
 
     with httpx.Client(timeout=20.0) as client:
-        ready = client.get(f'{base_url}/ready', headers=headers)
-        _raise_for_status(ready, '/ready')
+        _get_ready(client, base_url, headers)
         response = client.post(f'{base_url}/v1/chat/completions', headers=headers, json=payload)
         _raise_for_status(response, '/v1/chat/completions')
         body = response.json()

--- a/backend/scripts/smoke-llm-gateway.py
+++ b/backend/scripts/smoke-llm-gateway.py
@@ -54,7 +54,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    token = args.token or os.environ.get('OMI_LLM_GATEWAY_SERVICE_TOKEN')
+    token = (args.token or os.environ.get('OMI_LLM_GATEWAY_SERVICE_TOKEN') or '').strip()
     if not token:
         print('ERROR: provide --token or set OMI_LLM_GATEWAY_SERVICE_TOKEN env var')
         return 2

--- a/backend/scripts/validate-llm-gateway-env.py
+++ b/backend/scripts/validate-llm-gateway-env.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print('usage: validate-llm-gateway-env.py <backend-listen-values.yaml> <llm-gateway-values.yaml>')
+        return 2
+
+    backend_values = _load_yaml(Path(sys.argv[1]))
+    gateway_values = _load_yaml(Path(sys.argv[2]))
+    errors: list[str] = []
+
+    backend_env = _env_map(backend_values)
+    gateway_env = _env_map(gateway_values)
+
+    if 'OMI_LLM_GATEWAY_URL' in backend_env and 'OMI_LLM_GATEWAY_SERVICE_TOKEN' not in backend_env:
+        errors.append('backend has OMI_LLM_GATEWAY_URL but no OMI_LLM_GATEWAY_SERVICE_TOKEN')
+    if 'OMI_LLM_GATEWAY_SERVICE_TOKEN' not in gateway_env and 'LLM_GATEWAY_SERVICE_TOKEN' not in gateway_env:
+        errors.append('gateway has no service token env')
+    if 'OPENAI_API_KEY' not in gateway_env:
+        errors.append('gateway has no OPENAI_API_KEY env')
+
+    for error in errors:
+        print(f'ERROR: {error}')
+    return 1 if errors else 0
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = yaml.safe_load(handle)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _env_map(values: dict) -> dict[str, dict]:
+    env = values.get('env', [])
+    if not isinstance(env, list):
+        return {}
+    result: dict[str, dict] = {}
+    for item in env:
+        if isinstance(item, dict) and isinstance(item.get('name'), str):
+            result[item['name']] = item
+    return result
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/validate-llm-gateway-env.py
+++ b/backend/scripts/validate-llm-gateway-env.py
@@ -14,26 +14,39 @@ def main() -> int:
 
     backend_values = _load_yaml(Path(sys.argv[1]))
     gateway_values = _load_yaml(Path(sys.argv[2]))
+    if backend_values is None or gateway_values is None:
+        return 1
     errors: list[str] = []
 
     backend_env = _env_map(backend_values)
     gateway_env = _env_map(gateway_values)
 
-    if 'OMI_LLM_GATEWAY_URL' in backend_env and 'OMI_LLM_GATEWAY_SERVICE_TOKEN' not in backend_env:
-        errors.append('backend has OMI_LLM_GATEWAY_URL but no OMI_LLM_GATEWAY_SERVICE_TOKEN')
-    if 'OMI_LLM_GATEWAY_SERVICE_TOKEN' not in gateway_env and 'LLM_GATEWAY_SERVICE_TOKEN' not in gateway_env:
+    if 'OMI_LLM_GATEWAY_URL' in backend_env:
+        _require('OMI_LLM_GATEWAY_SERVICE_TOKEN', backend_env, errors, 'backend')
+
+    token_entry = gateway_env.get('OMI_LLM_GATEWAY_SERVICE_TOKEN') or gateway_env.get('LLM_GATEWAY_SERVICE_TOKEN')
+    if token_entry is None:
         errors.append('gateway has no service token env')
-    if 'OPENAI_API_KEY' not in gateway_env:
-        errors.append('gateway has no OPENAI_API_KEY env')
+    elif not _has_value(token_entry):
+        errors.append('gateway service token env has no value or valid secret reference')
+
+    _require('OPENAI_API_KEY', gateway_env, errors, 'gateway')
 
     for error in errors:
         print(f'ERROR: {error}')
     return 1 if errors else 0
 
 
-def _load_yaml(path: Path) -> dict:
-    with path.open('r', encoding='utf-8') as handle:
-        loaded = yaml.safe_load(handle)
+def _load_yaml(path: Path) -> dict | None:
+    try:
+        with path.open('r', encoding='utf-8') as handle:
+            loaded = yaml.safe_load(handle)
+    except OSError as exc:
+        print(f'ERROR: could not read {path}: {exc}')
+        return None
+    except yaml.YAMLError as exc:
+        print(f'ERROR: invalid YAML in {path}: {exc}')
+        return None
     return loaded if isinstance(loaded, dict) else {}
 
 
@@ -46,6 +59,29 @@ def _env_map(values: dict) -> dict[str, dict]:
         if isinstance(item, dict) and isinstance(item.get('name'), str):
             result[item['name']] = item
     return result
+
+
+def _has_value(entry: dict) -> bool:
+    """Check whether an env var has an actual value or a valid secret reference."""
+    if entry.get('value') not in (None, ''):
+        return True
+    value_from = entry.get('valueFrom')
+    if isinstance(value_from, dict):
+        secret_ref = value_from.get('secretKeyRef')
+        if isinstance(secret_ref, dict) and secret_ref.get('name') and secret_ref.get('key'):
+            return True
+        config_ref = value_from.get('configMapKeyRef')
+        if isinstance(config_ref, dict) and config_ref.get('name') and config_ref.get('key'):
+            return True
+    return False
+
+
+def _require(needle: str, env_map: dict[str, dict], errors: list[str], label: str) -> None:
+    entry = env_map.get(needle)
+    if entry is None:
+        errors.append(f'{label} has no {needle} env')
+    elif not _has_value(entry):
+        errors.append(f'{label} has {needle} env but no value or valid secret reference')
 
 
 if __name__ == '__main__':

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -50,6 +50,7 @@ pytest tests/unit/test_llm_gateway_credentials.py -v
 pytest tests/unit/test_llm_gateway_validator.py -v
 pytest tests/unit/test_llm_gateway_resolver.py -v
 pytest tests/unit/test_llm_gateway_executor.py -v
+pytest tests/unit/test_llm_gateway_openai_compatible.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -50,6 +50,7 @@ pytest tests/unit/test_llm_gateway_credentials.py -v
 pytest tests/unit/test_llm_gateway_validator.py -v
 pytest tests/unit/test_llm_gateway_resolver.py -v
 pytest tests/unit/test_llm_gateway_executor.py -v
+pytest tests/unit/test_llm_gateway_openai_provider.py -v
 pytest tests/unit/test_llm_gateway_openai_compatible.py -v
 pytest tests/unit/test_llm_gateway_readiness.py -v
 pytest tests/unit/test_llm_gateway_client_config.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -49,6 +49,7 @@ pytest tests/unit/test_llm_gateway_auth.py -v
 pytest tests/unit/test_llm_gateway_credentials.py -v
 pytest tests/unit/test_llm_gateway_validator.py -v
 pytest tests/unit/test_llm_gateway_resolver.py -v
+pytest tests/unit/test_llm_gateway_executor.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -53,6 +53,7 @@ pytest tests/unit/test_llm_gateway_executor.py -v
 pytest tests/unit/test_llm_gateway_openai_compatible.py -v
 pytest tests/unit/test_llm_gateway_readiness.py -v
 pytest tests/unit/test_llm_gateway_client_config.py -v
+pytest tests/unit/test_llm_gateway_route_refs.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -47,6 +47,8 @@ pytest tests/unit/test_llm_gateway_service.py -v
 pytest tests/unit/test_llm_gateway_config.py -v
 pytest tests/unit/test_llm_gateway_auth.py -v
 pytest tests/unit/test_llm_gateway_credentials.py -v
+pytest tests/unit/test_llm_gateway_validator.py -v
+pytest tests/unit/test_llm_gateway_resolver.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -55,6 +55,7 @@ pytest tests/unit/test_llm_gateway_openai_compatible.py -v
 pytest tests/unit/test_llm_gateway_readiness.py -v
 pytest tests/unit/test_llm_gateway_client_config.py -v
 pytest tests/unit/test_llm_gateway_route_refs.py -v
+pytest tests/unit/test_llm_gateway_dependencies.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -44,6 +44,7 @@ pytest tests/unit/test_memories_validation.py -v
 pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_announcement_malformed_type.py -v
 pytest tests/unit/test_llm_gateway_service.py -v
+pytest tests/unit/test_llm_gateway_config.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -56,6 +56,7 @@ pytest tests/unit/test_llm_gateway_readiness.py -v
 pytest tests/unit/test_llm_gateway_client_config.py -v
 pytest tests/unit/test_llm_gateway_route_refs.py -v
 pytest tests/unit/test_llm_gateway_dependencies.py -v
+pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -45,6 +45,8 @@ pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_announcement_malformed_type.py -v
 pytest tests/unit/test_llm_gateway_service.py -v
 pytest tests/unit/test_llm_gateway_config.py -v
+pytest tests/unit/test_llm_gateway_auth.py -v
+pytest tests/unit/test_llm_gateway_credentials.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -43,6 +43,7 @@ pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v
 pytest tests/unit/test_memories_user_review.py -v
 pytest tests/unit/test_announcement_malformed_type.py -v
+pytest tests/unit/test_llm_gateway_service.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -51,6 +51,8 @@ pytest tests/unit/test_llm_gateway_validator.py -v
 pytest tests/unit/test_llm_gateway_resolver.py -v
 pytest tests/unit/test_llm_gateway_executor.py -v
 pytest tests/unit/test_llm_gateway_openai_compatible.py -v
+pytest tests/unit/test_llm_gateway_readiness.py -v
+pytest tests/unit/test_llm_gateway_client_config.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/tests/unit/test_llm_gateway_auth.py
+++ b/backend/tests/unit/test_llm_gateway_auth.py
@@ -116,3 +116,62 @@ def test_auth_dependency_returns_service_caller_model():
     assert caller.name == 'backend'
     assert caller.user_uid == 'user-123'
     assert caller.tenant_id == 'tenant-abc'
+
+
+def test_primary_service_token_env_var_is_accepted(monkeypatch):
+    """Gateway must accept OMI_LLM_GATEWAY_SERVICE_TOKEN (the client's primary var)."""
+    monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'primary-token')
+    monkeypatch.delenv('LLM_GATEWAY_SERVICE_TOKEN', raising=False)
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={'authorization': 'Bearer primary-token', 'x-omi-service-caller': 'backend'},
+    )
+
+    assert response.status_code == 200
+
+
+def test_primary_service_token_takes_precedence_over_legacy(monkeypatch):
+    """When both vars are set, the OMI_ prefixed one must win (matching the client)."""
+    monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'primary-token')
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'legacy-token')
+
+    client = TestClient(_protected_app())
+    primary = client.get(
+        '/protected',
+        headers={'authorization': 'Bearer primary-token', 'x-omi-service-caller': 'backend'},
+    )
+    legacy = client.get(
+        '/protected',
+        headers={'authorization': 'Bearer legacy-token', 'x-omi-service-caller': 'backend'},
+    )
+
+    assert primary.status_code == 200
+    # Legacy token is rejected because the gateway resolves to the primary value.
+    assert legacy.status_code == 401
+
+
+def test_legacy_service_token_still_accepted_when_primary_absent(monkeypatch):
+    """Bare LLM_GATEWAY_SERVICE_TOKEN still works for backward compatibility."""
+    monkeypatch.delenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', raising=False)
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'legacy-token')
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={'authorization': 'Bearer legacy-token', 'x-omi-service-caller': 'backend'},
+    )
+
+    assert response.status_code == 200
+
+
+def test_both_service_token_vars_blank_fails_closed(monkeypatch):
+    """Blank values in both vars must fail closed (503)."""
+    monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', '   ')
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', '')
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={'authorization': 'Bearer anything', 'x-omi-service-caller': 'backend'},
+    )
+
+    assert response.status_code == 503

--- a/backend/tests/unit/test_llm_gateway_auth.py
+++ b/backend/tests/unit/test_llm_gateway_auth.py
@@ -71,6 +71,21 @@ def test_unknown_caller_is_rejected(monkeypatch):
     assert response.status_code == 403
 
 
+def test_malformed_caller_is_rejected_without_500(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={
+            'authorization': 'Bearer shared-secret',
+            'x-omi-service-caller': 'not valid',
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()['detail'] == 'invalid service caller'
+
+
 def test_backend_and_pusher_callers_succeed_by_default(monkeypatch):
     monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
     client = TestClient(_protected_app())

--- a/backend/tests/unit/test_llm_gateway_auth.py
+++ b/backend/tests/unit/test_llm_gateway_auth.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from llm_gateway.gateway.auth import ServiceAuthDependency, ServiceCaller, require_service_auth
+from llm_gateway.main import app as gateway_app
+
+
+def _protected_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get('/protected')
+    def protected(caller: ServiceAuthDependency):
+        return caller.model_dump(mode='json')
+
+    return app
+
+
+def test_health_remains_unauthenticated_when_service_token_is_missing(monkeypatch):
+    monkeypatch.delenv('LLM_GATEWAY_SERVICE_TOKEN', raising=False)
+
+    response = TestClient(gateway_app).get('/health')
+
+    assert response.status_code == 200
+    assert response.json() == {'status': 'healthy'}
+
+
+def test_missing_service_token_config_fails_closed(monkeypatch):
+    monkeypatch.delenv('LLM_GATEWAY_SERVICE_TOKEN', raising=False)
+
+    response = TestClient(_protected_app()).get('/protected')
+
+    assert response.status_code == 503
+    assert response.json()['detail'] == 'llm gateway service auth is not configured'
+
+
+def test_missing_auth_header_is_rejected(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(_protected_app()).get('/protected', headers={'x-omi-service-caller': 'backend'})
+
+    assert response.status_code == 401
+
+
+def test_wrong_token_is_rejected(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={
+            'authorization': 'Bearer wrong-secret',
+            'x-omi-service-caller': 'backend',
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_unknown_caller_is_rejected(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(_protected_app()).get(
+        '/protected',
+        headers={
+            'authorization': 'Bearer shared-secret',
+            'x-omi-service-caller': 'desktop',
+        },
+    )
+
+    assert response.status_code == 403
+
+
+def test_backend_and_pusher_callers_succeed_by_default(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    client = TestClient(_protected_app())
+
+    for caller in ('backend', 'pusher'):
+        response = client.get(
+            '/protected',
+            headers={
+                'authorization': 'Bearer shared-secret',
+                'x-omi-service-caller': caller,
+                'x-omi-user-uid': 'user-123',
+                'x-omi-tenant-id': 'tenant-abc',
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'name': caller,
+            'user_uid': 'user-123',
+            'tenant_id': 'tenant-abc',
+        }
+
+
+def test_auth_dependency_returns_service_caller_model():
+    assert require_service_auth
+    caller = ServiceCaller(name='Backend', user_uid=' user-123 ', tenant_id=' tenant-abc ')
+
+    assert caller.name == 'backend'
+    assert caller.user_uid == 'user-123'
+    assert caller.tenant_id == 'tenant-abc'

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import sys
+import types
+import logging
+from contextlib import contextmanager
+
+import pytest
+
+for module_name in (
+    'database.auth',
+    'database.goals',
+    'database.notifications',
+    'database.redis_db',
+    'database.users',
+):
+    sys.modules.setdefault(module_name, types.ModuleType(module_name))
+
+sys.modules['database.auth'].get_user_name = lambda uid: 'Test User'
+sys.modules['database.redis_db'].add_filter_category_item = lambda *args, **kwargs: None
+
+
+@contextmanager
+def _track_usage(*args, **kwargs):
+    yield
+
+
+usage_tracker_stub = types.ModuleType('utils.llm.usage_tracker')
+usage_tracker_stub.track_usage = _track_usage
+usage_tracker_stub.Features = types.SimpleNamespace(CHAT='chat')
+sys.modules.setdefault('utils.llm.usage_tracker', usage_tracker_stub)
+
+memory_stub = types.ModuleType('utils.llms.memory')
+memory_stub.get_prompt_memories = lambda uid: ('Test User', '')
+sys.modules.setdefault('utils.llms.memory', memory_stub)
+
+clients_stub = types.ModuleType('utils.llm.clients')
+clients_stub.get_llm = lambda feature: None
+sys.modules.setdefault('utils.llm.clients', clients_stub)
+
+from utils import byok
+from utils.llm import chat, gateway_client
+
+
+class FakeParser:
+    def __init__(self, response):
+        self.response = response
+
+    def invoke(self, prompt):
+        return self.response
+
+
+class FakeLLM:
+    def __init__(self, response, calls):
+        self.response = response
+        self.calls = calls
+
+    def with_structured_output(self, output_model):
+        self.calls.append(output_model)
+        return FakeParser(self.response)
+
+
+class FakeGatewayResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.body
+
+
+@pytest.fixture(autouse=True)
+def clear_byok_context():
+    byok.set_byok_keys({})
+    yield
+    byok.set_byok_keys({})
+
+
+def test_requires_context_flag_off_skips_gateway_and_uses_existing_path(monkeypatch):
+    monkeypatch.delenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', raising=False)
+    existing_calls = []
+    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
+    monkeypatch.setattr(
+        chat,
+        'invoke_chat_structured_gateway',
+        lambda *args, **kwargs: pytest.fail('gateway should not be called when pilot flag is off'),
+    )
+
+    assert chat.requires_context('hello?') is True
+    assert existing_calls == [chat.RequiresContext]
+
+
+def test_requires_context_flag_on_gateway_success_returns_parsed_result(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+    monkeypatch.setattr(
+        chat,
+        'get_llm',
+        lambda feature: pytest.fail('existing path should not be called after gateway success'),
+    )
+    monkeypatch.setattr(
+        chat,
+        'invoke_chat_structured_gateway',
+        lambda prompt, output_model, *, feature: output_model(value=True),
+    )
+
+    assert chat.requires_context('what did I discuss yesterday?') is True
+
+
+def test_requires_context_flag_on_gateway_failure_falls_back(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+    existing_calls = []
+    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
+    monkeypatch.setattr(chat, 'invoke_chat_structured_gateway', lambda *args, **kwargs: None)
+
+    assert chat.requires_context('what did I discuss yesterday?') is False
+    assert existing_calls == [chat.RequiresContext]
+
+
+def test_requires_context_byok_context_skips_gateway(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+    byok.set_byok_keys({'openai': 'secret'})
+    existing_calls = []
+    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
+    monkeypatch.setattr(
+        chat,
+        'invoke_chat_structured_gateway',
+        lambda *args, **kwargs: pytest.fail('gateway should not be called for BYOK requests'),
+    )
+
+    assert chat.requires_context('what did I discuss yesterday?') is True
+    assert existing_calls == [chat.RequiresContext]
+
+
+def test_requires_context_invalid_gateway_content_falls_back(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+    existing_calls = []
+    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
+    monkeypatch.setattr(
+        gateway_client.httpx,
+        'post',
+        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]}),
+    )
+
+    assert chat.requires_context('what did I discuss yesterday?') is False
+    assert existing_calls == [chat.RequiresContext]
+
+
+def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://gateway.test/')
+    monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
+    captured = {}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.update({'url': url, 'headers': headers, 'json': json, 'timeout': timeout})
+        return FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]})
+
+    monkeypatch.setattr(gateway_client.httpx, 'post', fake_post)
+
+    result = gateway_client.invoke_chat_structured_gateway(
+        'classified prompt',
+        chat.RequiresContext,
+        feature='chat_extraction.requires_context',
+    )
+
+    assert result == chat.RequiresContext(value=True)
+    assert captured['url'] == 'http://gateway.test/v1/chat/completions'
+    assert captured['headers']['Authorization'] == 'Bearer service-token'
+    assert captured['headers']['X-Omi-Service-Caller'] == 'backend'
+    assert captured['json']['model'] == 'omi:auto:chat-structured'
+    assert captured['json']['messages'] == [{'role': 'user', 'content': 'classified prompt'}]
+    assert captured['json']['response_format']['type'] == 'json_schema'
+    assert captured['json']['response_format']['json_schema']['schema']['properties']['value']['type'] == 'boolean'
+
+
+def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(monkeypatch, caplog):
+    def fake_post(*args, **kwargs):
+        raise RuntimeError('raw provider body should not be logged')
+
+    monkeypatch.setattr(gateway_client.httpx, 'post', fake_post)
+
+    with caplog.at_level(logging.DEBUG):
+        result = gateway_client.invoke_chat_structured_gateway(
+            'raw user question should not be logged',
+            chat.RequiresContext,
+            feature='chat_extraction.requires_context',
+        )
+
+    assert result is None
+    assert 'raw user question should not be logged' not in caplog.text
+    assert 'raw provider body should not be logged' not in caplog.text

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -78,22 +78,39 @@ def clear_byok_context():
     byok.set_byok_keys({})
 
 
-def test_requires_context_flag_off_skips_gateway_and_uses_existing_path(monkeypatch):
-    monkeypatch.delenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', raising=False)
-    existing_calls = []
-    monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
+class FakeCounterChild:
+    def __init__(self, parent, labels):
+        self.parent = parent
+        self.labels = labels
+
+    def inc(self, amount=1):
+        self.parent.calls.append((self.labels, amount))
+
+
+class FakeCounter:
+    def __init__(self):
+        self.calls = []
+
+    def labels(self, **labels):
+        return FakeCounterChild(self, labels)
+
+
+def test_requires_context_non_byok_tries_gateway_by_default(monkeypatch):
     monkeypatch.setattr(
         chat,
         'invoke_chat_structured_gateway',
-        lambda *args, **kwargs: pytest.fail('gateway should not be called when pilot flag is off'),
+        lambda prompt, output_model, *, feature: output_model(value=True),
+    )
+    monkeypatch.setattr(
+        chat,
+        'get_llm',
+        lambda feature: pytest.fail('existing path should not be called after gateway success'),
     )
 
     assert chat.requires_context('hello?') is True
-    assert existing_calls == [chat.RequiresContext]
 
 
-def test_requires_context_flag_on_gateway_success_returns_parsed_result(monkeypatch):
-    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+def test_requires_context_gateway_success_returns_parsed_result(monkeypatch):
     monkeypatch.setattr(
         chat,
         'get_llm',
@@ -108,8 +125,7 @@ def test_requires_context_flag_on_gateway_success_returns_parsed_result(monkeypa
     assert chat.requires_context('what did I discuss yesterday?') is True
 
 
-def test_requires_context_flag_on_gateway_failure_falls_back(monkeypatch):
-    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
+def test_requires_context_gateway_failure_falls_back(monkeypatch):
     existing_calls = []
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
     monkeypatch.setattr(chat, 'invoke_chat_structured_gateway', lambda *args, **kwargs: None)
@@ -119,9 +135,13 @@ def test_requires_context_flag_on_gateway_failure_falls_back(monkeypatch):
 
 
 def test_requires_context_byok_context_skips_gateway(monkeypatch):
-    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
     byok.set_byok_keys({'openai': 'secret'})
     existing_calls = []
+    counter = FakeCounter()
+    monkeypatch.setattr(
+        chat, 'record_chat_extraction_gateway_result', gateway_client.record_chat_extraction_gateway_result
+    )
+    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
     monkeypatch.setattr(
         chat,
@@ -131,10 +151,19 @@ def test_requires_context_byok_context_skips_gateway(monkeypatch):
 
     assert chat.requires_context('what did I discuss yesterday?') is True
     assert existing_calls == [chat.RequiresContext]
+    assert counter.calls == [
+        (
+            {
+                'feature': 'chat_extraction.requires_context',
+                'outcome': 'skipped',
+                'reason': 'byok',
+            },
+            1,
+        )
+    ]
 
 
 def test_requires_context_invalid_gateway_content_falls_back(monkeypatch):
-    monkeypatch.setenv('OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED', 'true')
     existing_calls = []
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
     monkeypatch.setattr(
@@ -172,6 +201,62 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
     assert captured['json']['messages'] == [{'role': 'user', 'content': 'classified prompt'}]
     assert captured['json']['response_format']['type'] == 'json_schema'
     assert captured['json']['response_format']['json_schema']['schema']['properties']['value']['type'] == 'boolean'
+
+
+def test_chat_structured_gateway_records_success_metric(monkeypatch):
+    counter = FakeCounter()
+    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(
+        gateway_client.httpx,
+        'post',
+        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]}),
+    )
+
+    result = gateway_client.invoke_chat_structured_gateway(
+        'classified prompt',
+        chat.RequiresContext,
+        feature='chat_extraction.requires_context',
+    )
+
+    assert result == chat.RequiresContext(value=True)
+    assert counter.calls == [
+        (
+            {
+                'feature': 'chat_extraction.requires_context',
+                'outcome': 'success',
+                'reason': 'ok',
+            },
+            1,
+        )
+    ]
+
+
+def test_chat_structured_gateway_records_fallback_reason_metric(monkeypatch):
+    counter = FakeCounter()
+    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(
+        gateway_client.httpx,
+        'post',
+        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]}),
+    )
+
+    result = gateway_client.invoke_chat_structured_gateway(
+        'classified prompt',
+        chat.RequiresContext,
+        feature='chat_extraction.requires_context',
+    )
+
+    assert result is None
+    assert counter.calls == [
+        (
+            {
+                'feature': 'chat_extraction.requires_context',
+                'outcome': 'fallback',
+                'reason': 'schema_validation',
+            },
+            1,
+        )
+    ]
 
 
 def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(monkeypatch, caplog):

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -71,6 +71,22 @@ class FakeGatewayResponse:
         return self.body
 
 
+class FakeGatewayClient:
+    """Fake ``httpx.Client`` for tests. Returns a canned response from post()."""
+
+    def __init__(self, fake_post):
+        self._fake_post = fake_post
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def post(self, url, *, headers=None, json=None, **kwargs):
+        return self._fake_post(url, headers=headers, json=json, **kwargs)
+
+
 @pytest.fixture(autouse=True)
 def clear_byok_context():
     byok.set_byok_keys({})
@@ -95,19 +111,17 @@ class FakeCounter:
         return FakeCounterChild(self, labels)
 
 
-def test_requires_context_non_byok_tries_gateway_by_default(monkeypatch):
-    monkeypatch.setattr(
-        chat,
-        'invoke_chat_structured_gateway',
-        lambda prompt, output_model, *, feature: output_model(value=True),
-    )
-    monkeypatch.setattr(
-        chat,
-        'get_llm',
-        lambda feature: pytest.fail('existing path should not be called after gateway success'),
-    )
+def _mock_gateway_client(monkeypatch, fake_post):
+    """Patch ``httpx.Client`` so the gateway_client uses a fake HTTP client."""
 
-    assert chat.requires_context('hello?') is True
+    def fake_client(*args, **kwargs):
+        return FakeGatewayClient(fake_post)
+
+    monkeypatch.setattr(gateway_client.httpx, 'Client', fake_client)
+
+
+_VALUE_TRUE_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]})
+_UNEXPECTED_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]})
 
 
 def test_requires_context_gateway_success_returns_parsed_result(monkeypatch):
@@ -166,11 +180,7 @@ def test_requires_context_byok_context_skips_gateway(monkeypatch):
 def test_requires_context_invalid_gateway_content_falls_back(monkeypatch):
     existing_calls = []
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=False), existing_calls))
-    monkeypatch.setattr(
-        gateway_client.httpx,
-        'post',
-        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]}),
-    )
+    _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _UNEXPECTED_RESPONSE)
 
     assert chat.requires_context('what did I discuss yesterday?') is False
     assert existing_calls == [chat.RequiresContext]
@@ -181,11 +191,11 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
     monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
     captured = {}
 
-    def fake_post(url, *, headers, json, timeout):
-        captured.update({'url': url, 'headers': headers, 'json': json, 'timeout': timeout})
-        return FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]})
+    def fake_post(url, *, headers=None, json=None, **kwargs):
+        captured.update({'url': url, 'headers': headers, 'json': json})
+        return _VALUE_TRUE_RESPONSE
 
-    monkeypatch.setattr(gateway_client.httpx, 'post', fake_post)
+    _mock_gateway_client(monkeypatch, fake_post)
 
     result = gateway_client.invoke_chat_structured_gateway(
         'classified prompt',
@@ -206,11 +216,7 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
 def test_chat_structured_gateway_records_success_metric(monkeypatch):
     counter = FakeCounter()
     monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
-    monkeypatch.setattr(
-        gateway_client.httpx,
-        'post',
-        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]}),
-    )
+    _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _VALUE_TRUE_RESPONSE)
 
     result = gateway_client.invoke_chat_structured_gateway(
         'classified prompt',
@@ -234,11 +240,7 @@ def test_chat_structured_gateway_records_success_metric(monkeypatch):
 def test_chat_structured_gateway_records_fallback_reason_metric(monkeypatch):
     counter = FakeCounter()
     monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
-    monkeypatch.setattr(
-        gateway_client.httpx,
-        'post',
-        lambda *args, **kwargs: FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]}),
-    )
+    _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _UNEXPECTED_RESPONSE)
 
     result = gateway_client.invoke_chat_structured_gateway(
         'classified prompt',
@@ -263,7 +265,7 @@ def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(mon
     def fake_post(*args, **kwargs):
         raise RuntimeError('raw provider body should not be logged')
 
-    monkeypatch.setattr(gateway_client.httpx, 'post', fake_post)
+    _mock_gateway_client(monkeypatch, fake_post)
 
     with caplog.at_level(logging.DEBUG):
         result = gateway_client.invoke_chat_structured_gateway(

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, get_llm_gateway_base_url
+
+
+def test_llm_gateway_base_url_defaults_to_local_service(monkeypatch):
+    monkeypatch.delenv('OMI_LLM_GATEWAY_URL', raising=False)
+
+    assert get_llm_gateway_base_url() == DEFAULT_LLM_GATEWAY_URL
+
+
+def test_llm_gateway_base_url_uses_repo_local_env_config(monkeypatch):
+    monkeypatch.setenv('OMI_LLM_GATEWAY_URL', ' http://llm-gateway.internal:8080/ ')
+
+    assert get_llm_gateway_base_url() == 'http://llm-gateway.internal:8080'

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -167,6 +167,7 @@ def credential_policy(mode: str = 'omi_paid') -> dict:
             'byok_auth',
             'byok_quota',
             'byok_rate_limit',
+            'byok_unsupported_provider',
             'missing_byok_key',
             'capability_mismatch',
             'invalid_config',

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -20,7 +20,7 @@ def test_loads_default_gateway_config():
     assert lane.active_route == ACTIVE_ROUTE
     assert lane.last_known_good == LKG_ROUTE
     assert config.route_artifacts[ACTIVE_ROUTE].content_digest.startswith('sha256:')
-    assert config.feature_bundles['memories'].lane_id == LANE_ID
+    assert config.feature_bundles['chat_extraction.requires_context'].lane_id == LANE_ID
 
 
 def test_missing_active_route_fails(tmp_path):
@@ -101,6 +101,21 @@ def test_mock_benchmark_evidence_rejected_in_prod_mode(tmp_path):
         load_gateway_config(tmp_path, prod_mode=True)
 
 
+@pytest.mark.parametrize(
+    'rollout',
+    [
+        {'stage': 'active', 'percent': 99},
+        {'stage': 'shadow', 'percent': 1},
+        {'stage': 'disabled', 'percent': 1},
+    ],
+)
+def test_invalid_rollout_stage_percent_combination_fails(tmp_path, rollout):
+    write_config(tmp_path, active_overrides={'rollout': rollout})
+
+    with pytest.raises(ValueError, match='rollout stage must use percent'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
 def write_config(
     config_dir: Path,
     *,
@@ -132,11 +147,11 @@ def write_config(
         route_artifacts = [active, lkg]
 
     feature_bundle = {
-        'feature': 'memories',
+        'feature': 'chat_extraction.requires_context',
         'lane_id': LANE_ID,
-        'prompt_version': 'memory_extraction.v17',
-        'parser_version': 'memory_schema.v9',
-        'eval_suite': 'memory_precision_recall.v5',
+        'prompt_version': 'chat_extraction.requires_context.v1',
+        'parser_version': 'RequiresContext.v1',
+        'eval_suite': 'chat_extraction_requires_context.v1',
         'promotion_gates': {'schema_valid_rate': '>= 99.5%'},
     }
 

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from llm_gateway.gateway.config_loader import ConfigValidationError, load_gateway_config
+
+LANE_ID = 'omi:auto:chat-structured'
+ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
+LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
+
+
+def test_loads_default_gateway_config():
+    config = load_gateway_config(prod_mode=True)
+
+    assert set(config.lanes) == {LANE_ID}
+    lane = config.lanes[LANE_ID]
+    assert lane.active_route == ACTIVE_ROUTE
+    assert lane.last_known_good == LKG_ROUTE
+    assert config.route_artifacts[ACTIVE_ROUTE].content_digest.startswith('sha256:')
+    assert config.feature_bundles['memories'].lane_id == LANE_ID
+
+
+def test_missing_active_route_fails(tmp_path):
+    write_config(tmp_path, lane_overrides={'active_route': 'route.missing'})
+
+    with pytest.raises(ConfigValidationError, match='active_route route not found'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
+def test_missing_lkg_route_fails(tmp_path):
+    write_config(tmp_path, lane_overrides={'last_known_good': 'route.missing'})
+
+    with pytest.raises(ConfigValidationError, match='last_known_good route not found'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
+def test_invalid_lkg_capability_fails(tmp_path):
+    write_config(tmp_path, lkg_overrides={'capabilities': capabilities(structured_output='json_object')})
+
+    with pytest.raises(ConfigValidationError, match='last_known_good.*structured_output mismatch'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
+def test_invalid_lkg_credential_mode_fails(tmp_path):
+    write_config(
+        tmp_path,
+        lkg_overrides={'credential_policy': credential_policy(mode='byok')},
+    )
+
+    with pytest.raises(ConfigValidationError, match='last_known_good.*credential mode mismatch'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
+def test_duplicate_route_id_fails(tmp_path):
+    active = route_artifact(ACTIVE_ROUTE)
+    write_config(tmp_path, route_artifacts=[active, {**route_artifact(LKG_ROUTE), 'route_artifact_id': ACTIVE_ROUTE}])
+
+    with pytest.raises(ConfigValidationError, match='duplicate route_artifact_id'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+
+def test_artifact_digest_is_stable_and_excludes_artifact_digest(tmp_path):
+    artifact = route_artifact(ACTIVE_ROUTE)
+    write_config(tmp_path, route_artifacts=[artifact, route_artifact(LKG_ROUTE, model='gpt-4o-mini')])
+    first = load_gateway_config(tmp_path, prod_mode=False).route_artifacts[ACTIVE_ROUTE].content_digest
+
+    write_config(
+        tmp_path,
+        route_artifacts=[
+            {**artifact, 'artifact_digest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000'},
+            route_artifact(LKG_ROUTE, model='gpt-4o-mini'),
+        ],
+    )
+
+    with pytest.raises(ConfigValidationError, match='artifact_digest mismatch'):
+        load_gateway_config(tmp_path, prod_mode=False)
+
+    write_config(tmp_path, route_artifacts=[{**artifact, 'artifact_digest': first}, route_artifact(LKG_ROUTE)])
+    second = load_gateway_config(tmp_path, prod_mode=False).route_artifacts[ACTIVE_ROUTE].content_digest
+    assert second == first
+
+
+def test_mock_benchmark_evidence_rejected_in_prod_mode(tmp_path):
+    write_config(
+        tmp_path,
+        active_overrides={
+            'evidence': {
+                'benchmark_snapshot': 'bench.dev.fixture',
+                'eval_report': 'eval.dev.fixture',
+                'benchmark_source': 'mock',
+                'dev_only': True,
+            }
+        },
+    )
+
+    load_gateway_config(tmp_path, prod_mode=False)
+    with pytest.raises(ConfigValidationError, match='dev-only benchmark evidence'):
+        load_gateway_config(tmp_path, prod_mode=True)
+
+
+def write_config(
+    config_dir: Path,
+    *,
+    lane_overrides: dict | None = None,
+    active_overrides: dict | None = None,
+    lkg_overrides: dict | None = None,
+    route_artifacts: list[dict] | None = None,
+) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    lane = {
+        'lane_id': LANE_ID,
+        'surface': 'openai.chat_completions',
+        'capabilities': capabilities(),
+        'objective': {'quality': 0.6, 'latency': 0.2, 'cost': 0.2},
+        'credential_policy': credential_policy(),
+        'active_route': ACTIVE_ROUTE,
+        'last_known_good': LKG_ROUTE,
+    }
+    if lane_overrides:
+        lane.update(lane_overrides)
+
+    if route_artifacts is None:
+        active = route_artifact(ACTIVE_ROUTE, model='gpt-4.1-mini')
+        lkg = route_artifact(LKG_ROUTE, model='gpt-4o-mini')
+        if active_overrides:
+            active.update(active_overrides)
+        if lkg_overrides:
+            lkg.update(lkg_overrides)
+        route_artifacts = [active, lkg]
+
+    feature_bundle = {
+        'feature': 'memories',
+        'lane_id': LANE_ID,
+        'prompt_version': 'memory_extraction.v17',
+        'parser_version': 'memory_schema.v9',
+        'eval_suite': 'memory_precision_recall.v5',
+        'promotion_gates': {'schema_valid_rate': '>= 99.5%'},
+    }
+
+    write_yaml(config_dir / 'lanes.yaml', {'lanes': [lane]})
+    write_yaml(config_dir / 'route_artifacts.yaml', {'route_artifacts': route_artifacts})
+    write_yaml(config_dir / 'feature_bundles.yaml', {'feature_bundles': [feature_bundle]})
+
+
+def capabilities(structured_output: str = 'json_schema') -> dict:
+    return {
+        'text_input': True,
+        'streaming': False,
+        'structured_output': structured_output,
+        'tools': False,
+    }
+
+
+def credential_policy(mode: str = 'omi_paid') -> dict:
+    return {
+        'mode': mode,
+        'allow_byok_to_omi_paid_fallback': False,
+        'fallback_eligible_failure_classes': [
+            'timeout_before_output',
+            'provider_429_omi_paid',
+            'provider_5xx_omi_paid',
+        ],
+        'never_fallback_failure_classes': [
+            'byok_auth',
+            'byok_quota',
+            'byok_rate_limit',
+            'missing_byok_key',
+            'capability_mismatch',
+            'invalid_config',
+        ],
+    }
+
+
+def route_artifact(route_artifact_id: str, *, model: str = 'gpt-4.1-mini') -> dict:
+    return {
+        'route_artifact_id': route_artifact_id,
+        'lane_id': LANE_ID,
+        'surface': 'openai.chat_completions',
+        'primary': {'provider': 'openai', 'model': model},
+        'fallbacks': [],
+        'timeouts': {'request_ms': 8000},
+        'retry': {'max_attempts': 1},
+        'capabilities': capabilities(),
+        'evidence': {
+            'benchmark_snapshot': 'bench.omi.chat_structured.2026_06_27',
+            'eval_report': 'eval.memory_extraction.2026_06_27',
+            'benchmark_source': 'omi_eval',
+            'dev_only': False,
+        },
+        'rollout': {'stage': 'shadow', 'percent': 0},
+        'credential_policy': credential_policy(),
+        'fallback_policy': {
+            'fallback_on': ['timeout_before_output', 'provider_429_omi_paid', 'provider_5xx_omi_paid'],
+            'never_fallback_on': [
+                'byok_auth',
+                'byok_quota',
+                'byok_rate_limit',
+                'missing_byok_key',
+                'capability_mismatch',
+                'invalid_config',
+            ],
+        },
+    }
+
+
+def write_yaml(path: Path, payload: dict) -> None:
+    with path.open('w', encoding='utf-8') as handle:
+        yaml.safe_dump(payload, handle, sort_keys=False)

--- a/backend/tests/unit/test_llm_gateway_credentials.py
+++ b/backend/tests/unit/test_llm_gateway_credentials.py
@@ -49,6 +49,15 @@ def test_key_reference_credential_context_exposes_references_not_raw_keys():
     assert dumped['provider_keys']['openai']['key_ref'] == 'secret-manager://projects/omi/secrets/openai-user-123'
 
 
+def test_key_reference_credential_context_rejects_whitespace_only_ref():
+    context = build_key_reference_credential_context(
+        ServiceCaller(name='pusher'),
+        {'openai': '   '},
+    )
+
+    assert not context.has_provider_key('openai')
+
+
 def test_byok_failure_classes_are_visible_and_not_fallback_eligible_by_default():
     policy = CredentialPolicy(
         mode=CredentialMode.BYOK,

--- a/backend/tests/unit/test_llm_gateway_credentials.py
+++ b/backend/tests/unit/test_llm_gateway_credentials.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from llm_gateway.gateway.auth import ServiceCaller
+from llm_gateway.gateway.credentials import (
+    BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES,
+    BYOK_UNSUPPORTED_PROVIDER_FAILURE,
+    build_byok_credential_context,
+    build_key_reference_credential_context,
+    build_omi_managed_credential_context,
+    is_byok_failure_class,
+    is_fallback_eligible_by_default,
+)
+from llm_gateway.gateway.schemas import CredentialMode, CredentialPolicy, FailureClass
+
+
+def test_omi_managed_credential_context_has_no_provider_keys():
+    context = build_omi_managed_credential_context(ServiceCaller(name='backend'))
+
+    assert context.mode == CredentialMode.OMI_PAID
+    assert context.provider_keys == {}
+    assert not context.has_provider_key('openai')
+
+
+def test_byok_credential_context_exposes_presence_without_raw_keys():
+    raw_secret = 'sk-super-secret'
+    context = build_byok_credential_context(
+        ServiceCaller(name='backend', user_uid='user-123'),
+        {'openai': raw_secret, 'anthropic': '', 'gemini': None},
+    )
+
+    assert context.mode == CredentialMode.BYOK
+    assert context.has_provider_key('openai')
+    assert not context.has_provider_key('anthropic')
+    assert not context.has_provider_key('gemini')
+    assert raw_secret not in repr(context)
+    assert raw_secret not in str(context.safe_model_dump())
+    assert raw_secret not in context.model_dump_json()
+
+
+def test_key_reference_credential_context_exposes_references_not_raw_keys():
+    context = build_key_reference_credential_context(
+        ServiceCaller(name='pusher'),
+        {'openai': 'secret-manager://projects/omi/secrets/openai-user-123'},
+    )
+
+    dumped = context.safe_model_dump()
+    assert context.has_provider_key('openai')
+    assert dumped['provider_keys']['openai']['present'] is True
+    assert dumped['provider_keys']['openai']['key_ref'] == 'secret-manager://projects/omi/secrets/openai-user-123'
+
+
+def test_byok_failure_classes_are_visible_and_not_fallback_eligible_by_default():
+    policy = CredentialPolicy(
+        mode=CredentialMode.BYOK,
+        allow_byok_to_omi_paid_fallback=False,
+        fallback_eligible_failure_classes=[
+            FailureClass.TIMEOUT_BEFORE_OUTPUT,
+            FailureClass.BYOK_AUTH,
+            FailureClass.BYOK_QUOTA,
+            FailureClass.BYOK_RATE_LIMIT,
+            FailureClass.MISSING_BYOK_KEY,
+        ],
+        never_fallback_failure_classes=[],
+    )
+
+    for failure_class in BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES:
+        assert is_byok_failure_class(failure_class)
+        assert not is_fallback_eligible_by_default(failure_class, policy)
+
+    assert BYOK_UNSUPPORTED_PROVIDER_FAILURE in BYOK_DEFAULT_VISIBLE_FAILURE_CLASSES
+
+
+def test_omi_paid_policy_keeps_non_byok_fallbacks_visible():
+    policy = CredentialPolicy(
+        mode=CredentialMode.OMI_PAID,
+        allow_byok_to_omi_paid_fallback=False,
+        fallback_eligible_failure_classes=[
+            FailureClass.TIMEOUT_BEFORE_OUTPUT,
+            FailureClass.PROVIDER_429_OMI_PAID,
+            FailureClass.PROVIDER_5XX_OMI_PAID,
+        ],
+        never_fallback_failure_classes=[FailureClass.INVALID_CONFIG],
+    )
+
+    assert is_fallback_eligible_by_default(FailureClass.TIMEOUT_BEFORE_OUTPUT, policy)
+    assert is_fallback_eligible_by_default(FailureClass.PROVIDER_429_OMI_PAID, policy)
+    assert is_fallback_eligible_by_default(FailureClass.PROVIDER_5XX_OMI_PAID, policy)
+    assert not is_fallback_eligible_by_default(FailureClass.INVALID_CONFIG, policy)

--- a/backend/tests/unit/test_llm_gateway_dependencies.py
+++ b/backend/tests/unit/test_llm_gateway_dependencies.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from llm_gateway.routers.dependencies import close_provider_registry, get_provider_registry
+
+
+@pytest.mark.asyncio
+async def test_provider_registry_is_cached_and_closed():
+    get_provider_registry.cache_clear()
+    first = get_provider_registry()
+    second = get_provider_registry()
+
+    assert first is second
+
+    await close_provider_registry()
+
+    assert get_provider_registry() is not first
+    await close_provider_registry()

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -160,11 +160,11 @@ async def test_executor_uses_lkg_only_when_active_route_policy_allows():
 
     assert result.response['model'] == LANE_ID
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4o-mini'
+    assert result.selected_model == 'gpt-4.1-mini'
     assert result.fallback_used
     assert result.fallback_reason == FailureClass.TIMEOUT_BEFORE_OUTPUT
     assert result.used_lkg
-    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4o-mini']
+    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4.1-mini']
 
 
 @pytest.mark.asyncio
@@ -288,8 +288,9 @@ async def test_shadow_active_route_serves_lkg_not_active():
     config = config_with_active_route(shadow_route)
     resolved = resolve_chat_completion_route(config, valid_request())
 
-    # Provider should be called with the LKG model (gpt-4o-mini), not the
-    # active route's primary (gpt-4.1-mini).
+    # Provider should be called with the LKG model (gpt-4.1-mini, which now
+    # matches the legacy chat_extraction model). The LKG is aligned with the
+    # legacy route by design so the shadow pilot is a no-user-visible match.
     provider = FakeChatCompletionProvider(
         [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
     )
@@ -301,9 +302,9 @@ async def test_shadow_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4o-mini'
+    assert result.selected_model == 'gpt-4.1-mini'
     assert result.used_lkg
-    assert provider.calls[0].request['model'] == 'gpt-4o-mini'
+    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
 
 
 @pytest.mark.asyncio
@@ -327,7 +328,7 @@ async def test_disabled_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-4o-mini'
+    assert result.selected_model == 'gpt-4.1-mini'
     assert result.used_lkg
 
 

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -78,6 +78,36 @@ async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    'failure_class,error_type',
+    [
+        (FailureClass.INVALID_CONFIG, GatewayInvalidRouteConfigError),
+        (FailureClass.CAPABILITY_MISMATCH, GatewayCapabilityMismatchError),
+        (FailureClass.BYOK_AUTH, GatewayCredentialFailureError),
+        (FailureClass.BYOK_QUOTA, GatewayCredentialFailureError),
+        (FailureClass.BYOK_RATE_LIMIT, GatewayCredentialFailureError),
+    ],
+)
+async def test_executor_does_not_retry_terminal_provider_failures(failure_class, error_type):
+    config = config_with_active_route(
+        active_route_with_fallbacks([]).model_copy(
+            update={'retry': type(load_gateway_config().route_artifacts[ACTIVE_ROUTE].retry)(max_attempts=3)}
+        )
+    )
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider([ProviderFailure(failure_class)])
+
+    with pytest.raises(error_type):
+        await execute_chat_completion(
+            resolved,
+            omi_credentials(),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     'failure_class',
     [
         FailureClass.TIMEOUT_BEFORE_OUTPUT,

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -354,6 +354,74 @@ async def test_canary_active_route_with_percent_zero_serves_lkg():
     assert result.used_lkg
 
 
+@pytest.mark.asyncio
+async def test_canary_route_enforces_partial_rollout_percentage():
+    """A canary route at <100% should send only a proportional fraction of
+    requests to the active route, with the rest falling back to LKG.
+
+    Deterministic hashing means the distribution is stable per-request, but
+    over many distinct requests the percentage is honored within a tolerance.
+    """
+    from llm_gateway.gateway.executor import _is_route_eligible_to_serve
+
+    canary_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.CANARY, percent=30)}
+    )
+    config = config_with_active_route(canary_route)
+
+    active_count = 0
+    total = 500
+    from llm_gateway.gateway.resolver import resolve_chat_completion_route as _resolve
+
+    for i in range(total):
+        resolved = _resolve(config, valid_request(messages=[{'role': 'user', 'content': f'msg {i}'}]))
+        if _is_route_eligible_to_serve(resolved.active_route, resolved.validated_request):
+            active_count += 1
+
+    # With 30% canary, expect ~150 ± 30 (generous tolerance for deterministic hash)
+    assert 100 <= active_count <= 200, f'canary distribution off: {active_count}/{total}'
+
+
+@pytest.mark.asyncio
+async def test_canary_sampling_is_deterministic_for_same_request():
+    """The same request should consistently get the same canary decision."""
+    from llm_gateway.gateway.executor import _is_route_eligible_to_serve
+
+    canary_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.CANARY, percent=50)}
+    )
+    config = config_with_active_route(canary_route)
+
+    resolved = resolve_chat_completion_route(config, valid_request())
+    decision1 = _is_route_eligible_to_serve(resolved.active_route, resolved.validated_request)
+    decision2 = _is_route_eligible_to_serve(resolved.active_route, resolved.validated_request)
+
+    assert decision1 == decision2
+
+
+@pytest.mark.asyncio
+async def test_canary_route_at_100_percent_serves_active():
+    """A canary route at 100% should serve all traffic from the active route."""
+    canary_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.CANARY, percent=100)}
+    )
+    config = config_with_active_route(canary_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    provider = FakeChatCompletionProvider(
+        [fake_success_response(resolved.active_route.primary, content='{"answer":"active"}')]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.selected_route_artifact_id == ACTIVE_ROUTE
+    assert not result.used_lkg
+
+
 def valid_request(**overrides):
     request = {
         'model': LANE_ID,

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -14,7 +14,7 @@ from llm_gateway.gateway.errors import (
 from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
 from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure, fake_success_response
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
-from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutPolicy, RolloutStage
 
 LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
@@ -47,8 +47,6 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
 
 @pytest.mark.asyncio
 async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
-    """retry.max_attempts is honored: transient failures are retried before
-    falling through to the next provider."""
     fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
     config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))
     # Override retry to 3 attempts on the active route
@@ -279,6 +277,83 @@ async def test_raw_byok_key_is_not_in_provider_error_repr_or_dump():
     assert raw_key not in str(provider.calls[0].request)
 
 
+@pytest.mark.asyncio
+async def test_shadow_active_route_serves_lkg_not_active():
+    """When the active route is in shadow rollout (percent 0), traffic should
+    be served by the last-known-good route, not the shadow candidate."""
+    # Keep the checked-in shadow rollout on the active route
+    shadow_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.SHADOW, percent=0)}
+    )
+    config = config_with_active_route(shadow_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    # Provider should be called with the LKG model (gpt-4o-mini), not the
+    # active route's primary (gpt-4.1-mini).
+    provider = FakeChatCompletionProvider(
+        [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.selected_route_artifact_id == LKG_ROUTE
+    assert result.selected_model == 'gpt-4o-mini'
+    assert result.used_lkg
+    assert provider.calls[0].request['model'] == 'gpt-4o-mini'
+
+
+@pytest.mark.asyncio
+async def test_disabled_active_route_serves_lkg_not_active():
+    """When the active route is disabled rollout, traffic should fall back to
+    the last-known-good route."""
+    disabled_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.DISABLED, percent=0)}
+    )
+    config = config_with_active_route(disabled_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    provider = FakeChatCompletionProvider(
+        [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.selected_route_artifact_id == LKG_ROUTE
+    assert result.selected_model == 'gpt-4o-mini'
+    assert result.used_lkg
+
+
+@pytest.mark.asyncio
+async def test_canary_active_route_with_percent_zero_serves_lkg():
+    """A canary route with percent 0 should not serve live traffic."""
+    canary_route = active_route_with_fallbacks([]).model_copy(
+        update={'rollout': RolloutPolicy(stage=RolloutStage.CANARY, percent=0)}
+    )
+    config = config_with_active_route(canary_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    provider = FakeChatCompletionProvider(
+        [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.selected_route_artifact_id == LKG_ROUTE
+    assert result.used_lkg
+
+
 def valid_request(**overrides):
     request = {
         'model': LANE_ID,
@@ -306,7 +381,12 @@ def omi_credentials():
 
 def active_route_with_fallbacks(fallbacks: list[ProviderRef]):
     active_route = load_gateway_config(prod_mode=True).route_artifacts[ACTIVE_ROUTE]
-    return active_route.model_copy(update={'fallbacks': fallbacks})
+    return active_route.model_copy(update={'fallbacks': fallbacks, **_active_rollout_kwargs(active_route)})
+
+
+def _active_rollout_kwargs(active_route):
+    """Return model_copy update dict to promote a route to serving rollout."""
+    return {'rollout': RolloutPolicy(stage=RolloutStage.ACTIVE, percent=100)}
 
 
 def config_with_active_route(active_route):

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -46,6 +46,39 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
 
 
 @pytest.mark.asyncio
+async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
+    """retry.max_attempts is honored: transient failures are retried before
+    falling through to the next provider."""
+    fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
+    config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))
+    # Override retry to 3 attempts on the active route
+    active_route = config.route_artifacts[ACTIVE_ROUTE].model_copy(
+        update={'retry': type(config.route_artifacts[ACTIVE_ROUTE].retry)(max_attempts=3)}
+    )
+    config = config_with_active_route(active_route.model_copy(update={'fallbacks': [fallback_ref]}))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    # 3 transient failures then fallback succeeds
+    provider = FakeChatCompletionProvider(
+        [
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            fake_success_response(fallback_ref, content='{"answer":"fallback"}'),
+        ]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    # Primary tried 3 times (max_attempts), then fallback once
+    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4.1-mini', 'gpt-4.1-mini', 'gpt-4o-mini']
+    assert result.response['choices'][0]['message']['content'] == '{"answer":"fallback"}'
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'failure_class',
     [

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import pytest
+
+from llm_gateway.gateway.auth import ServiceCaller
+from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.credentials import build_byok_credential_context, build_omi_managed_credential_context
+from llm_gateway.gateway.errors import (
+    GatewayCapabilityMismatchError,
+    GatewayCredentialFailureError,
+    GatewayInvalidRouteConfigError,
+    GatewayProviderFailureError,
+)
+from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
+from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure, fake_success_response
+from llm_gateway.gateway.resolver import resolve_chat_completion_route
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef
+
+LANE_ID = 'omi:auto:chat-structured'
+ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
+LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
+
+
+@pytest.mark.asyncio
+async def test_executor_success_uses_active_primary_and_exposes_lane_model():
+    config = config_with_active_route(active_route_with_fallbacks([]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    active_primary = resolved.active_route.primary
+    provider = FakeChatCompletionProvider([fake_success_response(active_primary, content='{"answer":"primary"}')])
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.response['model'] == LANE_ID
+    assert result.response['choices'][0]['message']['content'] == '{"answer":"primary"}'
+    assert result.selected_route_artifact_id == ACTIVE_ROUTE
+    assert result.selected_provider == 'openai'
+    assert result.selected_model == 'gpt-4.1-mini'
+    assert not result.fallback_used
+    assert not result.used_lkg
+    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert provider.calls[0].request['stream'] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'failure_class',
+    [
+        FailureClass.TIMEOUT_BEFORE_OUTPUT,
+        FailureClass.PROVIDER_429_OMI_PAID,
+        FailureClass.PROVIDER_5XX_OMI_PAID,
+    ],
+)
+async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(failure_class):
+    fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
+    config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider(
+        [
+            ProviderFailure(failure_class, safe_message='raw provider detail should not leak'),
+            fake_success_response(fallback_ref, content='{"answer":"fallback"}'),
+        ]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.response['model'] == LANE_ID
+    assert result.response['choices'][0]['message']['content'] == '{"answer":"fallback"}'
+    assert result.selected_route_artifact_id == ACTIVE_ROUTE
+    assert result.selected_model == 'gpt-4o-mini'
+    assert result.fallback_used
+    assert result.fallback_reason == failure_class
+    assert not result.used_lkg
+    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4o-mini']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'failure_class,error_type',
+    [
+        (FailureClass.INVALID_CONFIG, GatewayInvalidRouteConfigError),
+        (FailureClass.CAPABILITY_MISMATCH, GatewayCapabilityMismatchError),
+        (FailureClass.BYOK_AUTH, GatewayCredentialFailureError),
+        (FailureClass.BYOK_QUOTA, GatewayCredentialFailureError),
+        (FailureClass.BYOK_RATE_LIMIT, GatewayCredentialFailureError),
+        (FailureClass.MISSING_BYOK_KEY, GatewayCredentialFailureError),
+    ],
+)
+async def test_executor_does_not_fallback_for_non_eligible_failures(failure_class, error_type):
+    fallback_ref = ProviderRef(provider='openai', model='gpt-4o-mini')
+    config = config_with_active_route(active_route_with_fallbacks([fallback_ref]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider([ProviderFailure(failure_class)])
+
+    with pytest.raises(error_type) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            omi_credentials(),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert exc_info.value.failure_class == failure_class
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_executor_uses_lkg_only_when_active_route_policy_allows():
+    config = config_with_active_route(active_route_with_fallbacks([]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider(
+        [
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}'),
+        ]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.response['model'] == LANE_ID
+    assert result.selected_route_artifact_id == LKG_ROUTE
+    assert result.selected_model == 'gpt-4o-mini'
+    assert result.fallback_used
+    assert result.fallback_reason == FailureClass.TIMEOUT_BEFORE_OUTPUT
+    assert result.used_lkg
+    assert [call.model for call in provider.calls] == ['gpt-4.1-mini', 'gpt-4o-mini']
+
+
+@pytest.mark.asyncio
+async def test_executor_does_not_use_lkg_when_active_route_policy_rejects_failure():
+    active_route = active_route_with_fallbacks([])
+    config = config_with_active_route(
+        active_route.model_copy(
+            update={
+                'fallback_policy': active_route.fallback_policy.model_copy(
+                    update={'fallback_on': [FailureClass.PROVIDER_429_OMI_PAID]}
+                )
+            }
+        )
+    )
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider([ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT)])
+
+    with pytest.raises(GatewayProviderFailureError) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            omi_credentials(),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert exc_info.value.failure_class == FailureClass.TIMEOUT_BEFORE_OUTPUT
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unsupported_omi_paid_provider_is_visible_and_does_not_fallback():
+    active_route = active_route_with_fallbacks([ProviderRef(provider='openai', model='gpt-4o-mini')]).model_copy(
+        update={'primary': ProviderRef(provider='missing-provider', model='missing-model')}
+    )
+    config = config_with_active_route(active_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider()
+
+    with pytest.raises(GatewayInvalidRouteConfigError) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            omi_credentials(),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert exc_info.value.failure_class == FailureClass.INVALID_CONFIG
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_byok_missing_key_and_unsupported_provider_fail_without_fallback_or_lkg():
+    active_route = active_route_with_fallbacks([ProviderRef(provider='openai', model='gpt-4o-mini')]).model_copy(
+        update={
+            'credential_policy': byok_policy(),
+            'primary': ProviderRef(provider='anthropic', model='claude-test'),
+        }
+    )
+    lkg_route = (
+        load_gateway_config(prod_mode=True)
+        .route_artifacts[LKG_ROUTE]
+        .model_copy(update={'credential_policy': byok_policy()})
+    )
+    config = config_with_routes(active_route, lkg_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    with pytest.raises(GatewayCredentialFailureError) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            build_byok_credential_context(ServiceCaller(name='backend'), {'openai': ''}),
+            ProviderRegistry({'openai': FakeChatCompletionProvider()}),
+        )
+
+    assert exc_info.value.failure_class == FailureClass.BYOK_UNSUPPORTED_PROVIDER
+
+    supported_active = active_route.model_copy(update={'primary': ProviderRef(provider='openai', model='gpt-4.1-mini')})
+    resolved = resolve_chat_completion_route(config_with_routes(supported_active, lkg_route), valid_request())
+    with pytest.raises(GatewayCredentialFailureError) as missing_key_info:
+        await execute_chat_completion(
+            resolved,
+            build_byok_credential_context(ServiceCaller(name='backend'), {'openai': ''}),
+            ProviderRegistry({'openai': FakeChatCompletionProvider()}),
+        )
+
+    assert missing_key_info.value.failure_class == FailureClass.MISSING_BYOK_KEY
+
+
+@pytest.mark.asyncio
+async def test_raw_byok_key_is_not_in_provider_error_repr_or_dump():
+    raw_key = 'sk-test-secret-should-not-appear'
+    active_route = active_route_with_fallbacks([]).model_copy(update={'credential_policy': byok_policy()})
+    lkg_route = (
+        load_gateway_config(prod_mode=True)
+        .route_artifacts[LKG_ROUTE]
+        .model_copy(update={'credential_policy': byok_policy()})
+    )
+    config = config_with_routes(active_route, lkg_route)
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider(
+        [ProviderFailure(FailureClass.BYOK_AUTH, safe_message=f'provider rejected {raw_key}')]
+    )
+
+    with pytest.raises(GatewayCredentialFailureError) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            build_byok_credential_context(ServiceCaller(name='backend'), {'openai': raw_key}),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert raw_key not in repr(exc_info.value)
+    assert raw_key not in str(exc_info.value.to_error_dict())
+    assert raw_key not in str(provider.calls[0].request)
+
+
+def valid_request(**overrides):
+    request = {
+        'model': LANE_ID,
+        'messages': [{'role': 'user', 'content': 'Return JSON.'}],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'test_schema',
+                'schema': {
+                    'type': 'object',
+                    'properties': {'answer': {'type': 'string'}},
+                    'required': ['answer'],
+                    'additionalProperties': False,
+                },
+            },
+        },
+    }
+    request.update(overrides)
+    return request
+
+
+def omi_credentials():
+    return build_omi_managed_credential_context(ServiceCaller(name='backend'))
+
+
+def active_route_with_fallbacks(fallbacks: list[ProviderRef]):
+    active_route = load_gateway_config(prod_mode=True).route_artifacts[ACTIVE_ROUTE]
+    return active_route.model_copy(update={'fallbacks': fallbacks})
+
+
+def config_with_active_route(active_route):
+    base = load_gateway_config(prod_mode=True)
+    return config_with_routes(active_route, base.route_artifacts[LKG_ROUTE])
+
+
+def config_with_routes(active_route, lkg_route):
+    base = load_gateway_config(prod_mode=True)
+    route_artifacts = dict(base.route_artifacts)
+    route_artifacts[ACTIVE_ROUTE] = active_route
+    route_artifacts[LKG_ROUTE] = lkg_route
+    lanes = dict(base.lanes)
+    lanes[LANE_ID] = lanes[LANE_ID].model_copy(update={'credential_policy': active_route.credential_policy})
+    return GatewayConfig(
+        lanes=lanes,
+        route_artifacts=route_artifacts,
+        feature_bundles=base.feature_bundles,
+    )
+
+
+def byok_policy():
+    return (
+        load_gateway_config(prod_mode=True)
+        .lanes[LANE_ID]
+        .credential_policy.model_copy(update={'mode': CredentialMode.BYOK})
+    )

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -26,7 +26,7 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     try:
         response = TestClient(app).post(
             '/v1/chat/completions',
-            json=valid_request(temperature=0, max_completion_tokens=64),
+            json=valid_request(temperature=0, max_completion_tokens=64, metadata={'omi_feature': 'smoke'}),
             headers=auth_headers(),
         )
     finally:
@@ -46,6 +46,7 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
+    assert 'metadata' not in provider.calls[0].request
 
 
 def test_chat_completions_rejects_unknown_auto_lane(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -73,8 +73,9 @@ def test_chat_completions_rejects_unsupported_capability(monkeypatch):
     assert response.json()['error']['param'] == 'stream'
 
 
-def test_chat_completions_fails_closed_when_provider_registry_is_not_wired(monkeypatch):
+def test_chat_completions_fails_closed_when_openai_key_is_not_configured(monkeypatch):
     monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
 
     response = TestClient(app).post('/v1/chat/completions', json=valid_request(), headers=auth_headers())
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -26,7 +26,7 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     try:
         response = TestClient(app).post(
             '/v1/chat/completions',
-            json=valid_request(),
+            json=valid_request(temperature=0, max_completion_tokens=64),
             headers=auth_headers(),
         )
     finally:
@@ -40,6 +40,8 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert 'selected_route_artifact_id' not in body
     assert provider.calls[0].model == 'gpt-4.1-mini'
     assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert provider.calls[0].request['temperature'] == 0
+    assert provider.calls[0].request['max_completion_tokens'] == 64
 
 
 def test_chat_completions_rejects_unknown_auto_lane(monkeypatch):
@@ -71,6 +73,17 @@ def test_chat_completions_rejects_unsupported_capability(monkeypatch):
     assert response.status_code == 400
     assert response.json()['error']['code'] == 'capability_not_supported'
     assert response.json()['error']['param'] == 'stream'
+
+
+def test_chat_completions_rejects_unknown_request_parameter(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    request = valid_request(unexpected_parameter=True)
+
+    response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json()['error']['code'] == 'invalid_request'
+    assert response.json()['error']['param'] == 'unexpected_parameter'
 
 
 def test_chat_completions_fails_closed_when_openai_key_is_not_configured(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -39,9 +39,11 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert 'selected_provider' not in body
     assert 'selected_route_artifact_id' not in body
     # The checked-in active route is in shadow rollout (percent 0), so live
-    # traffic is served by the last-known-good route (gpt-4o-mini).
-    assert provider.calls[0].model == 'gpt-4o-mini'
-    assert provider.calls[0].request['model'] == 'gpt-4o-mini'
+    # traffic is served by the last-known-good route. The LKG primary matches
+    # the legacy `chat_extraction` model (gpt-4.1-mini) so enabling the pilot
+    # is a no-user-visible behavior match while shadow-only.
+    assert provider.calls[0].model == 'gpt-4.1-mini'
+    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import FakeChatCompletionProvider
 from llm_gateway.main import app
-from llm_gateway.routers import openai_compatible
+from llm_gateway.routers import dependencies
 
 LANE_ID = 'omi:auto:chat-structured'
 
@@ -22,7 +22,7 @@ def test_chat_completions_requires_service_auth(monkeypatch):
 def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monkeypatch):
     monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
     provider = FakeChatCompletionProvider()
-    app.dependency_overrides[openai_compatible.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
     try:
         response = TestClient(app).post(
             '/v1/chat/completions',

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -38,8 +38,10 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert body['model'] == LANE_ID
     assert 'selected_provider' not in body
     assert 'selected_route_artifact_id' not in body
-    assert provider.calls[0].model == 'gpt-4.1-mini'
-    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    # The checked-in active route is in shadow rollout (percent 0), so live
+    # traffic is served by the last-known-good route (gpt-4o-mini).
+    assert provider.calls[0].model == 'gpt-4o-mini'
+    assert provider.calls[0].request['model'] == 'gpt-4o-mini'
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -72,7 +72,20 @@ def test_chat_completions_rejects_unsupported_capability(monkeypatch):
 
     assert response.status_code == 400
     assert response.json()['error']['code'] == 'capability_not_supported'
+    assert response.json()['error']['type'] == 'invalid_request_error'
     assert response.json()['error']['param'] == 'stream'
+
+
+def test_chat_completions_error_type_is_openai_category_not_code_duplicate(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    request = valid_request(unexpected_parameter=True)
+
+    response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+
+    assert response.status_code == 400
+    error = response.json()['error']
+    assert error['type'] == 'invalid_request_error'
+    assert error['code'] != error['type']
 
 
 def test_chat_completions_rejects_unknown_request_parameter(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from llm_gateway.gateway.executor import ProviderRegistry
+from llm_gateway.gateway.providers import FakeChatCompletionProvider
+from llm_gateway.main import app
+from llm_gateway.routers import openai_compatible
+
+LANE_ID = 'omi:auto:chat-structured'
+
+
+def test_chat_completions_requires_service_auth(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(app).post('/v1/chat/completions', json=valid_request())
+
+    assert response.status_code == 401
+    assert response.json()['detail'] == 'invalid service authentication'
+
+
+def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    provider = FakeChatCompletionProvider()
+    app.dependency_overrides[openai_compatible.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    try:
+        response = TestClient(app).post(
+            '/v1/chat/completions',
+            json=valid_request(),
+            headers=auth_headers(),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['object'] == 'chat.completion'
+    assert body['model'] == LANE_ID
+    assert 'selected_provider' not in body
+    assert 'selected_route_artifact_id' not in body
+    assert provider.calls[0].model == 'gpt-4.1-mini'
+    assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+
+
+def test_chat_completions_rejects_unknown_auto_lane(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    request = valid_request(model='omi:auto:unknown')
+
+    response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+
+    assert response.status_code == 404
+    assert response.json()['error']['code'] == 'model_not_found'
+
+
+def test_chat_completions_rejects_bare_provider_model(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    request = valid_request(model='gpt-4o-mini')
+
+    response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json()['error']['code'] == 'unsupported_model'
+
+
+def test_chat_completions_rejects_unsupported_capability(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    request = valid_request(stream=True)
+
+    response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json()['error']['code'] == 'capability_not_supported'
+    assert response.json()['error']['param'] == 'stream'
+
+
+def test_chat_completions_fails_closed_when_provider_registry_is_not_wired(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(app).post('/v1/chat/completions', json=valid_request(), headers=auth_headers())
+
+    assert response.status_code == 503
+    assert response.json()['error']['code'] == 'invalid_route_config'
+
+
+def auth_headers() -> dict[str, str]:
+    return {
+        'authorization': 'Bearer shared-secret',
+        'x-omi-service-caller': 'backend',
+        'x-omi-user-uid': 'user-123',
+    }
+
+
+def valid_request(**overrides):
+    request = {
+        'model': LANE_ID,
+        'messages': [
+            {'role': 'system', 'content': 'Return structured JSON.'},
+            {'role': 'user', 'content': 'Extract the memory.'},
+        ],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'memory_extraction',
+                'strict': True,
+                'schema': {
+                    'type': 'object',
+                    'properties': {'memory': {'type': 'string'}},
+                    'required': ['memory'],
+                    'additionalProperties': False,
+                },
+            },
+        },
+    }
+    request.update(overrides)
+    return request

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -5,7 +5,11 @@ import pytest
 
 from llm_gateway.gateway.auth import ServiceCaller
 from llm_gateway.gateway.credentials import build_byok_credential_context, build_omi_managed_credential_context
-from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider, ProviderFailure
+from llm_gateway.gateway.providers import (
+    MAX_RESPONSE_BYTES_ENV_VAR,
+    OpenAICompatibleChatCompletionProvider,
+    ProviderFailure,
+)
 from llm_gateway.gateway.schemas import FailureClass, ProviderRef
 
 
@@ -22,7 +26,7 @@ async def test_openai_compatible_provider_posts_chat_completion(monkeypatch):
                 'id': 'chatcmpl_test',
                 'object': 'chat.completion',
                 'model': 'gpt-4.1-mini',
-                'choices': [],
+                'choices': [{'message': {'role': 'assistant', 'content': '{}'}}],
             },
         )
 
@@ -43,6 +47,15 @@ async def test_openai_compatible_provider_posts_chat_completion(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_openai_compatible_provider_closes_owned_http_client():
+    provider = OpenAICompatibleChatCompletionProvider()
+
+    await provider.aclose()
+
+    assert provider._http_client.is_closed
+
+
+@pytest.mark.asyncio
 async def test_openai_compatible_provider_fails_closed_without_api_key(monkeypatch):
     monkeypatch.delenv('OPENAI_API_KEY', raising=False)
     provider = OpenAICompatibleChatCompletionProvider(
@@ -58,6 +71,50 @@ async def test_openai_compatible_provider_fails_closed_without_api_key(monkeypat
         )
 
     assert exc_info.value.failure_class == FailureClass.INVALID_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_maps_timeout(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout('test timeout')
+
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.TIMEOUT_BEFORE_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_maps_transport_error(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('test connect error')
+
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.PROVIDER_5XX_OMI_PAID
 
 
 @pytest.mark.asyncio
@@ -90,6 +147,55 @@ async def test_openai_compatible_provider_maps_status_without_leaking_body(monke
 
     assert exc_info.value.failure_class == failure_class
     assert raw_body not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'response',
+    [
+        httpx.Response(200, text='not json'),
+        httpx.Response(200, json=[]),
+        httpx.Response(200, json={'object': 'not.chat.completion', 'id': 'x', 'model': 'm', 'choices': []}),
+        httpx.Response(200, json={'object': 'chat.completion', 'id': 'x', 'model': 'm', 'choices': []}),
+        httpx.Response(200, json={'object': 'chat.completion', 'id': 'x', 'model': 'm', 'choices': [{}]}),
+    ],
+)
+async def test_openai_compatible_provider_rejects_malformed_success_response(monkeypatch, response):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response)),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.PROVIDER_5XX_OMI_PAID
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_rejects_oversized_response(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    monkeypatch.setenv(MAX_RESPONSE_BYTES_ENV_VAR, '8')
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, content=b'{"too":"large"}'))
+        ),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.PROVIDER_5XX_OMI_PAID
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from llm_gateway.gateway.auth import ServiceCaller
+from llm_gateway.gateway.credentials import build_byok_credential_context, build_omi_managed_credential_context
+from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider, ProviderFailure
+from llm_gateway.gateway.schemas import FailureClass, ProviderRef
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_posts_chat_completion(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    seen_requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                'id': 'chatcmpl_test',
+                'object': 'chat.completion',
+                'model': 'gpt-4.1-mini',
+                'choices': [],
+            },
+        )
+
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    response = await provider.create_chat_completion(
+        {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+        provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+        credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+        timeout_ms=8000,
+    )
+
+    assert response['id'] == 'chatcmpl_test'
+    assert seen_requests[0].url == 'https://api.openai.com/v1/chat/completions'
+    assert seen_requests[0].headers['authorization'] == 'Bearer test-key'
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_fails_closed_without_api_key(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(200, json={}))),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.INVALID_CONFIG
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status_code', 'failure_class'),
+    [
+        (400, FailureClass.CAPABILITY_MISMATCH),
+        (401, FailureClass.INVALID_CONFIG),
+        (403, FailureClass.INVALID_CONFIG),
+        (429, FailureClass.PROVIDER_429_OMI_PAID),
+        (500, FailureClass.PROVIDER_5XX_OMI_PAID),
+    ],
+)
+async def test_openai_compatible_provider_maps_status_without_leaking_body(monkeypatch, status_code, failure_class):
+    raw_body = 'raw provider error with sensitive prompt'
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(status_code, text=raw_body))
+        ),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [{'role': 'user', 'content': 'secret'}], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == failure_class
+    assert raw_body not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_keeps_byok_failure_visible(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(200, json={}))),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-4.1-mini', 'messages': [], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            credentials=build_byok_credential_context(ServiceCaller(name='backend'), {'openai': 'sk-test'}),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == FailureClass.BYOK_UNSUPPORTED_PROVIDER

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -124,6 +124,7 @@ async def test_openai_compatible_provider_maps_transport_error(monkeypatch):
         (400, FailureClass.CAPABILITY_MISMATCH),
         (401, FailureClass.INVALID_CONFIG),
         (403, FailureClass.INVALID_CONFIG),
+        (408, FailureClass.TIMEOUT_BEFORE_OUTPUT),
         (429, FailureClass.PROVIDER_429_OMI_PAID),
         (500, FailureClass.PROVIDER_5XX_OMI_PAID),
     ],

--- a/backend/tests/unit/test_llm_gateway_readiness.py
+++ b/backend/tests/unit/test_llm_gateway_readiness.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from llm_gateway.gateway.config_loader import ConfigValidationError
+from llm_gateway.main import app
+from llm_gateway.routers import health
+
+
+def test_ready_requires_service_auth(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(app).get('/ready')
+
+    assert response.status_code == 401
+    assert response.json()['detail'] == 'invalid service authentication'
+
+
+def test_ready_validates_gateway_config(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    response = TestClient(app).get('/ready', headers=auth_headers())
+
+    assert response.status_code == 200
+    assert response.json()['status'] == 'ready'
+    assert response.json()['lanes'] == ['omi:auto:chat-structured']
+    assert response.json()['route_artifact_count'] == 2
+
+
+def test_ready_fails_closed_on_invalid_gateway_config(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    def invalid_config():
+        raise ConfigValidationError('bad test config')
+
+    monkeypatch.setattr(health, 'get_gateway_config', invalid_config)
+
+    response = TestClient(app).get('/ready', headers=auth_headers())
+
+    assert response.status_code == 503
+    assert response.json()['detail'] == 'llm gateway config is invalid'
+
+
+def auth_headers() -> dict[str, str]:
+    return {
+        'authorization': 'Bearer shared-secret',
+        'x-omi-service-caller': 'backend',
+    }

--- a/backend/tests/unit/test_llm_gateway_readiness.py
+++ b/backend/tests/unit/test_llm_gateway_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from llm_gateway.gateway.config_loader import ConfigValidationError
+from llm_gateway.gateway.schemas import LaneConfig
 from llm_gateway.main import app
 from llm_gateway.routers import health
 
@@ -32,6 +33,20 @@ def test_ready_fails_closed_on_invalid_gateway_config(monkeypatch):
 
     def invalid_config():
         raise ConfigValidationError('bad test config')
+
+    monkeypatch.setattr(health, 'get_gateway_config', invalid_config)
+
+    response = TestClient(app).get('/ready', headers=auth_headers())
+
+    assert response.status_code == 503
+    assert response.json()['detail'] == 'llm gateway config is invalid'
+
+
+def test_ready_fails_closed_on_schema_validation_error(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+
+    def invalid_config():
+        LaneConfig.model_validate({})
 
     monkeypatch.setattr(health, 'get_gateway_config', invalid_config)
 

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -5,6 +5,7 @@ import pytest
 from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
 from llm_gateway.gateway.errors import (
     GatewayCapabilityMismatchError,
+    GatewayInvalidRequestError,
     GatewayInvalidRouteConfigError,
     GatewayModelNotFoundError,
     GatewayUnsupportedModelError,
@@ -42,6 +43,13 @@ def test_unknown_auto_lane_is_model_not_found():
     request = valid_request(model='omi:auto:unknown')
 
     with pytest.raises(GatewayModelNotFoundError, match='auto lane not found'):
+        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+
+
+def test_missing_model_is_invalid_request_not_model_not_found():
+    request = valid_request(model='')
+
+    with pytest.raises(GatewayInvalidRequestError, match='model is required'):
         resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
 
 

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import pytest
+
+from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.errors import (
+    GatewayCapabilityMismatchError,
+    GatewayInvalidRouteConfigError,
+    GatewayModelNotFoundError,
+    GatewayUnsupportedModelError,
+)
+from llm_gateway.gateway.resolver import (
+    is_auto_lane_id,
+    is_lkg_eligible,
+    resolve_chat_completion_route,
+    select_lkg_route_for_failure,
+)
+from llm_gateway.gateway.schemas import FailureClass, StructuredOutputMode
+
+LANE_ID = 'omi:auto:chat-structured'
+ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
+LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
+
+
+def test_is_auto_lane_id_only_matches_omi_auto_namespace():
+    assert is_auto_lane_id(LANE_ID)
+    assert not is_auto_lane_id('gpt-4o-mini')
+    assert not is_auto_lane_id('openai:gpt-4o-mini')
+
+
+def test_resolves_supported_auto_lane_to_active_artifact():
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+
+    assert resolved.lane.lane_id == LANE_ID
+    assert resolved.active_route.route_artifact_id == ACTIVE_ROUTE
+    assert resolved.last_known_good_route.route_artifact_id == LKG_ROUTE
+    assert resolved.active_route.primary.provider == 'openai'
+    assert resolved.validated_request.model == LANE_ID
+
+
+def test_unknown_auto_lane_is_model_not_found():
+    request = valid_request(model='omi:auto:unknown')
+
+    with pytest.raises(GatewayModelNotFoundError, match='auto lane not found'):
+        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+
+
+def test_bare_provider_model_is_rejected():
+    request = valid_request(model='gpt-4o-mini')
+
+    with pytest.raises(GatewayUnsupportedModelError, match='provider model names'):
+        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+
+
+def test_request_capability_mismatch_is_not_lkg_eligible():
+    request = valid_request(stream=True)
+
+    with pytest.raises(GatewayCapabilityMismatchError) as exc_info:
+        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+
+    assert getattr(exc_info.value, 'failure_class', None) == FailureClass.CAPABILITY_MISMATCH
+    route = load_gateway_config(prod_mode=True).route_artifacts[ACTIVE_ROUTE]
+    assert not is_lkg_eligible(route, FailureClass.CAPABILITY_MISMATCH)
+
+
+def test_active_artifact_capability_mismatch_is_invalid_config():
+    base = load_gateway_config(prod_mode=True)
+    config = config_with_active_route(
+        base.route_artifacts[ACTIVE_ROUTE].model_copy(
+            update={
+                'capabilities': base.route_artifacts[ACTIVE_ROUTE].capabilities.model_copy(
+                    update={'structured_output': StructuredOutputMode.JSON_OBJECT}
+                )
+            }
+        )
+    )
+
+    with pytest.raises(GatewayInvalidRouteConfigError, match='capabilities mismatch') as exc_info:
+        resolve_chat_completion_route(config, valid_request())
+
+    assert exc_info.value.failure_class == FailureClass.INVALID_CONFIG
+
+
+def test_lkg_is_selected_only_for_active_route_policy_allowed_failure():
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+
+    selected = select_lkg_route_for_failure(resolved, FailureClass.TIMEOUT_BEFORE_OUTPUT)
+
+    assert selected is not None
+    assert selected.route_artifact_id == LKG_ROUTE
+
+
+@pytest.mark.parametrize(
+    'failure_class',
+    [
+        FailureClass.BYOK_AUTH,
+        FailureClass.BYOK_QUOTA,
+        FailureClass.BYOK_RATE_LIMIT,
+        FailureClass.BYOK_UNSUPPORTED_PROVIDER,
+        FailureClass.MISSING_BYOK_KEY,
+        FailureClass.CAPABILITY_MISMATCH,
+        FailureClass.INVALID_CONFIG,
+    ],
+)
+def test_lkg_rejected_for_byok_capability_and_config_failure_classes(failure_class):
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+
+    assert not is_lkg_eligible(resolved.active_route, failure_class)
+    assert select_lkg_route_for_failure(resolved, failure_class) is None
+
+
+def test_lkg_rejected_when_failure_not_in_active_route_fallback_policy():
+    base = load_gateway_config(prod_mode=True)
+    active_route = base.route_artifacts[ACTIVE_ROUTE]
+    config = config_with_active_route(
+        active_route.model_copy(
+            update={
+                'fallback_policy': active_route.fallback_policy.model_copy(
+                    update={
+                        'fallback_on': [FailureClass.TIMEOUT_BEFORE_OUTPUT],
+                        'never_fallback_on': active_route.fallback_policy.never_fallback_on,
+                    }
+                )
+            }
+        )
+    )
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    assert not is_lkg_eligible(resolved.active_route, FailureClass.PROVIDER_429_OMI_PAID)
+    assert select_lkg_route_for_failure(resolved, FailureClass.PROVIDER_429_OMI_PAID) is None
+
+
+def valid_request(**overrides):
+    request = {
+        'model': LANE_ID,
+        'messages': [{'role': 'user', 'content': 'Return JSON.'}],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'test_schema',
+                'schema': {
+                    'type': 'object',
+                    'properties': {'answer': {'type': 'string'}},
+                    'required': ['answer'],
+                    'additionalProperties': False,
+                },
+            },
+        },
+    }
+    request.update(overrides)
+    return request
+
+
+def config_with_active_route(active_route):
+    base = load_gateway_config(prod_mode=True)
+    route_artifacts = dict(base.route_artifacts)
+    route_artifacts[ACTIVE_ROUTE] = active_route
+    return GatewayConfig(
+        lanes=base.lanes,
+        route_artifacts=route_artifacts,
+        feature_bundles=base.feature_bundles,
+    )

--- a/backend/tests/unit/test_llm_gateway_route_refs.py
+++ b/backend/tests/unit/test_llm_gateway_route_refs.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from utils.llm import model_config
+from utils.llm.gateway_client import is_auto_lane_id
+from utils.llm.model_config import (
+    AutoLaneRouteRef,
+    ExplicitRouteRef,
+    get_model,
+    get_provider,
+    get_route_options,
+    get_route_ref,
+)
+
+
+def test_known_feature_returns_explicit_route_ref_without_changing_model_or_provider():
+    feature = 'conv_action_items'
+    before_model = get_model(feature)
+    before_provider = get_provider(feature)
+
+    route_ref = get_route_ref(feature)
+
+    assert route_ref == ExplicitRouteRef(
+        feature=feature,
+        model=before_model,
+        provider=before_provider,
+        options=get_route_options(feature, before_model, before_provider),
+    )
+    assert get_model(feature) == before_model
+    assert get_provider(feature) == before_provider
+
+
+def test_unknown_feature_route_ref_uses_default_explicit_route():
+    feature = 'unknown_route_ref_feature'
+
+    route_ref = get_route_ref(feature)
+
+    assert route_ref == ExplicitRouteRef(
+        feature=feature,
+        model='gpt-4.1-mini',
+        provider='openai',
+        options={},
+    )
+    assert get_model(feature) == 'gpt-4.1-mini'
+    assert get_provider(feature) == 'openai'
+
+
+def test_pinned_feature_route_ref_preserves_pinned_route_and_options():
+    route_ref = get_route_ref('fair_use')
+
+    assert route_ref == ExplicitRouteRef(
+        feature='fair_use',
+        model='gpt-5.1',
+        provider='openai',
+        options={'extra_body': {"prompt_cache_retention": "24h"}},
+    )
+    assert get_model('fair_use') == 'gpt-5.1'
+    assert get_provider('fair_use') == 'openai'
+
+
+def test_route_ref_preserves_provider_route_options():
+    openrouter_ref = get_route_ref('wrapped_analysis')
+    gemini_ref = get_route_ref('followup')
+
+    assert isinstance(openrouter_ref, ExplicitRouteRef)
+    assert openrouter_ref.provider == 'openrouter'
+    assert openrouter_ref.options == {'temperature': 0.7}
+
+    assert isinstance(gemini_ref, ExplicitRouteRef)
+    assert gemini_ref.provider == 'gemini'
+    assert gemini_ref.options == {'thinking_budget': 0}
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('omi:auto:chat-structured', True),
+        ('omi:auto:', True),
+        ('gpt-4.1-mini', False),
+        ('openai/gpt-4.1-mini', False),
+        (' omi:auto:chat-structured', False),
+        ('OMI:AUTO:chat-structured', False),
+        (None, False),
+    ],
+)
+def test_is_auto_lane_id_matches_gateway_namespace(value, expected):
+    assert is_auto_lane_id(value) is expected
+    assert model_config.is_auto_lane_id(value) is expected
+
+
+def test_auto_lane_mapping_is_opt_in_and_does_not_change_existing_direct_helpers(monkeypatch):
+    feature = 'chat_extraction'
+    before_model = get_model(feature)
+    before_provider = get_provider(feature)
+
+    monkeypatch.setitem(model_config._AUTO_LANE_FEATURES, feature, 'omi:auto:chat-structured')
+
+    route_ref = get_route_ref(feature)
+
+    assert route_ref == AutoLaneRouteRef(feature=feature, lane_id='omi:auto:chat-structured')
+    assert get_model(feature) == before_model
+    assert get_provider(feature) == before_provider
+
+
+def test_auto_lane_mapping_rejects_non_gateway_namespace(monkeypatch):
+    monkeypatch.setitem(model_config._AUTO_LANE_FEATURES, 'chat_extraction', 'gpt-4.1-mini')
+
+    with pytest.raises(ValueError, match='omi:auto'):
+        get_route_ref('chat_extraction')

--- a/backend/tests/unit/test_llm_gateway_service.py
+++ b/backend/tests/unit/test_llm_gateway_service.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from llm_gateway.main import app
+
+
+def test_llm_gateway_app_imports_and_health_is_public():
+    client = TestClient(app)
+
+    response = client.get('/health')
+
+    assert response.status_code == 200
+    assert response.json() == {'status': 'healthy'}

--- a/backend/tests/unit/test_llm_gateway_validator.py
+++ b/backend/tests/unit/test_llm_gateway_validator.py
@@ -80,6 +80,22 @@ def test_rejects_missing_json_schema_body():
         validate_chat_completion_request(request, lane)
 
 
+def test_rejects_missing_json_schema_name():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(
+        response_format={
+            'type': 'json_schema',
+            'json_schema': {
+                'strict': True,
+                'schema': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            },
+        }
+    )
+
+    with pytest.raises(GatewayInvalidRequestError, match='response_format.json_schema.name'):
+        validate_chat_completion_request(request, lane)
+
+
 def valid_request(**overrides):
     request = {
         'model': LANE_ID,

--- a/backend/tests/unit/test_llm_gateway_validator.py
+++ b/backend/tests/unit/test_llm_gateway_validator.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from llm_gateway.gateway.config_loader import load_gateway_config
+from llm_gateway.gateway.errors import GatewayCapabilityMismatchError, GatewayInvalidRequestError
+from llm_gateway.gateway.validator import validate_chat_completion_request
+
+LANE_ID = 'omi:auto:chat-structured'
+
+
+def test_accepts_non_streaming_text_messages_with_json_schema_output():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+
+    validated = validate_chat_completion_request(valid_request(), lane)
+
+    assert validated.model == LANE_ID
+    assert len(validated.messages) == 2
+    assert validated.response_format['type'] == 'json_schema'
+
+
+def test_rejects_streaming():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(stream=True)
+
+    with pytest.raises(GatewayCapabilityMismatchError, match='streaming'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_tools():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(tools=[{'type': 'function'}])
+
+    with pytest.raises(GatewayCapabilityMismatchError, match='tools'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_missing_messages():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request()
+    request.pop('messages')
+
+    with pytest.raises(GatewayInvalidRequestError, match='messages'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_invalid_messages():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(messages=[])
+
+    with pytest.raises(GatewayInvalidRequestError, match='messages'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_non_text_message_content():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(
+        messages=[
+            {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'https://example.com/image.png'}}]}
+        ]
+    )
+
+    with pytest.raises(GatewayCapabilityMismatchError, match='text message content'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_structured_output_modes_other_than_json_schema():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(response_format={'type': 'json_object'})
+
+    with pytest.raises(GatewayCapabilityMismatchError, match='json_schema'):
+        validate_chat_completion_request(request, lane)
+
+
+def test_rejects_missing_json_schema_body():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(response_format={'type': 'json_schema'})
+
+    with pytest.raises(GatewayInvalidRequestError, match='response_format.json_schema'):
+        validate_chat_completion_request(request, lane)
+
+
+def valid_request(**overrides):
+    request = {
+        'model': LANE_ID,
+        'messages': [
+            {'role': 'system', 'content': 'Return structured JSON.'},
+            {'role': 'user', 'content': 'Extract the memory.'},
+        ],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'memory_extraction',
+                'strict': True,
+                'schema': {
+                    'type': 'object',
+                    'properties': {'memory': {'type': 'string'}},
+                    'required': ['memory'],
+                    'additionalProperties': False,
+                },
+            },
+        },
+    }
+    request.update(overrides)
+    return request

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -21,7 +21,7 @@ from models.structured import ActionItem, Event
 from models.other import Person
 from models.transcript_segment import TranscriptSegment
 from utils.byok import has_byok_keys
-from utils.llm.gateway_client import invoke_chat_structured_gateway, is_llm_gateway_chat_extraction_enabled
+from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
 from utils.llms.memory import get_prompt_memories
 from utils.llm.usage_tracker import track_usage, Features
 
@@ -103,6 +103,7 @@ class DatesContext(BaseModel):
 
 
 def requires_context(question: str) -> bool:
+    feature = 'chat_extraction.requires_context'
     prompt = f'''
     Based on the current question your task is to determine whether the user is asking a question that requires context outside the conversation to be answered.
     Take as example: if the user is saying "Hi", "Hello", "How are you?", "Good morning", etc, the answer is False.
@@ -110,12 +111,12 @@ def requires_context(question: str) -> bool:
     User's Question:
     {question}
     '''
-    if is_llm_gateway_chat_extraction_enabled() and not has_byok_keys():
-        gateway_response = invoke_chat_structured_gateway(
-            prompt, RequiresContext, feature='chat_extraction.requires_context'
-        )
+    if not has_byok_keys():
+        gateway_response = invoke_chat_structured_gateway(prompt, RequiresContext, feature=feature)
         if gateway_response is not None:
             return gateway_response.value
+    else:
+        record_chat_extraction_gateway_result(feature=feature, outcome='skipped', reason='byok')
 
     with_parser = get_llm('chat_extraction').with_structured_output(RequiresContext)
     response: RequiresContext = with_parser.invoke(prompt)

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1,7 +1,6 @@
-from .clients import get_llm
 import json
-import re
 import os
+import re
 from datetime import datetime, timezone
 from typing import List, Optional
 from zoneinfo import ZoneInfo
@@ -21,8 +20,12 @@ from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, Event
 from models.other import Person
 from models.transcript_segment import TranscriptSegment
+from utils.byok import has_byok_keys
+from utils.llm.gateway_client import invoke_chat_structured_gateway, is_llm_gateway_chat_extraction_enabled
 from utils.llms.memory import get_prompt_memories
 from utils.llm.usage_tracker import track_usage, Features
+
+from .clients import get_llm
 import logging
 
 logger = logging.getLogger(__name__)
@@ -107,6 +110,13 @@ def requires_context(question: str) -> bool:
     User's Question:
     {question}
     '''
+    if is_llm_gateway_chat_extraction_enabled() and not has_byok_keys():
+        gateway_response = invoke_chat_structured_gateway(
+            prompt, RequiresContext, feature='chat_extraction.requires_context'
+        )
+        if gateway_response is not None:
+            return gateway_response.value
+
     with_parser = get_llm('chat_extraction').with_structured_output(RequiresContext)
     response: RequiresContext = with_parser.invoke(prompt)
     try:

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -6,9 +6,10 @@ from collections.abc import Mapping
 from typing import TypeVar
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
-LLM_GATEWAY_CHAT_EXTRACTION_ENABLED_ENV_VAR = 'OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED'
+from utils.metrics import LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS
+
 LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'OMI_LLM_GATEWAY_SERVICE_TOKEN'
 LEGACY_LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
 LLM_GATEWAY_URL_ENV_VAR = 'OMI_LLM_GATEWAY_URL'
@@ -34,11 +35,6 @@ def get_llm_gateway_service_token() -> str | None:
     return None
 
 
-def is_llm_gateway_chat_extraction_enabled() -> bool:
-    configured = os.getenv(LLM_GATEWAY_CHAT_EXTRACTION_ENABLED_ENV_VAR, '')
-    return configured.strip().lower() in {'1', 'true', 'yes', 'on'}
-
-
 def is_auto_lane_id(model_or_lane: object) -> bool:
     return isinstance(model_or_lane, str) and model_or_lane.startswith(LLM_GATEWAY_AUTO_LANE_PREFIX)
 
@@ -59,13 +55,42 @@ def invoke_chat_structured_gateway(
         response.raise_for_status()
         content = _extract_choice_content(response.json())
         if not isinstance(content, str) or not content.strip():
+            record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='empty_content')
             return None
-        decoded = json.loads(content)
+        try:
+            decoded = json.loads(content)
+        except json.JSONDecodeError:
+            record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='invalid_json')
+            return None
         if not isinstance(decoded, Mapping):
+            record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='invalid_json_shape')
             return None
-        return _validate_output_model(output_model, decoded)
-    except Exception:
+        result = _validate_output_model(output_model, decoded)
+        record_chat_extraction_gateway_result(feature=feature, outcome='success', reason='ok')
+        return result
+    except httpx.HTTPStatusError as exc:
+        reason = f'http_{exc.response.status_code}' if exc.response is not None else 'http_status'
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason=reason)
         return None
+    except httpx.TimeoutException:
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='timeout')
+        return None
+    except httpx.RequestError:
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='request_error')
+        return None
+    except ValidationError:
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='schema_validation')
+        return None
+    except Exception:
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='unexpected_error')
+        return None
+
+
+def record_chat_extraction_gateway_result(*, feature: str, outcome: str, reason: str) -> None:
+    try:
+        LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS.labels(feature=feature, outcome=outcome, reason=reason).inc()
+    except Exception:
+        pass
 
 
 def _gateway_headers() -> dict[str, str]:

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+
+LLM_GATEWAY_URL_ENV_VAR = 'OMI_LLM_GATEWAY_URL'
+DEFAULT_LLM_GATEWAY_URL = 'http://127.0.0.1:9080'
+
+
+def get_llm_gateway_base_url() -> str:
+    configured = os.getenv(LLM_GATEWAY_URL_ENV_VAR, '').strip()
+    return configured.rstrip('/') if configured else DEFAULT_LLM_GATEWAY_URL

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -45,15 +45,24 @@ def invoke_chat_structured_gateway(
     *,
     feature: str,
 ) -> StructuredOutput | None:
+    """Call the LLM gateway for chat structured extraction (pilot).
+
+    This is a **synchronous** function intended to be called only from sync
+    ``def`` call sites (e.g. ``requires_context``). When such a sync function
+    is invoked by FastAPI it runs inside a threadpool, so the blocking HTTP
+    call does not stall the event loop. Do **not** call this from ``async def``
+    code without first offloading via ``run_blocking(llm_executor, ...)``.
+    """
     try:
-        response = httpx.post(
-            f'{get_llm_gateway_base_url()}/v1/chat/completions',
-            headers=_gateway_headers(),
-            json=_chat_structured_payload(prompt, output_model, feature=feature),
-            timeout=CHAT_EXTRACTION_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        content = _extract_choice_content(response.json())
+        with httpx.Client(timeout=CHAT_EXTRACTION_TIMEOUT_SECONDS) as client:
+            response = client.post(
+                f'{get_llm_gateway_base_url()}/v1/chat/completions',
+                headers=_gateway_headers(),
+                json=_chat_structured_payload(prompt, output_model, feature=feature),
+            )
+            response.raise_for_status()
+            response_body = response.json()
+        content = _extract_choice_content(response_body)
         if not isinstance(content, str) or not content.strip():
             record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='empty_content')
             return None
@@ -113,7 +122,7 @@ def _chat_structured_payload(prompt: str, output_model: type[BaseModel], *, feat
             'json_schema': {
                 'name': output_model.__name__,
                 'strict': True,
-                'schema': _model_json_schema(output_model),
+                'schema': _strict_model_json_schema(output_model),
             },
         },
         'metadata': {
@@ -124,10 +133,42 @@ def _chat_structured_payload(prompt: str, output_model: type[BaseModel], *, feat
     }
 
 
-def _model_json_schema(output_model: type[BaseModel]) -> dict:
-    if hasattr(output_model, 'model_json_schema'):
-        return output_model.model_json_schema()
-    return output_model.schema()
+def _strict_model_json_schema(output_model: type[BaseModel]) -> dict:
+    """Generate a strict-compatible JSON Schema for OpenAI Structured Outputs.
+
+    OpenAI requires every object schema to include ``additionalProperties: false``
+    when ``strict`` mode is set. Pydantic's ``model_json_schema()`` does not add
+    that by default, so we inject it recursively for all ``type: object`` schemas.
+    """
+    schema = output_model.model_json_schema()
+    _enforce_additional_properties_false(schema)
+    return schema
+
+
+def _enforce_additional_properties_false(schema: dict) -> None:
+    """Recursively add ``additionalProperties: false`` to all object schemas."""
+    if not isinstance(schema, dict):
+        return
+    if schema.get('type') == 'object' and 'additionalProperties' not in schema:
+        schema['additionalProperties'] = False
+    # Recurse into nested schemas under $defs, properties, items, etc.
+    for key in ('$defs', 'definitions'):
+        defs = schema.get(key)
+        if isinstance(defs, dict):
+            for def_schema in defs.values():
+                _enforce_additional_properties_false(def_schema)
+    properties = schema.get('properties')
+    if isinstance(properties, dict):
+        for prop_schema in properties.values():
+            _enforce_additional_properties_false(prop_schema)
+    items = schema.get('items')
+    if isinstance(items, dict):
+        _enforce_additional_properties_false(items)
+    for ref_key in ('anyOf', 'oneOf', 'allOf'):
+        alternatives = schema.get(ref_key)
+        if isinstance(alternatives, list):
+            for alt_schema in alternatives:
+                _enforce_additional_properties_false(alt_schema)
 
 
 def _extract_choice_content(response_body: object) -> object:
@@ -149,6 +190,4 @@ def _validate_output_model(
     output_model: type[StructuredOutput],
     decoded: Mapping[str, object],
 ) -> StructuredOutput:
-    if hasattr(output_model, 'model_validate'):
-        return output_model.model_validate(decoded)
-    return output_model.parse_obj(decoded)
+    return output_model.model_validate(decoded)

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -4,8 +4,13 @@ import os
 
 LLM_GATEWAY_URL_ENV_VAR = 'OMI_LLM_GATEWAY_URL'
 DEFAULT_LLM_GATEWAY_URL = 'http://127.0.0.1:9080'
+LLM_GATEWAY_AUTO_LANE_PREFIX = 'omi:auto:'
 
 
 def get_llm_gateway_base_url() -> str:
     configured = os.getenv(LLM_GATEWAY_URL_ENV_VAR, '').strip()
     return configured.rstrip('/') if configured else DEFAULT_LLM_GATEWAY_URL
+
+
+def is_auto_lane_id(model_or_lane: object) -> bool:
+    return isinstance(model_or_lane, str) and model_or_lane.startswith(LLM_GATEWAY_AUTO_LANE_PREFIX)

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
+import json
 import os
+from collections.abc import Mapping
+from typing import TypeVar
 
+import httpx
+from pydantic import BaseModel
+
+LLM_GATEWAY_CHAT_EXTRACTION_ENABLED_ENV_VAR = 'OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED'
+LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'OMI_LLM_GATEWAY_SERVICE_TOKEN'
+LEGACY_LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
 LLM_GATEWAY_URL_ENV_VAR = 'OMI_LLM_GATEWAY_URL'
 DEFAULT_LLM_GATEWAY_URL = 'http://127.0.0.1:9080'
 LLM_GATEWAY_AUTO_LANE_PREFIX = 'omi:auto:'
+CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
+LLM_GATEWAY_CALLER = 'backend'
+CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
+
+StructuredOutput = TypeVar('StructuredOutput', bound=BaseModel)
 
 
 def get_llm_gateway_base_url() -> str:
@@ -12,5 +26,104 @@ def get_llm_gateway_base_url() -> str:
     return configured.rstrip('/') if configured else DEFAULT_LLM_GATEWAY_URL
 
 
+def get_llm_gateway_service_token() -> str | None:
+    for env_var in (LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR, LEGACY_LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR):
+        configured = os.getenv(env_var)
+        if configured is not None and configured.strip():
+            return configured.strip()
+    return None
+
+
+def is_llm_gateway_chat_extraction_enabled() -> bool:
+    configured = os.getenv(LLM_GATEWAY_CHAT_EXTRACTION_ENABLED_ENV_VAR, '')
+    return configured.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
 def is_auto_lane_id(model_or_lane: object) -> bool:
     return isinstance(model_or_lane, str) and model_or_lane.startswith(LLM_GATEWAY_AUTO_LANE_PREFIX)
+
+
+def invoke_chat_structured_gateway(
+    prompt: str,
+    output_model: type[StructuredOutput],
+    *,
+    feature: str,
+) -> StructuredOutput | None:
+    try:
+        response = httpx.post(
+            f'{get_llm_gateway_base_url()}/v1/chat/completions',
+            headers=_gateway_headers(),
+            json=_chat_structured_payload(prompt, output_model, feature=feature),
+            timeout=CHAT_EXTRACTION_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        content = _extract_choice_content(response.json())
+        if not isinstance(content, str) or not content.strip():
+            return None
+        decoded = json.loads(content)
+        if not isinstance(decoded, Mapping):
+            return None
+        return _validate_output_model(output_model, decoded)
+    except Exception:
+        return None
+
+
+def _gateway_headers() -> dict[str, str]:
+    headers = {
+        'Content-Type': 'application/json',
+        'X-Omi-Service-Caller': LLM_GATEWAY_CALLER,
+    }
+    service_token = get_llm_gateway_service_token()
+    if service_token is not None:
+        headers['Authorization'] = f'Bearer {service_token}'
+    return headers
+
+
+def _chat_structured_payload(prompt: str, output_model: type[BaseModel], *, feature: str) -> dict:
+    return {
+        'model': CHAT_STRUCTURED_AUTO_LANE_ID,
+        'messages': [{'role': 'user', 'content': prompt}],
+        'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': output_model.__name__,
+                'strict': True,
+                'schema': _model_json_schema(output_model),
+            },
+        },
+        'metadata': {
+            'omi_feature': feature,
+            'prompt_version': f'{feature}.v1',
+            'parser_version': f'{output_model.__name__}.v1',
+        },
+    }
+
+
+def _model_json_schema(output_model: type[BaseModel]) -> dict:
+    if hasattr(output_model, 'model_json_schema'):
+        return output_model.model_json_schema()
+    return output_model.schema()
+
+
+def _extract_choice_content(response_body: object) -> object:
+    if not isinstance(response_body, Mapping):
+        return None
+    choices = response_body.get('choices')
+    if not isinstance(choices, list) or not choices:
+        return None
+    first_choice = choices[0]
+    if not isinstance(first_choice, Mapping):
+        return None
+    message = first_choice.get('message')
+    if not isinstance(message, Mapping):
+        return None
+    return message.get('content')
+
+
+def _validate_output_model(
+    output_model: type[StructuredOutput],
+    decoded: Mapping[str, object],
+) -> StructuredOutput:
+    if hasattr(output_model, 'model_validate'):
+        return output_model.model_validate(decoded)
+    return output_model.parse_obj(decoded)

--- a/backend/utils/llm/model_config.py
+++ b/backend/utils/llm/model_config.py
@@ -7,9 +7,29 @@ continue to use ``clients.get_llm(feature)``.
 
 import logging
 import os
-from typing import Dict, Tuple
+from dataclasses import dataclass
+from typing import Dict, Tuple, Union
+
+from utils.llm.gateway_client import is_auto_lane_id
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExplicitRouteRef:
+    feature: str
+    model: str
+    provider: str
+    options: Dict[str, object]
+
+
+@dataclass(frozen=True)
+class AutoLaneRouteRef:
+    feature: str
+    lane_id: str
+
+
+RouteRef = Union[ExplicitRouteRef, AutoLaneRouteRef]
 
 # ---------------------------------------------------------------------------
 # Model QoS Profile System
@@ -225,6 +245,11 @@ _STRUCTURED_OUTPUT_FEATURES = {
 
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
+# Future migration point for features that should call the gateway via an auto
+# lane. Keep empty until a ticket explicitly wires and verifies shadow/live
+# traffic; existing direct LLM routing never consults this map.
+_AUTO_LANE_FEATURES: Dict[str, str] = {}
+
 
 def _get_model_config(feature: str) -> Tuple[str, str]:
     """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
@@ -273,6 +298,29 @@ def get_route_options(feature: str, model: str, provider: str) -> Dict[str, obje
         # Mechanical Gemini-routed features do not need paid thinking tokens.
         options['thinking_budget'] = 0
     return options
+
+
+def get_route_ref(feature: str) -> RouteRef:
+    """Return the typed route reference for a feature without changing legacy routing.
+
+    Existing features resolve to explicit provider/model refs by default. Auto-lane
+    refs are opt-in through _AUTO_LANE_FEATURES and are not used by get_model(),
+    get_provider(), or get_llm().
+    """
+
+    lane_id = _AUTO_LANE_FEATURES.get(feature)
+    if lane_id is not None:
+        if not is_auto_lane_id(lane_id):
+            raise ValueError(f"Auto lane route for feature '{feature}' must use omi:auto: namespace")
+        return AutoLaneRouteRef(feature=feature, lane_id=lane_id)
+
+    model, provider = _get_model_config(feature)
+    return ExplicitRouteRef(
+        feature=feature,
+        model=model,
+        provider=provider,
+        options=get_route_options(feature, model, provider),
+    )
 
 
 def supports_prompt_cache(model: str) -> bool:

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -26,6 +26,12 @@ PUSHER_SESSION_DEGRADED = Gauge(
     'Number of sessions currently in degraded mode (pusher unavailable)',
 )
 
+LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS = Counter(
+    'llm_gateway_chat_extraction_requests_total',
+    'Chat extraction requests routed through or around the LLM gateway',
+    ['feature', 'outcome', 'reason'],
+)
+
 
 def metrics_response() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -225,15 +225,15 @@ Or an Omi lane:
   "response_format": {
     "type": "json_schema",
     "json_schema": {
-      "name": "memory_extraction",
+      "name": "RequiresContext",
       "strict": true,
       "schema": {}
     }
   },
   "metadata": {
-    "omi_feature": "memories",
-    "prompt_version": "memory_extraction.v17",
-    "parser_version": "memory_schema.v9"
+    "omi_feature": "chat_extraction.requires_context",
+    "prompt_version": "chat_extraction.requires_context.v1",
+    "parser_version": "RequiresContext.v1"
   }
 }
 ```
@@ -299,7 +299,7 @@ primary:
   model: gpt-4.1-mini
 fallbacks:
   - provider: openai
-    model: gpt-5.4-mini
+    model: gpt-4.1-mini
 timeouts:
   request_ms: 8000
 retry:
@@ -308,10 +308,11 @@ capabilities:
   structured_output: json_schema
   streaming: false
 evidence:
-  benchmark_snapshot: bench.aa.2026_06_27
-  eval_report: eval.memory_extraction.2026_06_27
+  benchmark_snapshot: bench.omi.chat_structured.2026_06_27
+  eval_report: eval.chat_extraction_requires_context.2026_06_27
 rollout:
   stage: shadow
+  percent: 0
 credential_policy:
   mode: omi_paid
   allow_byok_to_omi_paid_fallback: false
@@ -333,15 +334,15 @@ artifact_digest: sha256:<computed-by-validation>
 Feature bundle:
 
 ```yaml
-feature: memories
+feature: chat_extraction.requires_context
 lane_id: omi:auto:chat-structured
-prompt_version: memory_extraction.v17
-parser_version: memory_schema.v9
-eval_suite: memory_precision_recall.v5
+prompt_version: chat_extraction.requires_context.v1
+parser_version: RequiresContext.v1
+eval_suite: chat_extraction_requires_context.v1
 promotion_gates:
   schema_valid_rate: ">= 99.5%"
-  precision_regression: "none"
-  recall_delta: ">= 0"
+  classification_agreement_delta: ">= 0"
+  false_negative_regression: "none"
   p95_latency_ms: "<= LKG + 10%"
   cost_per_success: "<= LKG + 15%"
 ```

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -349,11 +349,14 @@ Validation rejects duplicate `route_artifact_id` values and exposes a content di
 ```python
 @dataclass(frozen=True)
 class ExplicitRouteRef:
+    feature: str
     model: str
     provider: str
+    options: dict[str, object]
 
 @dataclass(frozen=True)
 class AutoLaneRouteRef:
+    feature: str
     lane_id: str
 ```
 
@@ -371,7 +374,9 @@ get_route_ref(feature) -> ExplicitRouteRef | AutoLaneRouteRef
 is_auto_lane_id(model: str) -> bool
 ```
 
-Backend callers that use `get_llm(feature)` can be migrated feature by feature. For the first pilot, route only one structured feature through the gateway and keep all other features explicit.
+Implemented route refs are additive only. `get_route_ref(feature)` currently returns an `ExplicitRouteRef` for every existing feature by default, including pinned routes, profile routes, fallback routes, and provider/model construction options from `get_route_options(feature, model, provider)`. `AutoLaneRouteRef` is available behind an intentionally empty feature-to-lane mapping in `model_config.py` so a later ticket can map selected features to `omi:auto:chat-structured` without changing the legacy helpers.
+
+Backend callers that use `get_llm(feature)` can be migrated feature by feature. This route-ref ticket does not migrate any production callsite, does not send shadow traffic, and does not change return values from `get_model(feature)`, `get_provider(feature)`, or `get_llm(feature)`. For the first pilot, route only one structured feature through the gateway and keep all other features explicit.
 
 ## BYOK Policy
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, `/health`, repo-local config schemas/loader, and checked-in `omi:auto:chat-structured` lane artifacts.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, and request-level credential context helpers.
 
 ## Decision
 
@@ -108,8 +108,6 @@ Planned modules:
 
 ```text
 backend/llm_gateway/gateway/
-  auth.py
-  credentials.py
   validator.py
   resolver.py
   executor.py
@@ -119,6 +117,10 @@ backend/llm_gateway/gateway/
 ```
 
 Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
+
+Implemented internal service auth uses `Authorization: Bearer <LLM_GATEWAY_SERVICE_TOKEN>` plus `X-Omi-Service-Caller`. The default allowlist is low-cardinality service names `backend` and `pusher`; optional `X-Omi-User-Uid` and `X-Omi-Tenant-Id` populate request context only. `/health` remains unauthenticated. Future `/ready` and `/v1/chat/completions` routes should depend on these helpers instead of Firebase user auth.
+
+Credential context is request-level metadata. It records credential mode, caller, and provider-key presence or approved key references without exposing raw key material in model dumps or repr output. BYOK credential failures such as missing key, invalid auth, quota, rate-limit, and unsupported provider are visible errors and are not fallback-eligible by default.
 
 ## Deployment Shape
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -6,9 +6,9 @@ description: "Architecture for Omi's internal LLM routing gateway, auto lanes, r
 
 # LLM Gateway Architecture
 
-> Status: v1 foundation implemented; first backend pilot is available behind an off-by-default flag.
+> Status: v1 foundation implemented; first backend pilot is code-on by default with application-level fallback.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, local service URL configuration for backend callers, and a gated `chat_extraction.requires_context` caller pilot.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, local service URL configuration for backend callers, and a code-on `chat_extraction.requires_context` caller pilot with application-level fallback.
 
 ## Decision
 
@@ -38,11 +38,13 @@ For v1, this is the only supported OpenAI-compatible chat-completions interface.
 
 `chat-structured` is for non-streaming structured extraction and classification work, such as memory extraction, chat extraction helpers, conversation post-processing structure, and schema-bound feature decisions. It is the safest first lane because it has clear success checks: JSON/schema validity, parser repair rate, extraction precision/recall, latency, and cost.
 
-The first concrete backend pilot is `utils.llm.chat.requires_context(question: str) -> bool`, enabled only when `OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED=true`. When the flag is off, the helper does not call the gateway and continues to use `get_llm('chat_extraction').with_structured_output(RequiresContext)`.
+The first concrete backend pilot is `utils.llm.chat.requires_context(question: str) -> bool`. Non-BYOK requests call the gateway first and fall back to the existing provider path if the gateway misses or fails, so this is an infrastructure change with no intended user-visible behavior change.
 
-When the flag is on, non-BYOK requests call `/v1/chat/completions` first with `model: "omi:auto:chat-structured"`, text-only messages, and a JSON schema response format for `RequiresContext`. The caller sends low-cardinality metadata identifying `chat_extraction.requires_context`, not raw user text in logs or telemetry. Service auth uses the existing bearer-token contract; backend callers read `OMI_LLM_GATEWAY_SERVICE_TOKEN` first and then `LLM_GATEWAY_SERVICE_TOKEN` for local compatibility.
+Non-BYOK requests call `/v1/chat/completions` first with `model: "omi:auto:chat-structured"`, text-only messages, and a JSON schema response format for `RequiresContext`. The caller sends low-cardinality metadata identifying `chat_extraction.requires_context`, not raw user text in logs or telemetry. Service auth uses the existing bearer-token contract; backend callers read `OMI_LLM_GATEWAY_SERVICE_TOKEN` first and then `LLM_GATEWAY_SERVICE_TOKEN` for local compatibility.
 
 BYOK requests skip this pilot because gateway BYOK forwarding is not implemented yet. The application-level fallback is the safety mechanism: any gateway HTTP error, timeout, unsupported capability response, malformed JSON, missing or invalid content, Pydantic validation failure, or unexpected exception falls back to the existing `get_llm('chat_extraction').with_structured_output(...)` path and returns that result. The pilot does not depend on gateway route/LKG fallback; if the gateway internally returns an error after trying its configured policy, the caller still treats that as a miss and uses the existing path.
+
+The backend exposes the Prometheus counter `llm_gateway_chat_extraction_requests_total{feature,outcome,reason}` for this pilot. Current outcomes are `success`, `fallback`, and `skipped`; reasons are bounded classes such as `ok`, `timeout`, `request_error`, `http_503`, `invalid_json`, `schema_validation`, `unexpected_error`, and `byok`.
 
 Primary user chat should follow later as a separate lane, likely:
 
@@ -382,7 +384,7 @@ is_auto_lane_id(model: str) -> bool
 
 Implemented route refs are additive only. `get_route_ref(feature)` currently returns an `ExplicitRouteRef` for every existing feature by default, including pinned routes, profile routes, fallback routes, and provider/model construction options from `get_route_options(feature, model, provider)`. `AutoLaneRouteRef` is available behind an intentionally empty feature-to-lane mapping in `model_config.py` so a later ticket can map selected features to `omi:auto:chat-structured` without changing the legacy helpers.
 
-Backend callers that use `get_llm(feature)` can be migrated feature by feature. Route refs do not change return values from `get_model(feature)`, `get_provider(feature)`, or `get_llm(feature)`. The first pilot routes only `utils.llm.chat.requires_context` through the gateway when `OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED=true`; all other `chat_extraction` helpers remain on the existing explicit path.
+Backend callers that use `get_llm(feature)` can be migrated feature by feature. Route refs do not change return values from `get_model(feature)`, `get_provider(feature)`, or `get_llm(feature)`. The first pilot routes only non-BYOK `utils.llm.chat.requires_context` calls through the gateway first; all other `chat_extraction` helpers remain on the existing explicit path.
 
 ## BYOK Policy
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor with fake providers for deterministic tests, and local service URL configuration for backend callers.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, and local service URL configuration for backend callers.
 
 ## Decision
 
@@ -110,7 +110,7 @@ backend/llm_gateway/
     validator.py
     resolver.py
     executor.py
-    providers.py
+  providers.py
 ```
 
 Planned modules:
@@ -449,7 +449,7 @@ Runtime fail-open means active route failure may use LKG only for failure classe
 - maps typed gateway exceptions to OpenAI-style error envelopes with `error.message`, `error.type`, `error.param`, and `error.code`;
 - rejects unknown auto lanes, bare provider model names, streaming, tools, and unsupported capabilities before provider execution.
 
-The default provider registry is empty until live provider adapters are wired, so the route fails closed with `invalid_route_config` unless tests or deployment code provide a registry. That is intentional: the route exists before it can accidentally proxy arbitrary model traffic.
+The default provider registry includes the OpenAI-compatible adapter for the checked-in `openai` provider route. It uses `OPENAI_API_KEY` and optional `OPENAI_BASE_URL`, posts to `/chat/completions` with `httpx.AsyncClient`, and fails closed with `invalid_route_config` when the managed key is absent or rejected. Tests can still override the registry with fake providers.
 
 ## Provider Execution
 
@@ -469,7 +469,12 @@ Fallback is deliberately narrow:
 - Omi-paid timeout before output, provider 429, and provider 5xx may fall back only when the route artifact allows those classes;
 - streaming-after-first-token recovery is unsupported for MVP. The executor assumes no partial output exists and does not try to recover or replay partial responses.
 
-The current provider abstraction is an async protocol plus in-memory fake providers for unit tests. Live provider HTTP adapters should use pooled `httpx.AsyncClient` instances and must not log raw provider response bodies, prompts, transcripts, screenshots, memory contents, or BYOK keys.
+The current provider abstraction is an async protocol plus:
+
+- `OpenAICompatibleChatCompletionProvider` for live non-streaming OpenAI-compatible calls;
+- in-memory fake providers for unit tests.
+
+The live adapter does not log raw provider response bodies, prompts, transcripts, screenshots, memory contents, or BYOK keys. It maps missing Omi-managed keys and provider 401/403 responses to config failure, provider 429 to Omi-paid rate-limit failure, provider 5xx/network failures to Omi-paid provider failure, and provider 4xx request failures to capability mismatch.
 
 ## Observability
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -6,9 +6,9 @@ description: "Architecture for Omi's internal LLM routing gateway, auto lanes, r
 
 # LLM Gateway Architecture
 
-> Status: v1 foundation implemented; not yet receiving production traffic.
+> Status: v1 foundation implemented; first backend pilot is available behind an off-by-default flag.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, and local service URL configuration for backend callers.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, local service URL configuration for backend callers, and a gated `chat_extraction.requires_context` caller pilot.
 
 ## Decision
 
@@ -37,6 +37,12 @@ omi:auto:chat-structured
 For v1, this is the only supported OpenAI-compatible chat-completions interface. It is structured and non-streaming. The broader streaming product chat path remains `/v2/messages`, backed by the retrieval and agentic chat graph documented in [Chat System Architecture](/doc/developer/backend/chat_system).
 
 `chat-structured` is for non-streaming structured extraction and classification work, such as memory extraction, chat extraction helpers, conversation post-processing structure, and schema-bound feature decisions. It is the safest first lane because it has clear success checks: JSON/schema validity, parser repair rate, extraction precision/recall, latency, and cost.
+
+The first concrete backend pilot is `utils.llm.chat.requires_context(question: str) -> bool`, enabled only when `OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED=true`. When the flag is off, the helper does not call the gateway and continues to use `get_llm('chat_extraction').with_structured_output(RequiresContext)`.
+
+When the flag is on, non-BYOK requests call `/v1/chat/completions` first with `model: "omi:auto:chat-structured"`, text-only messages, and a JSON schema response format for `RequiresContext`. The caller sends low-cardinality metadata identifying `chat_extraction.requires_context`, not raw user text in logs or telemetry. Service auth uses the existing bearer-token contract; backend callers read `OMI_LLM_GATEWAY_SERVICE_TOKEN` first and then `LLM_GATEWAY_SERVICE_TOKEN` for local compatibility.
+
+BYOK requests skip this pilot because gateway BYOK forwarding is not implemented yet. The application-level fallback is the safety mechanism: any gateway HTTP error, timeout, unsupported capability response, malformed JSON, missing or invalid content, Pydantic validation failure, or unexpected exception falls back to the existing `get_llm('chat_extraction').with_structured_output(...)` path and returns that result. The pilot does not depend on gateway route/LKG fallback; if the gateway internally returns an error after trying its configured policy, the caller still treats that as a miss and uses the existing path.
 
 Primary user chat should follow later as a separate lane, likely:
 
@@ -376,7 +382,7 @@ is_auto_lane_id(model: str) -> bool
 
 Implemented route refs are additive only. `get_route_ref(feature)` currently returns an `ExplicitRouteRef` for every existing feature by default, including pinned routes, profile routes, fallback routes, and provider/model construction options from `get_route_options(feature, model, provider)`. `AutoLaneRouteRef` is available behind an intentionally empty feature-to-lane mapping in `model_config.py` so a later ticket can map selected features to `omi:auto:chat-structured` without changing the legacy helpers.
 
-Backend callers that use `get_llm(feature)` can be migrated feature by feature. This route-ref ticket does not migrate any production callsite, does not send shadow traffic, and does not change return values from `get_model(feature)`, `get_provider(feature)`, or `get_llm(feature)`. For the first pilot, route only one structured feature through the gateway and keep all other features explicit.
+Backend callers that use `get_llm(feature)` can be migrated feature by feature. Route refs do not change return values from `get_model(feature)`, `get_provider(feature)`, or `get_llm(feature)`. The first pilot routes only `utils.llm.chat.requires_context` through the gateway when `OMI_LLM_GATEWAY_CHAT_EXTRACTION_ENABLED=true`; all other `chat_extraction` helpers remain on the existing explicit path.
 
 ## BYOK Policy
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -200,7 +200,7 @@ prod: based-hardware     / OMI_LLM_GATEWAY_SERVICE_TOKEN
 
 Do not use remote config for this rollout. Rotate the service token through Secret Manager and ExternalSecrets, not through app config.
 
-The chart exposes only a `ClusterIP` service. `/health` is unauthenticated. Kubernetes liveness/startup probes call `/health`; readiness uses an `exec` probe that reads `OMI_LLM_GATEWAY_SERVICE_TOKEN` from pod env and calls `/ready` with `Authorization: Bearer ...` plus `X-Omi-Service-Caller: backend`.
+The chart exposes only a `ClusterIP` service. `/health` is unauthenticated. Kubernetes liveness/startup/readiness probes call `/health`; the deployment workflow then runs an in-cluster authenticated smoke test against `/ready` and `/v1/chat/completions` with `Authorization: Bearer ...` plus `X-Omi-Service-Caller: backend`.
 
 Before any deploy, validate the values files:
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -1,12 +1,12 @@
 ---
 title: "LLM Gateway"
 icon: "route"
-description: "Architecture spec for Omi's internal LLM routing gateway, auto lanes, route artifacts, and first chat-structured pilot."
+description: "Architecture for Omi's internal LLM routing gateway, auto lanes, route artifacts, and first chat-structured pilot."
 ---
 
 # LLM Gateway Architecture
 
-> Status: implemented architecture in progress.
+> Status: v1 foundation implemented; not yet receiving production traffic.
 >
 > Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, and local service URL configuration for backend callers.
 
@@ -500,9 +500,9 @@ cohort
 
 Do not log raw prompts, transcripts, screenshots, memory contents, provider response bodies, or BYOK keys. Use existing sanitizer patterns for error bodies and user text.
 
-## Implementation Sequence
+## Build Status
 
-1. Add this doc and an implementation checklist. Done.
+1. Add this architecture doc and temporary implementation tickets. Done.
 2. Add `llm_gateway` service skeleton with health endpoint. Done.
 3. Add Pydantic schemas for lane config, route artifacts, feature bundles, capability declarations, retries, timeouts, rollout, evidence, credential policy, fallback policy, and LKG. Done.
 4. Add service-auth and credential-policy contracts. Done.
@@ -511,7 +511,7 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 7. Add provider executor with fake providers and fallback/error normalization tests. Done.
 8. Add `/v1/chat/completions` non-streaming support behind service auth. Done.
 9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic. Partially done: `/ready`, local run command, and URL config are implemented; Docker/Helm deployment wiring is still pending.
-10. Add gateway client helper in main backend so selected `model_config.py` features can call the gateway.
+10. Add route refs and gateway URL helpers in main backend so selected `model_config.py` features can call the gateway later. Done.
 11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode.
 12. Add Omi eval reports and promote only after schema validity, extraction quality, latency, and cost gates pass.
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -6,9 +6,9 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 # LLM Gateway Architecture
 
-> Status: architecture spec for implementation coordination.
+> Status: implemented architecture in progress.
 >
-> Scope: repo-owned gateway service, repo-checked configuration, first lane `omi:auto:chat-structured`.
+> Implemented so far: separate FastAPI service skeleton, `/health`, repo-local config schemas/loader, and checked-in `omi:auto:chat-structured` lane artifacts.
 
 ## Decision
 
@@ -87,7 +87,7 @@ Reasons:
 
 Do not make the gateway a Swift, Rust, Node, Go, or Kubernetes-controller project for v1. Those choices would increase operational and review burden without helping the first `chat-structured` lane.
 
-Recommended service layout:
+Current service layout:
 
 ```text
 backend/llm_gateway/
@@ -102,16 +102,23 @@ backend/llm_gateway/
   gateway/
     schemas.py
     config_loader.py
-    validator.py
-    resolver.py
-    executor.py
-    providers.py
-    metrics.py
-    errors.py
-  tests/
 ```
 
-The exact directory can change during implementation, but keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
+Planned modules:
+
+```text
+backend/llm_gateway/gateway/
+  auth.py
+  credentials.py
+  validator.py
+  resolver.py
+  executor.py
+  providers.py
+  metrics.py
+  errors.py
+```
+
+Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
 
 ## Deployment Shape
 
@@ -232,6 +239,16 @@ Provider/model details stay internal by default.
 
 All config is checked into this repo for v1.
 
+Implemented config files:
+
+```text
+backend/llm_gateway/config/lanes.yaml
+backend/llm_gateway/config/route_artifacts.yaml
+backend/llm_gateway/config/feature_bundles.yaml
+```
+
+`backend/llm_gateway/gateway/config_loader.py` loads those files by default, validates cross-file references, rejects duplicate route IDs, validates active/LKG compatibility, rejects dev/mock evidence in prod mode, and validates route artifact digests.
+
 Lane config:
 
 ```yaml
@@ -309,7 +326,7 @@ promotion_gates:
 
 Route artifacts are immutable. Promotion creates a new artifact and updates the lane pointer. Rollback updates the lane pointer back to LKG.
 
-Validation must reject duplicate `route_artifact_id` values and expose a content digest for every artifact. Once an artifact ID has shipped, changing its content is treated as invalid operational behavior; create a new artifact ID instead.
+Validation rejects duplicate `route_artifact_id` values and exposes a content digest for every artifact. Checked-in artifacts should include `artifact_digest`; if the artifact content changes without changing the digest, validation fails. Once an artifact ID has shipped, changing its content is treated as invalid operational behavior; create a new artifact ID instead.
 
 ## Integration With Existing Backend Code
 
@@ -417,9 +434,9 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 
 ## Implementation Sequence
 
-1. Add this doc and an implementation checklist.
-2. Add `llm_gateway` service skeleton with health endpoint and config validation command.
-3. Add Pydantic schemas for lane config, route artifacts, feature bundles, capability declarations, retries, timeouts, rollout, and LKG.
+1. Add this doc and an implementation checklist. Done.
+2. Add `llm_gateway` service skeleton with health endpoint. Done.
+3. Add Pydantic schemas for lane config, route artifacts, feature bundles, capability declarations, retries, timeouts, rollout, evidence, credential policy, fallback policy, and LKG. Done.
 4. Add service-auth and credential-policy contracts.
 5. Add resolver tests with no network calls.
 6. Add capability validator tests for `chat-structured`.

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -1,0 +1,477 @@
+---
+title: "LLM Gateway"
+icon: "route"
+description: "Architecture spec for Omi's internal LLM routing gateway, auto lanes, route artifacts, and first chat-structured pilot."
+---
+
+# LLM Gateway Architecture
+
+> Status: architecture spec for implementation coordination.
+>
+> Scope: repo-owned gateway service, repo-checked configuration, first lane `omi:auto:chat-structured`.
+
+## Decision
+
+Build a separate **LLM Gateway** service in this repo. Backend, pusher, and later desktop-facing relay surfaces call it through an OpenAI-compatible HTTP surface instead of choosing providers directly for auto-routed work.
+
+The gateway is intentionally narrow:
+
+- Accept explicit model IDs exactly as before, or `omi:auto:*` lane IDs.
+- Resolve an auto lane to a versioned route artifact.
+- Validate request capabilities before execution.
+- Execute the primary provider/model and compatible fallbacks.
+- Return a normal provider-compatible response while recording route/fallback/cost metrics.
+
+Do not build a user-facing router product. Do not add sliders, per-user routing preferences, Firestore routing prefs, desktop route caches, or a public `/pick` endpoint for product clients.
+
+The existing realtime `backend/routers/auto_model.py` and desktop `AutoModelSelector` path are legacy context, not the template for this service. New gateway work must not add a public picker endpoint, must not fetch benchmark data in the request path, and must not expand desktop-side routing caches.
+
+## First Pilot
+
+The first lane is:
+
+```text
+omi:auto:chat-structured
+```
+
+This is **not** the primary user chat interface. The primary chat interface is `/v2/messages`, backed by the retrieval and agentic chat graph documented in [Chat System Architecture](/doc/developer/backend/chat_system).
+
+`chat-structured` is for non-streaming structured extraction and classification work, such as memory extraction, chat extraction helpers, conversation post-processing structure, and schema-bound feature decisions. It is the safest first lane because it has clear success checks: JSON/schema validity, parser repair rate, extraction precision/recall, latency, and cost.
+
+Primary user chat should follow later as a separate lane, likely:
+
+```text
+omi:auto:chat-fast-memory
+omi:auto:chat-smart-tools
+```
+
+Those lanes involve streaming, tool use, retrieval quality, citations, and user-visible response behavior, so they need a stronger evaluation and rollback story.
+
+## Why A Separate Service
+
+The current backend keeps model/provider routing in `backend/utils/llm/model_config.py`, constructs clients in `backend/utils/llm/providers.py`, and exposes callers through `backend/utils/llm/clients.py`. That remains the source of truth for feature routing, but the new auto-route execution brain should be isolated as a service because:
+
+- backend and pusher both run LLM workloads and should share one runtime policy;
+- route artifacts need deploy-time validation and runtime fallback independent of product code;
+- route observability needs one consistent set of labels;
+- future surfaces can call the same OpenAI-compatible gateway without learning provider details;
+- rollback must be config-only and not require desktop or mobile releases.
+
+The service boundary should look like this:
+
+```mermaid
+flowchart TD
+    A["Backend feature code"] --> B["model_config.py feature route ref"]
+    P["Pusher feature code"] --> B
+    B --> C{"Explicit or auto?"}
+    C -->|"explicit"| D["Existing provider/model route"]
+    C -->|"omi:auto:*"| G["LLM Gateway service"]
+    G --> R["Lane resolver"]
+    R --> V["Capability validator"]
+    V --> E["Route executor"]
+    E --> O["OpenAI / Gemini / OpenRouter / Anthropic-compatible provider"]
+    E --> M["Metrics + cost + fallback events"]
+```
+
+## Language And Framework
+
+Use **Python 3.11 + FastAPI + Pydantic + httpx**.
+
+Reasons:
+
+- The backend is already Python 3.11 and FastAPI.
+- Existing auth, logging, sanitizer, executor, test, and deployment patterns are Python.
+- Existing LLM provider knowledge lives in Python modules.
+- Pydantic is already the natural schema/validation tool for FastAPI.
+- `httpx.AsyncClient` matches backend async I/O rules and avoids blocking the event loop.
+
+Do not make the gateway a Swift, Rust, Node, Go, or Kubernetes-controller project for v1. Those choices would increase operational and review burden without helping the first `chat-structured` lane.
+
+Recommended service layout:
+
+```text
+backend/llm_gateway/
+  main.py
+  config/
+    lanes.yaml
+    route_artifacts.yaml
+    feature_bundles.yaml
+  routers/
+    openai_compatible.py
+    admin.py
+  gateway/
+    schemas.py
+    config_loader.py
+    validator.py
+    resolver.py
+    executor.py
+    providers.py
+    metrics.py
+    errors.py
+  tests/
+```
+
+The exact directory can change during implementation, but keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
+
+## Deployment Shape
+
+For v1, build the gateway as a separate FastAPI app in the backend tree, using the same Python toolchain and dependency-lock workflow as the main backend.
+
+Preferred rollout:
+
+1. Add the app entrypoint and unit tests without any production traffic.
+2. Add a local run command and Docker/Helm wiring for a separately named service.
+3. Add `/ready` startup/readiness validation that fails closed unless active and LKG route config is valid.
+4. Add service-to-service auth from backend and pusher to the gateway.
+5. Route one structured feature through the gateway in shadow mode.
+6. Promote only after the route artifact has an Omi eval report and rollback has been tested.
+
+Do not start by embedding the gateway router into `backend/main.py`. That would make the gateway look separate in code while still sharing the main backend process, lifecycle, scaling, and blast radius.
+
+## Major Library Choices
+
+Use:
+
+- **FastAPI** for HTTP endpoints and service lifecycle.
+- **Pydantic** for lane, artifact, request, and validation schemas.
+- **httpx.AsyncClient** for provider HTTP calls and gateway-to-provider calls.
+- **OpenAI Python SDK only where it materially reduces request/stream parsing risk.** Prefer direct `httpx` for the gateway core so we preserve request/response metadata, timeouts, headers, and streaming behavior consistently.
+- **Prometheus-compatible metrics** following existing backend observability conventions.
+- **pytest** for deterministic resolver, validator, and executor tests.
+
+Avoid for v1:
+
+- LangChain inside the gateway execution path. Existing product code can keep using LangChain, but the gateway should speak provider HTTP contracts directly so it can preserve OpenAI-compatible request/response shapes and streaming semantics.
+- Firestore/Redis as routing config stores. All lane and route artifacts live in repo files for v1.
+- LiteLLM, Portkey, Envoy AI Gateway, or Kong as the gateway foundation.
+- Runtime benchmark fetching, including Artificial Analysis calls, inside request handling.
+
+## Open Source Position
+
+We should learn from existing gateways, but not build on top of them for v1.
+
+| Project | Use For | Do Not Use For |
+|---|---|---|
+| LiteLLM | Provider normalization ideas, error mapping, cost accounting examples, OpenAI-compatible proxy behavior | Canonical gateway foundation, admin dashboard, virtual keys, spend product, broad registry |
+| Portkey Gateway | Config-driven fallback/routing patterns and composable fallback examples | User prefs, hosted-control-plane assumptions, its config DSL as our source of truth |
+| Envoy AI Gateway | Edge gateway inspiration if Omi later standardizes on Envoy/Kubernetes AI traffic policy | Application route brain or first implementation substrate |
+| Kong AI Gateway | Mature edge/platform concepts | Omi route artifacts or feature-to-lane semantics |
+
+Current public docs describe LiteLLM as a self-hosted OpenAI-compatible gateway for 100+ providers with virtual keys, spend tracking, guardrails, load balancing, and dashboard features. Portkey similarly focuses on broad model routing, guardrails, fallbacks, and hosted/enterprise gateway workflows. Envoy AI Gateway provides OpenAI-compatible and Anthropic-compatible routing with provider fallback and load balancing, but assumes an Envoy/Kubernetes operating model.
+
+Those are useful references, but they are broader than Omi's target. Omi needs a small internal service that preserves `model_config.py` as the feature route source and promotes route artifacts through Omi evals.
+
+Reference links checked while writing this spec:
+
+- [LiteLLM](https://github.com/BerriAI/litellm)
+- [LiteLLM proxy docs](https://docs.litellm.ai/docs/)
+- [Portkey Gateway](https://github.com/Portkey-AI/gateway)
+- [Envoy AI Gateway supported endpoints](https://aigateway.envoyproxy.io/docs/0.5/capabilities/llm-integrations/supported-endpoints/)
+
+## API Surface
+
+MVP endpoint:
+
+```http
+POST /v1/chat/completions
+```
+
+Requests may use either an explicit model:
+
+```json
+{
+  "model": "gpt-4.1-mini",
+  "messages": []
+}
+```
+
+For v1, explicit-model execution through the gateway is not a generic arbitrary-model proxy. Explicit routes either stay on the existing backend clients or are sent to the gateway as an internal provider-qualified route resolved by `model_config.py`. A bare model string is not enough because Omi's source of truth is `(provider, model)`, not model name alone.
+
+Or an Omi lane:
+
+```json
+{
+  "model": "omi:auto:chat-structured",
+  "messages": [],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "memory_extraction",
+      "strict": true,
+      "schema": {}
+    }
+  },
+  "metadata": {
+    "omi_feature": "memories",
+    "prompt_version": "memory_extraction.v17",
+    "parser_version": "memory_schema.v9"
+  }
+}
+```
+
+Normal responses return the requested lane ID:
+
+```json
+{
+  "model": "omi:auto:chat-structured",
+  "choices": []
+}
+```
+
+Internal debug may expose route IDs through admin-only headers:
+
+```http
+X-Omi-Lane-Id: omi:auto:chat-structured
+X-Omi-Route-Id: route.chat_structured.2026_06_27.001
+X-Omi-Fallback-Used: false
+```
+
+Provider/model details stay internal by default.
+
+## Config Model
+
+All config is checked into this repo for v1.
+
+Lane config:
+
+```yaml
+lane_id: omi:auto:chat-structured
+surface: openai.chat_completions
+capabilities:
+  text_input: true
+  streaming: false
+  structured_output: json_schema
+  tools: false
+objective:
+  quality: 0.60
+  latency: 0.20
+  cost: 0.20
+active_route: route.chat_structured.2026_06_27.001
+last_known_good: route.chat_structured.2026_06_20.001
+```
+
+Route artifact:
+
+```yaml
+route_artifact_id: route.chat_structured.2026_06_27.001
+lane_id: omi:auto:chat-structured
+primary:
+  provider: openai
+  model: gpt-4.1-mini
+fallbacks:
+  - provider: openai
+    model: gpt-5.4-mini
+timeouts:
+  request_ms: 8000
+retry:
+  max_attempts: 1
+capabilities:
+  structured_output: json_schema
+  streaming: false
+evidence:
+  benchmark_snapshot: bench.aa.2026_06_27
+  eval_report: eval.memory_extraction.2026_06_27
+rollout:
+  stage: shadow
+credential_policy:
+  mode: omi_paid
+  allow_byok_to_omi_paid_fallback: false
+fallback_policy:
+  fallback_on:
+    - timeout_before_output
+    - provider_429_omi_paid
+    - provider_5xx_omi_paid
+  never_fallback_on:
+    - byok_auth
+    - byok_quota
+    - byok_rate_limit
+    - missing_byok_key
+    - capability_mismatch
+    - invalid_config
+artifact_digest: sha256:<computed-by-validation>
+```
+
+Feature bundle:
+
+```yaml
+feature: memories
+lane_id: omi:auto:chat-structured
+prompt_version: memory_extraction.v17
+parser_version: memory_schema.v9
+eval_suite: memory_precision_recall.v5
+promotion_gates:
+  schema_valid_rate: ">= 99.5%"
+  precision_regression: "none"
+  recall_delta: ">= 0"
+  p95_latency_ms: "<= LKG + 10%"
+  cost_per_success: "<= LKG + 15%"
+```
+
+Route artifacts are immutable. Promotion creates a new artifact and updates the lane pointer. Rollback updates the lane pointer back to LKG.
+
+Validation must reject duplicate `route_artifact_id` values and expose a content digest for every artifact. Once an artifact ID has shipped, changing its content is treated as invalid operational behavior; create a new artifact ID instead.
+
+## Integration With Existing Backend Code
+
+`backend/utils/llm/model_config.py` remains the feature routing source. Add typed route refs behind it:
+
+```python
+@dataclass(frozen=True)
+class ExplicitRouteRef:
+    model: str
+    provider: str
+
+@dataclass(frozen=True)
+class AutoLaneRouteRef:
+    lane_id: str
+```
+
+Existing APIs must keep working:
+
+- `get_model(feature)`
+- `get_provider(feature)`
+- `get_llm(feature)`
+- `get_route_options(feature, model, provider)`
+
+For auto lanes, product code should not call `get_provider()` expecting a concrete provider. The initial migration should keep existing tuple behavior for all current features, then add explicit new helpers:
+
+```python
+get_route_ref(feature) -> ExplicitRouteRef | AutoLaneRouteRef
+is_auto_lane_id(model: str) -> bool
+```
+
+Backend callers that use `get_llm(feature)` can be migrated feature by feature. For the first pilot, route only one structured feature through the gateway and keep all other features explicit.
+
+## BYOK Policy
+
+BYOK failures fail visibly by default.
+
+If a request is using a user-provided provider key and that key is invalid, rate-limited, out of quota, or rejected by the provider, the gateway returns a clear typed error. It must not silently fall back to an Omi-paid provider route unless a route artifact explicitly allows that behavior and the product owner has approved it.
+
+The gateway must not reuse current backend BYOK fallback behavior where unsupported BYOK chat clients or failed embedding calls can fall back to Omi-paid credentials. That behavior may remain in legacy callers until migrated, but the gateway contract is stricter.
+
+Gateway requests carry a `CredentialContext` owned by service-authenticated backend/pusher callers. Desktop and mobile clients never call the gateway directly and never send raw BYOK credentials directly to it. The initial implementation must choose one of these internal patterns before live traffic:
+
+- backend forwards a short-lived BYOK credential envelope to the gateway over service-authenticated transport;
+- gateway receives a key reference and resolves it through an approved internal secret path.
+
+The route artifact credential policy controls whether a route is `omi_paid` or `byok`, whether BYOK-to-Omi-paid fallback is allowed, and which failure classes are fallback eligible.
+
+Default behavior:
+
+| Failure | Behavior |
+|---|---|
+| BYOK invalid key | visible auth error |
+| BYOK quota/rate limit | visible provider/key error |
+| BYOK unsupported provider for route | capability/config error |
+| Omi-paid primary timeout before output | retry/fallback if route policy allows |
+| Omi-paid primary schema invalid | repair attempt or compatible fallback if route policy allows |
+
+## Service Auth
+
+`/health` may be unauthenticated.
+
+`/ready` and `/v1/chat/completions` require internal service authentication. The first allowed callers are backend and pusher. Requests must propagate enough caller, tenant, user, BYOK, and usage context for accounting and policy enforcement, but must not expose provider keys in logs or metrics.
+
+Desktop, mobile, and third-party product clients must not call the gateway directly in v1.
+
+## Capability Validation
+
+Before execution, validate:
+
+- surface: chat completions for MVP;
+- streaming: false for `chat-structured` MVP;
+- tools: false for `chat-structured` MVP;
+- structured output mode: JSON schema or parser-compatible JSON;
+- input modalities: text only for MVP;
+- provider/model supports requested response format;
+- route artifact lane matches requested lane;
+- active and LKG artifacts are valid at startup;
+- LKG matches requested lane, surface, capabilities, structured-output mode, and credential mode.
+
+Runtime fail-open means active route failure may use LKG only for failure classes allowed by the route artifact. Deploy/startup fail-closed means invalid LKG or invalid config prevents the service from starting. Do not use LKG for BYOK credential failures, capability mismatches, missing BYOK keys, or invalid config.
+
+## Observability
+
+Record metrics with these dimensions:
+
+```text
+lane_id
+route_artifact_id
+requested_model
+surface
+feature_id
+prompt_version
+parser_version
+provider
+model
+fallback_used
+fallback_reason
+error_class
+streaming
+byok
+cohort
+```
+
+Do not log raw prompts, transcripts, screenshots, memory contents, provider response bodies, or BYOK keys. Use existing sanitizer patterns for error bodies and user text.
+
+## Implementation Sequence
+
+1. Add this doc and an implementation checklist.
+2. Add `llm_gateway` service skeleton with health endpoint and config validation command.
+3. Add Pydantic schemas for lane config, route artifacts, feature bundles, capability declarations, retries, timeouts, rollout, and LKG.
+4. Add service-auth and credential-policy contracts.
+5. Add resolver tests with no network calls.
+6. Add capability validator tests for `chat-structured`.
+7. Add provider executor with fake providers and fallback/error normalization tests.
+8. Add `/v1/chat/completions` non-streaming support behind service auth.
+9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic.
+10. Add gateway client helper in main backend so selected `model_config.py` features can call the gateway.
+11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode.
+12. Add Omi eval reports and promote only after schema validity, extraction quality, latency, and cost gates pass.
+
+## Shadow Safety
+
+Shadow mode must be explicitly bounded before any live user content goes through the gateway:
+
+- feature-owner/privacy approval for the feature being shadowed;
+- sampling limits and a kill switch;
+- cost cap;
+- no BYOK shadow by default;
+- no provider expansion beyond the current production provider class without approval;
+- no persistence of raw prompts or raw responses;
+- metrics-only comparison unless an approved eval store exists.
+
+Prefer offline replay/eval before live shadow for memory- or transcript-heavy workloads.
+
+## Explicit Non-Goals
+
+- No desktop Settings UI.
+- No quality/latency/cost sliders.
+- No per-user routing preferences.
+- No Firestore or Redis routing prefs.
+- No desktop-side model/route cache.
+- No public `/v1/auto-router/pick`.
+- No new public `/v1/auto/model-pick`.
+- No request-path benchmark fetching.
+- No production route from mock benchmark data.
+- No benchmark-only promotion.
+- No wholesale LiteLLM, Portkey, Envoy AI Gateway, or Kong adoption.
+
+## Maintainer Checklist
+
+Before broad production traffic:
+
+- explicit model routing remains backward compatible;
+- `model_config.py` still owns feature-to-route mapping;
+- gateway config validation fails closed on invalid prod config;
+- active route has valid LKG;
+- route artifacts are immutable;
+- BYOK failure does not silently fall back to Omi-paid traffic;
+- `/v1/chat/completions` requires internal service auth;
+- LKG/fallback is limited to artifact-approved failure classes;
+- mock benchmarks cannot load in prod;
+- Omi eval report exists;
+- shadow/canary completed;
+- rollback is config-only;
+- observability includes route, fallback, latency, errors, and cost.

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -446,10 +446,11 @@ Runtime fail-open means active route failure may use LKG only for failure classe
 - builds an Omi-managed request credential context for the current v1 lane;
 - resolves `model: "omi:auto:chat-structured"` to the checked-in active route;
 - calls the executor and returns the provider response payload with `model` rewritten to the requested lane ID;
+- forwards supported OpenAI chat-completions controls such as `temperature`, `max_tokens`, `max_completion_tokens`, `seed`, `top_p`, penalties, `stop`, and `user`;
 - maps typed gateway exceptions to OpenAI-style error envelopes with `error.message`, `error.type`, `error.param`, and `error.code`;
-- rejects unknown auto lanes, bare provider model names, streaming, tools, and unsupported capabilities before provider execution.
+- rejects unknown auto lanes, bare provider model names, streaming, tools, unsupported capabilities, and unknown top-level request parameters before provider execution.
 
-The default provider registry includes the OpenAI-compatible adapter for the checked-in `openai` provider route. It uses `OPENAI_API_KEY` and optional `OPENAI_BASE_URL`, posts to `/chat/completions` with `httpx.AsyncClient`, and fails closed with `invalid_route_config` when the managed key is absent or rejected. Tests can still override the registry with fake providers.
+The default provider registry includes the OpenAI-compatible adapter for the checked-in `openai` provider route. It is cached per process, closed during FastAPI lifespan shutdown, uses `OPENAI_API_KEY`, optional `OPENAI_BASE_URL`, and optional `OPENAI_MAX_RESPONSE_BYTES`, posts to `/chat/completions` with `httpx.AsyncClient`, and fails closed with `invalid_route_config` when the managed key is absent or rejected. Tests can still override the registry with fake providers.
 
 ## Provider Execution
 
@@ -474,7 +475,7 @@ The current provider abstraction is an async protocol plus:
 - `OpenAICompatibleChatCompletionProvider` for live non-streaming OpenAI-compatible calls;
 - in-memory fake providers for unit tests.
 
-The live adapter does not log raw provider response bodies, prompts, transcripts, screenshots, memory contents, or BYOK keys. It maps missing Omi-managed keys and provider 401/403 responses to config failure, provider 429 to Omi-paid rate-limit failure, provider 5xx/network failures to Omi-paid provider failure, and provider 4xx request failures to capability mismatch.
+The live adapter does not log raw provider response bodies, prompts, transcripts, screenshots, memory contents, or BYOK keys. It bounds successful response bodies, validates that success responses look like OpenAI chat completions, maps missing Omi-managed keys and provider 401/403 responses to config failure, provider 429 to Omi-paid rate-limit failure, provider 5xx/network failures to Omi-paid provider failure, and provider 4xx request failures to capability mismatch.
 
 ## Observability
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, and request-level credential context helpers.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, and route resolution for the v1 auto lane.
 
 ## Decision
 
@@ -34,7 +34,7 @@ The first lane is:
 omi:auto:chat-structured
 ```
 
-This is **not** the primary user chat interface. The primary chat interface is `/v2/messages`, backed by the retrieval and agentic chat graph documented in [Chat System Architecture](/doc/developer/backend/chat_system).
+For v1, this is the only supported OpenAI-compatible chat-completions interface. It is structured and non-streaming. The broader streaming product chat path remains `/v2/messages`, backed by the retrieval and agentic chat graph documented in [Chat System Architecture](/doc/developer/backend/chat_system).
 
 `chat-structured` is for non-streaming structured extraction and classification work, such as memory extraction, chat extraction helpers, conversation post-processing structure, and schema-bound feature decisions. It is the safest first lane because it has clear success checks: JSON/schema validity, parser repair rate, extraction precision/recall, latency, and cost.
 
@@ -102,18 +102,20 @@ backend/llm_gateway/
   gateway/
     schemas.py
     config_loader.py
+    auth.py
+    credentials.py
+    errors.py
+    validator.py
+    resolver.py
 ```
 
 Planned modules:
 
 ```text
 backend/llm_gateway/gateway/
-  validator.py
-  resolver.py
   executor.py
   providers.py
   metrics.py
-  errors.py
 ```
 
 Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
@@ -394,19 +396,27 @@ Default behavior:
 
 Desktop, mobile, and third-party product clients must not call the gateway directly in v1.
 
-## Capability Validation
+## Request Validation And Route Resolution
 
-Before execution, validate:
+Implemented v1 route resolution is intentionally narrow:
 
-- surface: chat completions for MVP;
-- streaming: false for `chat-structured` MVP;
-- tools: false for `chat-structured` MVP;
-- structured output mode: JSON schema or parser-compatible JSON;
-- input modalities: text only for MVP;
-- provider/model supports requested response format;
-- route artifact lane matches requested lane;
-- active and LKG artifacts are valid at startup;
-- LKG matches requested lane, surface, capabilities, structured-output mode, and credential mode.
+- `is_auto_lane_id(model)` recognizes only the `omi:auto:` namespace.
+- `omi:auto:chat-structured` is the only supported auto lane.
+- unknown `omi:auto:*` lanes return a typed model-not-found error.
+- bare provider model names such as `gpt-4o-mini` are not direct gateway routes in v1 and return a typed unsupported-model error.
+- the resolver maps the supported lane to its configured `active_route` and `last_known_good` route artifact.
+- runtime route checks defensively reject active/LKG lane, surface, capability, and credential-mode mismatches as invalid config.
+
+Before execution, the validator accepts only OpenAI chat-completions-shaped requests with:
+
+- `model: "omi:auto:chat-structured"`;
+- non-empty text `messages`;
+- `stream` absent or false;
+- no tool use;
+- `response_format.type: "json_schema"`;
+- a `response_format.json_schema.schema` object.
+
+The validator rejects streaming, tools, missing or invalid messages, non-text or multimodal content, and structured-output modes other than JSON schema for this lane. These failures are typed gateway exceptions, not ad hoc strings, so future HTTP endpoint code can map them to OpenAI-compatible error envelopes.
 
 Runtime fail-open means active route failure may use LKG only for failure classes allowed by the route artifact. Deploy/startup fail-closed means invalid LKG or invalid config prevents the service from starting. Do not use LKG for BYOK credential failures, capability mismatches, missing BYOK keys, or invalid config.
 
@@ -439,9 +449,9 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 1. Add this doc and an implementation checklist. Done.
 2. Add `llm_gateway` service skeleton with health endpoint. Done.
 3. Add Pydantic schemas for lane config, route artifacts, feature bundles, capability declarations, retries, timeouts, rollout, evidence, credential policy, fallback policy, and LKG. Done.
-4. Add service-auth and credential-policy contracts.
-5. Add resolver tests with no network calls.
-6. Add capability validator tests for `chat-structured`.
+4. Add service-auth and credential-policy contracts. Done.
+5. Add resolver tests with no network calls. Done.
+6. Add capability validator tests for `chat-structured`. Done.
 7. Add provider executor with fake providers and fallback/error normalization tests.
 8. Add `/v1/chat/completions` non-streaming support behind service auth.
 9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic.

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, and the non-streaming provider executor with fake providers for deterministic tests.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, and the non-streaming provider executor with fake providers for deterministic tests.
 
 ## Decision
 
@@ -97,8 +97,8 @@ backend/llm_gateway/
     route_artifacts.yaml
     feature_bundles.yaml
   routers/
+    health.py
     openai_compatible.py
-    admin.py
   gateway/
     schemas.py
     config_loader.py
@@ -107,20 +107,20 @@ backend/llm_gateway/
     errors.py
     validator.py
     resolver.py
+    executor.py
+    providers.py
 ```
 
 Planned modules:
 
 ```text
 backend/llm_gateway/gateway/
-  executor.py
-  providers.py
   metrics.py
 ```
 
 Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
 
-Implemented internal service auth uses `Authorization: Bearer <LLM_GATEWAY_SERVICE_TOKEN>` plus `X-Omi-Service-Caller`. The default allowlist is low-cardinality service names `backend` and `pusher`; optional `X-Omi-User-Uid` and `X-Omi-Tenant-Id` populate request context only. `/health` remains unauthenticated. Future `/ready` and `/v1/chat/completions` routes should depend on these helpers instead of Firebase user auth.
+Implemented internal service auth uses `Authorization: Bearer <LLM_GATEWAY_SERVICE_TOKEN>` plus `X-Omi-Service-Caller`. The default allowlist is low-cardinality service names `backend` and `pusher`; optional `X-Omi-User-Uid` and `X-Omi-Tenant-Id` populate request context only. `/health` remains unauthenticated. `/v1/chat/completions` depends on these helpers instead of Firebase user auth, and `/ready` should use the same internal boundary when added.
 
 Credential context is request-level metadata. It records credential mode, caller, and provider-key presence or approved key references without exposing raw key material in model dumps or repr output. BYOK credential failures such as missing key, invalid auth, quota, rate-limit, and unsupported provider are visible errors and are not fallback-eligible by default.
 
@@ -420,6 +420,20 @@ The validator rejects streaming, tools, missing or invalid messages, non-text or
 
 Runtime fail-open means active route failure may use LKG only for failure classes allowed by the route artifact. Deploy/startup fail-closed means invalid LKG or invalid config prevents the service from starting. Do not use LKG for BYOK credential failures, capability mismatches, missing BYOK keys, or invalid config.
 
+## HTTP Surface
+
+`POST /v1/chat/completions` is implemented as an OpenAI-compatible non-streaming route for internal services:
+
+- requires service auth;
+- accepts the same request shape validated by the resolver;
+- builds an Omi-managed request credential context for the current v1 lane;
+- resolves `model: "omi:auto:chat-structured"` to the checked-in active route;
+- calls the executor and returns the provider response payload with `model` rewritten to the requested lane ID;
+- maps typed gateway exceptions to OpenAI-style error envelopes with `error.message`, `error.type`, `error.param`, and `error.code`;
+- rejects unknown auto lanes, bare provider model names, streaming, tools, and unsupported capabilities before provider execution.
+
+The default provider registry is empty until live provider adapters are wired, so the route fails closed with `invalid_route_config` unless tests or deployment code provide a registry. That is intentional: the route exists before it can accidentally proxy arbitrary model traffic.
+
 ## Provider Execution
 
 Implemented executor behavior is non-streaming only:
@@ -473,7 +487,7 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 5. Add resolver tests with no network calls. Done.
 6. Add capability validator tests for `chat-structured`. Done.
 7. Add provider executor with fake providers and fallback/error normalization tests. Done.
-8. Add `/v1/chat/completions` non-streaming support behind service auth.
+8. Add `/v1/chat/completions` non-streaming support behind service auth. Done.
 9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic.
 10. Add gateway client helper in main backend so selected `model_config.py` features can call the gateway.
 11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode.

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -99,6 +99,8 @@ Current service layout:
 
 ```text
 backend/scripts/dev-serve-llm-gateway.sh
+backend/scripts/validate-llm-gateway-env.py
+backend/scripts/smoke-llm-gateway.py
 backend/llm_gateway/
   main.py
   config/
@@ -118,14 +120,7 @@ backend/llm_gateway/
     validator.py
     resolver.py
     executor.py
-  providers.py
-```
-
-Planned modules:
-
-```text
-backend/llm_gateway/gateway/
-  metrics.py
+    metrics.py
 ```
 
 Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
@@ -156,6 +151,90 @@ cd backend && ./scripts/dev-serve-llm-gateway.sh
 ```
 
 The script derives a per-worktree port from `scripts/dev-instance.sh` and defaults to `PYTHON_PORT + 1000`. Override with `LLM_GATEWAY_PORT=<port>` when needed. Backend callers use repo-local configuration through `OMI_LLM_GATEWAY_URL`; `utils.llm.gateway_client.get_llm_gateway_base_url()` defaults to `http://127.0.0.1:9080` for the primary checkout and strips trailing slashes from explicit values.
+
+## Deployment Configuration
+
+The deployed gateway is a separate internal GKE service, not a public client endpoint. The Helm release name is:
+
+```text
+<env>-omi-llm-gateway
+```
+
+Backend-listen calls the gateway through Kubernetes DNS:
+
+```text
+dev:  http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080
+prod: http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080
+```
+
+Repo wiring:
+
+- gateway chart: `backend/charts/llm-gateway/`
+- manual workflow: `.github/workflows/gcp_llm_gateway.yml`
+- backend caller env: `backend/charts/backend-listen/{dev,prod}_omi_backend_listen_values.yaml`
+- shared secret mapping: `backend/charts/backend-secrets/{dev,prod}_omi_backend_secrets_values.yaml`
+
+Backend-listen env:
+
+| Env | Value |
+|---|---|
+| `OMI_LLM_GATEWAY_URL` | Internal service URL above |
+| `OMI_LLM_GATEWAY_SERVICE_TOKEN` | `*-omi-backend-secrets` key `OMI_LLM_GATEWAY_SERVICE_TOKEN` |
+
+Gateway env:
+
+| Env | Value |
+|---|---|
+| `OMI_LLM_GATEWAY_PROD` | `true` |
+| `OMI_LLM_GATEWAY_SERVICE_TOKEN` | same `*-omi-backend-secrets` key `OMI_LLM_GATEWAY_SERVICE_TOKEN` |
+| `LLM_GATEWAY_ALLOWED_CALLERS` | `backend` |
+| `OPENAI_API_KEY` | existing `*-omi-backend-secrets` key `OPENAI_API_KEY` |
+| `METRICS_SECRET` | existing `*-omi-backend-secrets` key `METRICS_SECRET` |
+
+ExternalSecrets expect a GCP Secret Manager secret named `OMI_LLM_GATEWAY_SERVICE_TOKEN` in both projects:
+
+```text
+dev:  based-hardware-dev / OMI_LLM_GATEWAY_SERVICE_TOKEN
+prod: based-hardware     / OMI_LLM_GATEWAY_SERVICE_TOKEN
+```
+
+Do not use remote config for this rollout. Rotate the service token through Secret Manager and ExternalSecrets, not through app config.
+
+The chart exposes only a `ClusterIP` service. `/health` is unauthenticated. Kubernetes liveness/startup probes call `/health`; readiness uses an `exec` probe that reads `OMI_LLM_GATEWAY_SERVICE_TOKEN` from pod env and calls `/ready` with `Authorization: Bearer ...` plus `X-Omi-Service-Caller: backend`.
+
+Before any deploy, validate the values files:
+
+```bash
+python backend/scripts/validate-llm-gateway-env.py \
+  backend/charts/backend-listen/dev_omi_backend_listen_values.yaml \
+  backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+```
+
+Post-deploy smoke check, from inside the GKE network or a pod with cluster DNS access:
+
+```bash
+python backend/scripts/smoke-llm-gateway.py \
+  --url http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080 \
+  --token "$OMI_LLM_GATEWAY_SERVICE_TOKEN"
+```
+
+DEV readiness order:
+
+1. Create or verify `OMI_LLM_GATEWAY_SERVICE_TOKEN` in `based-hardware-dev` Secret Manager.
+2. Run the values validation command above.
+3. Run focused gateway unit tests and preflight checks.
+4. Manually dispatch `gcp_llm_gateway.yml` to `development`.
+5. Run `/ready` and chat-completions smoke checks.
+6. Deploy backend-listen values only after gateway smoke passes, so backend callers do not point at a missing service.
+
+PROD readiness order:
+
+1. Create or verify an independent `OMI_LLM_GATEWAY_SERVICE_TOKEN` in `based-hardware` Secret Manager.
+2. Confirm DEV smoke passed with the same image/commit.
+3. Run the prod values validation command.
+4. Manually dispatch `gcp_llm_gateway.yml` to `prod`.
+5. Run prod `/ready` and chat-completions smoke checks from the prod GKE network.
+6. Deploy backend-listen prod values after gateway prod smoke passes.
 
 ## Major Library Choices
 
@@ -488,25 +567,16 @@ The live adapter does not log raw provider response bodies, prompts, transcripts
 
 ## Observability
 
-Record metrics with these dimensions:
+Gateway-side Prometheus metrics are exposed on `/metrics` with `METRICS_SECRET` bearer auth. The main gateway request metrics are:
 
 ```text
-lane_id
-route_artifact_id
-requested_model
-surface
-feature_id
-prompt_version
-parser_version
-provider
-model
-fallback_used
-fallback_reason
-error_class
-streaming
-byok
-cohort
+llm_gateway_requests_total
+llm_gateway_request_latency_seconds
 ```
+
+Labels are bounded and low-cardinality: `lane_id`, `route_artifact_id`, `provider`, `model`, `used_lkg`, `fallback_used`, `fallback_reason`, `outcome`, and `error_class`.
+
+The backend caller also exposes `llm_gateway_chat_extraction_requests_total{feature,outcome,reason}` for app-level success/fallback/skipped behavior.
 
 Do not log raw prompts, transcripts, screenshots, memory contents, provider response bodies, or BYOK keys. Use existing sanitizer patterns for error bodies and user text.
 
@@ -520,10 +590,11 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 6. Add capability validator tests for `chat-structured`. Done.
 7. Add provider executor with fake providers and fallback/error normalization tests. Done.
 8. Add `/v1/chat/completions` non-streaming support behind service auth. Done.
-9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic. Partially done: `/ready`, local run command, and URL config are implemented; Docker/Helm deployment wiring is still pending.
+9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic. Done.
 10. Add route refs and gateway URL helpers in main backend so selected `model_config.py` features can call the gateway later. Done.
-11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode.
-12. Add Omi eval reports and promote only after schema validity, extraction quality, latency, and cost gates pass.
+11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode. Done for non-BYOK `chat_extraction.requires_context`, protected by application-level fallback.
+12. Add gateway-side metrics and authenticated metrics endpoint. Done.
+13. Add Omi eval reports and promote only after schema validity, extraction quality, latency, and cost gates pass.
 
 ## Shadow Safety
 

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, and route resolution for the v1 auto lane.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, and the non-streaming provider executor with fake providers for deterministic tests.
 
 ## Decision
 
@@ -420,6 +420,26 @@ The validator rejects streaming, tools, missing or invalid messages, non-text or
 
 Runtime fail-open means active route failure may use LKG only for failure classes allowed by the route artifact. Deploy/startup fail-closed means invalid LKG or invalid config prevents the service from starting. Do not use LKG for BYOK credential failures, capability mismatches, missing BYOK keys, or invalid config.
 
+## Provider Execution
+
+Implemented executor behavior is non-streaming only:
+
+- the caller passes a resolved route plus a request-level `CredentialContext`;
+- the executor sends an OpenAI-compatible chat-completions payload to the active route primary provider first;
+- the provider-facing payload replaces the lane model with the selected provider model and forces `stream: false`;
+- the caller-facing response payload keeps the normal provider response shape but reports `model` as the requested lane ID, such as `omi:auto:chat-structured`;
+- selected route artifact, provider, provider model, fallback reason, and LKG usage are returned only on the executor result metadata, not embedded into the response payload.
+
+Fallback is deliberately narrow:
+
+- active route fallbacks are attempted only when the route policy allows the normalized failure class;
+- LKG is attempted only through `select_lkg_route_for_failure`, so active route policy remains the single gate for runtime LKG;
+- BYOK missing key, auth, quota, rate limit, unsupported provider, capability mismatch, and invalid config failures fail visibly and do not fall back by default;
+- Omi-paid timeout before output, provider 429, and provider 5xx may fall back only when the route artifact allows those classes;
+- streaming-after-first-token recovery is unsupported for MVP. The executor assumes no partial output exists and does not try to recover or replay partial responses.
+
+The current provider abstraction is an async protocol plus in-memory fake providers for unit tests. Live provider HTTP adapters should use pooled `httpx.AsyncClient` instances and must not log raw provider response bodies, prompts, transcripts, screenshots, memory contents, or BYOK keys.
+
 ## Observability
 
 Record metrics with these dimensions:
@@ -452,7 +472,7 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 4. Add service-auth and credential-policy contracts. Done.
 5. Add resolver tests with no network calls. Done.
 6. Add capability validator tests for `chat-structured`. Done.
-7. Add provider executor with fake providers and fallback/error normalization tests.
+7. Add provider executor with fake providers and fallback/error normalization tests. Done.
 8. Add `/v1/chat/completions` non-streaming support behind service auth.
 9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic.
 10. Add gateway client helper in main backend so selected `model_config.py` features can call the gateway.

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture spec for Omi's internal LLM routing gateway, auto lan
 
 > Status: implemented architecture in progress.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, and the non-streaming provider executor with fake providers for deterministic tests.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor with fake providers for deterministic tests, and local service URL configuration for backend callers.
 
 ## Decision
 
@@ -90,6 +90,7 @@ Do not make the gateway a Swift, Rust, Node, Go, or Kubernetes-controller projec
 Current service layout:
 
 ```text
+backend/scripts/dev-serve-llm-gateway.sh
 backend/llm_gateway/
   main.py
   config/
@@ -99,6 +100,7 @@ backend/llm_gateway/
   routers/
     health.py
     openai_compatible.py
+    dependencies.py
   gateway/
     schemas.py
     config_loader.py
@@ -120,7 +122,7 @@ backend/llm_gateway/gateway/
 
 Keep it a separate service entrypoint. Do not place a parallel `utils/auto_router` package under the main backend and do not wire a public task picker into `backend/main.py`.
 
-Implemented internal service auth uses `Authorization: Bearer <LLM_GATEWAY_SERVICE_TOKEN>` plus `X-Omi-Service-Caller`. The default allowlist is low-cardinality service names `backend` and `pusher`; optional `X-Omi-User-Uid` and `X-Omi-Tenant-Id` populate request context only. `/health` remains unauthenticated. `/v1/chat/completions` depends on these helpers instead of Firebase user auth, and `/ready` should use the same internal boundary when added.
+Implemented internal service auth uses `Authorization: Bearer <LLM_GATEWAY_SERVICE_TOKEN>` plus `X-Omi-Service-Caller`. The default allowlist is low-cardinality service names `backend` and `pusher`; optional `X-Omi-User-Uid` and `X-Omi-Tenant-Id` populate request context only. `/health` remains unauthenticated. `/ready` and `/v1/chat/completions` depend on these helpers instead of Firebase user auth.
 
 Credential context is request-level metadata. It records credential mode, caller, and provider-key presence or approved key references without exposing raw key material in model dumps or repr output. BYOK credential failures such as missing key, invalid auth, quota, rate-limit, and unsupported provider are visible errors and are not fallback-eligible by default.
 
@@ -138,6 +140,14 @@ Preferred rollout:
 6. Promote only after the route artifact has an Omi eval report and rollback has been tested.
 
 Do not start by embedding the gateway router into `backend/main.py`. That would make the gateway look separate in code while still sharing the main backend process, lifecycle, scaling, and blast radius.
+
+Local development runs the gateway as its own process:
+
+```bash
+cd backend && ./scripts/dev-serve-llm-gateway.sh
+```
+
+The script derives a per-worktree port from `scripts/dev-instance.sh` and defaults to `PYTHON_PORT + 1000`. Override with `LLM_GATEWAY_PORT=<port>` when needed. Backend callers use repo-local configuration through `OMI_LLM_GATEWAY_URL`; `utils.llm.gateway_client.get_llm_gateway_base_url()` defaults to `http://127.0.0.1:9080` for the primary checkout and strips trailing slashes from explicit values.
 
 ## Major Library Choices
 
@@ -422,6 +432,8 @@ Runtime fail-open means active route failure may use LKG only for failure classe
 
 ## HTTP Surface
 
+`GET /ready` is implemented as a service-authenticated readiness check. It loads the same repo-local gateway config used by the route dependency, validates active/LKG artifacts through `load_gateway_config(prod_mode=True)`, and returns lane IDs plus route artifact count. Config validation failures return 503 with a generic message.
+
 `POST /v1/chat/completions` is implemented as an OpenAI-compatible non-streaming route for internal services:
 
 - requires service auth;
@@ -488,7 +500,7 @@ Do not log raw prompts, transcripts, screenshots, memory contents, provider resp
 6. Add capability validator tests for `chat-structured`. Done.
 7. Add provider executor with fake providers and fallback/error normalization tests. Done.
 8. Add `/v1/chat/completions` non-streaming support behind service auth. Done.
-9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic.
+9. Add `/ready`, local run command, service URL configuration, and separate-process deployment wiring before shadow traffic. Partially done: `/ready`, local run command, and URL config are implemented; Docker/Helm deployment wiring is still pending.
 10. Add gateway client helper in main backend so selected `model_config.py` features can call the gateway.
 11. Route one low-risk structured feature to `omi:auto:chat-structured` in shadow mode.
 12. Add Omi eval reports and promote only after schema validity, extraction quality, latency, and cost gates pass.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,7 @@
                   "doc/developer/backend/Backend_Setup",
                   "doc/developer/backend/backend_deepdive",
                   "doc/developer/backend/chat_system",
+                  "doc/developer/backend/llm_gateway",
                   "doc/developer/backend/StoringConversations",
                   "doc/developer/backend/transcription",
                   "doc/developer/backend/listen_pusher_pipeline"


### PR DESCRIPTION
## Summary
- add a separate FastAPI LLM gateway with repo-local auto-route config, service auth, readiness, and OpenAI-compatible chat completions
- route non-BYOK chat extraction `requires_context` through `omi:auto:chat-structured` first, with existing provider fallback on gateway miss or failure
- add bounded Prometheus telemetry for chat extraction gateway success, fallback, and BYOK skip outcomes
- document the LLM gateway architecture, rollout behavior, BYOK policy, and remaining migration boundaries

## Validation
- `rtk pytest backend/tests/unit/test_llm_gateway_service.py backend/tests/unit/test_llm_gateway_config.py backend/tests/unit/test_llm_gateway_auth.py backend/tests/unit/test_llm_gateway_credentials.py backend/tests/unit/test_llm_gateway_validator.py backend/tests/unit/test_llm_gateway_resolver.py backend/tests/unit/test_llm_gateway_executor.py backend/tests/unit/test_llm_gateway_openai_provider.py backend/tests/unit/test_llm_gateway_openai_compatible.py backend/tests/unit/test_llm_gateway_readiness.py backend/tests/unit/test_llm_gateway_client_config.py backend/tests/unit/test_llm_gateway_route_refs.py backend/tests/unit/test_llm_gateway_dependencies.py backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py -v` (113 passed)
- `rtk bash backend/test-preflight.sh` (passed with optional dependency warnings)
- `rtk python backend/scripts/scan_async_blockers.py` (completed; reports existing unrelated blockers)

## Notes
- `origin/main` was already an ancestor of this branch after fetch, so no merge commit was needed.
- `backend/test.sh` was not used for final validation because it invokes bare `pytest` in this shell; the equivalent gateway-focused tests were run through `rtk pytest`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

