### PR TITLE
Enable parakeet duration guard (600s) — reject files near OOM boundary

### DIFF
--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -111,7 +111,7 @@ env:
   - name: PARAKEET_LOCAL_ATTN_CONTEXT
     value: "128,128"
   - name: PARAKEET_MAX_FILE_DURATION
-    value: "0"
+    value: "600"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://prod-omi-diarizer.prod-omi-backend.svc.cluster.local:8080"
 


### PR DESCRIPTION
## Summary

- Enable `PARAKEET_MAX_FILE_DURATION=600` in prod Helm values
- Rejects files >10 min with HTTP 413 before GPU inference
- Keeps `ATTENTION_MODE=full` + `torch.compile=true` (proven stable config from PR #8428)

## Context

PR #8428 deployed the auto-attention system, but Phase 2 (enabling `ATTENTION_MODE=auto`) was **rolled back** after 14 OOMs and 22% error rate in 27 minutes. Root cause: auto mode disables `torch.compile`, which increases VRAM ~3x under load.

**Recommended approach** (from @zen): keep full attention + torch.compile + duration guard. Omi audio is short (p50=34s, p95=59s) — no files need >10 min full attention. The duration guard rejects anything near the OOM boundary before it reaches the GPU.

## What changes

| Setting | Before | After |
|---------|--------|-------|
| `PARAKEET_MAX_FILE_DURATION` | `0` (disabled) | `600` (reject >10 min) |
| `PARAKEET_ATTENTION_MODE` | `full` | `full` (unchanged) |

## Deployment

Single-step deploy — no behavior change except 413 rejection for >10 min files:
```bash
gh workflow run gcp_parakeet.yml -f environment=prod -f branch=main
```

## Risk

Low — only adds a pre-inference guard. Files under 10 min (>99% of Omi traffic) are unaffected.

_by AI for @beastoin_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

