### PR TITLE
Harden Windows Google integrations, OAuth, and network clients

### DIFF
--- a/desktop/windows/src/main/integrations/google.test.ts
+++ b/desktop/windows/src/main/integrations/google.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('./oauth', () => ({
+  getAccessToken: async () => 'tok',
+  invalidateAccessToken: () => {}
+}))
+
+import { fetchGmail } from './google'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('fetchGmail', () => {
+  it('skips a message that fails to fetch and keeps the rest of the batch', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/messages?q=')) {
+        return { ok: true, status: 200, json: async () => ({ messages: [{ id: 'a' }, { id: 'b' }] }) }
+      }
+      if (url.includes('/messages/a')) {
+        return { ok: false, status: 500, text: async () => 'boom' }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'b', payload: { headers: [{ name: 'Subject', value: 'Hi' }] } })
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const items = await fetchGmail()
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('b')
+    expect(items[0].subject).toBe('Hi')
+  })
+})

--- a/desktop/windows/src/main/integrations/google.ts
+++ b/desktop/windows/src/main/integrations/google.ts
@@ -29,11 +29,17 @@ export async function fetchGmail(): Promise<GmailItem[]> {
   const ids = (list.messages ?? []).map((m) => m.id)
   const items: GmailItem[] = []
   for (const id of ids) {
-    const msg = await authedJson<GmailMessageJson>(
-      `${GMAIL_BASE}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From`
-    )
-    const item = mapGmailMessage(msg)
-    if (item) items.push(item)
+    try {
+      const msg = await authedJson<GmailMessageJson>(
+        `${GMAIL_BASE}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From`
+      )
+      const item = mapGmailMessage(msg)
+      if (item) items.push(item)
+    } catch {
+      // One message failing (rate limit, or deleted between the list and the get)
+      // should not discard the whole batch — skip it and keep the rest.
+      continue
+    }
   }
   return items
 }

--- a/desktop/windows/src/main/integrations/googleMap.test.ts
+++ b/desktop/windows/src/main/integrations/googleMap.test.ts
@@ -28,6 +28,19 @@ describe('mapGmailMessage', () => {
     expect(item).toEqual({ id: 'm2', subject: 'Hi', from: '', snippet: '', internalDateMs: 0 })
   })
 
+  it('ignores a header object that has no name', () => {
+    const item = mapGmailMessage({
+      id: 'm3',
+      payload: {
+        headers: [
+          { value: 'orphan' } as unknown as { name: string; value: string },
+          { name: 'Subject', value: 'Hi' }
+        ]
+      }
+    })
+    expect(item).toEqual({ id: 'm3', subject: 'Hi', from: '', snippet: '', internalDateMs: 0 })
+  })
+
   it('returns null without an id', () => {
     expect(mapGmailMessage({ snippet: 'x' })).toBeNull()
   })

--- a/desktop/windows/src/main/integrations/googleMap.test.ts
+++ b/desktop/windows/src/main/integrations/googleMap.test.ts
@@ -24,7 +24,10 @@ describe('mapGmailMessage', () => {
   })
 
   it('header lookup is case-insensitive and tolerates missing fields', () => {
-    const item = mapGmailMessage({ id: 'm2', payload: { headers: [{ name: 'subject', value: 'Hi' }] } })
+    const item = mapGmailMessage({
+      id: 'm2',
+      payload: { headers: [{ name: 'subject', value: 'Hi' }] }
+    })
     expect(item).toEqual({ id: 'm2', subject: 'Hi', from: '', snippet: '', internalDateMs: 0 })
   })
 
@@ -39,6 +42,19 @@ describe('mapGmailMessage', () => {
       }
     })
     expect(item).toEqual({ id: 'm3', subject: 'Hi', from: '', snippet: '', internalDateMs: 0 })
+  })
+
+  it('ignores a header whose name is not a string', () => {
+    const item = mapGmailMessage({
+      id: 'm4',
+      payload: {
+        headers: [
+          { name: 123, value: 'numeric' } as unknown as { name: string; value: string },
+          { name: 'Subject', value: 'Hi' }
+        ]
+      }
+    })
+    expect(item).toEqual({ id: 'm4', subject: 'Hi', from: '', snippet: '', internalDateMs: 0 })
   })
 
   it('returns null without an id', () => {
@@ -64,7 +80,11 @@ describe('mapCalendarEvent', () => {
   })
 
   it('handles all-day events (date, not dateTime) and missing summary', () => {
-    const item = mapCalendarEvent({ id: 'e2', start: { date: '2026-06-10' }, end: { date: '2026-06-11' } })
+    const item = mapCalendarEvent({
+      id: 'e2',
+      start: { date: '2026-06-10' },
+      end: { date: '2026-06-11' }
+    })
     expect(item?.title).toBe('(no title)')
     expect(item?.startMs).toBe(Date.parse('2026-06-10'))
     expect(item?.location).toBeUndefined()

--- a/desktop/windows/src/main/integrations/googleMap.ts
+++ b/desktop/windows/src/main/integrations/googleMap.ts
@@ -10,7 +10,9 @@ export type GmailMessageJson = {
 }
 
 function header(headers: GmailHeader[] | undefined, name: string): string {
-  const h = headers?.find((x) => x.name.toLowerCase() === name.toLowerCase())
+  // headers come from an untyped res.json(); a member missing `name` would throw
+  // on .toLowerCase() and take down the whole message map.
+  const h = headers?.find((x) => x?.name?.toLowerCase() === name.toLowerCase())
   return h?.value ?? ''
 }
 

--- a/desktop/windows/src/main/integrations/googleMap.ts
+++ b/desktop/windows/src/main/integrations/googleMap.ts
@@ -10,9 +10,12 @@ export type GmailMessageJson = {
 }
 
 function header(headers: GmailHeader[] | undefined, name: string): string {
-  // headers come from an untyped res.json(); a member missing `name` would throw
-  // on .toLowerCase() and take down the whole message map.
-  const h = headers?.find((x) => x?.name?.toLowerCase() === name.toLowerCase())
+  // headers come from an untyped res.json(); a member with a missing or
+  // non-string `name` (optional chaining does not short-circuit a number/object)
+  // would otherwise throw on .toLowerCase() and take down the whole message map.
+  const h = headers?.find(
+    (x) => typeof x?.name === 'string' && x.name.toLowerCase() === name.toLowerCase()
+  )
   return h?.value ?? ''
 }
 

--- a/desktop/windows/src/main/integrations/oauth.ts
+++ b/desktop/windows/src/main/integrations/oauth.ts
@@ -156,20 +156,29 @@ function runLoopback(
     })
     server.on('error', fail)
     server.listen(0, '127.0.0.1', () => {
-      const addr = server.address() as AddressInfo
-      const redirectUri = `http://127.0.0.1:${addr.port}`
-      oauthLog('loopback listening, opening consent', { redirectUri })
-      const authUrl = buildAuthUrl({ clientId: clientId(), redirectUri, challenge, state })
-      void shell.openExternal(authUrl)
-      timer = setTimeout(() => {
-        oauthLog('timed out waiting for the OAuth callback')
-        fail(
-          new Error(
-            'Timed out waiting for Google. In the browser, finish the consent: ' +
-              'Advanced → Go to Omi (unsafe) → Allow, then reconnect.'
-          )
+      try {
+        const addr = server.address() as AddressInfo
+        const redirectUri = `http://127.0.0.1:${addr.port}`
+        oauthLog('loopback listening, opening consent', { redirectUri })
+        // clientId()/buildAuthUrl can throw (missing config). Inside this bare
+        // listen callback an uncaught throw would leave connect() hanging and leak
+        // the server + timer, so route any failure through fail().
+        const authUrl = buildAuthUrl({ clientId: clientId(), redirectUri, challenge, state })
+        shell.openExternal(authUrl).catch((e) =>
+          fail(new Error('Could not open the browser for Google sign-in: ' + (e as Error).message))
         )
-      }, LOOPBACK_TIMEOUT_MS)
+        timer = setTimeout(() => {
+          oauthLog('timed out waiting for the OAuth callback')
+          fail(
+            new Error(
+              'Timed out waiting for Google. In the browser, finish the consent: ' +
+                'Advanced → Go to Omi (unsafe) → Allow, then reconnect.'
+            )
+          )
+        }, LOOPBACK_TIMEOUT_MS)
+      } catch (e) {
+        fail(e as Error)
+      }
     })
   })
 }

--- a/desktop/windows/src/renderer/src/lib/geminiClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/geminiClient.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('./firebase', () => ({
+  auth: { currentUser: { getIdToken: async () => 'tok' } }
+}))
+
+import { generate } from './geminiClient'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('generate', () => {
+  it('retries when a 200 response body is not valid JSON, then succeeds', async () => {
+    let n = 0
+    const fetchMock = vi.fn(async () => {
+      n++
+      if (n === 1) {
+        return {
+          ok: true,
+          json: async () => {
+            throw new SyntaxError('truncated body')
+          }
+        }
+      }
+      return { ok: true, json: async () => ({ candidates: [{ content: { parts: [{ text: 'hello' }] } }] }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await generate({ model: 'm', parts: [{ text: 'hi' }] })
+    expect(out).toBe('hello')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects with a sanitized message after a network error exhausts retries', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('ECONNREFUSED 10.0.0.1 secret')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(generate({ model: 'm', parts: [{ text: 'hi' }] })).rejects.toThrow(/after retries/)
+    await expect(generate({ model: 'm', parts: [{ text: 'hi' }] })).rejects.not.toThrow(/secret/)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/geminiClient.ts
+++ b/desktop/windows/src/renderer/src/lib/geminiClient.ts
@@ -12,6 +12,9 @@ export type GenerateArgs = {
 
 const DEFAULT_MODEL = (import.meta.env.VITE_GEMINI_MODEL as string) || 'gemini-2.5-flash'
 const MAX_RETRIES = 2
+// A hung proxy must not stall every Gemini-backed feature forever (the macOS
+// client relied on URLSession's request timeout, which this port had dropped).
+const GENERATE_TIMEOUT_MS = 30_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms))
@@ -47,17 +50,40 @@ export async function generate(args: GenerateArgs): Promise<string> {
 
   let lastError = ''
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      body: JSON.stringify(body)
-    })
-    if (res.ok) {
-      const json = (await res.json()) as {
-        candidates?: { content?: { parts?: { text?: string }[] } }[]
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(GENERATE_TIMEOUT_MS)
+      })
+    } catch (e) {
+      // Transport error or timeout — retry like a 503 instead of letting a raw
+      // error (which may carry connection details) escape.
+      lastError = (e as Error).name === 'TimeoutError' ? 'timeout' : 'network error'
+      if (attempt < MAX_RETRIES) {
+        await sleep(400 * (attempt + 1))
+        continue
       }
-      const text = json.candidates?.[0]?.content?.parts?.map((p) => p.text ?? '').join('') ?? ''
-      return text.trim()
+      break
+    }
+    if (res.ok) {
+      try {
+        const json = (await res.json()) as {
+          candidates?: { content?: { parts?: { text?: string }[] } }[]
+        }
+        const text = json.candidates?.[0]?.content?.parts?.map((p) => p.text ?? '').join('') ?? ''
+        return text.trim()
+      } catch {
+        // 200 with a truncated/non-JSON body (gateway page, cut connection).
+        lastError = 'invalid response body'
+        if (attempt < MAX_RETRIES) {
+          await sleep(400 * (attempt + 1))
+          continue
+        }
+        break
+      }
     }
     if (res.status === 429 || res.status === 503) {
       lastError = `status ${res.status}`

--- a/desktop/windows/src/renderer/src/lib/googleSync.ts
+++ b/desktop/windows/src/renderer/src/lib/googleSync.ts
@@ -16,7 +16,14 @@ async function syncGmail(existingMemories: string[]): Promise<{ added: number; e
   if (!res.ok) return res.error === 'not_connected' ? { added: 0 } : { added: 0, error: res.error }
   if (res.items.length === 0) return { added: 0 }
 
-  const memories = await extractGmailMemories(res.items, existingMemories)
+  let memories: string[]
+  try {
+    memories = await extractGmailMemories(res.items, existingMemories)
+  } catch (e) {
+    // A synthesis (LLM) failure is this source's error, reported per-source so the
+    // Calendar sync still runs, not a rejection that aborts the whole sync.
+    return { added: 0, error: (e as Error).message }
+  }
   let added = 0
   let writeError = ''
   for (const content of memories) {
@@ -53,7 +60,12 @@ async function syncCalendar(): Promise<{ added: number; error?: string }> {
   if (!res.ok) return res.error === 'not_connected' ? { added: 0 } : { added: 0, error: res.error }
   if (res.items.length === 0) return { added: 0 }
 
-  const tasks = await extractCalendarTasks(res.items)
+  let tasks: Awaited<ReturnType<typeof extractCalendarTasks>>
+  try {
+    tasks = await extractCalendarTasks(res.items)
+  } catch (e) {
+    return { added: 0, error: (e as Error).message }
+  }
   const existing = await openTaskDescriptions()
   let added = 0
   let writeError = ''

--- a/desktop/windows/src/renderer/src/lib/liveMicSession.ts
+++ b/desktop/windows/src/renderer/src/lib/liveMicSession.ts
@@ -9,11 +9,11 @@ import { buildLocalGraph } from './kgSynthesis'
 // throttled to once per 30 min (the rebuild is two LLM calls). Delayed so the
 // backend has extracted memories from the just-saved conversation first.
 let lastKgRebuildAt = 0
-function requestKgRebuild(): void {
+function requestKgRebuild(): ReturnType<typeof setTimeout> | null {
   const now = Date.now()
-  if (now - lastKgRebuildAt < 30 * 60 * 1000) return
+  if (now - lastKgRebuildAt < 30 * 60 * 1000) return null
   lastKgRebuildAt = now
-  setTimeout(() => void buildLocalGraph(), 120000)
+  return setTimeout(() => void buildLocalGraph(), 120000)
 }
 
 // After this much silence (no new finalized speech) the current conversation is
@@ -84,8 +84,10 @@ export function startLiveMicSession(): LiveMicController {
     liveConversation.markSaved()
     pollForNewConversation()
     // New conversation-derived memories should reach the brain map without waiting
-    // for the next launch; force a throttled KG rebuild (helper above).
-    requestKgRebuild()
+    // for the next launch; force a throttled KG rebuild (helper above). Track its
+    // timer so stop() can cancel it — otherwise it fires for a torn-down session.
+    const kgTimer = requestKgRebuild()
+    if (kgTimer) timers.push(kgTimer)
   }
 
   // Finalize on the silence timeout or "Save now": end the session (the backend
@@ -119,7 +121,12 @@ export function startLiveMicSession(): LiveMicController {
       },
       onInterim: () => {},
       onBackend: () => {
-        if (!cancelled) liveConversation.setStatus('live')
+        if (cancelled) return
+        // A successful connect resets the retry budget so it counts CONSECUTIVE
+        // connect failures, not lifetime drops (an always-on session that flaps a
+        // few times over hours should not permanently error out).
+        attempt = 0
+        liveConversation.setStatus('live')
       },
       onEvent: (ev) => {
         if (cancelled) return
@@ -133,6 +140,11 @@ export function startLiveMicSession(): LiveMicController {
       },
       onError: (e) => {
         if (cancelled) return
+        // Stop the dropped session's own audio before reconnecting, otherwise the
+        // old mic stream / AudioContext keeps running and a second pipeline starts
+        // on top of it (only the latest handle is torn down by stop()).
+        try { handle?.stop() } catch { /* ignore */ }
+        handle = null
         if (attempt < MAX_ATTEMPTS) {
           attempt++
           liveConversation.setStatus('connecting')

--- a/desktop/windows/src/renderer/src/lib/omiListenClient.ts
+++ b/desktop/windows/src/renderer/src/lib/omiListenClient.ts
@@ -69,10 +69,25 @@ export async function startOmiListen(
       ? await navigator.mediaDevices.getUserMedia({ audio: true })
       : await getSystemAudioStream()
 
-  const audioCtx = new AudioContext({ sampleRate: 16000 })
-  const node = audioCtx.createMediaStreamSource(stream)
-  const processor = audioCtx.createScriptProcessor(4096, 1, 1)
-  node.connect(processor)
+  let audioCtx: AudioContext
+  let node: MediaStreamAudioSourceNode
+  let processor: ScriptProcessorNode
+  try {
+    audioCtx = new AudioContext({ sampleRate: 16000 })
+    node = audioCtx.createMediaStreamSource(stream)
+    processor = audioCtx.createScriptProcessor(4096, 1, 1)
+    node.connect(processor)
+  } catch (e) {
+    // AudioContext setup can throw (e.g. the browser's concurrent-context cap).
+    // The mic/system stream is already live, so stop it before rethrowing — else
+    // the OS mic indicator stays on with no active session.
+    try {
+      stream.getTracks().forEach((t) => t.stop())
+    } catch {
+      /* ignore */
+    }
+    throw e
+  }
 
   let stopped = false
   let connected = false
@@ -127,11 +142,7 @@ export async function startOmiListen(
     } catch {
       /* ignore */
     }
-    try {
-      void audioCtx.close()
-    } catch {
-      /* ignore */
-    }
+    audioCtx.close().catch(() => {})
     throw e
   }
 
@@ -167,12 +178,11 @@ export async function startOmiListen(
       } catch {
         /* ignore */
       }
-      try {
-        void audioCtx.close()
-      } catch {
-        /* ignore */
-      }
-      void window.omi.listenStop(sessionId)
+      // close() and listenStop() return promises; a teardown-time rejection (an
+      // already-closed context, or an IPC reject mid-shutdown) must be caught or
+      // it surfaces as an unhandled rejection.
+      audioCtx.close().catch(() => {})
+      void window.omi.listenStop(sessionId).catch(() => {})
     }
   }
 }


### PR DESCRIPTION
## Summary

Reliability fixes for the Windows app's Google integrations (Gmail and Calendar reads), the Google OAuth PKCE loopback flow, and the renderer-side network clients (the Gemini proxy client and the two live transcription clients). These cover hangs, unhandled rejections, and partial-failure handling that surface as a stuck feature or lost work. Found while reading the code; no filed issue, no happy-path behavior change.

## What this fixes

- The Gemini proxy client had no request timeout, so a backend that accepts the connection but never responds left every Gemini-backed feature (memory, calendar, and Gmail extraction) hung forever. The macOS client relied on URLSession's request timeout, which this port had dropped. It now uses `AbortSignal.timeout`. The same call also did not guard `fetch` / `res.json()`, so a transport error or a non-JSON 200 body threw a raw error that was never retried; both are now caught and retried like a 503.
- The OAuth loopback could hang the connect flow forever. `clientId()` is first called inside the bare `server.listen` callback, so a missing `MAIN_VITE_GOOGLE_CLIENT_ID` threw there as an uncaught exception and the `connect()` promise never settled, leaking the server and timer. The listen callback is now wrapped so any failure rejects cleanly, and the consent-browser launch (`shell.openExternal`) is no longer a swallowed floating promise.
- One failed Gmail message aborted the whole inbox fetch. `fetchGmail` loops per message and a single transient error (a 429, a 500, or a 404 for a message deleted between the list and the get) threw and discarded every already-fetched item. It now skips the bad message and keeps the rest. A Gmail header object with no `name` field (the payload is untyped `res.json()`) also crashed the mapper, which is now guarded.
- A Google sync failure in one source aborted the other. `runGoogleSync` is designed to report a per-source error and still run the second source, but the `extractGmailMemories` / `extractCalendarTasks` LLM calls were awaited outside any try/catch, so a Gmail failure rejected the whole sync before Calendar ran. Each extract is now wrapped so its failure is reported per source.
- The live mic session leaked audio on every reconnect and could permanently kill itself. On a dropped session it scheduled a reconnect without stopping the old handle, so the previous mic stream and AudioContext kept running and a second capture pipeline started on top. Its retry counter was also only reset on a successful save (which needs five words of speech), so a few lifetime socket flaps drove an always-on session to a fatal error even though every reconnect had succeeded. The retry budget now resets on a real connect, and the dropped session is torn down before reconnecting. A throttled knowledge-graph rebuild timer was also untracked, so it fired two minutes after the session was stopped; it is now tracked and cleared.
- The omi-listen client leaked the mic on a setup failure and produced unhandled rejections on teardown. The mic/system stream was acquired before the AudioContext setup that runs outside the guarded block, so a setup throw (for example the browser's concurrent-AudioContext cap) left the OS mic indicator on with no session. Teardown also fired `audioCtx.close()` and `listenStop()` as uncaught promises inside a try/catch that cannot catch an async rejection. Both are fixed.

## Testing

- Added a vitest test for the Gemini client (retry on a non-JSON 200 body, and a sanitized rejection after a network error exhausts retries) and for the Gmail batch skip, verified red to green. The Gmail header guard is covered by the existing `googleMap` tests plus a new case.
- `npm run typecheck` passes for both projects. The OAuth, liveMic, and omiListen changes depend on Electron and browser audio APIs and are verified by typecheck and inspection (the project has no Electron/jsdom mock harness).

## PR status check

Touches `desktop/windows/src/main/integrations/{oauth,google,googleMap}.ts` and `desktop/windows/src/renderer/src/lib/{geminiClient,googleSync,liveMicSession,omiListenClient}.ts` plus tests. I checked the open Windows PRs and none of them modify these files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

