### PR TITLE
feat(desktop): track chat stall telemetry

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -514,14 +514,8 @@ class AnalyticsManager {
 
   /// Track individual tool calls made by the Claude agent
   func chatToolCallCompleted(toolName: String, durationMs: Int) {
-    let cleanName: String
-    if toolName.hasPrefix("mcp__") {
-      cleanName = String(toolName.split(separator: "__").last ?? Substring(toolName))
-    } else {
-      cleanName = toolName
-    }
     let props: [String: Any] = [
-      "tool_name": cleanName,
+      "tool_name": Self.normalizedToolName(toolName),
       "duration_ms": durationMs,
     ]
     PostHogManager.shared.track("chat_tool_call_completed", properties: props)
@@ -529,18 +523,19 @@ class AnalyticsManager {
 
   /// Track when client-side stall detection promotes an in-flight tool.
   func chatToolStallTransition(toolName: String, status: String, thresholdMs: Int) {
-    let cleanName: String
-    if toolName.hasPrefix("mcp__") {
-      cleanName = String(toolName.split(separator: "__").last ?? Substring(toolName))
-    } else {
-      cleanName = toolName
-    }
     let props: [String: Any] = [
-      "tool_name": cleanName,
+      "tool_name": Self.normalizedToolName(toolName),
       "status": status,
       "threshold_ms": thresholdMs,
     ]
     PostHogManager.shared.track("chat_tool_stall_transition", properties: props)
+  }
+
+  private static func normalizedToolName(_ toolName: String) -> String {
+    if toolName.hasPrefix("mcp__") {
+      return String(toolName.split(separator: "__").last ?? Substring(toolName))
+    }
+    return toolName
   }
 
   /// Track user stop requests so stalled-tool false positives can be tuned.

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -527,6 +527,33 @@ class AnalyticsManager {
     PostHogManager.shared.track("chat_tool_call_completed", properties: props)
   }
 
+  /// Track when client-side stall detection promotes an in-flight tool.
+  func chatToolStallTransition(toolName: String, status: String, thresholdMs: Int) {
+    let cleanName: String
+    if toolName.hasPrefix("mcp__") {
+      cleanName = String(toolName.split(separator: "__").last ?? Substring(toolName))
+    } else {
+      cleanName = toolName
+    }
+    let props: [String: Any] = [
+      "tool_name": cleanName,
+      "status": status,
+      "threshold_ms": thresholdMs,
+    ]
+    PostHogManager.shared.track("chat_tool_stall_transition", properties: props)
+  }
+
+  /// Track user stop requests so stalled-tool false positives can be tuned.
+  func chatAgentStopRequested(inFlightToolCount: Int, slowToolCount: Int, stalledToolCount: Int) {
+    let props: [String: Any] = [
+      "in_flight_tool_count": inFlightToolCount,
+      "slow_tool_count": slowToolCount,
+      "stalled_tool_count": stalledToolCount,
+      "has_slow_or_stalled_tool": slowToolCount > 0 || stalledToolCount > 0,
+    ]
+    PostHogManager.shared.track("chat_agent_stop_requested", properties: props)
+  }
+
   /// Track when the Claude agent bridge fails to start or errors
   func chatAgentError(error: String, rawError: String? = nil) {
     var props: [String: Any] = ["error": error]

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2478,6 +2478,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Stop the running agent, keeping partial response
     func stopAgent() {
         guard isSending else { return }
+        let counts = currentStreamingToolStatusCounts()
+        AnalyticsManager.shared.chatAgentStopRequested(
+            inFlightToolCount: counts.inFlight,
+            slowToolCount: counts.slow,
+            stalledToolCount: counts.stalled
+        )
         isStopping = true
         sendGeneration += 1
         let myGen = sendGeneration
@@ -3901,13 +3907,51 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 if case .toolCall(let blockId, let name, let oldStatus, let tuid, let input, let output) = messages[index].contentBlocks[i],
                    ChatProvider.stallTrackingId(toolUseId: tuid, name: name) == id,
                    oldStatus.isInFlight {
+                    let newStatus = mapDetectorState(to)
                     messages[index].contentBlocks[i] = .toolCall(
-                        id: blockId, name: name, status: mapDetectorState(to),
+                        id: blockId, name: name, status: newStatus,
                         toolUseId: tuid, input: input, output: output
                     )
+                    trackStallTransition(toolName: name, status: newStatus)
                 }
             }
         }
+    }
+
+    private func trackStallTransition(toolName: String, status: ToolCallStatus) {
+        let thresholdMs: Int
+        let statusName: String
+        switch status {
+        case .slow:
+            thresholdMs = StallThresholds.v1Defaults.slowGapMs
+            statusName = "slow"
+        case .stalled:
+            thresholdMs = StallThresholds.v1Defaults.stalledGapMs
+            statusName = "stalled"
+        case .running, .completed, .failed:
+            return
+        }
+
+        AnalyticsManager.shared.chatToolStallTransition(
+            toolName: toolName,
+            status: statusName,
+            thresholdMs: thresholdMs
+        )
+    }
+
+    private func currentStreamingToolStatusCounts() -> (inFlight: Int, slow: Int, stalled: Int) {
+        var counts = (inFlight: 0, slow: 0, stalled: 0)
+        guard let message = messages.last(where: { $0.sender == .ai && $0.isStreaming }) else {
+            return counts
+        }
+
+        for block in message.contentBlocks {
+            guard case .toolCall(_, _, let status, _, _, _) = block else { continue }
+            if status.isInFlight { counts.inFlight += 1 }
+            if status == .slow { counts.slow += 1 }
+            if status == .stalled { counts.stalled += 1 }
+        }
+        return counts
     }
 
     /// Serialize tool calls from a message's contentBlocks into a JSON metadata string.

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3024,8 +3024,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         // ToolCallStatus updates on individual tool-call blocks; the
         // banner appears via ToolCallsGroup's hasStalledTool check.
         let turnStartMs = ChatProvider.monotonicNowMs()
+        let stallThresholds = StallThresholds.v1Defaults
         let stallDetector = StallDetector(
-            thresholds: .v1Defaults,
+            thresholds: stallThresholds,
             startedAtMs: turnStartMs
         )
 
@@ -3109,7 +3110,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 Task { @MainActor [weak self] in
                     self?.appendToMessage(id: aiMessageId, text: delta)
                     let transitions = await stallDetector.step(kind: .other, atMs: nowMs)
-                    self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                    self?.applyStallTransitions(
+                        messageId: aiMessageId,
+                        transitions: transitions,
+                        thresholds: stallThresholds
+                    )
                 }
             }
             let toolCallHandler: AgentBridge.ToolCallHandler = { callId, name, input in
@@ -3208,7 +3213,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         }
                     }
                     let transitions = await stallDetector.step(kind: detectorKind, atMs: nowMs)
-                    self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                    self?.applyStallTransitions(
+                        messageId: aiMessageId,
+                        transitions: transitions,
+                        thresholds: stallThresholds
+                    )
                 }
             }
             let thinkingDeltaHandler: AgentBridge.ThinkingDeltaHandler = { [weak self] text in
@@ -3216,7 +3225,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 Task { @MainActor [weak self] in
                     self?.appendThinking(messageId: aiMessageId, text: text)
                     let transitions = await stallDetector.step(kind: .other, atMs: nowMs)
-                    self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                    self?.applyStallTransitions(
+                        messageId: aiMessageId,
+                        transitions: transitions,
+                        thresholds: stallThresholds
+                    )
                 }
             }
             let toolResultDisplayHandler: AgentBridge.ToolResultDisplayHandler = { [weak self] toolUseId, name, output in
@@ -3224,7 +3237,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 Task { @MainActor [weak self] in
                     self?.addToolResult(messageId: aiMessageId, toolUseId: toolUseId, name: name, output: output)
                     let transitions = await stallDetector.step(kind: .other, atMs: nowMs)
-                    self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                    self?.applyStallTransitions(
+                        messageId: aiMessageId,
+                        transitions: transitions,
+                        thresholds: stallThresholds
+                    )
                 }
             }
 
@@ -3239,7 +3256,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     let transitions = await stallDetector.tick(atMs: nowMs)
                     if transitions.isEmpty { continue }
                     await MainActor.run { [weak self] in
-                        self?.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+                        self?.applyStallTransitions(
+                            messageId: aiMessageId,
+                            transitions: transitions,
+                            thresholds: stallThresholds
+                        )
                     }
                 }
             }
@@ -3896,13 +3917,15 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// `.interEvent` transitions are observed but not rendered here.
     private func applyStallTransitions(
         messageId: String,
-        transitions: [StallDetector.Transition]
+        transitions: [StallDetector.Transition],
+        thresholds: StallThresholds
     ) {
         guard !transitions.isEmpty,
               let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
 
         for transition in transitions {
             guard case .tool(let id, _, let to) = transition else { continue }
+            var trackedTransition = false
             for i in messages[index].contentBlocks.indices {
                 if case .toolCall(let blockId, let name, let oldStatus, let tuid, let input, let output) = messages[index].contentBlocks[i],
                    ChatProvider.stallTrackingId(toolUseId: tuid, name: name) == id,
@@ -3912,21 +3935,28 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         id: blockId, name: name, status: newStatus,
                         toolUseId: tuid, input: input, output: output
                     )
-                    trackStallTransition(toolName: name, status: newStatus)
+                    if !trackedTransition {
+                        trackStallTransition(toolName: name, status: newStatus, thresholds: thresholds)
+                        trackedTransition = true
+                    }
                 }
             }
         }
     }
 
-    private func trackStallTransition(toolName: String, status: ToolCallStatus) {
+    private func trackStallTransition(
+        toolName: String,
+        status: ToolCallStatus,
+        thresholds: StallThresholds
+    ) {
         let thresholdMs: Int
         let statusName: String
         switch status {
         case .slow:
-            thresholdMs = StallThresholds.v1Defaults.slowGapMs
+            thresholdMs = thresholds.slowGapMs
             statusName = "slow"
         case .stalled:
-            thresholdMs = StallThresholds.v1Defaults.stalledGapMs
+            thresholdMs = thresholds.stalledGapMs
             statusName = "stalled"
         case .running, .completed, .failed:
             return

--- a/desktop/macos/changelog/unreleased/chat-stall-telemetry.json
+++ b/desktop/macos/changelog/unreleased/chat-stall-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added desktop chat stall telemetry to help tune slow and stalled tool-call thresholds"
+}

--- a/desktop/macos/changelog/unreleased/chat-stall-telemetry.json
+++ b/desktop/macos/changelog/unreleased/chat-stall-telemetry.json
@@ -1,3 +1,0 @@
-{
-  "change": "Added desktop chat stall telemetry to help tune slow and stalled tool-call thresholds"
-}


### PR DESCRIPTION
## Summary

- Adds privacy-safe telemetry when desktop chat tool calls transition to `.slow` or `.stalled`.
- Tracks user stop requests with counts of in-flight, slow, and stalled tools visible at the time of stop.
- Adds an unreleased desktop changelog fragment.

## Why

PR #7555 intentionally left threshold tuning as a follow-up. This PR gives us the data needed to tune the shared 8s / 20s thresholds against real usage instead of guessing.

## Telemetry added

- `chat_tool_stall_transition`
  - `tool_name`
  - `status` (`slow` or `stalled`)
  - `threshold_ms`
- `chat_agent_stop_requested`
  - `in_flight_tool_count`
  - `slow_tool_count`
  - `stalled_tool_count`
  - `has_slow_or_stalled_tool`

No prompt text, tool input, tool output, or message content is tracked.

## Verification

- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter 'StallDetectorTests|ToolCallStatusTests'` -> 23 tests, 0 failures
- `xcrun swift build -c debug --package-path desktop/macos/Desktop` -> build complete
- `python3 .github/scripts/check-desktop-changelog.py --base upstream/main --head HEAD` -> Desktop changelog fragment found
- `git diff --check` -> clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

