### PR TITLE
Improve macOS chat scrolling with MessageScroller-style intent

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3063,6 +3063,6 @@
     "deviceOnboardingIntroTitle": "تعرّف على Omi",
     "deviceOnboardingIntroSubtitle": "جولة سريعة وعملية على كل ما يمكن أن يفعله جهاز Omi.",
     "deviceOnboardingIntroDuration": "حوالي دقيقة واحدة",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "الانتقال إلى أحدث رسالة",
+    "latest": "الأحدث"
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3062,5 +3062,7 @@
     "deviceOnboardingFinish": "إنهاء",
     "deviceOnboardingIntroTitle": "تعرّف على Omi",
     "deviceOnboardingIntroSubtitle": "جولة سريعة وعملية على كل ما يمكن أن يفعله جهاز Omi.",
-    "deviceOnboardingIntroDuration": "حوالي دقيقة واحدة"
+    "deviceOnboardingIntroDuration": "حوالي دقيقة واحدة",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Пазнаёмцеся з Omi",
     "deviceOnboardingIntroSubtitle": "Хуткі практычны агляд усяго, што ўмее ваш Omi.",
     "deviceOnboardingIntroDuration": "Каля 1 хвіліны",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Перайсці да апошняга паведамлення",
+    "latest": "Апошні"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Гатова",
     "deviceOnboardingIntroTitle": "Пазнаёмцеся з Omi",
     "deviceOnboardingIntroSubtitle": "Хуткі практычны агляд усяго, што ўмее ваш Omi.",
-    "deviceOnboardingIntroDuration": "Каля 1 хвіліны"
+    "deviceOnboardingIntroDuration": "Каля 1 хвіліны",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3064,5 +3064,7 @@
     "deviceOnboardingFinish": "Готово",
     "deviceOnboardingIntroTitle": "Опознайте своя Omi",
     "deviceOnboardingIntroSubtitle": "Бърза практическа обиколка на всичко, което вашият Omi може да прави.",
-    "deviceOnboardingIntroDuration": "Около 1 минута"
+    "deviceOnboardingIntroDuration": "Около 1 минута",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3065,6 +3065,6 @@
     "deviceOnboardingIntroTitle": "Опознайте своя Omi",
     "deviceOnboardingIntroSubtitle": "Бърза практическа обиколка на всичко, което вашият Omi може да прави.",
     "deviceOnboardingIntroDuration": "Около 1 минута",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Отиди до последното съобщение",
+    "latest": "Последно"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "সম্পন্ন করুন",
     "deviceOnboardingIntroTitle": "আপনার Omi-কে জানুন",
     "deviceOnboardingIntroSubtitle": "আপনার Omi যা যা করতে পারে তার একটি দ্রুত, হাতে-কলমে ভ্রমণ।",
-    "deviceOnboardingIntroDuration": "প্রায় ১ মিনিট"
+    "deviceOnboardingIntroDuration": "প্রায় ১ মিনিট",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "আপনার Omi-কে জানুন",
     "deviceOnboardingIntroSubtitle": "আপনার Omi যা যা করতে পারে তার একটি দ্রুত, হাতে-কলমে ভ্রমণ।",
     "deviceOnboardingIntroDuration": "প্রায় ১ মিনিট",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "সর্বশেষ বার্তায় যান",
+    "latest": "সর্বশেষ"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Završi",
     "deviceOnboardingIntroTitle": "Upoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Brz, praktičan obilazak svega što vaš Omi može.",
-    "deviceOnboardingIntroDuration": "Oko 1 minute"
+    "deviceOnboardingIntroDuration": "Oko 1 minute",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Upoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Brz, praktičan obilazak svega što vaš Omi može.",
     "deviceOnboardingIntroDuration": "Oko 1 minute",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Idi na najnoviju poruku",
+    "latest": "Najnovije"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3065,6 +3065,6 @@
     "deviceOnboardingIntroTitle": "Coneix el teu Omi",
     "deviceOnboardingIntroSubtitle": "Un recorregut ràpid i pràctic per tot el que pot fer el teu Omi.",
     "deviceOnboardingIntroDuration": "Aproximadament 1 minut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Vés a l'últim missatge",
+    "latest": "Últim"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3064,5 +3064,7 @@
     "deviceOnboardingFinish": "Finalitza",
     "deviceOnboardingIntroTitle": "Coneix el teu Omi",
     "deviceOnboardingIntroSubtitle": "Un recorregut ràpid i pràctic per tot el que pot fer el teu Omi.",
-    "deviceOnboardingIntroDuration": "Aproximadament 1 minut"
+    "deviceOnboardingIntroDuration": "Aproximadament 1 minut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3064,5 +3064,7 @@
     "deviceOnboardingFinish": "Dokončit",
     "deviceOnboardingIntroTitle": "Poznejte svůj Omi",
     "deviceOnboardingIntroSubtitle": "Rychlá praktická prohlídka všeho, co váš Omi umí.",
-    "deviceOnboardingIntroDuration": "Přibližně 1 minuta"
+    "deviceOnboardingIntroDuration": "Přibližně 1 minuta",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3065,6 +3065,6 @@
     "deviceOnboardingIntroTitle": "Poznejte svůj Omi",
     "deviceOnboardingIntroSubtitle": "Rychlá praktická prohlídka všeho, co váš Omi umí.",
     "deviceOnboardingIntroDuration": "Přibližně 1 minuta",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Přejít na nejnovější zprávu",
+    "latest": "Nejnovější"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3105,6 +3105,6 @@
     "deviceOnboardingIntroTitle": "Lær din Omi at kende",
     "deviceOnboardingIntroSubtitle": "En hurtig, praktisk rundvisning i alt, hvad din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Gå til nyeste besked",
+    "latest": "Nyeste"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3104,5 +3104,7 @@
     "deviceOnboardingFinish": "Afslut",
     "deviceOnboardingIntroTitle": "Lær din Omi at kende",
     "deviceOnboardingIntroSubtitle": "En hurtig, praktisk rundvisning i alt, hvad din Omi kan.",
-    "deviceOnboardingIntroDuration": "Cirka 1 minut"
+    "deviceOnboardingIntroDuration": "Cirka 1 minut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3064,6 +3064,6 @@
     "deviceOnboardingIntroTitle": "Lerne dein Omi kennen",
     "deviceOnboardingIntroSubtitle": "Ein kurzer, praktischer Rundgang durch alles, was dein Omi kann.",
     "deviceOnboardingIntroDuration": "Etwa 1 Minute",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Zur neuesten Nachricht springen",
+    "latest": "Neueste"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3063,5 +3063,7 @@
     "deviceOnboardingFinish": "Fertig",
     "deviceOnboardingIntroTitle": "Lerne dein Omi kennen",
     "deviceOnboardingIntroSubtitle": "Ein kurzer, praktischer Rundgang durch alles, was dein Omi kann.",
-    "deviceOnboardingIntroDuration": "Etwa 1 Minute"
+    "deviceOnboardingIntroDuration": "Etwa 1 Minute",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Τέλος",
     "deviceOnboardingIntroTitle": "Γνωρίστε το Omi σας",
     "deviceOnboardingIntroSubtitle": "Μια γρήγορη, πρακτική περιήγηση σε όλα όσα μπορεί να κάνει το Omi σας.",
-    "deviceOnboardingIntroDuration": "Περίπου 1 λεπτό"
+    "deviceOnboardingIntroDuration": "Περίπου 1 λεπτό",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Γνωρίστε το Omi σας",
     "deviceOnboardingIntroSubtitle": "Μια γρήγορη, πρακτική περιήγηση σε όλα όσα μπορεί να κάνει το Omi σας.",
     "deviceOnboardingIntroDuration": "Περίπου 1 λεπτό",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Μετάβαση στο πιο πρόσφατο μήνυμα",
+    "latest": "Πρόσφατο"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11202,5 +11202,13 @@
     "deviceOnboardingIntroDuration": "About 1 minute",
     "@deviceOnboardingIntroDuration": {
         "description": "Onboarding intro screen estimated duration hint"
+    },
+    "jumpToLatestMessage": "Jump to latest message",
+    "@jumpToLatestMessage": {
+        "description": "Accessibility label and tooltip for the jump-to-latest button in chat"
+    },
+    "latest": "Latest",
+    "@latest": {
+        "description": "Visible label for the jump-to-latest button in chat"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3096,5 +3096,7 @@
     "deviceOnboardingFinish": "Finalizar",
     "deviceOnboardingIntroTitle": "Conoce tu Omi",
     "deviceOnboardingIntroSubtitle": "Un recorrido rápido y práctico por todo lo que tu Omi puede hacer.",
-    "deviceOnboardingIntroDuration": "Aproximadamente 1 minuto"
+    "deviceOnboardingIntroDuration": "Aproximadamente 1 minuto",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3097,6 +3097,6 @@
     "deviceOnboardingIntroTitle": "Conoce tu Omi",
     "deviceOnboardingIntroSubtitle": "Un recorrido rápido y práctico por todo lo que tu Omi puede hacer.",
     "deviceOnboardingIntroDuration": "Aproximadamente 1 minuto",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Ir al mensaje más reciente",
+    "latest": "Más reciente"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Tutvu oma Omiga",
     "deviceOnboardingIntroSubtitle": "Kiire ja praktiline ülevaade kõigest, mida sinu Omi suudab.",
     "deviceOnboardingIntroDuration": "Umbes 1 minut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Hüppa uusima sõnumi juurde",
+    "latest": "Uusim"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Lõpeta",
     "deviceOnboardingIntroTitle": "Tutvu oma Omiga",
     "deviceOnboardingIntroSubtitle": "Kiire ja praktiline ülevaade kõigest, mida sinu Omi suudab.",
-    "deviceOnboardingIntroDuration": "Umbes 1 minut"
+    "deviceOnboardingIntroDuration": "Umbes 1 minut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "با Omi خود آشنا شوید",
     "deviceOnboardingIntroSubtitle": "یک گشت سریع و کاربردی در همه‌ی کارهایی که Omi شما می‌تواند انجام دهد.",
     "deviceOnboardingIntroDuration": "حدود ۱ دقیقه",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "پرش به آخرین پیام",
+    "latest": "آخرین"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "پایان",
     "deviceOnboardingIntroTitle": "با Omi خود آشنا شوید",
     "deviceOnboardingIntroSubtitle": "یک گشت سریع و کاربردی در همه‌ی کارهایی که Omi شما می‌تواند انجام دهد.",
-    "deviceOnboardingIntroDuration": "حدود ۱ دقیقه"
+    "deviceOnboardingIntroDuration": "حدود ۱ دقیقه",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Valmis",
     "deviceOnboardingIntroTitle": "Tutustu Omiisi",
     "deviceOnboardingIntroSubtitle": "Nopea ja käytännönläheinen kierros kaikkeen, mitä Omisi osaa.",
-    "deviceOnboardingIntroDuration": "Noin 1 minuutti"
+    "deviceOnboardingIntroDuration": "Noin 1 minuutti",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Tutustu Omiisi",
     "deviceOnboardingIntroSubtitle": "Nopea ja käytännönläheinen kierros kaikkeen, mitä Omisi osaa.",
     "deviceOnboardingIntroDuration": "Noin 1 minuutti",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Siirry uusimpaan viestiin",
+    "latest": "Uusin"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3131,6 +3131,6 @@
     "deviceOnboardingIntroTitle": "Faites connaissance avec votre Omi",
     "deviceOnboardingIntroSubtitle": "Un tour rapide et pratique de tout ce que votre Omi peut faire.",
     "deviceOnboardingIntroDuration": "Environ 1 minute",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Aller au dernier message",
+    "latest": "Récent"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3130,5 +3130,7 @@
     "deviceOnboardingFinish": "Terminer",
     "deviceOnboardingIntroTitle": "Faites connaissance avec votre Omi",
     "deviceOnboardingIntroSubtitle": "Un tour rapide et pratique de tout ce que votre Omi peut faire.",
-    "deviceOnboardingIntroDuration": "Environ 1 minute"
+    "deviceOnboardingIntroDuration": "Environ 1 minute",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "סיום",
     "deviceOnboardingIntroTitle": "הכירו את ה-Omi שלכם",
     "deviceOnboardingIntroSubtitle": "סיור מהיר ומעשי בכל מה שה-Omi שלכם יכול לעשות.",
-    "deviceOnboardingIntroDuration": "כדקה אחת"
+    "deviceOnboardingIntroDuration": "כדקה אחת",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "הכירו את ה-Omi שלכם",
     "deviceOnboardingIntroSubtitle": "סיור מהיר ומעשי בכל מה שה-Omi שלכם יכול לעשות.",
     "deviceOnboardingIntroDuration": "כדקה אחת",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "קפוץ להודעה האחרונה",
+    "latest": "האחרון"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3096,5 +3096,7 @@
     "deviceOnboardingFinish": "पूरा करें",
     "deviceOnboardingIntroTitle": "अपने Omi को जानें",
     "deviceOnboardingIntroSubtitle": "आपका Omi जो कुछ भी कर सकता है, उसका एक त्वरित और व्यावहारिक दौरा।",
-    "deviceOnboardingIntroDuration": "लगभग 1 मिनट"
+    "deviceOnboardingIntroDuration": "लगभग 1 मिनट",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3097,6 +3097,6 @@
     "deviceOnboardingIntroTitle": "अपने Omi को जानें",
     "deviceOnboardingIntroSubtitle": "आपका Omi जो कुछ भी कर सकता है, उसका एक त्वरित और व्यावहारिक दौरा।",
     "deviceOnboardingIntroDuration": "लगभग 1 मिनट",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "नवीनतम संदेश पर जाएं",
+    "latest": "नवीनतम"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Završi",
     "deviceOnboardingIntroTitle": "Upoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Brz i praktičan obilazak svega što vaš Omi može.",
-    "deviceOnboardingIntroDuration": "Otprilike 1 minuta"
+    "deviceOnboardingIntroDuration": "Otprilike 1 minuta",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Upoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Brz i praktičan obilazak svega što vaš Omi može.",
     "deviceOnboardingIntroDuration": "Otprilike 1 minuta",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Idi na najnoviju poruku",
+    "latest": "Najnovije"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3192,6 +3192,6 @@
     "deviceOnboardingIntroTitle": "Ismerd meg az Omidat",
     "deviceOnboardingIntroSubtitle": "Gyors, gyakorlatias bemutató mindarról, amire az Omid képes.",
     "deviceOnboardingIntroDuration": "Körülbelül 1 perc",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Ugrás a legújabb üzenethez",
+    "latest": "Legújabb"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3191,5 +3191,7 @@
     "deviceOnboardingFinish": "Befejezés",
     "deviceOnboardingIntroTitle": "Ismerd meg az Omidat",
     "deviceOnboardingIntroSubtitle": "Gyors, gyakorlatias bemutató mindarról, amire az Omid képes.",
-    "deviceOnboardingIntroDuration": "Körülbelül 1 perc"
+    "deviceOnboardingIntroDuration": "Körülbelül 1 perc",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3137,5 +3137,7 @@
     "deviceOnboardingFinish": "Selesai",
     "deviceOnboardingIntroTitle": "Kenali Omi Anda",
     "deviceOnboardingIntroSubtitle": "Tur singkat dan praktis tentang semua yang bisa dilakukan Omi Anda.",
-    "deviceOnboardingIntroDuration": "Sekitar 1 menit"
+    "deviceOnboardingIntroDuration": "Sekitar 1 menit",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3138,6 +3138,6 @@
     "deviceOnboardingIntroTitle": "Kenali Omi Anda",
     "deviceOnboardingIntroSubtitle": "Tur singkat dan praktis tentang semua yang bisa dilakukan Omi Anda.",
     "deviceOnboardingIntroDuration": "Sekitar 1 menit",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Lompat ke pesan terbaru",
+    "latest": "Terbaru"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Fine",
     "deviceOnboardingIntroTitle": "Scopri il tuo Omi",
     "deviceOnboardingIntroSubtitle": "Un tour rapido e pratico di tutto ciò che il tuo Omi può fare.",
-    "deviceOnboardingIntroDuration": "Circa 1 minuto"
+    "deviceOnboardingIntroDuration": "Circa 1 minuto",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Scopri il tuo Omi",
     "deviceOnboardingIntroSubtitle": "Un tour rapido e pratico di tutto ciò che il tuo Omi può fare.",
     "deviceOnboardingIntroDuration": "Circa 1 minuto",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Vai all'ultimo messaggio",
+    "latest": "Più recente"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3096,5 +3096,7 @@
     "deviceOnboardingFinish": "完了",
     "deviceOnboardingIntroTitle": "Omi を知ろう",
     "deviceOnboardingIntroSubtitle": "Omi にできることを、すべて手軽に体験できるクイックツアー。",
-    "deviceOnboardingIntroDuration": "約1分"
+    "deviceOnboardingIntroDuration": "約1分",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3097,6 +3097,6 @@
     "deviceOnboardingIntroTitle": "Omi を知ろう",
     "deviceOnboardingIntroSubtitle": "Omi にできることを、すべて手軽に体験できるクイックツアー。",
     "deviceOnboardingIntroDuration": "約1分",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "最新のメッセージにジャンプ",
+    "latest": "最新"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "ನಿಮ್ಮ Omi ಅನ್ನು ತಿಳಿಯಿರಿ",
     "deviceOnboardingIntroSubtitle": "ನಿಮ್ಮ Omi ಮಾಡಬಲ್ಲ ಎಲ್ಲದರ ತ್ವರಿತ, ಪ್ರಾಯೋಗಿಕ ಪರಿಚಯ.",
     "deviceOnboardingIntroDuration": "ಸುಮಾರು 1 ನಿಮಿಷ",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "ಇತ್ತೀಚಿನ ಸಂದೇಶಕ್ಕೆ ಹೋಗಿ",
+    "latest": "ಇತ್ತೀಚಿನ"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "ಮುಗಿಸಿ",
     "deviceOnboardingIntroTitle": "ನಿಮ್ಮ Omi ಅನ್ನು ತಿಳಿಯಿರಿ",
     "deviceOnboardingIntroSubtitle": "ನಿಮ್ಮ Omi ಮಾಡಬಲ್ಲ ಎಲ್ಲದರ ತ್ವರಿತ, ಪ್ರಾಯೋಗಿಕ ಪರಿಚಯ.",
-    "deviceOnboardingIntroDuration": "ಸುಮಾರು 1 ನಿಮಿಷ"
+    "deviceOnboardingIntroDuration": "ಸುಮಾರು 1 ನಿಮಿಷ",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "완료",
     "deviceOnboardingIntroTitle": "Omi 알아보기",
     "deviceOnboardingIntroSubtitle": "Omi가 할 수 있는 모든 것을 빠르게 직접 둘러보세요.",
-    "deviceOnboardingIntroDuration": "약 1분"
+    "deviceOnboardingIntroDuration": "약 1분",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Omi 알아보기",
     "deviceOnboardingIntroSubtitle": "Omi가 할 수 있는 모든 것을 빠르게 직접 둘러보세요.",
     "deviceOnboardingIntroDuration": "약 1분",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "최신 메시지로 이동",
+    "latest": "최신"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17648,6 +17648,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'About 1 minute'**
   String get deviceOnboardingIntroDuration;
+
+  /// Accessibility label and tooltip for the jump-to-latest button in chat
+  ///
+  /// In en, this message translates to:
+  /// **'Jump to latest message'**
+  String get jumpToLatestMessage;
+
+  /// Visible label for the jump-to-latest button in chat
+  ///
+  /// In en, this message translates to:
+  /// **'Latest'**
+  String get latest;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9406,4 +9406,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'حوالي دقيقة واحدة';
+  @override
+  String get jumpToLatestMessage => 'الانتقال إلى أحدث رسالة';
+
+  @override
+  String get latest => 'الأحدث';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9492,4 +9492,9 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Каля 1 хвіліны';
+  @override
+  String get jumpToLatestMessage => 'Перайсці да апошняга паведамлення';
+
+  @override
+  String get latest => 'Апошні';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9498,4 +9498,9 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Около 1 минута';
+  @override
+  String get jumpToLatestMessage => 'Отиди до последното съобщение';
+
+  @override
+  String get latest => 'Последно';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9469,4 +9469,9 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'প্রায় ১ মিনিট';
+  @override
+  String get jumpToLatestMessage => 'সর্বশেষ বার্তায় যান';
+
+  @override
+  String get latest => 'সর্বশেষ';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9489,4 +9489,9 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Oko 1 minute';
+  @override
+  String get jumpToLatestMessage => 'Idi na najnoviju poruku';
+
+  @override
+  String get latest => 'Najnovije';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9517,4 +9517,9 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Aproximadament 1 minut';
+  @override
+  String get jumpToLatestMessage => 'Vés a l\'últim missatge';
+
+  @override
+  String get latest => 'Últim';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9463,4 +9463,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Přibližně 1 minuta';
+  @override
+  String get jumpToLatestMessage => 'Přejít na nejnovější zprávu';
+
+  @override
+  String get latest => 'Nejnovější';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9448,4 +9448,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Cirka 1 minut';
+  @override
+  String get jumpToLatestMessage => 'Gå til nyeste besked';
+
+  @override
+  String get latest => 'Nyeste';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9541,4 +9541,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Etwa 1 Minute';
+  @override
+  String get jumpToLatestMessage => 'Zur neuesten Nachricht springen';
+
+  @override
+  String get latest => 'Neueste';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9530,4 +9530,9 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Περίπου 1 λεπτό';
+  @override
+  String get jumpToLatestMessage => 'Μετάβαση στο πιο πρόσφατο μήνυμα';
+
+  @override
+  String get latest => 'Πρόσφατο';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9458,4 +9458,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'About 1 minute';
+  @override
+  String get jumpToLatestMessage => 'Jump to latest message';
+
+  @override
+  String get latest => 'Latest';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9484,4 +9484,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Aproximadamente 1 minuto';
+  @override
+  String get jumpToLatestMessage => 'Ir al mensaje más reciente';
+
+  @override
+  String get latest => 'Más reciente';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9460,4 +9460,9 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Umbes 1 minut';
+  @override
+  String get jumpToLatestMessage => 'Hüppa uusima sõnumi juurde';
+
+  @override
+  String get latest => 'Uusim';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9465,4 +9465,9 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'حدود ۱ دقیقه';
+  @override
+  String get jumpToLatestMessage => 'پرش به آخرین پیام';
+
+  @override
+  String get latest => 'آخرین';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9463,4 +9463,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Noin 1 minuutti';
+  @override
+  String get jumpToLatestMessage => 'Siirry uusimpaan viestiin';
+
+  @override
+  String get latest => 'Uusin';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9548,4 +9548,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Environ 1 minute';
+  @override
+  String get jumpToLatestMessage => 'Aller au dernier message';
+
+  @override
+  String get latest => 'Récent';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9391,4 +9391,9 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'כדקה אחת';
+  @override
+  String get jumpToLatestMessage => 'קפוץ להודעה האחרונה';
+
+  @override
+  String get latest => 'האחרון';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9439,4 +9439,9 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'लगभग 1 मिनट';
+  @override
+  String get jumpToLatestMessage => 'नवीनतम संदेश पर जाएं';
+
+  @override
+  String get latest => 'नवीनतम';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9496,4 +9496,9 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Otprilike 1 minuta';
+  @override
+  String get jumpToLatestMessage => 'Idi na najnoviju poruku';
+
+  @override
+  String get latest => 'Najnovije';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9503,4 +9503,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Körülbelül 1 perc';
+  @override
+  String get jumpToLatestMessage => 'Ugrás a legújabb üzenethez';
+
+  @override
+  String get latest => 'Legújabb';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9472,4 +9472,9 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Sekitar 1 menit';
+  @override
+  String get jumpToLatestMessage => 'Lompat ke pesan terbaru';
+
+  @override
+  String get latest => 'Terbaru';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9518,4 +9518,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Circa 1 minuto';
+  @override
+  String get jumpToLatestMessage => 'Vai all\'ultimo messaggio';
+
+  @override
+  String get latest => 'Più recente';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9308,4 +9308,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => '約1分';
+  @override
+  String get jumpToLatestMessage => '最新のメッセージにジャンプ';
+
+  @override
+  String get latest => '最新';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9493,4 +9493,9 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'ಸುಮಾರು 1 ನಿಮಿಷ';
+  @override
+  String get jumpToLatestMessage => 'ಇತ್ತೀಚಿನ ಸಂದೇಶಕ್ಕೆ ಹೋಗಿ';
+
+  @override
+  String get latest => 'ಇತ್ತೀಚಿನ';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9309,4 +9309,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => '약 1분';
+  @override
+  String get jumpToLatestMessage => '최신 메시지로 이동';
+
+  @override
+  String get latest => '최신';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9479,4 +9479,9 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Maždaug 1 minutė';
+  @override
+  String get jumpToLatestMessage => 'Peršokti į naujausią pranešimą';
+
+  @override
+  String get latest => 'Naujausias';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9485,4 +9485,9 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Apmēram 1 minūte';
+  @override
+  String get jumpToLatestMessage => 'Pārlēkt uz jaunāko ziņojumu';
+
+  @override
+  String get latest => 'Jaunākais';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9513,4 +9513,9 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Околу 1 минута';
+  @override
+  String get jumpToLatestMessage => 'Оди до последната порака';
+
+  @override
+  String get latest => 'Најново';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9472,4 +9472,9 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'सुमारे 1 मिनिट';
+  @override
+  String get jumpToLatestMessage => 'नवीनतम संदेशावर जा';
+
+  @override
+  String get latest => 'नवीनतम';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9488,4 +9488,9 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Kira-kira 1 minit';
+  @override
+  String get jumpToLatestMessage => 'Lompat ke mesej terkini';
+
+  @override
+  String get latest => 'Terkini';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9489,4 +9489,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Ongeveer 1 minuut';
+  @override
+  String get jumpToLatestMessage => 'Naar nieuwste bericht springen';
+
+  @override
+  String get latest => 'Nieuwste';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9460,4 +9460,9 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Cirka 1 minutt';
+  @override
+  String get jumpToLatestMessage => 'Gå til nyeste melding';
+
+  @override
+  String get latest => 'Nyeste';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9488,4 +9488,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Około 1 minuty';
+  @override
+  String get jumpToLatestMessage => 'Przejdź do najnowszej wiadomości';
+
+  @override
+  String get latest => 'Najnowsza';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9468,4 +9468,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Cerca de 1 minuto';
+  @override
+  String get jumpToLatestMessage => 'Ir para a mensagem mais recente';
+
+  @override
+  String get latest => 'Mais recente';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9508,4 +9508,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Aproximativ 1 minut';
+  @override
+  String get jumpToLatestMessage => 'Sari la cel mai recent mesaj';
+
+  @override
+  String get latest => 'Recent';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9497,4 +9497,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Около 1 минуты';
+  @override
+  String get jumpToLatestMessage => 'Перейти к последнему сообщению';
+
+  @override
+  String get latest => 'Последнее';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9454,4 +9454,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Približne 1 minúta';
+  @override
+  String get jumpToLatestMessage => 'Prejsť na najnovšiu správu';
+
+  @override
+  String get latest => 'Najnovšia';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9490,4 +9490,9 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Približno 1 minuta';
+  @override
+  String get jumpToLatestMessage => 'Skoči na najnovejše sporočilo';
+
+  @override
+  String get latest => 'Najnovejše';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9476,4 +9476,9 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Око 1 минута';
+  @override
+  String get jumpToLatestMessage => 'Иди на најновију поруку';
+
+  @override
+  String get latest => 'Најновије';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9468,4 +9468,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Cirka 1 minut';
+  @override
+  String get jumpToLatestMessage => 'Hoppa till senaste meddelandet';
+
+  @override
+  String get latest => 'Senaste';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9531,4 +9531,9 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'சுமார் 1 நிமிடம்';
+  @override
+  String get jumpToLatestMessage => 'சமீபத்திய செய்திக்குச் செல்';
+
+  @override
+  String get latest => 'சமீபத்தியது';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9511,4 +9511,9 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'సుమారు 1 నిమిషం';
+  @override
+  String get jumpToLatestMessage => 'తాజా సందేశానికి వెళ్ళు';
+
+  @override
+  String get latest => 'తాజా';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9411,4 +9411,9 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'ประมาณ 1 นาที';
+  @override
+  String get jumpToLatestMessage => 'ไปยังข้อความล่าสุด';
+
+  @override
+  String get latest => 'ล่าสุด';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9551,4 +9551,9 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Mga 1 minuto';
+  @override
+  String get jumpToLatestMessage => 'Tumalon sa pinakabagong mensahe';
+
+  @override
+  String get latest => 'Pinakabago';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9473,4 +9473,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Yaklaşık 1 dakika';
+  @override
+  String get jumpToLatestMessage => 'En son mesaja git';
+
+  @override
+  String get latest => 'En son';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9482,4 +9482,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Близько 1 хвилини';
+  @override
+  String get jumpToLatestMessage => 'Перейти до останнього повідомлення';
+
+  @override
+  String get latest => 'Останнє';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9477,4 +9477,9 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'تقریباً 1 منٹ';
+  @override
+  String get jumpToLatestMessage => 'تازہ ترین پیغام پر جائیں';
+
+  @override
+  String get latest => 'تازہ ترین';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9460,4 +9460,9 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => 'Khoảng 1 phút';
+  @override
+  String get jumpToLatestMessage => 'Đi đến tin nhắn mới nhất';
+
+  @override
+  String get latest => 'Mới nhất';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9292,4 +9292,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get deviceOnboardingIntroDuration => '大约 1 分钟';
+  @override
+  String get jumpToLatestMessage => '跳转到最新消息';
+
+  @override
+  String get latest => '最新';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Baigti",
     "deviceOnboardingIntroTitle": "Susipažinkite su savo Omi",
     "deviceOnboardingIntroSubtitle": "Greita praktinė apžvalga visko, ką gali jūsų Omi.",
-    "deviceOnboardingIntroDuration": "Maždaug 1 minutė"
+    "deviceOnboardingIntroDuration": "Maždaug 1 minutė",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Susipažinkite su savo Omi",
     "deviceOnboardingIntroSubtitle": "Greita praktinė apžvalga visko, ką gali jūsų Omi.",
     "deviceOnboardingIntroDuration": "Maždaug 1 minutė",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Peršokti į naujausią pranešimą",
+    "latest": "Naujausias"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Pabeigt",
     "deviceOnboardingIntroTitle": "Iepazīsti savu Omi",
     "deviceOnboardingIntroSubtitle": "Ātrs, praktisks ieskats visā, ko spēj tavs Omi.",
-    "deviceOnboardingIntroDuration": "Apmēram 1 minūte"
+    "deviceOnboardingIntroDuration": "Apmēram 1 minūte",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Iepazīsti savu Omi",
     "deviceOnboardingIntroSubtitle": "Ātrs, praktisks ieskats visā, ko spēj tavs Omi.",
     "deviceOnboardingIntroDuration": "Apmēram 1 minūte",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Pārlēkt uz jaunāko ziņojumu",
+    "latest": "Jaunākais"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Запознајте се со вашиот Omi",
     "deviceOnboardingIntroSubtitle": "Брза, практична прошетка низ сè што може да направи вашиот Omi.",
     "deviceOnboardingIntroDuration": "Околу 1 минута",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Оди до последната порака",
+    "latest": "Најново"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Заврши",
     "deviceOnboardingIntroTitle": "Запознајте се со вашиот Omi",
     "deviceOnboardingIntroSubtitle": "Брза, практична прошетка низ сè што може да направи вашиот Omi.",
-    "deviceOnboardingIntroDuration": "Околу 1 минута"
+    "deviceOnboardingIntroDuration": "Околу 1 минута",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "तुमच्या Omi ला जाणून घ्या",
     "deviceOnboardingIntroSubtitle": "तुमचा Omi जे काही करू शकतो त्याची झटपट, प्रत्यक्ष ओळख.",
     "deviceOnboardingIntroDuration": "सुमारे 1 मिनिट",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "नवीनतम संदेशावर जा",
+    "latest": "नवीनतम"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "पूर्ण करा",
     "deviceOnboardingIntroTitle": "तुमच्या Omi ला जाणून घ्या",
     "deviceOnboardingIntroSubtitle": "तुमचा Omi जे काही करू शकतो त्याची झटपट, प्रत्यक्ष ओळख.",
-    "deviceOnboardingIntroDuration": "सुमारे 1 मिनिट"
+    "deviceOnboardingIntroDuration": "सुमारे 1 मिनिट",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Selesai",
     "deviceOnboardingIntroTitle": "Kenali Omi Anda",
     "deviceOnboardingIntroSubtitle": "Lawatan ringkas dan praktikal tentang semua yang Omi anda boleh lakukan.",
-    "deviceOnboardingIntroDuration": "Kira-kira 1 minit"
+    "deviceOnboardingIntroDuration": "Kira-kira 1 minit",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Kenali Omi Anda",
     "deviceOnboardingIntroSubtitle": "Lawatan ringkas dan praktikal tentang semua yang Omi anda boleh lakukan.",
     "deviceOnboardingIntroDuration": "Kira-kira 1 minit",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Lompat ke mesej terkini",
+    "latest": "Terkini"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Voltooien",
     "deviceOnboardingIntroTitle": "Maak kennis met je Omi",
     "deviceOnboardingIntroSubtitle": "Een snelle, praktische rondleiding langs alles wat je Omi kan.",
-    "deviceOnboardingIntroDuration": "Ongeveer 1 minuut"
+    "deviceOnboardingIntroDuration": "Ongeveer 1 minuut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Maak kennis met je Omi",
     "deviceOnboardingIntroSubtitle": "Een snelle, praktische rondleiding langs alles wat je Omi kan.",
     "deviceOnboardingIntroDuration": "Ongeveer 1 minuut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Naar nieuwste bericht springen",
+    "latest": "Nieuwste"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Fullfør",
     "deviceOnboardingIntroTitle": "Bli kjent med din Omi",
     "deviceOnboardingIntroSubtitle": "En rask, praktisk omvisning i alt din Omi kan.",
-    "deviceOnboardingIntroDuration": "Cirka 1 minutt"
+    "deviceOnboardingIntroDuration": "Cirka 1 minutt",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Bli kjent med din Omi",
     "deviceOnboardingIntroSubtitle": "En rask, praktisk omvisning i alt din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minutt",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Gå til nyeste melding",
+    "latest": "Nyeste"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3130,5 +3130,7 @@
     "deviceOnboardingFinish": "Zakończ",
     "deviceOnboardingIntroTitle": "Poznaj swoje Omi",
     "deviceOnboardingIntroSubtitle": "Szybki, praktyczny przegląd wszystkiego, co potrafi Twoje Omi.",
-    "deviceOnboardingIntroDuration": "Około 1 minuty"
+    "deviceOnboardingIntroDuration": "Około 1 minuty",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3131,6 +3131,6 @@
     "deviceOnboardingIntroTitle": "Poznaj swoje Omi",
     "deviceOnboardingIntroSubtitle": "Szybki, praktyczny przegląd wszystkiego, co potrafi Twoje Omi.",
     "deviceOnboardingIntroDuration": "Około 1 minuty",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Przejdź do najnowszej wiadomości",
+    "latest": "Najnowsza"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3131,5 +3131,7 @@
     "deviceOnboardingFinish": "Concluir",
     "deviceOnboardingIntroTitle": "Conheça o seu Omi",
     "deviceOnboardingIntroSubtitle": "Um tour rápido e prático por tudo o que o seu Omi pode fazer.",
-    "deviceOnboardingIntroDuration": "Cerca de 1 minuto"
+    "deviceOnboardingIntroDuration": "Cerca de 1 minuto",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3132,6 +3132,6 @@
     "deviceOnboardingIntroTitle": "Conheça o seu Omi",
     "deviceOnboardingIntroSubtitle": "Um tour rápido e prático por tudo o que o seu Omi pode fazer.",
     "deviceOnboardingIntroDuration": "Cerca de 1 minuto",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Ir para a mensagem mais recente",
+    "latest": "Mais recente"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Cunoaște-ți Omi-ul",
     "deviceOnboardingIntroSubtitle": "Un tur rapid și practic prin tot ce poate face Omi-ul tău.",
     "deviceOnboardingIntroDuration": "Aproximativ 1 minut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Sari la cel mai recent mesaj",
+    "latest": "Recent"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Termină",
     "deviceOnboardingIntroTitle": "Cunoaște-ți Omi-ul",
     "deviceOnboardingIntroSubtitle": "Un tur rapid și practic prin tot ce poate face Omi-ul tău.",
-    "deviceOnboardingIntroDuration": "Aproximativ 1 minut"
+    "deviceOnboardingIntroDuration": "Aproximativ 1 minut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3131,6 +3131,6 @@
     "deviceOnboardingIntroTitle": "Знакомство с Omi",
     "deviceOnboardingIntroSubtitle": "Быстрый практический обзор всего, что умеет ваш Omi.",
     "deviceOnboardingIntroDuration": "Около 1 минуты",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Перейти к последнему сообщению",
+    "latest": "Последнее"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3130,5 +3130,7 @@
     "deviceOnboardingFinish": "Готово",
     "deviceOnboardingIntroTitle": "Знакомство с Omi",
     "deviceOnboardingIntroSubtitle": "Быстрый практический обзор всего, что умеет ваш Omi.",
-    "deviceOnboardingIntroDuration": "Около 1 минуты"
+    "deviceOnboardingIntroDuration": "Около 1 минуты",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3101,6 +3101,6 @@
     "deviceOnboardingIntroTitle": "Spoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Rýchla praktická prehliadka všetkého, čo váš Omi dokáže.",
     "deviceOnboardingIntroDuration": "Približne 1 minúta",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Prejsť na najnovšiu správu",
+    "latest": "Najnovšia"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3100,5 +3100,7 @@
     "deviceOnboardingFinish": "Dokončiť",
     "deviceOnboardingIntroTitle": "Spoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Rýchla praktická prehliadka všetkého, čo váš Omi dokáže.",
-    "deviceOnboardingIntroDuration": "Približne 1 minúta"
+    "deviceOnboardingIntroDuration": "Približne 1 minúta",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Spoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Hiter, praktičen ogled vsega, kar zmore vaš Omi.",
     "deviceOnboardingIntroDuration": "Približno 1 minuta",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Skoči na najnovejše sporočilo",
+    "latest": "Najnovejše"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Končaj",
     "deviceOnboardingIntroTitle": "Spoznajte svoj Omi",
     "deviceOnboardingIntroSubtitle": "Hiter, praktičen ogled vsega, kar zmore vaš Omi.",
-    "deviceOnboardingIntroDuration": "Približno 1 minuta"
+    "deviceOnboardingIntroDuration": "Približno 1 minuta",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Упознајте свој Omi",
     "deviceOnboardingIntroSubtitle": "Брз, практичан обилазак свега што ваш Omi може.",
     "deviceOnboardingIntroDuration": "Око 1 минута",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Иди на најновију поруку",
+    "latest": "Најновије"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Заврши",
     "deviceOnboardingIntroTitle": "Упознајте свој Omi",
     "deviceOnboardingIntroSubtitle": "Брз, практичан обилазак свега што ваш Omi може.",
-    "deviceOnboardingIntroDuration": "Око 1 минута"
+    "deviceOnboardingIntroDuration": "Око 1 минута",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Slutför",
     "deviceOnboardingIntroTitle": "Lär känna din Omi",
     "deviceOnboardingIntroSubtitle": "En snabb, praktisk rundtur i allt din Omi kan.",
-    "deviceOnboardingIntroDuration": "Cirka 1 minut"
+    "deviceOnboardingIntroDuration": "Cirka 1 minut",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Lär känna din Omi",
     "deviceOnboardingIntroSubtitle": "En snabb, praktisk rundtur i allt din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minut",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Hoppa till senaste meddelandet",
+    "latest": "Senaste"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "முடிக்கவும்",
     "deviceOnboardingIntroTitle": "உங்கள் Omi-ஐ அறிந்துகொள்ளுங்கள்",
     "deviceOnboardingIntroSubtitle": "உங்கள் Omi செய்யக்கூடிய அனைத்தையும் விரைவாக நேரடியாகப் பார்க்கும் சுற்றுலா.",
-    "deviceOnboardingIntroDuration": "சுமார் 1 நிமிடம்"
+    "deviceOnboardingIntroDuration": "சுமார் 1 நிமிடம்",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "உங்கள் Omi-ஐ அறிந்துகொள்ளுங்கள்",
     "deviceOnboardingIntroSubtitle": "உங்கள் Omi செய்யக்கூடிய அனைத்தையும் விரைவாக நேரடியாகப் பார்க்கும் சுற்றுலா.",
     "deviceOnboardingIntroDuration": "சுமார் 1 நிமிடம்",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "சமீபத்திய செய்திக்குச் செல்",
+    "latest": "சமீபத்தியது"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "ముగించు",
     "deviceOnboardingIntroTitle": "మీ Omiని తెలుసుకోండి",
     "deviceOnboardingIntroSubtitle": "మీ Omi చేయగలిగే ప్రతిదాని గురించి త్వరిత, ప్రత్యక్ష పరిచయం.",
-    "deviceOnboardingIntroDuration": "సుమారు 1 నిమిషం"
+    "deviceOnboardingIntroDuration": "సుమారు 1 నిమిషం",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "మీ Omiని తెలుసుకోండి",
     "deviceOnboardingIntroSubtitle": "మీ Omi చేయగలిగే ప్రతిదాని గురించి త్వరిత, ప్రత్యక్ష పరిచయం.",
     "deviceOnboardingIntroDuration": "సుమారు 1 నిమిషం",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "తాజా సందేశానికి వెళ్ళు",
+    "latest": "తాజా"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "ทำความรู้จักกับ Omi ของคุณ",
     "deviceOnboardingIntroSubtitle": "ทัวร์สั้น ๆ แบบลงมือทำจริงเกี่ยวกับทุกสิ่งที่ Omi ของคุณทำได้",
     "deviceOnboardingIntroDuration": "ประมาณ 1 นาที",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "ไปยังข้อความล่าสุด",
+    "latest": "ล่าสุด"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "เสร็จสิ้น",
     "deviceOnboardingIntroTitle": "ทำความรู้จักกับ Omi ของคุณ",
     "deviceOnboardingIntroSubtitle": "ทัวร์สั้น ๆ แบบลงมือทำจริงเกี่ยวกับทุกสิ่งที่ Omi ของคุณทำได้",
-    "deviceOnboardingIntroDuration": "ประมาณ 1 นาที"
+    "deviceOnboardingIntroDuration": "ประมาณ 1 นาที",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "Kilalanin ang Iyong Omi",
     "deviceOnboardingIntroSubtitle": "Isang mabilis at praktikal na pamamasyal sa lahat ng kayang gawin ng iyong Omi.",
     "deviceOnboardingIntroDuration": "Mga 1 minuto",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Tumalon sa pinakabagong mensahe",
+    "latest": "Pinakabago"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "Tapusin",
     "deviceOnboardingIntroTitle": "Kilalanin ang Iyong Omi",
     "deviceOnboardingIntroSubtitle": "Isang mabilis at praktikal na pamamasyal sa lahat ng kayang gawin ng iyong Omi.",
-    "deviceOnboardingIntroDuration": "Mga 1 minuto"
+    "deviceOnboardingIntroDuration": "Mga 1 minuto",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3130,5 +3130,7 @@
     "deviceOnboardingFinish": "Bitir",
     "deviceOnboardingIntroTitle": "Omi'nizi Tanıyın",
     "deviceOnboardingIntroSubtitle": "Omi'nizin yapabileceği her şeyin hızlı ve uygulamalı bir turu.",
-    "deviceOnboardingIntroDuration": "Yaklaşık 1 dakika"
+    "deviceOnboardingIntroDuration": "Yaklaşık 1 dakika",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3131,6 +3131,6 @@
     "deviceOnboardingIntroTitle": "Omi'nizi Tanıyın",
     "deviceOnboardingIntroSubtitle": "Omi'nizin yapabileceği her şeyin hızlı ve uygulamalı bir turu.",
     "deviceOnboardingIntroDuration": "Yaklaşık 1 dakika",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "En son mesaja git",
+    "latest": "En son"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3095,5 +3095,7 @@
     "deviceOnboardingFinish": "Завершити",
     "deviceOnboardingIntroTitle": "Знайомство з Omi",
     "deviceOnboardingIntroSubtitle": "Швидкий практичний огляд усього, що вміє ваш Omi.",
-    "deviceOnboardingIntroDuration": "Близько 1 хвилини"
+    "deviceOnboardingIntroDuration": "Близько 1 хвилини",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3096,6 +3096,6 @@
     "deviceOnboardingIntroTitle": "Знайомство з Omi",
     "deviceOnboardingIntroSubtitle": "Швидкий практичний огляд усього, що вміє ваш Omi.",
     "deviceOnboardingIntroDuration": "Близько 1 хвилини",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Перейти до останнього повідомлення",
+    "latest": "Останнє"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10673,5 +10673,7 @@
     "deviceOnboardingFinish": "مکمل کریں",
     "deviceOnboardingIntroTitle": "اپنے Omi کو جانیں",
     "deviceOnboardingIntroSubtitle": "آپ کا Omi جو کچھ کر سکتا ہے اس کا ایک تیز اور عملی جائزہ۔",
-    "deviceOnboardingIntroDuration": "تقریباً 1 منٹ"
+    "deviceOnboardingIntroDuration": "تقریباً 1 منٹ",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10674,6 +10674,6 @@
     "deviceOnboardingIntroTitle": "اپنے Omi کو جانیں",
     "deviceOnboardingIntroSubtitle": "آپ کا Omi جو کچھ کر سکتا ہے اس کا ایک تیز اور عملی جائزہ۔",
     "deviceOnboardingIntroDuration": "تقریباً 1 منٹ",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "تازہ ترین پیغام پر جائیں",
+    "latest": "تازہ ترین"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3100,5 +3100,7 @@
     "deviceOnboardingFinish": "Hoàn tất",
     "deviceOnboardingIntroTitle": "Tìm hiểu về Omi của bạn",
     "deviceOnboardingIntroSubtitle": "Một chuyến tham quan nhanh, thực tế về mọi điều Omi của bạn có thể làm.",
-    "deviceOnboardingIntroDuration": "Khoảng 1 phút"
+    "deviceOnboardingIntroDuration": "Khoảng 1 phút",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3101,6 +3101,6 @@
     "deviceOnboardingIntroTitle": "Tìm hiểu về Omi của bạn",
     "deviceOnboardingIntroSubtitle": "Một chuyến tham quan nhanh, thực tế về mọi điều Omi của bạn có thể làm.",
     "deviceOnboardingIntroDuration": "Khoảng 1 phút",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "Đi đến tin nhắn mới nhất",
+    "latest": "Mới nhất"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3118,6 +3118,6 @@
     "deviceOnboardingIntroTitle": "了解你的 Omi",
     "deviceOnboardingIntroSubtitle": "快速、上手地体验 Omi 的全部功能。",
     "deviceOnboardingIntroDuration": "大约 1 分钟",
-    "jumpToLatestMessage": "Jump to latest message",
-    "latest": "Latest"
+    "jumpToLatestMessage": "跳转到最新消息",
+    "latest": "最新"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3117,5 +3117,7 @@
     "deviceOnboardingFinish": "完成",
     "deviceOnboardingIntroTitle": "了解你的 Omi",
     "deviceOnboardingIntroSubtitle": "快速、上手地体验 Omi 的全部功能。",
-    "deviceOnboardingIntroDuration": "大约 1 分钟"
+    "deviceOnboardingIntroDuration": "大约 1 分钟",
+    "jumpToLatestMessage": "Jump to latest message",
+    "latest": "Latest"
 }

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -980,8 +980,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     final addedMessages = count > _lastObservedMessageCount;
     final lastMessageChanged = lastId != _lastObservedMessageId;
     final streamedTextChanged = lastId == _lastObservedMessageId && textLength != _lastObservedTextLength;
-    final streamedBlocksChanged =
-        lastId == _lastObservedMessageId && thinkingCount != _lastObservedContentBlockCount;
+    final streamedBlocksChanged = lastId == _lastObservedMessageId && thinkingCount != _lastObservedContentBlockCount;
 
     _lastObservedMessageCount = count;
     _lastObservedMessageId = lastId;

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -36,6 +38,8 @@ import 'package:omi/utils/other/temp.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:omi/widgets/bottom_nav_bar.dart';
 
+enum _ChatScrollMode { followingBottom, freeScrolling }
+
 class ChatPage extends StatefulWidget {
   final bool isPivotBottom;
   final String? autoMessage;
@@ -56,6 +60,14 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   bool _hasInitialScrolled = false;
   MessageProvider? _messageProvider;
 
+  _ChatScrollMode _chatScrollMode = _ChatScrollMode.followingBottom;
+  final List<Timer> _pendingScrollTimers = [];
+  bool _isProgrammaticScroll = false;
+  int _lastObservedMessageCount = 0;
+  String? _lastObservedMessageId;
+  int _lastObservedTextLength = 0;
+  int _lastObservedContentBlockCount = 0;
+
   var prefs = SharedPreferencesUtil();
   late List<App> apps;
 
@@ -74,7 +86,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   @override
   void initState() {
     apps = prefs.appsList;
-    scrollController = ScrollController(initialScrollOffset: 1e9);
+    scrollController = ScrollController();
     textFieldFocusNode = FocusNode();
     textController.addListener(() {
       setState(() {});
@@ -82,8 +94,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     textFieldFocusNode.addListener(() {
       setState(() {});
       if (textFieldFocusNode.hasFocus) {
-        // Scroll to bottom when keyboard opens, with delay to allow keyboard animation
-        _ensureAtBottom(delayMs: 300);
+        // Keep the live edge visible when the keyboard opens only if the reader is following.
+        _scheduleModeAwareScroll(delayMs: 300, animated: true);
       }
     });
 
@@ -141,12 +153,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
               askForNps: false,
             );
             context.read<MessageProvider>().addMessage(aiMessage);
-            // Scroll after the message is added and rendered
-            Future.delayed(const Duration(milliseconds: 100), () {
-              if (mounted) {
-                scrollToBottom();
-              }
-            });
+            // Scroll after the message is added and rendered only while following.
+            _scheduleModeAwareScroll(delayMs: 100);
           }
         });
       }
@@ -167,6 +175,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   @override
   void dispose() {
     _messageProvider?.removeListener(_onMessageProviderChanged);
+    _cancelPendingScrolls();
     textController.dispose();
     scrollController.dispose();
     textFieldFocusNode.dispose();
@@ -191,6 +200,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
     return Consumer2<MessageProvider, ConnectivityProvider>(
       builder: (context, provider, connectivityProvider, child) {
+        _observeMessagesForAutoScroll(provider);
+
         return Scaffold(
           key: scaffoldKey,
           backgroundColor: Theme.of(context).colorScheme.primary,
@@ -221,113 +232,121 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                           ],
                         )
                       : provider.isClearingChat
-                      ? Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
-                            const SizedBox(height: 16),
-                            Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
-                          ],
-                        )
-                      : (provider.messages.isEmpty)
-                      ? Center(
-                          child: Padding(
-                            padding: const EdgeInsets.only(bottom: 100.0),
-                            child: Text(
-                              connectivityProvider.isConnected
-                                  ? context.l10n.noMessagesYet
-                                  : context.l10n.noInternetConnection,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                          ),
-                        )
-                      : LayoutBuilder(
-                          builder: (context, constraints) {
-                            return Theme(
-                              data: Theme.of(context).copyWith(
-                                textSelectionTheme: TextSelectionThemeData(
-                                  selectionColor: Colors.white.withOpacity(0.3),
-                                  selectionHandleColor: Colors.blue,
-                                ),
-                              ),
-                              child: ListView.builder(
-                                shrinkWrap: false,
-                                reverse: false,
-                                controller: scrollController,
-                                padding: const EdgeInsets.fromLTRB(18, 16, 18, 10),
-                                itemCount: provider.messages.length,
-                                itemBuilder: (context, chatIndex) {
-                                  if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
-                                    _hasInitialScrolled = true;
-                                    SchedulerBinding.instance.addPostFrameCallback((_) {
-                                      if (scrollController.hasClients) {
-                                        scrollController.jumpTo(scrollController.position.maxScrollExtent);
-                                      }
-                                    });
-                                  }
+                          ? Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const CircularProgressIndicator(
+                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
+                                const SizedBox(height: 16),
+                                Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
+                              ],
+                            )
+                          : (provider.messages.isEmpty)
+                              ? Center(
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(bottom: 100.0),
+                                    child: Text(
+                                      connectivityProvider.isConnected
+                                          ? context.l10n.noMessagesYet
+                                          : context.l10n.noInternetConnection,
+                                      textAlign: TextAlign.center,
+                                      style: const TextStyle(color: Colors.white),
+                                    ),
+                                  ),
+                                )
+                              : LayoutBuilder(
+                                  builder: (context, constraints) {
+                                    return Theme(
+                                      data: Theme.of(context).copyWith(
+                                        textSelectionTheme: TextSelectionThemeData(
+                                          selectionColor: Colors.white.withOpacity(0.3),
+                                          selectionHandleColor: Colors.blue,
+                                        ),
+                                      ),
+                                      child: Stack(
+                                        children: [
+                                          NotificationListener<ScrollNotification>(
+                                            onNotification: _handleScrollNotification,
+                                            child: ListView.builder(
+                                              shrinkWrap: false,
+                                              reverse: false,
+                                              controller: scrollController,
+                                              padding: const EdgeInsets.fromLTRB(18, 16, 18, 10),
+                                              itemCount: provider.messages.length,
+                                              itemBuilder: (context, chatIndex) {
+                                                if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
+                                                  _hasInitialScrolled = true;
+                                                  _schedulePostFrameModeAwareScroll();
+                                                }
 
-                                  final message = provider.messages[chatIndex];
-                                  double topPadding = chatIndex == provider.messages.length - 1 ? 8 : 16;
-                                  double bottomPadding = chatIndex == 0 ? 16 : 0;
+                                                final message = provider.messages[chatIndex];
+                                                double topPadding = chatIndex == provider.messages.length - 1 ? 8 : 16;
+                                                double bottomPadding = chatIndex == 0 ? 16 : 0;
 
-                                  return Padding(
-                                    key: ValueKey(message.id),
-                                    padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
-                                    child: message.sender == MessageSender.ai
-                                        ? Builder(
-                                            builder: (context) {
-                                              final child = AIMessage(
-                                                showTypingIndicator:
-                                                    provider.showTypingIndicator &&
-                                                    chatIndex == provider.messages.length - 1,
-                                                showThinkingAfterText: provider.agentThinkingAfterText,
-                                                message: message,
-                                                sendMessage: _sendMessageUtil,
-                                                onAskOmi: (text) {
-                                                  setState(() {
-                                                    _selectedContext = text;
-                                                  });
-                                                  textFieldFocusNode.requestFocus();
-                                                },
-                                                displayOptions: provider.messages.length <= 1,
-                                                appSender: provider.messageSenderApp(message.appId),
-                                                updateConversation: (ServerConversation conversation) {
-                                                  context.read<ConversationProvider>().updateConversation(conversation);
-                                                },
-                                                setMessageNps: (int value, {String? reason}) {
-                                                  provider.setMessageNps(message, value, reason: reason);
-                                                },
-                                              );
+                                                return Padding(
+                                                  key: ValueKey(message.id),
+                                                  padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
+                                                  child: message.sender == MessageSender.ai
+                                                      ? Builder(
+                                                          builder: (context) {
+                                                            final child = AIMessage(
+                                                              showTypingIndicator: provider.showTypingIndicator &&
+                                                                  chatIndex == provider.messages.length - 1,
+                                                              showThinkingAfterText: provider.agentThinkingAfterText,
+                                                              message: message,
+                                                              sendMessage: _sendMessageUtil,
+                                                              onAskOmi: (text) {
+                                                                setState(() {
+                                                                  _selectedContext = text;
+                                                                });
+                                                                textFieldFocusNode.requestFocus();
+                                                              },
+                                                              displayOptions: provider.messages.length <= 1,
+                                                              appSender: provider.messageSenderApp(message.appId),
+                                                              updateConversation: (ServerConversation conversation) {
+                                                                context.read<ConversationProvider>().updateConversation(
+                                                                      conversation,
+                                                                    );
+                                                              },
+                                                              setMessageNps: (int value, {String? reason}) {
+                                                                provider.setMessageNps(message, value, reason: reason);
+                                                              },
+                                                            );
 
-                                              // Dynamic spacer logic
-                                              if (chatIndex == provider.messages.length - 1 && _allowSpacer) {
-                                                return Container(
-                                                  constraints: BoxConstraints(
-                                                    minHeight: MediaQuery.of(context).size.height * 0.5,
-                                                  ),
-                                                  alignment: Alignment.topLeft,
-                                                  child: child,
+                                                            // Dynamic spacer logic
+                                                            if (chatIndex == provider.messages.length - 1 &&
+                                                                _allowSpacer) {
+                                                              return Container(
+                                                                constraints: BoxConstraints(
+                                                                  minHeight: MediaQuery.of(context).size.height * 0.5,
+                                                                ),
+                                                                alignment: Alignment.topLeft,
+                                                                child: child,
+                                                              );
+                                                            }
+                                                            return child;
+                                                          },
+                                                        )
+                                                      : HumanMessage(
+                                                          message: message,
+                                                          onAskOmi: (text) {
+                                                            setState(() {
+                                                              _selectedContext = text;
+                                                            });
+                                                            textFieldFocusNode.requestFocus();
+                                                          },
+                                                        ),
                                                 );
-                                              }
-                                              return child;
-                                            },
-                                          )
-                                        : HumanMessage(
-                                            message: message,
-                                            onAskOmi: (text) {
-                                              setState(() {
-                                                _selectedContext = text;
-                                              });
-                                              textFieldFocusNode.requestFocus();
-                                            },
+                                              },
+                                            ),
                                           ),
-                                  );
-                                },
-                              ),
-                            );
-                          },
-                        ),
+                                          if (_chatScrollMode == _ChatScrollMode.freeScrolling)
+                                            _buildJumpToLatestButton(),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                ),
                 ),
                 // Send message area
                 Container(
@@ -450,9 +469,9 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                 bottom: widget.isPivotBottom
                                     ? 6
                                     : (textFieldFocusNode.hasFocus &&
-                                              (textController.text.length > 40 || textController.text.contains('\n'))
-                                          ? 0
-                                          : 2),
+                                            (textController.text.length > 40 || textController.text.contains('\n'))
+                                        ? 0
+                                        : 2),
                               ),
                               child: Stack(
                                 clipBehavior: Clip.none,
@@ -646,8 +665,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                         FontAwesomeIcons.arrowUp,
                                                         color:
                                                             voiceRecorderProvider.state == VoiceRecorderState.recording
-                                                            ? const Color(0xFF1f1f25)
-                                                            : Colors.grey.shade400,
+                                                                ? const Color(0xFF1f1f25)
+                                                                : Colors.grey.shade400,
                                                         size: 16,
                                                       ),
                                                     ),
@@ -687,8 +706,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                     bool hasText = value.text.trim().isNotEmpty;
                                                     if (!hasText) return const SizedBox.shrink();
 
-                                                    bool canSend =
-                                                        hasText &&
+                                                    bool canSend = hasText &&
                                                         !provider.sendingMessage &&
                                                         !provider.isUploadingFiles &&
                                                         connectivityProvider.isConnected;
@@ -918,9 +936,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     provider.addMessageLocally(text);
     textController.clear();
 
-    Future.delayed(const Duration(milliseconds: 300), () {
-      if (mounted) scrollToBottomOnSend();
-    });
+    _resumeFollowingAndScroll(delayMs: 300, animated: true);
 
     await provider.sendMessageStreamToServer(text);
 
@@ -944,76 +960,169 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
   sendInitialAppMessage(App? app) async {
     context.read<MessageProvider>().setSendingMessage(true);
-    scrollToBottom();
+    _resumeFollowingAndScroll();
     ServerMessage message = await getInitialAppMessage(app?.id);
     if (mounted) {
       context.read<MessageProvider>().addMessage(message);
-      scrollToBottom();
+      _resumeFollowingAndScroll();
       context.read<MessageProvider>().setSendingMessage(false);
     }
   }
 
+  void _observeMessagesForAutoScroll(MessageProvider provider) {
+    final messages = provider.messages;
+    final count = messages.length;
+    final lastMessage = messages.isNotEmpty ? messages.last : null;
+    final lastId = lastMessage?.id;
+    final textLength = lastMessage?.text.length ?? 0;
+    final contentBlockCount = lastMessage?.contentBlocks.length ?? 0;
+
+    final addedMessages = count > _lastObservedMessageCount;
+    final lastMessageChanged = lastId != _lastObservedMessageId;
+    final streamedTextChanged = lastId == _lastObservedMessageId && textLength != _lastObservedTextLength;
+    final streamedBlocksChanged =
+        lastId == _lastObservedMessageId && contentBlockCount != _lastObservedContentBlockCount;
+
+    _lastObservedMessageCount = count;
+    _lastObservedMessageId = lastId;
+    _lastObservedTextLength = textLength;
+    _lastObservedContentBlockCount = contentBlockCount;
+
+    if (count == 0) return;
+
+    if (addedMessages && !_hasInitialScrolled) {
+      _hasInitialScrolled = true;
+      _schedulePostFrameModeAwareScroll();
+      return;
+    }
+
+    if (_chatScrollMode == _ChatScrollMode.followingBottom &&
+        (addedMessages || lastMessageChanged || streamedTextChanged || streamedBlocksChanged)) {
+      _scheduleModeAwareScroll(delayMs: 0, animated: streamedTextChanged || streamedBlocksChanged);
+    }
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification.depth != 0) return false;
+
+    final isUserScroll = notification is UserScrollNotification && notification.direction != ScrollDirection.idle;
+    final isDragScroll = notification is ScrollUpdateNotification && notification.dragDetails != null;
+
+    if (_isProgrammaticScroll && !isUserScroll && !isDragScroll) return false;
+
+    if (isUserScroll || isDragScroll) {
+      _chatScrollMode = _ChatScrollMode.freeScrolling;
+      _cancelPendingScrolls();
+      if (mounted) setState(() {});
+    }
+
+    return false;
+  }
+
+  Widget _buildJumpToLatestButton() {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 16,
+      child: Center(
+        child: Semantics(
+          label: 'Jump to latest message',
+          button: true,
+          child: Tooltip(
+            message: 'Jump to latest message',
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(24),
+                onTap: () => _resumeFollowingAndScroll(animated: true),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1F1F25).withOpacity(0.95),
+                    borderRadius: BorderRadius.circular(24),
+                    border: Border.all(color: Colors.white.withOpacity(0.18), width: 1),
+                    boxShadow: [
+                      BoxShadow(color: Colors.black.withOpacity(0.28), blurRadius: 12, offset: const Offset(0, 4)),
+                    ],
+                  ),
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.keyboard_arrow_down_rounded, color: Colors.white, size: 22),
+                      SizedBox(width: 6),
+                      Text(
+                        'Latest',
+                        style: TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   void scrollToBottomOnSend() {
-    if (!scrollController.hasClients) return;
+    _resumeFollowingAndScroll(animated: true);
+  }
 
-    // Wait for the new message to be added to the widget tree
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!scrollController.hasClients) return;
+  void _resumeFollowingAndScroll({int delayMs = 0, bool animated = false}) {
+    _cancelPendingScrolls();
+    _chatScrollMode = _ChatScrollMode.followingBottom;
+    if (mounted) setState(() {});
+    _scheduleModeAwareScroll(delayMs: delayMs, animated: animated, force: true);
+  }
 
-      final currentPosition = scrollController.position.pixels;
-      final maxExtent = scrollController.position.maxScrollExtent;
-      final distance = (maxExtent - currentPosition).abs();
-
-      // If user is very far from bottom, just jump instantly
-      if (distance > 1000) {
-        scrollController.jumpTo(maxExtent);
-        // After jump, check once more after layout settles
-        _ensureAtBottom(delayMs: 100);
-      } else if (distance > 300) {
-        // Medium distance - smooth but quick animation
-        scrollController
-            .animateTo(maxExtent, duration: const Duration(milliseconds: 400), curve: Curves.easeOut)
-            .then((_) => _ensureAtBottom(delayMs: 50));
-      } else {
-        // Already near bottom - gentle animation
-        scrollController
-            .animateTo(maxExtent, duration: const Duration(milliseconds: 300), curve: Curves.easeOutCubic)
-            .then((_) => _ensureAtBottom(delayMs: 50));
-      }
+  void _schedulePostFrameModeAwareScroll({bool animated = false, bool force = false}) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _scheduleModeAwareScroll(delayMs: 0, animated: animated, force: force);
     });
   }
 
-  void _ensureAtBottom({int delayMs = 50}) {
-    Future.delayed(Duration(milliseconds: delayMs), () {
-      if (!scrollController.hasClients) return;
-
-      final current = scrollController.position.pixels;
-      final max = scrollController.position.maxScrollExtent;
-
-      // Only adjust if we're noticeably not at bottom (more than 20 pixels off)
-      if (max - current > 20) {
-        scrollController.animateTo(max, duration: const Duration(milliseconds: 150), curve: Curves.easeOut);
-      }
+  void _scheduleModeAwareScroll({int delayMs = 50, bool animated = false, bool force = false}) {
+    final timer = Timer(Duration(milliseconds: delayMs), () {
+      _pendingScrollTimers.removeWhere((candidate) => !candidate.isActive);
+      if (!mounted) return;
+      _scrollToBottom(animated: animated, force: force);
     });
+    _pendingScrollTimers.add(timer);
+  }
+
+  void _cancelPendingScrolls() {
+    for (final timer in _pendingScrollTimers) {
+      timer.cancel();
+    }
+    _pendingScrollTimers.clear();
   }
 
   void scrollToBottom({bool animated = false}) {
+    _scrollToBottom(animated: animated);
+  }
+
+  void _scrollToBottom({bool animated = false, bool force = false}) {
     if (!scrollController.hasClients) return;
+    if (!force && _chatScrollMode != _ChatScrollMode.followingBottom) return;
 
     final position = scrollController.position;
     final target = position.maxScrollExtent;
     final distance = (target - position.pixels).abs();
+    if (distance <= 20) return;
 
-    if (distance > 350) {
+    _isProgrammaticScroll = true;
+
+    if (distance > 350 || !animated) {
       scrollController.jumpTo(target);
+      _isProgrammaticScroll = false;
       return;
     }
 
-    if (animated) {
-      scrollController.animateTo(target, duration: const Duration(milliseconds: 220), curve: Curves.easeOut);
-    } else {
-      scrollController.jumpTo(target);
-    }
+    scrollController
+        .animateTo(target, duration: const Duration(milliseconds: 220), curve: Curves.easeOut)
+        .whenComplete(() => _isProgrammaticScroll = false);
   }
 
   void _handleAppSelection(String? val, AppProvider provider) {
@@ -1431,18 +1540,18 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
               child: FaIcon(FontAwesomeIcons.solidCircleCheck, color: Colors.white, size: 18),
             )
           : appId != null && onConfirmDelete != null
-          ? GestureDetector(
-              onTap: () {
-                setState(() {
-                  _pendingDeleteAppId = appId;
-                });
-              },
-              child: const Padding(
-                padding: EdgeInsets.only(left: 2, top: 1),
-                child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
-              ),
-            )
-          : null,
+              ? GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _pendingDeleteAppId = appId;
+                    });
+                  },
+                  child: const Padding(
+                    padding: EdgeInsets.only(left: 2, top: 1),
+                    child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
+                  ),
+                )
+              : null,
       selected: isSelected,
       selectedTileColor: Colors.white.withOpacity(0.1),
       onTap: onTap,

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -975,18 +975,18 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     final lastMessage = messages.isNotEmpty ? messages.last : null;
     final lastId = lastMessage?.id;
     final textLength = lastMessage?.text.length ?? 0;
-    final contentBlockCount = lastMessage?.contentBlocks.length ?? 0;
+    final thinkingCount = lastMessage?.thinkings.length ?? 0;
 
     final addedMessages = count > _lastObservedMessageCount;
     final lastMessageChanged = lastId != _lastObservedMessageId;
     final streamedTextChanged = lastId == _lastObservedMessageId && textLength != _lastObservedTextLength;
     final streamedBlocksChanged =
-        lastId == _lastObservedMessageId && contentBlockCount != _lastObservedContentBlockCount;
+        lastId == _lastObservedMessageId && thinkingCount != _lastObservedContentBlockCount;
 
     _lastObservedMessageCount = count;
     _lastObservedMessageId = lastId;
     _lastObservedTextLength = textLength;
-    _lastObservedContentBlockCount = contentBlockCount;
+    _lastObservedContentBlockCount = thinkingCount;
 
     if (count == 0) return;
 
@@ -1010,6 +1010,18 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
     if (_isProgrammaticScroll && !isUserScroll && !isDragScroll) return false;
 
+    // Resume live following when the reader scrolls back to the live edge.
+    // maxScrollExtent - pixels <= threshold means we're at/near the bottom.
+    if (notification.metrics.maxScrollExtent - notification.metrics.pixels <= 24 &&
+        notification.metrics.maxScrollExtent > 0) {
+      if (_chatScrollMode == _ChatScrollMode.freeScrolling) {
+        _chatScrollMode = _ChatScrollMode.followingBottom;
+        _cancelPendingScrolls();
+        if (mounted) setState(() {});
+      }
+      return false;
+    }
+
     if (isUserScroll || isDragScroll) {
       _chatScrollMode = _ChatScrollMode.freeScrolling;
       _cancelPendingScrolls();
@@ -1026,10 +1038,10 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
       bottom: 16,
       child: Center(
         child: Semantics(
-          label: 'Jump to latest message',
+          label: context.l10n.jumpToLatestMessage,
           button: true,
           child: Tooltip(
-            message: 'Jump to latest message',
+            message: context.l10n.jumpToLatestMessage,
             child: Material(
               color: Colors.transparent,
               child: InkWell(
@@ -1045,14 +1057,14 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                       BoxShadow(color: Colors.black.withOpacity(0.28), blurRadius: 12, offset: const Offset(0, 4)),
                     ],
                   ),
-                  child: const Row(
+                  child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(Icons.keyboard_arrow_down_rounded, color: Colors.white, size: 22),
-                      SizedBox(width: 6),
+                      const Icon(Icons.keyboard_arrow_down_rounded, color: Colors.white, size: 22),
+                      const SizedBox(width: 6),
                       Text(
-                        'Latest',
-                        style: TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
+                        context.l10n.latest,
+                        style: const TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
                       ),
                     ],
                   ),

--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Improved chat scrolling across desktop and mobile so streamed replies follow only while you are at the live edge"
+  ],
   "releases": [
     {
       "version": "0.11.547",
@@ -75,7 +77,7 @@
       "version": "0.11.539",
       "date": "2026-06-26",
       "changes": [
-        "Developer named bundles now start quiet \u2014 lazy permissions, no auto screen/audio capture \u2014 unless explicitly seeded eager"
+        "Developer named bundles now start quiet — lazy permissions, no auto screen/audio capture — unless explicitly seeded eager"
       ]
     },
     {
@@ -289,14 +291,14 @@
       "version": "0.11.500",
       "date": "2026-06-23",
       "changes": [
-        "Proactive assistants (Insights, Focus, Tasks, Memory) now pause when their notifications are off \u2014 no background screen analysis unless you turn notifications on, saving battery and cost"
+        "Proactive assistants (Insights, Focus, Tasks, Memory) now pause when their notifications are off — no background screen analysis unless you turn notifications on, saving battery and cost"
       ]
     },
     {
       "version": "0.11.499",
       "date": "2026-06-23",
       "changes": [
-        "Fixed voice replies sometimes doing nothing after the Mac wakes from sleep \u2014 the realtime voice session now refreshes on wake instead of using a stale connection"
+        "Fixed voice replies sometimes doing nothing after the Mac wakes from sleep — the realtime voice session now refreshes on wake instead of using a stale connection"
       ]
     },
     {
@@ -331,7 +333,7 @@
       "version": "0.11.493",
       "date": "2026-06-22",
       "changes": [
-        "Premium trial no longer starts automatically \u2014 opt in from the welcome popup or Settings \u2192 Plan & Usage"
+        "Premium trial no longer starts automatically — opt in from the welcome popup or Settings → Plan & Usage"
       ]
     },
     {
@@ -394,8 +396,8 @@
       "version": "0.11.484",
       "date": "2026-06-20",
       "changes": [
-        "Push-to-talk now always answers \u2014 if the realtime voice connection drops mid-turn (or sends nothing usable), it falls back to Deepgram transcription instead of failing silently",
-        "Added a What's New link in Settings \u2192 About that opens the release notes for your version",
+        "Push-to-talk now always answers — if the realtime voice connection drops mid-turn (or sends nothing usable), it falls back to Deepgram transcription instead of failing silently",
+        "Added a What's New link in Settings → About that opens the release notes for your version",
         "Show a What's New popup in the corner after the app updates to a new version"
       ]
     },
@@ -417,7 +419,7 @@
       "version": "0.11.480",
       "date": "2026-06-20",
       "changes": [
-        "Fixed push-to-talk voice responses falling back to the slower model \u2014 the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
+        "Fixed push-to-talk voice responses falling back to the slower model — the realtime voice connection now stays warm and auto-reconnects (keepalive, relentless reconnect, re-warm on wake)"
       ]
     },
     {
@@ -481,7 +483,7 @@
       "version": "0.11.468",
       "date": "2026-06-18",
       "changes": [
-        "Recording now captures audio only during meetings by default \u2014 the mic and other apps' audio are captured only while you're in a call. Change this anytime in Settings \u2192 General \u2192 System Audio (Always / Only during meetings / Never)"
+        "Recording now captures audio only during meetings by default — the mic and other apps' audio are captured only while you're in a call. Change this anytime in Settings → General → System Audio (Always / Only during meetings / Never)"
       ]
     },
     {
@@ -489,7 +491,7 @@
       "date": "2026-06-17",
       "changes": [
         "Faster, cheaper assistant responses via Anthropic prompt caching of the system+tools prefix and conversation history",
-        "Added an experimental Realtime Voice Hub (Settings \u2192 Floating Bar): the realtime model handles your whole voice turn \u2014 listening, deciding, and speaking \u2014 for noticeably faster replies",
+        "Added an experimental Realtime Voice Hub (Settings → Floating Bar): the realtime model handles your whole voice turn — listening, deciding, and speaking — for noticeably faster replies",
         "Redesigned the floating bar voice indicator with smooth, distinct idle, listening, thinking, and speaking states so you always know whether the assistant is working or done",
         "Voice (push-to-talk) conversations now appear in your chat history",
         "Fixed older chat messages failing to load in long chats"
@@ -549,17 +551,17 @@
       "version": "0.11.457",
       "date": "2026-06-09",
       "changes": [
-        "Fixed the floating bar reappearing after you turned off \u201cShow floating bar\u201d \u2014 it now stays hidden even while a background browser action runs",
+        "Fixed the floating bar reappearing after you turned off “Show floating bar” — it now stays hidden even while a background browser action runs",
         "Fixed Ask Omi chat occasionally failing with a rate-limit error when on-screen assistants were active",
         "Restored the Device settings page so you can pair and manage a Bluetooth device from Settings",
-        "Recording no longer goes blank if on-device transcription fails to load \u2014 it automatically falls back to cloud transcription"
+        "Recording no longer goes blank if on-device transcription fails to load — it automatically falls back to cloud transcription"
       ]
     },
     {
       "version": "0.11.455",
       "date": "2026-06-09",
       "changes": [
-        "Improved chat and voice reliability \u2014 the backend now retries transient AI provider errors instead of failing the request"
+        "Improved chat and voice reliability — the backend now retries transient AI provider errors instead of failing the request"
       ]
     },
     {
@@ -580,7 +582,7 @@
       "version": "0.11.452",
       "date": "2026-06-07",
       "changes": [
-        "Proactive notifications are now off by default \u2014 turn them on anytime in Settings"
+        "Proactive notifications are now off by default — turn them on anytime in Settings"
       ]
     },
     {
@@ -603,8 +605,8 @@
       "changes": [
         "Fixed drag handle on Tasks page not appearing when hovering over a row",
         "Fixed drag-to-reorder on Tasks page not persisting when date filters are active",
-        "Fixed drag-to-reorder on Tasks page \u2014 dragged row now visually dims while in flight",
-        "Fixed manual tasks producing duplicate rows on every backend sync \u2014 orphan adoption now matches by description only, since the backend does not preserve the client-side source value",
+        "Fixed drag-to-reorder on Tasks page — dragged row now visually dims while in flight",
+        "Fixed manual tasks producing duplicate rows on every backend sync — orphan adoption now matches by description only, since the backend does not preserve the client-side source value",
         "Fixed Floating Bar positioning so the input field is no longer hidden behind the macOS Dock"
       ]
     },
@@ -821,7 +823,7 @@
       "version": "0.11.414",
       "date": "2026-05-21",
       "changes": [
-        "Fixed memories created on desktop showing up under \"Manual\" on mobile \u2014 they now appear under \"About You\" or \"Insights\" based on their type",
+        "Fixed memories created on desktop showing up under \"Manual\" on mobile — they now appear under \"About You\" or \"Insights\" based on their type",
         "Screen Capture and Microphone menu bar toggles now show as off when your trial has expired or you hit your usage limit, and tapping them brings up the upgrade prompt"
       ]
     },
@@ -836,14 +838,14 @@
       "version": "0.11.411",
       "date": "2026-05-18",
       "changes": [
-        "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+        "Fixed BYOK keys not being used for Gemini and Anthropic requests — users who bring their own API keys now bypass server keys and rate limits for all AI features"
       ]
     },
     {
       "version": "0.11.409",
       "date": "2026-05-18",
       "changes": [
-        "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+        "Fixed BYOK keys not being used for Gemini and Anthropic requests — users who bring their own API keys now bypass server keys and rate limits for all AI features"
       ]
     },
     {
@@ -857,7 +859,7 @@
       "version": "0.11.407",
       "date": "2026-05-16",
       "changes": [
-        "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured \u2014 request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
+        "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured — request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
       ]
     },
     {
@@ -878,7 +880,7 @@
       "version": "0.11.404",
       "date": "2026-05-15",
       "changes": [
-        "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
+        "Task notifications fire within seconds instead of waiting up to 5 minutes — promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
       ]
     },
     {
@@ -892,7 +894,7 @@
       "version": "0.11.402",
       "date": "2026-05-15",
       "changes": [
-        "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks"
+        "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first — a chat asking for two unrelated deliverables in one message creates two tasks"
       ]
     },
     {
@@ -913,7 +915,7 @@
       "version": "0.11.398",
       "date": "2026-05-14",
       "changes": [
-        "Smarter task analyzer dedupe \u2014 per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
+        "Smarter task analyzer dedupe — per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
       ]
     },
     {
@@ -1011,7 +1013,7 @@
       "version": "0.11.380",
       "date": "2026-05-10",
       "changes": [
-        "Beta builds now talk to the development backend for faster fixes \u2014 your data still lives in production"
+        "Beta builds now talk to the development backend for faster fixes — your data still lives in production"
       ]
     },
     {
@@ -1081,7 +1083,7 @@
       "version": "0.11.370",
       "date": "2026-04-29",
       "changes": [
-        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents \u2014 Claude Haiku decides whether each message is a quick answer or a real task"
+        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents — Claude Haiku decides whether each message is a quick answer or a real task"
       ]
     },
     {
@@ -1102,7 +1104,7 @@
       "version": "0.11.367",
       "date": "2026-04-26",
       "changes": [
-        "Stop creating up to 5 tasks (and notifications) on every app launch \u2014 task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
+        "Stop creating up to 5 tasks (and notifications) on every app launch — task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
       ]
     },
     {
@@ -1124,7 +1126,7 @@
       "date": "2026-04-26",
       "changes": [
         "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
-        "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
+        "Added Execute button on floating-bar notification cards and task rows — one click spawns an agent that handles the item end-to-end"
       ]
     },
     {
@@ -1209,7 +1211,7 @@
       "version": "0.11.350",
       "date": "2026-04-21",
       "changes": [
-        "Auto-updates no longer install during an active conversation \u2014 the app waits for 2 minutes of silence before restarting"
+        "Auto-updates no longer install during an active conversation — the app waits for 2 minutes of silence before restarting"
       ]
     },
     {
@@ -1224,7 +1226,7 @@
       "date": "2026-04-21",
       "changes": [
         "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen",
-        "Usage-based overage on Operator plan \u2014 chat past 500 questions is billed as real provider cost + 15% at end of cycle"
+        "Usage-based overage on Operator plan — chat past 500 questions is billed as real provider cost + 15% at end of cycle"
       ]
     },
     {
@@ -2447,8 +2449,8 @@
       "version": "0.11.134",
       "date": "2026-03-18",
       "changes": [
-        "Removed intro video from Rewind tab \u2014 screenshots are shown immediately",
-        "Fixed delayed screenshot capture after onboarding \u2014 first screenshot is now taken instantly"
+        "Removed intro video from Rewind tab — screenshots are shown immediately",
+        "Fixed delayed screenshot capture after onboarding — first screenshot is now taken instantly"
       ]
     },
     {
@@ -2852,8 +2854,8 @@
         "Added live 3D knowledge graph visualization during onboarding that builds incrementally as AI discovers information about you",
         "Added interaction hints to onboarding knowledge graph (drag, zoom, pan)",
         "Fixed onboarding resuming after Quit & Reopen for screen recording permission",
-        "Parallel AI exploration during onboarding \u2014 builds your digital profile and knowledge graph while you set up permissions",
-        "Automated release notes \u2014 changes are now tracked as they happen"
+        "Parallel AI exploration during onboarding — builds your digital profile and knowledge graph while you set up permissions",
+        "Automated release notes — changes are now tracked as they happen"
       ]
     },
     {
@@ -2929,9 +2931,9 @@
         "If the Install button fails, download manually from <a href='https://macos.omi.me' style='font-weight:bold'>macos.omi.me</a> (known issue on macOS 26)",
         "Task chat session history: resume previous AI conversations about tasks across app restarts",
         "Dedicated task chat side panel with better layout isolation and session ID display",
-        "Add task button in toolbar (\u2318N) for quick inline task creation",
+        "Add task button in toolbar (⌘N) for quick inline task creation",
         "File graph keyboard hints: drag to rotate, right-drag to pan, scroll to zoom",
-        "Removed per-message timeouts in AI bridge \u2014 long-running tools no longer fail prematurely",
+        "Removed per-message timeouts in AI bridge — long-running tools no longer fail prematurely",
         "Chat memory capped at 200 messages to prevent unbounded growth",
         "Auto-restart memory threshold lowered from 4GB to 3GB for safer recovery",
         "Fixed PostHog lifecycle capture causing 2-second XPC hangs to Spotlight",
@@ -2946,7 +2948,7 @@
       "version": "0.10.9",
       "date": "2026-02-23",
       "changes": [
-        "<span style='color:red;font-size:16px;font-weight:bold'>\u26a0\ufe0f AUTO-UPDATE IS BROKEN \u2014 YOU MUST DOWNLOAD MANUALLY</span>",
+        "<span style='color:red;font-size:16px;font-weight:bold'>⚠️ AUTO-UPDATE IS BROKEN — YOU MUST DOWNLOAD MANUALLY</span>",
         "<span style='color:red'>The Install button will NOT work.</span> Please download the new version here: <a href='https://macos.omi.me' style='color:red;font-weight:bold;font-size:15px'>macos.omi.me</a>",
         "Steps: 1) Click the link above or open <a href='https://macos.omi.me'>macos.omi.me</a> in your browser  2) Download the DMG  3) Open it and drag Omi to Applications  4) Replace the existing app when prompted",
         "This is a one-time fix. After installing manually, all future updates will work normally.",
@@ -3191,7 +3193,7 @@
         "Hardware-accelerated screen recording (hevc_videotoolbox) for lower CPU usage",
         "Auto-detects video calls (Zoom, Teams, Meet) and reduces capture frequency to avoid slowdowns",
         "Floating bar shows OMI logo and no longer drifts across the screen or off-screen on monitor disconnect",
-        "AI agent turn limit removed \u2014 tasks can run as many steps as needed",
+        "AI agent turn limit removed — tasks can run as many steps as needed",
         "Capped in-memory embeddings to 5,000 entries to prevent unbounded memory growth",
         "Fixed database crashes from concurrent sync operations during memory and action item writes",
         "Reduced error noise: cleaner Sentry logs, quieter Crisp polling, slower recovery retries"
@@ -3220,7 +3222,7 @@
         "Accessibility permission reset: detects broken state after macOS updates and offers one-click fix",
         "Database upgraded to connection pool for better performance during concurrent reads",
         "Automation permission check now handles System Events not running (fixes -600 error)",
-        "Onboarding no longer blocks on permissions \u2014 grant them later from Settings",
+        "Onboarding no longer blocks on permissions — grant them later from Settings",
         "Hiding the floating bar now persists across app restarts",
         "Native notifications when support replies in Help chat",
         "Faster conversation sync by skipping unchanged sessions"
@@ -3234,7 +3236,7 @@
         "Model picker: switch between Sonnet and Opus directly from the floating bar",
         "Voice follow-up: use push-to-talk while viewing an AI response to continue the conversation",
         "Batch transcription mode: record first, transcribe after for better accuracy (Settings > Shortcuts)",
-        "Customizable Ask Omi shortcut: choose \u2318Enter, \u2318\u21e7Enter, \u2318J, or \u2318O (Settings > Shortcuts)",
+        "Customizable Ask Omi shortcut: choose ⌘Enter, ⌘⇧Enter, ⌘J, or ⌘O (Settings > Shortcuts)",
         "Push-to-talk sounds can now be toggled off in settings",
         "AI chat now includes your tasks for more context-aware responses",
         "Long chat messages are auto-truncated with Show more/less toggle",

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -588,7 +588,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                 // again; only atBottom == false is ambiguous (it can be a
                 // geometry/layout change, not user intent) and must NOT switch
                 // to .freeScrolling on its own.
-                if atBottom && scrollMode == .freeScrolling {
+                if atBottom && (scrollMode == .freeScrolling || scrollMode == .anchoringTurn) {
                     cancelAllPendingScrolls()
                     userIsScrolling = false
                     scrollMode = .followingBottom

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-/// Detects user scroll-wheel / trackpad gestures on the enclosing NSScrollView
-/// and fires a callback immediately — before the scroll position settles.
+/// Detects user scroll-wheel / trackpad gestures, mouse interactions, and
+/// keyboard scroll-navigation on the enclosing NSScrollView and fires a
+/// callback immediately — before the scroll position settles.
 /// This wins the race against throttled programmatic scrolls during streaming.
 private struct UserScrollDetector: NSViewRepresentable {
     let onUserScroll: () -> Void
@@ -24,6 +25,17 @@ private struct UserScrollDetector: NSViewRepresentable {
         let onUserScroll: () -> Void
         private var monitor: Any?
 
+        /// Key codes that navigate within a scroll view when it has keyboard
+        /// focus. These are unambiguous reader-intent scroll signals.
+        private static let scrollNavigationKeyCodes: Set<UInt16> = [
+            125,  // Down arrow
+            126,  // Up arrow
+            116,  // Page Up
+            121,  // Page Down
+            115,  // Home
+            119,  // End
+        ]
+
         init(onUserScroll: @escaping () -> Void) {
             self.onUserScroll = onUserScroll
         }
@@ -41,29 +53,48 @@ private struct UserScrollDetector: NSViewRepresentable {
             }
             let targetScrollView = scrollView
 
-            monitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .leftMouseDragged]) { [weak self] event in
+            monitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .leftMouseDown, .leftMouseDragged, .keyDown]) { [weak self] event in
                 guard let self = self, let targetScrollView = targetScrollView else { return event }
                 // Only respond to events in our scroll view's window
                 guard event.window == targetScrollView.window else { return event }
-                // Check if the event location is inside our scroll view
-                let locationInWindow = event.locationInWindow
-                let locationInScrollView = targetScrollView.convert(locationInWindow, from: nil)
-                guard targetScrollView.bounds.contains(locationInScrollView) else { return event }
-                if event.type == .scrollWheel {
-                    // deltaY > 0 means scrolling up (towards earlier content, away from
-                    // the live edge). Only that direction is reader intent to leave the
-                    // bottom; a downward nudge at the live edge is a no-op and must not
-                    // release following. Plain clicks (.leftMouseDown) are excluded
-                    // entirely so idle clicks don't kill following.
-                    if event.scrollingDeltaY > 0 {
+
+                if event.type == .keyDown {
+                    // Keyboard scroll-navigation (Page Up/Down, arrows, Home/End)
+                    // is reader intent — but only when a text-editing control
+                    // does NOT have keyboard focus. Otherwise arrow keys and
+                    // Page Up/Down go to the chat input or a selected text view,
+                    // not the scroll view.
+                    guard Self.scrollNavigationKeyCodes.contains(event.keyCode) else { return event }
+                    if Self.isFirstResponderEditingText(in: event.window) { return event }
+                    self.onUserScroll()
+                } else {
+                    // Mouse/wheel events: check if inside the scroll view
+                    let locationInWindow = event.locationInWindow
+                    let locationInScrollView = targetScrollView.convert(locationInWindow, from: nil)
+                    guard targetScrollView.bounds.contains(locationInScrollView) else { return event }
+                    if event.type == .scrollWheel {
+                        // Any physical wheel/trackpad scroll inside the transcript is reader intent.
+                        if event.scrollingDeltaY != 0 || event.scrollingDeltaX != 0 {
+                            self.onUserScroll()
+                        }
+                    } else {
+                        // Mouse click/drag inside the transcript is reader intent: it may be
+                        // a scrollbar drag, text selection, or another reading interaction.
                         self.onUserScroll()
                     }
-                } else {
-                    // Mouse drag inside the transcript is reader intent.
-                    self.onUserScroll()
                 }
                 return event
             }
+        }
+
+        /// Returns true if the window's first responder is a text-editing
+        /// control (NSTextView backs both NSTextField via field editor and
+        /// SwiftUI text inputs). Used to distinguish typing in the chat input
+        /// from keyboard-driven scroll navigation.
+        private static func isFirstResponderEditingText(in window: NSWindow?) -> Bool {
+            guard let window = window else { return false }
+            let fr = window.firstResponder
+            return fr is NSTextView
         }
 
         deinit {
@@ -77,9 +108,22 @@ private struct UserScrollDetector: NSViewRepresentable {
 /// Explicit scroll intent model for streaming follow behavior.
 /// `followingBottom` = the reader is at the live edge; streamed chunks may auto-scroll.
 /// `freeScrolling`  = the reader intentionally scrolled away; viewport must not move.
+/// `anchoringTurn`  = the viewport is intentionally anchored to the latest local
+///                     user turn; assistant streaming below must not yank to bottom.
 private enum ChatScrollMode: Equatable {
     case followingBottom
     case freeScrolling
+    case anchoringTurn
+}
+
+/// A token that callers pass when the local user sends a message.
+/// This allows ChatMessagesView to distinguish genuine user sends from
+/// messages arriving via polling, sync, or other sources — without
+/// inferring solely from messages.count changes.
+struct LocalSendToken: Equatable {
+    /// Monotonic counter that increments on every local send.
+    /// ChatMessagesView tracks the last seen value and reacts to increments.
+    let generation: Int
 }
 
 /// Reusable chat messages scroll view extracted from ChatPage.
@@ -96,6 +140,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     var onCitationTap: ((Citation) -> Void)? = nil
     var sessionsLoadError: String? = nil
     var onRetry: (() -> Void)? = nil
+    /// Token that increments each time the local user sends a message.
+    /// ChatMessagesView uses this to anchor the new user message near the
+    /// top of the viewport (one-shot) before the assistant streams below.
+    /// Pass nil when the caller cannot distinguish local sends (e.g. TaskChatPanel
+    /// with its own send path).
+    var localSendToken: LocalSendToken? = nil
     @ViewBuilder var welcomeContent: () -> WelcomeContent
 
     /// IDs of messages that are near-duplicates of an earlier message in the same session.
@@ -116,9 +166,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         return dupes
     }
 
+    // MARK: - Scroll State
+
     @State private var isUserAtBottom = true
     /// Source of truth for scroll intent. Geometry/layout changes alone must NOT
-    /// switch this to `.freeScrolling` — only physical wheel/trackpad user scroll.
+    /// switch this to `.freeScrolling` — only physical user input (wheel/trackpad,
+    /// mouse, or keyboard scroll-navigation).
     @State private var scrollMode: ChatScrollMode = .followingBottom
     /// Throttle token for scrollToBottom — prevents the streaming + scroll
     /// detection feedback loop from saturating the main thread.
@@ -131,6 +184,31 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     /// Tracks work items for delayed initial bottom scrolls so they can be
     /// canceled on user scroll or disappear.
     @State private var initialScrollWorkItems: [DispatchWorkItem] = []
+
+    // MARK: - Local Send Anchoring
+
+    /// Last observed local send token generation. When it increments, we know
+    /// a local user send just happened and can anchor the viewport.
+    @State private var lastSeenSendGeneration: Int = 0
+
+    // MARK: - Saved Restore
+
+    /// Whether the initial history load for this conversation has been handled.
+    /// Prevents re-anchoring on subsequent messages.count changes after restore.
+    @State private var initialRestoreHandled = false
+
+    // MARK: - Prepend Preservation (Load Earlier Messages)
+
+    /// The ID of the first visible message before a "Load earlier" operation.
+    /// After load completes, we scroll to reposition this message at the top
+    /// of the viewport, preserving the user's reading position.
+    @State private var prependAnchorId: String?
+
+    // MARK: - Activity Below Indicator
+
+    /// True when new content arrived while the user is scrolled away, so the
+    /// jump-to-bottom affordance should be shown.
+    @State private var hasActivityBelow = false
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -163,53 +241,189 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                     .id("bottom-anchor")
             }
         }
+        // MARK: - React to message count changes
         .onChange(of: messages.count) { oldCount, newCount in
-            if newCount > oldCount || oldCount == 0 {
-                if scrollMode == .followingBottom || oldCount == 0 {
-                    // oldCount == 0 means the first real messages just arrived
-                    // (history load). A stray wheel/click may have flipped
-                    // scrollMode to .freeScrolling before this fired; force the
-                    // viewport back to the live edge so the initial load lands
-                    // at the latest message, not at the top.
-                    if oldCount == 0 && scrollMode != .followingBottom {
-                        scrollMode = .followingBottom
-                    }
-                    scrollToBottom(proxy: proxy)
-                    if oldCount == 0 {
-                        scheduleInitialScroll(proxy: proxy, delay: 0.3)
-                    }
-                }
-            }
+            handleMessagesCountChange(oldCount: oldCount, newCount: newCount, proxy: proxy)
         }
+        // MARK: - React to streaming text changes
         .onChange(of: messages.last?.text) { _, _ in
-            if scrollMode == .followingBottom {
-                throttledScrollToBottom(proxy: proxy)
-            }
+            handleLiveContentChange(proxy: proxy)
         }
+        // MARK: - React to content block changes (tool calls, etc.)
         .onChange(of: messages.last?.contentBlocks.count) { _, _ in
-            if scrollMode == .followingBottom {
-                throttledScrollToBottom(proxy: proxy)
+            handleLiveContentChange(proxy: proxy)
+        }
+        // MARK: - React to local send token (turn anchoring)
+        .onChange(of: localSendToken?.generation) { oldGen, newGen in
+            guard let newGen = newGen else { return }
+            if newGen > lastSeenSendGeneration {
+                lastSeenSendGeneration = newGen
+                handleLocalSend(proxy: proxy)
             }
         }
+        // MARK: - React to isSending (send started)
         .onChange(of: isSending) { oldValue, newValue in
-            if newValue && !oldValue {
+            if newValue && !oldValue && localSendToken == nil {
                 cancelAllPendingScrolls()
                 userIsScrolling = false
                 scrollMode = .followingBottom
+                hasActivityBelow = false
                 scrollToBottom(proxy: proxy)
             }
         }
+        // MARK: - React to isLoadingMoreMessages (prepend preservation)
+        .onChange(of: isLoadingMoreMessages) { _, isLoading in
+            if isLoading {
+                // Capture the first message ID before the load begins
+                prependAnchorId = messages.first?.id
+            } else {
+                // Load finished — restore prepend anchor if user hasn't scrolled
+                restorePrependAnchor(proxy: proxy)
+            }
+        }
         .onAppear {
-            if scrollMode == .followingBottom {
-                scrollToBottom(proxy: proxy)
-                scheduleInitialScroll(proxy: proxy, delay: 0.3)
-                scheduleInitialScroll(proxy: proxy, delay: 0.7)
+            if !messages.isEmpty {
+                handleInitialRestore(proxy: proxy)
             }
         }
         .onDisappear {
             cancelAllPendingScrolls()
         }
     }
+
+    // MARK: - Message Count Change Handler
+
+    /// Central handler for messages.count changes. Handles:
+    /// - Initial restore (scroll to last user message on first load)
+    /// - New messages arriving while following
+    /// - New messages arriving while scrolled away (activity indicator)
+    /// - Prepend detection (load earlier)
+    private func handleMessagesCountChange(oldCount: Int, newCount: Int, proxy: ScrollViewProxy) {
+        if newCount > oldCount {
+            // --- Initial restore: messages went from 0→N ---
+            if oldCount == 0 && newCount > 0 {
+                handleInitialRestore(proxy: proxy)
+                return
+            }
+
+            // --- Prepend: new older messages inserted ---
+            // If prependAnchorId is set and the count increase corresponds to
+            // older messages, the onChange(of: isLoadingMoreMessages) handler
+            // takes care of repositioning.
+
+            // --- New live messages arriving ---
+            if scrollMode == .followingBottom {
+                scrollToBottom(proxy: proxy)
+            } else if scrollMode == .anchoringTurn {
+                // While anchored to the new turn, keep the prompt stable and
+                // surface that live activity is arriving below.
+                hasActivityBelow = true
+            } else {
+                // freeScrolling — new content arrived below
+                hasActivityBelow = true
+            }
+        }
+    }
+
+    private func handleLiveContentChange(proxy: ScrollViewProxy) {
+        switch scrollMode {
+        case .followingBottom:
+            throttledScrollToBottom(proxy: proxy)
+        case .freeScrolling, .anchoringTurn:
+            hasActivityBelow = true
+        }
+    }
+
+    // MARK: - Initial Restore
+
+    /// On the first load of a saved conversation, scroll to the last user
+    /// message rather than absolute bottom. This lets the user see their
+    /// last question and the beginning of the AI response, with more context
+    /// above. Fallback: for chats with no user messages or only one turn,
+    /// just go to bottom.
+    private func handleInitialRestore(proxy: ScrollViewProxy) {
+        guard !initialRestoreHandled else { return }
+        initialRestoreHandled = true
+
+        // Find the last user message
+        let lastUserMsg = messages.last { $0.sender == .user }
+
+        if let anchorMsg = lastUserMsg, messages.count > 2 {
+            scrollMode = .anchoringTurn
+            hasActivityBelow = true
+            // Scroll so the last user message appears near the top of the
+            // viewport. We use a small delay to let the LazyVStack render.
+            let anchorId = anchorMsg.id
+            let work = DispatchWorkItem { [self] in
+                guard scrollMode == .followingBottom || scrollMode == .anchoringTurn else { return }
+                proxy.scrollTo(anchorId, anchor: .top)
+            }
+            initialScrollWorkItems.append(work)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
+        } else {
+            // Fallback: no user messages, or very short chat — scroll to bottom
+            scrollMode = .followingBottom
+            hasActivityBelow = false
+            scrollToBottom(proxy: proxy)
+        }
+    }
+
+    // MARK: - Local Send / Turn Anchoring
+
+    /// Called when the local send token increments. Anchors the newest user
+    /// message near the top of the viewport so the assistant response streams
+    /// below it, giving the user a stable reading frame.
+    private func handleLocalSend(proxy: ScrollViewProxy) {
+        guard !messages.isEmpty else { return }
+
+        // Find the most recently added user message
+        let lastUserMsg = messages.last { $0.sender == .user }
+        guard let anchorMsg = lastUserMsg else {
+            // No user message found (shouldn't happen on a local send, but be safe)
+            scrollMode = .followingBottom
+            scrollToBottom(proxy: proxy)
+            return
+        }
+
+        cancelAllPendingScrolls()
+        scrollMode = .anchoringTurn
+
+        let anchorId = anchorMsg.id
+        // Small delay to let SwiftUI commit the new message into the LazyVStack
+        let work = DispatchWorkItem { [self] in
+            guard scrollMode == .anchoringTurn else { return }
+            proxy.scrollTo(anchorId, anchor: .top)
+        }
+        initialScrollWorkItems.append(work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: work)
+    }
+
+    // MARK: - Prepend Preservation
+
+    /// After "Load earlier messages" completes, scroll to restore the message
+    /// that was at the top before the load. Skipped if the user scrolled during
+    /// the load or if the anchor message is no longer present.
+    private func restorePrependAnchor(proxy: ScrollViewProxy) {
+        guard let anchorId = prependAnchorId else { return }
+        prependAnchorId = nil
+
+        // If the user scrolled during the load, don't override their position
+        guard scrollMode != .freeScrolling else { return }
+
+        // Verify the anchor message is still in the list
+        let stillExists = messages.contains { $0.id == anchorId }
+        guard stillExists else { return }
+
+        // Scroll anchor to top without animation
+        let work = DispatchWorkItem { [self] in
+            guard self.scrollMode != .freeScrolling else { return }
+            proxy.scrollTo(anchorId, anchor: .top)
+        }
+        initialScrollWorkItems.append(work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+    }
+
+    // MARK: - Scheduled Scrolls
 
     /// Schedules a delayed bottom scroll that is mode-aware and cancelable.
     private func scheduleInitialScroll(proxy: ScrollViewProxy, delay: TimeInterval) {
@@ -241,10 +455,13 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         initialScrollWorkItems.removeAll()
     }
 
+    // MARK: - Subviews
+
     @ViewBuilder
     private var loadMoreButton: some View {
         if hasMoreMessages {
             Button {
+                prependAnchorId = messages.first?.id
                 Task {
                     await onLoadMore()
                 }
@@ -348,11 +565,20 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                     cancelAllPendingScrolls()
                     userIsScrolling = false
                     scrollMode = .followingBottom
+                    hasActivityBelow = false
                 }
             }
             UserScrollDetector {
-                scrollMode = .freeScrolling
+                if scrollMode == .anchoringTurn {
+                    // If user scrolls during turn anchoring, cancel the anchor
+                    // and go to free-scrolling immediately.
+                    scrollMode = .freeScrolling
+                    cancelAllPendingScrolls()
+                } else {
+                    scrollMode = .freeScrolling
+                }
                 userIsScrolling = true
+                hasActivityBelow = false
                 cancelAllPendingScrolls()
                 let endWork = DispatchWorkItem {
                     userIsScrolling = false
@@ -365,28 +591,40 @@ struct ChatMessagesView<WelcomeContent: View>: View {
 
     @ViewBuilder
     private func scrollToBottomButton(proxy: ScrollViewProxy) -> some View {
-        if scrollMode == .freeScrolling && !messages.isEmpty {
+        // Show when: free-scrolled, OR anchoring turn (give user escape hatch),
+        // AND there are messages, AND either there's activity below or we're
+        // in a non-following mode.
+        if (scrollMode == .freeScrolling || scrollMode == .anchoringTurn) && !messages.isEmpty {
             Button {
                 cancelAllPendingScrolls()
                 userIsScrolling = false
                 scrollMode = .followingBottom
+                hasActivityBelow = false
                 scrollToBottom(proxy: proxy)
             } label: {
-                Image(systemName: "arrow.down.circle.fill")
-                    .scaledFont(size: 32)
-                    .foregroundColor(OmiColors.textSecondary)
-                    .background(
-                        Circle()
-                            .fill(OmiColors.backgroundPrimary)
-                            .frame(width: 28, height: 28)
-                    )
-                    .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+                ZStack(alignment: .center) {
+                    Circle()
+                        .fill(OmiColors.backgroundPrimary)
+                        .frame(width: 36, height: 36)
+                        .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+                    Image(systemName: "arrow.down.circle.fill")
+                        .scaledFont(size: 28)
+                        .foregroundColor(OmiColors.textSecondary)
+                }
+                // Activity pulse: subtle white glow when new content arrived below
+                .overlay(
+                    Circle()
+                        .stroke(OmiColors.textSecondary.opacity(hasActivityBelow ? 0.6 : 0), lineWidth: 1.5)
+                )
+                .opacity(hasActivityBelow ? 1.0 : 0.85)
+                .scaleEffect(hasActivityBelow ? 1.08 : 1.0)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Jump to latest message")
             .padding(.bottom, 16)
             .transition(.scale.combined(with: .opacity))
             .animation(.easeInOut(duration: 0.2), value: scrollMode)
+            .animation(.easeInOut(duration: 0.3), value: hasActivityBelow)
         }
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -60,12 +60,12 @@ private struct UserScrollDetector: NSViewRepresentable {
 
                 if event.type == .keyDown {
                     // Keyboard scroll-navigation (Page Up/Down, arrows, Home/End)
-                    // is reader intent — but only when a text-editing control
-                    // does NOT have keyboard focus. Otherwise arrow keys and
-                    // Page Up/Down go to the chat input or a selected text view,
-                    // not the scroll view.
+                    // is reader intent — but only when the scroll view (or a
+                    // descendant view like the document content) is the keyboard
+                    // target. This prevents sidebar tables, buttons, or other
+                    // controls in the same window from falsely breaking live-follow.
                     guard Self.scrollNavigationKeyCodes.contains(event.keyCode) else { return event }
-                    if Self.isFirstResponderEditingText(in: event.window) { return event }
+                    guard Self.isScrollViewKeyboardTarget(in: event.window, scrollView: targetScrollView) else { return event }
                     self.onUserScroll()
                 } else {
                     // Mouse/wheel events: check if inside the scroll view
@@ -87,14 +87,16 @@ private struct UserScrollDetector: NSViewRepresentable {
             }
         }
 
-        /// Returns true if the window's first responder is a text-editing
-        /// control (NSTextView backs both NSTextField via field editor and
-        /// SwiftUI text inputs). Used to distinguish typing in the chat input
-        /// from keyboard-driven scroll navigation.
-        private static func isFirstResponderEditingText(in window: NSWindow?) -> Bool {
+        /// Returns true if the window's first responder is the scroll view or a
+        /// descendant of it — meaning keyboard events go to the scroll view and
+        /// should be treated as scroll navigation. This is more precise than
+        /// checking "not a text view": it excludes sidebar tables, buttons, and
+        /// other controls that happen to have keyboard focus in the same window.
+        private static func isScrollViewKeyboardTarget(in window: NSWindow?, scrollView: NSScrollView) -> Bool {
             guard let window = window else { return false }
             let fr = window.firstResponder
-            return fr is NSTextView
+            guard let frView = fr as? NSView else { return false }
+            return frView === scrollView || frView.isDescendant(of: scrollView)
         }
 
         deinit {
@@ -210,6 +212,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     /// jump-to-bottom affordance should be shown.
     @State private var hasActivityBelow = false
 
+    // MARK: - Conversation Identity
+
+    /// The first message ID of the conversation this view is currently tracking.
+    /// Used to detect conversation switches so session-scoped @State can be reset.
+    @State private var trackedConversationId: String?
+
     var body: some View {
         ScrollViewReader { proxy in
             ZStack(alignment: .bottom) {
@@ -279,6 +287,25 @@ struct ChatMessagesView<WelcomeContent: View>: View {
             } else {
                 // Load finished — restore prepend anchor if user hasn't scrolled
                 restorePrependAnchor(proxy: proxy)
+            }
+        }
+        // MARK: - Reset session state on conversation switch
+        .onChange(of: messages.first?.id) { oldId, newId in
+            // When the first message ID changes, the user switched to a
+            // different conversation (or a new one was loaded). Reset all
+            // session-scoped @State so stale tracking doesn't leak across.
+            guard newId != trackedConversationId, newId != nil else { return }
+            trackedConversationId = newId
+            if oldId != nil {
+                // Reset conversation-scoped state. Only do this on an actual
+                // switch (oldId != nil), not the initial population.
+                initialRestoreHandled = false
+                lastSeenSendGeneration = localSendToken?.generation ?? 0
+                prependAnchorId = nil
+                hasActivityBelow = false
+                scrollMode = .followingBottom
+                userIsScrolling = false
+                isUserAtBottom = true
             }
         }
         .onAppear {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// and fires a callback immediately — before the scroll position settles.
 /// This wins the race against throttled programmatic scrolls during streaming.
 private struct UserScrollDetector: NSViewRepresentable {
-    let onUserScrollUp: () -> Void
+    let onUserScroll: () -> Void
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
@@ -17,15 +17,15 @@ private struct UserScrollDetector: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onUserScrollUp: onUserScrollUp)
+        Coordinator(onUserScroll: onUserScroll)
     }
 
     class Coordinator: NSObject {
-        let onUserScrollUp: () -> Void
+        let onUserScroll: () -> Void
         private var monitor: Any?
 
-        init(onUserScrollUp: @escaping () -> Void) {
-            self.onUserScrollUp = onUserScrollUp
+        init(onUserScroll: @escaping () -> Void) {
+            self.onUserScroll = onUserScroll
         }
 
         func install(for view: NSView) {
@@ -41,7 +41,7 @@ private struct UserScrollDetector: NSViewRepresentable {
             }
             let targetScrollView = scrollView
 
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+            monitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .leftMouseDown, .leftMouseDragged]) { [weak self] event in
                 guard let self = self, let targetScrollView = targetScrollView else { return event }
                 // Only respond to events in our scroll view's window
                 guard event.window == targetScrollView.window else { return event }
@@ -49,9 +49,13 @@ private struct UserScrollDetector: NSViewRepresentable {
                 let locationInWindow = event.locationInWindow
                 let locationInScrollView = targetScrollView.convert(locationInWindow, from: nil)
                 guard targetScrollView.bounds.contains(locationInScrollView) else { return event }
-                // deltaY > 0 means scrolling up (towards earlier content)
-                if event.scrollingDeltaY > 0 {
-                    self.onUserScrollUp()
+                // Any physical wheel/trackpad scroll or mouse drag/click inside the transcript is reader intent.
+                if event.type == .scrollWheel {
+                    if event.scrollingDeltaY != 0 || event.scrollingDeltaX != 0 {
+                        self.onUserScroll()
+                    }
+                } else {
+                    self.onUserScroll()
                 }
                 return event
             }
@@ -63,6 +67,14 @@ private struct UserScrollDetector: NSViewRepresentable {
             }
         }
     }
+}
+
+/// Explicit scroll intent model for streaming follow behavior.
+/// `followingBottom` = the reader is at the live edge; streamed chunks may auto-scroll.
+/// `freeScrolling`  = the reader intentionally scrolled away; viewport must not move.
+private enum ChatScrollMode: Equatable {
+    case followingBottom
+    case freeScrolling
 }
 
 /// Reusable chat messages scroll view extracted from ChatPage.
@@ -100,17 +112,9 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     }
 
     @State private var isUserAtBottom = true
-    /// Tracks whether we should follow new content (survives the race between
-    /// content growth and scroll position detection). Only set to false when
-    /// the user actively scrolls up (not when content grows past the viewport).
-    @State private var shouldFollowContent = true
-    /// True while a programmatic scroll is in-flight, so we can distinguish
-    /// user-initiated scrolls from our own.
-    @State private var isProgrammaticScroll = false
-    /// True for ~1s after the view appears, suppressing shouldFollowContent=false
-    /// during the LazyVStack/Markdown layout settling period. Without this guard,
-    /// content height changes from lazy rendering are misinterpreted as user scrolling.
-    @State private var isSettlingAfterAppear = false
+    /// Source of truth for scroll intent. Geometry/layout changes alone must NOT
+    /// switch this to `.freeScrolling` — only physical wheel/trackpad user scroll.
+    @State private var scrollMode: ChatScrollMode = .followingBottom
     /// Throttle token for scrollToBottom — prevents the streaming + scroll
     /// detection feedback loop from saturating the main thread.
     @State private var scrollThrottleWorkItem: DispatchWorkItem?
@@ -119,6 +123,9 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     /// throttled programmatic scrolls during streaming.
     @State private var userIsScrolling = false
     @State private var userScrollEndWorkItem: DispatchWorkItem?
+    /// Tracks work items for delayed initial bottom scrolls so they can be
+    /// canceled on user scroll or disappear.
+    @State private var initialScrollWorkItems: [DispatchWorkItem] = []
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -153,44 +160,72 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         }
         .onChange(of: messages.count) { oldCount, newCount in
             if newCount > oldCount || oldCount == 0 {
-                if shouldFollowContent || oldCount == 0 {
+                if scrollMode == .followingBottom || oldCount == 0 {
                     scrollToBottom(proxy: proxy)
                     if oldCount == 0 {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            scrollToBottom(proxy: proxy)
-                        }
+                        scheduleInitialScroll(proxy: proxy, delay: 0.3)
                     }
                 }
             }
         }
         .onChange(of: messages.last?.text) { _, _ in
-            if shouldFollowContent {
+            if scrollMode == .followingBottom {
                 throttledScrollToBottom(proxy: proxy)
             }
         }
         .onChange(of: messages.last?.contentBlocks.count) { _, _ in
-            if shouldFollowContent {
+            if scrollMode == .followingBottom {
                 throttledScrollToBottom(proxy: proxy)
             }
         }
         .onChange(of: isSending) { oldValue, newValue in
-            if newValue && !oldValue && isUserAtBottom {
-                shouldFollowContent = true
+            if newValue && !oldValue {
+                cancelAllPendingScrolls()
+                userIsScrolling = false
+                scrollMode = .followingBottom
+                scrollToBottom(proxy: proxy)
             }
         }
         .onAppear {
-            isSettlingAfterAppear = true
-            scrollToBottom(proxy: proxy)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            if scrollMode == .followingBottom {
                 scrollToBottom(proxy: proxy)
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                scrollToBottom(proxy: proxy)
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                isSettlingAfterAppear = false
+                scheduleInitialScroll(proxy: proxy, delay: 0.3)
+                scheduleInitialScroll(proxy: proxy, delay: 0.7)
             }
         }
+        .onDisappear {
+            cancelAllPendingScrolls()
+        }
+    }
+
+    /// Schedules a delayed bottom scroll that is mode-aware and cancelable.
+    private func scheduleInitialScroll(proxy: ScrollViewProxy, delay: TimeInterval) {
+        var workItem: DispatchWorkItem?
+        workItem = DispatchWorkItem { [self] in
+            // Only fire if still following — user may have scrolled during settling
+            if scrollMode == .followingBottom {
+                scrollToBottom(proxy: proxy)
+            }
+            if let workItem {
+                initialScrollWorkItems.removeAll { $0 === workItem }
+            }
+        }
+        if let workItem {
+            initialScrollWorkItems.append(workItem)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
+    }
+
+    /// Cancels all pending scheduled scrolls (throttle, initial, user-scroll-end).
+    private func cancelAllPendingScrolls() {
+        scrollThrottleWorkItem?.cancel()
+        scrollThrottleWorkItem = nil
+        userScrollEndWorkItem?.cancel()
+        userScrollEndWorkItem = nil
+        for item in initialScrollWorkItems {
+            item.cancel()
+        }
+        initialScrollWorkItems.removeAll()
     }
 
     @ViewBuilder
@@ -291,19 +326,16 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         ZStack {
             ScrollPositionDetector { atBottom in
                 isUserAtBottom = atBottom
-                if atBottom {
-                    shouldFollowContent = true
-                } else if !isProgrammaticScroll && !isSettlingAfterAppear {
-                    shouldFollowContent = false
-                }
+                // atBottom == false alone must NOT switch to freeScrolling.
+                // Geometry/layout changes (content growth, markdown layout,
+                // LazyVStack realization, citations, window resize) can make
+                // the viewport not-at-bottom without user intent.
+                // Only atBottom == true updates isUserAtBottom tracking.
             }
             UserScrollDetector {
-                guard !isSettlingAfterAppear else { return }
-                shouldFollowContent = false
+                scrollMode = .freeScrolling
                 userIsScrolling = true
-                scrollThrottleWorkItem?.cancel()
-                scrollThrottleWorkItem = nil
-                userScrollEndWorkItem?.cancel()
+                cancelAllPendingScrolls()
                 let endWork = DispatchWorkItem {
                     userIsScrolling = false
                 }
@@ -315,14 +347,16 @@ struct ChatMessagesView<WelcomeContent: View>: View {
 
     @ViewBuilder
     private func scrollToBottomButton(proxy: ScrollViewProxy) -> some View {
-        if !shouldFollowContent && !messages.isEmpty {
+        if scrollMode == .freeScrolling && !messages.isEmpty {
             Button {
-                shouldFollowContent = true
+                cancelAllPendingScrolls()
+                userIsScrolling = false
+                scrollMode = .followingBottom
                 scrollToBottom(proxy: proxy)
             } label: {
                 Image(systemName: "arrow.down.circle.fill")
                     .scaledFont(size: 32)
-                    .foregroundColor(OmiColors.purplePrimary)
+                    .foregroundColor(OmiColors.textSecondary)
                     .background(
                         Circle()
                             .fill(OmiColors.backgroundPrimary)
@@ -331,22 +365,19 @@ struct ChatMessagesView<WelcomeContent: View>: View {
                     .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Jump to latest message")
             .padding(.bottom, 16)
             .transition(.scale.combined(with: .opacity))
-            .animation(.easeInOut(duration: 0.2), value: shouldFollowContent)
+            .animation(.easeInOut(duration: 0.2), value: scrollMode)
         }
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {
-        // Don't fight the user — skip if they're actively scrolling up
+        guard scrollMode == .followingBottom else { return }
+        // Don't fight the user — skip if they're actively wheel/trackpad scrolling
         guard !userIsScrolling else { return }
         guard !messages.isEmpty else { return }
-        isProgrammaticScroll = true
         proxy.scrollTo("bottom-anchor", anchor: .bottom)
-        // Reset after a short delay to allow the scroll to settle
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            isProgrammaticScroll = false
-        }
     }
 
     /// Throttled version of scrollToBottom — coalesces rapid calls (e.g. during

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -41,7 +41,7 @@ private struct UserScrollDetector: NSViewRepresentable {
             }
             let targetScrollView = scrollView
 
-            monitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .leftMouseDown, .leftMouseDragged]) { [weak self] event in
+            monitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .leftMouseDragged]) { [weak self] event in
                 guard let self = self, let targetScrollView = targetScrollView else { return event }
                 // Only respond to events in our scroll view's window
                 guard event.window == targetScrollView.window else { return event }
@@ -49,12 +49,17 @@ private struct UserScrollDetector: NSViewRepresentable {
                 let locationInWindow = event.locationInWindow
                 let locationInScrollView = targetScrollView.convert(locationInWindow, from: nil)
                 guard targetScrollView.bounds.contains(locationInScrollView) else { return event }
-                // Any physical wheel/trackpad scroll or mouse drag/click inside the transcript is reader intent.
                 if event.type == .scrollWheel {
-                    if event.scrollingDeltaY != 0 || event.scrollingDeltaX != 0 {
+                    // deltaY > 0 means scrolling up (towards earlier content, away from
+                    // the live edge). Only that direction is reader intent to leave the
+                    // bottom; a downward nudge at the live edge is a no-op and must not
+                    // release following. Plain clicks (.leftMouseDown) are excluded
+                    // entirely so idle clicks don't kill following.
+                    if event.scrollingDeltaY > 0 {
                         self.onUserScroll()
                     }
                 } else {
+                    // Mouse drag inside the transcript is reader intent.
                     self.onUserScroll()
                 }
                 return event
@@ -161,6 +166,14 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         .onChange(of: messages.count) { oldCount, newCount in
             if newCount > oldCount || oldCount == 0 {
                 if scrollMode == .followingBottom || oldCount == 0 {
+                    // oldCount == 0 means the first real messages just arrived
+                    // (history load). A stray wheel/click may have flipped
+                    // scrollMode to .freeScrolling before this fired; force the
+                    // viewport back to the live edge so the initial load lands
+                    // at the latest message, not at the top.
+                    if oldCount == 0 && scrollMode != .followingBottom {
+                        scrollMode = .followingBottom
+                    }
                     scrollToBottom(proxy: proxy)
                     if oldCount == 0 {
                         scheduleInitialScroll(proxy: proxy, delay: 0.3)
@@ -326,11 +339,16 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         ZStack {
             ScrollPositionDetector { atBottom in
                 isUserAtBottom = atBottom
-                // atBottom == false alone must NOT switch to freeScrolling.
-                // Geometry/layout changes (content growth, markdown layout,
-                // LazyVStack realization, citations, window resize) can make
-                // the viewport not-at-bottom without user intent.
-                // Only atBottom == true updates isUserAtBottom tracking.
+                // Resume live following when the reader scrolls back to the
+                // live edge. atBottom == true is unambiguous intent to follow
+                // again; only atBottom == false is ambiguous (it can be a
+                // geometry/layout change, not user intent) and must NOT switch
+                // to .freeScrolling on its own.
+                if atBottom && scrollMode == .freeScrolling {
+                    cancelAllPendingScrolls()
+                    userIsScrolling = false
+                    scrollMode = .followingBottom
+                }
             }
             UserScrollDetector {
                 scrollMode = .freeScrolling

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
@@ -47,6 +47,7 @@ struct TaskChatPanel: View {
                     app: nil,
                     onLoadMore: { },
                     onRate: { _, _ in },
+                    localSendToken: taskState.localSendToken,
                     welcomeContent: { taskWelcome }
                 )
                 .frame(maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -480,6 +480,7 @@ struct ChatPage: View {
       },
       sessionsLoadError: chatProvider.sessionsLoadError,
       onRetry: { Task { await chatProvider.retryLoad() } },
+      localSendToken: chatProvider.localSendToken,
       welcomeContent: { welcomeMessage }
     )
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -349,6 +349,7 @@ struct DashboardPage: View {
                 },
                 sessionsLoadError: chatProvider.sessionsLoadError,
                 onRetry: { Task { await chatProvider.retryLoad() } },
+                localSendToken: chatProvider.localSendToken,
                 welcomeContent: { dashboardChatWelcome }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -15,6 +15,9 @@ class TaskChatState: ObservableObject {
     @Published var draftText = ""
     @Published var errorMessage: String?
     @Published var chatMode: ChatMode = .act
+    /// Monotonic token that increments each time the local user sends a message
+    /// in this task chat. ChatMessagesView observes this for turn anchoring.
+    @Published var localSendToken: LocalSendToken = LocalSendToken(generation: 0)
 
     /// Own bridge process — completely independent from sidebar chat
     private var agentBridge: AgentBridge?
@@ -170,6 +173,8 @@ class TaskChatState: ObservableObject {
         isSending = true
         errorMessage = nil
         TaskAgentStatusRegistry.shared.markRunning(taskId: taskId)
+        // Signal local send for turn anchoring.
+        localSendToken = LocalSendToken(generation: localSendToken.generation + 1)
 
         // Add user message to local messages and persist
         // Skip for follow-ups — sendFollowUp() already added and persisted it

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -521,6 +521,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @Published var isStopping = false
     @Published var isClearing = false
     @Published var errorMessage: String?
+    /// Monotonic token that increments each time the local user sends a message.
+    /// ChatMessagesView observes this to anchor the viewport on send, rather than
+    /// inferring solely from messages.count changes (which can also come from
+    /// polling/sync).
+    @Published var localSendToken: LocalSendToken = LocalSendToken(generation: 0)
 
     // MARK: - ChatErrorState (structured replacement for the inline error banner)
     //
@@ -2490,6 +2495,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             sender: .user
         )
         messages.append(userMessage)
+        // Signal local send for turn anchoring.
+        localSendToken = LocalSendToken(generation: localSendToken.generation + 1)
 
         // Persist to backend and sync server ID back to prevent poll duplicates.
         //
@@ -2950,6 +2957,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 attachments: attachmentsForMessage
             )
             messages.append(userMessage)
+            // Signal to ChatMessagesView after the local user row exists so
+            // it anchors the new turn, not the previous one.
+            localSendToken = LocalSendToken(generation: sendGeneration)
 
             // Track onboarding user messages with full content
             if isOnboarding {

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -139,8 +139,10 @@ export function Home(): React.JSX.Element {
       // A downward wheel at the bottom is a no-op; don't release.
       const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
       if (distFromBottom <= 8) {
-        // At/near bottom — only release on explicit upward wheel intent
-        if (e && 'deltaY' in e && e.deltaY < 0) {
+        // At/near bottom — only release on explicit upward wheel intent, and
+        // only if the thread actually overflows (short threads can't scroll
+        // away, so an upward wheel is a no-op that shouldn't release following).
+        if (e && 'deltaY' in e && e.deltaY < 0 && el.scrollHeight > el.clientHeight + 8) {
           releaseFollowing()
         }
         return

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -125,6 +125,18 @@ export function Home(): React.JSX.Element {
     setScrollMode('freeScrolling')
   }, [cancelPendingScroll, setScrollMode])
 
+  // Release following only when the reader actually scrolls AWAY from the live
+  // edge. A downward wheel at the bottom (no movement) must NOT release, and
+  // plain mouse clicks must NOT release (they are not scroll intent). This
+  // avoids breaking live-follow on no-op input. Used for onWheel/onTouchMove.
+  const releaseFollowingIfScrolledAway = useCallback((): void => {
+    const el = chatScrollRef.current
+    if (!el) return
+    // If we're still at/near the bottom, this wheel/touch is a no-op; don't release.
+    if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) return
+    releaseFollowing()
+  }, [releaseFollowing])
+
   // Windowed history rendering: an infinite thread can hold thousands of
   // messages, so we only render the last `visibleCount` and reveal older ones a
   // page at a time as the user scrolls to the top. This keeps the DOM small
@@ -246,6 +258,12 @@ export function Home(): React.JSX.Element {
     const el = chatScrollRef.current
     if (!el) return
     setOverflowing(el.scrollHeight > el.clientHeight + 4)
+    // Resume live following when the reader scrolls back to the live edge.
+    if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) {
+      if (scrollModeRef.current !== 'followingBottom') {
+        setScrollMode('followingBottom')
+      }
+    }
     if (el.scrollTop < 80 && visibleCount < chat.history.length) {
       restoreFromBottom.current = el.scrollHeight - el.scrollTop
       setVisibleCount((n) => Math.min(n + PAGE_SIZE, chat.history.length))
@@ -299,79 +317,83 @@ export function Home(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Middle: the thread (active) or the greeting (idle). */}
-      <div
-        ref={chatScrollRef}
-        onScroll={onThreadScroll}
-        onWheel={releaseFollowing}
-        onTouchMove={releaseFollowing}
-        onMouseDown={releaseFollowing}
-        className="relative min-h-0 overflow-y-auto"
-        style={{ WebkitMaskImage: mask, maskImage: mask }}
-      >
-        <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col">
-          <div className="mt-auto space-y-2 pb-2">
-            {started && showThread ? (
-              windowed.map((m, i) => {
-                const isUser = m.role === 'user'
-                const isLast = i === windowed.length - 1
-                return (
-                  <div
-                    key={m.id ?? `${windowStart}-${i}`}
-                    className={cn('flex items-end gap-2.5', isUser && 'flex-row-reverse')}
-                  >
-                    {isUser ? (
-                      <div className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full border border-white/10">
-                        <img
-                          src={photoURL ?? ''}
-                          alt=""
-                          className={cn(
-                            'h-full w-full object-cover',
-                            photoURL ? 'block' : 'hidden'
-                          )}
-                          referrerPolicy="no-referrer"
-                          onError={(e) => {
-                            const el = e.currentTarget
-                            el.classList.add('hidden')
-                            el.nextElementSibling?.classList.remove('hidden')
-                          }}
-                        />
-                        <div
-                          className={cn(
-                            'flex h-full w-full items-center justify-center bg-white/10 text-[11px] font-semibold text-white',
-                            photoURL ? 'hidden' : ''
-                          )}
-                        >
-                          {initial}
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white">
-                        <img src={omiMark} alt="Omi" className="h-4 w-4 object-contain" />
-                      </div>
-                    )}
+      {/* Middle: the thread (active) or the greeting (idle). The scroller is
+          wrapped in a relative container so the Latest overlay is a sibling of
+          the scroller — an absolute child of a scrolled element moves with the
+          scrollable content and can scroll out of the visible viewport. */}
+      <div className="relative min-h-0">
+        <div
+          ref={chatScrollRef}
+          onScroll={onThreadScroll}
+          onWheel={releaseFollowingIfScrolledAway}
+          onTouchMove={releaseFollowingIfScrolledAway}
+          className="h-full overflow-y-auto"
+          style={{ WebkitMaskImage: mask, maskImage: mask }}
+        >
+          <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col">
+            <div className="mt-auto space-y-2 pb-2">
+              {started && showThread ? (
+                windowed.map((m, i) => {
+                  const isUser = m.role === 'user'
+                  const isLast = i === windowed.length - 1
+                  return (
                     <div
-                      className={cn(
-                        'bubble-in w-fit max-w-[80%] rounded-2xl px-3.5 py-2 text-sm leading-snug',
-                        isUser
-                          ? 'rounded-br-md bg-[color:var(--accent)] text-right text-white'
-                          : 'rounded-bl-md bg-white/[0.06] text-left text-white/80'
-                      )}
+                      key={m.id ?? `${windowStart}-${i}`}
+                      className={cn('flex items-end gap-2.5', isUser && 'flex-row-reverse')}
                     >
                       {isUser ? (
-                        <div className="whitespace-pre-wrap">{m.content}</div>
+                        <div className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full border border-white/10">
+                          <img
+                            src={photoURL ?? ''}
+                            alt=""
+                            className={cn(
+                              'h-full w-full object-cover',
+                              photoURL ? 'block' : 'hidden'
+                            )}
+                            referrerPolicy="no-referrer"
+                            onError={(e) => {
+                              const el = e.currentTarget
+                              el.classList.add('hidden')
+                              el.nextElementSibling?.classList.remove('hidden')
+                            }}
+                          />
+                          <div
+                            className={cn(
+                              'flex h-full w-full items-center justify-center bg-white/10 text-[11px] font-semibold text-white',
+                              photoURL ? 'hidden' : ''
+                            )}
+                          >
+                            {initial}
+                          </div>
+                        </div>
                       ) : (
-                        <Markdown text={m.content || (chat.sending && isLast ? '…' : '')} />
+                        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white">
+                          <img src={omiMark} alt="Omi" className="h-4 w-4 object-contain" />
+                        </div>
                       )}
+                      <div
+                        className={cn(
+                          'bubble-in w-fit max-w-[80%] rounded-2xl px-3.5 py-2 text-sm leading-snug',
+                          isUser
+                            ? 'rounded-br-md bg-[color:var(--accent)] text-right text-white'
+                            : 'rounded-bl-md bg-white/[0.06] text-left text-white/80'
+                        )}
+                      >
+                        {isUser ? (
+                          <div className="whitespace-pre-wrap">{m.content}</div>
+                        ) : (
+                          <Markdown text={m.content || (chat.sending && isLast ? '…' : '')} />
+                        )}
+                      </div>
                     </div>
-                  </div>
-                )
-              })
-            ) : !started ? (
-              <h1 className="fade-in-slow pb-2 text-center font-display text-4xl font-semibold tracking-tight text-white">
-                Hi, {firstName(user)}
-              </h1>
-            ) : null}
+                  )
+                })
+              ) : !started ? (
+                <h1 className="fade-in-slow pb-2 text-center font-display text-4xl font-semibold tracking-tight text-white">
+                  Hi, {firstName(user)}
+                </h1>
+              ) : null}
+            </div>
           </div>
         </div>
         {scrollMode === 'freeScrolling' && started ? (

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -129,13 +129,26 @@ export function Home(): React.JSX.Element {
   // edge. A downward wheel at the bottom (no movement) must NOT release, and
   // plain mouse clicks must NOT release (they are not scroll intent). This
   // avoids breaking live-follow on no-op input. Used for onWheel/onTouchMove.
-  const releaseFollowingIfScrolledAway = useCallback((): void => {
-    const el = chatScrollRef.current
-    if (!el) return
-    // If we're still at/near the bottom, this wheel/touch is a no-op; don't release.
-    if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) return
-    releaseFollowing()
-  }, [releaseFollowing])
+  const releaseFollowingIfScrolledAway = useCallback(
+    (e?: React.WheelEvent | WheelEvent): void => {
+      const el = chatScrollRef.current
+      if (!el) return
+      // If we're still at/near the bottom, check wheel direction: an upward
+      // wheel (deltaY < 0) is reader intent to leave the live edge and should
+      // release following even though the browser hasn't applied the delta yet.
+      // A downward wheel at the bottom is a no-op; don't release.
+      const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      if (distFromBottom <= 8) {
+        // At/near bottom — only release on explicit upward wheel intent
+        if (e && 'deltaY' in e && e.deltaY < 0) {
+          releaseFollowing()
+        }
+        return
+      }
+      releaseFollowing()
+    },
+    [releaseFollowing]
+  )
 
   // Windowed history rendering: an infinite thread can hold thousands of
   // messages, so we only render the last `visibleCount` and reveal older ones a
@@ -325,8 +338,8 @@ export function Home(): React.JSX.Element {
         <div
           ref={chatScrollRef}
           onScroll={onThreadScroll}
-          onWheel={releaseFollowingIfScrolledAway}
-          onTouchMove={releaseFollowingIfScrolledAway}
+          onWheel={(e) => releaseFollowingIfScrolledAway(e)}
+          onTouchMove={() => releaseFollowingIfScrolledAway()}
           className="h-full overflow-y-auto"
           style={{ WebkitMaskImage: mask, maskImage: mask }}
         >

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -273,11 +273,20 @@ export function Home(): React.JSX.Element {
     const el = chatScrollRef.current
     if (!el) return
     setOverflowing(el.scrollHeight > el.clientHeight + 4)
-    // Resume live following when the reader scrolls back to the live edge.
-    if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) {
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (distFromBottom <= 8) {
+      // Resume live following when the reader scrolls back to the live edge.
       if (scrollModeRef.current !== 'followingBottom') {
         setScrollMode('followingBottom')
       }
+    } else if (
+      scrollModeRef.current === 'followingBottom' &&
+      !isProgrammaticScrollRef.current
+    ) {
+      // Release following when the viewport moves away from the live edge via
+      // a non-programmatic scroll (scrollbar thumb drag, keyboard arrows, etc).
+      // onWheel/onTouchMove already cover wheel/touch; this covers the rest.
+      setScrollMode('freeScrolling')
     }
     if (el.scrollTop < 80 && visibleCount < chat.history.length) {
       restoreFromBottom.current = el.scrollHeight - el.scrollTop

--- a/desktop/windows/src/renderer/src/pages/Home.tsx
+++ b/desktop/windows/src/renderer/src/pages/Home.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Send } from 'lucide-react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { ArrowDown, Send } from 'lucide-react'
 import type { User } from 'firebase/auth'
 import { auth, onAuthStateChanged } from '../lib/firebase'
 import { useAppState } from '../state/AppStateProvider'
@@ -23,6 +23,7 @@ function firstName(u: User | null): string {
 // Bubbles dissolve across the top ~190px of the thread (only once it overflows),
 // so they fade out before reaching the widgets above.
 const FADE_MASK = 'linear-gradient(to bottom, transparent 0px, #000 190px)'
+type ChatScrollMode = 'followingBottom' | 'freeScrolling'
 
 // 5 grid rows: [topSpacer][widgets][middle][bar][bottomSpacer]. Only the
 // SPACERS and the MIDDLE ever change, and they're all `fr` — the widgets and bar
@@ -70,6 +71,59 @@ export function Home(): React.JSX.Element {
   const chatScrollRef = useRef<HTMLDivElement>(null)
   const widgetsGridRef = useRef<HTMLDivElement>(null)
   const lastLenRef = useRef(0)
+  const [scrollMode, setScrollModeState] = useState<ChatScrollMode>('followingBottom')
+  const scrollModeRef = useRef<ChatScrollMode>('followingBottom')
+  const isProgrammaticScrollRef = useRef(false)
+  const pendingScrollFrameRef = useRef<number | null>(null)
+
+  const setScrollMode = useCallback((mode: ChatScrollMode): void => {
+    scrollModeRef.current = mode
+    setScrollModeState(mode)
+  }, [])
+
+  const cancelPendingScroll = useCallback((): void => {
+    if (pendingScrollFrameRef.current == null) return
+    window.cancelAnimationFrame(pendingScrollFrameRef.current)
+    pendingScrollFrameRef.current = null
+  }, [])
+
+  const scrollToLatest = useCallback(
+    (opts: { smooth?: boolean; force?: boolean } = {}): void => {
+      const { smooth = false, force = false } = opts
+      const el = chatScrollRef.current
+      if (!el) return
+      if (!force && scrollModeRef.current !== 'followingBottom') return
+
+      cancelPendingScroll()
+      pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+        pendingScrollFrameRef.current = null
+        const currentEl = chatScrollRef.current
+        if (!currentEl) return
+        if (!force && scrollModeRef.current !== 'followingBottom') return
+        isProgrammaticScrollRef.current = true
+        currentEl.style.scrollBehavior = smooth ? 'smooth' : 'auto'
+        currentEl.scrollTop = currentEl.scrollHeight
+        window.requestAnimationFrame(() => {
+          isProgrammaticScrollRef.current = false
+        })
+      })
+    },
+    [cancelPendingScroll]
+  )
+
+  const resumeFollowing = useCallback(
+    (smooth = true): void => {
+      setScrollMode('followingBottom')
+      scrollToLatest({ smooth, force: true })
+    },
+    [scrollToLatest, setScrollMode]
+  )
+
+  const releaseFollowing = useCallback((): void => {
+    cancelPendingScroll()
+    isProgrammaticScrollRef.current = false
+    setScrollMode('freeScrolling')
+  }, [cancelPendingScroll, setScrollMode])
 
   // Windowed history rendering: an infinite thread can hold thousands of
   // messages, so we only render the last `visibleCount` and reveal older ones a
@@ -81,12 +135,6 @@ export function Home(): React.JSX.Element {
   const PAGE_SIZE = 30
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
   const restoreFromBottom = useRef<number | null>(null)
-  // Whether the view is currently near the bottom. Used to decide if a streaming
-  // reply / cross-window update should keep the view pinned to the bottom, or
-  // leave it put because the user has scrolled up to read older history. Starts
-  // true so the initial load lands at the bottom.
-  const nearBottomRef = useRef(true)
-
   // Measured natural height of the widgets grid. The widget row animates its
   // height from 0 → this once BOTH widgets' data is ready, so they appear
   // together and slide the chat smoothly — no per-widget pop-in / reshuffle.
@@ -118,10 +166,13 @@ export function Home(): React.JSX.Element {
     const text = input
     if (!text.trim() || chat.sending) return
     setInput('')
+    resumeFollowing(true)
     void chat.send(text)
   }
 
   useEffect(() => onAuthStateChanged(auth, (u) => setUser(u)), [])
+
+  useEffect(() => () => cancelPendingScroll(), [cancelPendingScroll])
 
   // Lazily (re)build the local knowledge graph in the background — deferred past
   // the entrance animations so its DB/synthesis work can't stall them.
@@ -172,42 +223,28 @@ export function Home(): React.JSX.Element {
     }
   }, [started])
 
-  // Pin the thread to the bottom. Smooth-scroll on a NEW message (so existing
-  // bubbles glide up to make room); instant while a reply streams in.
-  // `showThread` is a dep so that on app startup — where infinite-mode history
-  // loads async and the thread only mounts after the split animation (showThread
-  // flips ~1150ms later) — this fires once the bubbles actually render and lands
-  // the view at the bottom instead of the top.
-  // `widgetsReady`/`widgetsH` are deps because the Tasks/Goals row pops from
-  // height 0 → full height instantly when both load (often a beat after the chat
-  // first paints), which shrinks the thread viewport from the top and would
-  // otherwise leave the view scrolled up. Re-pin (only if the reader is near the
-  // bottom) so the latest message stays in view when the widgets land.
+  // Follow live output only while the reader is following the live edge.
+  // Physical wheel/touch scroll releases following; geometry/layout changes
+  // (stream growth, widget height, Markdown rendering) do not count as intent.
   useEffect(() => {
     const el = chatScrollRef.current
     if (!el) return
-    const isNewMessage = chat.history.length !== lastLenRef.current
+    const previousLen = lastLenRef.current
+    const isNewMessage = chat.history.length !== previousLen
+    const isInitialReveal = previousLen === 0 && chat.history.length > 0
     lastLenRef.current = chat.history.length
-    // Pin to the bottom on a new message or the first reveal, but while a reply
-    // streams in (content grows without the count changing) only keep pinning if
-    // the user is already near the bottom — otherwise leave them where they
-    // scrolled to read older history instead of yanking them down.
-    if (isNewMessage || nearBottomRef.current) {
-      el.style.scrollBehavior = isNewMessage ? 'smooth' : 'auto'
-      el.scrollTop = el.scrollHeight
-      nearBottomRef.current = true
+
+    if (isInitialReveal || scrollModeRef.current === 'followingBottom') {
+      scrollToLatest({ smooth: isNewMessage && !isInitialReveal })
     }
     setOverflowing(el.scrollHeight > el.clientHeight + 4)
-  }, [chat.history, chat.sending, showThread, widgetsReady, widgetsH])
+  }, [chat.history, chat.sending, showThread, scrollToLatest, widgetsReady, widgetsH])
 
   // Reveal an older page when the user scrolls near the top, capturing the
   // current distance-from-bottom so the view can be pinned in place afterward.
   const onThreadScroll = (): void => {
     const el = chatScrollRef.current
     if (!el) return
-    // Track whether we're near the bottom so the pin effect knows whether a
-    // streaming reply should keep following or leave the reader in place.
-    nearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 120
     setOverflowing(el.scrollHeight > el.clientHeight + 4)
     if (el.scrollTop < 80 && visibleCount < chat.history.length) {
       restoreFromBottom.current = el.scrollHeight - el.scrollTop
@@ -266,7 +303,10 @@ export function Home(): React.JSX.Element {
       <div
         ref={chatScrollRef}
         onScroll={onThreadScroll}
-        className="min-h-0 overflow-y-auto"
+        onWheel={releaseFollowing}
+        onTouchMove={releaseFollowing}
+        onMouseDown={releaseFollowing}
+        className="relative min-h-0 overflow-y-auto"
         style={{ WebkitMaskImage: mask, maskImage: mask }}
       >
         <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col">
@@ -285,7 +325,10 @@ export function Home(): React.JSX.Element {
                         <img
                           src={photoURL ?? ''}
                           alt=""
-                          className={cn('h-full w-full object-cover', photoURL ? 'block' : 'hidden')}
+                          className={cn(
+                            'h-full w-full object-cover',
+                            photoURL ? 'block' : 'hidden'
+                          )}
                           referrerPolicy="no-referrer"
                           onError={(e) => {
                             const el = e.currentTarget
@@ -318,9 +361,7 @@ export function Home(): React.JSX.Element {
                       {isUser ? (
                         <div className="whitespace-pre-wrap">{m.content}</div>
                       ) : (
-                        <Markdown
-                          text={m.content || (chat.sending && isLast ? '…' : '')}
-                        />
+                        <Markdown text={m.content || (chat.sending && isLast ? '…' : '')} />
                       )}
                     </div>
                   </div>
@@ -333,6 +374,17 @@ export function Home(): React.JSX.Element {
             ) : null}
           </div>
         </div>
+        {scrollMode === 'freeScrolling' && started ? (
+          <button
+            type="button"
+            aria-label="Jump to latest message"
+            onClick={() => resumeFollowing(true)}
+            className="absolute bottom-4 left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-white/15 bg-white/10 px-3 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-white/15"
+          >
+            <ArrowDown className="h-4 w-4" />
+            Latest
+          </button>
+        ) : null}
       </div>
 
       {/* Chat bar — rides to the bottom via the spacer collapse. */}


### PR DESCRIPTION
## Summary
- Focus the shadcn/ui `MessageScroller` adaptation on macOS desktop chat UX
- Add intent-aware chat scrolling so streamed replies follow only while the reader is following the live edge
- Keep the already-added Flutter mobile and Windows/Electron guard work in this branch, but treat those as early platform coverage, not parity scope

## Scope
This PR should be reviewed as a macOS desktop chat improvement PR. The target component is `ChatMessagesView.swift`, used by the main chat and task chat surfaces.

The intended macOS scope is the full chat-scroll ticket set for this PR: reader intent preservation during streaming, local-turn anchoring, activity-below handling, approximate prepend preservation, and saved-conversation restore at a meaningful user turn where feasible.

Flutter mobile and Windows/Electron changes may remain in the branch, but they are not the parity target for this PR. We will bring those clients up to the same macOS behavior later.

## Test Plan
- [x] GitHub `Lint & Format Check` passed before the scope correction
- [x] Prior focused checks covered `git diff --check`, macOS Swift parse, Flutter format, Windows Prettier, and static scroll-intent invariants
- [ ] Re-run focused macOS verification after the remaining macOS ticket work is implemented

## Verification limitations
- Full Flutter analysis/build was not run locally because `flutter` is not installed on the host; formatting was verified against a Flutter Linux container matching CI behavior.
- Windows/Electron typecheck could not run locally because `node_modules` is absent and the checked-in pnpm lock is currently out of sync with `package.json`; focused Prettier and static review were run instead.
- Full Xcode build was not run because local `xcodebuild -list` is blocked by the machine's Xcode plugin load failure (`IDESimulatorFoundation` / `DVTDownloads` symbol mismatch); focused Swift parse succeeded.
