### PR TITLE
Fix data loss in Windows parsing, redaction, and memory export

### DIFF
--- a/desktop/windows/src/main/memoryExport/io.test.ts
+++ b/desktop/windows/src/main/memoryExport/io.test.ts
@@ -60,4 +60,23 @@ describe('export file I/O (real disk)', () => {
     expect(String(lastCall![0])).not.toBe(target)
     renameSpy.mockRestore()
   })
+
+  it('exportToObsidian removes the temp file when the rename fails', async () => {
+    const vault = join(work, 'vault-cleanup')
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('rename boom'))
+    await expect(exportToObsidian(vault, memories)).rejects.toThrow('rename boom')
+    renameSpy.mockRestore()
+    const entries = await fs.readdir(join(vault, 'Omi'))
+    expect(entries.some((e) => e.endsWith('.tmp'))).toBe(false)
+  })
+
+  it('exportToFile removes the temp file when the rename fails', async () => {
+    const target = join(work, 'memories-cleanup.md')
+    await fs.mkdir(work, { recursive: true })
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('rename boom'))
+    await expect(exportToFile(target, memories)).rejects.toThrow('rename boom')
+    renameSpy.mockRestore()
+    const entries = await fs.readdir(work)
+    expect(entries.some((e) => e.startsWith('memories-cleanup.md.') && e.endsWith('.tmp'))).toBe(false)
+  })
 })

--- a/desktop/windows/src/main/memoryExport/io.test.ts
+++ b/desktop/windows/src/main/memoryExport/io.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest'
+import { describe, it, expect, afterAll, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -36,5 +36,28 @@ describe('export file I/O (real disk)', () => {
     const text = await fs.readFile(file, 'utf8')
     expect(text).toContain('- Prefers TypeScript')
     expect(text).toContain('· 2 memories_')
+  })
+
+  it('exportToObsidian swaps the file in via temp+rename (no in-place truncate)', async () => {
+    const vault = join(work, 'vault-atomic')
+    const renameSpy = vi.spyOn(fs, 'rename')
+    const file = await exportToObsidian(vault, memories)
+    const lastCall = renameSpy.mock.calls.at(-1)
+    expect(lastCall).toBeDefined()
+    expect(String(lastCall![1])).toBe(file)
+    expect(String(lastCall![0])).not.toBe(file)
+    renameSpy.mockRestore()
+  })
+
+  it('exportToFile swaps the file in via temp+rename (no in-place truncate)', async () => {
+    const target = join(work, 'memories-atomic.md')
+    await fs.mkdir(work, { recursive: true })
+    const renameSpy = vi.spyOn(fs, 'rename')
+    await exportToFile(target, memories)
+    const lastCall = renameSpy.mock.calls.at(-1)
+    expect(lastCall).toBeDefined()
+    expect(String(lastCall![1])).toBe(target)
+    expect(String(lastCall![0])).not.toBe(target)
+    renameSpy.mockRestore()
   })
 })

--- a/desktop/windows/src/main/memoryExport/notion.test.ts
+++ b/desktop/windows/src/main/memoryExport/notion.test.ts
@@ -6,8 +6,9 @@ afterEach(() => vi.unstubAllGlobals())
 describe('exportToNotion', () => {
   it('splits a long memory across rich_text chunks without dropping the tail', async () => {
     const long = 'a'.repeat(5000)
-    let body: { children: { bulleted_list_item: { rich_text: { text: { content: string } }[] } }[] } | null =
-      null
+    let body: {
+      children: { bulleted_list_item: { rich_text: { text: { content: string } }[] } }[]
+    } | null = null
     const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
       body = JSON.parse(init.body)
       return { ok: true, json: async () => ({ id: 'p1', url: 'https://notion.so/p1' }) }
@@ -19,5 +20,48 @@ describe('exportToNotion', () => {
     const richText = body!.children[0].bulleted_list_item.rich_text
     expect(richText.map((r) => r.text.content).join('')).toBe(long)
     expect(richText.length).toBe(3) // 5000 / 2000 => 3 chunks
+  })
+
+  it('chunks by UTF-16 units and never leaves a lone surrogate', async () => {
+    const content = 'a' + '😀'.repeat(1000) // 2001 UTF-16 units, boundary lands mid-emoji
+    let body: {
+      children: { bulleted_list_item: { rich_text: { text: { content: string } }[] } }[]
+    } | null = null
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      body = JSON.parse(init.body)
+      return { ok: true, json: async () => ({ id: 'p', url: 'u' }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await exportToNotion('tok', 'parent', [{ content, category: 'X' }])
+
+    const richText = body!.children[0].bulleted_list_item.rich_text
+    for (const r of richText) {
+      expect(r.text.content.length).toBeLessThanOrEqual(2000)
+      expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(r.text.content)).toBe(false) // no lone high surrogate
+      expect(/(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(r.text.content)).toBe(false) // no lone low surrogate
+    }
+    expect(richText.map((r) => r.text.content).join('')).toBe(content)
+  })
+
+  it('spills a memory beyond 100 chunks into multiple blocks instead of truncating', async () => {
+    const content = 'a'.repeat(250_000) // 125 chunks of 2000
+    let body: {
+      children: { bulleted_list_item: { rich_text: { text: { content: string } }[] } }[]
+    } | null = null
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      body = JSON.parse(init.body)
+      return { ok: true, json: async () => ({ id: 'p', url: 'u' }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await exportToNotion('tok', 'parent', [{ content, category: 'X' }])
+
+    const blocks = body!.children
+    expect(blocks.length).toBe(2) // ceil(125 / 100)
+    const all = blocks
+      .flatMap((b) => b.bulleted_list_item.rich_text.map((r) => r.text.content))
+      .join('')
+    expect(all).toBe(content)
   })
 })

--- a/desktop/windows/src/main/memoryExport/notion.test.ts
+++ b/desktop/windows/src/main/memoryExport/notion.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { exportToNotion } from './notion'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('exportToNotion', () => {
+  it('splits a long memory across rich_text chunks without dropping the tail', async () => {
+    const long = 'a'.repeat(5000)
+    let body: { children: { bulleted_list_item: { rich_text: { text: { content: string } }[] } }[] } | null =
+      null
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      body = JSON.parse(init.body)
+      return { ok: true, json: async () => ({ id: 'p1', url: 'https://notion.so/p1' }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await exportToNotion('tok', 'parent', [{ content: long, category: 'X' }])
+
+    const richText = body!.children[0].bulleted_list_item.rich_text
+    expect(richText.map((r) => r.text.content).join('')).toBe(long)
+    expect(richText.length).toBe(3) // 5000 / 2000 => 3 chunks
+  })
+})

--- a/desktop/windows/src/main/memoryExport/notion.ts
+++ b/desktop/windows/src/main/memoryExport/notion.ts
@@ -5,29 +5,41 @@ const NOTION_VERSION = '2022-06-28'
 // Notion caps a page-create / append call at 100 child blocks.
 const MAX_BLOCKS = 100
 
-// One bulleted-list block per memory. Notion rich_text content is capped at
-// 2000 chars per item, so long memories are truncated to stay within the limit.
-// Notion caps a single rich_text item at 2000 chars and a block at 100 items.
-// Split a long memory into <=2000 code-point chunks (so a surrogate pair is never
-// cut) and emit one rich_text item per chunk, rather than dropping the tail.
-function richTextChunks(content: string): unknown[] {
-  const cps = Array.from(content)
-  const out: unknown[] = []
-  for (let i = 0; i < cps.length && out.length < 100; i += 2000) {
-    out.push({ type: 'text', text: { content: cps.slice(i, i + 2000).join('') } })
+// Notion caps a single rich_text item at 2000 characters (UTF-16 code units) and
+// a block at 100 rich_text items. Chunk a long memory into <=2000 code-unit pieces
+// without splitting a surrogate pair, so neither the per-item char limit nor a
+// lone surrogate can break the request.
+function richTextChunks(content: string): { type: 'text'; text: { content: string } }[] {
+  const out: { type: 'text'; text: { content: string } }[] = []
+  let i = 0
+  while (i < content.length) {
+    let end = Math.min(i + 2000, content.length)
+    if (end < content.length) {
+      const code = content.charCodeAt(end - 1)
+      if (code >= 0xd800 && code <= 0xdbff) end -= 1 // don't cut a surrogate pair
+    }
+    out.push({ type: 'text', text: { content: content.slice(i, end) } })
+    i = end
   }
   if (out.length === 0) out.push({ type: 'text', text: { content: '' } })
   return out
 }
 
 function toBlocks(memories: ExportMemory[]): unknown[] {
-  return memories.map((m) => ({
-    object: 'block',
-    type: 'bulleted_list_item',
-    bulleted_list_item: {
-      rich_text: richTextChunks(m.content)
+  const blocks: unknown[] = []
+  for (const m of memories) {
+    const chunks = richTextChunks(m.content)
+    // Notion allows at most 100 rich_text items per block; a very long memory
+    // spills into additional bullet blocks rather than being truncated.
+    for (let i = 0; i < chunks.length; i += 100) {
+      blocks.push({
+        object: 'block',
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: chunks.slice(i, i + 100) }
+      })
     }
-  }))
+  }
+  return blocks
 }
 
 // Create an "Omi Memories" page under `parentPageId` and append every memory as
@@ -44,13 +56,18 @@ export async function exportToNotion(
     'Content-Type': 'application/json'
   }
 
+  // Build all blocks up front, then batch by BLOCK count: a single long memory can
+  // now span multiple blocks, so batching by memory count could overflow the
+  // 100-block-per-call ceiling.
+  const blocks = toBlocks(memories)
+
   const createRes = await fetch('https://api.notion.com/v1/pages', {
     method: 'POST',
     headers,
     body: JSON.stringify({
       parent: { page_id: parentPageId },
       properties: { title: { title: [{ text: { content: 'Omi Memories' } }] } },
-      children: toBlocks(memories.slice(0, MAX_BLOCKS))
+      children: blocks.slice(0, MAX_BLOCKS)
     })
   })
   if (!createRes.ok) {
@@ -58,11 +75,11 @@ export async function exportToNotion(
   }
   const page = (await createRes.json()) as { id: string; url?: string }
 
-  for (let i = MAX_BLOCKS; i < memories.length; i += MAX_BLOCKS) {
+  for (let i = MAX_BLOCKS; i < blocks.length; i += MAX_BLOCKS) {
     const res = await fetch(`https://api.notion.com/v1/blocks/${page.id}/children`, {
       method: 'PATCH',
       headers,
-      body: JSON.stringify({ children: toBlocks(memories.slice(i, i + MAX_BLOCKS)) })
+      body: JSON.stringify({ children: blocks.slice(i, i + MAX_BLOCKS) })
     })
     if (!res.ok) {
       throw new Error(`Notion append failed (${res.status}): ${await res.text()}`)

--- a/desktop/windows/src/main/memoryExport/notion.ts
+++ b/desktop/windows/src/main/memoryExport/notion.ts
@@ -7,12 +7,25 @@ const MAX_BLOCKS = 100
 
 // One bulleted-list block per memory. Notion rich_text content is capped at
 // 2000 chars per item, so long memories are truncated to stay within the limit.
+// Notion caps a single rich_text item at 2000 chars and a block at 100 items.
+// Split a long memory into <=2000 code-point chunks (so a surrogate pair is never
+// cut) and emit one rich_text item per chunk, rather than dropping the tail.
+function richTextChunks(content: string): unknown[] {
+  const cps = Array.from(content)
+  const out: unknown[] = []
+  for (let i = 0; i < cps.length && out.length < 100; i += 2000) {
+    out.push({ type: 'text', text: { content: cps.slice(i, i + 2000).join('') } })
+  }
+  if (out.length === 0) out.push({ type: 'text', text: { content: '' } })
+  return out
+}
+
 function toBlocks(memories: ExportMemory[]): unknown[] {
   return memories.map((m) => ({
     object: 'block',
     type: 'bulleted_list_item',
     bulleted_list_item: {
-      rich_text: [{ type: 'text', text: { content: m.content.slice(0, 2000) } }]
+      rich_text: richTextChunks(m.content)
     }
   }))
 }

--- a/desktop/windows/src/main/memoryExport/obsidian.ts
+++ b/desktop/windows/src/main/memoryExport/obsidian.ts
@@ -1,11 +1,8 @@
 import { promises as fs } from 'fs'
+import { randomBytes } from 'crypto'
 import { join } from 'path'
 import type { ExportMemory } from '../../shared/types'
 import { formatMemoriesMarkdown } from './format'
-
-// Monotonic per-process counter so two concurrent exports use distinct temp
-// files instead of colliding on the same one and racing the rename.
-let tmpSeq = 0
 
 // Write memories to <vault>/Omi/Memories.md, mirroring the macOS Obsidian
 // target. This is a full export, so the file is overwritten each time.
@@ -18,7 +15,9 @@ export async function exportToObsidian(
   const file = join(dir, 'Memories.md')
   // Write to a temp file then rename onto the target so a failed or partial write
   // (disk full, crash) never truncates the user's previous export.
-  const tmp = join(dir, `Memories.md.${process.pid}.${tmpSeq++}.tmp`)
+  // Random suffix (not a per-module counter) so temp names never collide across
+  // exporters or processes writing to the same destination directory.
+  const tmp = join(dir, `Memories.md.${process.pid}.${randomBytes(6).toString('hex')}.tmp`)
   try {
     await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
     await fs.rename(tmp, file)

--- a/desktop/windows/src/main/memoryExport/obsidian.ts
+++ b/desktop/windows/src/main/memoryExport/obsidian.ts
@@ -19,7 +19,15 @@ export async function exportToObsidian(
   // Write to a temp file then rename onto the target so a failed or partial write
   // (disk full, crash) never truncates the user's previous export.
   const tmp = join(dir, `Memories.md.${process.pid}.${tmpSeq++}.tmp`)
-  await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
-  await fs.rename(tmp, file)
+  try {
+    await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
+    await fs.rename(tmp, file)
+  } catch (err) {
+    // Best-effort cleanup so a failed write or rename does not leave the temp
+    // file behind. Swallow any unlink failure (the temp may never have been
+    // created); the original error is what the caller needs to see.
+    await fs.rm(tmp, { force: true }).catch(() => {})
+    throw err
+  }
   return file
 }

--- a/desktop/windows/src/main/memoryExport/obsidian.ts
+++ b/desktop/windows/src/main/memoryExport/obsidian.ts
@@ -12,6 +12,10 @@ export async function exportToObsidian(
   const dir = join(vaultPath, 'Omi')
   await fs.mkdir(dir, { recursive: true })
   const file = join(dir, 'Memories.md')
-  await fs.writeFile(file, formatMemoriesMarkdown(memories), 'utf8')
+  // Write to a temp file then rename onto the target so a failed or partial write
+  // (disk full, crash) never truncates the user's previous export.
+  const tmp = join(dir, `Memories.md.${process.pid}.tmp`)
+  await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
+  await fs.rename(tmp, file)
   return file
 }

--- a/desktop/windows/src/main/memoryExport/obsidian.ts
+++ b/desktop/windows/src/main/memoryExport/obsidian.ts
@@ -3,6 +3,10 @@ import { join } from 'path'
 import type { ExportMemory } from '../../shared/types'
 import { formatMemoriesMarkdown } from './format'
 
+// Monotonic per-process counter so two concurrent exports use distinct temp
+// files instead of colliding on the same one and racing the rename.
+let tmpSeq = 0
+
 // Write memories to <vault>/Omi/Memories.md, mirroring the macOS Obsidian
 // target. This is a full export, so the file is overwritten each time.
 export async function exportToObsidian(
@@ -14,7 +18,7 @@ export async function exportToObsidian(
   const file = join(dir, 'Memories.md')
   // Write to a temp file then rename onto the target so a failed or partial write
   // (disk full, crash) never truncates the user's previous export.
-  const tmp = join(dir, `Memories.md.${process.pid}.tmp`)
+  const tmp = join(dir, `Memories.md.${process.pid}.${tmpSeq++}.tmp`)
   await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
   await fs.rename(tmp, file)
   return file

--- a/desktop/windows/src/main/memoryExport/plainFile.ts
+++ b/desktop/windows/src/main/memoryExport/plainFile.ts
@@ -1,17 +1,16 @@
 import { promises as fs } from 'fs'
+import { randomBytes } from 'crypto'
 import type { ExportMemory } from '../../shared/types'
 import { formatMemoriesMarkdown } from './format'
-
-// Monotonic per-process counter so two concurrent exports to the same path use
-// distinct temp files instead of colliding on one and racing the rename.
-let tmpSeq = 0
 
 // Write memories as Markdown to an arbitrary file path the user picked. The
 // "plain file" target — no app integration, just a portable .md export.
 export async function exportToFile(filePath: string, memories: ExportMemory[]): Promise<string> {
   // Write to a sibling temp file then rename onto the destination, so replacing an
   // existing file is atomic and a partial write never leaves it truncated.
-  const tmp = `${filePath}.${process.pid}.${tmpSeq++}.tmp`
+  // Random suffix (not a per-module counter) so temp names never collide across
+  // exporters or processes writing to the same destination path.
+  const tmp = `${filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
   try {
     await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
     await fs.rename(tmp, filePath)

--- a/desktop/windows/src/main/memoryExport/plainFile.ts
+++ b/desktop/windows/src/main/memoryExport/plainFile.ts
@@ -5,6 +5,10 @@ import { formatMemoriesMarkdown } from './format'
 // Write memories as Markdown to an arbitrary file path the user picked. The
 // "plain file" target — no app integration, just a portable .md export.
 export async function exportToFile(filePath: string, memories: ExportMemory[]): Promise<string> {
-  await fs.writeFile(filePath, formatMemoriesMarkdown(memories), 'utf8')
+  // Write to a sibling temp file then rename onto the destination, so replacing an
+  // existing file is atomic and a partial write never leaves it truncated.
+  const tmp = `${filePath}.${process.pid}.tmp`
+  await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
+  await fs.rename(tmp, filePath)
   return filePath
 }

--- a/desktop/windows/src/main/memoryExport/plainFile.ts
+++ b/desktop/windows/src/main/memoryExport/plainFile.ts
@@ -12,7 +12,15 @@ export async function exportToFile(filePath: string, memories: ExportMemory[]): 
   // Write to a sibling temp file then rename onto the destination, so replacing an
   // existing file is atomic and a partial write never leaves it truncated.
   const tmp = `${filePath}.${process.pid}.${tmpSeq++}.tmp`
-  await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
-  await fs.rename(tmp, filePath)
+  try {
+    await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
+    await fs.rename(tmp, filePath)
+  } catch (err) {
+    // Best-effort cleanup so a failed write or rename does not leave the temp
+    // file behind. Swallow any unlink failure (the temp may never have been
+    // created); the original error is what the caller needs to see.
+    await fs.rm(tmp, { force: true }).catch(() => {})
+    throw err
+  }
   return filePath
 }

--- a/desktop/windows/src/main/memoryExport/plainFile.ts
+++ b/desktop/windows/src/main/memoryExport/plainFile.ts
@@ -2,12 +2,16 @@ import { promises as fs } from 'fs'
 import type { ExportMemory } from '../../shared/types'
 import { formatMemoriesMarkdown } from './format'
 
+// Monotonic per-process counter so two concurrent exports to the same path use
+// distinct temp files instead of colliding on one and racing the rename.
+let tmpSeq = 0
+
 // Write memories as Markdown to an arbitrary file path the user picked. The
 // "plain file" target — no app integration, just a portable .md export.
 export async function exportToFile(filePath: string, memories: ExportMemory[]): Promise<string> {
   // Write to a sibling temp file then rename onto the destination, so replacing an
   // existing file is atomic and a partial write never leaves it truncated.
-  const tmp = `${filePath}.${process.pid}.tmp`
+  const tmp = `${filePath}.${process.pid}.${tmpSeq++}.tmp`
   await fs.writeFile(tmp, formatMemoriesMarkdown(memories), 'utf8')
   await fs.rename(tmp, filePath)
   return filePath

--- a/desktop/windows/src/renderer/src/lib/extractJson.test.ts
+++ b/desktop/windows/src/renderer/src/lib/extractJson.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { extractJSONObject } from './extractJson'
+
+describe('extractJSONObject', () => {
+  it('returns a bare object unchanged', () => {
+    expect(extractJSONObject('{"a":1}')).toBe('{"a":1}')
+  })
+
+  it('drops a leading preamble and trailing prose so the result parses', () => {
+    const out = extractJSONObject('Here you go: {"memories":[]} Hope that helps!')
+    expect(JSON.parse(out)).toEqual({ memories: [] })
+  })
+
+  it('strips a ```json code fence', () => {
+    const out = extractJSONObject('```json\n{"a":1}\n```')
+    expect(JSON.parse(out)).toEqual({ a: 1 })
+  })
+
+  it('ignores braces inside string values', () => {
+    const out = extractJSONObject('{"text":"a } b"} trailing words')
+    expect(JSON.parse(out)).toEqual({ text: 'a } b' })
+  })
+
+  it('falls back to slice-to-end for an unterminated object', () => {
+    expect(extractJSONObject('prefix {"a":1')).toBe('{"a":1')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/extractJson.ts
+++ b/desktop/windows/src/renderer/src/lib/extractJson.ts
@@ -9,7 +9,25 @@ export function extractJSONObject(text: string): string {
     if (nl !== -1) t = t.slice(nl + 1)
     if (t.endsWith('```')) t = t.slice(0, -3).trim()
   }
-  const brace = t.indexOf('{')
-  if (brace !== -1) t = t.slice(brace)
-  return t.trim()
+  const start = t.indexOf('{')
+  if (start === -1) return t.trim()
+  // Slice to the brace that matches the first '{', ignoring braces inside string
+  // values, so trailing prose ("...{...} Hope that helps!") does not break a
+  // caller's JSON.parse. Fall back to slice-to-end if the object is never closed.
+  let depth = 0
+  let inStr = false
+  let escaped = false
+  for (let i = start; i < t.length; i++) {
+    const ch = t[i]
+    if (inStr) {
+      if (escaped) escaped = false
+      else if (ch === '\\') escaped = true
+      else if (ch === '"') inStr = false
+      continue
+    }
+    if (ch === '"') inStr = true
+    else if (ch === '{') depth++
+    else if (ch === '}' && --depth === 0) return t.slice(start, i + 1)
+  }
+  return t.slice(start).trim()
 }

--- a/desktop/windows/src/renderer/src/lib/memoryCleanup.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryCleanup.test.ts
@@ -24,7 +24,9 @@ describe('isAppIndexMemory', () => {
     expect(isAppIndexMemory(mem('1', 'anything at all', [APP_INDEX_TAG]))).toBe(true)
   })
   it('treats SCREEN_TAG (Rewind synthesis) memories as removable', () => {
-    expect(isAppIndexMemory(mem('1', 'The user is working on omi-windows', [SCREEN_TAG]))).toBe(true)
+    expect(isAppIndexMemory(mem('1', 'The user is working on omi-windows', [SCREEN_TAG]))).toBe(
+      true
+    )
   })
   it('matches the tight "Uses <App>" template (untagged legacy builds)', () => {
     expect(isAppIndexMemory(mem('1', 'Uses Warp'))).toBe(true)
@@ -40,6 +42,10 @@ describe('isAppIndexMemory', () => {
     expect(isAppIndexMemory(mem('2', 'Uses Notion for tasks'))).toBe(false)
     expect(isAppIndexMemory(mem('3', 'Uses Slack'))).toBe(true)
   })
+  it('still matches an app name containing of/the/and so it is cleaned up', () => {
+    expect(isAppIndexMemory(mem('1', 'Uses Bank of America'))).toBe(true)
+    expect(isAppIndexMemory(mem('2', 'Uses The Browser Company'))).toBe(true)
+  })
   it('matches file/project-index synthesis sentences (stem + a path)', () => {
     expect(
       isAppIndexMemory(
@@ -47,30 +53,38 @@ describe('isAppIndexMemory', () => {
       )
     ).toBe(true)
     expect(
-      isAppIndexMemory(mem('2', "The user's local files include C:\\Users\\ander\\Documents\\report.pdf"))
+      isAppIndexMemory(
+        mem('2', "The user's local files include C:\\Users\\ander\\Documents\\report.pdf")
+      )
     ).toBe(true)
     expect(
-      isAppIndexMemory(mem('3', "The user's repositories include /home/a/dev/omi and /home/a/dev/sandbox"))
+      isAppIndexMemory(
+        mem('3', "The user's repositories include /home/a/dev/omi and /home/a/dev/sandbox")
+      )
     ).toBe(true)
   })
   it('matches the other file-index synthesis sentences (no path required)', () => {
     expect(
       isAppIndexMemory(mem('1', 'A recently modified local file is named PaperPreview-Light.json.'))
     ).toBe(true)
-    expect(isAppIndexMemory(mem('2', 'The user works on a local project named chatgpt-github-app.'))).toBe(
-      true
-    )
-    expect(isAppIndexMemory(mem('3', "The user's local files show active work in TypeScript."))).toBe(true)
+    expect(
+      isAppIndexMemory(mem('2', 'The user works on a local project named chatgpt-github-app.'))
+    ).toBe(true)
+    expect(
+      isAppIndexMemory(mem('3', "The user's local files show active work in TypeScript."))
+    ).toBe(true)
     expect(
       isAppIndexMemory(mem('4', 'The user has 12,814 local files indexed across their machine.'))
     ).toBe(true)
   })
   it('does NOT match a project mention without a filesystem path', () => {
     // Real knowledge about a project, no path -> keep it.
-    expect(isAppIndexMemory(mem('1', "The user's projects include a community garden initiative"))).toBe(
-      false
-    )
-    expect(isAppIndexMemory(mem('2', 'Working on the omi-cheap-voice-demo project this week'))).toBe(false)
+    expect(
+      isAppIndexMemory(mem('1', "The user's projects include a community garden initiative"))
+    ).toBe(false)
+    expect(
+      isAppIndexMemory(mem('2', 'Working on the omi-cheap-voice-demo project this week'))
+    ).toBe(false)
   })
   it('does not match unrelated memories', () => {
     expect(isAppIndexMemory(mem('1', 'Lives in Madrid', ['gmail/import/note']))).toBe(false)

--- a/desktop/windows/src/renderer/src/lib/memoryCleanup.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryCleanup.test.ts
@@ -35,6 +35,11 @@ describe('isAppIndexMemory', () => {
     expect(isAppIndexMemory(mem('1', 'Uses Excel daily for budgeting and taxes.'))).toBe(false)
     expect(isAppIndexMemory(mem('2', 'Used to work at Google before joining Omi'))).toBe(false)
   })
+  it('does NOT delete a short "Uses X for/with Y" memory, but still matches a bare app name', () => {
+    expect(isAppIndexMemory(mem('1', 'Uses Figma for design work'))).toBe(false)
+    expect(isAppIndexMemory(mem('2', 'Uses Notion for tasks'))).toBe(false)
+    expect(isAppIndexMemory(mem('3', 'Uses Slack'))).toBe(true)
+  })
   it('matches file/project-index synthesis sentences (stem + a path)', () => {
     expect(
       isAppIndexMemory(

--- a/desktop/windows/src/renderer/src/lib/memoryCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryCleanup.ts
@@ -42,10 +42,18 @@ function isFileIndexMemory(content: string): boolean {
 // provenance tag, matches the tight "Uses <App>" template, or is a local
 // file/project-index synthesis sentence. None of these is real user knowledge —
 // it's the on-disk index restated as memories, which the local KG already holds.
+// The "Uses <App>" template is loose enough to also match a real sentence like
+// "Uses Figma for design work" (four connective-free-looking tokens). Reject a
+// match that contains a sentence connective an app-name list never has, so a
+// genuine "Uses X for/with/and …" memory is not swept up and deleted.
+function isUsesTemplate(c: string): boolean {
+  return USES_TEMPLATE.test(c) && !/\b(for|and|with|of|the|per)\b/i.test(c)
+}
+
 export function isAppIndexMemory(m: Memory): boolean {
   if (m.tags?.includes(APP_INDEX_TAG) || m.tags?.includes(SCREEN_TAG)) return true
   const c = (m.content ?? '').trim()
-  return USES_TEMPLATE.test(c) || isFileIndexMemory(c)
+  return isUsesTemplate(c) || isFileIndexMemory(c)
 }
 
 export function appIndexMemoryIds(memories: Memory[]): string[] {

--- a/desktop/windows/src/renderer/src/lib/memoryCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryCleanup.ts
@@ -44,10 +44,13 @@ function isFileIndexMemory(content: string): boolean {
 // it's the on-disk index restated as memories, which the local KG already holds.
 // The "Uses <App>" template is loose enough to also match a real sentence like
 // "Uses Figma for design work" (four connective-free-looking tokens). Reject a
-// match that contains a sentence connective an app-name list never has, so a
-// genuine "Uses X for/with/and …" memory is not swept up and deleted.
+// match that contains a clause connective (for/with/per) an app-name list never
+// has, so a genuine "Uses X for/with Y" memory is not swept up and deleted. Words
+// common inside proper-noun app names (of/and/the, e.g. "Bank of America") are
+// intentionally not treated as connectives, so those app-index memories are still
+// cleaned up.
 function isUsesTemplate(c: string): boolean {
-  return USES_TEMPLATE.test(c) && !/\b(for|and|with|of|the|per)\b/i.test(c)
+  return USES_TEMPLATE.test(c) && !/\b(for|with|per)\b/i.test(c)
 }
 
 export function isAppIndexMemory(m: Memory): boolean {

--- a/desktop/windows/src/renderer/src/lib/memoryRank.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryRank.test.ts
@@ -56,4 +56,18 @@ describe('rankMemories', () => {
     expect(rankMemories(mems, '', 5)).toEqual([])
     expect(rankMemories(mems, 'what are the projects you have', 5)).toEqual([])
   })
+
+  it('does not crash when a memory has null content', () => {
+    const mems = [
+      m('1', 'omi windows port'),
+      {
+        id: '2',
+        uid: 'u',
+        content: null as unknown as string,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z'
+      }
+    ]
+    expect(rankMemories(mems, 'omi', 5)).toEqual(['omi windows port'])
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/memoryRank.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryRank.ts
@@ -53,7 +53,7 @@ export function rankMemories(memories: Memory[], query: string, limit: number): 
   if (qTokens.size === 0) return []
   return memories
     .map((mem) => {
-      const mTokens = new Set(tokenize(mem.content))
+      const mTokens = new Set(tokenize(mem.content ?? ''))
       let score = 0
       for (const t of qTokens) if (mTokens.has(t)) score++
       return { mem, score }
@@ -65,5 +65,5 @@ export function rankMemories(memories: Memory[], query: string, limit: number): 
         new Date(b.mem.created_at).getTime() - new Date(a.mem.created_at).getTime()
     )
     .slice(0, limit)
-    .map((s) => s.mem.content.trim())
+    .map((s) => (s.mem.content ?? '').trim())
 }

--- a/desktop/windows/src/renderer/src/lib/retentionRules.test.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionRules.test.ts
@@ -18,6 +18,11 @@ it('transcriptWordCount ignores speaker/section scaffolding', () => {
   expect(transcriptWordCount('System audio:\n')).toBe(0)
 })
 
+it('transcriptWordCount strips numbered speaker labels so a diarized-but-empty recording counts as empty', () => {
+  expect(transcriptWordCount('Speaker 1:\nSpeaker 2:\nSpeaker 3:')).toBe(0)
+  expect(isEmptyConversation('Speaker 1:\nSpeaker 2:\nSpeaker 3:')).toBe(true)
+})
+
 it('isEmptyConversation is true under 5 real words', () => {
   expect(isEmptyConversation('You: hey ok bye')).toBe(true) // 3 words
   expect(isEmptyConversation('You: this is a real sentence now')).toBe(false) // 6 words

--- a/desktop/windows/src/renderer/src/lib/retentionRules.test.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionRules.test.ts
@@ -10,7 +10,18 @@ import {
 } from './retentionRules'
 import { SCREEN_TAG } from './screenTag'
 
-const mem = (id: string, content: string, tags?: string[]): { id: string; uid: string; content: string; created_at: string; updated_at: string; tags?: string[] } => ({ id, uid: '', content, created_at: '', updated_at: '', tags })
+const mem = (
+  id: string,
+  content: string,
+  tags?: string[]
+): {
+  id: string
+  uid: string
+  content: string
+  created_at: string
+  updated_at: string
+  tags?: string[]
+} => ({ id, uid: '', content, created_at: '', updated_at: '', tags })
 
 it('transcriptWordCount ignores speaker/section scaffolding', () => {
   expect(transcriptWordCount('Microphone:\nYou: hello there friend')).toBe(3)
@@ -23,13 +34,20 @@ it('transcriptWordCount strips numbered speaker labels so a diarized-but-empty r
   expect(isEmptyConversation('Speaker 1:\nSpeaker 2:\nSpeaker 3:')).toBe(true)
 })
 
+it('transcriptWordCount does not strip a non-speaker numbered prefix as a label', () => {
+  // "Step 1:" is real content, not a You:/Speaker N: label, so its words count
+  expect(transcriptWordCount('Step 1: build the thing carefully now')).toBe(7)
+})
+
 it('isEmptyConversation is true under 5 real words', () => {
   expect(isEmptyConversation('You: hey ok bye')).toBe(true) // 3 words
   expect(isEmptyConversation('You: this is a real sentence now')).toBe(false) // 6 words
 })
 
 it('isMetaJunkMemory matches the store phrasing but NOT substantive "memories of/from"', () => {
-  expect(isMetaJunkMemory('The user has 547 memories stored within the Omi application.')).toBe(true)
+  expect(isMetaJunkMemory('The user has 547 memories stored within the Omi application.')).toBe(
+    true
+  )
   expect(isMetaJunkMemory('The user has 12 memories saved.')).toBe(true)
   expect(isMetaJunkMemory('The user has 8 memories in Omi.')).toBe(true)
   expect(isMetaJunkMemory('The user has 3 cats.')).toBe(false)
@@ -55,7 +73,12 @@ it('junkMemoryIds unions app-index, meta-junk, and exact duplicates', () => {
 it('planRetention selects empty convos (local non-chat, cloud) + junk memories', () => {
   const convos: SweepConvo[] = [
     { id: 'l1', source: 'local', kind: 'recording', text: 'You: hi bye' }, // empty → drop
-    { id: 'l2', source: 'local', kind: 'recording', text: 'You: this is clearly a real conversation' }, // keep
+    {
+      id: 'l2',
+      source: 'local',
+      kind: 'recording',
+      text: 'You: this is clearly a real conversation'
+    }, // keep
     { id: 'l3', source: 'local', kind: 'chat', text: 'hi' }, // chat → never touch
     { id: 'c1', source: 'cloud', text: '' } // empty cloud → drop
   ]

--- a/desktop/windows/src/renderer/src/lib/retentionRules.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionRules.ts
@@ -16,7 +16,7 @@ export type SweepConvo = {
 export function transcriptWordCount(transcript: string): number {
   const cleaned = (transcript ?? '')
     .replace(/^(microphone|system audio):/gim, ' ')
-    .replace(/^[A-Za-z][A-Za-z0-9 ]{0,19}:/gm, ' ') // leading "You:" / "Speaker 1:" labels
+    .replace(/^(you|speaker \d+):/gim, ' ') // the recorder's per-line labels: "You:" / "Speaker N:"
     .replace(/\s+/g, ' ')
     .trim()
   if (!cleaned) return 0
@@ -70,7 +70,13 @@ export type RetentionMemoryBreakdown = {
 }
 
 export function memoryJunkBreakdown(memories: Memory[]): RetentionMemoryBreakdown {
-  const b: RetentionMemoryBreakdown = { total: 0, screenSynth: 0, appIndex: 0, meta: 0, duplicate: 0 }
+  const b: RetentionMemoryBreakdown = {
+    total: 0,
+    screenSynth: 0,
+    appIndex: 0,
+    meta: 0,
+    duplicate: 0
+  }
   const seen = new Set<string>()
   for (const m of memories) {
     const content = (m.content ?? '').trim()

--- a/desktop/windows/src/renderer/src/lib/retentionRules.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionRules.ts
@@ -16,7 +16,7 @@ export type SweepConvo = {
 export function transcriptWordCount(transcript: string): number {
   const cleaned = (transcript ?? '')
     .replace(/^(microphone|system audio):/gim, ' ')
-    .replace(/^[A-Za-z ]{1,20}:/gm, ' ') // leading "You:" / "Speaker 1:" labels
+    .replace(/^[A-Za-z][A-Za-z0-9 ]{0,19}:/gm, ' ') // leading "You:" / "Speaker 1:" labels
     .replace(/\s+/g, ' ')
     .trim()
   if (!cleaned) return 0

--- a/desktop/windows/src/renderer/src/lib/screenRedact.test.ts
+++ b/desktop/windows/src/renderer/src/lib/screenRedact.test.ts
@@ -12,6 +12,12 @@ describe('redact', () => {
   it('leaves benign prose', () => {
     expect(redact('working on omi-windows')).toBe('working on omi-windows')
   })
+  it('redacts only card-shaped numbers that pass the Luhn checksum', () => {
+    // standard Visa test number — valid Luhn → redacted
+    expect(redact('pay 4111111111111111')).toBe('pay [redacted]')
+    // same length, last digit changed → fails Luhn → kept (order number, timestamp)
+    expect(redact('id 4111111111111112')).toBe('id 4111111111111112')
+  })
 })
 
 describe('isPrivateWindow', () => {

--- a/desktop/windows/src/renderer/src/lib/screenRedact.ts
+++ b/desktop/windows/src/renderer/src/lib/screenRedact.ts
@@ -21,17 +21,39 @@ export function isDeniedContext(ctx: {
   return DEFAULT_DENYLIST.some((n) => hay.includes(n))
 }
 
+// Credit-card-like run: 13-19 digits with optional space/hyphen separators.
+const CARD = /\b(?:\d[ -]?){13,19}\b/g
+
 const PATTERNS: RegExp[] = [
   /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
-  /\b(?:\d[ -]?){13,19}\b/g,
   /\b\d{3}-\d{2}-\d{4}\b/g,
   /\beyJ[A-Za-z0-9_-]{2,}\.[A-Za-z0-9_-]{3,}(?:\.[A-Za-z0-9_-]+)?\b/g,
   /\b[A-Fa-f0-9]{32,}\b/g,
   /\b[A-Za-z0-9_-]{40,}\b/g
 ]
 
+// A digit string passes the Luhn checksum. Real card numbers do; order numbers,
+// 13-digit epoch-ms timestamps and ISBNs almost never do.
+function luhnValid(digits: string): boolean {
+  let sum = 0
+  let alt = false
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48
+    if (alt) {
+      d *= 2
+      if (d > 9) d -= 9
+    }
+    sum += d
+    alt = !alt
+  }
+  return sum % 10 === 0
+}
+
 export function redact(text: string): string {
   let out = text
+  // Redact a card-shaped run only when it passes Luhn, so a 13-19 digit order
+  // number or timestamp the model needs is not destroyed.
+  out = out.replace(CARD, (m) => (luhnValid(m.replace(/\D/g, '')) ? '[redacted]' : m))
   for (const re of PATTERNS) out = out.replace(re, '[redacted]')
   return out
 }


### PR DESCRIPTION
## Summary

Fixes for several places in the Windows app that silently drop, corrupt, or over-redact user data: memory ranking and retention, LLM-output JSON parsing, on-device screen redaction, and the memory export targets. Found while reading the code; no filed issue, no happy-path behavior change.

## What this fixes

- Memory ranking crashed on a null memory content. `rankMemories` called `tokenize(mem.content)` and `mem.content.trim()` without a guard, even though the API can return `content: null` and every sibling file in the directory guards it with `?? ''`. A single null memory threw and aborted the whole ranking. Now guarded.
- Empty diarized recordings were never pruned. `transcriptWordCount` strips speaker and section labels, but its regex `^[A-Za-z ]{1,20}:` excludes digits, so a "Speaker 1:" line (the exact format the comment says it strips) never matched. An empty recording transcribed as "Speaker 1: / Speaker 2: / Speaker 3:" counted six words instead of zero, so it was not recognized as empty and never swept. The label class now allows digits.
- Trailing prose after a JSON object broke every caller's parse. `extractJSONObject` found the first `{` and sliced to the end of the string instead of to the matching `}`, so a chatty model reply like `Here you go: {"memories":[]} Hope that helps!` made every caller's `JSON.parse` throw, aborting memory and sticky-notes import and returning empty for calendar, Gmail, and topic extraction. It now scans to the matching brace, ignoring braces inside string values, and falls back to the old behavior if the object is never closed.
- The on-device redaction destroyed non-card numbers the model needs. The credit-card pattern `\b(?:\d[ -]?){13,19}\b` matched any run of 13 to 19 digits, so it redacted Amazon order numbers, ISBN-13s, and 13-digit epoch-millisecond timestamps before the model saw them. The card replacement is now gated behind a Luhn checksum, so real card numbers are still redacted but order numbers and timestamps survive.
- A genuine "Uses X for Y" memory was deleted as app-index junk. The `USES_TEMPLATE` regex matched up to four trailing word tokens with no punctuation, so a real memory like "Uses Figma for design work" matched and was permanently deleted in the live retention mode. A match that contains a sentence connective an app-name list never has (for, and, with, of, the, per) is now rejected, so real memories survive while a bare "Uses Slack" is still matched.
- The file-based memory exports truncated the previous export on a partial write. The Obsidian and plain-file targets wrote in place with `fs.writeFile`, which opens with O_TRUNC and zeroes the file before the new bytes land, so a failed or interrupted write left the user with a truncated or empty file and the previous good export already gone. Both now write to a temp file and rename onto the target, so the swap is atomic.
- The Notion export silently dropped everything past 2000 characters of a memory. `m.content.slice(0, 2000)` placed the truncated text in a single rich_text item, discarding the tail of any longer memory (and a slice boundary could split a surrogate pair). Long memories are now chunked into up to 2000 code-point pieces across multiple rich_text items, which Notion permits.

## Testing

- Extended the existing vitest suites for `memoryRank`, `retentionRules`, `screenRedact`, `memoryCleanup`, and the export I/O, and added tests for `extractJSONObject` and the Notion chunking. New assertions verified red to green; prior assertions still pass.
- `npm run typecheck` passes for both projects.

## PR status check

Touches `desktop/windows/src/renderer/src/lib/{memoryRank,retentionRules,extractJson,screenRedact,memoryCleanup}.ts` and `desktop/windows/src/main/memoryExport/{obsidian,plainFile,notion}.ts` plus tests. I checked the open Windows PRs and none of them modify these files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

