### PR TITLE
fix(chat): import rendering for ScrollDirection

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 


### PR DESCRIPTION
## Problem

The build is broken on `main`:

```
lib/pages/chat/page.dart:1007:94: Error: The getter 'ScrollDirection' isn't defined for the type 'ChatPageState'.
```

Commit e94de7e9e (*fix(chat): respect scroll intent while streaming*) added a use of `ScrollDirection.idle` in `_handleScrollNotification` but did not import the package that defines `ScrollDirection`. `page.dart` imports `material.dart`, `scheduler.dart`, and `services.dart`, none of which re-export `ScrollDirection`.

## Fix

Add the missing import:

```dart
import 'package:flutter/rendering.dart';
```

## Verification

`flutter analyze lib/pages/chat/page.dart` — the `ScrollDirection` error is gone; only pre-existing info-level lints remain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

