### PR TITLE
fix(onboarding): gate device tutorial to Omi devices only

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -478,6 +478,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   bool _deviceOnboardingShown = false;
 
   void _checkDeviceOnboarding(BtDevice device) async {
+    if (device.type != DeviceType.omi) return;
     if (_deviceOnboardingShown) return;
     if (SharedPreferencesUtil().deviceOnboardingCompleted) return;
 

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -15,6 +15,7 @@ import 'package:omi/pages/memories/page.dart';
 import 'package:omi/pages/settings/integrations_page.dart';
 import 'package:omi/pages/settings/usage_page.dart';
 import 'package:omi/pages/referral/referral_page.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/models/subscription.dart';
@@ -579,14 +580,16 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                             Navigator.of(context).push(MaterialPageRoute(builder: (context) => const DeviceSettings()));
                           },
                         ),
-                        const Divider(height: 1, color: Color(0xFF3C3C43)),
-                        _buildSettingsItem(
-                          title: context.l10n.deviceTutorial,
-                          icon: const FaIcon(FontAwesomeIcons.graduationCap, color: Color(0xFF8E8E93), size: 20),
-                          onTap: () {
-                            routeToPage(context, const InteractiveDeviceOnboardingWrapper(allowExit: true));
-                          },
-                        ),
+                        if (deviceProvider.connectedDevice?.type == DeviceType.omi) ...[
+                          const Divider(height: 1, color: Color(0xFF3C3C43)),
+                          _buildSettingsItem(
+                            title: context.l10n.deviceTutorial,
+                            icon: const FaIcon(FontAwesomeIcons.graduationCap, color: Color(0xFF8E8E93), size: 20),
+                            onTap: () {
+                              routeToPage(context, const InteractiveDeviceOnboardingWrapper(allowExit: true));
+                            },
+                          ),
+                        ],
                       ],
                     );
                   },


### PR DESCRIPTION
## Summary
The interactive device onboarding tutorial (#6124) auto-triggers on **any** device connection and shows a **non-skippable** flow whose steps (button press, live transcription, long-press power cycle, double-tap) assume an Omi device. This gates it to `DeviceType.omi` only.

## Why
- The auto-trigger ran for every connected device type (Apple Watch, Bee, Fieldy, Frame, Limitless, Plaud, …), where the steps can't be completed — and the forced first-run has no skip/back, so non-Omi users could get stuck.
- Restricting to Omi keeps the tutorial only where it actually works.

## Changes
- `home/page.dart` — `_checkDeviceOnboarding()` returns early unless `device.type == DeviceType.omi` (the forced auto-trigger).
- `settings_drawer.dart` — the **Device Tutorial** settings row is shown only when the connected device is an Omi (Device Settings still shows for all devices).

## Notes
- Pure gating change; no behavior change for Omi devices.
- Does not change the existing-user exposure (the `deviceOnboardingCompleted` local/Firestore flags are unchanged) — Omi users who haven't completed it will still see it once. Happy to add an existing-user exemption in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

