### PR TITLE
fix uncaught exception in sendInitialAppMessage crashing the app

### DIFF
--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -978,10 +978,15 @@ class MessageProvider extends ChangeNotifier {
 
   Future sendInitialAppMessage(App? app) async {
     setSendingMessage(true);
-    ServerMessage message = await getInitialAppMessage(app?.id);
-    addMessage(message);
-    setSendingMessage(false);
-    notifyListeners();
+    try {
+      ServerMessage message = await getInitialAppMessage(app?.id);
+      addMessage(message);
+    } catch (e) {
+      Logger.error('sendInitialAppMessage failed: $e');
+    } finally {
+      setSendingMessage(false);
+      notifyListeners();
+    }
   }
 
   App? messageSenderApp(String? appId) {


### PR DESCRIPTION
## Summary

- Wrap `getInitialAppMessage` in a try/catch in `sendInitialAppMessage` so network errors and non-200 responses no longer propagate as unhandled exceptions and crash the app
- Move `setSendingMessage(false)` and `notifyListeners()` into a `finally` block so sending state is always released even on failure

## Crash

**getInitialAppMessage.<fn>**
`io.flutter.plugins.firebase.crashlytics.FlutterError - Exception: Failed to send message`

`package:omi/backend/http/api/messages.dart:110`

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/a775945d1840f9480071f250ba10f3c9?time=7d&types=crash&sessionEventKey=6A3EF6EB015E00010757A164B989CA74_2234273527452994990

## Logs

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Exception: Failed to send message
       at getInitialAppMessage.<fn>(messages.dart:123)
       at _CustomZone.runUnary(dart:async)
       at MessageProvider.sendInitialAppMessage(message_provider.dart:981)
```

## Test plan

- [ ] Open a chat with an app that has an initial message — works normally
- [ ] Simulate a network failure when opening the chat — no crash, sending state is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

