### PR TITLE
[codex] Fix deferred desktop auto-update installs

### DIFF
--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -41,6 +41,7 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
 
   /// Back-reference to the view model (set after init)
   weak var viewModel: UpdaterViewModel?
+  private var deferredInstall: DeferredUpdateInstall?
 
   // NOTE: All delegate methods use logSync() to write synchronously to disk.
   // Sparkle may terminate the app immediately after willInstallUpdate / didAbortWithError,
@@ -209,7 +210,14 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
         logSync(
           "Sparkle: Deferring update v\(version) — speech detected \(Int(secondsSinceSpeech))s ago (active recording)"
         )
-        return false
+        deferredInstall = DeferredUpdateInstall(
+          version: version,
+          silenceWindow: UpdaterDelegate.activeCallSilenceWindow,
+          lastSpeechProvider: { VADGateService.lastSpeechAt },
+          install: installationBlock
+        )
+        deferredInstall?.start()
+        return true
       }
     }
 
@@ -221,6 +229,78 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
   /// Minimum seconds of VAD silence required before an auto-install is allowed.
   /// Matches the typical pause threshold at which a real conversation has wound down.
   fileprivate static let activeCallSilenceWindow: TimeInterval = 120
+}
+
+final class DeferredUpdateInstall {
+  private static let minimumRetryDelay: TimeInterval = 5
+
+  private let version: String
+  private let silenceWindow: TimeInterval
+  private let lastSpeechProvider: () -> Date?
+  private let install: () -> Void
+  private var pendingWorkItem: DispatchWorkItem?
+  private var didInstall = false
+
+  init(
+    version: String,
+    silenceWindow: TimeInterval,
+    lastSpeechProvider: @escaping () -> Date?,
+    install: @escaping () -> Void
+  ) {
+    self.version = version
+    self.silenceWindow = silenceWindow
+    self.lastSpeechProvider = lastSpeechProvider
+    self.install = install
+  }
+
+  deinit {
+    pendingWorkItem?.cancel()
+  }
+
+  func start(now: Date = Date()) {
+    pendingWorkItem?.cancel()
+    scheduleNextCheck(now: now)
+  }
+
+  private func scheduleNextCheck(now: Date) {
+    guard !didInstall else { return }
+
+    if let delay = Self.nextDelay(
+      now: now,
+      lastSpeechAt: lastSpeechProvider(),
+      silenceWindow: silenceWindow,
+      minimumRetryDelay: Self.minimumRetryDelay
+    ) {
+      logSync(
+        "Sparkle: Deferred install for v\(version) will retry after \(Int(ceil(delay)))s of remaining silence"
+      )
+      let workItem = DispatchWorkItem { [weak self] in
+        self?.scheduleNextCheck(now: Date())
+      }
+      pendingWorkItem = workItem
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+      return
+    }
+
+    didInstall = true
+    pendingWorkItem = nil
+    logSync("Sparkle: Silence window satisfied, installing deferred update v\(version)")
+    install()
+  }
+
+  static func nextDelay(
+    now: Date,
+    lastSpeechAt: Date?,
+    silenceWindow: TimeInterval,
+    minimumRetryDelay: TimeInterval = minimumRetryDelay
+  ) -> TimeInterval? {
+    guard let lastSpeechAt else { return nil }
+
+    let secondsSinceSpeech = now.timeIntervalSince(lastSpeechAt)
+    guard secondsSinceSpeech < silenceWindow else { return nil }
+
+    return max(minimumRetryDelay, silenceWindow - secondsSinceSpeech)
+  }
 }
 
 /// View model for managing Sparkle auto-updates

--- a/desktop/macos/Desktop/Tests/DeferredUpdateInstallTests.swift
+++ b/desktop/macos/Desktop/Tests/DeferredUpdateInstallTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DeferredUpdateInstallTests: XCTestCase {
+  func testNoRecentSpeechInstallsImmediately() {
+    XCTAssertNil(
+      DeferredUpdateInstall.nextDelay(
+        now: Date(timeIntervalSince1970: 1_000),
+        lastSpeechAt: nil,
+        silenceWindow: 120
+      )
+    )
+  }
+
+  func testExpiredSilenceWindowInstallsImmediately() {
+    let now = Date(timeIntervalSince1970: 1_000)
+    XCTAssertNil(
+      DeferredUpdateInstall.nextDelay(
+        now: now,
+        lastSpeechAt: now.addingTimeInterval(-121),
+        silenceWindow: 120
+      )
+    )
+  }
+
+  func testRecentSpeechWaitsForRemainingSilenceWindow() {
+    let now = Date(timeIntervalSince1970: 1_000)
+    XCTAssertEqual(
+      DeferredUpdateInstall.nextDelay(
+        now: now,
+        lastSpeechAt: now.addingTimeInterval(-30),
+        silenceWindow: 120
+      ),
+      90
+    )
+  }
+
+  func testNearBoundaryUsesMinimumRetryDelay() {
+    let now = Date(timeIntervalSince1970: 1_000)
+    XCTAssertEqual(
+      DeferredUpdateInstall.nextDelay(
+        now: now,
+        lastSpeechAt: now.addingTimeInterval(-119),
+        silenceWindow: 120,
+        minimumRetryDelay: 5
+      ),
+      5
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260628-deferred-auto-update-install.json
+++ b/desktop/macos/changelog/unreleased/20260628-deferred-auto-update-install.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed automatic desktop updates getting stuck after they were deferred during active conversations"
+}


### PR DESCRIPTION
## Summary

Fixes a macOS desktop auto-update stall where Sparkle downloaded an update, deferred installation because recent VAD speech indicated an active conversation, and then left the update waiting for app quit instead of retrying after the conversation went quiet.

## Root Cause

`willInstallUpdateOnQuit` returned `false` for the active-conversation path. That preserved the no-restart-during-speech behavior, but it also handed the update back to Sparkle as an install-on-quit update with no app-owned quiet-time retry. Long-running sessions could therefore sit on a downloaded update indefinitely.

## Changes

- Keep ownership of deferred Sparkle installs when recent speech blocks immediate restart.
- Retry after the remaining silence window and invoke Sparkle's installation block once the app has been quiet long enough.
- Add focused tests for deferred-install timing.
- Add an unreleased desktop changelog fragment.

## Validation

- `xcrun swift test --package-path desktop/macos/Desktop --filter DeferredUpdateInstallTests`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

