### PR TITLE
Render calendar event times in the user's timezone in chat (#4643)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -85,6 +85,7 @@ pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v
 pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
+pytest tests/unit/test_calendar_timezone.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v
 pytest tests/unit/test_firestore_cache.py -v

--- a/backend/tests/unit/test_calendar_timezone.py
+++ b/backend/tests/unit/test_calendar_timezone.py
@@ -6,13 +6,14 @@ event's own zone, so the chat model mislabeled the time of day ("tonight" vs
 helpers, which these tests cover directly (no Google API or async needed).
 """
 
+import asyncio
 import importlib.util
 import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -124,3 +125,17 @@ class TestFormatEventDt:
         # Tokyo is UTC+9, so 22:00 UTC is 07:00 the next day.
         out = calendar_tools._format_event_dt(_UTC_INSTANT, ZoneInfo("Asia/Tokyo"), "Asia/Tokyo")
         assert out == "2026-07-01 07:00:00 Asia/Tokyo"
+
+
+class TestUserDisplayTz:
+    def test_lookup_success(self):
+        with patch.object(calendar_tools, "run_blocking", new=AsyncMock(return_value="America/Los_Angeles")):
+            tzinfo, label = asyncio.run(calendar_tools._get_user_display_tz("uid"))
+        assert tzinfo == _LA and label == "America/Los_Angeles"
+
+    def test_lookup_failure_falls_back_to_utc(self):
+        # A Firestore failure in the timezone lookup must not abort the tool; it
+        # falls back to UTC so the calendar events still render (cubic on #8495).
+        with patch.object(calendar_tools, "run_blocking", new=AsyncMock(side_effect=RuntimeError("firestore down"))):
+            tzinfo, label = asyncio.run(calendar_tools._get_user_display_tz("uid"))
+        assert tzinfo == timezone.utc and label == "UTC"

--- a/backend/tests/unit/test_calendar_timezone.py
+++ b/backend/tests/unit/test_calendar_timezone.py
@@ -1,0 +1,126 @@
+"""Tests for timezone-aware calendar event times in chat (issue #4643).
+
+``get_calendar_events_tool`` rendered Google Calendar event times in raw UTC / the
+event's own zone, so the chat model mislabeled the time of day ("tonight" vs
+"this afternoon"). It now renders Start/End in the user's timezone via two pure
+helpers, which these tests cover directly (no Google API or async needed).
+"""
+
+import importlib.util
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _register(name):
+    mod = sys.modules.get(name)
+    if not isinstance(mod, _AutoMockModule):
+        mod = _AutoMockModule(name)
+        sys.modules[name] = mod
+        if "." in name:
+            parent_name, attr = name.rsplit(".", 1)
+            setattr(_register(parent_name), attr, mod)
+    return mod
+
+
+# Stub the heavy imports calendar_tools pulls at module load.
+for _name in [
+    "httpx",
+    "langchain_core",
+    "langchain_core.tools",
+    "langchain_core.runnables",
+    "database",
+    "database.users",
+    "database.notifications",
+    "models",
+    "models.calendar_mutation",
+    "utils",
+    "utils.executors",
+    "utils.http_client",
+    "utils.log_sanitizer",
+    "utils.retrieval",
+    "utils.retrieval.tools",
+    "utils.retrieval.tools.integration_base",
+    "utils.retrieval.tools.google_utils",
+]:
+    _register(_name)
+
+# Passthrough @tool decorator so the tool stays a plain callable.
+sys.modules["langchain_core.tools"].tool = lambda func=None, **kw: (func if func is not None else (lambda f: f))
+
+
+def _load_module_from_file(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+calendar_tools = _load_module_from_file(
+    "utils.retrieval.tools.calendar_tools",
+    BACKEND_DIR / "utils" / "retrieval" / "tools" / "calendar_tools.py",
+)
+
+# 22:00 UTC == 15:00 in America/Los_Angeles (PDT, UTC-7 in June).
+_UTC_INSTANT = datetime(2026, 6, 30, 22, 0, 0, tzinfo=timezone.utc)
+_LA = ZoneInfo("America/Los_Angeles")
+
+
+class TestResolveDisplayTz:
+    def test_valid_zone(self):
+        tzinfo, label = calendar_tools._resolve_display_tz("America/Los_Angeles")
+        assert tzinfo == _LA and label == "America/Los_Angeles"
+
+    def test_missing_or_invalid_falls_back_to_utc(self):
+        for bad in (None, "", "Not/AZone"):
+            tzinfo, label = calendar_tools._resolve_display_tz(bad)
+            assert tzinfo == timezone.utc and label == "UTC"
+
+
+class TestFormatEventDt:
+    def test_aware_utc_converted_to_user_tz_with_label(self):
+        assert calendar_tools._format_event_dt(_UTC_INSTANT, _LA, "America/Los_Angeles") == (
+            "2026-06-30 15:00:00 America/Los_Angeles"
+        )
+
+    def test_naive_value_treated_as_utc(self):
+        naive = datetime(2026, 6, 30, 22, 0, 0)
+        assert calendar_tools._format_event_dt(naive, _LA, "America/Los_Angeles") == (
+            "2026-06-30 15:00:00 America/Los_Angeles"
+        )
+
+    def test_utc_label_unchanged(self):
+        assert calendar_tools._format_event_dt(_UTC_INSTANT, timezone.utc, "UTC") == "2026-06-30 22:00:00 UTC"
+
+    def test_crosses_day_boundary_in_user_tz(self):
+        # Tokyo is UTC+9, so 22:00 UTC is 07:00 the next day.
+        out = calendar_tools._format_event_dt(_UTC_INSTANT, ZoneInfo("Asia/Tokyo"), "Asia/Tokyo")
+        assert out == "2026-07-01 07:00:00 Asia/Tokyo"

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -7,17 +7,20 @@ import os
 import contextvars
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 import httpx
 from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
 import database.users as users_db
+import database.notifications as notification_db
 from models.calendar_mutation import (
     CalendarMutationResult,
     event_title as calendar_event_title,
     format_deleted_calendar_events,
 )
+from utils.executors import db_executor, run_blocking
 from utils.http_client import get_auth_client
 from utils.retrieval.tools.integration_base import (
     ensure_capped,
@@ -28,6 +31,30 @@ from utils.retrieval.tools.google_utils import google_api_request, GoogleAPIErro
 
 # Import shared Google utilities
 from utils.retrieval.tools.google_utils import refresh_google_token
+
+
+def _resolve_display_tz(tz):
+    """Return ``(tzinfo, label)`` for rendering event times in the user's timezone,
+    falling back to UTC on a missing or invalid zone (issue #4643)."""
+    if tz:
+        try:
+            return ZoneInfo(tz), tz
+        except Exception:
+            pass
+    return timezone.utc, "UTC"
+
+
+def _format_event_dt(dt: datetime, display_tz, tz_label: str) -> str:
+    """Render a calendar event datetime in the user's timezone with a label.
+
+    Google event times are tz-aware; a naive value is treated as UTC so the chat
+    model never sees an unlabeled wall-clock time and mislabels the time of day.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
+
+
 from utils.log_sanitizer import sanitize, sanitize_pii
 import logging
 
@@ -687,6 +714,10 @@ async def get_calendar_events_tool(
             return f"No calendar events found{date_info}."
 
         # Format events
+        # Render event times in the user's timezone so the chat model labels the time
+        # of day correctly (issue #4643). The tz read is sync Firestore, so offload it.
+        tz = await run_blocking(db_executor, notification_db.get_user_time_zone, uid)
+        display_tz, tz_label = _resolve_display_tz(tz)
         result = f"Calendar Events ({len(events)} found):\n\n"
 
         for i, event in enumerate(events, 1):
@@ -698,7 +729,7 @@ async def get_calendar_events_tool(
             if 'dateTime' in start:
                 try:
                     start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
-                    result += f"   Start: {start_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+                    result += f"   Start: {_format_event_dt(start_dt, display_tz, tz_label)}\n"
                 except:
                     result += f"   Start: {start.get('dateTime', 'Unknown')}\n"
             elif 'date' in start:
@@ -709,7 +740,7 @@ async def get_calendar_events_tool(
             if 'dateTime' in end:
                 try:
                     end_dt = datetime.fromisoformat(end['dateTime'].replace('Z', '+00:00'))
-                    result += f"   End: {end_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+                    result += f"   End: {_format_event_dt(end_dt, display_tz, tz_label)}\n"
                 except:
                     result += f"   End: {end.get('dateTime', 'Unknown')}\n"
             elif 'date' in end:

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -55,6 +55,20 @@ def _format_event_dt(dt: datetime, display_tz, tz_label: str) -> str:
     return f"{dt.astimezone(display_tz).strftime('%Y-%m-%d %H:%M:%S')} {tz_label}"
 
 
+async def _get_user_display_tz(uid: str):
+    """Return ``(tzinfo, label)`` for the user's timezone, read off the event loop.
+
+    A timezone lookup failure must never abort the calendar tool, so fall back to
+    UTC and let the events still render (issue #4643).
+    """
+    try:
+        tz = await run_blocking(db_executor, notification_db.get_user_time_zone, uid)
+    except Exception as tz_error:
+        logger.warning(f"get_calendar_events_tool - timezone lookup failed, formatting in UTC: {tz_error}")
+        tz = None
+    return _resolve_display_tz(tz)
+
+
 from utils.log_sanitizer import sanitize, sanitize_pii
 import logging
 
@@ -716,8 +730,7 @@ async def get_calendar_events_tool(
         # Format events
         # Render event times in the user's timezone so the chat model labels the time
         # of day correctly (issue #4643). The tz read is sync Firestore, so offload it.
-        tz = await run_blocking(db_executor, notification_db.get_user_time_zone, uid)
-        display_tz, tz_label = _resolve_display_tz(tz)
+        display_tz, tz_label = await _get_user_display_tz(uid)
         result = f"Calendar Events ({len(events)} found):\n\n"
 
         for i, event in enumerate(events, 1):


### PR DESCRIPTION
## Summary

Completes the #4643 follow-up I flagged in #8483. The agentic chat's calendar tool, `get_calendar_events_tool`, rendered Google Calendar event Start and End times in raw UTC / the event's own zone (`strftime` with `%Z`), not the user's timezone. So when the model answers "when is my meeting," it can read a UTC wall clock as the user's local time and mislabel the time of day, the same class of bug #8483 fixed for action items.

## Fix

Render event Start and End in the user's timezone with an explicit label, for example `Start: 2026-06-30 15:00:00 America/Los_Angeles` instead of a UTC time. Two small helpers do the work:

- `_resolve_display_tz(tz)`: the user's `ZoneInfo` and a label, falling back to UTC on a missing or invalid zone.
- `_format_event_dt(dt, display_tz, label)`: convert a tz-aware event time to the user's zone (a naive value is treated as UTC) and append the label.

`get_calendar_events_tool` is async, so the user's timezone is read off the event loop via `run_blocking(db_executor, get_user_time_zone, uid)` before the events are formatted. All-day events (date only, no time) are left unchanged. This only touches the read tool the chat model uses to answer time questions.

## Testing

New `tests/unit/test_calendar_timezone.py` (registered in `test.sh`): the helpers convert to the user's zone with a label, fall back to UTC for missing/invalid/empty zones, treat a naive time as UTC, and handle a day-boundary crossing (22:00 UTC is 07:00 the next day in Tokyo). Black and the async-blocker lint are clean (the timezone read is offloaded, so the event loop is not blocked).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

