### PR TITLE
fix(backend): bound the conversations chat tool over wide date ranges (#4927)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -81,6 +81,7 @@ pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_retrieval_semantics.py -v
+pytest tests/unit/test_conversation_tool_date_range_bound.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v

--- a/backend/tests/unit/test_conversation_tool_date_range_bound.py
+++ b/backend/tests/unit/test_conversation_tool_date_range_bound.py
@@ -1,0 +1,126 @@
+"""Tests for bounding the conversations chat tool over wide date ranges (issue #4927).
+
+Asking the chat about "my last 30 days" matched up to 5000 conversations and formatted all of
+them into one tool result, which flooded the chat model's context so it froze or refused
+("that's quite a bit of information to process at once"). get_conversations_tool now caps how
+many conversations (and how many characters) it returns and appends a note telling the model to
+summarize what it has and offer to narrow. These tests cover the two pure bounding helpers.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _pkg(name):
+    mod = sys.modules.get(name)
+    if mod is None or not hasattr(mod, "__path__"):
+        mod = types.ModuleType(name)
+        mod.__path__ = []
+        sys.modules[name] = mod
+    return mod
+
+
+def _mod(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load(module_name, rel_path):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, str(BACKEND_DIR / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Stub the heavy leaves conversation_tools imports; langchain_core is used for real (the @tool
+# decorator needs it). None of these are exercised by the pure helpers under test.
+for _p in [
+    "database",
+    "models",
+    "utils",
+    "utils.conversations",
+    "utils.llm",
+    "utils.retrieval",
+    "utils.retrieval.tools",
+]:
+    _pkg(_p)
+for _name, _attrs in {
+    "database.conversations": [],
+    "database.notifications": ["get_user_time_zone"],
+    "database.users": ["get_people_by_ids"],
+    "database.vector_db": [],
+    "models.conversation": ["Conversation"],
+    "models.other": ["Person"],
+    "utils.conversations.factory": ["deserialize_conversation"],
+    "utils.conversations.render": ["conversations_to_string"],
+    "utils.conversations.search": ["keyword_search_conversation_ids", "merge_conversation_search_ids"],
+    "utils.llm.clients": ["embeddings"],
+    "utils.retrieval.agentic": ["agent_config_context"],
+}.items():
+    _m = _mod(_name)
+    for _a in _attrs:
+        setattr(_m, _a, MagicMock())
+
+ct = _load("utils.retrieval.tools.conversation_tools", "utils/retrieval/tools/conversation_tools.py")
+
+
+class TestCapConversationsForLlm:
+    def test_caps_to_most_recent_and_flags_truncation(self):
+        items = list(range(150))  # stand-ins; newest-first order is preserved
+        capped, total, truncated = ct._cap_conversations_for_llm(items)
+        assert total == 150
+        assert truncated is True
+        assert len(capped) == ct.MAX_CONVERSATIONS_FOR_LLM
+        assert capped == items[: ct.MAX_CONVERSATIONS_FOR_LLM]  # most recent kept
+
+    def test_under_cap_is_untouched(self):
+        items = list(range(50))
+        capped, total, truncated = ct._cap_conversations_for_llm(items)
+        assert capped == items and total == 50 and truncated is False
+
+    def test_exactly_at_cap_is_not_truncated(self):
+        items = list(range(ct.MAX_CONVERSATIONS_FOR_LLM))
+        capped, total, truncated = ct._cap_conversations_for_llm(items)
+        assert truncated is False and len(capped) == ct.MAX_CONVERSATIONS_FOR_LLM
+
+    def test_empty_list(self):
+        capped, total, truncated = ct._cap_conversations_for_llm([])
+        assert capped == [] and total == 0 and truncated is False
+
+
+class TestBoundedResult:
+    def test_truncated_appends_guidance_note(self):
+        out = ct._bounded_result("Conversation #1\nsome summary", total_found=150, truncated=True)
+        assert "150 conversations" in out
+        assert "Summarize what is shown" in out
+        assert "narrow" in out
+
+    def test_not_truncated_short_result_unchanged(self):
+        body = "Conversation #1\nshort"
+        assert ct._bounded_result(body, total_found=5, truncated=False) == body
+
+    def test_oversized_result_is_clipped_at_a_conversation_boundary(self):
+        big = "Conversation #1\n" + ("x" * 30000) + "\nConversation #2\n" + ("y" * 40000)
+        out = ct._bounded_result(big, total_found=2, truncated=False)
+        # Clipped under the budget, cut before the second record, and noted.
+        assert "Conversation #2" not in out
+        assert "yyyy" not in out
+        assert len(out) <= ct.MAX_RESULT_CHARS + 400  # budget plus the appended note
+        assert "Summarize what is shown" in out

--- a/backend/utils/retrieval/tools/conversation_tools.py
+++ b/backend/utils/retrieval/tools/conversation_tools.py
@@ -32,6 +32,43 @@ except ImportError:
     agent_config_context = contextvars.ContextVar('agent_config', default=None)
 
 
+# A wide date range ("analyze my last 30 days") can match hundreds of conversations. Feeding all of
+# them to the chat model floods its context, so it freezes or refuses with "that's quite a bit of
+# information to process at once" (#4927). Bound both the count and the raw size of what we return.
+MAX_CONVERSATIONS_FOR_LLM = 100
+MAX_RESULT_CHARS = 60000
+
+
+def _cap_conversations_for_llm(conversations: list):
+    """Keep at most ``MAX_CONVERSATIONS_FOR_LLM`` conversations for the chat model.
+
+    The DB returns conversations newest-first, so this keeps the most recent ones. Returns
+    ``(capped_list, total_found, truncated)`` where ``truncated`` is True when some were dropped.
+    """
+    total_found = len(conversations)
+    if total_found > MAX_CONVERSATIONS_FOR_LLM:
+        return conversations[:MAX_CONVERSATIONS_FOR_LLM], total_found, True
+    return list(conversations), total_found, False
+
+
+def _bounded_result(result: str, total_found: int, truncated: bool) -> str:
+    """Apply a hard size budget and, when the range was truncated, append a note telling the model
+    to summarize what it has and offer to narrow, so it answers instead of freezing (#4927)."""
+    if len(result) > MAX_RESULT_CHARS:
+        # Cut at a conversation boundary when possible so a record is not split mid-way.
+        clipped = result[:MAX_RESULT_CHARS]
+        boundary = clipped.rfind("\nConversation #")
+        result = clipped[:boundary] if boundary > 0 else clipped
+        truncated = True
+    if truncated:
+        result += (
+            f"\n\n[This date range contains {total_found} conversations; only the most recent ones are "
+            f"shown to stay within limits. Summarize what is shown and tell the user they can narrow to a "
+            f"shorter time frame or a specific topic for more detail.]"
+        )
+    return result
+
+
 @tool
 def get_conversations_tool(
     start_date: Optional[str] = None,
@@ -55,9 +92,9 @@ def get_conversations_tool(
 
     **IMPORTANT for summarization queries:**
     When user asks for weekly, monthly, or yearly summaries/overviews:
-    - Set limit=5000 to retrieve ALL conversations in that period
-    - Set max_transcript_segments=0 to exclude transcripts (reduce context size)
-    - This prevents missing conversations and avoids context overflow from transcripts
+    - Set a high limit (e.g. 200) and max_transcript_segments=0 to retrieve summaries without transcripts
+    - For very wide ranges the result is automatically capped to the most recent conversations so it cannot
+      overflow context; summarize what is returned and offer to narrow the range if the user needs more detail
     Examples: "summarize my week", "what did I do this month", "recap my year"
 
     Transcript retrieval guidance:
@@ -184,8 +221,13 @@ def get_conversations_tool(
     if conversations_data:
         conversations_data = [c for c in conversations_data if not c.get('is_locked', False)]
 
+    # Bound how many conversations are formatted for the chat model so a wide date range cannot
+    # flood its context and freeze it (#4927). Newest-first, so this keeps the most recent.
+    conversations_data, total_found, results_truncated = _cap_conversations_for_llm(conversations_data or [])
+
     logger.info(
-        f"📊 get_conversations_tool - found {len(conversations_data) if conversations_data else 0} conversations"
+        f"📊 get_conversations_tool - found {total_found} conversations"
+        + (f" (showing most recent {len(conversations_data)})" if results_truncated else "")
     )
 
     if not conversations_data:
@@ -263,6 +305,7 @@ def get_conversations_tool(
             people=people,
             tz=notification_db.get_user_time_zone(uid),
         )
+        result = _bounded_result(result, total_found, results_truncated)
         logger.info(f"🔍 get_conversations_tool - Generated result string, length: {len(result)}")
         return result
 


### PR DESCRIPTION
## Summary

Fixes #4927: asking the chat about a wide date range ("analyze my last 30 days", "summarize my month") could freeze with no response, or refuse with "That's quite a bit of information to process at once! Could you please narrow down your request?" A memory device should be able to answer these.

## Root cause

get_conversations_tool (utils/retrieval/tools/conversation_tools.py) is the agentic chat tool that retrieves conversations by date range. Its own docstring instructs the model: "When user asks for weekly, monthly, or yearly summaries: Set limit=5000 to retrieve ALL conversations in that period." The tool then formats every matched conversation into a single string via conversations_to_string and returns it. For a wide range that is hundreds or thousands of conversations, and even with transcripts excluded the combined summaries (title, overview, action items, events, attendees) produce a result large enough to overflow the chat model's context. The model then either times out (the freeze) or refuses.

## Fix

Bound what the tool returns so it cannot flood the model:

- _cap_conversations_for_llm: keep at most the 100 most recent conversations (the DB returns them newest-first) and report the true total found.
- _bounded_result: apply a hard character budget (60000) as a backstop, cutting at a conversation boundary so no record is split, and when the range was truncated append a note that tells the model to summarize what it has and to suggest the user narrow to a shorter time frame or a specific topic.
- The cap is applied to the raw conversation list before deserialization and people loading, so the expensive work is also bounded.
- Updated the tool docstring so it no longer tells the model to set limit=5000, and explains that wide ranges are capped to the most recent conversations.

The effect: instead of freezing or refusing, the chat summarizes the most recent conversations in the range and offers to narrow. A full map-reduce summary over an unbounded range (so every conversation in a month is reflected) is a larger follow-up; this change fixes the freeze and returns a useful answer.

## Testing

- New tests/unit/test_conversation_tool_date_range_bound.py (7 tests): _cap_conversations_for_llm (caps to the most recent, reports the total, leaves small sets and the exact-boundary case untouched, handles empty) and _bounded_result (appends the summarize-and-narrow note when truncated, leaves a small untruncated result unchanged, clips an oversized result at a conversation boundary under the budget). Registered in test.sh.
- Proven red against the pre-change version (all 7 fail without the helpers), green after.
- test_tools_router.py, test_retrieval_semantics.py, and test_conversation_hybrid_search.py still pass in isolation, confirming no regression to the retrieval tools.

Refs #4927.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

