### PR TITLE
Revert PR #8428: parakeet auto attention + duration guard

### DIFF
--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -104,14 +104,6 @@ env:
     value: "true"
   - name: PARAKEET_CUDA_GRAPHS
     value: "true"
-  - name: PARAKEET_ATTENTION_MODE
-    value: "full"
-  - name: PARAKEET_AUTO_ATTN_THRESHOLD
-    value: "300"
-  - name: PARAKEET_LOCAL_ATTN_CONTEXT
-    value: "128,128"
-  - name: PARAKEET_MAX_FILE_DURATION
-    value: "0"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://prod-omi-diarizer.prod-omi-backend.svc.cluster.local:8080"
 

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -72,11 +72,10 @@ class GPUWorker:
         self._attn_mode = os.getenv("PARAKEET_ATTENTION_MODE", "full").lower()
         if self._attn_mode not in _VALID_ATTN_MODES:
             raise ValueError(f"PARAKEET_ATTENTION_MODE must be one of {_VALID_ATTN_MODES}, got '{self._attn_mode}'")
-        self._attn_auto_threshold_sec = float(os.getenv("PARAKEET_AUTO_ATTN_THRESHOLD", "300"))
+        self._attn_auto_threshold_sec = float(os.getenv("PARAKEET_AUTO_ATTN_THRESHOLD", "600"))
         ctx_raw = os.getenv("PARAKEET_LOCAL_ATTN_CONTEXT", "128,128")
         self._attn_local_context = [int(x.strip()) for x in ctx_raw.split(",")]
         self._attn_is_local = False
-        self._model_dtype = None
         self._max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
     @property
@@ -229,7 +228,6 @@ class GPUWorker:
         if use_bf16:
             logger.info(f"Converting {model_name} to BF16 (halves GPU memory)")
             model = model.to(torch.bfloat16)
-            self._model_dtype = torch.bfloat16
         model.eval()
 
         if disable_cuda_graphs:
@@ -240,8 +238,6 @@ class GPUWorker:
         if self._attn_mode == "local":
             model.change_attention_model("rel_pos_local_attn", self._attn_local_context)
             model.change_subsampling_conv_chunking_factor(1)
-            if self._model_dtype is not None:
-                model.to(self._model_dtype)
             self._attn_is_local = True
             logger.info(f"Attention mode: local (context={self._attn_local_context}) — linear VRAM scaling")
         elif self._attn_mode == "auto":
@@ -331,8 +327,6 @@ class GPUWorker:
         else:
             self._model.change_attention_model("rel_pos")
             self._attn_is_local = False
-        if self._model_dtype is not None:
-            self._model.to(self._model_dtype)
 
     @torch.inference_mode()
     def _batch_transcribe(self, payload: dict) -> list:

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -1,15 +1,12 @@
 import asyncio
 import functools
 import gc
-import math
 import os
 import time
 import uuid
 import logging
 import io as _io
 import wave as _wave
-
-import soundfile as sf
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -89,23 +86,10 @@ _max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
 
 def _get_audio_duration_from_bytes(data: bytes) -> float:
     try:
-        info = sf.info(_io.BytesIO(data))
-        return info.duration
-    except Exception:
-        pass
-    try:
         with _wave.open(_io.BytesIO(data), 'rb') as wf:
             return wf.getnframes() / wf.getframerate()
     except Exception:
-        if _max_file_duration_sec > 0:
-            return float('inf')
         return 0.0
-
-
-def _duration_limit_detail(audio_dur: float) -> str:
-    if math.isinf(audio_dur):
-        return "Cannot determine audio duration"
-    return f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"
 
 
 def _on_batch_complete(queue_durations, inference_seconds, batch_size):
@@ -185,14 +169,14 @@ async def transcribe(file: UploadFile = File(...)):
     try:
         data = await file.read()
         audio_dur = _get_audio_duration_from_bytes(data)
+        if audio_dur > 0:
+            AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
             status = "rejected"
             return JSONResponse(
                 status_code=413,
-                content={"detail": _duration_limit_detail(audio_dur)},
+                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
             )
-        if audio_dur > 0 and math.isfinite(audio_dur):
-            AUDIO_DURATION.observe(audio_dur)
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:
@@ -241,14 +225,14 @@ async def transcribe_v2(
     try:
         data = await file.read()
         audio_dur = _get_audio_duration_from_bytes(data)
+        if audio_dur > 0:
+            AUDIO_DURATION.observe(audio_dur)
         if _max_file_duration_sec > 0 and audio_dur > _max_file_duration_sec:
             status = "rejected"
             return JSONResponse(
                 status_code=413,
-                content={"detail": _duration_limit_detail(audio_dur)},
+                content={"detail": f"Audio duration {audio_dur:.0f}s exceeds limit ({_max_file_duration_sec:.0f}s)"},
             )
-        if audio_dur > 0 and math.isfinite(audio_dur):
-            AUDIO_DURATION.observe(audio_dur)
         await loop.run_in_executor(_io_pool, _write_file, file_path, data)
 
         if batch_engine is not None:

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -6,9 +6,7 @@ import sys
 import wave
 from unittest.mock import MagicMock, AsyncMock, patch
 
-import numpy as np
 import pytest
-import soundfile as sf
 
 os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
 os.environ.setdefault("PARAKEET_DEVICE", "cpu")
@@ -242,22 +240,6 @@ class TestAudioDurationFromBytes:
 
         assert _get_audio_duration_from_bytes(b"") == 0.0
 
-    def test_invalid_bytes_return_inf_when_guard_enabled(self):
-        _, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
-        mod._max_file_duration_sec = 5.0
-        try:
-            assert mod._get_audio_duration_from_bytes(b"not audio") == float('inf')
-        finally:
-            mod._max_file_duration_sec = 0.0
-
-    def test_flac_returns_positive_duration(self):
-        from main import _get_audio_duration_from_bytes
-
-        buf = io.BytesIO()
-        sf.write(buf, np.zeros(16000 * 3, dtype='float32'), 16000, format='FLAC')
-        dur = _get_audio_duration_from_bytes(buf.getvalue())
-        assert abs(dur - 3.0) < 0.01
-
     def test_v1_with_real_wav_observes_audio_duration(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
 
@@ -297,65 +279,6 @@ class TestDurationGuardHTTP413:
         assert resp.status_code == 413
         assert "exceeds limit" in resp.json()["detail"].lower()
         mod._max_file_duration_sec = 0.0
-
-    def test_v1_returns_413_for_oversized_flac(self):
-        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
-        mod._max_file_duration_sec = 5.0
-        try:
-            buf = io.BytesIO()
-            sf.write(buf, np.zeros(16000 * 10, dtype='float32'), 16000, format='FLAC')
-            flac_data = buf.getvalue()
-            client = TestClient(app, raise_server_exceptions=False)
-            resp = client.post("/v1/transcribe", files={"file": ("long.flac", flac_data, "audio/flac")})
-            assert resp.status_code == 413
-            assert "exceeds limit" in resp.json()["detail"].lower()
-        finally:
-            mod._max_file_duration_sec = 0.0
-
-    def test_v1_rejects_unprobeable_audio_before_batch(self):
-        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
-        mod._max_file_duration_sec = 5.0
-        try:
-            client = TestClient(app, raise_server_exceptions=False)
-            resp = client.post("/v1/transcribe", files={"file": ("bad.bin", b"not audio", "application/octet-stream")})
-            assert resp.status_code == 413
-            assert "cannot determine audio duration" in resp.json()["detail"].lower()
-            engine.submit.assert_not_called()
-        finally:
-            mod._max_file_duration_sec = 0.0
-
-    def test_v2_rejects_unprobeable_audio_before_batch(self):
-        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
-        mod._max_file_duration_sec = 5.0
-        try:
-            client = TestClient(app, raise_server_exceptions=False)
-            resp = client.post(
-                "/v2/transcribe",
-                files={"file": ("bad.bin", b"not audio", "application/octet-stream")},
-                data={"diarize": "true"},
-            )
-            assert resp.status_code == 413
-            assert "cannot determine audio duration" in resp.json()["detail"].lower()
-            engine.submit.assert_not_called()
-        finally:
-            mod._max_file_duration_sec = 0.0
-
-    def test_unprobeable_upload_does_not_poison_audio_duration_metric(self):
-        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
-        mod._max_file_duration_sec = 5.0
-        try:
-            audio_dur_hist = mod.AUDIO_DURATION
-            before_sum = audio_dur_hist._sum.get()
-            client = TestClient(app, raise_server_exceptions=False)
-            resp = client.post("/v1/transcribe", files={"file": ("bad.bin", b"not audio", "application/octet-stream")})
-            assert resp.status_code == 413
-            after_sum = audio_dur_hist._sum.get()
-            assert after_sum == before_sum, f"AUDIO_DURATION sum changed from {before_sum} to {after_sum}"
-            import math
-
-            assert math.isfinite(after_sum), "AUDIO_DURATION sum is not finite"
-        finally:
-            mod._max_file_duration_sec = 0.0
 
     def test_v1_passes_when_under_limit(self):
         app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -586,37 +586,6 @@ class TestAttentionModeConfig:
         assert worker._attn_is_local is True
         worker.stop()
 
-    def test_local_mode_recasts_bf16_after_change_attention(self):
-        nemo_asr = _get_nemo_asr()
-        mock_model = _make_mock_model()
-        mock_model.to.return_value = mock_model
-        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
-        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
-
-        torch_mod = sys.modules["torch"]
-        orig_avail = torch_mod.cuda.is_available.return_value
-        torch_mod.cuda.is_available.return_value = True
-        torch_mod.cuda.is_bf16_supported.return_value = True
-
-        with patch.dict(
-            os.environ,
-            {
-                "PARAKEET_ATTENTION_MODE": "local",
-                "PARAKEET_LOCAL_ATTN_CONTEXT": "128,128",
-                "PARAKEET_TORCH_COMPILE": "false",
-                "PARAKEET_BF16": "1",
-            },
-        ):
-            worker = GPUWorker()
-            worker._load_model()
-
-        to_calls = mock_model.to.call_args_list
-        assert len(to_calls) >= 2
-        assert to_calls[0] == ((torch_mod.bfloat16,),)
-        assert to_calls[-1] == ((torch_mod.bfloat16,),)
-        torch_mod.cuda.is_available.return_value = orig_avail
-        worker.stop()
-
     def test_auto_mode_skips_torch_compile(self):
         import gpu_worker as gw_mod
 
@@ -679,39 +648,6 @@ class TestSwitchAttention:
             worker._switch_attention(to_local=True)
 
             worker._model.change_attention_model.assert_not_called()
-
-    def test_recast_bf16_after_switch_to_local(self):
-        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
-            worker = GPUWorker()
-            worker._model = MagicMock()
-            worker._model_dtype = _torch.bfloat16
-            worker._attn_is_local = False
-
-            worker._switch_attention(to_local=True)
-
-            worker._model.to.assert_called_once_with(_torch.bfloat16)
-
-    def test_recast_bf16_after_switch_to_full(self):
-        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
-            worker = GPUWorker()
-            worker._model = MagicMock()
-            worker._model_dtype = _torch.bfloat16
-            worker._attn_is_local = True
-
-            worker._switch_attention(to_local=False)
-
-            worker._model.to.assert_called_once_with(_torch.bfloat16)
-
-    def test_no_recast_when_dtype_is_none(self):
-        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto"}):
-            worker = GPUWorker()
-            worker._model = MagicMock()
-            worker._model_dtype = None
-            worker._attn_is_local = False
-
-            worker._switch_attention(to_local=True)
-
-            worker._model.to.assert_not_called()
 
 
 class TestDurationGuard:


### PR DESCRIPTION
## Summary

Reverts all changes from PR #8428 and related follow-up commits (Phase 2 enable + rollback) to restore main to a clean state.

**Why:** Phase 2 deployment of auto attention mode caused 14 OOMs and 22% error rate in 27 minutes — root cause was torch.compile being disabled for auto mode, which increased VRAM ~3x under production batch load. Main needs to be clean before re-landing the safe subset of changes.

**What's reverted:**
- `gpu_worker.py` — BF16 dtype tracking, auto attention threshold default change (600→300)
- `main.py` — soundfile import, pre-batch duration guard improvements, metrics poisoning fix
- `test_parakeet_gpu_worker.py` — BF16 recast and attention switch tests
- `test_parakeet_endpoints.py` — FLAC detection, unprobeable upload, metrics poisoning tests
- `prod_omi_parakeet_values.yaml` — removes 4 env vars (ATTENTION_MODE, THRESHOLD, LOCAL_CONTEXT, MAX_FILE_DURATION)

**What happens next:** A new clean PR will re-land only the proven-safe changes (duration guard + BF16 recast) with `ATTENTION_MODE=full` + `MAX_FILE_DURATION=600`.

Reverts #8428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

