### PR TITLE
[codex] add fast pre-push CI lint guards

### DIFF
--- a/.github/scripts/run-pre-push.sh
+++ b/.github/scripts/run-pre-push.sh
@@ -1,109 +1,13 @@
-#!/bin/bash
-# run-pre-push.sh — Run pre-push tests manually (without actually pushing)
+#!/usr/bin/env bash
+# Run the checked-in pre-push hook manually without pushing.
 #
 # Usage:
-#   ./github/scripts/run-pre-push.sh              # vs origin/main
-#   ./github/scripts/run-pre-push.sh upstream     # vs upstream/main
-#
-# Timing: ~5-30s depending on how many files changed
+#   .github/scripts/run-pre-push.sh          # vs origin/main
+#   .github/scripts/run-pre-push.sh upstream # vs upstream/main
 
 set -euo pipefail
-# Script lives in .github/scripts/ — cd to repo root
+
 cd "$(dirname "$0")/../.."
 
 REMOTE="${1:-origin}"
-
-echo "🔬 Running pre-push test check (simulated push to $REMOTE)..."
-echo ""
-
-# Export so the hook script sees it
-export PRE_PUSH_DRY_RUN=1
-
-# Detect the base branch (main or master)
-BASE_REF=""
-for candidate in main master; do
-  if git rev-parse --verify "$REMOTE/$candidate" >/dev/null 2>&1; then
-    BASE_REF="$REMOTE/$candidate"
-    break
-  fi
-done
-
-if [ -z "$BASE_REF" ]; then
-  echo "⚠️  Cannot find $REMOTE/main or $REMOTE/master"
-  exit 1
-fi
-
-MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "")
-if [ -z "$MERGE_BASE" ]; then
-  echo "⚠️  No merge-base with $BASE_REF"
-  exit 1
-fi
-
-# Match both backend/*.py (root-level) and backend/**/*.py (subdirectories)
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD -- 'backend/*.py' 'backend/**/*.py' 2>/dev/null || true)
-
-if [ -z "$CHANGED_FILES" ]; then
-  echo "ℹ️  No backend Python files changed"
-  exit 0
-fi
-
-echo "Changed files:"
-echo "$CHANGED_FILES" | sed 's/^/  /'
-echo ""
-
-# Find and run matching tests
-TEST_TMP=$(mktemp)
-trap "rm -f $TEST_TMP" EXIT
-
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  REL_PATH="${f#backend/}"
-  MODULE_NAME=$(basename "$f" .py)
-
-  # If the changed file IS a test file, run it directly
-  if [[ "$REL_PATH" == tests/*/test_*.py ]]; then
-    echo "$REL_PATH" >> "$TEST_TMP"
-    continue
-  fi
-
-  # Strategy 1: exact match — test_<module>.py in unit or integration
-  for candidate in "tests/unit/test_${MODULE_NAME}.py" "tests/integration/test_${MODULE_NAME}.py"; do
-    [ -f "backend/$candidate" ] && echo "$candidate" >> "$TEST_TMP"
-  done
-
-  # Strategy 2: prefix glob — test_<module_prefix>*.py
-  # Note: find outputs paths relative to cwd (repo root), so strip
-  # the leading "backend/" prefix to get test-relative paths
-  while IFS= read -r match; do
-    [ -z "$match" ] && continue
-    # Strip "backend/" prefix from find output
-    local_path="${match#backend/}"
-    echo "$local_path" >> "$TEST_TMP"
-  done < <(find backend/tests/unit backend/tests/integration \
-    -name "test_${MODULE_NAME}*.py" 2>/dev/null || true)
-done <<< "$CHANGED_FILES"
-
-TEST_TARGETS=$(sort -u "$TEST_TMP" | while read t; do
-  [ -f "backend/$t" ] && echo "$t" || true
-done | tr '\n' ' ')
-
-if [ -z "$TEST_TARGETS" ]; then
-  echo "ℹ️  No matching test files found"
-  exit 0
-fi
-
-COUNT=$(echo "$TEST_TARGETS" | wc -w | tr -d ' ')
-echo "Running: $COUNT test file(s)"
-echo ""
-
-cd backend
-
-# Build pytest args — only include --timeout if plugin is available
-PYTEST_ARGS="-v --tb=short"
-if python -m pytest --timeout-version >/dev/null 2>&1; then
-  PYTEST_ARGS="$PYTEST_ARGS --timeout=30"
-else
-  echo "ℹ️  pytest-timeout not installed, running without timeout"
-fi
-
-python -m pytest $PYTEST_ARGS $TEST_TARGETS
+exec scripts/pre-push "$REMOTE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,9 @@
 #   detect-secrets  ~1.2s   pre-commit-hooks ~0.1s
 #   Total:          ~2.0s
 #
-# Pre-push hook runs pytest on changed files (~10-30s).
-# See: .git/hooks/pre-push
+# Pre-push hook runs fast deterministic CI lint guards.
+# Install: hook="$(git rev-parse --git-path hooks/pre-push)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-push" "$hook"
+# Run manually: .github/scripts/run-pre-push.sh
 
 repos:
   # ── Python formatting (mirrors CI: black --line-length 120) ──

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
 #   Total:          ~2.0s
 #
 # Pre-push hook runs fast deterministic CI lint guards.
-# Install: hook="$(git rev-parse --git-path hooks/pre-push)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-push" "$hook"
+# Install repo hooks: make setup
 # Run manually: .github/scripts/run-pre-push.sh
 
 repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ These rules apply to every AI agent working in this repository. This file is the
 
 ## Setup
 
-- **Pre-commit hook (required — verify before first commit):** `test -f .git/hooks/pre-commit || ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit` — formatting is enforced by CI.
+- **Pre-commit hook (required — verify before first commit):** `hook="$(git rev-parse --git-path hooks/pre-commit)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-commit" "$hook"` — formatting is enforced by CI.
+- **Pre-push hook (required — verify before first push):** `hook="$(git rev-parse --git-path hooks/pre-push)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-push" "$hook"` — fast deterministic CI lint guards run before push.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 
 ## Safety Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,7 @@ These rules apply to every AI agent working in this repository. This file is the
 
 ## Setup
 
-- **Pre-commit hook (required — verify before first commit):** `hook="$(git rev-parse --git-path hooks/pre-commit)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-commit" "$hook"` — formatting is enforced by CI.
-- **Pre-push hook (required — verify before first push):** `hook="$(git rev-parse --git-path hooks/pre-push)"; test -f "$hook" || ln -s -f "$(git rev-parse --show-toplevel)/scripts/pre-push" "$hook"` — fast deterministic CI lint guards run before push.
+- **Worktree setup (required before first commit/push):** `make setup` — installs the repo Git hooks using linked-worktree-safe paths.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 
 ## Safety Rules

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+ROOT := $(shell git rev-parse --show-toplevel)
+HOOKS_DIR := $(shell git rev-parse --git-path hooks)
+
+.PHONY: setup setup-hooks
+
+setup: setup-hooks
+	@echo "Worktree setup complete."
+
+setup-hooks:
+	@mkdir -p "$(HOOKS_DIR)"
+	@ln -s -f "$(ROOT)/scripts/pre-commit" "$(HOOKS_DIR)/pre-commit"
+	@ln -s -f "$(ROOT)/scripts/pre-push" "$(HOOKS_DIR)/pre-push"
+	@chmod +x "$(ROOT)/scripts/pre-commit" "$(ROOT)/scripts/pre-push"
+	@echo "Installed Git hooks in $(HOOKS_DIR)."

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Builds the macOS app, connects to the cloud backend, and launches. No env files,
 
 > **Requirements:** macOS 14+, [Xcode](https://developer.apple.com/xcode/) (includes Swift & code signing), [Node.js](https://nodejs.org/)
 
+For development worktrees, run the cheap local setup once:
+
+```bash
+make setup
+```
+
 <details>
   <summary>Full Installation</summary>
   

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+REMOTE="${1:-origin}"
+BASE_BRANCH="${PRE_PUSH_BASE_BRANCH:-main}"
+BASE_REMOTE_REF="refs/remotes/${REMOTE}/${BASE_BRANCH}"
+
+if ! git rev-parse --verify "$BASE_REMOTE_REF" >/dev/null 2>&1; then
+  BASE_REMOTE_REF="refs/remotes/origin/${BASE_BRANCH}"
+fi
+
+if ! git rev-parse --verify "$BASE_REMOTE_REF" >/dev/null 2>&1; then
+  echo "FAIL: cannot find ${REMOTE}/${BASE_BRANCH} or origin/${BASE_BRANCH}. Run git fetch origin ${BASE_BRANCH}." >&2
+  exit 1
+fi
+
+BASE_REF=$(git merge-base "$BASE_REMOTE_REF" HEAD)
+CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD || true)
+
+echo "Running fast pre-push checks against ${BASE_REMOTE_REF#refs/remotes/} (merge-base ${BASE_REF:0:12})"
+
+declare -a CHANGED_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] && CHANGED_FILES+=("$file")
+done < <(git diff --name-only --diff-filter=ACM "$BASE_REF" HEAD)
+
+run_step() {
+  echo "==> $*"
+  "$@"
+}
+
+check_merge_conflicts() {
+  local failed=0
+  local file
+
+  for file in "${CHANGED_FILES[@]}"; do
+    [ -n "$file" ] || continue
+    if git cat-file -e "HEAD:$file" 2>/dev/null && git grep -n -I -E '^(<<<<<<<|>>>>>>>)' HEAD -- "$file"; then
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -eq 1 ]; then
+    echo "FAIL: unresolved merge conflict markers found in changed files" >&2
+    return 1
+  fi
+}
+
+check_optional_formatters() {
+  local -a dart_files=()
+  local -a python_files=()
+  local -a arb_files=()
+  local -a firmware_files=()
+  local file
+  local -a black_cmd=()
+
+  for file in "${CHANGED_FILES[@]}"; do
+    case "$file" in
+      *.dart)
+        if [[ "$file" != *.gen.dart && "$file" != *.g.dart ]]; then
+          dart_files+=("$file")
+        fi
+        ;;
+      backend/*.py|backend/**/*.py)
+        python_files+=("$file")
+        ;;
+      *.arb)
+        arb_files+=("$file")
+        ;;
+      omi/*.c|omi/*.cc|omi/*.cpp|omi/*.cxx|omi/*.h|omi/*.hpp|omiGlass/*.c|omiGlass/*.cc|omiGlass/*.cpp|omiGlass/*.cxx|omiGlass/*.h|omiGlass/*.hpp)
+        firmware_files+=("$file")
+        ;;
+    esac
+  done
+
+  if [ "${#dart_files[@]}" -gt 0 ]; then
+    if command -v dart >/dev/null 2>&1; then
+      echo "==> dart format --set-exit-if-changed (${#dart_files[@]} file(s))"
+      dart format --line-length 120 --set-exit-if-changed --output=none "${dart_files[@]}"
+    else
+      echo "Skipping Dart format check; dart is not installed."
+    fi
+  fi
+
+  if [ "${#python_files[@]}" -gt 0 ]; then
+    if command -v black >/dev/null 2>&1; then
+      black_cmd=(black)
+    elif python3 -m black --version >/dev/null 2>&1; then
+      black_cmd=(python3 -m black)
+    fi
+
+    if [ "${#black_cmd[@]}" -gt 0 ]; then
+      echo "==> black --check (${#python_files[@]} file(s))"
+      "${black_cmd[@]}" --check --line-length 120 --skip-string-normalization "${python_files[@]}"
+    else
+      echo "Skipping Python format check; black is not installed."
+    fi
+  fi
+
+  if [ "${#arb_files[@]}" -gt 0 ]; then
+    echo "==> ARB JSON formatting (${#arb_files[@]} file(s))"
+    python3 - "${arb_files[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+failed = False
+for raw_path in sys.argv[1:]:
+    path = Path(raw_path)
+    try:
+        original = path.read_text()
+        formatted = json.dumps(json.loads(original), indent=4, ensure_ascii=False) + "\n"
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: {path} is not valid JSON: {exc}", file=sys.stderr)
+        failed = True
+        continue
+    if original != formatted:
+        print(f"FAIL: {path} not formatted with 4-space indent", file=sys.stderr)
+        failed = True
+
+if failed:
+    print("Fix: jq --indent 4 '.' <file> > tmp && mv tmp <file>", file=sys.stderr)
+    sys.exit(1)
+PY
+  fi
+
+  if [ "${#firmware_files[@]}" -gt 0 ]; then
+    if command -v clang-format >/dev/null 2>&1; then
+      echo "==> clang-format --dry-run (${#firmware_files[@]} file(s))"
+      clang-format --dry-run --Werror "${firmware_files[@]}"
+    else
+      echo "Skipping C/C++ format check; clang-format is not installed."
+    fi
+  fi
+}
+
+run_step check_merge_conflicts
+run_step python3 .github/scripts/desktop-changelog.py validate
+
+if [[ "$CURRENT_BRANCH" == changelog/v* ]]; then
+  echo "Skipping desktop changelog entry check on release changelog branch $CURRENT_BRANCH."
+elif [ "${PRE_PUSH_SKIP_DESKTOP_CHANGELOG:-}" = "1" ]; then
+  echo "Skipping desktop changelog entry check because PRE_PUSH_SKIP_DESKTOP_CHANGELOG=1."
+else
+  run_step python3 .github/scripts/check-desktop-changelog.py --base "$BASE_REF" --head HEAD
+fi
+
+run_step python3 .github/scripts/check-desktop-prod-promotion-policy.py
+run_step check_optional_formatters
+
+echo "Fast pre-push checks passed."


### PR DESCRIPTION
## Summary
- Add a checked-in `scripts/pre-push` hook that runs fast deterministic CI lint guards against the merge-base with `origin/main`.
- Add a top-level `make setup` command for cheap per-worktree setup.
- Delegate `.github/scripts/run-pre-push.sh` to the checked-in hook so manual and git-hook execution use the same path.
- Document worktree setup in `AGENTS.md`, `.pre-commit-config.yaml`, and `README.md`.

## Checks run by the hook
- Changed-file merge conflict marker check.
- `python3 .github/scripts/desktop-changelog.py validate`.
- `python3 .github/scripts/check-desktop-changelog.py --base "$BASE_REF" --head HEAD` except release changelog branches, with `PRE_PUSH_SKIP_DESKTOP_CHANGELOG=1` available for label-equivalent local skips.
- `python3 .github/scripts/check-desktop-prod-promotion-policy.py`.
- Fast changed-file formatting checks when local tools are already available: Dart, backend Python via Black, ARB JSON formatting, and firmware C/C++ via clang-format.

## What `make setup` does
- Installs `scripts/pre-commit` and `scripts/pre-push` into Git's real hooks directory.
- Uses `git rev-parse --git-path` and `--show-toplevel`, so it works in normal clones and linked worktrees.
- Ensures the checked-in hook scripts are executable.

## Intentionally not run or installed
- Full Swift builds.
- Flutter setup or dependency resolution.
- npm installs or frontend lint suites.
- Rust `cargo check`.
- Backend test suites.
- Global package-manager installs.

## Install
```sh
make setup
```

Manual pre-push run:
```sh
.github/scripts/run-pre-push.sh
```

## Validation
- Ran `make setup` successfully in a linked worktree and confirmed both hooks point at the current checkout.
- Ran `.github/scripts/run-pre-push.sh` successfully before commit.
- Ran `python3 .github/scripts/desktop-changelog.py validate` successfully.
- Added a temporary malformed `desktop/macos/changelog/unreleased/*.json` fragment and confirmed `.github/scripts/run-pre-push.sh` failed at `desktop-changelog.py validate`, then removed the fragment.
- Ran `.github/scripts/run-pre-push.sh` successfully after commit.
- Pushed the branch and confirmed the installed pre-push hook ran and passed during `git push`.
