### PR TITLE
fix make mind map canvas tappable

### DIFF
--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -495,6 +495,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
 
   Widget _buildMindMapPreview(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: () => Navigator.push(
         context,
         MaterialPageRoute(builder: (context) => const MemoryGraphPage(trackOpenEvent: false)),


### PR DESCRIPTION
## Summary
- Add `behavior: HitTestBehavior.opaque` to the `GestureDetector` wrapping the mind map preview canvas

## Root Cause
The mind map preview uses `IgnorePointer` inside a `GestureDetector` to prevent the embedded `MemoryGraphPage` from consuming its own pointer events. However, with the default `HitTestBehavior.deferToChild`, the `GestureDetector` only claims a hit if a child accepts it — and since `IgnorePointer` rejects all hits, the tap on the canvas was silently dropped and never fired `onTap`.

## Fix
Setting `behavior: HitTestBehavior.opaque` makes the `GestureDetector` own its full bounding box regardless of what children report, so tapping anywhere on the canvas now correctly navigates to the full mind map.

## Test plan
- [ ] Open home screen with enough conversations to show the mind map section
- [ ] Tap anywhere on the mind map canvas — it should open the full mind map page
- [ ] Tap the "Expand" button — should also open the mind map

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

