### PR TITLE
Fix data loss and a layout crash in the Windows local knowledge graph

### DIFF
--- a/desktop/windows/src/renderer/src/lib/graphLayout.test.ts
+++ b/desktop/windows/src/renderer/src/lib/graphLayout.test.ts
@@ -65,4 +65,16 @@ describe('computeLayout', () => {
     expect(out.nodes).toHaveLength(1)
     expect(Number.isFinite(out.nodes[0].x)).toBe(true)
   })
+
+  it('ignores an edge whose endpoint id matches an inherited object property', () => {
+    const out = computeLayout(
+      {
+        nodes: [{ id: 'a', label: 'A', nodeType: 'person', aliases: [], memoryIds: [] }],
+        edges: [{ id: 'e', sourceId: 'a', targetId: '__proto__', label: '', memoryIds: [] }]
+      },
+      { iterations: 5 }
+    )
+    expect(out.nodes).toHaveLength(1)
+    expect(Number.isFinite(out.nodes[0].x)).toBe(true)
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/graphLayout.test.ts
+++ b/desktop/windows/src/renderer/src/lib/graphLayout.test.ts
@@ -53,4 +53,16 @@ describe('computeLayout', () => {
     )
     expect(out.nodes[0].degree).toBe(1)
   })
+
+  it('ignores an edge that points to a node that is not present', () => {
+    const out = computeLayout(
+      {
+        nodes: [{ id: 'a', label: 'A', nodeType: 'person', aliases: [], memoryIds: [] }],
+        edges: [{ id: 'e', sourceId: 'a', targetId: 'ghost', label: '', memoryIds: [] }]
+      },
+      { iterations: 5 }
+    )
+    expect(out.nodes).toHaveLength(1)
+    expect(Number.isFinite(out.nodes[0].x)).toBe(true)
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/graphLayout.ts
+++ b/desktop/windows/src/renderer/src/lib/graphLayout.ts
@@ -26,23 +26,33 @@ export function computeLayout(graph: KnowledgeGraph, opts: LayoutOptions = {}): 
   const degree: Record<string, number> = {}
   for (const n of graph.nodes) degree[n.id] = 0
   for (const e of graph.edges) {
-    if (e.sourceId in degree) degree[e.sourceId]++
-    if (e.targetId in degree && e.targetId !== e.sourceId) degree[e.targetId]++
+    if (Object.hasOwn(degree, e.sourceId)) degree[e.sourceId]++
+    if (Object.hasOwn(degree, e.targetId) && e.targetId !== e.sourceId) degree[e.targetId]++
   }
 
   const simNodes: SimNode[] = graph.nodes.map((n) => ({ ...n, degree: degree[n.id] ?? 0 }))
   // Skip edges whose endpoints are not both present. forceLink throws
   // "missing: <id>" on a dangling reference, and merge/onboarding can emit an
-  // edge before its node exists (degree above already tolerates this).
+  // edge before its node exists. Use Object.hasOwn rather than the `in` operator
+  // so an endpoint id equal to an inherited property name (__proto__, constructor,
+  // toString, ...) is not treated as a present node.
   const simLinks: SimLink[] = graph.edges
-    .filter((e) => e.sourceId in degree && e.targetId in degree)
+    .filter((e) => Object.hasOwn(degree, e.sourceId) && Object.hasOwn(degree, e.targetId))
     .map((e) => ({ source: e.sourceId, target: e.targetId }))
 
   const sim = forceSimulation<SimNode>(simNodes)
     .force('charge', forceManyBody().strength(-180))
-    .force('link', forceLink<SimNode, SimLink>(simLinks).id((d) => d.id).distance(70))
+    .force(
+      'link',
+      forceLink<SimNode, SimLink>(simLinks)
+        .id((d) => d.id)
+        .distance(70)
+    )
     .force('center', forceCenter(width / 2, height / 2))
-    .force('collide', forceCollide<SimNode>().radius((d) => 6 + Math.sqrt(d.degree) * 4))
+    .force(
+      'collide',
+      forceCollide<SimNode>().radius((d) => 6 + Math.sqrt(d.degree) * 4)
+    )
     .stop()
 
   sim.tick(iterations)

--- a/desktop/windows/src/renderer/src/lib/graphLayout.ts
+++ b/desktop/windows/src/renderer/src/lib/graphLayout.ts
@@ -31,7 +31,12 @@ export function computeLayout(graph: KnowledgeGraph, opts: LayoutOptions = {}): 
   }
 
   const simNodes: SimNode[] = graph.nodes.map((n) => ({ ...n, degree: degree[n.id] ?? 0 }))
-  const simLinks: SimLink[] = graph.edges.map((e) => ({ source: e.sourceId, target: e.targetId }))
+  // Skip edges whose endpoints are not both present. forceLink throws
+  // "missing: <id>" on a dangling reference, and merge/onboarding can emit an
+  // edge before its node exists (degree above already tolerates this).
+  const simLinks: SimLink[] = graph.edges
+    .filter((e) => e.sourceId in degree && e.targetId in degree)
+    .map((e) => ({ source: e.sourceId, target: e.targetId }))
 
   const sim = forceSimulation<SimNode>(simNodes)
     .force('charge', forceManyBody().strength(-180))

--- a/desktop/windows/src/renderer/src/lib/kgTech.test.ts
+++ b/desktop/windows/src/renderer/src/lib/kgTech.test.ts
@@ -53,7 +53,11 @@ describe('deriveFolderNodes', () => {
 describe('slugify / nodeId', () => {
   it('lowercases and hyphenates', () => {
     expect(slugify('Visual Studio Code')).toBe('visual-studio-code')
-    expect(slugify('C++')).toBe('c')
+  })
+  it('keeps C, C++ and C# distinct', () => {
+    expect(slugify('C')).toBe('c')
+    expect(slugify('C++')).toBe('cpp')
+    expect(slugify('C#')).toBe('csharp')
   })
   it('builds a stable id from label + type', () => {
     expect(nodeId('TypeScript', 'technology')).toBe('typescript:technology')
@@ -91,6 +95,15 @@ describe('deriveTechNodes', () => {
   it('ignores unknown extensions and a leading dot', () => {
     const nodes = deriveTechNodes({ '.py': 5, xyz: 100 }, now)
     expect(nodes.map((n) => n.label)).toEqual(['Python'])
+  })
+
+  it('keeps C, C++ and C# as separate technology nodes', () => {
+    const nodes = deriveTechNodes({ c: 5, cpp: 5, cs: 5 }, now)
+    expect(nodes.map((n) => n.id).sort()).toEqual([
+      'c:technology',
+      'cpp:technology',
+      'csharp:technology'
+    ])
   })
 })
 

--- a/desktop/windows/src/renderer/src/lib/kgTech.ts
+++ b/desktop/windows/src/renderer/src/lib/kgTech.ts
@@ -7,6 +7,10 @@ export const MIN_FILES_FOR_TECH = 3
 export function slugify(label: string): string {
   return label
     .toLowerCase()
+    // Preserve the C++ / C# distinction before the punctuation strip, otherwise
+    // "C", "C++" and "C#" all collapse to "c" and share one technology node id.
+    .replace(/\+/g, 'p')
+    .replace(/#/g, 'sharp')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
 }

--- a/desktop/windows/src/renderer/src/lib/memoryExtract.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryExtract.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// memoryExtract pulls in apiClient (axios/firebase) at import; stub it so the
+// pure normalize() can be unit-tested in isolation.
+vi.mock('./apiClient', () => ({ desktopApi: {}, omiApi: {} }))
+
+import { normalize } from './memoryExtract'
+
+describe('normalize', () => {
+  it('lowercases, drops punctuation, and collapses whitespace', () => {
+    expect(normalize('  Works in  NY. ')).toBe('works in ny')
+  })
+
+  it('keeps + and # so C++ and C# stay distinct dedupe keys', () => {
+    expect(normalize('Proficient in C++')).not.toBe(normalize('Proficient in C#'))
+    expect(normalize('Proficient in C++')).toBe('proficient in c++')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/memoryExtract.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryExtract.ts
@@ -76,7 +76,9 @@ function buildImportPrompt(rawText: string, source: MemorySource, existing: stri
 export function normalize(s: string): string {
   return s
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    // Keep + and # so distinct facts like "C++" and "C#" do not normalize to the
+    // same key and get dropped as duplicates of each other.
+    .replace(/[^\p{L}\p{N}+#\s]/gu, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/desktop/windows/src/renderer/src/lib/onboardingGraphModel.test.ts
+++ b/desktop/windows/src/renderer/src/lib/onboardingGraphModel.test.ts
@@ -44,4 +44,15 @@ describe('onboardingGraphModel', () => {
     const { nodes } = buildApps([{ name: '  ' }, { name: 'Figma' }])
     expect(nodes).toEqual([{ id: 'app_figma', label: 'Figma', nodeType: 'thing' }])
   })
+
+  it('dedupes a repeated app and names that slug to the same id', () => {
+    const { nodes, edges } = buildApps([
+      { name: 'Slack' },
+      { name: 'Slack' },
+      { name: 'Node.js' },
+      { name: 'Node js' }
+    ])
+    expect(nodes.map((n) => n.id)).toEqual(['app_slack', 'app_node-js'])
+    expect(edges).toHaveLength(2)
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/onboardingGraphModel.ts
+++ b/desktop/windows/src/renderer/src/lib/onboardingGraphModel.ts
@@ -29,10 +29,15 @@ export function buildLanguage(
 export function buildApps(apps: { name: string }[]): { nodes: OnboardingGraphNode[]; edges: OnboardingGraphEdge[] } {
   const nodes: OnboardingGraphNode[] = []
   const edges: OnboardingGraphEdge[] = []
+  const seen = new Set<string>()
   for (const app of apps) {
     const name = app.name.trim()
     if (!name) continue
     const id = `app_${slugId(name)}`
+    // A repeated app (scanned from two locations) or two names that slug the same
+    // would otherwise emit duplicate node and edge ids. Dedupe like deriveAppNodes.
+    if (seen.has(id)) continue
+    seen.add(id)
     nodes.push({ id, label: name, nodeType: 'thing' })
     edges.push({ id: `edge_${USER_NODE_ID}_${id}`, sourceId: USER_NODE_ID, targetId: id, label: 'uses' })
   }

--- a/desktop/windows/src/renderer/src/lib/screenGrouping.test.ts
+++ b/desktop/windows/src/renderer/src/lib/screenGrouping.test.ts
@@ -38,4 +38,12 @@ describe('budgetSegments', () => {
     expect(out.length).toBe(1)
     expect(out[0].app).toBe('A')
   })
+
+  it('keeps a truncated first segment when one segment exceeds the whole budget', () => {
+    const segs: ScreenSegment[] = [{ app: 'A', windowTitle: 'a', text: 'x'.repeat(100) }]
+    const out = budgetSegments(segs, 40)
+    expect(out.length).toBe(1)
+    expect(out[0].text.length).toBe(40)
+    expect(out[0].app).toBe('A')
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/screenGrouping.ts
+++ b/desktop/windows/src/renderer/src/lib/screenGrouping.ts
@@ -37,5 +37,11 @@ export function budgetSegments(segments: ScreenSegment[], maxChars: number): Scr
     out.push(s)
     used += s.text.length
   }
+  // Never return empty when segments exist. The caller advances its watermark on
+  // an empty result, so a single segment larger than the whole budget (a long
+  // doc/log in one window) would be skipped forever. Keep a truncated first one.
+  if (out.length === 0 && segments.length > 0) {
+    out.push({ ...segments[0], text: segments[0].text.slice(0, maxChars) })
+  }
   return out
 }


### PR DESCRIPTION
## Summary

Correctness fixes for the local knowledge graph and the memory-extraction dedupe that feeds it. Each one silently drops or corrupts data that the user expects to see in their graph or memories. Found while reading the code; no filed issue, no happy-path behavior change.

## What this fixes

- C, C++, and C# all collapsed into a single technology node. `slugify` strips `+` and `#`, so `slugify('C')`, `slugify('C++')`, and `slugify('C#')` all return `c`, giving every one the id `c:technology`. `mergeGraph` keys nodes by id, so the last one silently overwrites the others and two of the three languages disappear. `slugify` now maps `+` to `p` and `#` to `sharp` so the ids stay distinct. This is consistent with `EXT_TO_TECH`, which already maps `.c`, `.cpp`, and `.cs` to distinct labels.
- The force-directed layout threw on a dangling edge. `mergeGraphs` intentionally keeps edges whose endpoints are not both present, and onboarding can emit a user-to-app edge before the user node exists, but `computeLayout` mapped every edge into the simulation without checking, so `forceLink` threw `missing: <id>` and took down the whole layout. It now filters edges to those whose endpoints both exist, matching what `useGraphSimulation` already does.
- Onboarding emitted duplicate app nodes and edges. `buildApps` had no dedupe (unlike its `deriveAppNodes` sibling), so a repeated app from an installed-apps scan, or two names that slug to the same id, produced two nodes and two edges with identical ids. It now dedupes by id.
- One oversized screen window lost all of its extracted facts forever. `budgetSegments` returns `[]` the moment the first segment alone exceeds the budget, and the caller treats an empty result as handled and advances its watermark past those frames. A single window with more than the budget of OCR text (a long doc or log) therefore had all of its facts skipped permanently. It now keeps a truncated first segment when nothing else fits.
- The memory dedupe key collapsed distinct facts. `normalize` stripped every non-letter/number/space char, so "Proficient in C++" and "Proficient in C#" both normalized to `proficient in c` and the second was dropped as a duplicate. It now keeps `+` and `#` in the key.

## Testing

- Extended the existing vitest suites for `kgTech`, `graphLayout`, `onboardingGraphModel`, and `screenGrouping`, and added a `memoryExtract.normalize` test. New assertions verified red to green; the prior assertions still pass.
- `npm run typecheck` passes for both projects.

## PR status check

Touches `desktop/windows/src/renderer/src/lib/{kgTech,graphLayout,onboardingGraphModel,screenGrouping,memoryExtract}.ts` and their tests. I checked the open Windows PRs and none of them modify these files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

