### PR TITLE
fix(backend): enforce the daily proactive-notification cap across third-party apps and exempt developers

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -423,7 +423,7 @@ def get_proactive_noti_sent_at_ttl(uid: str, app_id: str):
 
 @try_catch_decorator
 def incr_daily_notification_count(uid: str) -> int:
-    """Atomically increment the daily mentor notification count for a user. Returns new count."""
+    """Atomically increment the daily proactive-notification count for a user (mentor + third-party apps). Returns new count."""
     from datetime import datetime, timezone
 
     key = f'{uid}:daily_noti_count:{datetime.now(timezone.utc).strftime("%Y-%m-%d")}'
@@ -434,7 +434,7 @@ def incr_daily_notification_count(uid: str) -> int:
 
 @try_catch_decorator
 def get_daily_notification_count(uid: str) -> int:
-    """Get the current daily mentor notification count for a user."""
+    """Get the current daily proactive-notification count for a user (mentor + third-party apps)."""
     from datetime import datetime, timezone
 
     key = f'{uid}:daily_noti_count:{datetime.now(timezone.utc).strftime("%Y-%m-%d")}'

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -26,6 +26,7 @@ from models.conversation_enums import (
 )
 from models.geolocation import Geolocation
 from utils.conversations.render import populate_speaker_names, populate_folder_names
+from utils.dev_cache import invalidate_developer_cache
 from models.transcript_segment import TranscriptSegment
 from dependencies import (
     get_current_user_id,
@@ -89,12 +90,16 @@ def create_key(key_data: DevApiKeyCreate, uid: str = Depends(get_current_user_id
             raise HTTPException(status_code=400, detail=f"Invalid scopes. Available: {AVAILABLE_SCOPES}")
 
     raw_key, api_key_data = dev_api_key_db.create_dev_key(uid, key_data.name.strip(), scopes=key_data.scopes)
+    # The proactive-notification cap exempts developers, so refresh that cache now
+    # that this user has a key, rather than waiting out its TTL.
+    invalidate_developer_cache(uid)
     return DevApiKeyCreated(**api_key_data.model_dump(), key=raw_key)
 
 
 @router.delete("/v1/dev/keys/{key_id}", status_code=204, tags=["developer"])
 def delete_key(key_id: str, uid: str = Depends(get_current_user_id)):
     dev_api_key_db.delete_dev_key(uid, key_id)
+    invalidate_developer_cache(uid)
     return
 
 

--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -909,13 +909,44 @@ def test_is_developer_detection():
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
     assert app_int._is_developer("u") is False
 
+    app_int._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
     assert app_int._is_developer("u") is True
 
+    app_int._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(side_effect=Exception("firestore down"))
     assert app_int._is_developer("u") is False  # fail closed: still apply the cap
 
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+
+
+def test_is_developer_is_cached():
+    """The developer lookup is cached, so a second cap check does not re-hit the DB."""
+    app_int = _fresh_app_integrations()
+    dev_mod = sys.modules["database.dev_api_key"]
+    app_int._DEV_STATUS_CACHE.clear()
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+
+    assert app_int._is_developer("cached-uid") is False
+    assert app_int._is_developer("cached-uid") is False
+    dev_mod.get_dev_keys_for_user.assert_called_once()  # second call served from cache
+
+
+def test_resolve_daily_cap_bounds():
+    """The env override is clamped: invalid falls back to the default, and 0/huge are bounded."""
+    import utils.llm.proactive_notification as pn
+
+    assert pn._resolve_daily_cap(default=9) == 9  # env unset in tests
+    with patch.dict(os.environ, {"MAX_DAILY_NOTIFICATIONS": "0"}):
+        assert pn._resolve_daily_cap(default=9, minimum=1) == 1  # cannot silently disable
+    with patch.dict(os.environ, {"MAX_DAILY_NOTIFICATIONS": "-5"}):
+        assert pn._resolve_daily_cap(default=9, minimum=1) == 1
+    with patch.dict(os.environ, {"MAX_DAILY_NOTIFICATIONS": "999999"}):
+        assert pn._resolve_daily_cap(default=9, maximum=1000) == 1000  # cannot remove throttling
+    with patch.dict(os.environ, {"MAX_DAILY_NOTIFICATIONS": "not-an-int"}):
+        assert pn._resolve_daily_cap(default=9) == 9  # falls back
+    with patch.dict(os.environ, {"MAX_DAILY_NOTIFICATIONS": "6"}):
+        assert pn._resolve_daily_cap(default=9) == 6  # valid override honored
 
 
 def test_proactive_daily_cap_helper():
@@ -931,6 +962,7 @@ def test_proactive_daily_cap_helper():
     assert app_int._proactive_daily_cap_reached("u") is True
 
     # Developer: exempt even far over the cap.
+    app_int._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
     redis_mod.get_daily_notification_count.return_value = 100
     assert app_int._proactive_daily_cap_reached("u") is False

--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -60,11 +60,14 @@ for submodule in [
     "mem_db",
     "notifications",
     "webhook_health",
+    "dev_api_key",
 ]:
     mod = _stub_module(f"database.{submodule}")
     setattr(database_mod, submodule, mod)
 
 sys.modules["database.llm_usage"].record_llm_usage = MagicMock()
+# Default: not a developer, so the daily-cap tests exercise the cap path.
+sys.modules["database.dev_api_key"].get_dev_keys_for_user = MagicMock(return_value=[])
 sys.modules["database.notifications"].get_mentor_notification_frequency = MagicMock(return_value=3)
 
 # Stub _client.db for auth.py top-level import
@@ -882,10 +885,101 @@ def test_frequency_thresholds():
 
 
 def test_max_daily_notifications():
-    """MAX_DAILY_NOTIFICATIONS should be 12."""
+    """MAX_DAILY_NOTIFICATIONS defaults under 10 (the #4859 target) and is env-tunable."""
     from utils.llm.proactive_notification import MAX_DAILY_NOTIFICATIONS
 
-    assert MAX_DAILY_NOTIFICATIONS == 12
+    assert MAX_DAILY_NOTIFICATIONS == 9
+    assert MAX_DAILY_NOTIFICATIONS < 10
+
+
+def _fresh_app_integrations():
+    _setup_app_integrations_stubs()
+    if "utils.app_integrations" in sys.modules:
+        del sys.modules["utils.app_integrations"]
+    import utils.app_integrations as app_int
+
+    return app_int
+
+
+def test_is_developer_detection():
+    """A user with any developer API key is a developer; a lookup error fails closed."""
+    app_int = _fresh_app_integrations()
+    dev_mod = sys.modules["database.dev_api_key"]
+
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+    assert app_int._is_developer("u") is False
+
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
+    assert app_int._is_developer("u") is True
+
+    dev_mod.get_dev_keys_for_user = MagicMock(side_effect=Exception("firestore down"))
+    assert app_int._is_developer("u") is False  # fail closed: still apply the cap
+
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+
+
+def test_proactive_daily_cap_helper():
+    """The shared cap triggers at/above MAX_DAILY_NOTIFICATIONS, and developers are exempt (#3346)."""
+    app_int = _fresh_app_integrations()
+    dev_mod = sys.modules["database.dev_api_key"]
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+
+    redis_mod.get_daily_notification_count.return_value = 0
+    assert app_int._proactive_daily_cap_reached("u") is False
+
+    redis_mod.get_daily_notification_count.return_value = 9  # at the default cap
+    assert app_int._proactive_daily_cap_reached("u") is True
+
+    # Developer: exempt even far over the cap.
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
+    redis_mod.get_daily_notification_count.return_value = 100
+    assert app_int._proactive_daily_cap_reached("u") is False
+
+    redis_mod.get_daily_notification_count.return_value = 0
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+
+
+def test_app_proactive_notification_respects_daily_cap():
+    """Core fix: a third-party app proactive notification is now blocked once the shared daily cap is hit."""
+    app_int = _fresh_app_integrations()
+    mem_mod.get_proactive_noti_sent_at.return_value = None
+    redis_mod.get_proactive_noti_sent_at.return_value = None
+    redis_mod.get_daily_notification_count.return_value = 9  # at the default cap
+    redis_mod.incr_daily_notification_count.reset_mock()
+    sys.modules["database.dev_api_key"].get_dev_keys_for_user = MagicMock(return_value=[])
+
+    app = MagicMock()
+    app.has_capability.return_value = True
+    app.id = "app-1"
+    app.name = "TestApp"
+
+    result = app_int._process_proactive_notification("uid_cap", app, {"prompt": "hello"})
+
+    assert result is None
+    redis_mod.incr_daily_notification_count.assert_not_called()
+    redis_mod.get_daily_notification_count.return_value = 0
+
+
+def test_app_proactive_notification_increments_shared_budget():
+    """A delivered app proactive notification increments the same daily counter mentor notifications use."""
+    app_int = _fresh_app_integrations()
+    mem_mod.get_proactive_noti_sent_at.return_value = None
+    redis_mod.get_proactive_noti_sent_at.return_value = None
+    redis_mod.get_daily_notification_count.return_value = 0  # under cap
+    redis_mod.incr_daily_notification_count.reset_mock()
+    sys.modules["database.dev_api_key"].get_dev_keys_for_user = MagicMock(return_value=[])
+    sys.modules["utils.llm.clients"].get_llm.return_value.invoke.return_value.content = "Here is a useful nudge."
+
+    app = MagicMock()
+    app.has_capability.return_value = True
+    app.id = "app-2"
+    app.name = "TestApp"
+    app.filter_proactive_notification_scopes.return_value = []
+
+    result = app_int._process_proactive_notification("uid_send", app, {"prompt": "hello", "params": []})
+
+    assert result == "Here is a useful nudge."
+    redis_mod.incr_daily_notification_count.assert_called_once_with("uid_send")
 
 
 def test_frequency_guidance_all_levels():

--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -898,6 +898,9 @@ def _fresh_app_integrations():
         del sys.modules["utils.app_integrations"]
     import utils.app_integrations as app_int
 
+    # The developer-status cache lives in utils.dev_cache, which persists across
+    # re-imports of app_integrations, so clear it for test isolation.
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
     return app_int
 
 
@@ -909,11 +912,11 @@ def test_is_developer_detection():
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
     assert app_int._is_developer("u") is False
 
-    app_int._DEV_STATUS_CACHE.clear()
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
     assert app_int._is_developer("u") is True
 
-    app_int._DEV_STATUS_CACHE.clear()
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(side_effect=Exception("firestore down"))
     assert app_int._is_developer("u") is False  # fail closed: still apply the cap
 
@@ -924,12 +927,28 @@ def test_is_developer_is_cached():
     """The developer lookup is cached, so a second cap check does not re-hit the DB."""
     app_int = _fresh_app_integrations()
     dev_mod = sys.modules["database.dev_api_key"]
-    app_int._DEV_STATUS_CACHE.clear()
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
 
     assert app_int._is_developer("cached-uid") is False
     assert app_int._is_developer("cached-uid") is False
     dev_mod.get_dev_keys_for_user.assert_called_once()  # second call served from cache
+
+
+def test_invalidate_developer_cache_takes_effect_immediately():
+    """Invalidating after a key change forces the next check to re-read, not serve stale status."""
+    app_int = _fresh_app_integrations()
+    dev_mod = sys.modules["database.dev_api_key"]
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
+
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[])
+    assert app_int._is_developer("u") is False  # cached as non-developer
+
+    # They create their first key; without invalidation the stale False would persist.
+    dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
+    assert app_int._is_developer("u") is False  # still serving the cached value
+    app_int.dev_cache.invalidate_developer_cache("u")
+    assert app_int._is_developer("u") is True  # re-read after invalidation
 
 
 def test_resolve_daily_cap_bounds():
@@ -962,7 +981,7 @@ def test_proactive_daily_cap_helper():
     assert app_int._proactive_daily_cap_reached("u") is True
 
     # Developer: exempt even far over the cap.
-    app_int._DEV_STATUS_CACHE.clear()
+    app_int.dev_cache._DEV_STATUS_CACHE.clear()
     dev_mod.get_dev_keys_for_user = MagicMock(return_value=[MagicMock()])
     redis_mod.get_daily_notification_count.return_value = 100
     assert app_int._proactive_daily_cap_reached("u") is False

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -5,7 +5,6 @@ import os
 import time
 
 import httpx
-from cachetools import TTLCache
 
 from utils.http_client import (
     get_webhook_client,
@@ -16,6 +15,7 @@ from utils.http_client import (
 )
 from utils.executors import db_executor, run_blocking
 from utils.async_tasks import gather_safe
+import utils.dev_cache as dev_cache
 
 import database.notifications as notification_db
 import database.dev_api_key as dev_api_key_db
@@ -317,21 +317,14 @@ def _set_proactive_noti_sent_at(uid: str, app: App):
     redis_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
 
 
-# Developer status rarely changes, but the cap is checked on every proactive
-# notification attempt, so cache it briefly to avoid a Firestore read per attempt.
-_DEV_STATUS_CACHE: TTLCache = TTLCache(maxsize=4096, ttl=300)
-_dev_status_lock = threading.Lock()
-
-
 def _is_developer(uid: str) -> bool:
     """A user with at least one developer API key is treated as a developer and
     is exempt from the daily proactive-notification cap (#3346), so building and
-    testing an app is not throttled. Result is cached for a few minutes to keep
-    the cap check off the Firestore hot path. Fails closed (treats the user as a
-    non-developer, and does not cache the failure) so a lookup error never
-    silently lifts the cap for everyone."""
-    with _dev_status_lock:
-        cached = _DEV_STATUS_CACHE.get(uid)
+    testing an app is not throttled. Result is cached (in ``utils.dev_cache``, and
+    invalidated on dev-key changes) to keep the cap check off the Firestore hot
+    path. Fails closed (treats the user as a non-developer, and does not cache the
+    failure) so a lookup error never silently lifts the cap for everyone."""
+    cached = dev_cache.get_cached_developer(uid)
     if cached is not None:
         return cached
     try:
@@ -339,8 +332,7 @@ def _is_developer(uid: str) -> bool:
     except Exception as e:
         logger.warning(f"proactive daily cap: developer check failed uid={uid}, applying cap: {e}")
         return False
-    with _dev_status_lock:
-        _DEV_STATUS_CACHE[uid] = result
+    dev_cache.set_cached_developer(uid, result)
     return result
 
 

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -17,6 +17,7 @@ from utils.executors import db_executor, run_blocking
 from utils.async_tasks import gather_safe
 
 import database.notifications as notification_db
+import database.dev_api_key as dev_api_key_db
 from database import mem_db
 from database import redis_db
 from database.apps import get_app_by_id_db, record_app_usage
@@ -315,6 +316,27 @@ def _set_proactive_noti_sent_at(uid: str, app: App):
     redis_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
 
 
+def _is_developer(uid: str) -> bool:
+    """A user with at least one developer API key is treated as a developer and
+    is exempt from the daily proactive-notification cap (#3346), so building and
+    testing an app is not throttled. Fails closed (treats the user as a
+    non-developer) so a lookup error never silently lifts the cap for everyone."""
+    try:
+        return bool(dev_api_key_db.get_dev_keys_for_user(uid))
+    except Exception as e:
+        logger.warning(f"proactive daily cap: developer check failed uid={uid}, applying cap: {e}")
+        return False
+
+
+def _proactive_daily_cap_reached(uid: str) -> bool:
+    """True when the user has already received the day's allotment of proactive
+    notifications. Counts every proactive source together (mentor + third-party
+    apps) against one per-user daily budget, and exempts developers (#3346)."""
+    if _is_developer(uid):
+        return False
+    return (get_daily_notification_count(uid) or 0) >= MAX_DAILY_NOTIFICATIONS
+
+
 MENTOR_RATE_LIMIT_SECONDS = 300  # 5 minutes between mentor notifications
 
 
@@ -348,10 +370,9 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
         logger.info(f"mentor_proactive rate_limited_remote uid={uid}")
         return None
 
-    # 3. Daily cap check
-    daily_count = get_daily_notification_count(uid) or 0
-    if daily_count >= MAX_DAILY_NOTIFICATIONS:
-        logger.info(f"mentor_proactive daily_cap_reached uid={uid} count={daily_count}")
+    # 3. Daily cap check (shared budget across all proactive sources; devs exempt)
+    if _proactive_daily_cap_reached(uid):
+        logger.info(f"mentor_proactive daily_cap_reached uid={uid}")
         return None
 
     # 4. Gather lightweight context (no vector search yet — save for step 2)
@@ -519,6 +540,13 @@ def _process_proactive_notification(uid: str, app: App, data):
         logger.info(f"App {app.id} is reach rate limits 1 noti per user per {PROACTIVE_NOTI_LIMIT_SECONDS}s {uid}")
         return None
 
+    # Daily cap: third-party proactive notifications share the same per-user daily
+    # budget as mentor notifications, so a user with several proactive apps cannot
+    # blow past the limit. Developers are exempt (#3346).
+    if _proactive_daily_cap_reached(uid):
+        logger.info(f"App {app.id} proactive daily_cap_reached {uid}")
+        return None
+
     max_prompt_char_limit = 128000
     min_message_char_limit = 5
 
@@ -571,6 +599,9 @@ def _process_proactive_notification(uid: str, app: App, data):
     send_app_notification(uid, app.name, app.id, message)
 
     _set_proactive_noti_sent_at(uid, app)
+    # Count this against the user's daily proactive budget so mentor + app
+    # notifications share one ceiling rather than each having their own.
+    incr_daily_notification_count(uid)
     return message
 
 

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -5,6 +5,7 @@ import os
 import time
 
 import httpx
+from cachetools import TTLCache
 
 from utils.http_client import (
     get_webhook_client,
@@ -316,16 +317,31 @@ def _set_proactive_noti_sent_at(uid: str, app: App):
     redis_db.set_proactive_noti_sent_at(uid, app_id=app.id, ts=int(ts), ttl=PROACTIVE_NOTI_LIMIT_SECONDS)
 
 
+# Developer status rarely changes, but the cap is checked on every proactive
+# notification attempt, so cache it briefly to avoid a Firestore read per attempt.
+_DEV_STATUS_CACHE: TTLCache = TTLCache(maxsize=4096, ttl=300)
+_dev_status_lock = threading.Lock()
+
+
 def _is_developer(uid: str) -> bool:
     """A user with at least one developer API key is treated as a developer and
     is exempt from the daily proactive-notification cap (#3346), so building and
-    testing an app is not throttled. Fails closed (treats the user as a
-    non-developer) so a lookup error never silently lifts the cap for everyone."""
+    testing an app is not throttled. Result is cached for a few minutes to keep
+    the cap check off the Firestore hot path. Fails closed (treats the user as a
+    non-developer, and does not cache the failure) so a lookup error never
+    silently lifts the cap for everyone."""
+    with _dev_status_lock:
+        cached = _DEV_STATUS_CACHE.get(uid)
+    if cached is not None:
+        return cached
     try:
-        return bool(dev_api_key_db.get_dev_keys_for_user(uid))
+        result = bool(dev_api_key_db.get_dev_keys_for_user(uid))
     except Exception as e:
         logger.warning(f"proactive daily cap: developer check failed uid={uid}, applying cap: {e}")
         return False
+    with _dev_status_lock:
+        _DEV_STATUS_CACHE[uid] = result
+    return result
 
 
 def _proactive_daily_cap_reached(uid: str) -> bool:

--- a/backend/utils/dev_cache.py
+++ b/backend/utils/dev_cache.py
@@ -1,0 +1,38 @@
+"""Tiny, dependency-light cache of developer status (does a user hold at least
+one developer API key).
+
+This lives in its own module, separate from the heavyweight ``app_integrations``,
+so the developer/dev-key router can invalidate it on a key change without pulling
+the notification/LLM import chain into that lightweight surface. The proactive
+notification cap exempts developers and is checked on every attempt, so caching
+keeps the check off the Firestore hot path; the short TTL bounds staleness and the
+explicit invalidate makes a create/delete take effect immediately.
+"""
+
+import threading
+from typing import Optional
+
+from cachetools import TTLCache
+
+_DEV_STATUS_CACHE: TTLCache = TTLCache(maxsize=4096, ttl=300)
+_lock = threading.Lock()
+
+
+def get_cached_developer(uid: str) -> Optional[bool]:
+    """Cached developer status, or None when not cached."""
+    with _lock:
+        return _DEV_STATUS_CACHE.get(uid)
+
+
+def set_cached_developer(uid: str, is_developer: bool) -> None:
+    with _lock:
+        _DEV_STATUS_CACHE[uid] = is_developer
+
+
+def invalidate_developer_cache(uid: str) -> None:
+    """Drop a user's cached developer status so a dev-key create/delete takes
+    effect immediately instead of waiting out the TTL — otherwise a brand-new
+    developer could stay capped, or a just-revoked one stay exempt, until the
+    entry expires."""
+    with _lock:
+        _DEV_STATUS_CACHE.pop(uid, None)

--- a/backend/utils/llm/proactive_notification.py
+++ b/backend/utils/llm/proactive_notification.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import List, Optional
 
@@ -253,11 +254,15 @@ FREQUENCY_GUIDANCE = {
     1: "Ultra selective. Only prevent clear mistakes or truly critical insights. 1-3 per day max.",
     2: "Very selective. Only non-obvious insights tied to specific goals or history. 3-5 per day.",
     3: "Balanced. Only when you have a specific, actionable insight the user would miss. 5-8 per day.",
-    4: "Proactive. Share specific insights connecting this conversation to goals/history. 8-12 per day.",
-    5: "Very proactive. Share insights when you spot non-obvious connections. Up to 12 per day.",
+    4: "Proactive. Share specific insights connecting this conversation to goals/history. 6-9 per day.",
+    5: "Very proactive. Share insights when you spot non-obvious connections. Up to 9 per day.",
 }
 
-MAX_DAILY_NOTIFICATIONS = 12
+# Hard ceiling on proactive notifications per user per day, across every source
+# (mentor + third-party proactive apps). Defaults to 9 to keep the user under the
+# "less than 10 daily notifs" target in #4859; override with the env var to tune
+# without a code change.
+MAX_DAILY_NOTIFICATIONS = int(os.getenv('MAX_DAILY_NOTIFICATIONS', '9'))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/llm/proactive_notification.py
+++ b/backend/utils/llm/proactive_notification.py
@@ -258,11 +258,27 @@ FREQUENCY_GUIDANCE = {
     5: "Very proactive. Share insights when you spot non-obvious connections. Up to 9 per day.",
 }
 
+
+def _resolve_daily_cap(default: int = 9, minimum: int = 1, maximum: int = 1000) -> int:
+    """Read the daily-cap override, clamped to a sane range.
+
+    A non-integer or unset value falls back to the default, and the result is
+    bounded so a typo cannot silently disable proactive notifications (0/negative)
+    or remove throttling entirely (an accidental huge value)."""
+    raw = os.getenv('MAX_DAILY_NOTIFICATIONS')
+    if raw is None:
+        return default
+    try:
+        return max(minimum, min(int(raw), maximum))
+    except (TypeError, ValueError):
+        return default
+
+
 # Hard ceiling on proactive notifications per user per day, across every source
 # (mentor + third-party proactive apps). Defaults to 9 to keep the user under the
 # "less than 10 daily notifs" target in #4859; override with the env var to tune
 # without a code change.
-MAX_DAILY_NOTIFICATIONS = int(os.getenv('MAX_DAILY_NOTIFICATIONS', '9'))
+MAX_DAILY_NOTIFICATIONS = _resolve_daily_cap()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Omi already caps proactive notifications per user per day, but only the mentor path enforced it. Third-party proactive apps (the `proactive_notification` capability) neither checked the cap nor counted toward it, so a user with several proactive apps could receive well over the limit, and those notifications stayed invisible to the mentor cap too. This wires the existing daily budget through the third-party path, makes the cap configurable, and exempts developers.

Refs #4859 and #4860 (the "less than 10 daily notifs" ask) and #3346 (do not limit notifications for devs).

## What changed

- Third-party proactive notifications now honor the same per-user daily cap as mentor notifications, and increment the same counter when one is sent. Mentor and app notifications now share one budget instead of the app path being unbounded. (`utils/app_integrations.py`)
- The cap is configurable and defaults under 10. `MAX_DAILY_NOTIFICATIONS` reads from the environment (default 9) to meet the "<10 daily notifs" target in #4859, tunable without a code change. The "very proactive" frequency copy used to say 12 per day; it now matches the new default. (`utils/llm/proactive_notification.py`)
- Developers are exempt from the cap (#3346): a user with at least one developer API key is not throttled, so building and testing an app is not blocked. The check fails closed (a lookup error keeps the cap on), so it can never silently lift the cap for everyone. (`utils/app_integrations.py`)
- The shared cap check (`_proactive_daily_cap_reached`) and developer check (`_is_developer`) are small helpers used by both the mentor and third-party paths, so the two cannot drift apart.

## Notes and scope

- The cap covers LLM-driven proactive notifications (mentor plus third-party `proactive_notification`). Transactional notifications (credit limit, subscription, training data) and an app's explicit reply message are intentionally not capped.
- The daily counter is keyed by UTC day with a 25 hour TTL (existing behavior), so it resets each day on its own.
- The default of 9 is the one product-ish number here; it is a single env var (`MAX_DAILY_NOTIFICATIONS`) if you want a different ceiling.

## Testing

- Extended `tests/unit/test_mentor_notifications.py`: developer detection (including the fail-closed path), the shared cap helper (under cap, at cap, developer bypass), the third-party path returning None once the cap is hit, and a delivered app notification incrementing the shared counter. All pass.
- The backend notification suites pass (`test_mentor_notifications`, `test_async_app_integrations`, `test_async_realtime_integrations_offload`). `black --line-length 120 --skip-string-normalization` is clean and `scripts/lint_async_blockers.py` reports no violations.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

