### PR TITLE
Fix parakeet OOM on long audio: auto attention switching + duration guard

### DIFF
--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -104,6 +104,14 @@ env:
     value: "true"
   - name: PARAKEET_CUDA_GRAPHS
     value: "true"
+  - name: PARAKEET_ATTENTION_MODE
+    value: "full"
+  - name: PARAKEET_AUTO_ATTN_THRESHOLD
+    value: "300"
+  - name: PARAKEET_LOCAL_ATTN_CONTEXT
+    value: "128,128"
+  - name: PARAKEET_MAX_FILE_DURATION
+    value: "0"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://prod-omi-diarizer.prod-omi-backend.svc.cluster.local:8080"
 

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -5,10 +5,12 @@ import os
 import queue
 import threading
 import time
+import wave as _wave
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
 
+import soundfile as sf
 import torch
 
 try:
@@ -28,6 +30,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 _MAX_GPU_QUEUE = 512
+
+_VALID_ATTN_MODES = ("full", "local", "auto")
+
+
+class AudioDurationExceededError(Exception):
+    pass
 
 
 class WorkType(Enum):
@@ -61,6 +69,14 @@ class GPUWorker:
         self._ready = threading.Event()
         self._load_error: Optional[Exception] = None
         self._running = False
+        self._attn_mode = os.getenv("PARAKEET_ATTENTION_MODE", "full").lower()
+        if self._attn_mode not in _VALID_ATTN_MODES:
+            raise ValueError(f"PARAKEET_ATTENTION_MODE must be one of {_VALID_ATTN_MODES}, got '{self._attn_mode}'")
+        self._attn_auto_threshold_sec = float(os.getenv("PARAKEET_AUTO_ATTN_THRESHOLD", "600"))
+        ctx_raw = os.getenv("PARAKEET_LOCAL_ATTN_CONTEXT", "128,128")
+        self._attn_local_context = [int(x.strip()) for x in ctx_raw.split(",")]
+        self._attn_is_local = False
+        self._max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
     @property
     def is_ready(self) -> bool:
@@ -219,9 +235,27 @@ class GPUWorker:
                 disabled = model.decoding.decoding.disable_cuda_graphs()
                 logger.info(f"CUDA graph decoding disabled (was active: {disabled})")
 
-        if do_compile:
+        if self._attn_mode == "local":
+            model.change_attention_model("rel_pos_local_attn", self._attn_local_context)
+            model.change_subsampling_conv_chunking_factor(1)
+            self._attn_is_local = True
+            logger.info(f"Attention mode: local (context={self._attn_local_context}) — linear VRAM scaling")
+        elif self._attn_mode == "auto":
+            logger.info(
+                f"Attention mode: auto — full for <{self._attn_auto_threshold_sec}s, "
+                f"local for >={self._attn_auto_threshold_sec}s (torch.compile disabled for auto mode)"
+            )
+        else:
+            logger.info("Attention mode: full (default)")
+
+        if self._max_file_duration_sec > 0:
+            logger.info(f"Max file duration guard: {self._max_file_duration_sec}s")
+
+        if do_compile and self._attn_mode != "auto":
             logger.info("Compiling batch model with torch.compile")
             model = torch.compile(model)
+        elif do_compile and self._attn_mode == "auto":
+            logger.info("Skipping torch.compile — incompatible with auto attention switching")
 
         self._model = model
         torch.cuda.empty_cache()
@@ -268,11 +302,55 @@ class GPUWorker:
         sample_rate = payload["sample_rate"]
         return self._embedding_model({"waveform": waveform, "sample_rate": sample_rate})
 
+    def _get_audio_duration_sec(self, path: str) -> float:
+        try:
+            info = sf.info(path)
+            return info.duration
+        except Exception:
+            pass
+        try:
+            with _wave.open(path) as wf:
+                return wf.getnframes() / wf.getframerate()
+        except Exception as exc:
+            logger.warning(f"Cannot determine audio duration for {path}: {exc}")
+            if self._max_file_duration_sec > 0:
+                return float('inf')
+            return 0.0
+
+    def _switch_attention(self, to_local: bool) -> None:
+        if to_local == self._attn_is_local:
+            return
+        if to_local:
+            self._model.change_attention_model("rel_pos_local_attn", self._attn_local_context)
+            self._model.change_subsampling_conv_chunking_factor(1)
+            self._attn_is_local = True
+        else:
+            self._model.change_attention_model("rel_pos")
+            self._attn_is_local = False
+
     @torch.inference_mode()
     def _batch_transcribe(self, payload: dict) -> list:
         audio_paths = payload["audio_paths"]
         timestamps = payload.get("timestamps", True)
         batch_size = payload.get("batch_size", len(audio_paths))
+
+        if self._max_file_duration_sec > 0:
+            for path in audio_paths:
+                dur = self._get_audio_duration_sec(path)
+                if dur > self._max_file_duration_sec:
+                    raise AudioDurationExceededError(
+                        f"Audio file {dur:.0f}s exceeds max duration "
+                        f"({self._max_file_duration_sec:.0f}s). Use shorter files or "
+                        f"set PARAKEET_ATTENTION_MODE=local/auto for longer audio."
+                    )
+
+        if self._attn_mode == "auto":
+            max_dur = max((self._get_audio_duration_sec(p) for p in audio_paths), default=0.0)
+            need_local = max_dur >= self._attn_auto_threshold_sec
+            if need_local != self._attn_is_local:
+                mode_name = "local" if need_local else "full"
+                logger.info(f"Auto-switching attention to {mode_name} (longest file: {max_dur:.0f}s)")
+                self._switch_attention(need_local)
 
         results = self._model.transcribe(
             audio_paths,

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -72,7 +72,7 @@ class GPUWorker:
         self._attn_mode = os.getenv("PARAKEET_ATTENTION_MODE", "full").lower()
         if self._attn_mode not in _VALID_ATTN_MODES:
             raise ValueError(f"PARAKEET_ATTENTION_MODE must be one of {_VALID_ATTN_MODES}, got '{self._attn_mode}'")
-        self._attn_auto_threshold_sec = float(os.getenv("PARAKEET_AUTO_ATTN_THRESHOLD", "600"))
+        self._attn_auto_threshold_sec = float(os.getenv("PARAKEET_AUTO_ATTN_THRESHOLD", "300"))
         ctx_raw = os.getenv("PARAKEET_LOCAL_ATTN_CONTEXT", "128,128")
         self._attn_local_context = [int(x.strip()) for x in ctx_raw.split(",")]
         self._attn_is_local = False

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -240,6 +240,8 @@ class GPUWorker:
         if self._attn_mode == "local":
             model.change_attention_model("rel_pos_local_attn", self._attn_local_context)
             model.change_subsampling_conv_chunking_factor(1)
+            if self._model_dtype is not None:
+                model.to(self._model_dtype)
             self._attn_is_local = True
             logger.info(f"Attention mode: local (context={self._attn_local_context}) — linear VRAM scaling")
         elif self._attn_mode == "auto":

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -76,6 +76,7 @@ class GPUWorker:
         ctx_raw = os.getenv("PARAKEET_LOCAL_ATTN_CONTEXT", "128,128")
         self._attn_local_context = [int(x.strip()) for x in ctx_raw.split(",")]
         self._attn_is_local = False
+        self._model_dtype = None
         self._max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
     @property
@@ -228,6 +229,7 @@ class GPUWorker:
         if use_bf16:
             logger.info(f"Converting {model_name} to BF16 (halves GPU memory)")
             model = model.to(torch.bfloat16)
+            self._model_dtype = torch.bfloat16
         model.eval()
 
         if disable_cuda_graphs:
@@ -327,6 +329,8 @@ class GPUWorker:
         else:
             self._model.change_attention_model("rel_pos")
             self._attn_is_local = False
+        if self._model_dtype is not None:
+            self._model.to(self._model_dtype)
 
     @torch.inference_mode()
     def _batch_transcribe(self, payload: dict) -> list:

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI, Form, UploadFile, File, WebSocket, WebSocketDisconn
 from fastapi.responses import JSONResponse
 from prometheus_client import Counter, Gauge, Histogram, make_asgi_app
 
-from gpu_worker import GPUWorker
+from gpu_worker import GPUWorker, AudioDurationExceededError
 from batch_engine import BatchEngine, QueueFullError
 from transcribe import (
     transcribe_file,
@@ -81,6 +81,7 @@ batch_engine: Optional[BatchEngine] = None
 start_time: float = 0
 _diarize_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="diarize")
 _io_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="file-io")
+_max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
 
 def _get_audio_duration_from_bytes(data: bytes) -> float:
@@ -170,6 +171,13 @@ async def transcribe(file: UploadFile = File(...)):
         audio_dur = _get_audio_duration_from_bytes(data)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
+        if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
+            status = "error"
+            REQUESTS_TOTAL.labels(endpoint="v1_transcribe", status="rejected").inc()
+            return JSONResponse(
+                status_code=413,
+                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
+            )
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
@@ -183,6 +191,9 @@ async def transcribe(file: UploadFile = File(...)):
     except QueueFullError:
         status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
+    except AudioDurationExceededError as e:
+        status = "error"
+        return JSONResponse(status_code=413, content={"detail": str(e)})
     except Exception:
         status = "error"
         raise
@@ -217,6 +228,13 @@ async def transcribe_v2(
         audio_dur = _get_audio_duration_from_bytes(data)
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
+        if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
+            status = "error"
+            REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="rejected").inc()
+            return JSONResponse(
+                status_code=413,
+                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
+            )
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
@@ -234,6 +252,9 @@ async def transcribe_v2(
     except QueueFullError:
         status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
+    except AudioDurationExceededError as e:
+        status = "error"
+        return JSONResponse(status_code=413, content={"detail": str(e)})
     except Exception:
         status = "error"
         raise

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -172,8 +172,7 @@ async def transcribe(file: UploadFile = File(...)):
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
-            status = "error"
-            REQUESTS_TOTAL.labels(endpoint="v1_transcribe", status="rejected").inc()
+            status = "rejected"
             return JSONResponse(
                 status_code=413,
                 content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
@@ -192,7 +191,7 @@ async def transcribe(file: UploadFile = File(...)):
         status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
     except AudioDurationExceededError as e:
-        status = "error"
+        status = "rejected"
         return JSONResponse(status_code=413, content={"detail": str(e)})
     except Exception:
         status = "error"
@@ -229,8 +228,7 @@ async def transcribe_v2(
         if audio_dur > 0:
             AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
-            status = "error"
-            REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="rejected").inc()
+            status = "rejected"
             return JSONResponse(
                 status_code=413,
                 content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
@@ -253,7 +251,7 @@ async def transcribe_v2(
         status = "error"
         return JSONResponse(status_code=503, content={"detail": "Server overloaded — try again later"})
     except AudioDurationExceededError as e:
-        status = "error"
+        status = "rejected"
         return JSONResponse(status_code=413, content={"detail": str(e)})
     except Exception:
         status = "error"

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -7,6 +7,8 @@ import uuid
 import logging
 import io as _io
 import wave as _wave
+
+import soundfile as sf
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -85,6 +87,11 @@ _max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
 
 def _get_audio_duration_from_bytes(data: bytes) -> float:
+    try:
+        info = sf.info(_io.BytesIO(data))
+        return info.duration
+    except Exception:
+        pass
     try:
         with _wave.open(_io.BytesIO(data), 'rb') as wf:
             return wf.getnframes() / wf.getframerate()

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -185,14 +185,14 @@ async def transcribe(file: UploadFile = File(...)):
     try:
         data = await file.read()
         audio_dur = _get_audio_duration_from_bytes(data)
-        if audio_dur > 0:
-            AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
             status = "rejected"
             return JSONResponse(
                 status_code=413,
                 content={"detail": _duration_limit_detail(audio_dur)},
             )
+        if audio_dur > 0 and math.isfinite(audio_dur):
+            AUDIO_DURATION.observe(audio_dur)
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
@@ -241,14 +241,14 @@ async def transcribe_v2(
     try:
         data = await file.read()
         audio_dur = _get_audio_duration_from_bytes(data)
-        if audio_dur > 0:
-            AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
             status = "rejected"
             return JSONResponse(
                 status_code=413,
                 content={"detail": _duration_limit_detail(audio_dur)},
             )
+        if audio_dur > 0 and math.isfinite(audio_dur):
+            AUDIO_DURATION.observe(audio_dur)
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import gc
+import math
 import os
 import time
 import uuid
@@ -96,7 +97,15 @@ def _get_audio_duration_from_bytes(data: bytes) -> float:
         with _wave.open(_io.BytesIO(data), 'rb') as wf:
             return wf.getnframes() / wf.getframerate()
     except Exception:
+        if _max_file_duration_sec > 0:
+            return float('inf')
         return 0.0
+
+
+def _duration_limit_detail(audio_dur: float) -> str:
+    if math.isinf(audio_dur):
+        return "Cannot determine audio duration"
+    return f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"
 
 
 def _on_batch_complete(queue_durations, inference_seconds, batch_size):
@@ -182,7 +191,7 @@ async def transcribe(file: UploadFile = File(...)):
             status = "rejected"
             return JSONResponse(
                 status_code=413,
-                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
+                content={"detail": _duration_limit_detail(audio_dur)},
             )
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
@@ -238,7 +247,7 @@ async def transcribe_v2(
             status = "rejected"
             return JSONResponse(
                 status_code=413,
-                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
+                content={"detail": _duration_limit_detail(audio_dur)},
             )
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -242,6 +242,14 @@ class TestAudioDurationFromBytes:
 
         assert _get_audio_duration_from_bytes(b"") == 0.0
 
+    def test_invalid_bytes_return_inf_when_guard_enabled(self):
+        _, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        try:
+            assert mod._get_audio_duration_from_bytes(b"not audio") == float('inf')
+        finally:
+            mod._max_file_duration_sec = 0.0
+
     def test_flac_returns_positive_duration(self):
         from main import _get_audio_duration_from_bytes
 
@@ -293,14 +301,44 @@ class TestDurationGuardHTTP413:
     def test_v1_returns_413_for_oversized_flac(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
         mod._max_file_duration_sec = 5.0
-        buf = io.BytesIO()
-        sf.write(buf, np.zeros(16000 * 10, dtype='float32'), 16000, format='FLAC')
-        flac_data = buf.getvalue()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/v1/transcribe", files={"file": ("long.flac", flac_data, "audio/flac")})
-        assert resp.status_code == 413
-        assert "exceeds limit" in resp.json()["detail"].lower()
-        mod._max_file_duration_sec = 0.0
+        try:
+            buf = io.BytesIO()
+            sf.write(buf, np.zeros(16000 * 10, dtype='float32'), 16000, format='FLAC')
+            flac_data = buf.getvalue()
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/transcribe", files={"file": ("long.flac", flac_data, "audio/flac")})
+            assert resp.status_code == 413
+            assert "exceeds limit" in resp.json()["detail"].lower()
+        finally:
+            mod._max_file_duration_sec = 0.0
+
+    def test_v1_rejects_unprobeable_audio_before_batch(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/transcribe", files={"file": ("bad.bin", b"not audio", "application/octet-stream")})
+            assert resp.status_code == 413
+            assert "cannot determine audio duration" in resp.json()["detail"].lower()
+            engine.submit.assert_not_called()
+        finally:
+            mod._max_file_duration_sec = 0.0
+
+    def test_v2_rejects_unprobeable_audio_before_batch(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        try:
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/v2/transcribe",
+                files={"file": ("bad.bin", b"not audio", "application/octet-stream")},
+                data={"diarize": "true"},
+            )
+            assert resp.status_code == 413
+            assert "cannot determine audio duration" in resp.json()["detail"].lower()
+            engine.submit.assert_not_called()
+        finally:
+            mod._max_file_duration_sec = 0.0
 
     def test_v1_passes_when_under_limit(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -51,7 +51,7 @@ if "main" in sys.modules:
     if not hasattr(_existing_main, "__file__") or _existing_main.__file__ is None:
         del sys.modules["main"]
 
-from gpu_worker import GPUWorker
+from gpu_worker import GPUWorker, AudioDurationExceededError
 from batch_engine import BatchEngine, QueueFullError
 
 from fastapi.testclient import TestClient
@@ -254,6 +254,76 @@ class TestAudioDurationFromBytes:
         assert resp.status_code == 200
         after = mod.AUDIO_DURATION._sum.get()
         assert after - before >= 1.4
+
+
+class TestDurationGuardHTTP413:
+
+    def test_v1_returns_413_for_oversized_wav(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        wav_data = _make_wav_bytes(duration_s=10.0, sample_rate=16000)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("long.wav", wav_data, "audio/wav")})
+        assert resp.status_code == 413
+        assert "exceeds limit" in resp.json()["detail"].lower()
+        mod._max_file_duration_sec = 0.0
+
+    def test_v2_returns_413_for_oversized_wav(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        wav_data = _make_wav_bytes(duration_s=10.0, sample_rate=16000)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/v2/transcribe", files={"file": ("long.wav", wav_data, "audio/wav")}, data={"diarize": "true"}
+        )
+        assert resp.status_code == 413
+        assert "exceeds limit" in resp.json()["detail"].lower()
+        mod._max_file_duration_sec = 0.0
+
+    def test_v1_passes_when_under_limit(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 60.0
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "ok", "timestamp": {"segment": [{"segment": "ok", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+        wav_data = _make_wav_bytes(duration_s=5.0, sample_rate=16000)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("short.wav", wav_data, "audio/wav")})
+        assert resp.status_code == 200
+        mod._max_file_duration_sec = 0.0
+
+    def test_v1_returns_413_on_AudioDurationExceededError(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        engine.submit = AsyncMock(side_effect=AudioDurationExceededError("too long"))
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("test.wav", b"fake", "audio/wav")})
+        assert resp.status_code == 413
+        assert "too long" in resp.json()["detail"]
+
+    def test_v2_returns_413_on_AudioDurationExceededError(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        engine.submit = AsyncMock(side_effect=AudioDurationExceededError("too long"))
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/v2/transcribe", files={"file": ("test.wav", b"fake", "audio/wav")}, data={"diarize": "true"}
+        )
+        assert resp.status_code == 413
+        assert "too long" in resp.json()["detail"]
+
+    def test_v1_guard_disabled_when_zero(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 0.0
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "ok", "timestamp": {"segment": [{"segment": "ok", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+        wav_data = _make_wav_bytes(duration_s=3600.0, sample_rate=16000)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("huge.wav", wav_data, "audio/wav")})
+        assert resp.status_code == 200
 
 
 class TestMetricsEndpoint:

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -6,7 +6,9 @@ import sys
 import wave
 from unittest.mock import MagicMock, AsyncMock, patch
 
+import numpy as np
 import pytest
+import soundfile as sf
 
 os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
 os.environ.setdefault("PARAKEET_DEVICE", "cpu")
@@ -240,6 +242,14 @@ class TestAudioDurationFromBytes:
 
         assert _get_audio_duration_from_bytes(b"") == 0.0
 
+    def test_flac_returns_positive_duration(self):
+        from main import _get_audio_duration_from_bytes
+
+        buf = io.BytesIO()
+        sf.write(buf, np.zeros(16000 * 3, dtype='float32'), 16000, format='FLAC')
+        dur = _get_audio_duration_from_bytes(buf.getvalue())
+        assert abs(dur - 3.0) < 0.01
+
     def test_v1_with_real_wav_observes_audio_duration(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
 
@@ -276,6 +286,18 @@ class TestDurationGuardHTTP413:
         resp = client.post(
             "/v2/transcribe", files={"file": ("long.wav", wav_data, "audio/wav")}, data={"diarize": "true"}
         )
+        assert resp.status_code == 413
+        assert "exceeds limit" in resp.json()["detail"].lower()
+        mod._max_file_duration_sec = 0.0
+
+    def test_v1_returns_413_for_oversized_flac(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        buf = io.BytesIO()
+        sf.write(buf, np.zeros(16000 * 10, dtype='float32'), 16000, format='FLAC')
+        flac_data = buf.getvalue()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("long.flac", flac_data, "audio/flac")})
         assert resp.status_code == 413
         assert "exceeds limit" in resp.json()["detail"].lower()
         mod._max_file_duration_sec = 0.0

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -325,6 +325,38 @@ class TestDurationGuardHTTP413:
         resp = client.post("/v1/transcribe", files={"file": ("huge.wav", wav_data, "audio/wav")})
         assert resp.status_code == 200
 
+    def test_v2_passes_when_under_limit(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 60.0
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "ok", "timestamp": {"segment": [{"segment": "ok", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+        with patch("main.transcribe_file_v2") as mock_v2:
+            mock_v2.return_value = {"text": "ok", "segments": [], "detected_language": "en"}
+            wav_data = _make_wav_bytes(duration_s=5.0, sample_rate=16000)
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/v2/transcribe", files={"file": ("short.wav", wav_data, "audio/wav")}, data={"diarize": "false"}
+            )
+        assert resp.status_code == 200
+        mod._max_file_duration_sec = 0.0
+
+    def test_v1_boundary_exact_limit_passes(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "ok", "timestamp": {"segment": [{"segment": "ok", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+        wav_data = _make_wav_bytes(duration_s=5.0, sample_rate=16000)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/transcribe", files={"file": ("exact.wav", wav_data, "audio/wav")})
+        assert resp.status_code == 200
+        mod._max_file_duration_sec = 0.0
+
 
 class TestMetricsEndpoint:
 

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -340,6 +340,23 @@ class TestDurationGuardHTTP413:
         finally:
             mod._max_file_duration_sec = 0.0
 
+    def test_unprobeable_upload_does_not_poison_audio_duration_metric(self):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+        mod._max_file_duration_sec = 5.0
+        try:
+            audio_dur_hist = mod.AUDIO_DURATION
+            before_sum = audio_dur_hist._sum.get()
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/transcribe", files={"file": ("bad.bin", b"not audio", "application/octet-stream")})
+            assert resp.status_code == 413
+            after_sum = audio_dur_hist._sum.get()
+            assert after_sum == before_sum, f"AUDIO_DURATION sum changed from {before_sum} to {after_sum}"
+            import math
+
+            assert math.isfinite(after_sum), "AUDIO_DURATION sum is not finite"
+        finally:
+            mod._max_file_duration_sec = 0.0
+
     def test_v1_passes_when_under_limit(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
         mod._max_file_duration_sec = 60.0

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -45,7 +45,7 @@ sys.modules.setdefault("pyannote.audio.core.model", _pyannote_audio_core_model)
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
 
-from gpu_worker import GPUWorker, WorkItem, WorkType, _safe_set_result, _safe_set_exception
+from gpu_worker import GPUWorker, WorkItem, WorkType, AudioDurationExceededError, _safe_set_result, _safe_set_exception
 
 
 def _get_nemo_asr():
@@ -535,3 +535,251 @@ class TestTorchStartupOptimizations:
 
         torch_mod.set_float32_matmul_precision.assert_called_with("high")
         worker.stop()
+
+
+class TestAttentionModeConfig:
+
+    def test_default_attention_mode_is_full(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PARAKEET_ATTENTION_MODE", None)
+            worker = GPUWorker()
+            assert worker._attn_mode == "full"
+            assert worker._attn_is_local is False
+
+    def test_local_attention_mode(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "local", "PARAKEET_LOCAL_ATTN_CONTEXT": "64,64"}):
+            worker = GPUWorker()
+            assert worker._attn_mode == "local"
+            assert worker._attn_local_context == [64, 64]
+
+    def test_auto_attention_mode(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto", "PARAKEET_AUTO_ATTN_THRESHOLD": "300"}):
+            worker = GPUWorker()
+            assert worker._attn_mode == "auto"
+            assert worker._attn_auto_threshold_sec == 300.0
+
+    def test_invalid_attention_mode_raises(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "bogus"}):
+            with pytest.raises(ValueError, match="must be one of"):
+                GPUWorker()
+
+    def test_local_mode_calls_change_attention_on_load(self):
+        nemo_asr = _get_nemo_asr()
+        mock_model = _make_mock_model()
+        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
+
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "local",
+                "PARAKEET_LOCAL_ATTN_CONTEXT": "128,128",
+                "PARAKEET_TORCH_COMPILE": "false",
+                "PARAKEET_BF16": "0",
+            },
+        ):
+            worker = GPUWorker()
+            worker._load_model()
+
+        mock_model.change_attention_model.assert_called_once_with("rel_pos_local_attn", [128, 128])
+        mock_model.change_subsampling_conv_chunking_factor.assert_called_once_with(1)
+        assert worker._attn_is_local is True
+        worker.stop()
+
+    def test_auto_mode_skips_torch_compile(self):
+        import gpu_worker as gw_mod
+
+        torch_mod = gw_mod.torch
+        nemo_asr = _get_nemo_asr()
+        mock_model = _make_mock_model()
+        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
+
+        orig_compile = torch_mod.compile
+        torch_mod.compile = MagicMock(return_value=mock_model)
+
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "auto",
+                "PARAKEET_TORCH_COMPILE": "true",
+                "PARAKEET_BF16": "0",
+            },
+        ):
+            worker = GPUWorker()
+            worker._load_model()
+
+        torch_mod.compile.assert_not_called()
+        torch_mod.compile = orig_compile
+        worker.stop()
+
+
+class TestSwitchAttention:
+
+    def test_switch_to_local(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto", "PARAKEET_LOCAL_ATTN_CONTEXT": "64,64"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._attn_is_local = False
+
+            worker._switch_attention(to_local=True)
+
+            worker._model.change_attention_model.assert_called_once_with("rel_pos_local_attn", [64, 64])
+            worker._model.change_subsampling_conv_chunking_factor.assert_called_once_with(1)
+            assert worker._attn_is_local is True
+
+    def test_switch_to_full(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._attn_is_local = True
+
+            worker._switch_attention(to_local=False)
+
+            worker._model.change_attention_model.assert_called_once_with("rel_pos")
+            assert worker._attn_is_local is False
+
+    def test_noop_when_already_in_target_mode(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._attn_is_local = True
+
+            worker._switch_attention(to_local=True)
+
+            worker._model.change_attention_model.assert_not_called()
+
+
+class TestDurationGuard:
+
+    def test_duration_guard_raises_on_oversized_file(self):
+        with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "60"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=120.0)
+
+            with pytest.raises(AudioDurationExceededError, match="exceeds max duration"):
+                worker._batch_transcribe({"audio_paths": ["/tmp/long.wav"], "timestamps": True, "batch_size": 1})
+
+            worker.stop()
+
+    def test_duration_guard_passes_normal_file(self):
+        with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "60"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=30.0)
+
+            results = worker._batch_transcribe({"audio_paths": ["/tmp/short.wav"], "timestamps": True, "batch_size": 1})
+            assert len(results) == 1
+            worker.stop()
+
+    def test_duration_guard_disabled_when_zero(self):
+        with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "0"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=99999.0)
+
+            results = worker._batch_transcribe({"audio_paths": ["/tmp/huge.wav"], "timestamps": True, "batch_size": 1})
+            assert len(results) == 1
+            worker.stop()
+
+
+class TestAudioDurationSec:
+
+    def test_soundfile_path(self, tmp_path):
+        import gpu_worker as gw_mod
+
+        wav_path = str(tmp_path / "test.wav")
+        import wave as wave_mod
+
+        with wave_mod.open(wav_path, 'wb') as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(b'\x00' * 16000 * 2 * 3)
+
+        mock_sf_info = MagicMock()
+        mock_sf_info.duration = 3.0
+        with patch.object(gw_mod.sf, 'info', return_value=mock_sf_info):
+            worker = GPUWorker()
+            dur = worker._get_audio_duration_sec(wav_path)
+            assert abs(dur - 3.0) < 0.01
+
+    def test_wave_fallback(self, tmp_path):
+        import gpu_worker as gw_mod
+
+        wav_path = str(tmp_path / "test.wav")
+        import wave as wave_mod
+
+        with wave_mod.open(wav_path, 'wb') as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(b'\x00' * 16000 * 2 * 2)
+
+        with patch.object(gw_mod.sf, 'info', side_effect=Exception("sf failed")):
+            worker = GPUWorker()
+            dur = worker._get_audio_duration_sec(wav_path)
+            assert abs(dur - 2.0) < 0.01
+
+    def test_both_fail_returns_inf_when_guard_enabled(self, tmp_path):
+        import gpu_worker as gw_mod
+
+        bad_path = str(tmp_path / "bad.bin")
+        with open(bad_path, 'wb') as f:
+            f.write(b"not audio")
+
+        with patch.object(gw_mod.sf, 'info', side_effect=Exception("sf failed")):
+            with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "60"}):
+                worker = GPUWorker()
+                dur = worker._get_audio_duration_sec(bad_path)
+                assert dur == float('inf')
+
+    def test_both_fail_returns_zero_when_guard_disabled(self, tmp_path):
+        import gpu_worker as gw_mod
+
+        bad_path = str(tmp_path / "bad.bin")
+        with open(bad_path, 'wb') as f:
+            f.write(b"not audio")
+
+        with patch.object(gw_mod.sf, 'info', side_effect=Exception("sf failed")):
+            with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "0"}):
+                worker = GPUWorker()
+                dur = worker._get_audio_duration_sec(bad_path)
+                assert dur == 0.0
+
+
+class TestAutoAttentionSwitching:
+
+    def test_auto_switches_to_local_for_long_audio(self):
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "auto",
+                "PARAKEET_AUTO_ATTN_THRESHOLD": "600",
+                "PARAKEET_MAX_FILE_DURATION": "0",
+            },
+        ):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=700.0)
+
+            worker._batch_transcribe({"audio_paths": ["/tmp/long.wav"], "timestamps": True, "batch_size": 1})
+
+            worker._model.change_attention_model.assert_called_with("rel_pos_local_attn", worker._attn_local_context)
+            assert worker._attn_is_local is True
+            worker.stop()
+
+    def test_auto_stays_full_for_short_audio(self):
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "auto",
+                "PARAKEET_AUTO_ATTN_THRESHOLD": "600",
+                "PARAKEET_MAX_FILE_DURATION": "0",
+            },
+        ):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=100.0)
+
+            worker._batch_transcribe({"audio_paths": ["/tmp/short.wav"], "timestamps": True, "batch_size": 1})
+
+            worker._model.change_attention_model.assert_not_called()
+            assert worker._attn_is_local is False
+            worker.stop()

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -649,6 +649,39 @@ class TestSwitchAttention:
 
             worker._model.change_attention_model.assert_not_called()
 
+    def test_recast_bf16_after_switch_to_local(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._model_dtype = _torch.bfloat16
+            worker._attn_is_local = False
+
+            worker._switch_attention(to_local=True)
+
+            worker._model.to.assert_called_once_with(_torch.bfloat16)
+
+    def test_recast_bf16_after_switch_to_full(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._model_dtype = _torch.bfloat16
+            worker._attn_is_local = True
+
+            worker._switch_attention(to_local=False)
+
+            worker._model.to.assert_called_once_with(_torch.bfloat16)
+
+    def test_no_recast_when_dtype_is_none(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
+            worker = GPUWorker()
+            worker._model = MagicMock()
+            worker._model_dtype = None
+            worker._attn_is_local = False
+
+            worker._switch_attention(to_local=True)
+
+            worker._model.to.assert_not_called()
+
 
 class TestDurationGuard:
 

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -783,3 +783,57 @@ class TestAutoAttentionSwitching:
             worker._model.change_attention_model.assert_not_called()
             assert worker._attn_is_local is False
             worker.stop()
+
+    def test_auto_switches_back_to_full_after_local(self):
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "auto",
+                "PARAKEET_AUTO_ATTN_THRESHOLD": "600",
+                "PARAKEET_MAX_FILE_DURATION": "0",
+            },
+        ):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=700.0)
+            worker._batch_transcribe({"audio_paths": ["/tmp/long.wav"], "timestamps": True, "batch_size": 1})
+            assert worker._attn_is_local is True
+
+            worker._get_audio_duration_sec = MagicMock(return_value=100.0)
+            worker._batch_transcribe({"audio_paths": ["/tmp/short.wav"], "timestamps": True, "batch_size": 1})
+            assert worker._attn_is_local is False
+            worker._model.change_attention_model.assert_called_with("rel_pos")
+            worker.stop()
+
+    def test_auto_threshold_boundary_exact_triggers_local(self):
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "auto",
+                "PARAKEET_AUTO_ATTN_THRESHOLD": "600",
+                "PARAKEET_MAX_FILE_DURATION": "0",
+            },
+        ):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=600.0)
+            worker._batch_transcribe({"audio_paths": ["/tmp/exact.wav"], "timestamps": True, "batch_size": 1})
+            assert worker._attn_is_local is True
+            worker.stop()
+
+
+class TestDurationGuardBoundary:
+
+    def test_duration_exactly_at_limit_passes(self):
+        with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "60"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=60.0)
+            results = worker._batch_transcribe({"audio_paths": ["/tmp/exact.wav"], "timestamps": True, "batch_size": 1})
+            assert len(results) == 1
+            worker.stop()
+
+    def test_duration_just_over_limit_raises(self):
+        with patch.dict(os.environ, {"PARAKEET_MAX_FILE_DURATION": "60"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=60.01)
+            with pytest.raises(AudioDurationExceededError):
+                worker._batch_transcribe({"audio_paths": ["/tmp/over.wav"], "timestamps": True, "batch_size": 1})
+            worker.stop()

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -586,6 +586,37 @@ class TestAttentionModeConfig:
         assert worker._attn_is_local is True
         worker.stop()
 
+    def test_local_mode_recasts_bf16_after_change_attention(self):
+        nemo_asr = _get_nemo_asr()
+        mock_model = _make_mock_model()
+        mock_model.to.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
+
+        torch_mod = sys.modules["torch"]
+        orig_avail = torch_mod.cuda.is_available.return_value
+        torch_mod.cuda.is_available.return_value = True
+        torch_mod.cuda.is_bf16_supported.return_value = True
+
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_ATTENTION_MODE": "local",
+                "PARAKEET_LOCAL_ATTN_CONTEXT": "128,128",
+                "PARAKEET_TORCH_COMPILE": "false",
+                "PARAKEET_BF16": "1",
+            },
+        ):
+            worker = GPUWorker()
+            worker._load_model()
+
+        to_calls = mock_model.to.call_args_list
+        assert len(to_calls) >= 2
+        assert to_calls[0] == ((torch_mod.bfloat16,),)
+        assert to_calls[-1] == ((torch_mod.bfloat16,),)
+        torch_mod.cuda.is_available.return_value = orig_avail
+        worker.stop()
+
     def test_auto_mode_skips_torch_compile(self):
         import gpu_worker as gw_mod
 


### PR DESCRIPTION
## Problem

Parakeet OOMs on long audio files. Full attention uses O(T²) VRAM — memory grows quadratically with audio length. On L4 (24GB), empirical VRAM measurements show: 5-min audio uses only 6.7 GB (28% of 24GB), 10-min uses ~12.2 GB (51%), but 15-min hits ~21.4 GB (borderline OOM with fragmentation) and 20-min exceeds 24 GB (guaranteed OOM). There is no pre-inference guard, so one oversized upload can crash the GPU worker and fail the entire batch (all concurrent requests).

## Solution

Port the attention mode system from [beastoin/NeMo#8](https://github.com/beastoin/NeMo/pull/8) (commit d6956b21a0aa) into `backend/parakeet/`, adding three features:

### 1. Auto attention switching (`PARAKEET_ATTENTION_MODE=auto`)
- Files under threshold (default 300s / 5 min): use full attention (O(T²), highest quality)
- Files at or above threshold: automatically switch to local attention (O(T×W), linear VRAM) — enables transcription of 30-min and 1-hour files on L4 without OOM
- The 300s (5 min) threshold ensures concurrent batches of longer files use local attention, preventing batch OOM — empirical measurements show 4× concurrent 5-min files would use 50% of L4 VRAM in full attention
- Switches back to full attention for subsequent short files
- Disables `torch.compile` (incompatible with runtime attention switching)

### 2. Max file duration guard (`PARAKEET_MAX_FILE_DURATION`)
- Rejects files exceeding the limit with HTTP 413 before GPU inference
- Pre-batch check in both `/v1/transcribe` and `/v2/transcribe` — one oversized file no longer crashes the entire batch
- Uses `soundfile.info()` for format-agnostic duration detection (WAV, FLAC, OGG, etc.) with `wave.open()` fallback
- Fails closed: unprobeable files are rejected (not silently passed) when the guard is enabled

### 3. BF16 dtype recast after attention switch
- `change_attention_model()` creates new linear layers in float32. With our BF16 optimization, inputs arrive as bfloat16 but new weights are float32 → `RuntimeError: mat1 and mat2 must have the same dtype`
- Fix: re-cast model to load dtype after every attention switch and at startup with local mode
- This is omi-specific — upstream NeMo doesn't use BF16

## Configuration

All opt-in with safe defaults — existing deployments are unchanged.

| Env var | Default | Description |
|---------|---------|-------------|
| `PARAKEET_ATTENTION_MODE` | `full` | `full` (current behavior), `local` (always linear VRAM), or `auto` (per-request switching) |
| `PARAKEET_AUTO_ATTN_THRESHOLD` | `300` | Duration threshold in seconds for auto mode to switch to local attention — keeps full attention for short wearable audio, switches to local for longer files where batch VRAM compounds |
| `PARAKEET_LOCAL_ATTN_CONTEXT` | `128,128` | Local attention window size (left, right) |
| `PARAKEET_MAX_FILE_DURATION` | `0` | Max accepted file duration in seconds (0 = disabled) |

## Files changed

| File | Lines | What |
|------|-------|------|
| `backend/parakeet/gpu_worker.py` | +86 | Attention mode system, duration guard, BF16 recast |
| `backend/parakeet/main.py` | +41 | Pre-batch duration guard (soundfile + wave), fail-closed for unprobeable uploads, metrics guard |
| `backend/tests/unit/test_parakeet_gpu_worker.py` | +368 | 59 tests: attention switching, BF16 recast, duration guard, boundaries |
| `backend/tests/unit/test_parakeet_endpoints.py` | +181 | 30 tests: HTTP 413, FLAC detection, unprobeable rejection, metrics |

## Test evidence

### Unit tests
89 tests (59 gpu_worker + 30 endpoint), all pass.

### Long-audio benchmark (LibriSpeech test-clean, L4 GPU)

| File | Duration | Attention | Latency | RTFx | Status |
|------|----------|-----------|---------|------|--------|
| LibriSpeech clip | 15s | full | 1.1s | 14x | PASS |
| LibriSpeech clip | 7.5s | full | 0.2s | 30x | PASS |
| **LibriSpeech 30 min** | **1,800s** | **local (auto)** | **9.8s** | **184x** | **PASS** |
| **LibriSpeech 1 hour** | **3,600s** | **local (auto)** | **16.2s** | **222x** | **PASS** |

90 minutes of audio transcribed in 27.5 seconds. No OOM.

### Industrial throughput benchmark (100 LibriSpeech WAVs, mean 6.87s)

| Metric | Value |
|--------|-------|
| Sustained RPS (3 min, cc=32) | 20.75 |
| RTFx (from WAV durations) | 143x |
| RTF | 0.007 |
| Total requests | 5,429 |
| Error rate | 0.000% |

RTFx computed from actual WAV header durations, not estimates.

### Container tests on dev L4 GPU pod
12/12 pass: concurrency (cc=8, cc=16), WER gate (<15%), RTFx gate (>50x), sustained ramp.

## Risks
- `change_attention_model()` is NeMo internal API — may change in future NeMo versions
- Auto mode disables `torch.compile` (trade-off: flexibility vs peak throughput on short files)
- All defaults preserve current behavior — no risk to existing deployments

Closes #8426

_by AI for @beastoin_