### PR TITLE
[codex] Fix dashboard capture launch state

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -245,11 +245,15 @@ struct DashboardPage: View {
             return .blocked
         }
 
-        if screenAnalysisEnabled && isCaptureMonitoring {
+        if isCaptureLive {
             return .active
         }
 
         return .inactive
+    }
+
+    private var isCaptureLive: Bool {
+        isCaptureMonitoring || ProactiveAssistantsPlugin.shared.isMonitoring
     }
 
     private var hasOmiDeviceHistory: Bool {
@@ -721,7 +725,8 @@ struct DashboardPage: View {
     }
 
     private func toggleCapture() {
-        let enabled = !screenAnalysisEnabled
+        syncCaptureState()
+        let enabled = !isCaptureLive
         isTogglingCapture = true
 
         if enabled {

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+final class DashboardCaptureStateTests: XCTestCase {
+    func testDashboardCaptureStatusUsesLiveMonitoringState() throws {
+        let source = try dashboardSource()
+
+        XCTAssertTrue(
+            source.contains("private var isCaptureLive: Bool"),
+            "DashboardPage should centralize live capture state so the header reflects the running monitor"
+        )
+        XCTAssertTrue(
+            source.contains("if isCaptureLive {\n            return .active\n        }"),
+            "Capture status should light up when monitoring is live, even if persisted intent is stale"
+        )
+        XCTAssertFalse(
+            source.contains("if screenAnalysisEnabled && isCaptureMonitoring {\n            return .active\n        }"),
+            "Capture status must not require persisted intent to match the live monitor"
+        )
+    }
+
+    func testDashboardCaptureToggleDerivesFromLiveState() throws {
+        let source = try dashboardSource()
+
+        XCTAssertTrue(
+            source.contains("syncCaptureState()\n        let enabled = !isCaptureLive"),
+            "Capture toggles should reconcile the live monitor before deciding whether the click starts or stops capture"
+        )
+        XCTAssertFalse(
+            source.contains("let enabled = !screenAnalysisEnabled"),
+            "Capture toggles should not derive from stale persisted intent"
+        )
+    }
+
+    private func dashboardSource() throws -> String {
+        let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let dashboardURL = testsURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MainWindow/Pages/DashboardPage.swift")
+        return try String(contentsOf: dashboardURL, encoding: .utf8)
+    }
+}

--- a/desktop/macos/changelog/unreleased/fix-dashboard-capture-state.json
+++ b/desktop/macos/changelog/unreleased/fix-dashboard-capture-state.json
@@ -1,0 +1,4 @@
+{
+  "title": "Fix dashboard capture button launch state",
+  "description": "The dashboard Capture button now reflects live screen capture immediately after launch."
+}

--- a/desktop/macos/changelog/unreleased/fix-dashboard-capture-state.json
+++ b/desktop/macos/changelog/unreleased/fix-dashboard-capture-state.json
@@ -1,4 +1,3 @@
 {
-  "title": "Fix dashboard capture button launch state",
-  "description": "The dashboard Capture button now reflects live screen capture immediately after launch."
+  "change": "Fixed the dashboard Capture button so it reflects live screen capture immediately after launch"
 }


### PR DESCRIPTION
## Summary
- Make the dashboard Capture pill reflect the live proactive-monitoring state instead of requiring persisted `screenAnalysisEnabled` intent to also be true.
- Reconcile live capture state before handling a Capture click so a stale disabled preference no longer makes the first click a no-op/start attempt while capture is already running.
- Add a focused regression test and desktop changelog fragment.

## Root cause
The dashboard header combined persisted intent (`screenAnalysisEnabled`) with the live monitor flag (`isCaptureMonitoring`) to decide whether Capture looked active. If settings sync or launch ordering left persisted intent stale while `ProactiveAssistantsPlugin` was already monitoring, the UI rendered Capture as off even though capture was live.

## Validation
- `xcrun swift test --package-path Desktop --filter DashboardCaptureStateTests`
- `xcrun swift build -c debug --package-path Desktop`
- Launched `/Applications/omi-capture-state.app` via `OMI_APP_NAME="omi-capture-state" ./run.sh --yolo` and inspected Home with `agent-swift`; the named bundle correctly showed `Capture Blocked` because it has no macOS screen-recording grant, so the live-capture path was covered by the focused regression test rather than a TCC-granted named-bundle run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

