### PR TITLE
refactor(desktop): share tool activity block updates

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -218,7 +218,7 @@ class TaskChatState: ObservableObject {
                     self?.addToolActivity(
                         messageId: aiMessageId,
                         toolName: name,
-                        status: status == "started" ? .running : .completed,
+                        status: ChatProvider.mapBridgeToolStatus(status),
                         toolUseId: toolUseId,
                         input: input
                     )
@@ -408,47 +408,15 @@ class TaskChatState: ObservableObject {
         }
     }
 
-    // Mirrors ChatProvider.addToolActivity — kept in lockstep.
-    // TODO: DRY these two implementations into a shared helper.
     private func addToolActivity(messageId: String, toolName: String, status: ToolCallStatus, toolUseId: String? = nil, input: [String: Any]? = nil) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
-
-        if status == .running {
-            if let toolUseId = toolUseId, toolInput != nil {
-                for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                    if case .toolCall(let id, let name, let st, let existingTuid, _, let output) = messages[index].contentBlocks[i],
-                       (existingTuid == toolUseId || (existingTuid == nil && name == toolName && st.isInFlight)) {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: st,
-                            toolUseId: toolUseId, input: toolInput, output: output
-                        )
-                        return
-                    }
-                }
-            }
-            messages[index].contentBlocks.append(
-                .toolCall(id: UUID().uuidString, name: toolName, status: .running,
-                          toolUseId: toolUseId, input: toolInput)
-            )
-        } else {
-            for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                if case .toolCall(let id, let name, let st, let existingTuid, let existingInput, let output) = messages[index].contentBlocks[i],
-                   st.isInFlight {
-                    let matches = (toolUseId != nil && existingTuid == toolUseId) || (toolUseId == nil && name == toolName)
-                    if matches {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: .completed,
-                            toolUseId: toolUseId ?? existingTuid,
-                            input: toolInput ?? existingInput,
-                            output: output
-                        )
-                        break
-                    }
-                }
-            }
-        }
+        ChatContentBlock.applyToolActivity(
+            to: &messages[index].contentBlocks,
+            toolName: toolName,
+            status: status,
+            toolUseId: toolUseId,
+            input: input
+        )
     }
 
     private func addToolResult(messageId: String, toolUseId: String, name: String, output: String) {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -231,6 +231,61 @@ enum ToolCallStatus: CaseIterable {
     }
 }
 
+extension ChatContentBlock {
+    static func applyToolActivity(
+        to blocks: inout [ChatContentBlock],
+        toolName: String,
+        status: ToolCallStatus,
+        toolUseId: String? = nil,
+        input: [String: Any]? = nil
+    ) {
+        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
+
+        // Detector-promoted .slow / .stalled arrive through the stall
+        // status-update path, not here.
+        if status == .running {
+            // If we have a toolUseId and input, try to update an existing
+            // running block (input arrived after start).
+            if let toolUseId = toolUseId, toolInput != nil {
+                for i in stride(from: blocks.count - 1, through: 0, by: -1) {
+                    if case .toolCall(let id, let name, let st, let existingTuid, _, let output) = blocks[i],
+                       (existingTuid == toolUseId || (existingTuid == nil && name == toolName && st.isInFlight)) {
+                        blocks[i] = .toolCall(
+                            id: id, name: name, status: st,
+                            toolUseId: toolUseId, input: toolInput, output: output
+                        )
+                        return
+                    }
+                }
+            }
+            // No existing block to update — create a new one.
+            blocks.append(
+                .toolCall(id: UUID().uuidString, name: toolName, status: .running,
+                          toolUseId: toolUseId, input: toolInput)
+            )
+        } else {
+            // Mark as terminal — find by toolUseId first, fall back to name.
+            // Match any in-flight state so detector-promoted .slow / .stalled
+            // also resolve cleanly when the tool actually finishes.
+            for i in stride(from: blocks.count - 1, through: 0, by: -1) {
+                if case .toolCall(let id, let name, let existingStatus, let existingTuid, let existingInput, let output) = blocks[i],
+                   existingStatus.isInFlight {
+                    let matches = (toolUseId != nil && existingTuid == toolUseId) || (toolUseId == nil && name == toolName)
+                    if matches {
+                        blocks[i] = .toolCall(
+                            id: id, name: name, status: status,
+                            toolUseId: toolUseId ?? existingTuid,
+                            input: toolInput ?? existingInput,
+                            output: output
+                        )
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Chat Message Model
 
 /// Metadata about the context and resources used to generate an AI response
@@ -3742,50 +3797,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
     private func addToolActivity(messageId: String, toolName: String, status: ToolCallStatus, toolUseId: String? = nil, input: [String: Any]? = nil) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
-
-        // Detector-promoted .slow / .stalled arrive through the stall
-        // status-update path, not here.
-        if status == .running {
-            // If we have a toolUseId and input, try to update an existing running block (input arrived after start)
-            if let toolUseId = toolUseId, toolInput != nil {
-                for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                    if case .toolCall(let id, let name, let st, let existingTuid, _, let output) = messages[index].contentBlocks[i],
-                       (existingTuid == toolUseId || (existingTuid == nil && name == toolName && st == .running)) {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: st,
-                            toolUseId: toolUseId, input: toolInput, output: output
-                        )
-                        return
-                    }
-                }
-            }
-            // No existing block to update — create a new one
-            messages[index].contentBlocks.append(
-                .toolCall(id: UUID().uuidString, name: toolName, status: .running,
-                          toolUseId: toolUseId, input: toolInput)
-            )
-        } else {
-            // Mark as terminal — find by toolUseId first, fall back to name.
-            // Match any in-flight state so detector-promoted .slow / .stalled
-            // also resolve cleanly when the tool actually finishes.
-            for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                if case .toolCall(let id, let name, let existingStatus, let existingTuid, let existingInput, let output) = messages[index].contentBlocks[i],
-                   existingStatus.isInFlight {
-                    let matches = (toolUseId != nil && existingTuid == toolUseId) || (toolUseId == nil && name == toolName)
-                    if matches {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: status,
-                            toolUseId: toolUseId ?? existingTuid,
-                            input: toolInput ?? existingInput,
-                            output: output
-                        )
-                        break
-                    }
-                }
-            }
-        }
+        ChatContentBlock.applyToolActivity(
+            to: &messages[index].contentBlocks,
+            toolName: toolName,
+            status: status,
+            toolUseId: toolUseId,
+            input: input
+        )
     }
 
     /// Add tool result output to an existing tool call block

--- a/desktop/macos/Desktop/Tests/ChatContentBlockToolActivityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatContentBlockToolActivityTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ChatContentBlockToolActivityTests: XCTestCase {
+
+  func testApplyToolActivityCreatesRunningToolCall() {
+    var blocks: [ChatContentBlock] = []
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .running,
+      toolUseId: "tool-1",
+      input: ["command": "pwd"]
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    assertToolCall(
+      blocks[0],
+      name: "Bash",
+      status: .running,
+      toolUseId: "tool-1",
+      inputSummary: "pwd"
+    )
+  }
+
+  func testApplyToolActivityUpdatesExistingInFlightBlockWithInputByToolUseId() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "existing", name: "Bash", status: .running, toolUseId: "tool-1")
+    ]
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .running,
+      toolUseId: "tool-1",
+      input: ["command": "ls -la"]
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    assertToolCall(
+      blocks[0],
+      id: "existing",
+      name: "Bash",
+      status: .running,
+      toolUseId: "tool-1",
+      inputSummary: "ls -la"
+    )
+  }
+
+  func testApplyToolActivityUpdatesLegacyInFlightBlockByNameWhenToolUseIdArrivesLater() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "legacy", name: "execute_sql", status: .slow, toolUseId: nil)
+    ]
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "execute_sql",
+      status: .running,
+      toolUseId: "tool-2",
+      input: ["query": "select * from conversations"]
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    assertToolCall(
+      blocks[0],
+      id: "legacy",
+      name: "execute_sql",
+      status: .slow,
+      toolUseId: "tool-2",
+      inputSummary: "select * from conversations"
+    )
+  }
+
+  func testApplyToolActivityResolvesTerminalStatusByToolUseIdBeforeName() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "first", name: "Bash", status: .running, toolUseId: "tool-1"),
+      .toolCall(id: "second", name: "Bash", status: .stalled, toolUseId: "tool-2"),
+    ]
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .completed,
+      toolUseId: "tool-1"
+    )
+
+    assertToolCall(blocks[0], id: "first", name: "Bash", status: .completed, toolUseId: "tool-1")
+    assertToolCall(blocks[1], id: "second", name: "Bash", status: .stalled, toolUseId: "tool-2")
+  }
+
+  func testApplyToolActivityResolvesLatestInFlightBlockByNameWhenToolUseIdMissing() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "old", name: "Bash", status: .running, toolUseId: nil),
+      .toolCall(id: "new", name: "Bash", status: .slow, toolUseId: nil),
+    ]
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .failed
+    )
+
+    assertToolCall(blocks[0], id: "old", name: "Bash", status: .running, toolUseId: nil)
+    assertToolCall(blocks[1], id: "new", name: "Bash", status: .failed, toolUseId: nil)
+  }
+
+  func testApplyToolActivityDoesNotRewriteTerminalBlock() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "done", name: "Bash", status: .completed, toolUseId: "tool-1")
+    ]
+
+    ChatContentBlock.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .failed,
+      toolUseId: "tool-1"
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    assertToolCall(blocks[0], id: "done", name: "Bash", status: .completed, toolUseId: "tool-1")
+  }
+
+  private func assertToolCall(
+    _ block: ChatContentBlock,
+    id expectedId: String? = nil,
+    name expectedName: String,
+    status expectedStatus: ToolCallStatus,
+    toolUseId expectedToolUseId: String?,
+    inputSummary expectedInputSummary: String? = nil,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    guard case .toolCall(let id, let name, let status, let toolUseId, let input, _) = block else {
+      XCTFail("Expected toolCall block", file: file, line: line)
+      return
+    }
+
+    if let expectedId {
+      XCTAssertEqual(id, expectedId, file: file, line: line)
+    }
+    XCTAssertEqual(name, expectedName, file: file, line: line)
+    XCTAssertEqual(status, expectedStatus, file: file, line: line)
+    XCTAssertEqual(toolUseId, expectedToolUseId, file: file, line: line)
+    XCTAssertEqual(input?.summary, expectedInputSummary, file: file, line: line)
+  }
+}

--- a/desktop/macos/changelog/unreleased/dry-tool-activity.json
+++ b/desktop/macos/changelog/unreleased/dry-tool-activity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Shared desktop chat tool activity updates across main and task chat surfaces"
+}


### PR DESCRIPTION
## Summary

- Extracts shared tool-call content-block update logic into `ChatContentBlock.applyToolActivity`.
- Routes both main chat (`ChatProvider`) and task chat (`TaskChatState`) through the shared helper.
- Aligns task chat terminal status mapping with `ChatProvider.mapBridgeToolStatus`, so failed/cancelled/interrupted statuses do not get flattened to completed.

## Why draft

This is follow-up cleanup from PR #7555. It is not urgent for the stall telemetry rollout, but it removes duplicated logic that had already started to drift.

## Verification

- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter 'StallDetectorTests|ToolCallStatusTests'` -> 23 tests, 0 failures
- `xcrun swift build -c debug --package-path desktop/macos/Desktop` -> build complete
- `python3 .github/scripts/check-desktop-changelog.py --base upstream/main --head HEAD` -> Desktop changelog fragment found
- `git diff --check` -> clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

