### PR TITLE
Structure agent runtime failures

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct AgentRuntimeFailure: Equatable, Sendable {
+  let code: String
+  let userMessage: String
+  let technicalMessage: String?
+  let source: String?
+  let adapterId: String?
+  let provider: String?
+  let retryable: Bool?
+
+  var displayMessage: String {
+    let trimmed = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty {
+      return trimmed
+    }
+    return technicalMessage?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? "Agent run failed"
+  }
+
+  static func parse(from value: Any?) -> AgentRuntimeFailure? {
+    guard let payload = value as? [String: Any],
+      let code = payload["code"] as? String
+    else {
+      return nil
+    }
+
+    let userMessage = (payload["userMessage"] as? String)
+      ?? (payload["message"] as? String)
+      ?? (payload["technicalMessage"] as? String)
+      ?? "Agent run failed"
+
+    return AgentRuntimeFailure(
+      code: code,
+      userMessage: userMessage,
+      technicalMessage: payload["technicalMessage"] as? String,
+      source: payload["source"] as? String,
+      adapterId: payload["adapterId"] as? String,
+      provider: payload["provider"] as? String,
+      retryable: payload["retryable"] as? Bool
+    )
+  }
+}
+
+private extension String {
+  var nilIfEmpty: String? {
+    isEmpty ? nil : self
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -882,7 +882,8 @@ actor AgentRuntimeProcess {
   }
 
   private func failRequest(_ message: RuntimeMessage) {
-    let raw = message.payload["message"] as? String ?? "Unknown error"
+    let failure = AgentRuntimeFailure.parse(from: message.payload["failure"])
+    let raw = failure?.displayMessage ?? message.payload["message"] as? String ?? "Unknown error"
     if let requestKey = message.requestKey,
       let controlRequest = activeControlRequests.removeValue(forKey: requestKey)
     {

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeStatusStore.swift
@@ -92,6 +92,7 @@ struct AgentRunProjection: Identifiable, Sendable {
   var status: AgentRunProjectionStatus
   var statusText: String?
   var errorMessage: String?
+  var failure: AgentRuntimeFailure?
   var updatedAt: Date
   var completedAt: Date?
   var costUsd: Double?
@@ -141,7 +142,16 @@ final class AgentRuntimeStatusStore: ObservableObject {
   }
 
   func recordLocalFailure(surface: AgentSurfaceReference, error: String) {
-    update(surface: surface, status: .failed, statusText: nil, errorMessage: error, terminal: true)
+    let failure = AgentRuntimeFailure(
+      code: "local_failure",
+      userMessage: error,
+      technicalMessage: nil,
+      source: "runtime",
+      adapterId: nil,
+      provider: nil,
+      retryable: nil
+    )
+    update(surface: surface, status: .failed, statusText: nil, errorMessage: error, failure: failure, terminal: true)
   }
 
   func recordLocalCancellation(surface: AgentSurfaceReference, message: String? = nil) {
@@ -176,19 +186,24 @@ final class AgentRuntimeStatusStore: ObservableObject {
     case .result:
       let terminalStatus = AgentRunProjectionStatus.fromWire(message.payload["terminalStatus"] as? String) ?? .succeeded
       let text = (message.payload["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let failure = AgentRuntimeFailure.parse(from: message.payload["failure"])
       update(
         surface: surface,
         status: terminalStatus,
         statusText: text?.isEmpty == false ? text : nil,
+        errorMessage: failure?.displayMessage,
+        failure: failure,
         terminal: true,
         payload: message.payload
       )
     case .error:
+      let failure = AgentRuntimeFailure.parse(from: message.payload["failure"])
       update(
         surface: surface,
         status: .failed,
         statusText: nil,
-        errorMessage: message.payload["message"] as? String,
+        errorMessage: failure?.displayMessage ?? message.payload["message"] as? String,
+        failure: failure,
         terminal: true,
         payload: message.payload
       )
@@ -214,6 +229,7 @@ final class AgentRuntimeStatusStore: ObservableObject {
     status: AgentRunProjectionStatus,
     statusText: String?,
     errorMessage: String? = nil,
+    failure: AgentRuntimeFailure? = nil,
     terminal: Bool,
     payload: [String: Any] = [:]
   ) {
@@ -230,6 +246,7 @@ final class AgentRuntimeStatusStore: ObservableObject {
       status: .idle,
       statusText: nil,
       errorMessage: nil,
+      failure: nil,
       updatedAt: Date(),
       completedAt: nil,
       costUsd: nil,
@@ -246,7 +263,8 @@ final class AgentRuntimeStatusStore: ObservableObject {
       ?? projection.adapterSessionId
     projection.status = status
     projection.statusText = statusText
-    projection.errorMessage = errorMessage ?? (terminal || status.isActive ? nil : projection.errorMessage)
+    projection.failure = failure ?? (terminal || status.isActive ? nil : projection.failure)
+    projection.errorMessage = projection.failure?.displayMessage ?? errorMessage ?? (terminal || status.isActive ? nil : projection.errorMessage)
     projection.updatedAt = Date()
     projection.completedAt = terminal ? projection.updatedAt : nil
     projection.costUsd = (payload["costUsd"] as? Double) ?? projection.costUsd

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -1138,6 +1138,7 @@ final class AgentPillsManager: ObservableObject {
             pill.status = .failed(errorText)
             pill.latestActivity = errorText
             pill.completedAt = Date()
+            Self.ensureFailureMessage(errorText, for: pill)
             pill.markContentChanged()
         } else if let trimmedFinalText, !trimmedFinalText.isEmpty {
             pill.status = .done
@@ -1151,6 +1152,7 @@ final class AgentPillsManager: ObservableObject {
             pill.status = .failed("Agent ended before reporting a final result")
             pill.completedAt = Date()
             pill.latestActivity = "Agent ended before reporting a final result"
+            Self.ensureFailureMessage("Agent ended before reporting a final result", for: pill)
             pill.markContentChanged()
         }
         pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
@@ -1160,6 +1162,24 @@ final class AgentPillsManager: ObservableObject {
         // Keep the provider + stream alive after completion so a voice/text follow-up
         // can continue THIS agent's session with full context. They're torn down on
         // dismiss, or when the pill is trimmed at the maxPills cap (see cleanup()).
+    }
+
+    private static func ensureFailureMessage(_ errorText: String, for pill: AgentPill) {
+        let text = errorText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        let failureMessage = ChatMessage(text: "Failed: \(text)", sender: .ai)
+        if pill.conversationMessages.isEmpty {
+            pill.conversationMessages = [
+                ChatMessage(text: pill.query, sender: .user),
+                failureMessage,
+            ]
+        } else if !pill.conversationMessages.contains(where: { message in
+            message.sender == .ai
+                && message.text.trimmingCharacters(in: .whitespacesAndNewlines) == failureMessage.text
+        }) {
+            pill.conversationMessages.append(failureMessage)
+        }
+        pill.aiMessage = failureMessage
     }
 
     private static func apply(projection: AgentRunProjection, to pill: AgentPill) {
@@ -1184,10 +1204,11 @@ final class AgentPillsManager: ObservableObject {
                 }
             }
         case .failed, .timedOut, .orphaned:
-            let message = projection.errorMessage ?? "Agent failed"
+            let message = projection.failure?.displayMessage ?? projection.errorMessage ?? "Agent failed"
             pill.status = .failed(message)
             pill.latestActivity = message
             pill.completedAt = projection.completedAt ?? Date()
+            ensureFailureMessage(message, for: pill)
             pill.markContentChanged()
         case .cancelled:
             pill.status = .failed("Stopped by user")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -323,17 +323,25 @@ class TaskChatState: ObservableObject {
             streamingFlushWorkItem = nil
             flushStreamingBuffer()
 
+            let failedByUserStop: Bool
+            if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
+                failedByUserStop = true
+            } else {
+                failedByUserStop = false
+            }
+
             if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
-                if messages[index].text.isEmpty && messages[index].contentBlocks.isEmpty {
+                if failedByUserStop && messages[index].text.isEmpty && messages[index].contentBlocks.isEmpty {
                     messages.remove(at: index)
                 } else {
+                    Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: error.localizedDescription)
                     messages[index].isStreaming = false
                     completeRemainingToolCalls(messageId: aiMessageId)
                     persistMessage(messages[index])
                 }
             }
 
-            if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
+            if failedByUserStop {
                 TaskAgentStatusRegistry.shared.markStopped(taskId: taskId)
             } else {
                 errorMessage = error.localizedDescription
@@ -353,6 +361,12 @@ class TaskChatState: ObservableObject {
     }
 
     // MARK: - Follow-Up
+
+    static func applyFailureTextIfNeeded(to message: inout ChatMessage, errorDescription: String) {
+        if message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            message.text = "Failed: \(errorDescription)"
+        }
+    }
 
     func sendFollowUp(_ text: String) async {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -606,6 +606,11 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(
       source.contains(
         "pill.status = .failed(\"Agent ended before reporting a final result\")\n            pill.completedAt = Date()"))
+    XCTAssertTrue(source.contains("Self.ensureFailureMessage(errorText, for: pill)"))
+    XCTAssertTrue(source.contains("Self.ensureFailureMessage(\"Agent ended before reporting a final result\", for: pill)"))
+    XCTAssertTrue(source.contains("ensureFailureMessage(message, for: pill)"))
+    XCTAssertTrue(source.contains("projection.failure?.displayMessage ?? projection.errorMessage ?? \"Agent failed\""))
+    XCTAssertTrue(source.contains("ChatMessage(text: \"Failed: \\(text)\", sender: .ai)"))
   }
 
   func testLateMessageActivityCannotOverwriteTerminalPillStatus() throws {

--- a/desktop/macos/Desktop/Tests/AgentRuntimeStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeStatusStoreTests.swift
@@ -41,6 +41,24 @@ final class AgentRuntimeStatusStoreTests: XCTestCase {
     XCTAssertNil(projection?.completedAt)
   }
 
+  func testErrorProjectionUsesStructuredFailure() {
+    let store = AgentRuntimeStatusStore()
+    let surface = AgentSurfaceReference.floatingPill(pillId: UUID())
+    let message = AgentRuntimeProcess.RuntimeMessage.parse(
+      #"{"type":"error","protocolVersion":2,"requestId":"req","sessionId":"ses-failed","runId":"run-failed","attemptId":"attempt-failed","message":"legacy text","failure":{"code":"adapter_process_exited","source":"adapter_process","adapterId":"openclaw","provider":"openai","retryable":true,"userMessage":"OpenClaw failed: OpenAI API error: upstream unavailable","technicalMessage":"OpenAI API error: upstream unavailable"}}"#
+    )!
+
+    store.ingest(message: message, surface: surface)
+
+    let projection = store.projection(for: surface)
+    XCTAssertEqual(projection?.status, .failed)
+    XCTAssertEqual(projection?.errorMessage, "OpenClaw failed: OpenAI API error: upstream unavailable")
+    XCTAssertEqual(projection?.failure?.code, "adapter_process_exited")
+    XCTAssertEqual(projection?.failure?.adapterId, "openclaw")
+    XCTAssertEqual(projection?.failure?.provider, "openai")
+    XCTAssertEqual(projection?.failure?.retryable, true)
+  }
+
   func testUpdateActivityDoesNotReviveTerminalProjection() {
     let store = AgentRuntimeStatusStore()
     let surface = AgentSurfaceReference.taskChat(taskId: "task-terminal")

--- a/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
@@ -40,6 +40,31 @@ final class TaskChatLegacyAcpMigrationTests: XCTestCase {
     XCTAssertTrue(source.contains("let supportsLegacyResume = (currentHarness == \"acp\" || currentHarness == \"piMono\")"))
   }
 
+  func testTaskChatFailureKeepsVisibleAssistantMessage() throws {
+    let source = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift")
+
+    XCTAssertTrue(source.contains("Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: error.localizedDescription)"))
+    XCTAssertTrue(source.contains("persistMessage(messages[index])"))
+  }
+
+  @MainActor
+  func testTaskChatFailureAddsTextWhenMessageAlreadyHasBlocks() {
+    var message = ChatMessage(
+      id: "assistant-1",
+      text: "",
+      sender: .ai,
+      isStreaming: true,
+      contentBlocks: [
+        .toolCall(id: "tool-1", name: "Bash", status: .running, toolUseId: "tool-use-1", input: nil, output: nil)
+      ]
+    )
+
+    TaskChatState.applyFailureTextIfNeeded(to: &message, errorDescription: "OpenClaw failed")
+
+    XCTAssertEqual(message.text, "Failed: OpenClaw failed")
+    XCTAssertFalse(message.contentBlocks.isEmpty)
+  }
+
   func testActionItemChatSessionIdLegacyMarkerStillUsesTaskId() throws {
     let coordinator = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift")
 

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -17,6 +17,7 @@ import type {
   ResumeBindingInput,
   RuntimeAdapter,
 } from "./interface.js";
+import { AdapterRuntimeError, failureFromProcessError, failureFromProcessExit } from "../runtime/failures.js";
 
 type ResponseHandler = {
   resolve: (result: unknown) => void;
@@ -101,6 +102,16 @@ export class AcpError extends Error {
     this.code = code;
     this.data = data;
   }
+}
+
+const MAX_RECENT_STDERR_CHARS = 2_000;
+
+function appendRecentStderr(current: string, next: string): string {
+  const combined = `${current}${next}`;
+  if (combined.length <= MAX_RECENT_STDERR_CHARS) {
+    return combined;
+  }
+  return combined.slice(combined.length - MAX_RECENT_STDERR_CHARS);
 }
 
 export type AcpNotificationHandler = (method: string, params: unknown) => void;
@@ -212,17 +223,18 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
     }
     const proc = this.process;
     let finalized = false;
-    const finalizeProcess = (reason: string): void => {
+    let recentStderr = "";
+    const finalizeProcess = (error: Error): void => {
       if (finalized || this.process !== proc) return;
       finalized = true;
-      this.log(reason);
+      this.log(error.message);
       this.process = null;
       this.stdinWriter = null;
       this.readline = null;
       this.initialized = false;
       this.initializePromise = null;
       for (const [, handler] of this.responseHandlers) {
-        handler.reject(new Error(reason));
+        handler.reject(error);
       }
       this.responseHandlers.clear();
       this.onProcessExit?.();
@@ -233,7 +245,10 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
     }
 
     proc.on("error", (err) => {
-      finalizeProcess(`${this.adapterId} ACP process error: ${err.message}`);
+      finalizeProcess(new AdapterRuntimeError(failureFromProcessError({
+        adapterId: this.adapterId,
+        message: err.message,
+      })));
     });
 
     this.stdinWriter = (line: string) => {
@@ -254,12 +269,17 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
     proc.stderr.on("data", (data: Buffer) => {
       const text = data.toString().trim();
       if (text) {
+        recentStderr = appendRecentStderr(recentStderr, `${text}\n`);
         this.log(`ACP stderr: ${text}`);
       }
     });
 
     proc.on("exit", (code) => {
-      finalizeProcess(`ACP process exited with code ${code}`);
+      finalizeProcess(new AdapterRuntimeError(failureFromProcessExit({
+        adapterId: this.adapterId,
+        exitCode: code,
+        recentStderr,
+      })));
     });
   }
 

--- a/desktop/macos/agent/src/adapters/interface.ts
+++ b/desktop/macos/agent/src/adapters/interface.ts
@@ -4,6 +4,7 @@
 // Issue #6594: Pi-mono harness with Omi API proxy.
 
 import type { OutboundMessage, WarmupSessionConfig } from "../protocol.js";
+import type { RuntimeFailure } from "../runtime/failures.js";
 import type { ArtifactRole, ResumeFidelity, RunMode } from "../runtime/types.js";
 
 /**
@@ -371,6 +372,7 @@ export interface AdapterAttemptResult {
   /** Adapter-owned native session id exposed for compatibility fields while v1 clients migrate. */
   adapterSessionId: string;
   terminalStatus: "succeeded" | "failed" | "cancelled";
+  failure?: RuntimeFailure;
   artifacts?: AdapterArtifactReference[];
 }
 

--- a/desktop/macos/agent/src/adapters/local-subprocess.ts
+++ b/desktop/macos/agent/src/adapters/local-subprocess.ts
@@ -16,6 +16,7 @@ import type {
   RuntimeAdapter,
 } from "./interface.js";
 import type { ArtifactRole } from "../runtime/types.js";
+import { normalizeRuntimeFailure, type RuntimeFailure } from "../runtime/failures.js";
 import type { OutboundMessage } from "../protocol.js";
 
 type LocalSubprocessRequest = {
@@ -61,6 +62,7 @@ type LocalSubprocessMessage = {
   outputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  failure?: unknown;
 };
 
 type PendingRequest = {
@@ -541,8 +543,27 @@ export class LocalSubprocessRuntimeAdapter implements RuntimeAdapter {
       outputTokens: optionalNumber(result.outputTokens),
       cacheReadTokens: optionalNumber(result.cacheReadTokens),
       cacheWriteTokens: optionalNumber(result.cacheWriteTokens),
+      failure: this.failureFrom(result.failure),
       artifacts: artifacts.length > 0 ? artifacts : undefined,
     };
+  }
+
+  private failureFrom(value: unknown): RuntimeFailure | undefined {
+    if (!isRecord(value)) return undefined;
+    const code = optionalString(value.code);
+    const userMessage = optionalString(value.userMessage);
+    if (!code || !userMessage) return undefined;
+    return normalizeRuntimeFailure({
+      code,
+      userMessage,
+      technicalMessage: optionalString(value.technicalMessage),
+      source: value.source === "adapter_process" || value.source === "adapter_execution" || value.source === "runtime"
+        ? value.source
+        : undefined,
+      adapterId: optionalString(value.adapterId) ?? this.adapterId,
+      provider: optionalString(value.provider),
+      retryable: typeof value.retryable === "boolean" ? value.retryable : undefined,
+    });
   }
 
   private artifactFrom(value: unknown): AdapterArtifactReference | null {

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -152,11 +152,22 @@ export interface ResultMessage extends QueryScopedOutbound {
   text: string;
   sessionId: string;
   terminalStatus?: "succeeded" | "failed" | "cancelled";
+  failure?: RuntimeFailurePayload;
   costUsd?: number;
   inputTokens?: number;
   outputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+}
+
+export interface RuntimeFailurePayload {
+  code: string;
+  userMessage: string;
+  technicalMessage?: string;
+  source?: string;
+  adapterId?: string;
+  provider?: string;
+  retryable?: boolean;
 }
 
 export interface ToolActivityMessage extends QueryScopedOutbound {
@@ -182,6 +193,7 @@ export interface ThinkingDeltaMessage extends QueryScopedOutbound {
 export interface ErrorMessage extends QueryScopedOutbound {
   type: "error";
   message: string;
+  failure?: RuntimeFailurePayload;
 }
 
 /** Sent when ACP requires user authentication (OAuth) */

--- a/desktop/macos/agent/src/runtime/compatibility-facade.ts
+++ b/desktop/macos/agent/src/runtime/compatibility-facade.ts
@@ -14,6 +14,7 @@ import type {
   WarmupSessionConfig,
 } from "../protocol.js";
 import { requestIdFor } from "../protocol.js";
+import type { RuntimeFailure } from "./failures.js";
 import type { AgentEvent, RunMode } from "./types.js";
 import { AgentRuntimeKernel, type ExecuteAgentRunInput } from "./kernel.js";
 
@@ -224,9 +225,12 @@ export class JsonlCompatibilityFacade {
       context.adapterSessionId = result.adapterSessionId ?? undefined;
 
       if (result.terminalStatus === "failed") {
+        const failure = failureFromResultJson(result.run.resultJson);
+        const message = failure?.userMessage ?? result.run.errorMessage ?? "Agent run failed";
         const errorMessage: ErrorMessage = {
           type: "error",
-          message: result.run.errorMessage ?? "Agent run failed",
+          message,
+          failure,
         };
         this.send(this.withCorrelation(errorMessage, context));
         return;
@@ -238,6 +242,7 @@ export class JsonlCompatibilityFacade {
         sessionId: this.compatibilityResultSessionId(context, result.session.sessionId),
         adapterSessionId: result.adapterSessionId ?? undefined,
         terminalStatus: result.terminalStatus,
+        failure: failureFromResultJson(result.run.resultJson),
         costUsd: result.run.costUsd ?? 0,
         inputTokens: result.run.inputTokens ?? Math.ceil(input.prompt.length / 4),
         outputTokens: result.run.outputTokens ?? Math.ceil(result.text.length / 4),
@@ -692,6 +697,19 @@ export class JsonlCompatibilityFacade {
       return true;
     };
   }
+}
+
+function failureFromResultJson(resultJson: string | null): RuntimeFailure | undefined {
+  if (!resultJson) return undefined;
+  try {
+    const parsed = JSON.parse(resultJson) as { failure?: RuntimeFailure };
+    if (parsed.failure?.code && parsed.failure.userMessage) {
+      return parsed.failure;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 function parsePayload(payloadJson: string): Record<string, unknown> {

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -1,0 +1,130 @@
+import type { ProductionAdapterId } from "../adapters/interface.js";
+
+export type RuntimeFailureSource = "adapter_process" | "adapter_execution" | "runtime";
+
+export interface RuntimeFailure {
+  code: string;
+  userMessage: string;
+  technicalMessage?: string;
+  source?: RuntimeFailureSource;
+  adapterId?: string;
+  provider?: string;
+  retryable?: boolean;
+}
+
+export class AdapterRuntimeError extends Error {
+  readonly failure: RuntimeFailure;
+
+  constructor(failure: RuntimeFailure) {
+    super(failure.userMessage);
+    this.name = "AdapterRuntimeError";
+    this.failure = normalizeRuntimeFailure(failure);
+  }
+}
+
+export function messageFrom(error: unknown): string {
+  if (error instanceof AdapterRuntimeError) {
+    return error.failure.userMessage;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function failureFromError(
+  error: unknown,
+  fallback: Omit<RuntimeFailure, "userMessage"> & { userMessage?: string }
+): RuntimeFailure {
+  if (error instanceof AdapterRuntimeError) {
+    return error.failure;
+  }
+  return normalizeRuntimeFailure({
+    ...fallback,
+    userMessage: fallback.userMessage ?? messageFrom(error),
+    technicalMessage: fallback.technicalMessage ?? messageFrom(error),
+  });
+}
+
+export function normalizeRuntimeFailure(failure: RuntimeFailure): RuntimeFailure {
+  const userMessage = compactWhitespace(failure.userMessage) || "Agent run failed";
+  const technicalMessage = compactWhitespace(failure.technicalMessage ?? "");
+  return {
+    ...failure,
+    userMessage,
+    technicalMessage: technicalMessage || undefined,
+  };
+}
+
+export function sanitizeProcessDiagnostic(text: string): string {
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/sk-[A-Za-z0-9_-]{12,}/g, "sk-[redacted]")
+    .replace(/(api[_-]?key["'\s:=]+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1_000);
+}
+
+export function failureFromProcessExit(input: {
+  adapterId: ProductionAdapterId;
+  exitCode: number | null;
+  recentStderr: string;
+}): RuntimeFailure {
+  const diagnostic = sanitizeProcessDiagnostic(input.recentStderr);
+  const technicalMessage = diagnostic || `${input.adapterId} ACP process exited with code ${input.exitCode}`;
+  const provider = providerFromDiagnostic(diagnostic);
+  const label = adapterFailureLabel(input.adapterId, provider);
+  return normalizeRuntimeFailure({
+    code: "adapter_process_exited",
+    source: "adapter_process",
+    adapterId: input.adapterId,
+    provider,
+    retryable: true,
+    userMessage: `${label} failed: ${technicalMessage}`,
+    technicalMessage,
+  });
+}
+
+export function failureFromProcessError(input: {
+  adapterId: ProductionAdapterId;
+  message: string;
+}): RuntimeFailure {
+  const diagnostic = sanitizeProcessDiagnostic(input.message);
+  const provider = providerFromDiagnostic(diagnostic);
+  const label = adapterFailureLabel(input.adapterId, provider);
+  return normalizeRuntimeFailure({
+    code: "adapter_process_error",
+    source: "adapter_process",
+    adapterId: input.adapterId,
+    provider,
+    retryable: true,
+    userMessage: `${label} failed: ${diagnostic || `${input.adapterId} ACP process error`}`,
+    technicalMessage: diagnostic,
+  });
+}
+
+function providerFromDiagnostic(diagnostic: string): string | undefined {
+  const lower = diagnostic.toLowerCase();
+  if (lower.includes("openai")) return "openai";
+  if (lower.includes("anthropic") || lower.includes("claude")) return "anthropic";
+  if (lower.includes("gemini") || lower.includes("google")) return "google";
+  return undefined;
+}
+
+function adapterFailureLabel(adapterId: ProductionAdapterId, provider?: string): string {
+  switch (adapterId) {
+    case "openclaw":
+      return "OpenClaw";
+    case "hermes":
+      return "Hermes";
+    case "pi-mono":
+      return "pi-mono";
+    case "acp":
+      if (provider === "openai") {
+        return "OpenAI";
+      }
+      return "ACP";
+  }
+}
+
+function compactWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/desktop/macos/agent/src/runtime/kernel.ts
+++ b/desktop/macos/agent/src/runtime/kernel.ts
@@ -10,6 +10,7 @@ import type {
 import type { OutboundMessage } from "../protocol.js";
 import { AdapterRegistry } from "./adapter-registry.js";
 import { generateAgentId } from "./sqlite-store.js";
+import { AdapterRuntimeError, failureFromError, type RuntimeFailure } from "./failures.js";
 import type {
   AdapterBinding,
   AgentEvent,
@@ -638,6 +639,12 @@ export class AgentRuntimeKernel {
         }
         const wasCancelling = this.runStatus(accepted.run.runId) === "cancelling";
         const status: AttemptStatus = wasCancelling ? "cancelled" : "failed";
+        const failure = wasCancelling ? null : failureFromError(error, {
+          code: "adapter_execution_failed",
+          source: "adapter_execution",
+          adapterId: attempt.adapterId,
+          retryable: false,
+        });
         this.finishAttemptAndRun({
           sessionId: accepted.session.sessionId,
           runId: accepted.run.runId,
@@ -645,7 +652,8 @@ export class AgentRuntimeKernel {
           status,
           finalText: null,
           errorCode: wasCancelling ? null : "adapter_execution_failed",
-          errorMessage: wasCancelling ? null : messageFrom(error),
+          errorMessage: failure?.userMessage ?? null,
+          failure,
         });
         break;
       } finally {
@@ -1541,6 +1549,9 @@ export class AgentRuntimeKernel {
         status,
         finalText: result.text,
         result,
+        errorCode: status === "failed" ? result.failure?.code ?? "adapter_execution_failed" : null,
+        errorMessage: status === "failed" ? result.failure?.userMessage ?? null : null,
+        failure: result.failure,
       });
     });
     return {
@@ -1562,6 +1573,7 @@ export class AgentRuntimeKernel {
     result?: AdapterAttemptResult;
     errorCode?: string | null;
     errorMessage?: string | null;
+    failure?: RuntimeFailure | null;
   }): void {
     const now = Date.now();
     const completedStatus = input.status;
@@ -1575,7 +1587,7 @@ export class AgentRuntimeKernel {
     this.updateRun(input.runId, {
       status: completedStatus,
       finalText: input.finalText,
-      resultJson: input.result ? JSON.stringify(input.result) : null,
+      resultJson: input.result ? JSON.stringify(input.result) : input.failure ? JSON.stringify({ failure: input.failure }) : null,
       errorCode: input.errorCode ?? null,
       errorMessage: input.errorMessage ?? null,
       inputTokens: input.result?.inputTokens ?? null,
@@ -1592,7 +1604,7 @@ export class AgentRuntimeKernel {
         runId: input.runId,
         attemptId: input.attemptId,
         type: completedStatus === "failed" ? "attempt.failed" : "attempt.cancelled",
-        payload: { attemptId: input.attemptId, status: completedStatus },
+        payload: { attemptId: input.attemptId, status: completedStatus, failure: input.failure ?? input.result?.failure },
       });
     }
     if (completedStatus === "succeeded") {
@@ -1622,7 +1634,7 @@ export class AgentRuntimeKernel {
       runId: input.runId,
       attemptId: input.attemptId,
       type: `run.${completedStatus}`,
-      payload: { runId: input.runId, status: completedStatus },
+      payload: { runId: input.runId, status: completedStatus, failure: input.failure ?? input.result?.failure },
     });
   }
 
@@ -2191,6 +2203,9 @@ function isStaleBindingError(error: unknown): boolean {
 }
 
 function messageFrom(error: unknown): string {
+  if (error instanceof AdapterRuntimeError) {
+    return error.failure.userMessage;
+  }
   return error instanceof Error ? error.message : String(error);
 }
 

--- a/desktop/macos/agent/tests/compatibility-facade.test.ts
+++ b/desktop/macos/agent/tests/compatibility-facade.test.ts
@@ -9,6 +9,7 @@ import {
   selectAdapterScopedToolCallCorrelation,
   selectUnscopedToolCallCorrelation,
 } from "../src/runtime/compatibility-facade.js";
+import { AdapterRuntimeError } from "../src/runtime/failures.js";
 import { AgentRuntimeKernel } from "../src/runtime/kernel.js";
 import { SqliteAgentStore } from "../src/runtime/sqlite-store.js";
 import { baseRunInput, createKernelHarness, FakeRuntimeAdapter, waitUntil } from "./kernel-fakes.js";
@@ -39,6 +40,45 @@ describe("JsonlCompatibilityFacade", () => {
         clientId: "client-v2",
       }),
     ).rejects.toThrow("protocol v2 query requires requestId");
+    store.close();
+  });
+
+  it("emits structured runtime failures with the legacy error message", async () => {
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
+    const sent: OutboundMessage[] = [];
+    adapter.failNextExecutionError = new AdapterRuntimeError({
+      code: "adapter_process_exited",
+      source: "adapter_process",
+      adapterId: "openclaw",
+      provider: "openai",
+      retryable: true,
+      userMessage: "OpenClaw failed: OpenAI API error: upstream unavailable",
+      technicalMessage: "OpenAI API error: upstream unavailable",
+    });
+    const facade = new JsonlCompatibilityFacade({
+      kernel,
+      send: (message) => sent.push(message),
+      defaultAdapterId: "fake",
+      defaultCwd: () => "/tmp/default",
+    });
+
+    await facade.handleQuery({
+      ...v1Query({ id: "request-failed", prompt: "fail" }),
+      protocolVersion: 2,
+      requestId: "request-failed",
+      clientId: "client-failed",
+      adapterId: "fake",
+    });
+
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: "error",
+      message: "OpenClaw failed: OpenAI API error: upstream unavailable",
+      failure: expect.objectContaining({
+        code: "adapter_process_exited",
+        adapterId: "openclaw",
+        provider: "openai",
+      }),
+    }));
     store.close();
   });
 

--- a/desktop/macos/agent/tests/local-subprocess-adapter.test.ts
+++ b/desktop/macos/agent/tests/local-subprocess-adapter.test.ts
@@ -476,6 +476,57 @@ describe("env-command local subprocess adapters", () => {
     await adapter.stop();
   });
 
+  it("preserves structured failed-result payloads", async () => {
+    const proc = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(proc as any);
+    const adapter = new LocalSubprocessRuntimeAdapter({ adapterId: "openclaw", envCommandName: "OMI_OPENCLAW_ADAPTER_COMMAND", command: "openclaw-adapter" });
+
+    collectRequests(proc, (request) => {
+      if (request.type === "open") {
+        writeResponse(proc, request, {
+          type: "opened",
+          adapterNativeSessionId: "openclaw-native-1",
+        });
+      }
+      if (request.type === "execute") {
+        writeResponse(proc, request, {
+          type: "result",
+          text: "",
+          adapterSessionId: "openclaw-native-1",
+          terminalStatus: "failed",
+          failure: {
+            code: "adapter_process_exited",
+            source: "adapter_process",
+            adapterId: "openclaw",
+            provider: "openai",
+            retryable: true,
+            userMessage: "OpenClaw failed: OpenAI API error: upstream unavailable",
+            technicalMessage: "OpenAI API error: upstream unavailable",
+          },
+        });
+      }
+    });
+
+    await adapter.start();
+    const opened = await adapter.openBinding({
+      sessionId: "omi-session",
+      cwd: "/tmp/work",
+    });
+
+    const result = await adapter.executeAttempt(makeAttemptContext(opened), () => {}, new AbortController().signal);
+    expect(result).toMatchObject({
+      terminalStatus: "failed",
+      failure: {
+        code: "adapter_process_exited",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        provider: "openai",
+        userMessage: "OpenClaw failed: OpenAI API error: upstream unavailable",
+      },
+    });
+    await adapter.stop();
+  });
+
   it("does not import legacy permission policy from new adapter modules", () => {
     for (const file of [
       "src/adapters/local-subprocess.ts",

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -21,6 +21,7 @@ import type {
 } from "../src/adapters/interface.js";
 import { AdapterRegistry } from "../src/runtime/adapter-registry.js";
 import { AdapterWorkerPool, configuredMaxWorkers, configuredPiMonoMaxWorkers } from "../src/runtime/worker-pool.js";
+import { AdapterRuntimeError } from "../src/runtime/failures.js";
 import { FakeRuntimeAdapter } from "./kernel-fakes.js";
 
 vi.mock("child_process", async () => {
@@ -198,6 +199,97 @@ describe("AcpRuntimeAdapter process spawning", () => {
       if (saved.OMI_AUTH_TOKEN === undefined) delete process.env.OMI_AUTH_TOKEN;
       else process.env.OMI_AUTH_TOKEN = saved.OMI_AUTH_TOKEN;
     }
+  });
+
+  it("includes sanitized OpenAI stderr when the ACP subprocess exits", async () => {
+    const proc = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(proc as any);
+    const adapter = new AcpRuntimeAdapter({
+      adapterId: "acp",
+      nodeBin: "/node",
+      acpEntry: "/acp-entry.mjs",
+    });
+    proc.stdin.on("data", () => {});
+    await adapter.start();
+
+    const request = adapter.request("initialize");
+    proc.stderr.write("OpenAI API error: Authorization: Bearer secret-token sk-testsecret123456\n");
+    await Promise.resolve();
+    proc.emit("exit", 1);
+
+    await expect(request).rejects.toThrow(
+      /OpenAI failed: OpenAI API error: Authorization: Bearer \[redacted\] sk-\[redacted\]/
+    );
+    await request.catch((error) => {
+      expect(error).toBeInstanceOf(AdapterRuntimeError);
+      expect((error as AdapterRuntimeError).failure).toMatchObject({
+        code: "adapter_process_exited",
+        source: "adapter_process",
+        adapterId: "acp",
+        provider: "openai",
+        retryable: true,
+        technicalMessage: "OpenAI API error: Authorization: Bearer [redacted] sk-[redacted]",
+      });
+    });
+  });
+
+  it("labels OpenClaw subprocess exits as OpenClaw failures even when stderr mentions OpenAI", async () => {
+    const proc = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(proc as any);
+    const adapter = new AcpRuntimeAdapter({
+      adapterId: "openclaw",
+      command: "openclaw acp",
+      envCommandName: "OMI_OPENCLAW_ADAPTER_COMMAND",
+    });
+    proc.stdin.on("data", () => {});
+    await adapter.start();
+
+    const request = adapter.request("initialize");
+    proc.stderr.write("OpenAI API error: upstream unavailable\n");
+    await Promise.resolve();
+    proc.emit("exit", 1);
+
+    await expect(request).rejects.toThrow("OpenClaw failed: OpenAI API error: upstream unavailable");
+    await request.catch((error) => {
+      expect(error).toBeInstanceOf(AdapterRuntimeError);
+      expect((error as AdapterRuntimeError).failure).toMatchObject({
+        code: "adapter_process_exited",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        provider: "openai",
+        userMessage: "OpenClaw failed: OpenAI API error: upstream unavailable",
+      });
+    });
+  });
+
+  it("structures OpenClaw subprocess spawn errors", async () => {
+    const proc = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(proc as any);
+    const adapter = new AcpRuntimeAdapter({
+      adapterId: "openclaw",
+      command: "openclaw acp",
+      envCommandName: "OMI_OPENCLAW_ADAPTER_COMMAND",
+    });
+    await adapter.start();
+
+    const wroteInitialize = new Promise<void>((resolve) => {
+      proc.stdin.once("data", () => resolve());
+    });
+    const request = adapter.request("initialize");
+    await wroteInitialize;
+    proc.emit("error", new Error("spawn failed: OpenAI API key sk-testsecret123456"));
+
+    await expect(request).rejects.toThrow("OpenClaw failed: spawn failed: OpenAI API key sk-[redacted]");
+    await request.catch((error) => {
+      expect(error).toBeInstanceOf(AdapterRuntimeError);
+      expect((error as AdapterRuntimeError).failure).toMatchObject({
+        code: "adapter_process_error",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        provider: "openai",
+        retryable: true,
+      });
+    });
   });
 });
 

--- a/desktop/macos/changelog/unreleased/20260628-agent-failure-chat.json
+++ b/desktop/macos/changelog/unreleased/20260628-agent-failure-chat.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed failed agent runs so provider errors appear in the agent chat detail, not just the row summary"
+}


### PR DESCRIPTION
## Summary
- Add a typed runtime failure payload for adapter/process errors and carry it through kernel persistence, compatibility facade error messages, Swift status projections, and floating-pill chat detail.
- Preserve sanitized OpenClaw/OpenAI diagnostics from ACP exits and spawn errors without relying on UI-side hard-coded string parsing.
- Ensure task chat failures remain visible even when the failed assistant message already contains tool/thinking blocks.

## Review
- Independent sub-agent review found task-chat block failure visibility, ACP spawn-error structure, local subprocess failed-result structure, and behavioral coverage gaps.
- Addressed all findings before opening this PR.

## Test Plan
- `cd desktop/macos/agent && npm test -- --run tests/runtime-adapter.test.ts tests/compatibility-facade.test.ts tests/local-subprocess-adapter.test.ts`
- `cd desktop/macos/agent && npm run build`
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter 'AgentRuntimeStatusStoreTests|AgentPillLifecycleTests|TaskChatLegacyAcpMigrationTests'`
- `cd desktop/macos && OMI_APP_NAME="omi-agent-failure" ./run.sh --yolo`
- `cd desktop/macos && OMI_AUTOMATION_PORT=47919 ./scripts/omi-ctl state`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

