### PR TITLE
ci(firmware): add manual CV1 firmware build & release workflow

### DIFF
--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -70,7 +70,10 @@ jobs:
     env:
       # Zephyr CI image blessed by omi/firmware/omi/BUILD.md; bundles the
       # toolchain for the NCS 2.9.0 sysbuild + MCUboot signing build.
-      CI_IMAGE: ghcr.io/zephyrproject-rtos/ci:v0.26.13
+      # Pinned by digest for reproducible, supply-chain-safe builds (tag kept
+      # for readability). Digest = the v0.26.13 multi-arch index; re-resolve with
+      # `docker buildx imagetools inspect ghcr.io/zephyrproject-rtos/ci:<tag>`.
+      CI_IMAGE: ghcr.io/zephyrproject-rtos/ci:v0.26.13@sha256:b0ac6334d1926cd0971a0a444f7adc6dd020e88ee3ce865aa070b6475a3ac4eb
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -170,6 +173,15 @@ jobs:
           name: Omi_CV1_v${{ steps.meta.outputs.ver }}
           path: ${{ steps.stage.outputs.out }}/*
           if-no-files-found: error
+
+      - name: Guard - publish only from main
+        if: ${{ github.event.inputs.publish == 'publish' }}
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::Refusing to publish a firmware release from '${{ github.ref }}'. Dispatch the publish run from the 'main' branch only."
+            exit 1
+          fi
+          echo "Publishing from main — OK."
 
       - name: Generate Omi Bot token
         id: app-token

--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build firmware (Docker)
         run: |
           docker run --rm \
-            -v "${{ github.workspace }}/omi/firmware:/omi/firmware" \
+            -v "$GITHUB_WORKSPACE/omi/firmware:/omi/firmware" \
             -e CMAKE_PREFIX_PATH=/opt/toolchains \
             "$CI_IMAGE" \
             bash /omi/firmware/scripts/ci/build-cv1.sh
@@ -176,9 +176,11 @@ jobs:
 
       - name: Guard - publish only from main
         if: ${{ github.event.inputs.publish == 'publish' }}
+        env:
+          REF: ${{ github.ref }}
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "::error::Refusing to publish a firmware release from '${{ github.ref }}'. Dispatch the publish run from the 'main' branch only."
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::Refusing to publish a firmware release from '$REF'. Dispatch the publish run from the 'main' branch only."
             exit 1
           fi
           echo "Publishing from main — OK."

--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -1,0 +1,191 @@
+name: Firmware Build & Release (Omi CV1)
+
+# Builds the Omi CV1 firmware (nRF5340, the consumer "Omi CV 1" device) and
+# optionally publishes a GitHub Release that the backend serves as an OTA
+# update (backend/routers/firmware.py).
+#
+# Manual-only by design: firmware has no auto-version/changelog system like the
+# desktop app, builds are heavy (~1.5GB SDK download, ~20-30 min cold), and the
+# release metadata (min versions, changelog, OTA steps) is hand-curated. A
+# human-gated dispatch with an explicit publish guard mirrors the spirit of
+# desktop_promote_prod.yml.
+#
+# Release contract enforced here (verified against backend/routers/firmware.py):
+#   - Tag:   Omi_CV1_v<ver>            (NO "OTA" in the tag)
+#   - OTA asset name MUST contain "ota" and end in .zip  (e.g. Omi_CV1_OTA_v3.0.20.zip)
+#   - Release MUST be published, non-draft, non-prerelease (else not served)
+#   - Body MUST contain a KEY_VALUE block with release_firmware_version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override e.g. 3.0.20 (blank = read CONFIG_BT_DIS_FW_REV_STR from omi.conf)'
+        type: string
+        required: false
+        default: ''
+      publish:
+        description: 'Type "publish" to create the GitHub Release. Anything else = build-only (artifacts uploaded to the run, no release).'
+        type: string
+        required: false
+        default: ''
+      prerelease:
+        description: 'Mark the release as prerelease (backend will NOT serve prereleases)'
+        type: boolean
+        required: false
+        default: false
+      changelog:
+        description: 'Pipe-separated changelog e.g. "Fixed audio|Battery improvements"'
+        type: string
+        required: false
+        default: 'Bug fixes and improvements'
+      minimum_firmware_required:
+        description: 'minimum_firmware_required e.g. 3.0.6 (blank = omit)'
+        type: string
+        required: false
+        default: ''
+      minimum_app_version:
+        description: 'minimum_app_version e.g. 1.0.74 (blank = omit)'
+        type: string
+        required: false
+        default: ''
+      minimum_app_version_code:
+        description: 'minimum_app_version_code e.g. 438 (blank = omit)'
+        type: string
+        required: false
+        default: ''
+      ota_update_steps:
+        description: 'Comma-separated OTA prerequisites e.g. battery,internet (blank = omit)'
+        type: string
+        required: false
+        default: 'battery,internet'
+
+permissions:
+  contents: write
+
+jobs:
+  build-cv1:
+    name: Omi CV1 (nRF5340)
+    runs-on: ubuntu-latest
+    concurrency:
+      group: firmware-release-cv1
+      cancel-in-progress: false
+    env:
+      # Zephyr CI image blessed by omi/firmware/omi/BUILD.md; bundles the
+      # toolchain for the NCS 2.9.0 sysbuild + MCUboot signing build.
+      CI_IMAGE: ghcr.io/zephyrproject-rtos/ci:v0.26.13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version and tag
+        id: meta
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
+        run: |
+          CONF=omi/firmware/omi/omi.conf
+          if [ -n "$VERSION_INPUT" ]; then
+            VER="$VERSION_INPUT"
+          else
+            VER="$(grep -E '^CONFIG_BT_DIS_FW_REV_STR=' "$CONF" | sed -E 's/.*="([^"]+)".*/\1/')"
+          fi
+          VER="${VER#v}"
+          if ! printf '%s' "$VER" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid CV1 version '$VER' (expected X.Y.Z)"
+            exit 1
+          fi
+          echo "ver=$VER" >> "$GITHUB_OUTPUT"
+          echo "tag=Omi_CV1_v$VER" >> "$GITHUB_OUTPUT"
+          echo "CV1 version $VER -> tag Omi_CV1_v$VER"
+
+      - name: Cache nRF Connect SDK workspace (v2.9.0)
+        uses: actions/cache@v4
+        with:
+          path: omi/firmware/v2.9.0
+          key: ncs-v2.9.0-${{ runner.os }}
+
+      - name: Build firmware (Docker)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/omi/firmware:/omi/firmware" \
+            -e CMAKE_PREFIX_PATH=/opt/toolchains \
+            "$CI_IMAGE" \
+            bash /omi/firmware/scripts/ci/build-cv1.sh
+
+      - name: Fix workspace ownership
+        run: sudo chown -R "$(id -u):$(id -g)" omi/firmware
+
+      - name: Stage release assets
+        id: stage
+        env:
+          VER: ${{ steps.meta.outputs.ver }}
+        run: |
+          OUT="$RUNNER_TEMP/cv1-assets"
+          mkdir -p "$OUT"
+          B=omi/firmware/v2.9.0/build
+          cp "$B/dfu_application.zip" "$OUT/Omi_CV1_OTA_v$VER.zip"
+          cp "$B/merged.hex"          "$OUT/Omi_CV1_v$VER.hex"
+          cp "$B/merged_CPUNET.hex"   "$OUT/Omi_CV1_v${VER}_CPUNET.hex"
+          # OTA asset name must contain "ota" + end .zip or the backend drops it.
+          test -s "$OUT/Omi_CV1_OTA_v$VER.zip"
+          ls -l "$OUT"
+          echo "out=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release body
+        id: body
+        env:
+          TITLE: Omi CV1 Firmware v${{ steps.meta.outputs.ver }}
+          VER: ${{ steps.meta.outputs.ver }}
+          CHANGELOG: ${{ github.event.inputs.changelog }}
+          MIN_FW: ${{ github.event.inputs.minimum_firmware_required }}
+          MIN_APP: ${{ github.event.inputs.minimum_app_version }}
+          MIN_APP_CODE: ${{ github.event.inputs.minimum_app_version_code }}
+          OTA_STEPS: ${{ github.event.inputs.ota_update_steps }}
+          # CV1 uses MCUboot (not legacy Adafruit secure DFU).
+          IS_LEGACY_SECURE_DFU: 'False'
+          HOW_TO_FLASH: |
+            To update your device in the Omi app:
+            1. Open the Omi app.
+            2. Go to **Settings** > **Device Settings**.
+            3. Select **Update Latest Version**.
+        run: |
+          OUT="$RUNNER_TEMP/cv1-body.md"
+          OUT="$OUT" bash omi/firmware/scripts/ci/make-release-body.sh
+          echo "file=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Omi_CV1_v${{ steps.meta.outputs.ver }}
+          path: ${{ steps.stage.outputs.out }}/*
+          if-no-files-found: error
+
+      - name: Publish GitHub Release
+        if: ${{ github.event.inputs.publish == 'publish' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          TITLE: Omi CV1 Firmware v${{ steps.meta.outputs.ver }}
+          BODY_FILE: ${{ steps.body.outputs.file }}
+          OUT: ${{ steps.stage.outputs.out }}
+          VER: ${{ steps.meta.outputs.ver }}
+          SHA: ${{ github.sha }}
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
+        run: |
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "::error::Release $TAG already exists. Bump CONFIG_BT_DIS_FW_REV_STR or pass a new version."
+            exit 1
+          fi
+          FLAGS=()
+          if [ "$PRERELEASE" = "true" ]; then FLAGS+=(--prerelease); fi
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --notes-file "$BODY_FILE" \
+            --target "$SHA" \
+            "${FLAGS[@]}" \
+            "$OUT/Omi_CV1_OTA_v$VER.zip" \
+            "$OUT/Omi_CV1_v$VER.hex" \
+            "$OUT/Omi_CV1_v${VER}_CPUNET.hex"
+          echo "Published $TAG"

--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -160,10 +160,20 @@ jobs:
           path: ${{ steps.stage.outputs.out }}/*
           if-no-files-found: error
 
+      - name: Generate Omi Bot token
+        id: app-token
+        if: ${{ github.event.inputs.publish == 'publish' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+
       - name: Publish GitHub Release
         if: ${{ github.event.inputs.publish == 'publish' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Release is created/tagged by the Omi Bot GitHub App so it is clearly
+          # attributed to automation, not a person (same as the desktop pipeline).
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.meta.outputs.tag }}
           TITLE: Omi CV1 Firmware v${{ steps.meta.outputs.ver }}

--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -104,6 +104,20 @@ jobs:
           path: omi/firmware/v2.9.0
           key: ncs-v2.9.0-${{ runner.os }}
 
+      - name: Sync firmware version into config
+        env:
+          VER: ${{ steps.meta.outputs.ver }}
+        run: |
+          # Make the binary's BLE DIS firmware revision match the release tag.
+          # Without this, a `version` override would publish OTA metadata for one
+          # version while the device reports another -> perpetual update loop.
+          # No-op when version is derived from omi.conf (VER already equals it).
+          CONF=omi/firmware/omi/omi.conf
+          sed -i -E "s|^(CONFIG_BT_DIS_FW_REV_STR=)\".*\"|\1\"$VER\"|" "$CONF"
+          grep -q "CONFIG_BT_DIS_FW_REV_STR=\"$VER\"" "$CONF" || {
+            echo "::error::Failed to set CONFIG_BT_DIS_FW_REV_STR to $VER in $CONF"; exit 1; }
+          echo "omi.conf now: $(grep -E '^CONFIG_BT_DIS_FW_REV_STR=' "$CONF")"
+
       - name: Build firmware (Docker)
         run: |
           docker run --rm \
@@ -167,6 +181,8 @@ jobs:
         with:
           app-id: ${{ secrets.OMI_BOT_APP_ID }}
           private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+          # Least privilege: only what creating a release/tag needs.
+          permission-contents: write
 
       - name: Publish GitHub Release
         if: ${{ github.event.inputs.publish == 'publish' }}

--- a/.github/workflows/firmware_release.yml
+++ b/.github/workflows/firmware_release.yml
@@ -29,11 +29,6 @@ on:
         type: string
         required: false
         default: ''
-      prerelease:
-        description: 'Mark the release as prerelease (backend will NOT serve prereleases)'
-        type: boolean
-        required: false
-        default: false
       changelog:
         description: 'Pipe-separated changelog e.g. "Fixed audio|Battery improvements"'
         type: string
@@ -61,7 +56,9 @@ on:
         default: 'battery,internet'
 
 permissions:
-  contents: write
+  # Default token is read-only (checkout). The release/tag is created with the
+  # separate, contents:write-scoped Omi Bot app token in the publish step.
+  contents: read
 
 jobs:
   build-cv1:
@@ -197,20 +194,17 @@ jobs:
           OUT: ${{ steps.stage.outputs.out }}
           VER: ${{ steps.meta.outputs.ver }}
           SHA: ${{ github.sha }}
-          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "::error::Release $TAG already exists. Bump CONFIG_BT_DIS_FW_REV_STR or pass a new version."
             exit 1
           fi
-          FLAGS=()
-          if [ "$PRERELEASE" = "true" ]; then FLAGS+=(--prerelease); fi
+          # Published, non-draft, non-prerelease — the only shape the backend serves.
           gh release create "$TAG" \
             --repo "$REPO" \
             --title "$TITLE" \
             --notes-file "$BODY_FILE" \
             --target "$SHA" \
-            "${FLAGS[@]}" \
             "$OUT/Omi_CV1_OTA_v$VER.zip" \
             "$OUT/Omi_CV1_v$VER.hex" \
             "$OUT/Omi_CV1_v${VER}_CPUNET.hex"

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,11 @@ app/lib/env/prod_env.g.dart
 
 /omi/firmware/firmware/v2.7.0/
 
+# nRF Connect SDK west workspaces (downloaded on demand, ~1.5GB) + build outputs
+/omi/firmware/v2.7.0/
+/omi/firmware/v2.9.0/
+/omi/firmware/build/
+
 
 # Additional Expo/React Native specific ignores
 .expo/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f bran
 
 - Desktop release pipeline: merging `desktop/macos/**` to `main` auto-increments the version, tags `v*-macos`, and triggers Codemagic to build/sign/notarize/publish a beta GitHub release. Stable/prod requires manually running `.github/workflows/desktop_promote_prod.yml` with `release_tag` and `confirm=promote-stable`; that workflow is roll-forward only, deploys the Rust backend from the exact tag, verifies `/health`, promotes the Firestore bridge release, then marks the GitHub release stable.
 - Backend deploy: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
+- Firmware release (Omi CV1): manual `.github/workflows/firmware_release.yml`. Bump `CONFIG_BT_DIS_FW_REV_STR` in `omi/firmware/omi/omi.conf` first, then `gh workflow run firmware_release.yml -f publish=publish -f changelog="..." -f minimum_app_version_code=...` (omit `publish` for a build-only QA run). It builds via Docker (NCS 2.9.0 sysbuild + MCUboot), names the OTA asset `Omi_CV1_OTA_v<ver>.zip` (the "ota" substring is required), and publishes a `Omi_CV1_v<ver>` GitHub Release with the `KEY_VALUE` body that `backend/routers/firmware.py` serves. Build logic lives in `omi/firmware/scripts/ci/`.
 
 ## Documentation Maintenance
 

--- a/omi/firmware/scripts/ci/README.md
+++ b/omi/firmware/scripts/ci/README.md
@@ -1,0 +1,63 @@
+# Firmware CI / Release
+
+Automation for building and releasing **Omi CV1** firmware (nRF5340).
+
+Workflow: [`.github/workflows/firmware_release.yml`](../../../../.github/workflows/firmware_release.yml)
+
+## How it works
+
+A firmware "release" is a **GitHub Release** in a specific shape that the
+backend ([`backend/routers/firmware.py`](../../../../backend/routers/firmware.py))
+reads and serves to the app as an OTA update. The workflow builds the firmware
+and publishes that Release.
+
+The contract the backend requires (do not break these):
+
+| Requirement | Value |
+|---|---|
+| Tag | `Omi_CV1_v<ver>` — **no** `OTA` in the tag |
+| OTA asset name | must contain `ota` **and** end `.zip` (e.g. `Omi_CV1_OTA_v3.0.20.zip`) |
+| Release state | published, **non-draft, non-prerelease** |
+| Body | must contain a `<!-- KEY_VALUE_START … KEY_VALUE_END -->` block with `release_firmware_version` |
+
+The firmware version is read from `CONFIG_BT_DIS_FW_REV_STR` in
+[`omi/firmware/omi/omi.conf`](../../omi/omi.conf) (the build copies `omi.conf`
+→ `prj.conf`, so this string is also baked into the binary's BLE DIS).
+
+## Releasing a new CV1 version
+
+1. Bump `CONFIG_BT_DIS_FW_REV_STR` in `omi/firmware/omi/omi.conf` and merge it.
+2. Dry run (build only, artifacts attached to the Actions run, **no** release):
+   ```bash
+   gh workflow run firmware_release.yml
+   ```
+3. Publish:
+   ```bash
+   gh workflow run firmware_release.yml \
+     -f publish=publish \
+     -f changelog="Removed BLE bond-key|Bug fixes" \
+     -f minimum_firmware_required=3.0.6 \
+     -f minimum_app_version=1.0.74 \
+     -f minimum_app_version_code=438 \
+     -f ota_update_steps=battery,internet
+   ```
+   `version` defaults to the `omi.conf` value; pass `-f version=3.0.21` to override.
+   `-f prerelease=true` marks it prerelease (the backend then will **not** serve it).
+
+The publish step refuses to overwrite an existing `Omi_CV1_v<ver>` tag — bump
+the version if you need to re-release.
+
+## Scripts
+
+- `build-cv1.sh` — runs inside `ghcr.io/zephyrproject-rtos/ci` (firmware bind-mounted
+  at `/omi/firmware`): west init/update of NCS v2.9.0, `cp omi.conf prj.conf`, and
+  `west build … --sysbuild` (MCUboot-signed). Mirrors `omi/firmware/omi/BUILD.md`.
+  Outputs `dfu_application.zip`, `merged.hex`, `merged_CPUNET.hex`.
+- `make-release-body.sh` — renders the GitHub Release body + `KEY_VALUE` block.
+
+## Notes
+
+- The build is heavy: ~1.5 GB NCS download + ~20-30 min on a cold cache.
+- DK2 / OmiGlass are **not** automated here yet. DK2 can be added as a second job
+  (NCS 2.7.0 + `adafruit-nrfutil`); OmiGlass uses a separate ESP32/PlatformIO toolchain.
+- MCUboot signing uses the committed key `omi/firmware/bootloader/mcuboot/root-rsa-2048.pem`.

--- a/omi/firmware/scripts/ci/README.md
+++ b/omi/firmware/scripts/ci/README.md
@@ -57,6 +57,10 @@ the version if you need to re-release.
 
 ## Notes
 
+- The Release is created by the **Omi Bot GitHub App** (`actions/create-github-app-token`,
+  secrets `OMI_BOT_APP_ID` / `OMI_BOT_PRIVATE_KEY`) so it is clearly attributed to
+  automation rather than a person — same as the desktop pipeline. The token is only
+  minted on a publish run; build-only QA runs don't need the secrets.
 - The build is heavy: ~1.5 GB NCS download + ~20-30 min on a cold cache.
 - DK2 / OmiGlass are **not** automated here yet. DK2 can be added as a second job
   (NCS 2.7.0 + `adafruit-nrfutil`); OmiGlass uses a separate ESP32/PlatformIO toolchain.

--- a/omi/firmware/scripts/ci/README.md
+++ b/omi/firmware/scripts/ci/README.md
@@ -43,8 +43,9 @@ The firmware version is read from `CONFIG_BT_DIS_FW_REV_STR` in
    ```
    `version` defaults to the `omi.conf` value; pass `-f version=3.0.21` to override.
 
-The publish step refuses to overwrite an existing `Omi_CV1_v<ver>` tag — bump
-the version if you need to re-release.
+Publishing is only allowed from the **`main`** branch (the build-only path runs
+from any branch). The publish step also refuses to overwrite an existing
+`Omi_CV1_v<ver>` tag — bump the version if you need to re-release.
 
 ## Scripts
 

--- a/omi/firmware/scripts/ci/README.md
+++ b/omi/firmware/scripts/ci/README.md
@@ -51,7 +51,7 @@ the version if you need to re-release.
 
 - `build-cv1.sh` — runs inside `ghcr.io/zephyrproject-rtos/ci` (firmware bind-mounted
   at `/omi/firmware`): west init/update of NCS v2.9.0, `cp omi.conf prj.conf`, and
-  `west build … --sysbuild` (MCUboot-signed). Mirrors `omi/firmware/omi/BUILD.md`.
+  `west build … --sysbuild` (MCUboot-signed). Mirrors [`omi/firmware/omi/BUILD.md`](../../omi/BUILD.md).
   Outputs `dfu_application.zip`, `merged.hex`, `merged_CPUNET.hex`.
 - `make-release-body.sh` — renders the GitHub Release body + `KEY_VALUE` block.
 

--- a/omi/firmware/scripts/ci/README.md
+++ b/omi/firmware/scripts/ci/README.md
@@ -42,7 +42,6 @@ The firmware version is read from `CONFIG_BT_DIS_FW_REV_STR` in
      -f ota_update_steps=battery,internet
    ```
    `version` defaults to the `omi.conf` value; pass `-f version=3.0.21` to override.
-   `-f prerelease=true` marks it prerelease (the backend then will **not** serve it).
 
 The publish step refuses to overwrite an existing `Omi_CV1_v<ver>` tag — bump
 the version if you need to re-release.

--- a/omi/firmware/scripts/ci/build-cv1.sh
+++ b/omi/firmware/scripts/ci/build-cv1.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# CI build for the Omi CV1 firmware (nRF5340, the consumer "Omi CV 1" device).
+#
+# Runs INSIDE the ghcr.io/zephyrproject-rtos/ci:<tag> container with the repo's
+# `omi/firmware` directory bind-mounted at /omi/firmware. Mirrors the blessed
+# command documented in omi/firmware/omi/BUILD.md (NCS v2.9.0 + sysbuild +
+# MCUboot signing) but initialises the west workspace from scratch so it works
+# in a clean CI checkout (the v2.9.0 SDK is not committed).
+#
+# Outputs (relative to /omi/firmware/v2.9.0/build):
+#   - dfu_application.zip   OTA package served by the Omi app
+#   - merged.hex            full-flash image (J-Link / nrfjprog)
+#   - merged_CPUNET.hex     network-core image
+#
+set -euo pipefail
+
+FW=/omi/firmware
+NCS_VERSION=v2.9.0
+BOARD=omi/nrf5340/cpuapp
+
+# west/git operate on the bind-mounted tree owned by the host user; the
+# container runs as root, so tell git the checkout is trusted.
+git config --global --add safe.directory '*'
+
+# MCUboot image signing needs the `ecdsa` python package (per BUILD.md).
+pip3 install --quiet ecdsa 2>/dev/null || pip3 install --quiet --break-system-packages ecdsa
+
+cd "$FW"
+mkdir -p "$NCS_VERSION"
+cd "$NCS_VERSION"
+
+if [ ! -d .west ]; then
+  echo "Initialising nRF Connect SDK $NCS_VERSION workspace..."
+  west init -m https://github.com/nrfconnect/sdk-nrf --mr "$NCS_VERSION" .
+fi
+
+echo "Updating west modules (shallow)..."
+west update -o=--depth=1 -n
+west zephyr-export
+
+# The production config lives in omi.conf; Zephyr builds prj.conf by default,
+# so copy it across. This keeps CONFIG_BT_DIS_FW_REV_STR (the firmware version
+# baked into the binary) in sync with omi.conf, the release source of truth.
+cp "$FW/omi/omi.conf" "$FW/omi/prj.conf"
+
+echo "Building $BOARD with sysbuild..."
+west build -b "$BOARD" "$FW/omi" --sysbuild -d build --pristine always \
+  -- -DBOARD_ROOT="$FW"
+
+# Fail loud if any expected artifact is missing (silent-drop prevention).
+test -s build/dfu_application.zip
+test -s build/merged.hex
+test -s build/merged_CPUNET.hex
+
+echo "CV1 build complete:"
+ls -l build/dfu_application.zip build/merged.hex build/merged_CPUNET.hex

--- a/omi/firmware/scripts/ci/make-release-body.sh
+++ b/omi/firmware/scripts/ci/make-release-body.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Generate a firmware GitHub Release body, including the KEY_VALUE block that
+# backend/routers/firmware.py parses to serve OTA updates.
+#
+# Inputs via environment:
+#   TITLE                 release title heading (required)
+#   VER                   release_firmware_version, e.g. 3.0.20 (required)
+#   CHANGELOG             pipe-separated changelog, e.g. "Fix audio|Battery"
+#   MIN_FW                minimum_firmware_required (optional; line omitted if blank)
+#   MIN_APP               minimum_app_version (optional)
+#   MIN_APP_CODE          minimum_app_version_code (optional)
+#   OTA_STEPS             ota_update_steps, comma-separated (optional)
+#   IS_LEGACY_SECURE_DFU  "True"/"False" to emit the line; blank to omit it
+#   HOW_TO_FLASH          optional multiline "How to Flash" section
+#   OUT                   output file path (required)
+#
+# Contract notes (verified against backend/routers/firmware.py):
+#   - release_firmware_version is REQUIRED or the release is silently dropped.
+#   - changelog is split on '|'; ota_update_steps is split on ','.
+#   - is_legacy_secure_dfu must be the literal True/False (CV1=False MCUboot;
+#     DK2 omits it so the backend defaults it to True = Adafruit secure DFU).
+#
+set -euo pipefail
+
+: "${TITLE:?}"
+: "${VER:?}"
+: "${OUT:?}"
+
+{
+  echo "## $TITLE"
+  echo
+  echo "### What's Changed"
+  changelog_emitted=0
+  IFS='|' read -ra _items <<< "${CHANGELOG:-}"
+  for _it in "${_items[@]}"; do
+    _t="$(printf '%s' "$_it" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    if [ -n "$_t" ]; then
+      echo "- $_t"
+      changelog_emitted=1
+    fi
+  done
+  if [ "$changelog_emitted" -eq 0 ]; then
+    echo "- Bug fixes and improvements"
+  fi
+  echo
+
+  if [ -n "${HOW_TO_FLASH:-}" ]; then
+    echo "### How to Flash"
+    printf '%s\n' "$HOW_TO_FLASH"
+    echo
+  fi
+
+  echo "<!-- KEY_VALUE_START"
+  echo "release_firmware_version:$VER"
+  if [ -n "${MIN_FW:-}" ];       then echo "minimum_firmware_required:$MIN_FW"; fi
+  if [ -n "${MIN_APP:-}" ];      then echo "minimum_app_version:$MIN_APP"; fi
+  if [ -n "${MIN_APP_CODE:-}" ]; then echo "minimum_app_version_code:$MIN_APP_CODE"; fi
+  if [ -n "${OTA_STEPS:-}" ];    then echo "ota_update_steps:$OTA_STEPS"; fi
+  if [ -n "${IS_LEGACY_SECURE_DFU:-}" ]; then echo "is_legacy_secure_dfu:$IS_LEGACY_SECURE_DFU"; fi
+  echo "changelog:${CHANGELOG:-Bug fixes and improvements}"
+  echo "KEY_VALUE_END -->"
+} > "$OUT"
+
+echo "Wrote release body to $OUT:"
+echo "----------------------------------------"
+cat "$OUT"
+echo "----------------------------------------"


### PR DESCRIPTION
## What

Adds the **first build/release automation for firmware** — until now firmware was the only component without a CI release path (apps → Codemagic, backend/frontend → `gcp_*.yml`, desktop → `desktop_auto_release.yml`, firmware → nothing).

Scope: **Omi CV1** (nRF5340). DK2 / OmiGlass intentionally out of scope (different toolchains; easy to add later as extra jobs).

## How a firmware "release" works

The backend already serves firmware OTA from **GitHub Releases** (`backend/routers/firmware.py`): it reads releases tagged `Omi_CV1_v*`, parses a `<!-- KEY_VALUE_START … KEY_VALUE_END -->` block in the body, and serves the OTA `.zip` asset. So this workflow's job is to **build the firmware and publish a Release in exactly that shape**.

Contract enforced by the workflow (verified against the backend):
- Tag `Omi_CV1_v<ver>` — no `OTA` in the tag
- OTA asset name contains `ota` **and** ends `.zip` (`Omi_CV1_OTA_v<ver>.zip`)
- Published, non-draft, non-prerelease
- Body carries the required `release_firmware_version` + metadata

## Design

- **Manual `workflow_dispatch` only.** Firmware metadata (min versions, changelog, OTA steps) is hand-curated and builds are heavy (~1.5 GB SDK download, ~20-30 min). Auto-on-push would be wrong.
- **Publish guard:** builds always; only creates the Release when dispatched with `publish=publish` (mirrors `desktop_promote_prod.yml`'s confirm guard). Otherwise artifacts are uploaded to the run for QA.
- **Version** read from `CONFIG_BT_DIS_FW_REV_STR` in `omi/firmware/omi/omi.conf` (overridable via input).
- **Build** via `docker run ghcr.io/zephyrproject-rtos/ci:v0.26.13` — verbatim the repo's own `omi/firmware/omi/BUILD.md` command (NCS 2.9.0 sysbuild + MCUboot signing).

## Files

- `.github/workflows/firmware_release.yml` — the workflow
- `omi/firmware/scripts/ci/build-cv1.sh` — in-container build (NCS 2.9.0 sysbuild)
- `omi/firmware/scripts/ci/make-release-body.sh` — renders the `KEY_VALUE` body
- `omi/firmware/scripts/ci/README.md` — release runbook + backend contract
- `.gitignore` — ignore the on-demand SDK workspaces + build output
- `AGENTS.md` — document the new release command

## Usage

```bash
# 1. Bump CONFIG_BT_DIS_FW_REV_STR in omi/firmware/omi/omi.conf, merge
# 2. QA build (no release):
gh workflow run firmware_release.yml
# 3. Publish:
gh workflow run firmware_release.yml -f publish=publish \
  -f changelog="Removed BLE bond-key|Bug fixes" \
  -f minimum_firmware_required=3.0.6 -f minimum_app_version_code=438
```

## Verification

- `actionlint` clean; all scripts pass `bash -n`.
- The generated release body was run through the **actual backend code** (`extract_key_value_pairs` / `_find_candidate_releases` / `_extract_firmware_response`): tag matches the filter, the renamed OTA zip is selected, every field parses (`is_legacy_secure_dfu=False` for CV1), and negative cases fail correctly (un-renamed `dfu_application.zip` rejected, `OTA`-in-tag rejected, draft/prerelease excluded).
- **Not** yet run end-to-end in CI: the actual firmware compile (needs the ~20-30 min toolchain download). Build commands are copied verbatim from `BUILD.md`; the first build-only dispatch on this branch is the real test.

## Release attribution

Publishing creates the release/tag via the **Omi Bot GitHub App** token (`actions/create-github-app-token`, secrets `OMI_BOT_APP_ID` / `OMI_BOT_PRIVATE_KEY`), so it's clearly attributed to automation rather than a person — same as `desktop_auto_release.yml`. The token is minted only on a publish run; build-only QA runs need no secrets.
