### PR TITLE
Fix Notch Mode PTT playback and subagent navigation

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed push-to-talk voice replies cutting off, restored Notch Mode chat row clicks, and aligned subagent back buttons with the chat row list"
+  ],
   "releases": [
     {
       "version": "0.11.545",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -169,7 +169,7 @@ struct FloatingControlBarView: View {
                         .allowsHitTesting(notchSwitcherProgress > 0.6)
 
                         notchAgentLogoHitTarget
-                            .frame(width: notchChromeLayoutWidth, height: FloatingControlBarWindow.notchChromeHeight + notchHoverMenuHeight)
+                            .frame(width: notchChromeLayoutWidth, height: FloatingControlBarWindow.notchChromeHeight)
                     }
                 }
                 .frame(width: notchChromeLayoutWidth, height: FloatingControlBarWindow.notchChromeHeight + notchHoverMenuHeight)
@@ -523,8 +523,8 @@ struct FloatingControlBarView: View {
                 AgentMainChatView(
                     pill: activeAgentChatPill,
                     manager: agentPills,
-                    onBackToOmi: {
-                        exitAgentSurface()
+                    onBackToAgentRows: {
+                        showAgentListFromConversation()
                     },
                     onEscape: onEscape,
                     onSpawnSibling: { siblingID in
@@ -633,21 +633,6 @@ struct FloatingControlBarView: View {
         state.agentSwitcherHovering = state.agentSwitcherPinned
     }
 
-    private func exitAgentSurface() {
-        state.leaveAgentSurface()
-        let barWindow = window as? FloatingControlBarWindow
-        // When backing out of an agent chat with no main Omi conversation,
-        // leaveAgentSurface() lands on .mainInput. The response-sizing helper
-        // would force at least response height and install a response-height
-        // observer, leaving an oversized blank input panel. Route to the input
-        // height path instead so the panel shrinks to the normal Ask Omi size.
-        if state.conversationSurface == .mainInput {
-            barWindow?.resizeForMainInputAfterAgentExit()
-        } else {
-            barWindow?.resizeForActiveAgentChatPublic(pillID: nil, animated: true)
-        }
-    }
-
     private func setNotchLogoHovering(_ hovering: Bool) {
         withAnimation(.spring(response: 0.18, dampingFraction: 0.74)) {
             notchLogoHovering = hovering
@@ -658,7 +643,7 @@ struct FloatingControlBarView: View {
     private func openAgentInChat(_ pill: AgentPill) {
         guard agentPills.pills.contains(where: { $0.id == pill.id }) else { return }
         if state.conversationSurface == .agent(pill.id) {
-            exitAgentSurface()
+            showAgentListFromConversation()
             return
         }
         agentPills.markViewed(pillID: pill.id)
@@ -676,16 +661,7 @@ struct FloatingControlBarView: View {
     }
 
     private func showAgentListFromConversation() {
-        guard !agentPills.pills.isEmpty else {
-            onCloseAI()
-            return
-        }
-        withAnimation(agentChatSwitchTransition) {
-            state.hideConversationSurface()
-        }
-        DispatchQueue.main.async {
-            (window as? FloatingControlBarWindow)?.openNotchHoverMenuUntilExit()
-        }
+        (window as? FloatingControlBarWindow)?.showAgentRowsFromConversation() ?? onCloseAI()
     }
 
     private func handleBarHover(_ hovering: Bool) {
@@ -1294,7 +1270,7 @@ private struct AgentMainChatView: View {
     @EnvironmentObject var state: FloatingControlBarState
     @ObservedObject var pill: AgentPill
     @ObservedObject var manager: AgentPillsManager
-    let onBackToOmi: () -> Void
+    let onBackToAgentRows: () -> Void
     let onEscape: () -> Void
     let onSpawnSibling: (UUID) -> Void
 
@@ -1390,7 +1366,7 @@ private struct AgentMainChatView: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            Button(action: onBackToOmi) {
+            Button(action: onBackToAgentRows) {
                 Image(systemName: "chevron.left")
                     .scaledFont(size: 13, weight: .semibold)
                     .foregroundColor(.white.opacity(0.82))
@@ -1398,7 +1374,7 @@ private struct AgentMainChatView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .help("Back to Omi chat")
+            .help("Back to chats")
 
             Text(pill.title)
                 .scaledFont(size: 13, weight: .bold)
@@ -1416,7 +1392,7 @@ private struct AgentMainChatView: View {
             if pill.status == .done {
                 Button {
                     manager.dismiss(pillID: pill.id)
-                    onBackToOmi()
+                    onBackToAgentRows()
                 } label: {
                     statusBadgeLabel
                 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1015,6 +1015,22 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     }
 
+    func showAgentRowsFromConversation() {
+        guard !AgentPillsManager.shared.pills.isEmpty else {
+            closeAIConversation()
+            return
+        }
+
+        responseHeightCancellable?.cancel()
+        responseHeightCancellable = nil
+        cancelInputHeightObserver()
+
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+            state.hideConversationSurface()
+        }
+        openNotchHoverMenuUntilExit()
+    }
+
     private func animateNotchReveal(from sourceSize: NSSize, to targetSize: NSSize, duration: TimeInterval) {
         let startWidth = max(Self.notchCompactSize.width, min(sourceSize.width, targetSize.width))
         let startHeight = max(Self.notchChromeHeight, min(sourceSize.height, targetSize.height))
@@ -1040,22 +1056,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         guard state.showingAIConversation else { return }
 
         if state.activeAgentChatPillID != nil {
-            // Use the same leaveAgentSurface() + observer reset path used by the
-            // Back button. Only nil-ing activeAgentChatPillID leaves
-            // conversationSurface as .agent(id) with the response-height observer
-            // still keyed to that agent, so the view falls through to the main
-            // response UI and subsequent height reports are ignored.
-            state.leaveAgentSurface()
-            // Mirror the Back button path: when leaveAgentSurface() lands on
-            // .mainInput (no prior Omi conversation), use the input-height resize
-            // so the panel shrinks to the normal Ask Omi size instead of staying
-            // at the oversized response height with a response-height observer.
-            if state.conversationSurface == .mainInput {
-                resizeForMainInputAfterAgentExit()
-            } else {
-                resizeForActiveAgentChatPublic(pillID: nil, animated: true)
-            }
-            focusInputField()
+            showAgentRowsFromConversation()
             return
         }
 
@@ -1732,12 +1733,7 @@ class FloatingControlBarManager {
     /// chat when dismissing a pill.)
     func leaveActiveAgentSurfaceFromPillDismiss() {
         guard let window else { return }
-        window.state.leaveAgentSurface()
-        if window.state.conversationSurface == .mainInput {
-            window.resizeForMainInputAfterAgentExit()
-        } else {
-            window.resizeForActiveAgentChatPublic(pillID: nil, animated: true)
-        }
+        window.showAgentRowsFromConversation()
     }
     private var pendingNotifications: [FloatingBarNotification] = []
     private var notificationDismissWorkItem: DispatchWorkItem?
@@ -2142,16 +2138,23 @@ class FloatingControlBarManager {
             return ["error": "floating_bar_window_unavailable"]
         }
         let start = ContinuousClock.now
-        window.state.leaveAgentSurface()
+        window.showAgentRowsFromConversation()
         guard wait else {
-            return ["triggered": "true", "active": window.state.activeAgentChatPillID?.uuidString ?? ""]
+            return [
+                "triggered": "true",
+                "active": window.state.activeAgentChatPillID?.uuidString ?? "",
+                "rowsOpen": window.state.isNotchHoverMenuVisible ? "true" : "false",
+            ]
         }
         let backMs = await waitForAutomationCondition {
             window.state.activeAgentChatPillID == nil
+                && !window.state.showingAIConversation
+                && window.state.isNotchHoverMenuVisible
         }
         return [
             "backMs": backMs ?? "timeout",
             "elapsedMs": start.duration(to: .now).millisecondsString,
+            "rowsOpen": window.state.isNotchHoverMenuVisible ? "true" : "false",
             "frame": NSStringFromRect(window.frame),
         ]
     }
@@ -3353,20 +3356,6 @@ extension FloatingControlBarWindow {
         state.resetMeasuredContentHeight(for: .mainResponse)
         beginMainResponseHeight(animated: animated)
         orderFrontRegardless()
-    }
-
-    /// Resize the window to the normal Ask Omi input height after exiting an
-    /// agent surface to `.mainInput`. Cancels the response-height observer and
-    /// installs the input-height observer so the panel sizes to the input view
-    /// instead of staying at the oversized response height.
-    func resizeForMainInputAfterAgentExit() {
-        responseHeightCancellable?.cancel()
-        responseHeightCancellable = nil
-        state.responseContentHeight = 0
-        state.inputViewHeight = inputPanelHeight
-        let inputSize = NSSize(width: expandedContentWidth, height: inputPanelHeight)
-        resizeAnchored(to: inputSize, makeResizable: false, animated: true, anchorTop: true)
-        setupInputHeightObserver()
     }
 
     /// Save the current center point so closeAIConversation can restore position.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -152,6 +152,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   /// True between commit and turn-done — used to detect barge-in (a new PTT while
   /// the previous reply is still in flight).
   private var responding = false
+  /// True while native realtime PCM has been scheduled locally but has not drained yet.
+  /// Provider turn completion means the server finished sending; the Mac may still be
+  /// playing the queued tail, and a new PTT during that tail is still a barge-in.
+  private var realtimePlaybackActive = false
 
   /// Log tag for the currently-connected provider.
   private var providerTag: String { sessionProvider == .gemini ? "gemini" : "openai" }
@@ -360,6 +364,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     let player = StreamingPCMPlayer(sampleRate: 24000)
     player.onPlaybackIdle = { [weak self] in
       Task { @MainActor in
+        self?.realtimePlaybackActive = false
         self?.clearResponseGlowIfRealtimeAudioIdle()
       }
     }
@@ -373,8 +378,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   func beginTurn() {
     // Barge-in: was a reply from the previous turn still in flight when the user
     // started talking again?
-    let bargeIn = responding
+    let bargeIn = responding || realtimePlaybackActive || localSpeechActive || speech.isSpeaking
     responding = false
+    realtimePlaybackActive = false
     turnTranscript = ""
     assistantText = ""
     speculativeWarmDone = false
@@ -383,7 +389,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     suppressAssistantOutputForCurrentTurn = false
     turnRecorded = false
     lastTurnAt = Date()
-    pcmPlayer?.stop()  // stop any prior reply locally
+    if bargeIn {
+      pcmPlayer?.stop()  // stop the prior reply locally only for a real barge-in.
+    }
     // Stop any queued or active local speech BEFORE resetting the flag, so a
     // barge-in before the synthesizer started playback still cancels the prior
     // turn's reply. Using localSpeechActive (set synchronously in speak) instead
@@ -441,6 +449,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   /// turn behind, or the model answers the non-speech later.
   func cancelTurn() {
     responding = false
+    realtimePlaybackActive = false
     turnTranscript = ""
     assistantText = ""
     // Abandon the open turn WITHOUT tearing down the socket: close the speech window
@@ -488,6 +497,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       return
     }
     audioReceivedThisTurn = true
+    realtimePlaybackActive = true
     responseGlowGate.markPlaybackActive()
   }
 
@@ -755,6 +765,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     let heard = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
     let reply = assistantText.trimmingCharacters(in: .whitespacesAndNewlines)
     log("RealtimeHub[\(providerTag)]: turn done — heard=\"\(heard.prefix(80))\" audio=\(audioReceivedThisTurn)")
+    if realtimePlaybackActive {
+      log("RealtimeHub[\(providerTag)]: server turn done; waiting for local playback to drain")
+    }
     // Record the completed turn into chat history (+ backend sync) in the background.
     // The hub plays its reply itself and never routes through the query path, so this is
     // the only place voice turns get persisted. Idempotent per turn; recordVoiceTurn is
@@ -794,6 +807,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     }
     // The reply is dead — stop any buffered audio before collapsing.
     pcmPlayer?.stop()
+    realtimePlaybackActive = false
     if localSpeechActive || speech.isSpeaking {
       speech.stopSpeaking(at: .immediate)
       localSpeechActive = false

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -38,6 +38,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains(".markdownTheme(.aiMessage(scale: 0.88))"))
     XCTAssertTrue(source.contains(".frame(width: 36, height: 36)"))
     XCTAssertTrue(source.contains(".contentShape(Rectangle())"))
+    XCTAssertTrue(source.contains("let onBackToAgentRows: () -> Void"))
+    XCTAssertTrue(source.contains(".help(\"Back to chats\")"))
     XCTAssertTrue(source.contains("barWindow?.resizeForActiveAgentChatPublic(pillID: pill.id, animated: !wasShowingConversation)"))
   }
 
@@ -96,6 +98,13 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(rowSource.contains("notchShortcutHint(\"Ask\""))
     XCTAssertTrue(rowSource.contains("notchShortcutHint(systemImage: \"mic.fill\""))
     XCTAssertFalse(rowSource.contains("notchShortcutHint(\"PTT\""))
+  }
+
+  func testNotchSettingsHitTargetDoesNotCoverChatRows() throws {
+    let source = try floatingControlBarViewSource()
+
+    XCTAssertTrue(source.contains("notchAgentLogoHitTarget\n                            .frame(width: notchChromeLayoutWidth, height: FloatingControlBarWindow.notchChromeHeight)"))
+    XCTAssertFalse(source.contains("notchAgentLogoHitTarget\n                            .frame(width: notchChromeLayoutWidth, height: FloatingControlBarWindow.notchChromeHeight + notchHoverMenuHeight)"))
   }
 
   func testNotchChatSizingPreservesSurfaceWidthAndGlowList() throws {
@@ -171,7 +180,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("setAgentSwitcherHovering(hovering)"))
     XCTAssertFalse(source.contains("@State private var agentSwitcherPinned"))
     XCTAssertFalse(source.contains("@State private var agentSwitcherHovering"))
-    XCTAssertTrue(source.contains("state.hideConversationSurface()"))
+    XCTAssertTrue(source.contains("showAgentRowsFromConversation()"))
     XCTAssertTrue(source.contains("Text(\"Omi Chat\")"))
     XCTAssertTrue(source.contains("barWindow?.resizeForActiveAgentChatPublic(pillID: pill.id, animated: !wasShowingConversation)"))
     XCTAssertTrue(source.contains("ForEach(0..<NotchAgentStackMetrics.maxAgents"))
@@ -356,7 +365,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(playerSource.contains("@discardableResult\n  func enqueue(_ data: Data) -> Bool"))
     XCTAssertTrue(hubSource.contains("guard pcmPlayer?.enqueue(pcm24k) == true else"))
     XCTAssertTrue(hubSource.contains("keeping text fallback armed"))
-    XCTAssertTrue(hubSource.contains("audioReceivedThisTurn = true\n    responseGlowGate.markPlaybackActive()"))
+    XCTAssertTrue(hubSource.contains("audioReceivedThisTurn = true\n    realtimePlaybackActive = true\n    responseGlowGate.markPlaybackActive()"))
     XCTAssertFalse(hubSource.contains("audioReceivedThisTurn = true\n    // If PTT muted music/system output"))
   }
 
@@ -370,6 +379,21 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("if localSpeechActive || speech.isSpeaking {"))
     XCTAssertTrue(source.contains("speech.stopSpeaking(at: .immediate)\n      localSpeechActive = false\n    }"))
     XCTAssertFalse(source.contains("audioReceivedThisTurn = false\n    localSpeechActive = false\n    suppressAssistantOutputForCurrentTurn = false"))
+  }
+
+  func testRealtimeBargeInTracksLocalPlaybackNotOnlyServerTurn() throws {
+    let source = try realtimeHubControllerSource()
+
+    // Provider turn completion only means the server finished sending audio; the
+    // local AVAudioPlayerNode may still be draining queued PCM. Keep playback as
+    // an explicit owner so the next PTT is classified correctly and non-barge-in
+    // starts do not blindly stop the player.
+    XCTAssertTrue(source.contains("private var realtimePlaybackActive = false"))
+    XCTAssertTrue(source.contains("let bargeIn = responding || realtimePlaybackActive || localSpeechActive || speech.isSpeaking"))
+    XCTAssertTrue(source.contains("if bargeIn {\n      pcmPlayer?.stop()"))
+    XCTAssertTrue(source.contains("audioReceivedThisTurn = true\n    realtimePlaybackActive = true"))
+    XCTAssertTrue(source.contains("self?.realtimePlaybackActive = false"))
+    XCTAssertTrue(source.contains("server turn done; waiting for local playback to drain"))
   }
 
   func testSpeechSynthesizerDidCancelClearsGlow() throws {
@@ -391,12 +415,19 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("self.resizeAnchored(to: self.collapsedBarSize, makeResizable: false, animated: false, anchorTop: true)"))
   }
 
-  func testEscapeFromAgentUsesInputResizeWhenMainInput() throws {
-    let source = try floatingControlBarWindowSource()
+  func testBackFromAgentUsesSharedRowsPath() throws {
+    let viewSource = try floatingControlBarViewSource()
+    let windowSource = try floatingControlBarWindowSource()
 
-    // The Escape path must mirror the Back button: use input-height resize
-    // when leaveAgentSurface() lands on .mainInput, not the response-size helper.
-    XCTAssertTrue(source.contains("if state.conversationSurface == .mainInput {\n                resizeForMainInputAfterAgentExit()"))
+    // Both the Omi Chat header and subagent header should use the same window
+    // transition: close the conversation surface and reopen the Notch row list.
+    XCTAssertTrue(viewSource.contains("onBackToAgentRows: {\n                        showAgentListFromConversation()"))
+    XCTAssertTrue(viewSource.contains("private func showAgentListFromConversation() {\n        (window as? FloatingControlBarWindow)?.showAgentRowsFromConversation() ?? onCloseAI()\n    }"))
+    XCTAssertTrue(windowSource.contains("func showAgentRowsFromConversation()"))
+    XCTAssertTrue(windowSource.contains("state.hideConversationSurface()"))
+    XCTAssertTrue(windowSource.contains("openNotchHoverMenuUntilExit()"))
+    XCTAssertTrue(windowSource.contains("window.showAgentRowsFromConversation()"))
+    XCTAssertFalse(viewSource.contains("let onBackToOmi: () -> Void"))
   }
 
   func testPTTCollapsePreservesGlowPaddingOnLegacyDisplays() throws {


### PR DESCRIPTION
## Summary
- keep realtime PTT playback alive until local PCM drains instead of treating provider turn completion as playback completion
- restrict the Notch Mode settings hit target to the chrome so chat/subagent rows receive clicks
- route Omi Chat and subagent back actions through one shared Notch row-list transition

## Review
- subagent review completed with no blocking findings

## Verification
- `xcrun swift test --package-path Desktop --filter 'AgentPillLifecycleTests|FloatingControlBarStateTests|FloatingBarGeometryTests|RealtimeResponseGlowGateTests|StreamingPCMPlaybackQueueTests'`\n- `./scripts/agent-logic-harness.sh --swift-only`\n- named bundle `/Applications/omi-agent-back.app`: seeded subagents, opened one, ran `back_from_subagent`, confirmed `rowsOpen=true`\n- named bundle `/Applications/omi-ptt-playback.app`: confirmed realtime logs show server turn done while waiting for local playback drain\n- `jq empty desktop/macos/CHANGELOG.json`\n- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

