### PR TITLE
fix(agent): nested withTransaction fails with 'cannot start a transaction within a transaction'

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed agent chat and task execution failing with a \"cannot start a transaction within a transaction\" database error"
+  ],
   "releases": [
     {
       "version": "0.11.543",

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -35,6 +35,7 @@ export interface SqliteAgentStoreOptions {
   databasePath?: string;
   reconcileOnOpen?: boolean;
   nowMs?: () => number;
+  databaseFactory?: DatabaseFactory;
 }
 
 export interface NodeSqliteProbeOptions {
@@ -323,11 +324,13 @@ export function probeNodeSqliteRuntime(options: NodeSqliteProbeOptions = {}): vo
 export class SqliteAgentStore implements AgentStore {
   private readonly db: DatabaseSync;
   private readonly nowMs: () => number;
+  private transactionDepth = 0;
 
   constructor(options: SqliteAgentStoreOptions = {}) {
     const databasePath = options.databasePath ?? databasePathForStateDir(requiredStateDir(options.stateDir));
     mkdirSync(dirname(databasePath), { recursive: true });
-    this.db = new DatabaseSync(databasePath);
+    const Database = options.databaseFactory ?? DatabaseSync;
+    this.db = new Database(databasePath) as DatabaseSync;
     this.nowMs = options.nowMs ?? Date.now;
 
     applyConnectionPragmas(this.db);
@@ -352,7 +355,30 @@ export class SqliteAgentStore implements AgentStore {
   }
 
   withTransaction<T>(work: () => T): T {
-    return runTransaction(this.db, work);
+    // Track nesting depth ourselves rather than trusting db.isTransaction: the
+    // bundled agent runtime does not reliably report an open transaction, so a
+    // nested call that issued its own BEGIN would fail with "cannot start a
+    // transaction within a transaction" and break every agent operation.
+    if (this.transactionDepth > 0) {
+      this.transactionDepth += 1;
+      try {
+        return work();
+      } finally {
+        this.transactionDepth -= 1;
+      }
+    }
+    this.transactionDepth += 1;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = work();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    } finally {
+      this.transactionDepth -= 1;
+    }
   }
 
   reconcileStartup(): StartupReconciliationResult {

--- a/desktop/macos/agent/tests/sqlite-store.test.ts
+++ b/desktop/macos/agent/tests/sqlite-store.test.ts
@@ -252,6 +252,56 @@ describe("SqliteAgentStore", () => {
     store.close();
   });
 
+  it("nests withTransaction safely when the runtime never reports isTransaction", () => {
+    // Reproduces the production failure: in the bundled agent runtime,
+    // DatabaseSync.isTransaction does not flip to true inside an open
+    // transaction, so a guard that trusts it cannot detect nesting. A real
+    // SQLite connection throws "cannot start a transaction within a
+    // transaction" on a nested BEGIN, so a nested withTransaction must reuse
+    // the outer transaction rather than issue a second BEGIN.
+    const execLog: string[] = [];
+    let open = false;
+    class NoIsTransactionDatabase {
+      readonly isTransaction = false; // never flips, like the bundled runtime
+      constructor(_path: string) {}
+      exec(sql: string): void {
+        const head = sql.trimStart().toUpperCase();
+        if (head.startsWith("BEGIN")) {
+          if (open) {
+            throw new Error("cannot start a transaction within a transaction");
+          }
+          open = true;
+          execLog.push("BEGIN");
+        } else if (head.startsWith("COMMIT")) {
+          open = false;
+          execLog.push("COMMIT");
+        } else if (head.startsWith("ROLLBACK")) {
+          open = false;
+          execLog.push("ROLLBACK");
+        }
+      }
+      prepare(_sql: string) {
+        return { run: () => {}, get: () => undefined, all: () => [] };
+      }
+      close(): void {}
+    }
+
+    const store = new SqliteAgentStore({
+      databasePath: ":memory:",
+      reconcileOnOpen: false,
+      databaseFactory: NoIsTransactionDatabase,
+    });
+
+    execLog.length = 0; // ignore BEGIN/COMMIT from constructor migrations
+
+    const result = store.withTransaction(() => store.withTransaction(() => "inner-result"));
+
+    expect(result).toBe("inner-result");
+    // Exactly one real transaction was opened — the nested call reused it.
+    expect(execLog).toEqual(["BEGIN", "COMMIT"]);
+    store.close();
+  });
+
   it("rolls back artifact and lifecycle event writes atomically", () => {
     const store = newStore({ reconcileOnOpen: false });
     const session = store.insertSession({


### PR DESCRIPTION
Closes #8444

## Problem

On the desktop app, chat, task execution, and background synthesis all fail instantly. The agent runtime logs:

```
AgentRuntimeProcess: agent error (raw): cannot start a transaction within a transaction
Failed to get AI response: Something went wrong. Please try again.
```

It fires on the very first agent operation (e.g. Apple Notes synthesis on startup), so the agent is effectively unusable.

## Root cause

Two layers leave nested transactions unguarded:

- `kernel.ts` `withTransaction` increments a `transactionDepth` counter but **still calls `store.withTransaction(work)` on every nested call** — that counter is only used to defer subscriber-event notifications, not to prevent nested DB transactions.
- `sqlite-store.ts` `runTransaction` is therefore the only real nesting guard, and it relies on `db.isTransaction` before issuing `BEGIN IMMEDIATE`. In the bundled agent runtime that flag does not reliably report an open transaction, so a nested call issues a **second `BEGIN IMMEDIATE`** → SQLite rejects it with `cannot start a transaction within a transaction`.

Because the kernel nests `withTransaction` heavily (artifact persistence, reconcile, etc.), nearly every agent operation hits this.

## Fix

Track transaction depth inside `SqliteAgentStore` instead of trusting `db.isTransaction`. The outermost call issues `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`; nested calls reuse the open transaction. This is robust regardless of whether the runtime implements `isTransaction`.

## Tests

- Added a unit test that reproduces the production failure: a fake database whose `isTransaction` never flips to `true` (matching the bundled runtime) plus real SQLite nested-`BEGIN`-throws semantics. It fails on `main` with the exact production error and passes with this change.
- Full agent suite green: **233/233**. `tsc` build clean.

## Verification

Built the desktop app locally from this branch and exercised the real chat pipeline end-to-end: the `cannot start a transaction within a transaction` error no longer appears (0 occurrences across startup + chat), the agent runtime initializes, registers its tools, and chat responds normally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
