### PR TITLE
feat home mind map section header tappable and Expand button label

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2507,6 +2507,7 @@
     "addTask": "إضافة مهمة",
     "newTask": "مهمة جديدة",
     "viewAll": "عرض الكل",
+    "expand": "توسيع",
     "whatsNewInVersion": "ما الجديد في {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Паглядзець ўсё",
+    "expand": "Разгарнуць",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2509,6 +2509,7 @@
     "addTask": "Добавяне на задача",
     "newTask": "Нова задача",
     "viewAll": "Виж всички",
+    "expand": "Разгъни",
     "whatsNewInVersion": "Какво ново във {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "সব দেখুন",
+    "expand": "প্রসারিত করুন",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Prikaži sve",
+    "expand": "Proširi",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2509,6 +2509,7 @@
     "addTask": "Afegir tasca",
     "newTask": "Nova tasca",
     "viewAll": "Veure tot",
+    "expand": "Expandeix",
     "whatsNewInVersion": "Novetats a {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2509,6 +2509,7 @@
     "addTask": "Přidat úkol",
     "newTask": "Nový úkol",
     "viewAll": "Zobrazit vše",
+    "expand": "Rozbalit",
     "whatsNewInVersion": "Co je nového ve {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2549,6 +2549,7 @@
     "addTask": "Tilføj opgave",
     "newTask": "Ny opgave",
     "viewAll": "Vis alle",
+    "expand": "Udvid",
     "whatsNewInVersion": "Nyheder i {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2508,6 +2508,7 @@
     "addTask": "Aufgabe hinzufügen",
     "newTask": "Neue Aufgabe",
     "viewAll": "Alle anzeigen",
+    "expand": "Erweitern",
     "whatsNewInVersion": "Neuigkeiten in {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Προσθήκη εργασίας",
     "newTask": "Νέα εργασία",
     "viewAll": "Προβολή όλων",
+    "expand": "Ανάπτυξη",
     "whatsNewInVersion": "Τι νέο υπάρχει στο {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -9550,6 +9550,10 @@
     "@viewAll": {
         "description": "Button text to view all items"
     },
+    "expand": "Expand",
+    "@expand": {
+        "description": "Button text to expand/open a section such as the mind map preview"
+    },
     "addTask": "Add Task",
     "@addTask": {
         "description": "Menu option to add a new task"

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2541,6 +2541,7 @@
     "addTask": "Añadir tarea",
     "newTask": "Nueva tarea",
     "viewAll": "Ver todo",
+    "expand": "Expandir",
     "whatsNewInVersion": "Novedades en {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Lisa ülesanne",
     "newTask": "Uus ülesanne",
     "viewAll": "Vaata kõiki",
+    "expand": "Laienda",
     "whatsNewInVersion": "Mis on uut versioonis {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "مشاهده همه",
+    "expand": "گسترش",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Lisää tehtävä",
     "newTask": "Uusi tehtävä",
     "viewAll": "Näytä kaikki",
+    "expand": "Laajenna",
     "whatsNewInVersion": "Uutta versiossa {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2575,6 +2575,7 @@
     "addTask": "Ajouter une tâche",
     "newTask": "Nouvelle tâche",
     "viewAll": "Tout afficher",
+    "expand": "Développer",
     "whatsNewInVersion": "Nouveautés de {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "צפה בהכל",
+    "expand": "הרחב",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2541,6 +2541,7 @@
     "addTask": "कार्य जोड़ें",
     "newTask": "नया कार्य",
     "viewAll": "सभी देखें",
+    "expand": "विस्तार करें",
     "whatsNewInVersion": "{version} में नया क्या है",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Prikaži sve",
+    "expand": "Proširi",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2636,6 +2636,7 @@
     "addTask": "Feladat hozzáadása",
     "newTask": "Új feladat",
     "viewAll": "Összes megtekintése",
+    "expand": "Kibontás",
     "whatsNewInVersion": "Újdonságok a {version} verzióban",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2582,6 +2582,7 @@
     "addTask": "Tambah tugas",
     "newTask": "Tugas baru",
     "viewAll": "Lihat semua",
+    "expand": "Perluas",
     "whatsNewInVersion": "Yang Baru di {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Aggiungi attività",
     "newTask": "Nuova attività",
     "viewAll": "Vedi tutto",
+    "expand": "Espandi",
     "whatsNewInVersion": "Novità nella {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2541,6 +2541,7 @@
     "addTask": "タスクを追加",
     "newTask": "新しいタスク",
     "viewAll": "すべて表示",
+    "expand": "展開",
     "whatsNewInVersion": "{version} の新機能",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "ಎಲ್ಲವನ್ನೂ ವೀಕ್ಷಿಸಿ",
+    "expand": "ವಿಸ್ತರಿಸಿ",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2540,6 +2540,7 @@
     "addTask": "작업 추가",
     "newTask": "새 작업",
     "viewAll": "모두 보기",
+    "expand": "펼치기",
     "whatsNewInVersion": "{version}의 새로운 기능",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -14523,6 +14523,12 @@ abstract class AppLocalizations {
   /// **'View All'**
   String get viewAll;
 
+  /// Button text to expand/open a section such as the mind map preview
+  ///
+  /// In en, this message translates to:
+  /// **'Expand'**
+  String get expand;
+
   /// Menu option to add a new task
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -7711,6 +7711,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get viewAll => 'عرض الكل';
 
   @override
+  String get expand => 'توسيع';
+
+  @override
   String get addTask => 'إضافة مهمة';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -7788,6 +7788,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get viewAll => 'Паглядзець ўсё';
 
   @override
+  String get expand => 'Разгарнуць';
+
+  @override
   String get addTask => 'Дадаць задачу';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -7794,6 +7794,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get viewAll => 'Виж всички';
 
   @override
+  String get expand => 'Разгъни';
+
+  @override
   String get addTask => 'Добавяне на задача';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -7774,6 +7774,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get viewAll => 'সব দেখুন';
 
   @override
+  String get expand => 'প্রসারিত করুন';
+
+  @override
   String get addTask => 'কাজ যোগ করুন';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -7788,6 +7788,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get viewAll => 'Prikaži sve';
 
   @override
+  String get expand => 'Proširi';
+
+  @override
   String get addTask => 'Dodaj zadatak';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -7811,6 +7811,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get viewAll => 'Veure tot';
 
   @override
+  String get expand => 'Expandeix';
+
+  @override
   String get addTask => 'Afegir tasca';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -7760,6 +7760,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get viewAll => 'Zobrazit vše';
 
   @override
+  String get expand => 'Rozbalit';
+
+  @override
   String get addTask => 'Přidat úkol';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -7748,6 +7748,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get viewAll => 'Vis alle';
 
   @override
+  String get expand => 'Udvid';
+
+  @override
   String get addTask => 'Tilføj opgave';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -7827,6 +7827,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get viewAll => 'Alle anzeigen';
 
   @override
+  String get expand => 'Erweitern';
+
+  @override
   String get addTask => 'Aufgabe hinzufügen';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -7819,6 +7819,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get viewAll => 'Προβολή όλων';
 
   @override
+  String get expand => 'Ανάπτυξη';
+
+  @override
   String get addTask => 'Προσθήκη εργασίας';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -7762,6 +7762,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get viewAll => 'View All';
 
   @override
+  String get expand => 'Expand';
+
+  @override
   String get addTask => 'Add Task';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -7778,6 +7778,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get viewAll => 'Ver todo';
 
   @override
+  String get expand => 'Expandir';
+
+  @override
   String get addTask => 'Añadir tarea';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -7764,6 +7764,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get viewAll => 'Vaata kõiki';
 
   @override
+  String get expand => 'Laienda';
+
+  @override
   String get addTask => 'Lisa ülesanne';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -7769,6 +7769,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get viewAll => 'مشاهده همه';
 
   @override
+  String get expand => 'گسترش';
+
+  @override
   String get addTask => 'افزودن کار';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -7764,6 +7764,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get viewAll => 'Näytä kaikki';
 
   @override
+  String get expand => 'Laajenna';
+
+  @override
   String get addTask => 'Lisää tehtävä';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -7836,6 +7836,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get viewAll => 'Tout afficher';
 
   @override
+  String get expand => 'Développer';
+
+  @override
   String get addTask => 'Ajouter une tâche';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -7703,6 +7703,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get viewAll => 'צפה בהכל';
 
   @override
+  String get expand => 'הרחב';
+
+  @override
   String get addTask => 'הוסף משימה';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -7740,6 +7740,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get viewAll => 'सभी देखें';
 
   @override
+  String get expand => 'विस्तार करें';
+
+  @override
   String get addTask => 'कार्य जोड़ें';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -7793,6 +7793,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get viewAll => 'Prikaži sve';
 
   @override
+  String get expand => 'Proširi';
+
+  @override
   String get addTask => 'Dodaj zadatak';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -7800,6 +7800,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get viewAll => 'Összes megtekintése';
 
   @override
+  String get expand => 'Kibontás';
+
+  @override
   String get addTask => 'Feladat hozzáadása';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -7775,6 +7775,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get viewAll => 'Lihat semua';
 
   @override
+  String get expand => 'Perluas';
+
+  @override
   String get addTask => 'Tambah tugas';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -7812,6 +7812,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get viewAll => 'Vedi tutto';
 
   @override
+  String get expand => 'Espandi';
+
+  @override
   String get addTask => 'Aggiungi attività';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -7637,6 +7637,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get viewAll => 'すべて表示';
 
   @override
+  String get expand => '展開';
+
+  @override
   String get addTask => 'タスクを追加';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -7793,6 +7793,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get viewAll => 'ಎಲ್ಲವನ್ನೂ ವೀಕ್ಷಿಸಿ';
 
   @override
+  String get expand => 'ವಿಸ್ತರಿಸಿ';
+
+  @override
   String get addTask => 'ಕಾರ್ಯ ಸೇರಿಸಿ';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -7639,6 +7639,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get viewAll => '모두 보기';
 
   @override
+  String get expand => '펼치기';
+
+  @override
   String get addTask => '작업 추가';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -7772,6 +7772,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get viewAll => 'Peržiūrėti viską';
 
   @override
+  String get expand => 'Išskleisti';
+
+  @override
   String get addTask => 'Pridėti užduotį';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -7783,6 +7783,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get viewAll => 'Skatīt visu';
 
   @override
+  String get expand => 'Izvērst';
+
+  @override
   String get addTask => 'Pievienot uzdevumu';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -7808,6 +7808,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get viewAll => 'Преглед на сите';
 
   @override
+  String get expand => 'Прошири';
+
+  @override
   String get addTask => 'Додај задача';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -7778,6 +7778,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get viewAll => 'सर्व पाहा';
 
   @override
+  String get expand => 'विस्तारित करा';
+
+  @override
   String get addTask => 'कार्य जोडा';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -7787,6 +7787,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get viewAll => 'Lihat semua';
 
   @override
+  String get expand => 'Kembangkan';
+
+  @override
   String get addTask => 'Tambah tugas';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -7787,6 +7787,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get viewAll => 'Alles bekijken';
 
   @override
+  String get expand => 'Uitvouwen';
+
+  @override
   String get addTask => 'Taak toevoegen';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -7761,6 +7761,9 @@ class AppLocalizationsNo extends AppLocalizations {
   String get viewAll => 'Vis alle';
 
   @override
+  String get expand => 'Utvid';
+
+  @override
   String get addTask => 'Legg til oppgave';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -7782,6 +7782,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get viewAll => 'Pokaż wszystko';
 
   @override
+  String get expand => 'Rozwiń';
+
+  @override
   String get addTask => 'Dodaj zadanie';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -7764,6 +7764,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get viewAll => 'Ver tudo';
 
   @override
+  String get expand => 'Expandir';
+
+  @override
   String get addTask => 'Adicionar tarefa';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -7802,6 +7802,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get viewAll => 'Vezi tot';
 
   @override
+  String get expand => 'Extinde';
+
+  @override
   String get addTask => 'Adaugă sarcină';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -7789,6 +7789,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get viewAll => 'Показать все';
 
   @override
+  String get expand => 'Развернуть';
+
+  @override
   String get addTask => 'Добавить задачу';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -7756,6 +7756,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get viewAll => 'Zobraziť všetko';
 
   @override
+  String get expand => 'Rozbaliť';
+
+  @override
   String get addTask => 'Pridať úlohu';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -7787,6 +7787,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get viewAll => 'Prikaži vse';
 
   @override
+  String get expand => 'Razširi';
+
+  @override
   String get addTask => 'Dodaj opravilo';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -7777,6 +7777,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get viewAll => 'Погледај све';
 
   @override
+  String get expand => 'Прошири';
+
+  @override
   String get addTask => 'Додај задатак';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -7770,6 +7770,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get viewAll => 'Visa alla';
 
   @override
+  String get expand => 'Expandera';
+
+  @override
   String get addTask => 'Lägg till uppgift';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -7820,6 +7820,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get viewAll => 'அனைத்தையும் பார்';
 
   @override
+  String get expand => 'விரிவாக்கு';
+
+  @override
   String get addTask => 'பணியைச் சேர்க்க';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -7810,6 +7810,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get viewAll => 'అన్నీ చూడండి';
 
   @override
+  String get expand => 'విస్తరించు';
+
+  @override
   String get addTask => 'కార్యం జోడించండి';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -7729,6 +7729,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get viewAll => 'ดูทั้งหมด';
 
   @override
+  String get expand => 'ขยาย';
+
+  @override
   String get addTask => 'เพิ่มงาน';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -7835,6 +7835,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get viewAll => 'Tingnan Lahat';
 
   @override
+  String get expand => 'Palawakin';
+
+  @override
   String get addTask => 'Magdagdag ng Task';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -7778,6 +7778,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get viewAll => 'Tümünü gör';
 
   @override
+  String get expand => 'Genişlet';
+
+  @override
   String get addTask => 'Görev ekle';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -7777,6 +7777,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get viewAll => 'Переглянути все';
 
   @override
+  String get expand => 'Розгорнути';
+
+  @override
   String get addTask => 'Додати завдання';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -7777,6 +7777,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get viewAll => 'سب دیکھیں';
 
   @override
+  String get expand => 'پھیلائیں';
+
+  @override
   String get addTask => 'کام شامل کریں';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -7766,6 +7766,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get viewAll => 'Xem tất cả';
 
   @override
+  String get expand => 'Mở rộng';
+
+  @override
   String get addTask => 'Thêm nhiệm vụ';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -7628,6 +7628,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get viewAll => '查看全部';
 
   @override
+  String get expand => '展开';
+
+  @override
   String get addTask => '添加任务';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Pridėti užduotį",
     "newTask": "Nauja užduotis",
     "viewAll": "Peržiūrėti viską",
+    "expand": "Išskleisti",
     "whatsNewInVersion": "Kas naujo {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Pievienot uzdevumu",
     "newTask": "Jauns uzdevums",
     "viewAll": "Skatīt visu",
+    "expand": "Izvērst",
     "whatsNewInVersion": "Kas jauns {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Преглед на сите",
+    "expand": "Прошири",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "सर्व पाहा",
+    "expand": "विस्तारित करा",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Tambah tugas",
     "newTask": "Tugas baru",
     "viewAll": "Lihat semua",
+    "expand": "Kembangkan",
     "whatsNewInVersion": "Apa yang Baharu dalam {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Taak toevoegen",
     "newTask": "Nieuwe taak",
     "viewAll": "Alles bekijken",
+    "expand": "Uitvouwen",
     "whatsNewInVersion": "Nieuw in {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Legg til oppgave",
     "newTask": "Ny oppgave",
     "viewAll": "Vis alle",
+    "expand": "Utvid",
     "whatsNewInVersion": "Nyheter i {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2575,6 +2575,7 @@
     "addTask": "Dodaj zadanie",
     "newTask": "Nowe zadanie",
     "viewAll": "Pokaż wszystko",
+    "expand": "Rozwiń",
     "whatsNewInVersion": "Co nowego w {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2576,6 +2576,7 @@
     "addTask": "Adicionar tarefa",
     "newTask": "Nova tarefa",
     "viewAll": "Ver tudo",
+    "expand": "Expandir",
     "whatsNewInVersion": "Novidades na {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Adaugă sarcină",
     "newTask": "Sarcină nouă",
     "viewAll": "Vezi tot",
+    "expand": "Extinde",
     "whatsNewInVersion": "Ce este nou în {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2575,6 +2575,7 @@
     "addTask": "Добавить задачу",
     "newTask": "Новая задача",
     "viewAll": "Показать все",
+    "expand": "Развернуть",
     "whatsNewInVersion": "Что нового в {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2545,6 +2545,7 @@
     "addTask": "Pridať úlohu",
     "newTask": "Nová úloha",
     "viewAll": "Zobraziť všetko",
+    "expand": "Rozbaliť",
     "whatsNewInVersion": "Čo je nové vo {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Prikaži vse",
+    "expand": "Razširi",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Погледај све",
+    "expand": "Прошири",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Lägg till uppgift",
     "newTask": "Ny uppgift",
     "viewAll": "Visa alla",
+    "expand": "Expandera",
     "whatsNewInVersion": "Nyheter i {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "அனைத்தையும் பார்",
+    "expand": "விரிவாக்கு",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "అన్నీ చూడండి",
+    "expand": "విస్తరించు",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2540,6 +2540,7 @@
     "addTask": "เพิ่มงาน",
     "newTask": "งานใหม่",
     "viewAll": "ดูทั้งหมด",
+    "expand": "ขยาย",
     "whatsNewInVersion": "มีอะไรใหม่ใน {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "Tingnan Lahat",
+    "expand": "Palawakin",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2575,6 +2575,7 @@
     "addTask": "Görev ekle",
     "newTask": "Yeni görev",
     "viewAll": "Tümünü gör",
+    "expand": "Genişlet",
     "whatsNewInVersion": "{version} sürümündeki yenilikler",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2540,6 +2540,7 @@
     "addTask": "Додати завдання",
     "newTask": "Нове завдання",
     "viewAll": "Переглянути все",
+    "expand": "Розгорнути",
     "whatsNewInVersion": "Що нового у {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -9537,6 +9537,7 @@
         "description": "Button text for creating a new task"
     },
     "viewAll": "سب دیکھیں",
+    "expand": "پھیلائیں",
     "@viewAll": {
         "description": "Button text to view all items"
     },

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2545,6 +2545,7 @@
     "addTask": "Thêm nhiệm vụ",
     "newTask": "Nhiệm vụ mới",
     "viewAll": "Xem tất cả",
+    "expand": "Mở rộng",
     "whatsNewInVersion": "Có gì mới trong {version}",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2562,6 +2562,7 @@
     "addTask": "添加任务",
     "newTask": "新任务",
     "viewAll": "查看全部",
+    "expand": "展开",
     "whatsNewInVersion": "{version} 的新功能",
     "@whatsNewInVersion": {
         "description": "Title for changelog with version number",

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -138,6 +138,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                       context,
                       MaterialPageRoute(builder: (context) => const MemoryGraphPage(trackOpenEvent: false)),
                     ),
+                    buttonLabel: context.l10n.expand,
                   ),
                 ),
                 SliverToBoxAdapter(child: _buildMindMapPreview(context)),
@@ -280,15 +281,18 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
     );
   }
 
-  Widget _buildSectionHeader(BuildContext context, String title, {VoidCallback? onViewAll}) {
+  Widget _buildSectionHeader(BuildContext context, String title, {VoidCallback? onViewAll, String? buttonLabel}) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 20, 16, 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            title,
-            style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+          GestureDetector(
+            onTap: onViewAll,
+            child: Text(
+              title,
+              style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+            ),
           ),
           if (onViewAll != null)
             GestureDetector(
@@ -300,7 +304,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                   borderRadius: BorderRadius.circular(18),
                 ),
                 child: Text(
-                  context.l10n.viewAll,
+                  buttonLabel ?? context.l10n.viewAll,
                   style: TextStyle(color: Colors.grey[400], fontSize: 12, fontWeight: FontWeight.w500),
                 ),
               ),


### PR DESCRIPTION
## Summary
- Tapping the "Mind Map" section title on the home screen now navigates to the mind map (same as the button)
- Renamed the "View All" button to "Expand" for the mind map section
- Added `expand` l10n key with translations across all 48 supported locales

## Test plan
- [ ] On home screen, tap the "Mind Map" section title — should open the mind map page
- [ ] The button next to the title should read "Expand" instead of "View All"
- [ ] Tapping "Expand" still navigates to the mind map page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

