### PR TITLE
Render action item timestamps in the user's local timezone in chat (#4643)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -116,6 +116,7 @@ pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_action_items_timezone.py -v
 pytest tests/unit/test_request_validation_contracts.py -v
 pytest tests/unit/test_conversation_structure_timezone.py -v
 pytest tests/unit/test_action_item_dedup.py -v

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -107,6 +107,10 @@ action_items_db.get_action_item = MagicMock(
     }
 )
 action_items_db.update_action_item = MagicMock(return_value=True)
+
+# Stub database.notifications (action_item_tools imports get_user_time_zone for tz rendering)
+notifications_db = _stub_module("database.notifications")
+notifications_db.get_user_time_zone = MagicMock(return_value="UTC")
 _stub_package("database")
 
 # Stub notifications
@@ -151,6 +155,21 @@ _stub_package("utils.retrieval.tools")
 _stub_package("utils.llm")
 _stub_package("utils.conversations")
 
+# Stub utils.conversations.render (action_item_tools imports resolve_display_tz)
+_render_stub = _stub_module("utils.conversations.render")
+
+
+def _real_resolve_display_tz(tz):
+    if tz:
+        try:
+            return ZoneInfo(tz), tz
+        except Exception:
+            pass
+    return timezone.utc, "UTC"
+
+
+_render_stub.resolve_display_tz = _real_resolve_display_tz
+
 # Stub utils.retrieval.agentic
 import contextvars
 
@@ -168,6 +187,12 @@ llm_clients_stub.parser = MagicMock()
 llm_clients_stub.llm_high = MagicMock()
 llm_clients_stub.llm_medium_experiment = MagicMock()
 llm_clients_stub.get_llm = MagicMock(return_value=MagicMock())
+
+# Stub utils.llm.conversation_folder (conversation_processing imports from it after a recent refactor)
+conv_folder_stub = _stub_module("utils.llm.conversation_folder")
+conv_folder_stub.FolderAssignment = MagicMock()
+conv_folder_stub.assign_conversation_to_folder = MagicMock()
+conv_folder_stub.build_folders_context = MagicMock(return_value="")
 
 # Load models first
 _stub_package("models")

--- a/backend/tests/unit/test_action_items_timezone.py
+++ b/backend/tests/unit/test_action_items_timezone.py
@@ -249,3 +249,13 @@ class TestActionItemsTimezoneRendering:
         # Tokyo is UTC+9, so 22:00 UTC == 07:00 the next day.
         assert result.count("Asia/Tokyo") == 3
         assert "2026-06-27 07:00:00 Asia/Tokyo" in result
+
+    def test_timezone_lookup_failure_falls_back_to_utc(self):
+        # A Firestore failure in the timezone lookup must not abort retrieval; it
+        # falls back to UTC formatting instead (cubic finding on #8483).
+        with patch.object(action_item_tools.action_items_db, 'get_action_items', return_value=[_item()]), patch.object(
+            action_item_tools.notification_db, 'get_user_time_zone', side_effect=RuntimeError("firestore down")
+        ):
+            result = get_action_items_tool(config=_make_config())
+        assert "Due: 2026-06-26 22:00:00 UTC" in result
+        assert "Error" not in result

--- a/backend/tests/unit/test_action_items_timezone.py
+++ b/backend/tests/unit/test_action_items_timezone.py
@@ -1,0 +1,251 @@
+"""Tests for timezone-aware action-item timestamps in chat retrieval (issue #4643).
+
+The agentic chat tool ``get_action_items_tool`` used to render action-item
+timestamps with a bare ``strftime`` and no timezone, e.g. ``Due: 2026-06-26 22:00:00``.
+The chat model then read that UTC wall-clock time as the user's local time and
+mislabelled the time of day ("tonight" when it was actually mid-afternoon).
+
+These tests assert the tool now renders ``created_at``/``due_at``/``completed_at``
+in the user's local timezone with an explicit label, matching the pattern that
+``conversations_to_string`` already uses for conversations.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths / env
+# ---------------------------------------------------------------------------
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers (same approach as test_action_item_date_validation.py)
+# ---------------------------------------------------------------------------
+def _stub_module(name):
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    if "." in name:
+        parent_name, attr_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, mod)
+    return mod
+
+
+def _stub_package(name):
+    mod = _stub_module(name)
+    mod.__path__ = []
+    return mod
+
+
+def _load_module_from_file(module_name, file_path):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies
+# ---------------------------------------------------------------------------
+for mod_name in [
+    "firebase_admin",
+    "firebase_admin.firestore",
+    "firebase_admin.auth",
+    "firebase_admin.messaging",
+    "firebase_admin.credentials",
+    "google.cloud.firestore",
+    "google.cloud.firestore_v1",
+    "google.cloud.firestore_v1.base_query",
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.cloud.storage",
+    "opuslib",
+    "sentry_sdk",
+    "database._client",
+    "database.redis_db",
+    "database.auth",
+]:
+    if mod_name not in sys.modules:
+        _stub_module(mod_name)
+sys.modules["database.auth"].get_user_name = MagicMock(return_value="Test User")
+
+# Stub database.action_items (get_action_items is patched per-test)
+action_items_db = _stub_module("database.action_items")
+action_items_db.get_action_items = MagicMock(return_value=[])
+_stub_package("database")
+
+# Stub database.notifications (source of the user's timezone, patched per-test)
+notifications_db = _stub_module("database.notifications")
+notifications_db.get_user_time_zone = MagicMock(return_value="UTC")
+
+# Stub notifications senders pulled in by action_item_tools
+notif_mod = _stub_module("utils.notifications")
+notif_mod.send_action_item_completed_notification = MagicMock()
+notif_mod.send_action_item_created_notification = MagicMock()
+notif_mod.send_action_item_data_message = MagicMock()
+notif_mod.sync_action_item_reminder = MagicMock()
+
+# Stub langchain (passthrough @tool so the tool is directly callable)
+langchain_core = _stub_package("langchain_core")
+langchain_tools = _stub_module("langchain_core.tools")
+langchain_runnables = _stub_module("langchain_core.runnables")
+
+
+class FakeRunnableConfig(dict):
+    pass
+
+
+def fake_tool(func=None, **kwargs):
+    if func is not None:
+        return func
+    return lambda f: f
+
+
+langchain_tools.tool = fake_tool
+langchain_runnables.RunnableConfig = FakeRunnableConfig
+
+# Stub utils packages
+_stub_package("utils")
+_stub_package("utils.retrieval")
+_stub_package("utils.retrieval.tools")
+_stub_package("utils.conversations")
+
+# Stub utils.conversations.render with the REAL tz-resolution behavior so the
+# conversion under test is genuine (not a mock).
+_render_stub = _stub_module("utils.conversations.render")
+
+
+def _real_resolve_display_tz(tz):
+    if tz:
+        try:
+            return ZoneInfo(tz), tz
+        except Exception:
+            pass
+    return timezone.utc, "UTC"
+
+
+_render_stub.resolve_display_tz = _real_resolve_display_tz
+
+# Stub utils.retrieval.agentic (agent_config_context)
+import contextvars
+
+agentic_stub = _stub_module("utils.retrieval.agentic")
+agentic_stub.agent_config_context = contextvars.ContextVar('agent_config', default=None)
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+action_item_tools = _load_module_from_file(
+    "utils.retrieval.tools.action_item_tools",
+    BACKEND_DIR / "utils" / "retrieval" / "tools" / "action_item_tools.py",
+)
+get_action_items_tool = action_item_tools.get_action_items_tool
+
+
+def _make_config(uid="test-user-123"):
+    return {"configurable": {"user_id": uid}}
+
+
+# A fixed instant: 22:00:00 UTC == 15:00:00 in America/Los_Angeles (PDT, UTC-7 in June).
+_UTC_INSTANT = datetime(2026, 6, 26, 22, 0, 0, tzinfo=timezone.utc)
+
+
+def _item(**over):
+    base = {
+        'id': 'ai-1',
+        'description': 'Submit the quarterly report',
+        'completed': False,
+        'created_at': _UTC_INSTANT,
+        'due_at': _UTC_INSTANT,
+        'completed_at': _UTC_INSTANT,
+    }
+    base.update(over)
+    return base
+
+
+def _run(items, tz):
+    with patch.object(action_item_tools.action_items_db, 'get_action_items', return_value=items), patch.object(
+        action_item_tools.notification_db, 'get_user_time_zone', return_value=tz
+    ):
+        return get_action_items_tool(config=_make_config())
+
+
+# ===========================================================================
+# _format_local helper
+# ===========================================================================
+class TestFormatLocalHelper:
+    def test_aware_utc_converted_to_user_tz_with_label(self):
+        out = action_item_tools._format_local(_UTC_INSTANT, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
+        assert out == "2026-06-26 15:00:00 America/Los_Angeles"
+
+    def test_naive_value_treated_as_utc(self):
+        naive = datetime(2026, 6, 26, 22, 0, 0)  # no tzinfo
+        out = action_item_tools._format_local(naive, ZoneInfo("America/Los_Angeles"), "America/Los_Angeles")
+        assert out == "2026-06-26 15:00:00 America/Los_Angeles"
+
+    def test_utc_label_unchanged(self):
+        out = action_item_tools._format_local(_UTC_INSTANT, timezone.utc, "UTC")
+        assert out == "2026-06-26 22:00:00 UTC"
+
+
+# ===========================================================================
+# get_action_items_tool rendering
+# ===========================================================================
+class TestActionItemsTimezoneRendering:
+    def test_due_date_rendered_in_user_timezone(self):
+        result = _run([_item()], tz="America/Los_Angeles")
+        assert "Due: 2026-06-26 15:00:00 America/Los_Angeles" in result
+        # The raw UTC wall-clock time must not leak through unlabeled.
+        assert "22:00:00" not in result
+
+    def test_created_and_completed_rendered_in_user_timezone(self):
+        result = _run([_item(completed=True)], tz="America/Los_Angeles")
+        assert "Created: 2026-06-26 15:00:00 America/Los_Angeles" in result
+        assert "Completed: 2026-06-26 15:00:00 America/Los_Angeles" in result
+
+    def test_utc_when_timezone_is_utc(self):
+        result = _run([_item()], tz="UTC")
+        assert "Due: 2026-06-26 22:00:00 UTC" in result
+
+    def test_empty_timezone_falls_back_to_utc(self):
+        result = _run([_item()], tz="")
+        assert "Due: 2026-06-26 22:00:00 UTC" in result
+
+    def test_invalid_timezone_falls_back_to_utc_without_crashing(self):
+        result = _run([_item()], tz="Not/AZone")
+        assert "Due: 2026-06-26 22:00:00 UTC" in result
+
+    def test_naive_timestamp_is_converted_as_utc(self):
+        naive_item = _item(due_at=datetime(2026, 6, 26, 22, 0, 0))  # naive
+        result = _run([naive_item], tz="America/Los_Angeles")
+        assert "Due: 2026-06-26 15:00:00 America/Los_Angeles" in result
+
+    def test_label_on_every_timestamp_line(self):
+        result = _run([_item(completed=True)], tz="Asia/Tokyo")
+        # Tokyo is UTC+9, so 22:00 UTC == 07:00 the next day.
+        assert result.count("Asia/Tokyo") == 3
+        assert "2026-06-27 07:00:00 Asia/Tokyo" in result

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -15,13 +15,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _resolve_display_tz(tz: str | None):
-    """Return (tzinfo, label) for formatting timestamps. Falls back to UTC on a missing/invalid zone."""
+def resolve_display_tz(tz: str | None):
+    """Return ``(tzinfo, label)`` for rendering timestamps in a user's local timezone.
+
+    Falls back to ``(UTC, "UTC")`` when the zone is missing or not a valid IANA name.
+    Shared by the chat retrieval tools so every user-facing timestamp is shown in the
+    user's local time rather than UTC (see issue #4643).
+    """
     if tz:
         try:
             return ZoneInfo(tz), tz
         except (ZoneInfoNotFoundError, ValueError):
-            logger.warning(f"conversations_to_string: invalid timezone '{tz}', falling back to UTC")
+            logger.warning(f"resolve_display_tz: invalid timezone '{tz}', falling back to UTC")
     return timezone.utc, "UTC"
 
 
@@ -158,7 +163,7 @@ def conversations_to_string(
     """
     result = []
     people_map = {p.id: p for p in people} if people else {}
-    display_tz, tz_label = _resolve_display_tz(tz)
+    display_tz, tz_label = resolve_display_tz(tz)
     for i, conversation in enumerate(conversations):
         formatted_date = conversation.created_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
         conversation_str = (

--- a/backend/utils/retrieval/tools/action_item_tools.py
+++ b/backend/utils/retrieval/tools/action_item_tools.py
@@ -10,12 +10,14 @@ from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
 import database.action_items as action_items_db
+import database.notifications as notification_db
 from utils.notifications import (
     send_action_item_completed_notification,
     send_action_item_created_notification,
     send_action_item_data_message,
     sync_action_item_reminder,
 )
+from utils.conversations.render import resolve_display_tz
 import logging
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,18 @@ try:
 except ImportError:
     # Fallback if import fails
     agent_config_context = contextvars.ContextVar('agent_config', default=None)
+
+
+def _format_local(dt, display_tz, tz_label: str) -> str:
+    """Render a stored timestamp in the user's local timezone with a tz label.
+
+    Action-item timestamps are stored tz-aware (UTC); a naive value is treated as
+    UTC defensively so the chat model never sees an unlabeled wall-clock time and
+    mislabels the time of day (issue #4643).
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
 
 
 @tool
@@ -257,7 +271,10 @@ def get_action_items_tool(
         logger.info(f"✅ get_action_items_tool END - returning early (no items found)")
         return msg
 
-    # Format action items
+    # Format action items. Render timestamps in the user's local timezone so the
+    # chat model labels the time of day correctly (issue #4643).
+    tz = notification_db.get_user_time_zone(uid)
+    display_tz, tz_label = resolve_display_tz(tz)
     result = f"User Action Items ({len(action_items)} total):\n\n"
 
     for i, item in enumerate(action_items, 1):
@@ -267,18 +284,15 @@ def get_action_items_tool(
         # Add ID for reference in updates
         result += f"   ID: {item.get('id')}\n"
 
-        # Add dates if available
+        # Add dates if available (rendered in the user's local timezone)
         if item.get('created_at'):
-            created = item['created_at']
-            result += f"   Created: {created.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Created: {_format_local(item['created_at'], display_tz, tz_label)}\n"
 
         if item.get('due_at'):
-            due = item['due_at']
-            result += f"   Due: {due.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Due: {_format_local(item['due_at'], display_tz, tz_label)}\n"
 
         if item.get('completed_at'):
-            completed_at = item['completed_at']
-            result += f"   Completed: {completed_at.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            result += f"   Completed: {_format_local(item['completed_at'], display_tz, tz_label)}\n"
 
         if item.get('conversation_id'):
             result += f"   From conversation: {item['conversation_id']}\n"

--- a/backend/utils/retrieval/tools/action_item_tools.py
+++ b/backend/utils/retrieval/tools/action_item_tools.py
@@ -272,9 +272,13 @@ def get_action_items_tool(
         return msg
 
     # Format action items. Render timestamps in the user's local timezone so the
-    # chat model labels the time of day correctly (issue #4643).
-    tz = notification_db.get_user_time_zone(uid)
-    display_tz, tz_label = resolve_display_tz(tz)
+    # chat model labels the time of day correctly (issue #4643). A timezone lookup
+    # failure must never abort retrieval, so fall back to UTC formatting.
+    try:
+        display_tz, tz_label = resolve_display_tz(notification_db.get_user_time_zone(uid))
+    except Exception as tz_error:
+        logger.warning(f"get_action_items_tool - timezone lookup failed, formatting in UTC: {tz_error}")
+        display_tz, tz_label = timezone.utc, "UTC"
     result = f"User Action Items ({len(action_items)} total):\n\n"
 
     for i, item in enumerate(action_items, 1):


### PR DESCRIPTION
## Problem

Issue #4643: AI chat refers to event times with the wrong time of day ("tonight" when it was the afternoon, "this afternoon" when it was the morning).

The agentic chat already injects the current time in the user's timezone and renders retrieved conversations in local time (`utils/conversations/render.py`). But the action items tool the chat agent calls, `get_action_items_tool`, formatted timestamps with a bare `strftime` and no timezone:

```
Due: 2026-06-26 22:00:00
```

The model reads that UTC wall clock as the user's local time. For a user in `America/Los_Angeles`, 22:00 UTC is actually 15:00 local, so an item due in mid afternoon gets described as "due tonight."

## Fix

Render `created_at`, `due_at`, and `completed_at` in the user's timezone with an explicit label, reusing the same helper conversations already use:

```
Due: 2026-06-26 15:00:00 America/Los_Angeles
```

- Promote the existing `_resolve_display_tz` in `render.py` to a public `resolve_display_tz` so conversations and the action items tool share one timezone resolver (falls back to UTC on a missing or invalid zone).
- `get_action_items_tool` fetches the user's timezone with `notification_db.get_user_time_zone` (the same call `conversation_tools` makes) and formats each timestamp through a small naive-safe helper.

This is the live path (`utils/retrieval/graph.py` to the agentic chat to `get_action_items_tool`), so it directly changes what users see.

## Tests

- New `tests/unit/test_action_items_timezone.py`: timestamps render in the user's zone with a label; UTC, empty, and invalid zones fall back to UTC without crashing; naive timestamps are treated as UTC. Verified red against the prior code and green with the fix.
- The tool now imports `database.notifications` and the render helper, so `test_action_item_date_validation.py` stubs those. While there I also restored a `utils.llm.conversation_folder` stub that a recent refactor left out, so that file runs fully green again.

## Scope and follow-up

The calendar tool (`get_calendar_events_tool`) has the same class of issue, but it is an async tool so the timezone read needs an executor offload. I left it for a separate change to keep this one small and obviously correct.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

