### PR TITLE
test(desktop): add tool stall state preview harness

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -1407,6 +1407,57 @@ struct ToolCallStalledBanner: View {
   }
 }
 
+#if DEBUG
+#Preview("Tool call stall states") {
+  VStack(alignment: .leading, spacing: 14) {
+    ToolCallsGroup(
+      calls: [
+        .toolCall(
+          id: "running-tool", name: "execute_sql", status: .running,
+          toolUseId: "tool-running",
+          input: ToolCallInput(summary: "SELECT * FROM memories", details: nil)
+        ),
+        .toolCall(
+          id: "slow-tool", name: "search_screen_history", status: .slow,
+          toolUseId: "tool-slow",
+          input: ToolCallInput(summary: "last 7 days", details: nil)
+        ),
+      ],
+      onCancel: {}
+    )
+
+    ToolCallsGroup(
+      calls: [
+        .toolCall(
+          id: "stalled-tool", name: "execute_sql", status: .stalled,
+          toolUseId: "tool-stalled",
+          input: ToolCallInput(
+            summary: "large local query",
+            details: "{\n  \"query\": \"SELECT * FROM screenshots ORDER BY timestamp DESC\"\n}"
+          )
+        ),
+        .toolCall(
+          id: "failed-tool", name: "request_screenshot", status: .failed,
+          toolUseId: "tool-failed",
+          input: ToolCallInput(summary: "screenshot_id: 42", details: nil),
+          output: "screenshot_pending"
+        ),
+        .toolCall(
+          id: "completed-tool", name: "create_action_item", status: .completed,
+          toolUseId: "tool-completed",
+          input: ToolCallInput(summary: "Follow up tomorrow", details: nil),
+          output: "Task created"
+        ),
+      ],
+      onCancel: {}
+    )
+  }
+  .padding(24)
+  .frame(width: 520)
+  .background(OmiColors.backgroundPrimary)
+}
+#endif
+
 // MARK: - Thinking Block
 
 struct ThinkingBlock: View {

--- a/desktop/macos/changelog/unreleased/tool-stall-preview-harness.json
+++ b/desktop/macos/changelog/unreleased/tool-stall-preview-harness.json
@@ -1,3 +1,0 @@
-{
-  "change": "Added a developer preview for desktop chat tool-call slow, stalled, failed, and completed states"
-}

--- a/desktop/macos/changelog/unreleased/tool-stall-preview-harness.json
+++ b/desktop/macos/changelog/unreleased/tool-stall-preview-harness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a developer preview for desktop chat tool-call slow, stalled, failed, and completed states"
+}


### PR DESCRIPTION
## Summary

- Adds a DEBUG-only SwiftUI preview for desktop chat tool-call states.
- Forces representative `.running`, `.slow`, `.stalled`, `.failed`, and `.completed` tool rows without requiring a live bridge.
- Includes a stalled group with the Cancel banner wired to a no-op preview action.

## Why draft

This is the first visual harness step from PR #7555 follow-up work. It is intentionally draft because the stronger follow-up is still a fake-bridge/dev runtime path that can drive the full chat surface end-to-end.

## Verification

- `xcrun swift build -c debug --package-path desktop/macos/Desktop` -> build complete
- `python3 .github/scripts/check-desktop-changelog.py --base upstream/main --head HEAD` -> Desktop changelog fragment found
- `git diff --check` -> clean

## Not included yet

- No fake bridge.
- No automated screenshot capture.
- No runtime path for forcing stall states outside SwiftUI previews.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

