### PR TITLE
[codex] Fix delayed PTT replies after realtime barge-in

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -104,6 +104,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   private weak var barState: FloatingControlBarState?
   private var session: RealtimeHubSession?
   private var sessionProvider: RealtimeHubProvider?
+  private var sessionAuth: HubAuth?
   private var pcmPlayer: StreamingPCMPlayer?
   private let speech = AVSpeechSynthesizer()
   private lazy var responseGlowGate = RealtimeResponseGlowGate { [weak self] active in
@@ -343,6 +344,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     hubConnected = false
     session = s
     sessionProvider = provider
+    sessionAuth = auth
     // Both providers stream native spoken audio (24k PCM) → StreamingPCMPlayer;
     // AVSpeech is only a no-audio fallback.
     if pcmPlayer == nil {
@@ -361,7 +363,21 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     session?.stop()
     session = nil
     sessionProvider = nil
+    sessionAuth = nil
     hubConnected = false  // no live session → PTT falls back to the cascade until re-warm
+  }
+
+  @discardableResult
+  private func restartSessionForBargeIn() -> Bool {
+    guard let provider = sessionProvider, let auth = sessionAuth else { return false }
+    session?.detach()
+    session?.stop()
+    session = nil
+    sessionProvider = nil
+    sessionAuth = nil
+    hubConnected = false
+    startSession(provider: provider, auth: auth)
+    return true
   }
 
   private func makePCMPlayer() -> StreamingPCMPlayer {
@@ -390,6 +406,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   func beginTurn() {
     // Barge-in: was a reply from the previous turn still in flight when the user
     // started talking again?
+    let providerResponseInFlight = responding
     let bargeIn = responding || realtimePlaybackActive || localSpeechActive || speech.isSpeaking
     responding = false
     realtimePlaybackActive = false
@@ -414,18 +431,30 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       localSpeechActive = false
     }
     responseGlowGate.clearImmediately()
-    if bargeIn {
-      // Interrupt the in-flight reply IN-SESSION (no teardown — the warm socket and
-      // its conversation context survive). OpenAI: response.cancel + clear input.
-      // Gemini: the fresh activityStart sent by beginInputTurn(interrupting:) cancels
-      // the current generation server-side; the pending-reply gate drops its tail.
-      log("RealtimeHub[\(providerTag)]: barge-in — interrupting in-flight reply (same session)")
-      session?.cancelActiveResponse()
+    if providerResponseInFlight {
+      switch session?.bargeInStrategy ?? .inSessionCancel {
+      case .inSessionCancel:
+        // OpenAI exposes an explicit response.cancel path, so the warm socket and
+        // conversation context survive while the next input buffer starts clean.
+        log("RealtimeHub[\(providerTag)]: barge-in — interrupting in-flight reply (same session)")
+        session?.cancelActiveResponse()
+      case .freshSession:
+        // Gemini Live has no reliable in-session cancel for a streaming reply. Reusing
+        // that socket can leave the next PTT turn queued behind the old generation, so
+        // replace the connection and let the fresh session buffer this new turn while it opens.
+        if restartSessionForBargeIn() {
+          log("RealtimeHub[\(providerTag)]: barge-in — replacing session for clean next turn")
+        } else {
+          session?.cancelActiveResponse()
+        }
+      }
+    } else if bargeIn {
+      log("RealtimeHub[\(providerTag)]: barge-in — stopping local playback tail")
     }
     ensureWarm()  // (re)connect only if the socket idle-closed
     // Open a fresh speech window for this turn (Gemini manual-VAD needs it EVERY
     // turn on a warm session; OpenAI no-op).
-    session?.beginInputTurn(interrupting: bargeIn)
+    session?.beginInputTurn(interrupting: providerResponseInFlight)
     // Capture the screen at turn START and, for Gemini, send it in-turn right away — early
     // enough that the ~450KB JPEG uploads/decodes during the seconds of speech, so the
     // model can see it when it answers. A frame attached at commit (PTT-up) lands too late:
@@ -475,13 +504,32 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
 
   // MARK: - RealtimeHubSessionDelegate
 
-  func hubDidConnect() {
+  private func isCurrentSession(_ source: RealtimeHubSession) -> Bool {
+    source === session
+  }
+
+  private func sendToolResultIfCurrent(
+    source: RealtimeHubSession,
+    callId: String,
+    name: String,
+    output: String
+  ) {
+    guard isCurrentSession(source) else {
+      log("RealtimeHub[\(providerTag)]: dropping stale tool result \(name)")
+      return
+    }
+    source.sendToolResult(callId: callId, name: name, output: output)
+  }
+
+  func hubDidConnect(source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     lastWarmAt = Date()
     hubConnected = true  // authenticated + ready — PTT may now route turns to the hub
     log("RealtimeHub: connected (\(sessionProvider?.displayName ?? "?"))")
   }
 
-  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool, source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     if isFinal {
       if !text.isEmpty { turnTranscript = text }
     } else {
@@ -501,7 +549,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     }
   }
 
-  func hubDidReceiveAudio(_ pcm24k: Data) {
+  func hubDidReceiveAudio(_ pcm24k: Data, source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     guard !suppressAssistantOutputForCurrentTurn else { return }
     // If PTT muted music/system output while listening, make sure the model's
     // reply is audible even if capture teardown restore is delayed by hardware.
@@ -516,7 +565,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     responseGlowGate.markPlaybackActive()
   }
 
-  func hubDidEmitText(_ text: String, isFinal: Bool) {
+  func hubDidEmitText(_ text: String, isFinal: Bool, source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     guard !suppressAssistantOutputForCurrentTurn else { return }
     if !text.isEmpty { assistantText += text }
     if isFinal {
@@ -536,6 +586,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
   /// empty/whitespace result → `emptyText`. Shared by the data read/write tool cases so the
   /// Task / do-catch / blank-check / log / sendToolResult tail lives in exactly one place.
   private func runToolAndSpeak(
+    source: RealtimeHubSession,
     callId: String, name: String, detail: String = "",
     emptyText: String, errorText: String,
     _ body: @escaping () async throws -> String
@@ -547,16 +598,17 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       if out.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { out = emptyText }
       let suffix = detail.isEmpty ? "" : " \(detail)"
       log("RealtimeHub[\(self.providerTag)]: tool \(name)\(suffix) → \(out.prefix(60))")
-      self.session?.sendToolResult(callId: callId, name: name, output: out)
+      self.sendToolResultIfCurrent(source: source, callId: callId, name: name, output: out)
     }
   }
 
-  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String) {
+  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String, source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     let arguments =
       (try? JSONSerialization.jsonObject(with: Data(argumentsJSON.utf8)) as? [String: Any]) ?? [:]
     guard let tool = HubTool(rawValue: name) else {
       log("RealtimeHub[\(providerTag)]: tool_call UNKNOWN \(name) — rejecting")
-      session?.sendToolResult(callId: callId, name: name, output: "Unknown tool.")
+      sendToolResultIfCurrent(source: source, callId: callId, name: name, output: "Unknown tool.")
       return
     }
     func arg(_ key: String) -> String { (arguments[key] as? String) ?? turnTranscript }
@@ -572,7 +624,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         guard let self else { return }
         let answer = await self.escalateToHigherModel(
           query, context: context, aboutUser: self.aboutUserCard)
-        self.session?.sendToolResult(callId: callId, name: name, output: answer)
+        self.sendToolResultIfCurrent(source: source, callId: callId, name: name, output: answer)
       }
     case .getTasks:
       // Fast LOCAL read — no agent. Fetch today's + overdue tasks and hand them back
@@ -591,11 +643,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         if !today.isEmpty { out += "Due today (\(today.count)):\n\(list(today))\n" }
         if out.isEmpty { out = "No tasks overdue or due today." }
         log("RealtimeHub[\(self.providerTag)]: tool get_tasks → \(overdue.count) overdue, \(today.count) today")
-        self.session?.sendToolResult(callId: callId, name: name, output: out)
+        self.sendToolResultIfCurrent(source: source, callId: callId, name: name, output: out)
       }
     case .getMemories:
       // Fast READ — "who am I" / "what do you know about me". Backend memories+facts.
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name,
         emptyText: "I don't have any memories saved about you yet.",
         errorText: "Could not read your memories right now."
@@ -603,6 +656,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     case .searchMemories:
       let query = arg("query")
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "q=\"\(query.prefix(60))\"",
         emptyText: "I couldn't find anything about that.",
         errorText: "Could not search your memories right now."
@@ -611,6 +665,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       // Capped for voice: top 5, summaries only (no full transcripts).
       let query = arg("query")
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "q=\"\(query.prefix(60))\"",
         emptyText: "I couldn't find a conversation about that.",
         errorText: "Could not search your conversations right now."
@@ -624,6 +679,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       // Capped for voice: top 3, summaries only. This is the recency path; search_conversations
       // is semantic and must NOT be used for "most recent".
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name,
         emptyText: "I don't see any recent conversations.",
         errorText: "Could not read your recent conversations right now."
@@ -638,6 +694,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       // chat answer "what did I do yesterday" from one code path.
       let daysAgo = argInt("days_ago") ?? 1
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "days_ago=\(daysAgo)",
         emptyText: "I don't have any activity recorded for then.",
         errorText: "Could not pull up your activity right now."
@@ -652,6 +709,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       let dueStart = arguments["due_start_date"] as? String
       let dueEnd = arguments["due_end_date"] as? String
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: completed.map { "completed=\($0)" } ?? "",
         emptyText: "I couldn't find any matching tasks.",
         errorText: "Could not read your tasks right now."
@@ -663,16 +721,17 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     case .getTaskAgentStatus:
       let result = TaskAgentStatusRegistry.shared.combinedSummary()
       log("RealtimeHub[\(providerTag)]: tool get_task_agent_status")
-      session?.sendToolResult(callId: callId, name: name, output: result)
+      sendToolResultIfCurrent(source: source, callId: callId, name: name, output: result)
     case .manageAgentPills:
       let action = ((arguments["action"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines))
         .flatMap { $0.isEmpty ? nil : $0 } ?? "list"
       let agentId = (arguments["agent_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
       let result = AgentPillsManager.shared.manage(action: action, agentId: agentId)
       log("RealtimeHub[\(providerTag)]: tool manage_agent_pills action=\(action)")
-      session?.sendToolResult(callId: callId, name: name, output: result)
+      sendToolResultIfCurrent(source: source, callId: callId, name: name, output: result)
     case .listAgentSessions, .getAgentRun, .cancelAgentRun, .inspectAgentArtifacts, .updateAgentArtifactLifecycle:
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: agentControlService.logDetail(name: name, arguments: arguments),
         emptyText: "No canonical agent data came back.",
         errorText: "Could not reach the agent control plane right now."
@@ -685,6 +744,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       var toolArgs: [String: Any] = ["query": query]
       if let days = argInt("days") { toolArgs["days"] = days }
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "q=\"\(query.prefix(60))\"",
         emptyText: "I couldn't find anything on your screen about that.",
         errorText: "Could not search your screen history right now."
@@ -697,11 +757,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
       let dueAt = arguments["due_at"] as? String
       guard !description.isEmpty else {
-        session?.sendToolResult(
-          callId: callId, name: name, output: "No task description was given.")
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name, output: "No task description was given.")
         return
       }
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "\"\(description.prefix(60))\"",
         emptyText: "Task created.",
         errorText: "Could not create the task right now."
@@ -712,8 +773,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       }
     case .updateActionItem:
       guard let id = (arguments["id"] as? String), !id.isEmpty else {
-        session?.sendToolResult(
-          callId: callId, name: name,
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name,
           output: "Missing the task id — call get_tasks first to find it.")
         return
       }
@@ -721,6 +782,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       let newDescription = arguments["description"] as? String
       let dueAt = arguments["due_at"] as? String
       runToolAndSpeak(
+        source: source,
         callId: callId, name: name, detail: "id=\(id.prefix(8))",
         emptyText: "Task updated.",
         errorText: "Could not update the task right now."
@@ -750,8 +812,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         speak(ack)
       }
       suppressAssistantOutputForCurrentTurn = true
-      session?.sendToolResult(
-        callId: callId, name: name,
+      sendToolResultIfCurrent(
+        source: source, callId: callId, name: name,
         output: "Agent started.")
     case .screenshot:
       // Gemini: the screen is already attached to every turn (see commitTurn), so the
@@ -761,20 +823,21 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       let shot = speculativeScreenshot ?? ScreenCaptureManager.captureScreenData()
       if sessionProvider == .openai, let shot { session?.injectImage(shot) }
       log("RealtimeHub[\(providerTag)]: tool screenshot → ack (\(shot?.count ?? 0) bytes, screen on turn)")
-      session?.sendToolResult(
-        callId: callId, name: name,
+      sendToolResultIfCurrent(
+        source: source, callId: callId, name: name,
         output: shot == nil ? "Could not capture the screen." : "Screen captured.")
     case .pointClick:
       let x = (arguments["x"] as? Double) ?? (arguments["x"] as? NSNumber)?.doubleValue ?? 0
       let y = (arguments["y"] as? Double) ?? (arguments["y"] as? NSNumber)?.doubleValue ?? 0
       let ok = Self.click(at: CGPoint(x: x, y: y))
-      session?.sendToolResult(
-        callId: callId, name: name,
+      sendToolResultIfCurrent(
+        source: source, callId: callId, name: name,
         output: ok ? "Clicked at \(Int(x)), \(Int(y))." : "Could not click.")
     }
   }
 
-  func hubDidFinishTurn() {
+  func hubDidFinishTurn(source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     responding = false
     hubReconnectStrikes = 0  // a completed turn proves the hub works — reset the budget
     let heard = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -794,7 +857,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     exitVoiceUI()
   }
 
-  func hubDidError(_ message: String) {
+  func hubDidError(_ message: String, source: RealtimeHubSession) {
+    guard isCurrentSession(source) else { return }
     // A socket we intentionally dropped is detached in teardownSession() before it's
     // released, so its death-rattle never reaches us — only the live session's errors
     // land here.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -181,6 +181,13 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
 
   /// In-flight ephemeral mint guard (managed users).
   private var minting = false
+  /// A Gemini active-reply barge-in replaces the whole session. Managed sessions
+  /// need a fresh one-use token first, so hold early mic chunks/commit until the
+  /// replacement session exists and can use its normal socket-open buffering.
+  private var bargeInReplacementInFlight = false
+  private var bargeInReplacementPendingTurn = false
+  private var bargeInReplacementPendingCommit = false
+  private var bargeInReplacementAudioBuffer: [Data] = []
 
   /// Failover chain: when the Auto-selected (primary) provider can't connect, the hub
   /// tries the OTHER realtime provider before dropping to the legacy Claude cascade.
@@ -365,6 +372,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     sessionProvider = nil
     sessionAuth = nil
     hubConnected = false  // no live session → PTT falls back to the cascade until re-warm
+    clearBargeInReplacementState()
+  }
+
+  private func clearBargeInReplacementState() {
+    bargeInReplacementInFlight = false
+    bargeInReplacementPendingTurn = false
+    bargeInReplacementPendingCommit = false
+    bargeInReplacementAudioBuffer.removeAll()
   }
 
   @discardableResult
@@ -376,8 +391,86 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     sessionProvider = nil
     sessionAuth = nil
     hubConnected = false
-    startSession(provider: provider, auth: auth)
+    bargeInReplacementInFlight = true
+    bargeInReplacementPendingTurn = true
+    bargeInReplacementPendingCommit = false
+    bargeInReplacementAudioBuffer.removeAll()
+    switch auth {
+    case .byokKey:
+      startReplacementSessionForBargeIn(provider: provider, auth: auth)
+    case .ephemeral:
+      remintReplacementSessionForBargeIn(provider: provider)
+    }
     return true
+  }
+
+  private func remintReplacementSessionForBargeIn(provider: RealtimeHubProvider) {
+    guard !minting else {
+      log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement skipped; token mint already in flight")
+      clearBargeInReplacementState()
+      return
+    }
+    minting = true
+    let providerParam = provider == .openai ? "openai" : "gemini"
+    log("RealtimeHub[\(provider.displayName)]: minting fresh token for barge-in replacement")
+    Task { [weak self] in
+      let token = await APIClient.shared.mintRealtimeToken(provider: providerParam)
+      guard let self else { return }
+      self.minting = false
+      guard self.bargeInReplacementInFlight else { return }
+      guard self.effectiveProvider == provider, self.session == nil else {
+        self.clearBargeInReplacementState()
+        self.ensureWarm()
+        return
+      }
+      guard let token else {
+        self.failBargeInReplacement(provider: provider, reason: "token mint failed")
+        if !self.failoverToAlternateProvider() {
+          log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement token mint failed")
+        }
+        return
+      }
+      self.startReplacementSessionForBargeIn(provider: provider, auth: .ephemeral(token))
+    }
+  }
+
+  private func startReplacementSessionForBargeIn(provider: RealtimeHubProvider, auth: HubAuth) {
+    startSession(provider: provider, auth: auth)
+    bargeInReplacementInFlight = false
+    if bargeInReplacementPendingTurn {
+      bargeInReplacementPendingTurn = false
+      session?.beginInputTurn(interrupting: false)
+    }
+    if provider == .gemini, let speculativeScreenshot {
+      session?.sendVideoFrame(speculativeScreenshot, mime: "image/jpeg")
+    }
+    flushBargeInReplacementAudioBuffer()
+    if bargeInReplacementPendingCommit {
+      bargeInReplacementPendingCommit = false
+      session?.commitInputTurn()
+    }
+  }
+
+  private func failBargeInReplacement(provider: RealtimeHubProvider, reason: String) {
+    let hadCommittedTurn = bargeInReplacementPendingCommit
+    clearBargeInReplacementState()
+    guard hadCommittedTurn else { return }
+    log("RealtimeHub[\(provider.displayName)]: barge-in replacement failed after commit — \(reason)")
+    responding = false
+    realtimePlaybackActive = false
+    realtimePlaybackEpoch += 1
+    pcmPlayer?.stop()
+    responseGlowGate.clearImmediately()
+    exitVoiceUI(clearResponseGlow: true)
+  }
+
+  private func flushBargeInReplacementAudioBuffer() {
+    guard let s = session, !bargeInReplacementAudioBuffer.isEmpty else { return }
+    let bufferedChunks = bargeInReplacementAudioBuffer
+    bargeInReplacementAudioBuffer.removeAll()
+    for pcm16k in bufferedChunks {
+      sendAudio(pcm16k, to: s)
+    }
   }
 
   private func makePCMPlayer() -> StreamingPCMPlayer {
@@ -411,6 +504,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     responding = false
     realtimePlaybackActive = false
     realtimePlaybackEpoch += 1
+    var replacementSessionOwnsInputTurn = false
     turnTranscript = ""
     assistantText = ""
     speculativeWarmDone = false
@@ -443,7 +537,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
         // that socket can leave the next PTT turn queued behind the old generation, so
         // replace the connection and let the fresh session buffer this new turn while it opens.
         if restartSessionForBargeIn() {
-          log("RealtimeHub[\(providerTag)]: barge-in — replacing session for clean next turn")
+          replacementSessionOwnsInputTurn = true
+          log("RealtimeHub: barge-in — replacing session for clean next turn")
         } else {
           session?.cancelActiveResponse()
         }
@@ -454,7 +549,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     ensureWarm()  // (re)connect only if the socket idle-closed
     // Open a fresh speech window for this turn (Gemini manual-VAD needs it EVERY
     // turn on a warm session; OpenAI no-op).
-    session?.beginInputTurn(interrupting: providerResponseInFlight)
+    if !replacementSessionOwnsInputTurn {
+      session?.beginInputTurn(interrupting: providerResponseInFlight)
+    }
     // Capture the screen at turn START and, for Gemini, send it in-turn right away — early
     // enough that the ~450KB JPEG uploads/decodes during the seconds of speech, so the
     // model can see it when it answers. A frame attached at commit (PTT-up) lands too late:
@@ -473,7 +570,16 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
 
   /// Mic chunk (16 kHz PCM16 mono) → resample to the provider's rate → session.
   func feedAudio(_ pcm16k: Data) {
-    guard let s = session else { return }
+    guard let s = session else {
+      if bargeInReplacementInFlight {
+        bargeInReplacementAudioBuffer.append(pcm16k)
+      }
+      return
+    }
+    sendAudio(pcm16k, to: s)
+  }
+
+  private func sendAudio(_ pcm16k: Data, to s: RealtimeHubSession) {
     let rate = s.requiredInputSampleRate
     let pcm = rate == 16000 ? pcm16k : PushToTalkManager.resamplePCM16(pcm16k, from: 16000, to: rate)
     s.sendAudio(pcm)
@@ -484,6 +590,15 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     responding = true
     // (The screen frame is sent at turn START — see beginTurn — so it has time to
     // upload/decode before the model answers. Nothing to attach here.)
+    guard session != nil else {
+      if bargeInReplacementInFlight {
+        bargeInReplacementPendingCommit = true
+      } else {
+        responding = false
+        exitVoiceUI(clearResponseGlow: true)
+      }
+      return
+    }
     session?.commitInputTurn()
   }
 
@@ -495,6 +610,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     realtimePlaybackEpoch += 1
     turnTranscript = ""
     assistantText = ""
+    clearBargeInReplacementState()
     // Abandon the open turn WITHOUT tearing down the socket: close the speech window
     // and leave the reply gated off so the model never answers the silence. Keeps the
     // warm session (and its context) so the next real turn is instant and in-context.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -17,8 +17,8 @@ import Network
 //               Transport: URLSession WebSocket (HTTP/1.1-friendly endpoint).
 //
 //   • Gemini  — wss://generativelanguage.googleapis.com/ws/…BidiGenerateContent?key=…
-//               half-cascade Live model, response modality TEXT + function calling.
-//               Text out is spoken by the caller via AVSpeechSynthesizer.
+//               Live model, response modality AUDIO + function calling.
+//               Native spoken audio out (PCM) + output transcription.
 //               Transport: Network.framework WebSocket with ALPN pinned to
 //               http/1.1 — Gemini's endpoint upgrades URLSession's WS to HTTP/2
 //               and resets it (the documented reason the legacy path needed a
@@ -29,16 +29,16 @@ import Network
 
 @MainActor
 protocol RealtimeHubSessionDelegate: AnyObject {
-  func hubDidConnect()
-  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool)
+  func hubDidConnect(source: RealtimeHubSession)
+  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool, source: RealtimeHubSession)
   /// OpenAI native spoken audio (PCM16 mono 24 kHz).
-  func hubDidReceiveAudio(_ pcm24k: Data)
+  func hubDidReceiveAudio(_ pcm24k: Data, source: RealtimeHubSession)
   /// Assistant text to display / speak. Gemini emits its whole reply here;
   /// OpenAI emits its spoken transcript here (for the on-screen bubble).
-  func hubDidEmitText(_ text: String, isFinal: Bool)
-  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String)
-  func hubDidFinishTurn()
-  func hubDidError(_ message: String)
+  func hubDidEmitText(_ text: String, isFinal: Bool, source: RealtimeHubSession)
+  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String, source: RealtimeHubSession)
+  func hubDidFinishTurn(source: RealtimeHubSession)
+  func hubDidError(_ message: String, source: RealtimeHubSession)
 }
 
 /// How the client authenticates to the realtime provider:
@@ -59,6 +59,11 @@ enum HubAuth {
   var isEphemeral: Bool { if case .ephemeral = self { return true } else { return false } }
 }
 
+enum RealtimeHubBargeInStrategy {
+  case inSessionCancel
+  case freshSession
+}
+
 final class RealtimeHubSession: NSObject {
   private let provider: RealtimeHubProvider
   private let auth: HubAuth
@@ -67,6 +72,10 @@ final class RealtimeHubSession: NSObject {
 
   /// Mic PCM input rate per provider (Gemini 16k native, OpenAI GA needs 24k).
   var requiredInputSampleRate: Int { provider == .openai ? 24000 : 16000 }
+  /// Provider-specific interruption contract for a new PTT turn while a reply is still streaming.
+  var bargeInStrategy: RealtimeHubBargeInStrategy {
+    provider == .gemini ? .freshSession : .inSessionCancel
+  }
 
   // All socket + state access is serialized here (audio arrives on the capture
   // thread; receives on the URLSession/NW queue). Delegate calls hop to main.
@@ -98,6 +107,8 @@ final class RealtimeHubSession: NSObject {
   /// OpenAI: a response is mid-flight — don't create a second one (the realtime
   /// API rejects "Conversation already has an active response in progress").
   private var openAIResponseActive = false
+  private var openAIResponseCreatePending = false
+  private var openAIActiveResponseID: String?
   /// Gemini: a committed turn is awaiting its spoken reply. Gates BOTH audio
   /// playback and turn completion to the CURRENT turn, so an interrupted/abandoned
   /// turn's trailing audio + bookkeeping `turnComplete` can't leak into the next
@@ -182,6 +193,8 @@ final class RealtimeHubSession: NSObject {
       self.activityOpen = false
       self.pendingActivityStart = false
       self.openAIResponseActive = false
+      self.openAIResponseCreatePending = false
+      self.openAIActiveResponseID = nil
       self.geminiResponsePending = false
     }
   }
@@ -190,7 +203,7 @@ final class RealtimeHubSession: NSObject {
     guard !terminated else { return }
     terminated = true
     let d = delegate
-    Task { @MainActor in d?.hubDidError(message) }
+    Task { @MainActor in d?.hubDidError(message, source: self) }
   }
 
   // MARK: Public stream API
@@ -206,6 +219,8 @@ final class RealtimeHubSession: NSObject {
         if self.openAIResponseActive {
           self.send(json: ["type": "response.cancel"])
           self.openAIResponseActive = false
+          self.openAIResponseCreatePending = false
+          self.openAIActiveResponseID = nil
         }
         // Drop any uncommitted mic input so it can't leak into the next turn.
         self.send(json: ["type": "input_audio_buffer.clear"])
@@ -256,10 +271,9 @@ final class RealtimeHubSession: NSObject {
     guard provider == .gemini else { return }
     q.async { [weak self] in
       guard let self else { return }
-      // Barge-in: abandon the previous turn's still-pending reply so its trailing
-      // audio + bookkeeping turnComplete are ignored. A fresh activityStart on the
-      // SAME socket cancels the in-flight generation server-side (it replies with
-      // serverContent.interrupted) — no teardown, so conversation context survives.
+      // Barge-in on a live Gemini generation uses a fresh session at the controller
+      // boundary. This same-session flag is only a local gate for abandoned/stale
+      // Gemini events that arrive before replacement or on non-provider interruptions.
       if interrupting {
         self.geminiResponsePending = false
       }
@@ -360,6 +374,8 @@ final class RealtimeHubSession: NSObject {
       return
     }
     openAIResponseActive = true
+    openAIResponseCreatePending = true
+    openAIActiveResponseID = nil
     send(json: ["type": "response.create", "response": ["output_modalities": [audio ? "audio" : "text"]]])
   }
 
@@ -483,7 +499,7 @@ final class RealtimeHubSession: NSObject {
       }
     }
     let d = delegate
-    Task { @MainActor in d?.hubDidConnect() }
+    Task { @MainActor in d?.hubDidConnect(source: self) }
   }
 
   // Send buffered audio after open (already on q).
@@ -531,31 +547,31 @@ final class RealtimeHubSession: NSObject {
   private func emitText(_ text: String, isFinal: Bool) {
     guard !text.isEmpty || isFinal else { return }
     let d = delegate
-    Task { @MainActor in d?.hubDidEmitText(text, isFinal: isFinal) }
+    Task { @MainActor in d?.hubDidEmitText(text, isFinal: isFinal, source: self) }
   }
 
   private func emitTranscript(_ text: String, isFinal: Bool) {
     let d = delegate
-    Task { @MainActor in d?.hubDidReceiveInputTranscript(text, isFinal: isFinal) }
+    Task { @MainActor in d?.hubDidReceiveInputTranscript(text, isFinal: isFinal, source: self) }
   }
 
   private func emitAudio(_ pcm: Data) {
     let d = delegate
-    Task { @MainActor in d?.hubDidReceiveAudio(pcm) }
+    Task { @MainActor in d?.hubDidReceiveAudio(pcm, source: self) }
   }
 
   private func emitTool(name: String, callId: String, argumentsJSON: String) {
     log("\(tag): tool_call \(name)(\(argumentsJSON.prefix(160)))")
     let d = delegate
     Task { @MainActor in
-      d?.hubDidRequestTool(name: name, callId: callId, argumentsJSON: argumentsJSON)
+      d?.hubDidRequestTool(name: name, callId: callId, argumentsJSON: argumentsJSON, source: self)
     }
   }
 
   private func finishTurn() {
     reportUsageIfNeeded()
     let d = delegate
-    Task { @MainActor in d?.hubDidFinishTurn() }
+    Task { @MainActor in d?.hubDidFinishTurn(source: self) }
   }
 
   // MARK: - Usage (client-reported billing, managed sessions only)
@@ -633,9 +649,18 @@ final class RealtimeHubSession: NSObject {
     switch type {
     case "session.created", "session.updated":
       markReady()
+    case "response.created":
+      if openAIResponseActive,
+        let response = e["response"] as? [String: Any], let id = response["id"] as? String
+      {
+        openAIActiveResponseID = id
+        openAIResponseCreatePending = false
+      }
     case "response.output_audio.delta":
+      guard isCurrentOpenAIResponseEvent(e) else { return }
       if let b64 = e["delta"] as? String, let d = Data(base64Encoded: b64) { emitAudio(d) }
     case "response.output_audio_transcript.delta":
+      guard isCurrentOpenAIResponseEvent(e) else { return }
       if let t = e["delta"] as? String { emitText(t, isFinal: false) }
     case "conversation.item.input_audio_transcription.delta":
       if let t = e["delta"] as? String { emitTranscript(t, isFinal: false) }
@@ -645,6 +670,7 @@ final class RealtimeHubSession: NSObject {
         emitTranscript(t, isFinal: true)
       }
     case "response.output_item.added":
+      guard isCurrentOpenAIResponseEvent(e) else { return }
       // Record function-call name keyed by call_id for the done parse below.
       if let item = e["item"] as? [String: Any], (item["type"] as? String) == "function_call",
         let callId = item["call_id"] as? String, let name = item["name"] as? String
@@ -655,6 +681,8 @@ final class RealtimeHubSession: NSObject {
       handleOpenAIResponseDone(e)
     case "error":
       openAIResponseActive = false
+      openAIResponseCreatePending = false
+      openAIActiveResponseID = nil
       let msg = (e["error"] as? [String: Any])?["message"] as? String ?? "OpenAI realtime error"
       notifyError(msg)
     default:
@@ -662,8 +690,22 @@ final class RealtimeHubSession: NSObject {
     }
   }
 
+  private func isCurrentOpenAIResponseEvent(_ e: [String: Any]) -> Bool {
+    guard openAIResponseActive else { return false }
+    guard !openAIResponseCreatePending, let expected = openAIActiveResponseID else { return false }
+    let eventResponseID = (e["response_id"] as? String)
+      ?? ((e["response"] as? [String: Any])?["id"] as? String)
+    return eventResponseID == expected
+  }
+
   private func handleOpenAIResponseDone(_ e: [String: Any]) {
+    guard isCurrentOpenAIResponseEvent(e) else {
+      log("\(tag): ignoring stale response.done")
+      return
+    }
     openAIResponseActive = false  // this response finished — a new one may be created
+    openAIResponseCreatePending = false
+    openAIActiveResponseID = nil
     if let usage = (e["response"] as? [String: Any])?["usage"] as? [String: Any] {
       accumulateOpenAIUsage(usage)
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -104,17 +104,17 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
 
   // MARK: RealtimeHubSessionDelegate
 
-  func hubDidConnect() { connected = true }
+  func hubDidConnect(source: RealtimeHubSession) { connected = true }
 
-  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+  func hubDidReceiveInputTranscript(_ text: String, isFinal: Bool, source: RealtimeHubSession) {
     if isFinal { if !text.isEmpty { transcriptIn = text } } else { transcriptIn += text }
   }
 
-  func hubDidReceiveAudio(_ pcm24k: Data) { audioBytes += pcm24k.count }
+  func hubDidReceiveAudio(_ pcm24k: Data, source: RealtimeHubSession) { audioBytes += pcm24k.count }
 
-  func hubDidEmitText(_ text: String, isFinal: Bool) { textOut += text }
+  func hubDidEmitText(_ text: String, isFinal: Bool, source: RealtimeHubSession) { textOut += text }
 
-  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String) {
+  func hubDidRequestTool(name: String, callId: String, argumentsJSON: String, source: RealtimeHubSession) {
     toolCalls.append("\(name)(\(argumentsJSON))")
     // Return a stub result so the turn completes and we observe the full loop —
     // without spawning real agents / network calls inside the test.
@@ -148,9 +148,9 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     session?.sendToolResult(callId: callId, name: name, output: stub)
   }
 
-  func hubDidFinishTurn() { finish(timedOut: false) }
+  func hubDidFinishTurn(source: RealtimeHubSession) { finish(timedOut: false) }
 
-  func hubDidError(_ message: String) {
+  func hubDidError(_ message: String, source: RealtimeHubSession) {
     if errorMsg == nil { errorMsg = message }
     finish(timedOut: false)
   }

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -407,17 +407,34 @@ final class AgentPillLifecycleTests: XCTestCase {
     let sessionSource = try realtimeHubSessionSource()
 
     // OpenAI can cancel a response in-session. Gemini cannot reliably cancel a
-    // streaming reply, so barge-in must replace the session and buffer the new
-    // PTT turn on the fresh connection instead of reusing the busy socket.
+    // streaming reply, so barge-in must replace the session. Managed Gemini
+    // tokens are single-use, so the replacement session remints before it
+    // connects and holds early PTT audio/commit during that remint gap.
     XCTAssertTrue(sessionSource.contains("enum RealtimeHubBargeInStrategy"))
     XCTAssertTrue(sessionSource.contains("provider == .gemini ? .freshSession : .inSessionCancel"))
     XCTAssertTrue(hubSource.contains("private var sessionAuth: HubAuth?"))
+    XCTAssertTrue(hubSource.contains("private var bargeInReplacementInFlight = false"))
+    XCTAssertTrue(hubSource.contains("private var bargeInReplacementPendingCommit = false"))
+    XCTAssertTrue(hubSource.contains("private var bargeInReplacementAudioBuffer: [Data] = []"))
     XCTAssertTrue(hubSource.contains("private func restartSessionForBargeIn() -> Bool"))
+    XCTAssertTrue(hubSource.contains("case .ephemeral:\n      remintReplacementSessionForBargeIn(provider: provider)"))
+    XCTAssertTrue(hubSource.contains("let token = await APIClient.shared.mintRealtimeToken(provider: providerParam)"))
+    XCTAssertTrue(hubSource.contains("startReplacementSessionForBargeIn(provider: provider, auth: .ephemeral(token))"))
+    XCTAssertTrue(hubSource.contains("bargeInReplacementAudioBuffer.append(pcm16k)"))
+    XCTAssertTrue(hubSource.contains("bargeInReplacementPendingCommit = true"))
+    XCTAssertTrue(hubSource.contains("failBargeInReplacement(provider: provider, reason: \"token mint failed\")"))
+    XCTAssertTrue(hubSource.contains("if provider == .gemini, let speculativeScreenshot"))
+    XCTAssertTrue(hubSource.contains("session?.sendVideoFrame(speculativeScreenshot, mime: \"image/jpeg\")"))
+    XCTAssertTrue(hubSource.contains("responding = false\n    realtimePlaybackActive = false"))
+    XCTAssertTrue(hubSource.contains("exitVoiceUI(clearResponseGlow: true)"))
+    XCTAssertTrue(hubSource.contains("} else {\n        responding = false\n        exitVoiceUI(clearResponseGlow: true)\n      }"))
     XCTAssertTrue(hubSource.contains("let providerResponseInFlight = responding"))
+    XCTAssertTrue(hubSource.contains("var replacementSessionOwnsInputTurn = false"))
     XCTAssertTrue(hubSource.contains("case .freshSession:"))
     XCTAssertTrue(hubSource.contains("replace the connection and let the fresh session buffer this new turn while it opens"))
     XCTAssertTrue(hubSource.contains("case .inSessionCancel:"))
     XCTAssertTrue(hubSource.contains("barge-in — stopping local playback tail"))
+    XCTAssertTrue(hubSource.contains("if !replacementSessionOwnsInputTurn"))
     XCTAssertTrue(hubSource.contains("session?.beginInputTurn(interrupting: providerResponseInFlight)"))
     XCTAssertTrue(hubSource.contains("session?.cancelActiveResponse()"))
     XCTAssertTrue(hubSource.contains("private func isCurrentSession(_ source: RealtimeHubSession) -> Bool"))

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -402,6 +402,37 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("server turn done; waiting for local playback to drain"))
   }
 
+  func testRealtimeBargeInUsesProviderInterruptionStrategy() throws {
+    let hubSource = try realtimeHubControllerSource()
+    let sessionSource = try realtimeHubSessionSource()
+
+    // OpenAI can cancel a response in-session. Gemini cannot reliably cancel a
+    // streaming reply, so barge-in must replace the session and buffer the new
+    // PTT turn on the fresh connection instead of reusing the busy socket.
+    XCTAssertTrue(sessionSource.contains("enum RealtimeHubBargeInStrategy"))
+    XCTAssertTrue(sessionSource.contains("provider == .gemini ? .freshSession : .inSessionCancel"))
+    XCTAssertTrue(hubSource.contains("private var sessionAuth: HubAuth?"))
+    XCTAssertTrue(hubSource.contains("private func restartSessionForBargeIn() -> Bool"))
+    XCTAssertTrue(hubSource.contains("let providerResponseInFlight = responding"))
+    XCTAssertTrue(hubSource.contains("case .freshSession:"))
+    XCTAssertTrue(hubSource.contains("replace the connection and let the fresh session buffer this new turn while it opens"))
+    XCTAssertTrue(hubSource.contains("case .inSessionCancel:"))
+    XCTAssertTrue(hubSource.contains("barge-in — stopping local playback tail"))
+    XCTAssertTrue(hubSource.contains("session?.beginInputTurn(interrupting: providerResponseInFlight)"))
+    XCTAssertTrue(hubSource.contains("session?.cancelActiveResponse()"))
+    XCTAssertTrue(hubSource.contains("private func isCurrentSession(_ source: RealtimeHubSession) -> Bool"))
+    XCTAssertTrue(hubSource.contains("guard isCurrentSession(source) else { return }"))
+    XCTAssertTrue(hubSource.contains("sendToolResultIfCurrent(source: source"))
+    XCTAssertFalse(hubSource.contains("self.session?.sendToolResult(callId: callId"))
+    XCTAssertTrue(sessionSource.contains("Task { @MainActor in d?.hubDidReceiveAudio(pcm, source: self) }"))
+    XCTAssertTrue(sessionSource.contains("guard isCurrentOpenAIResponseEvent(e) else"))
+    XCTAssertTrue(sessionSource.contains("private var openAIResponseCreatePending = false"))
+    XCTAssertTrue(sessionSource.contains("guard !openAIResponseCreatePending, let expected = openAIActiveResponseID else { return false }"))
+    XCTAssertTrue(sessionSource.contains("return eventResponseID == expected"))
+    XCTAssertFalse(sessionSource.contains("guard let expected = openAIActiveResponseID else { return true }"))
+    XCTAssertTrue(sessionSource.contains("ignoring stale response.done"))
+  }
+
   func testSpeechSynthesizerDidCancelClearsGlow() throws {
     let source = try realtimeHubControllerSource()
 
@@ -636,6 +667,14 @@ final class AgentPillLifecycleTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/RealtimeHubController.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private func realtimeHubSessionSource() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/FloatingControlBar/RealtimeHubSession.swift")
     return try String(contentsOf: sourceURL, encoding: .utf8)
   }
 

--- a/desktop/macos/changelog/unreleased/20260627-fix-ptt-barge-in-delay.json
+++ b/desktop/macos/changelog/unreleased/20260627-fix-ptt-barge-in-delay.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed delayed push-to-talk replies after interrupting a streaming voice response"
+}


### PR DESCRIPTION
## Summary
- replace Gemini realtime sessions when a new PTT interrupts an active provider-side voice response
- keep local playback-tail interruption local so completed Gemini turns do not churn the socket
- guard realtime callbacks and async tool results by source session, and harden OpenAI response event ownership after cancel
- add a desktop changelog fragment and focused regression guardrails

## Root cause
Gemini Live does not provide a reliable in-session cancel for an active streaming reply. The previous barge-in path reused the same socket and only cleared local pending state, so the next PTT could be delayed behind the old generation.

## Verification
- `xcrun swift test --package-path Desktop --filter 'AgentPillLifecycleTests|PushToTalkStateMachineTests|RealtimeHubCloseClassifierTests|StreamingPCMPlaybackQueueTests'`\n- `./scripts/agent-logic-harness.sh`\n- `git diff --check`\n- launched named bundle `OMI_APP_NAME="omi-ptt-barge-in" ./run.sh --yolo`; `OMI_AUTOMATION_PORT=47919 ./scripts/omi-ctl state` returned `ok: true`, signed in, main app state\n- independent subagent review found an OpenAI stale-event blocker; fixed and re-reviewed with no PR-blocking correctness issues

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

