### PR TITLE
[codex] Make OpenClaw use its standalone Node

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -578,17 +578,25 @@ actor AgentRuntimeProcess {
     if env["OMI_HERMES_ADAPTER_COMMAND"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
       let hermes = firstExecutable(named: "hermes", in: adapterSearchDirs)
     {
-      env["OMI_HERMES_ADAPTER_COMMAND"] = "\(shellQuote(hermes)) acp"
+      env["OMI_HERMES_ADAPTER_COMMAND"] = "\(Self.shellQuote(hermes)) acp"
     }
 
     if env["OMI_OPENCLAW_ADAPTER_COMMAND"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
       let openClaw = firstExecutable(named: "openclaw", in: adapterSearchDirs)
     {
-      env["OMI_OPENCLAW_ADAPTER_COMMAND"] = "\(shellQuote(openClaw)) acp"
+      env["OMI_OPENCLAW_ADAPTER_COMMAND"] = Self.openClawAdapterCommand(openClawPath: openClaw)
     }
   }
 
-  private func shellQuote(_ value: String) -> String {
+  static func openClawAdapterCommand(openClawPath: String, fileManager: FileManager = .default) -> String {
+    let nodePath = ((openClawPath as NSString).deletingLastPathComponent as NSString).appendingPathComponent("node")
+    if fileManager.isExecutableFile(atPath: nodePath) {
+      return "\(shellQuote(nodePath)) \(shellQuote(openClawPath)) acp"
+    }
+    return "\(shellQuote(openClawPath)) acp"
+  }
+
+  private static func shellQuote(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
   }
 

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -156,11 +156,45 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains(#"env["HOME"] = home"#))
     XCTAssertTrue(source.contains(#"env["HERMES_HOME"] = "\(home)/.hermes""#))
     XCTAssertTrue(source.contains(#""\(home)/.hermes/hermes-agent/venv/bin""#))
-    XCTAssertTrue(source.contains("existingPath.split(separator: \":\").map(String.init) + trustedPathDirs + adapterPathDirs"))
+    XCTAssertTrue(source.contains("existingPath.split(separator: \":\").map(String.init) + trustedPathDirs"))
+    XCTAssertTrue(source.contains("+ adapterPathDirs"))
     XCTAssertFalse(source.contains("adapterPathPrefixDirs + existingPath.split"))
     XCTAssertTrue(source.contains(#"env["PATH"] = pathElements.joined(separator: ":")"#))
     XCTAssertTrue(source.contains(#"env["OMI_OPENCLAW_ADAPTER_COMMAND"]"#))
     XCTAssertTrue(source.contains(#"env["OMI_HERMES_ADAPTER_COMMAND"]"#))
+  }
+
+  func testOpenClawAdapterCommandUsesSiblingNodeWhenAvailable() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("openclaw-command-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let nodePath = tempDir.appendingPathComponent("node").path
+    let openClawPath = tempDir.appendingPathComponent("openclaw").path
+    FileManager.default.createFile(atPath: nodePath, contents: Data("#!/bin/sh\n".utf8))
+    FileManager.default.createFile(atPath: openClawPath, contents: Data("#!/usr/bin/env node\n".utf8))
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: nodePath)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: openClawPath)
+
+    let command = AgentRuntimeProcess.openClawAdapterCommand(openClawPath: openClawPath)
+
+    XCTAssertEqual(command, "'\(nodePath)' '\(openClawPath)' acp")
+  }
+
+  func testOpenClawAdapterCommandFallsBackToLauncherWithoutSiblingNode() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("openclaw-command-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let openClawPath = tempDir.appendingPathComponent("openclaw").path
+    FileManager.default.createFile(atPath: openClawPath, contents: Data("#!/usr/bin/env node\n".utf8))
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: openClawPath)
+
+    let command = AgentRuntimeProcess.openClawAdapterCommand(openClawPath: openClawPath)
+
+    XCTAssertEqual(command, "'\(openClawPath)' acp")
   }
 
   func testStdoutReaderIsEventDrivenInsteadOfDetachedAvailableDataLoop() throws {
@@ -241,7 +275,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
       .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
-    XCTAssertTrue(source.contains("completeToolCall(callId: callId, result: result, requestId: request.requestId, clientId: request.clientId)"))
+    XCTAssertTrue(source.contains("completeToolCall("))
+    XCTAssertTrue(source.contains("requestId: request.requestId"))
+    XCTAssertTrue(source.contains("clientId: request.clientId"))
     XCTAssertTrue(source.contains(#"if let requestId { payload["requestId"] = requestId }"#))
     XCTAssertTrue(source.contains(#"if let clientId { payload["clientId"] = clientId }"#))
   }

--- a/desktop/macos/changelog/unreleased/20260628-openclaw-standalone-node.json
+++ b/desktop/macos/changelog/unreleased/20260628-openclaw-standalone-node.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed OpenClaw agent launch so it uses the Node runtime from its own install instead of the Omi app bundle."
+}


### PR DESCRIPTION
## Summary
- launch auto-discovered OpenClaw with the sibling `node` binary from the OpenClaw install when available
- keep the previous launcher fallback for installs without a sibling Node binary
- add regression coverage for both command shapes
- add a desktop changelog fragment

## Root Cause
The deployed app prepends Omi's bundled Node directory to `PATH` before the agent bridge launches external adapters. OpenClaw's launcher uses `#!/usr/bin/env node`, so it picked up Omi Beta's bundled Node v22.14.0 instead of OpenClaw's standalone install Node. Current OpenClaw requires Node v22.19+, so the ACP subprocess exited before startup.

## Validation
- `git diff --check`
- `npm test -- local-subprocess-adapter.test.ts`
- `xcrun swift test --package-path desktop/macos/Desktop --filter AgentRuntimeProcessTests`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

