### PR TITLE
[codex] Move desktop changelog to fragments

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Require desktop user-facing PRs to add an unreleased changelog entry."""
+"""Require desktop user-facing PRs to add an unreleased changelog fragment."""
 
 from __future__ import annotations
 
@@ -7,11 +7,10 @@ import argparse
 import json
 import subprocess
 import sys
-from collections import Counter
-from pathlib import Path
 
 
-CHANGELOG_PATH = Path("desktop/macos/CHANGELOG.json")
+UNRELEASED_CHANGELOG_PREFIX = "desktop/macos/changelog/unreleased/"
+CHANGELOG_PREFIX = "desktop/macos/changelog/"
 DESKTOP_PREFIX = "desktop/macos/"
 EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/CHANGELOG.json",
@@ -28,35 +27,52 @@ def changed_files(base_ref: str, head_ref: str) -> list[str]:
     return [line for line in output.splitlines() if line]
 
 
+def added_files(base_ref: str, head_ref: str) -> list[str]:
+    output = run_git(["diff", "--name-status", "--diff-filter=A", f"{base_ref}...{head_ref}"])
+    return [line.split("\t", 1)[1] for line in output.splitlines() if line.startswith("A\t")]
+
+
 def is_desktop_change_requiring_changelog(path: str) -> bool:
     if not path.startswith(DESKTOP_PREFIX):
         return False
     if path in EXEMPT_DESKTOP_PATHS:
         return False
+    if path.startswith(CHANGELOG_PREFIX):
+        return False
     return True
 
 
-def unreleased_entries(ref: str) -> list[str]:
+def validate_unreleased_fragment(head_ref: str, path: str) -> None:
     try:
-        raw = run_git(["show", f"{ref}:{CHANGELOG_PATH}"])
+        raw = run_git(["show", f"{head_ref}:{path}"])
     except subprocess.CalledProcessError:
-        return []
+        raise SystemExit(f"FAIL: could not read changelog fragment {path} at {head_ref}")
 
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"FAIL: {CHANGELOG_PATH} is not valid JSON at {ref}: {exc}") from exc
+        raise SystemExit(f"FAIL: {path} is not valid JSON at {head_ref}: {exc}") from exc
 
-    unreleased = data.get("unreleased", [])
-    if not isinstance(unreleased, list):
-        raise SystemExit(f"FAIL: {CHANGELOG_PATH} field 'unreleased' must be a list")
-    return [entry for entry in unreleased if isinstance(entry, str) and entry.strip()]
+    if not isinstance(data, dict):
+        raise SystemExit(f"FAIL: {path} must contain a JSON object")
+
+    if isinstance(data.get("change"), str) and data["change"].strip():
+        return
+    if isinstance(data.get("changes"), list) and any(isinstance(entry, str) and entry.strip() for entry in data["changes"]):
+        return
+
+    raise SystemExit(f"FAIL: {path} must contain a non-empty 'change' string or 'changes' list")
 
 
-def has_new_unreleased_entry(base_ref: str, head_ref: str) -> bool:
-    before = Counter(unreleased_entries(base_ref))
-    after = Counter(unreleased_entries(head_ref))
-    return bool(after - before)
+def has_new_unreleased_fragment(base_ref: str, head_ref: str) -> bool:
+    fragment_paths = [
+        path
+        for path in added_files(base_ref, head_ref)
+        if path.startswith(UNRELEASED_CHANGELOG_PREFIX) and path.endswith(".json")
+    ]
+    for path in fragment_paths:
+        validate_unreleased_fragment(head_ref, path)
+    return bool(fragment_paths)
 
 
 def main() -> int:
@@ -81,19 +97,19 @@ def main() -> int:
         print("No desktop changes require a changelog entry.")
         return 0
 
-    if has_new_unreleased_entry(args.base, args.head):
-        print("Desktop changelog entry found.")
+    if has_new_unreleased_fragment(args.base, args.head):
+        print("Desktop changelog fragment found.")
         return 0
 
-    print("FAIL: desktop changes require an unreleased changelog entry.", file=sys.stderr)
+    print("FAIL: desktop changes require an unreleased changelog fragment.", file=sys.stderr)
     print("", file=sys.stderr)
     print("Changed desktop files:", file=sys.stderr)
     for path in requiring_changelog:
         print(f"  - {path}", file=sys.stderr)
     print("", file=sys.stderr)
     print(
-        "Add a one-line user-facing entry to desktop/macos/CHANGELOG.json under "
-        "'unreleased', or label the PR no-changelog-needed for internal-only changes.",
+        "Add a one-line user-facing JSON fragment under desktop/macos/changelog/unreleased/, "
+        "or label the PR no-changelog-needed for internal-only changes.",
         file=sys.stderr,
     )
     return 1

--- a/.github/scripts/desktop-changelog.py
+++ b/.github/scripts/desktop-changelog.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Manage desktop changelog fragments and legacy changelog output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_DIR = ROOT / "desktop" / "macos"
+CHANGELOG_DIR = DESKTOP_DIR / "changelog"
+UNRELEASED_DIR = CHANGELOG_DIR / "unreleased"
+RELEASES_DIR = CHANGELOG_DIR / "releases"
+LEGACY_CHANGELOG_PATH = DESKTOP_DIR / "CHANGELOG.json"
+
+
+class ChangelogError(Exception):
+    pass
+
+
+def read_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ChangelogError(f"{path} is not valid JSON: {exc}") from exc
+
+
+def write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def normalize_changes(raw: object, path: Path) -> list[str]:
+    if isinstance(raw, str):
+        changes = [raw]
+    elif isinstance(raw, list):
+        changes = raw
+    else:
+        raise ChangelogError(f"{path} must contain a string change or a list of changes")
+
+    normalized = []
+    for change in changes:
+        if not isinstance(change, str) or not change.strip():
+            raise ChangelogError(f"{path} contains an empty or non-string changelog entry")
+        normalized.append(change.strip())
+    return normalized
+
+
+def read_unreleased_fragment(path: Path) -> list[str]:
+    data = read_json(path)
+    if isinstance(data, dict):
+        if "change" in data:
+            return normalize_changes(data["change"], path)
+        if "changes" in data:
+            return normalize_changes(data["changes"], path)
+    raise ChangelogError(f"{path} must contain a 'change' string or 'changes' list")
+
+
+def read_release_file(path: Path) -> dict[str, object]:
+    data = read_json(path)
+    if not isinstance(data, dict):
+        raise ChangelogError(f"{path} must contain a JSON object")
+
+    version = data.get("version")
+    release_date = data.get("date")
+    changes = data.get("changes")
+    if not isinstance(version, str) or not version.strip():
+        raise ChangelogError(f"{path} must contain a non-empty 'version'")
+    if not isinstance(release_date, str) or not release_date.strip():
+        raise ChangelogError(f"{path} must contain a non-empty 'date'")
+
+    return {
+        "version": version.strip(),
+        "date": release_date.strip(),
+        "changes": normalize_changes(changes, path),
+    }
+
+
+def version_sort_key(version: str) -> tuple[int, ...]:
+    version = version.removeprefix("v")
+    return tuple(int(part) for part in version.split("."))
+
+
+def unreleased_fragment_paths() -> list[Path]:
+    if not UNRELEASED_DIR.exists():
+        return []
+    return sorted(path for path in UNRELEASED_DIR.glob("*.json") if path.is_file())
+
+
+def release_file_paths() -> list[Path]:
+    if not RELEASES_DIR.exists():
+        return []
+    return sorted(path for path in RELEASES_DIR.glob("*.json") if path.is_file())
+
+
+def unreleased_changes() -> list[str]:
+    changes: list[str] = []
+    for path in unreleased_fragment_paths():
+        changes.extend(read_unreleased_fragment(path))
+    return changes
+
+
+def release_entries() -> list[dict[str, object]]:
+    releases = [read_release_file(path) for path in release_file_paths()]
+    seen_versions = {str(release["version"]) for release in releases}
+
+    if LEGACY_CHANGELOG_PATH.exists():
+        data = read_json(LEGACY_CHANGELOG_PATH)
+        if isinstance(data, dict):
+            for release in data.get("releases", []):
+                if not isinstance(release, dict):
+                    raise ChangelogError(f"{LEGACY_CHANGELOG_PATH} contains a non-object release")
+                normalized = read_release_file_from_legacy(release)
+                version = str(normalized["version"])
+                if version not in seen_versions:
+                    releases.append(normalized)
+                    seen_versions.add(version)
+
+    return sorted(releases, key=lambda release: (str(release["date"]), version_sort_key(str(release["version"]))), reverse=True)
+
+
+def legacy_changelog() -> dict[str, object]:
+    return {
+        "unreleased": unreleased_changes(),
+        "releases": release_entries(),
+    }
+
+
+def validate() -> None:
+    seen_versions: set[str] = set()
+    for path in unreleased_fragment_paths():
+        read_unreleased_fragment(path)
+
+    for path in release_file_paths():
+        release = read_release_file(path)
+        version = str(release["version"])
+        if version in seen_versions:
+            raise ChangelogError(f"duplicate release version {version}")
+        seen_versions.add(version)
+        if path.stem != version:
+            raise ChangelogError(f"{path} filename must match its version field")
+
+
+def format_changes(changes: list[str], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(changes)
+    if output_format == "pipe":
+        return "|".join(changes)
+    return "\n".join(f"- {change}" for change in changes)
+
+
+def consolidate(version: str, release_date: str, *, write: bool) -> dict[str, object]:
+    changes = unreleased_changes() or ["Bug fixes and improvements"]
+    release = {
+        "version": version,
+        "date": release_date,
+        "changes": changes,
+    }
+
+    if write:
+        write_json(RELEASES_DIR / f"{version}.json", release)
+        for path in unreleased_fragment_paths():
+            path.unlink()
+        write_json(LEGACY_CHANGELOG_PATH, legacy_changelog())
+
+    return release
+
+
+def migrate_from_legacy(*, write: bool) -> None:
+    data = read_json(LEGACY_CHANGELOG_PATH)
+    if not isinstance(data, dict):
+        raise ChangelogError(f"{LEGACY_CHANGELOG_PATH} must contain a JSON object")
+
+    for release in data.get("releases", []):
+        if not isinstance(release, dict):
+            raise ChangelogError(f"{LEGACY_CHANGELOG_PATH} contains a non-object release")
+        normalized = read_release_file_from_legacy(release)
+        if write:
+            write_json(RELEASES_DIR / f"{normalized['version']}.json", normalized)
+
+    unreleased = normalize_changes(data.get("unreleased", []), LEGACY_CHANGELOG_PATH)
+    for index, change in enumerate(unreleased, start=1):
+        filename = f"{date.today().strftime('%Y%m%d')}-{index:02d}.json"
+        if write:
+            write_json(UNRELEASED_DIR / filename, {"change": change})
+
+
+def read_release_file_from_legacy(data: dict[str, object]) -> dict[str, object]:
+    version = data.get("version")
+    release_date = data.get("date")
+    changes = data.get("changes")
+    if not isinstance(version, str) or not version.strip():
+        raise ChangelogError(f"{LEGACY_CHANGELOG_PATH} contains a release without a version")
+    if not isinstance(release_date, str) or not release_date.strip():
+        raise ChangelogError(f"{LEGACY_CHANGELOG_PATH} contains release {version} without a date")
+    return {
+        "version": version.strip(),
+        "date": release_date.strip(),
+        "changes": normalize_changes(changes, LEGACY_CHANGELOG_PATH),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    output_parser = argparse.ArgumentParser(add_help=False)
+    output_parser.add_argument("--format", choices=["markdown", "json", "pipe"], default="markdown")
+
+    subparsers.add_parser("validate")
+    subparsers.add_parser("generate-legacy")
+    subparsers.add_parser("migrate-from-legacy")
+    subparsers.add_parser("unreleased", parents=[output_parser])
+    subparsers.add_parser("latest-release", parents=[output_parser])
+
+    consolidate_parser = subparsers.add_parser("consolidate")
+    consolidate_parser.add_argument("--version", required=True)
+    consolidate_parser.add_argument("--date", default=date.today().strftime("%Y-%m-%d"))
+    consolidate_parser.add_argument("--write", action="store_true")
+
+    for command in ("generate-legacy", "migrate-from-legacy"):
+        subparsers.choices[command].add_argument("--write", action="store_true")
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == "validate":
+            validate()
+        elif args.command == "generate-legacy":
+            data = legacy_changelog()
+            if args.write:
+                write_json(LEGACY_CHANGELOG_PATH, data)
+            else:
+                print(json.dumps(data, indent=2, ensure_ascii=False))
+        elif args.command == "migrate-from-legacy":
+            migrate_from_legacy(write=args.write)
+        elif args.command == "unreleased":
+            print(format_changes(unreleased_changes(), args.format))
+        elif args.command == "latest-release":
+            releases = release_entries()
+            changes = releases[0]["changes"] if releases else ["Bug fixes and improvements"]
+            print(format_changes(list(changes), args.format))
+        elif args.command == "consolidate":
+            release = consolidate(args.version, args.date, write=args.write)
+            print(json.dumps(release, indent=2, ensure_ascii=False))
+    except ChangelogError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -49,6 +49,8 @@ def releasable_desktop_changes_since(ref: str | None) -> list[str]:
             continue
         if path == "desktop/macos/AGENTS.md":
             continue
+        if path.startswith("desktop/macos/changelog/"):
+            continue
         if path.startswith("desktop/macos/Backend-Rust/"):
             continue
         changes.append(path)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'desktop/macos/**'
       - '!desktop/macos/CHANGELOG.json'
+      - '!desktop/macos/changelog/**'
   schedule:
     # Pick up desktop merges that accumulated while Codemagic was busy.
     - cron: '*/5 * * * *'
@@ -128,33 +129,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
-          # Consolidate unreleased changelog entries into a versioned release
+          # Consolidate unreleased changelog fragments into a versioned release
           TODAY=$(date -u +%Y-%m-%d)
-          python3 -c "
-          import json, sys
-
-          with open('desktop/macos/CHANGELOG.json', 'r') as f:
-              data = json.load(f)
-
-          unreleased = data.get('unreleased', [])
-          if not unreleased:
-              unreleased = ['Bug fixes and improvements']
-
-          new_release = {
-              'version': '$VERSION',
-              'date': '$TODAY',
-              'changes': unreleased
-          }
-
-          data.setdefault('releases', []).insert(0, new_release)
-          data['unreleased'] = []
-
-          with open('desktop/macos/CHANGELOG.json', 'w') as f:
-              json.dump(data, f, indent=2)
-              f.write('\n')
-
-          print(f'Consolidated {len(unreleased)} changelog entries for v$VERSION')
-          "
+          python3 .github/scripts/desktop-changelog.py consolidate \
+            --version "$VERSION" \
+            --date "$TODAY" \
+            --write
 
       - name: Commit changelog and create tag
         if: steps.recheck.outputs.should_release == 'true'
@@ -164,7 +144,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add desktop/macos/CHANGELOG.json
+          git add desktop/macos/CHANGELOG.json desktop/macos/changelog
           git commit -m "chore: consolidate changelog for v${VERSION}" || echo "No changelog changes to commit"
 
           # Tag the changelog commit first; Codemagic uses this tag to trigger builds.
@@ -197,8 +177,8 @@ jobs:
 
           if [ -z "$PR_NUMBER" ]; then
             PR_URL=$(gh pr create \
-              --title "Update CHANGELOG.json for v${VERSION} [skip ci]" \
-              --body "Auto-generated: consolidates unreleased entries into v${VERSION} and clears the unreleased array." \
+              --title "Update desktop changelog for v${VERSION} [skip ci]" \
+              --body "Auto-generated: consolidates unreleased changelog fragments into v${VERSION} and regenerates CHANGELOG.json." \
               --base main \
               --head "$BRANCH")
             PR_NUMBER=$(echo "$PR_URL" | awk -F/ '{print $NF}')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check desktop changelog data
+        run: python3 .github/scripts/desktop-changelog.py validate
+
       - name: Check desktop changelog entry
         if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changelog/v')
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Key rules:
 ### Desktop (macOS — Swift app + Rust backend)
 
 The desktop app is a **Swift Package Manager** project (no Xcode project, no `.xcodeproj`). The Rust backend lives in `desktop/macos/Backend-Rust/`.
-- For user-visible desktop changes, follow `desktop/macos/AGENTS.md` → Changelog Entries and add a one-line `desktop/macos/CHANGELOG.json` `unreleased` entry.
+- For user-visible desktop changes, follow `desktop/macos/AGENTS.md` → Changelog Entries and add one `desktop/macos/changelog/unreleased/*.json` fragment.
 
 #### Building & Running
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2650,16 +2650,7 @@ workflows:
 
       - name: Create GitHub release
         script: |
-          CHANGELOG_MD=$(python3 -c "
-          import json
-          try:
-            with open('CHANGELOG.json') as f:
-              data = json.load(f)
-            changes = data.get('releases', [{}])[0].get('changes', [])
-            print('\n'.join('- ' + c for c in changes))
-          except:
-            print('- Bug fixes and improvements')
-          ")
+          CHANGELOG_MD=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format markdown || echo "- Bug fixes and improvements")
 
           # Build changelog as pipe-separated string for KEY_VALUE_START
           CHANGELOG_PIPE=$(echo "$CHANGELOG_MD" | sed 's/^- //' | tr '\n' '|' | sed 's/|$//')
@@ -2762,15 +2753,7 @@ workflows:
           # verified. Remove this step once the Rust backend is decommissioned.
           export DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$CM_TAG/Omi.zip"
 
-          export CHANGELOG_JSON=$(python3 -c "
-          import json
-          try:
-            with open('CHANGELOG.json') as f:
-              data = json.load(f)
-            print(json.dumps(data.get('releases', [{}])[0].get('changes', [])))
-          except:
-            print('[]')
-          ")
+          export CHANGELOG_JSON=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format json || echo "[]")
 
           RELEASE_JSON=$(python3 -c "
           import json, os

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -180,26 +180,24 @@ agent-swift screenshot /tmp/evidence.png             # capture app window
 
 ### Changelog Entries
 
-After completing a desktop task with user-visible impact, append a one-liner to `unreleased` in `desktop/macos/CHANGELOG.json`:
+After completing a desktop task with user-visible impact, add one fragment file under `desktop/macos/changelog/unreleased/`:
 
-```python
-python3 -c "
-import json
-with open('CHANGELOG.json', 'r') as f:
-    data = json.load(f)
-data.setdefault('unreleased', []).append('Your user-facing change description')
-with open('CHANGELOG.json', 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-"
+Example `desktop/macos/changelog/unreleased/20260628-short-description.json`:
+
+```json
+{
+  "change": "Your user-facing change description"
+}
 ```
 
 Guidelines:
 - Write from the user's perspective: "Fixed X", "Added Y", "Improved Z"
 - One sentence, no period at the end
+- Use a unique kebab-case filename so parallel PRs do not conflict
 - Skip internal-only changes (refactors, CI config, code cleanup)
 - HTML is allowed for links: `<a href='...'>text</a>`
-- Commit CHANGELOG.json with your other changes (same commit is fine)
+- Do not edit `CHANGELOG.json` by hand; release automation regenerates it
+- Commit the fragment with your other changes (same commit is fine)
 
 ## User Task Completion Reporting
 

--- a/desktop/macos/changelog/README.md
+++ b/desktop/macos/changelog/README.md
@@ -1,0 +1,12 @@
+# Desktop changelog
+
+Add one JSON file per user-facing PR under `unreleased/`:
+
+```json
+{
+  "change": "Fixed the user-visible behavior"
+}
+```
+
+Use a unique kebab-case filename, for example `20260628-chat-scrolling.json`.
+Release automation moves unreleased fragments into `releases/<version>.json` and regenerates `../CHANGELOG.json` for compatibility.

--- a/desktop/macos/changelog/unreleased/20260628-chat-scrolling.json
+++ b/desktop/macos/changelog/unreleased/20260628-chat-scrolling.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat scrolling across desktop and mobile so streamed replies follow only while you are at the live edge"
+}


### PR DESCRIPTION
## Summary
- replaces the shared desktop `CHANGELOG.json` unreleased-edit flow with per-PR JSON fragments under `desktop/macos/changelog/unreleased/`
- adds `.github/scripts/desktop-changelog.py` as the shared validator/consolidator/generator for CI, GitHub Actions, and Codemagic
- updates desktop auto-release to consolidate fragments into `desktop/macos/changelog/releases/<version>.json`, delete consumed fragments, and regenerate `CHANGELOG.json` for compatibility
- updates agent docs and adds a changelog README for the new contributor workflow

## Validation
- `python3 -m py_compile .github/scripts/desktop-changelog.py .github/scripts/check-desktop-changelog.py .github/scripts/plan-desktop-release.py`
- `python3 .github/scripts/desktop-changelog.py validate`
- `python3 .github/scripts/desktop-changelog.py consolidate --version 9.9.9 --date 2026-06-28`
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD`
- `python3 .github/scripts/plan-desktop-release.py --repository BasedHardware/omi --mode force_release`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop_auto_release.yml"); YAML.load_file(".github/workflows/lint.yml"); YAML.load_file("codemagic.yaml"); puts "yaml ok"'
- generated legacy changelog dry-run matches `desktop/macos/CHANGELOG.json`
- independent subagent review: no findings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

