### PR TITLE
Harden Notch Mode follow-up edge cases

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Hardened Notch Mode playback and subagent back-navigation edge cases"
+  ],
   "releases": [
     {
       "version": "0.11.546",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -661,7 +661,7 @@ struct FloatingControlBarView: View {
     }
 
     private func showAgentListFromConversation() {
-        (window as? FloatingControlBarWindow)?.showAgentRowsFromConversation() ?? onCloseAI()
+        (window as? FloatingControlBarWindow)?.leaveAgentConversation() ?? onCloseAI()
     }
 
     private func handleBarHover(_ hovering: Bool) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1015,11 +1015,16 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     }
 
-    func showAgentRowsFromConversation() {
-        guard !AgentPillsManager.shared.pills.isEmpty else {
-            closeAIConversation()
-            return
+    func leaveAgentConversation() {
+        if state.usesNotchIsland, !AgentPillsManager.shared.pills.isEmpty {
+            showAgentRowsFromConversation()
+        } else {
+            showMainConversationFromAgent()
         }
+    }
+
+    private func showAgentRowsFromConversation() {
+        guard !AgentPillsManager.shared.pills.isEmpty else { return showMainConversationFromAgent() }
 
         responseHeightCancellable?.cancel()
         responseHeightCancellable = nil
@@ -1029,6 +1034,21 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             state.hideConversationSurface()
         }
         openNotchHoverMenuUntilExit()
+    }
+
+    private func showMainConversationFromAgent() {
+        guard state.activeAgentChatPillID != nil else {
+            closeAIConversation()
+            return
+        }
+
+        state.leaveAgentSurface()
+        if state.conversationSurface == .mainInput {
+            resizeForMainInputAfterAgentExit()
+        } else {
+            resizeForActiveAgentChatPublic(pillID: nil, animated: true)
+        }
+        focusInputField()
     }
 
     private func animateNotchReveal(from sourceSize: NSSize, to targetSize: NSSize, duration: TimeInterval) {
@@ -1056,7 +1076,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         guard state.showingAIConversation else { return }
 
         if state.activeAgentChatPillID != nil {
-            showAgentRowsFromConversation()
+            leaveAgentConversation()
             return
         }
 
@@ -1733,7 +1753,7 @@ class FloatingControlBarManager {
     /// chat when dismissing a pill.)
     func leaveActiveAgentSurfaceFromPillDismiss() {
         guard let window else { return }
-        window.showAgentRowsFromConversation()
+        window.leaveAgentConversation()
     }
     private var pendingNotifications: [FloatingBarNotification] = []
     private var notificationDismissWorkItem: DispatchWorkItem?
@@ -2138,22 +2158,26 @@ class FloatingControlBarManager {
             return ["error": "floating_bar_window_unavailable"]
         }
         let start = ContinuousClock.now
-        window.showAgentRowsFromConversation()
+        let expectsRows = window.state.usesNotchIsland && !AgentPillsManager.shared.pills.isEmpty
+        window.leaveAgentConversation()
         guard wait else {
             return [
                 "triggered": "true",
                 "active": window.state.activeAgentChatPillID?.uuidString ?? "",
+                "mode": expectsRows ? "rows" : "main",
                 "rowsOpen": window.state.isNotchHoverMenuVisible ? "true" : "false",
             ]
         }
         let backMs = await waitForAutomationCondition {
             window.state.activeAgentChatPillID == nil
-                && !window.state.showingAIConversation
-                && window.state.isNotchHoverMenuVisible
+                && (expectsRows
+                    ? (!window.state.showingAIConversation && window.state.isNotchHoverMenuVisible)
+                    : window.state.showingAIConversation)
         }
         return [
             "backMs": backMs ?? "timeout",
             "elapsedMs": start.duration(to: .now).millisecondsString,
+            "mode": expectsRows ? "rows" : "main",
             "rowsOpen": window.state.isNotchHoverMenuVisible ? "true" : "false",
             "frame": NSStringFromRect(window.frame),
         ]
@@ -3356,6 +3380,20 @@ extension FloatingControlBarWindow {
         state.resetMeasuredContentHeight(for: .mainResponse)
         beginMainResponseHeight(animated: animated)
         orderFrontRegardless()
+    }
+
+    /// Resize the window to the normal Ask Omi input height after exiting an
+    /// agent surface to `.mainInput`. Cancels the response-height observer and
+    /// installs the input-height observer so non-Notch displays preserve the
+    /// legacy "back to Omi chat" behavior instead of using Notch row navigation.
+    func resizeForMainInputAfterAgentExit() {
+        responseHeightCancellable?.cancel()
+        responseHeightCancellable = nil
+        state.responseContentHeight = 0
+        state.inputViewHeight = inputPanelHeight
+        let inputSize = NSSize(width: expandedContentWidth, height: inputPanelHeight)
+        resizeAnchored(to: inputSize, makeResizable: false, animated: true, anchorTop: true)
+        setupInputHeightObserver()
     }
 
     /// Save the current center point so closeAIConversation can restore position.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -156,6 +156,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   /// Provider turn completion means the server finished sending; the Mac may still be
   /// playing the queued tail, and a new PTT during that tail is still a barge-in.
   private var realtimePlaybackActive = false
+  /// Monotonic owner for realtime playback-idle callbacks. The PCM player can
+  /// complete older buffers after a stop, rebuild, or newer audio chunk; only the
+  /// latest scheduled playback epoch may clear `realtimePlaybackActive`.
+  private var realtimePlaybackEpoch = 0
 
   /// Log tag for the currently-connected provider.
   private var providerTag: String { sessionProvider == .gemini ? "gemini" : "openai" }
@@ -362,10 +366,18 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
 
   private func makePCMPlayer() -> StreamingPCMPlayer {
     let player = StreamingPCMPlayer(sampleRate: 24000)
-    player.onPlaybackIdle = { [weak self] in
+    player.onPlaybackScheduled = { [weak self] playbackEpoch in
       Task { @MainActor in
-        self?.realtimePlaybackActive = false
-        self?.clearResponseGlowIfRealtimeAudioIdle()
+        guard let self else { return }
+        self.realtimePlaybackActive = true
+        self.realtimePlaybackEpoch = playbackEpoch
+      }
+    }
+    player.onPlaybackIdle = { [weak self] playbackEpoch in
+      Task { @MainActor in
+        guard let self, self.realtimePlaybackEpoch == playbackEpoch else { return }
+        self.realtimePlaybackActive = false
+        self.clearResponseGlowIfRealtimeAudioIdle()
       }
     }
     return player
@@ -381,6 +393,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     let bargeIn = responding || realtimePlaybackActive || localSpeechActive || speech.isSpeaking
     responding = false
     realtimePlaybackActive = false
+    realtimePlaybackEpoch += 1
     turnTranscript = ""
     assistantText = ""
     speculativeWarmDone = false
@@ -450,6 +463,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   func cancelTurn() {
     responding = false
     realtimePlaybackActive = false
+    realtimePlaybackEpoch += 1
     turnTranscript = ""
     assistantText = ""
     // Abandon the open turn WITHOUT tearing down the socket: close the speech window
@@ -492,12 +506,13 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     // If PTT muted music/system output while listening, make sure the model's
     // reply is audible even if capture teardown restore is delayed by hardware.
     SystemAudioMuteController.shared.restore()
-    guard pcmPlayer?.enqueue(pcm24k) == true else {
+    guard let pcmPlayer, pcmPlayer.enqueue(pcm24k) else {
       log("RealtimeHub[\(providerTag)]: native audio chunk could not be scheduled; keeping text fallback armed")
       return
     }
     audioReceivedThisTurn = true
     realtimePlaybackActive = true
+    realtimePlaybackEpoch = pcmPlayer.playbackEpoch
     responseGlowGate.markPlaybackActive()
   }
 
@@ -808,6 +823,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     // The reply is dead — stop any buffered audio before collapsing.
     pcmPlayer?.stop()
     realtimePlaybackActive = false
+    realtimePlaybackEpoch += 1
     if localSpeechActive || speech.isSpeaking {
       speech.stopSpeaking(at: .immediate)
       localSpeechActive = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
@@ -20,11 +20,14 @@ final class StreamingPCMPlaybackQueue<Buffer: AnyObject> {
     return generation
   }
 
-  func markPlayed(_ buffer: Buffer, generation completionGeneration: Int) {
-    guard completionGeneration == generation else { return }
+  @discardableResult
+  func markPlayed(_ buffer: Buffer, generation completionGeneration: Int) -> Bool {
+    guard completionGeneration == generation else { return false }
     if let index = scheduledBuffers.firstIndex(where: { $0 === buffer }) {
       scheduledBuffers.remove(at: index)
+      return true
     }
+    return false
   }
 
   func buffersToReplayAfterConfigurationChange() -> [Buffer] {
@@ -53,7 +56,9 @@ final class StreamingPCMPlayer {
   private let format: AVAudioFormat
   private var configObserver: NSObjectProtocol?
   private let playbackQueue = StreamingPCMPlaybackQueue<AVAudioPCMBuffer>()
-  var onPlaybackIdle: (() -> Void)?
+  private(set) var playbackEpoch = 0
+  var onPlaybackScheduled: ((Int) -> Void)?
+  var onPlaybackIdle: ((Int) -> Void)?
 
   init(sampleRate: Double = 24000) {
     // Float32 mono at the source rate; the mixer resamples to the device rate.
@@ -136,19 +141,23 @@ final class StreamingPCMPlayer {
   }
 
   private func schedule(_ buffer: AVAudioPCMBuffer) {
+    playbackEpoch += 1
+    let scheduledPlaybackEpoch = playbackEpoch
+    onPlaybackScheduled?(scheduledPlaybackEpoch)
     let generation = playbackQueue.appendScheduled(buffer)
     player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self, weak buffer] _ in
       DispatchQueue.main.async {
         guard let self, let buffer else { return }
-        self.playbackQueue.markPlayed(buffer, generation: generation)
-        if self.playbackQueue.isEmpty {
-          self.onPlaybackIdle?()
+        let didMarkPlayed = self.playbackQueue.markPlayed(buffer, generation: generation)
+        if didMarkPlayed, self.playbackQueue.isEmpty {
+          self.onPlaybackIdle?(scheduledPlaybackEpoch)
         }
       }
     }
   }
 
   func stop() {
+    playbackEpoch += 1
     playbackQueue.clearForExplicitStop()
     player.stop()
     engine.stop()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -180,7 +180,7 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("setAgentSwitcherHovering(hovering)"))
     XCTAssertFalse(source.contains("@State private var agentSwitcherPinned"))
     XCTAssertFalse(source.contains("@State private var agentSwitcherHovering"))
-    XCTAssertTrue(source.contains("showAgentRowsFromConversation()"))
+    XCTAssertTrue(source.contains("leaveAgentConversation()"))
     XCTAssertTrue(source.contains("Text(\"Omi Chat\")"))
     XCTAssertTrue(source.contains("barWindow?.resizeForActiveAgentChatPublic(pillID: pill.id, animated: !wasShowingConversation)"))
     XCTAssertTrue(source.contains("ForEach(0..<NotchAgentStackMetrics.maxAgents"))
@@ -363,9 +363,10 @@ final class AgentPillLifecycleTests: XCTestCase {
 
     XCTAssertTrue(playerSource.contains("private func ensureRunning() -> Bool"))
     XCTAssertTrue(playerSource.contains("@discardableResult\n  func enqueue(_ data: Data) -> Bool"))
-    XCTAssertTrue(hubSource.contains("guard pcmPlayer?.enqueue(pcm24k) == true else"))
+    XCTAssertTrue(hubSource.contains("guard let pcmPlayer, pcmPlayer.enqueue(pcm24k) else"))
     XCTAssertTrue(hubSource.contains("keeping text fallback armed"))
-    XCTAssertTrue(hubSource.contains("audioReceivedThisTurn = true\n    realtimePlaybackActive = true\n    responseGlowGate.markPlaybackActive()"))
+    XCTAssertTrue(hubSource.contains("audioReceivedThisTurn = true\n    realtimePlaybackActive = true\n    realtimePlaybackEpoch = pcmPlayer.playbackEpoch\n    responseGlowGate.markPlaybackActive()"))
+    XCTAssertFalse(hubSource.contains("pcmPlayer?.playbackEpoch ??"))
     XCTAssertFalse(hubSource.contains("audioReceivedThisTurn = true\n    // If PTT muted music/system output"))
   }
 
@@ -392,7 +393,12 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("let bargeIn = responding || realtimePlaybackActive || localSpeechActive || speech.isSpeaking"))
     XCTAssertTrue(source.contains("if bargeIn {\n      pcmPlayer?.stop()"))
     XCTAssertTrue(source.contains("audioReceivedThisTurn = true\n    realtimePlaybackActive = true"))
-    XCTAssertTrue(source.contains("self?.realtimePlaybackActive = false"))
+    XCTAssertTrue(source.contains("private var realtimePlaybackEpoch = 0"))
+    XCTAssertTrue(source.contains("player.onPlaybackScheduled = { [weak self] playbackEpoch in"))
+    XCTAssertTrue(source.contains("self.realtimePlaybackActive = true\n        self.realtimePlaybackEpoch = playbackEpoch"))
+    XCTAssertTrue(source.contains("player.onPlaybackIdle = { [weak self] playbackEpoch in"))
+    XCTAssertTrue(source.contains("guard let self, self.realtimePlaybackEpoch == playbackEpoch else { return }"))
+    XCTAssertTrue(source.contains("realtimePlaybackEpoch = pcmPlayer.playbackEpoch"))
     XCTAssertTrue(source.contains("server turn done; waiting for local playback to drain"))
   }
 
@@ -415,18 +421,25 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("self.resizeAnchored(to: self.collapsedBarSize, makeResizable: false, animated: false, anchorTop: true)"))
   }
 
-  func testBackFromAgentUsesSharedRowsPath() throws {
+  func testBackFromAgentUsesSharedDisplayAwarePath() throws {
     let viewSource = try floatingControlBarViewSource()
     let windowSource = try floatingControlBarWindowSource()
 
-    // Both the Omi Chat header and subagent header should use the same window
-    // transition: close the conversation surface and reopen the Notch row list.
+    // Both the Omi Chat header and subagent header should enter one shared
+    // window transition. Notch surfaces go back to the row list; legacy
+    // surfaces keep their previous main-input/main-response back behavior.
     XCTAssertTrue(viewSource.contains("onBackToAgentRows: {\n                        showAgentListFromConversation()"))
-    XCTAssertTrue(viewSource.contains("private func showAgentListFromConversation() {\n        (window as? FloatingControlBarWindow)?.showAgentRowsFromConversation() ?? onCloseAI()\n    }"))
-    XCTAssertTrue(windowSource.contains("func showAgentRowsFromConversation()"))
+    XCTAssertTrue(viewSource.contains("private func showAgentListFromConversation() {\n        (window as? FloatingControlBarWindow)?.leaveAgentConversation() ?? onCloseAI()\n    }"))
+    XCTAssertTrue(windowSource.contains("func leaveAgentConversation()"))
+    XCTAssertTrue(windowSource.contains("if state.usesNotchIsland, !AgentPillsManager.shared.pills.isEmpty"))
+    XCTAssertTrue(windowSource.contains("private func showAgentRowsFromConversation()"))
+    XCTAssertTrue(windowSource.contains("private func showMainConversationFromAgent()"))
     XCTAssertTrue(windowSource.contains("state.hideConversationSurface()"))
     XCTAssertTrue(windowSource.contains("openNotchHoverMenuUntilExit()"))
-    XCTAssertTrue(windowSource.contains("window.showAgentRowsFromConversation()"))
+    XCTAssertTrue(windowSource.contains("resizeForMainInputAfterAgentExit()"))
+    XCTAssertTrue(windowSource.contains("window.leaveAgentConversation()"))
+    XCTAssertTrue(windowSource.contains("let expectsRows = window.state.usesNotchIsland && !AgentPillsManager.shared.pills.isEmpty"))
+    XCTAssertTrue(windowSource.contains("\"mode\": expectsRows ? \"rows\" : \"main\""))
     XCTAssertFalse(viewSource.contains("let onBackToOmi: () -> Void"))
   }
 

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -4,6 +4,20 @@ import XCTest
 final class StreamingPCMPlaybackQueueTests: XCTestCase {
   private final class BufferBox {}
 
+  func testStreamingPlayerPublishesEpochForEveryScheduledBuffer() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Sources/FloatingControlBar/StreamingPCMPlayer.swift"),
+      encoding: .utf8
+    )
+
+    XCTAssertTrue(source.contains("var onPlaybackScheduled: ((Int) -> Void)?"))
+    XCTAssertTrue(source.contains("let scheduledPlaybackEpoch = playbackEpoch\n    onPlaybackScheduled?(scheduledPlaybackEpoch)"))
+    XCTAssertTrue(source.contains("for buffer in buffersToReplay {\n        self.schedule(buffer)\n      }"))
+  }
+
   func testConfigurationChangeReturnsScheduledTailForReplay() {
     let queue = StreamingPCMPlaybackQueue<BufferBox>()
     let first = BufferBox()
@@ -27,13 +41,13 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     _ = queue.buffersToReplayAfterConfigurationChange()
     let newGeneration = queue.appendScheduled(buffer)
 
-    queue.markPlayed(buffer, generation: oldGeneration)
+    XCTAssertFalse(queue.markPlayed(buffer, generation: oldGeneration))
     XCTAssertFalse(
       queue.isEmpty,
       "A completion from the pre-rebuild player must not remove the replayed buffer"
     )
 
-    queue.markPlayed(buffer, generation: newGeneration)
+    XCTAssertTrue(queue.markPlayed(buffer, generation: newGeneration))
     XCTAssertTrue(queue.isEmpty)
   }
 
@@ -47,7 +61,7 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     XCTAssertTrue(queue.isEmpty)
 
     queue.appendScheduled(buffer)
-    queue.markPlayed(buffer, generation: oldGeneration)
+    XCTAssertFalse(queue.markPlayed(buffer, generation: oldGeneration))
 
     XCTAssertFalse(
       queue.isEmpty,
@@ -63,7 +77,7 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     let generation = queue.appendScheduled(first)
     queue.appendScheduled(second)
 
-    queue.markPlayed(first, generation: generation)
+    XCTAssertTrue(queue.markPlayed(first, generation: generation))
 
     XCTAssertEqual(queue.scheduledBuffers.count, 1)
     XCTAssertTrue(queue.scheduledBuffers[0] === second)


### PR DESCRIPTION
## Summary
- address cubic-identified stale realtime playback idle callbacks by epoch-gating PCM idle ownership
- make subagent back/dismiss navigation display-aware: Notch surfaces return to chat rows, non-Notch surfaces keep legacy main chat behavior
- keep automation and tests aligned with the display-aware back behavior

## Review comments addressed
- `RealtimeHubController.swift`: stale/unversioned `realtimePlaybackActive` idle clearing
- `FloatingControlBarWindow.swift`: Notch-only row-list transition used for non-Notch agent dismiss/back

## Verification
- `xcrun swift test --package-path Desktop --filter 'AgentPillLifecycleTests|FloatingControlBarStateTests|FloatingBarGeometryTests|RealtimeResponseGlowGateTests|StreamingPCMPlaybackQueueTests'`\n- `./scripts/agent-logic-harness.sh --swift-only`\n- `jq empty desktop/macos/CHANGELOG.json`\n- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

