### PR TITLE
Fix Windows dev startup when ELECTRON_RUN_AS_NODE is set

### DIFF
--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -23,6 +23,11 @@ npm run dev
 config, so after `cp .env.example .env` the app runs and sign-in works with no extra
 keys to obtain.
 
+`npm run dev` automatically unsets `ELECTRON_RUN_AS_NODE` for the spawned Electron
+app. Some shell/tooling sessions leave that variable set after using Electron as a
+Node runtime; if it leaks into app startup, Electron does not expose `electron.app`
+and the dev app crashes before opening.
+
 ## Authentication
 
 - **App sign-in:** each user signs in with **their own** Google/Omi account through

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -12,7 +12,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "node scripts/dev.mjs",
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",

--- a/desktop/windows/scripts/dev.mjs
+++ b/desktop/windows/scripts/dev.mjs
@@ -7,12 +7,7 @@ import { fileURLToPath } from 'node:url'
 const env = { ...process.env }
 const args = ['dev', ...process.argv.slice(2)]
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
-const electronVite = join(
-  root,
-  'node_modules',
-  '.bin',
-  process.platform === 'win32' ? 'electron-vite.cmd' : 'electron-vite'
-)
+const electronVite = join(root, 'node_modules', 'electron-vite', 'bin', 'electron-vite.js')
 
 if (env.ELECTRON_RUN_AS_NODE) {
   console.warn(
@@ -22,9 +17,10 @@ if (env.ELECTRON_RUN_AS_NODE) {
   delete env.ELECTRON_RUN_AS_NODE
 }
 
-const child = spawn(electronVite, args, {
+const child = spawn(process.execPath, [electronVite, ...args], {
+  cwd: root,
   env,
-  shell: true,
+  shell: false,
   stdio: 'inherit'
 })
 

--- a/desktop/windows/scripts/dev.mjs
+++ b/desktop/windows/scripts/dev.mjs
@@ -1,8 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { spawn } from 'node:child_process'
+import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 const env = { ...process.env }
+const args = ['dev', ...process.argv.slice(2)]
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const electronVite = join(
+  root,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'electron-vite.cmd' : 'electron-vite'
+)
 
 if (env.ELECTRON_RUN_AS_NODE) {
   console.warn(
@@ -12,7 +22,7 @@ if (env.ELECTRON_RUN_AS_NODE) {
   delete env.ELECTRON_RUN_AS_NODE
 }
 
-const child = spawn('electron-vite', ['dev'], {
+const child = spawn(electronVite, args, {
   env,
   shell: true,
   stdio: 'inherit'

--- a/desktop/windows/scripts/dev.mjs
+++ b/desktop/windows/scripts/dev.mjs
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { spawn } from 'node:child_process'
+import process from 'node:process'
+
+const env = { ...process.env }
+
+if (env.ELECTRON_RUN_AS_NODE) {
+  console.warn(
+    '[dev] ELECTRON_RUN_AS_NODE is set; unsetting it for Electron.\n' +
+      '[dev] Electron needs to run as an app here, not as the Node runtime.'
+  )
+  delete env.ELECTRON_RUN_AS_NODE
+}
+
+const child = spawn('electron-vite', ['dev'], {
+  env,
+  shell: true,
+  stdio: 'inherit'
+})
+
+/**
+ * @param {NodeJS.Signals} signal
+ * @returns {void}
+ */
+const forwardSignal = (signal) => {
+  if (!child.killed) child.kill(signal)
+}
+
+process.on('SIGINT', () => forwardSignal('SIGINT'))
+process.on('SIGTERM', () => forwardSignal('SIGTERM'))
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal)
+  process.exit(code ?? 1)
+})


### PR DESCRIPTION
## Summary

- Add a Windows desktop dev wrapper that unsets `ELECTRON_RUN_AS_NODE` before launching `electron-vite dev`
- Keep the existing `npm run dev` command unchanged for developers
- Document why the wrapper exists in the Windows README

## Why

If `ELECTRON_RUN_AS_NODE=1` leaks into the shell, Electron starts as a Node runtime instead of an Electron app. That makes `electron.app` undefined and crashes startup inside `@electron-toolkit/utils`.

## Testing

- `npm run typecheck`
- `npx eslint scripts/dev.mjs`
- Verified `ELECTRON_RUN_AS_NODE=1 npm run dev` starts without the previous `electron.app.isPackaged` crash

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

