### PR TITLE
feat remove conversations section from home screen

### DIFF
--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -294,7 +294,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
   }
 
   Widget _buildDailyRecapsPreview(BuildContext context) {
-    final cardHeight = 130.0;
+    const cardHeight = 130.0;
     if (_loadingSummaries) {
       return Padding(
         padding: const EdgeInsets.only(top: 12),
@@ -486,7 +486,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(24),
-          child: SizedBox(
+          child: const SizedBox(
             height: 180,
             child: IgnorePointer(
               child: MemoryGraphPage(

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -7,10 +7,8 @@ import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/http/api/users.dart';
-import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/daily_summary.dart';
 import 'package:omi/pages/conversation_capturing/page.dart';
-import 'package:omi/pages/conversations/widgets/conversation_list_item.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
 import 'package:omi/pages/conversations/widgets/today_tasks_widget.dart';
 import 'package:omi/pages/memories/widgets/memory_graph_page.dart';
@@ -114,21 +112,6 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
               // big "get started" options so the home page doesn't feel
               // empty for new users.
               if (_nonDiscardedConversationCount(convoProvider) >= 3) ...[
-                SliverToBoxAdapter(
-                  child: _buildSectionHeader(
-                    context,
-                    context.l10n.conversations,
-                    onViewAll: () {
-                      // Reset the daily-summaries flag so the conversations tab
-                      // actually shows conversations (it persists from Daily
-                      // Recaps' View All otherwise).
-                      if (convoProvider.showDailySummaries) convoProvider.toggleDailySummaries();
-                      context.read<HomeProvider>().setIndex(1);
-                    },
-                  ),
-                ),
-                _buildConversationsPreview(convoProvider),
-
                 // Mind Map section — only shown for users with enough activity.
                 SliverToBoxAdapter(
                   child: _buildSectionHeader(
@@ -519,59 +502,6 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
           ),
         ),
       ),
-    );
-  }
-
-  Widget _buildConversationsPreview(ConversationProvider convoProvider) {
-    if (convoProvider.isLoadingConversations && convoProvider.conversations.isEmpty) {
-      return SliverToBoxAdapter(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Column(
-            children: List.generate(
-              2,
-              (_) => Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: ShimmerWithTimeout(
-                  baseColor: AppStyles.backgroundSecondary,
-                  highlightColor: AppStyles.backgroundTertiary,
-                  child: Container(
-                    height: 80,
-                    decoration: BoxDecoration(
-                      color: AppStyles.backgroundSecondary,
-                      borderRadius: BorderRadius.circular(24),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    // Use groupedConversations because it has the user's filters already applied
-    // (discarded / short / starred / date). conversations.take(3) ignores
-    // showDiscardedConversations and would show items that aren't on the
-    // conversations page.
-    final sortedDates = convoProvider.groupedConversations.keys.toList()..sort((a, b) => b.compareTo(a));
-    final recent = <ServerConversation>[];
-    for (final date in sortedDates) {
-      final list = convoProvider.groupedConversations[date] ?? const [];
-      for (final c in list) {
-        recent.add(c);
-        if (recent.length >= 3) break;
-      }
-      if (recent.length >= 3) break;
-    }
-    if (recent.isEmpty) return const SliverToBoxAdapter(child: SizedBox.shrink());
-
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(childCount: recent.length, (context, index) {
-        final c = recent[index];
-        final dateKey = DateTime(c.createdAt.year, c.createdAt.month, c.createdAt.day);
-        return ConversationListItem(key: ValueKey(c.id), conversation: c, date: dateKey, conversationIdx: index);
-      }),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Remove the Conversations section (header + list preview) from the home screen
- Clean up unused imports (`conversation_list_item.dart`, `ServerConversation`, `conversation.dart`) and the now-dead `_buildConversationsPreview` method
- Fix `prefer_const_declarations` (`final cardHeight` → `const cardHeight`) and `prefer_const_constructors` (`SizedBox`/`IgnorePointer`/`MemoryGraphPage`) lint warnings

## Test plan
- [ ] Build and run the app — home screen should show Daily Recaps and Mind Map but no Conversations section
- [ ] Users with ≥ 3 conversations should see Mind Map directly after Daily Recaps
- [ ] New users (< 3 conversations) should still see the "get started" triangle options
- [ ] `dart analyze lib/pages/home/home_content.dart` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

