### PR TITLE
Route conversation discard through LLM gateway

### DIFF
--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -4,6 +4,7 @@ import sys
 import types
 import logging
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 import pytest
 
@@ -36,10 +37,12 @@ sys.modules.setdefault('utils.llms.memory', memory_stub)
 
 clients_stub = types.ModuleType('utils.llm.clients')
 clients_stub.get_llm = lambda feature: None
+clients_stub.parser = object()
 sys.modules.setdefault('utils.llm.clients', clients_stub)
 
 from utils import byok
 from utils.llm import chat, gateway_client
+from utils.llm import conversation_processing
 
 
 class FakeParser:
@@ -277,3 +280,144 @@ def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(mon
     assert result is None
     assert 'raw user question should not be logged' not in caplog.text
     assert 'raw provider body should not be logged' not in caplog.text
+
+
+def test_conversation_discard_gateway_success_returns_without_legacy_llm(monkeypatch):
+    captured = {}
+
+    def fake_gateway(prompt, output_model, *, feature):
+        captured.update({'prompt': prompt, 'output_model': output_model, 'feature': feature})
+        return output_model(discard=True)
+
+    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(
+        conversation_processing,
+        'get_llm',
+        lambda feature, **kwargs: pytest.fail('legacy discard path should not be called after gateway success'),
+    )
+
+    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is True
+    assert captured['output_model'] is conversation_processing.DiscardConversation
+    assert captured['feature'] == 'conversation_discard.should_discard'
+    assert 'hello there' in captured['prompt']
+
+
+def test_conversation_discard_byok_skips_gateway_and_uses_legacy_llm(monkeypatch):
+    class FakeParser:
+        def __init__(self, pydantic_object):
+            self.pydantic_object = pydantic_object
+
+        def get_format_instructions(self):
+            return 'return structured output'
+
+    class FakePrompt:
+        def __or__(self, other):
+            return FakeChain()
+
+    class FakeChain:
+        def __or__(self, other):
+            return self
+
+        def invoke(self, values):
+            assert 'hello there' in values['full_context']
+            return conversation_processing.DiscardConversation(discard=False)
+
+    byok.set_byok_keys({'openai': 'secret'})
+    counter = FakeCounter()
+    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(
+        conversation_processing,
+        'invoke_chat_structured_gateway',
+        lambda *args, **kwargs: pytest.fail('gateway should not be called for BYOK requests'),
+    )
+    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
+    monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
+
+    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False
+    assert counter.calls == [
+        (
+            {
+                'feature': 'conversation_discard.should_discard',
+                'outcome': 'skipped',
+                'reason': 'byok',
+            },
+            1,
+        )
+    ]
+
+
+def test_conversation_discard_gateway_failure_falls_back_to_legacy_llm(monkeypatch):
+    class FakeParser:
+        def __init__(self, pydantic_object):
+            self.pydantic_object = pydantic_object
+
+        def get_format_instructions(self):
+            return 'return structured output'
+
+    class FakePrompt:
+        def __or__(self, other):
+            return FakeChain()
+
+    class FakeChain:
+        def __or__(self, other):
+            return self
+
+        def invoke(self, values):
+            assert 'hello there' in values['full_context']
+            return conversation_processing.DiscardConversation(discard=False)
+
+    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', lambda *args, **kwargs: None)
+    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
+    monkeypatch.setattr(
+        conversation_processing.ChatPromptTemplate,
+        'from_messages',
+        lambda messages: FakePrompt(),
+    )
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
+
+    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False
+
+
+def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
+    captured = {}
+
+    class FakeParser:
+        def __init__(self, pydantic_object):
+            self.pydantic_object = pydantic_object
+
+        def get_format_instructions(self):
+            return 'return structured output'
+
+    class FakePrompt:
+        def __or__(self, other):
+            return FakeChain()
+
+    class FakeChain:
+        def __or__(self, other):
+            return self
+
+        def invoke(self, values):
+            assert 'submit report by Friday' in values['conversation_context']
+            return conversation_processing.ActionItemsExtraction(action_items=[])
+
+    def fake_gateway(prompt, output_model, *, feature):
+        captured.update({'prompt': prompt, 'output_model': output_model, 'feature': feature})
+        return output_model(action_items=[])
+
+    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
+    monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
+    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+
+    result = conversation_processing.extract_action_items(
+        'submit report by Friday',
+        datetime(2026, 6, 28, tzinfo=timezone.utc),
+        'en',
+        'UTC',
+    )
+
+    assert result == []
+    assert captured['output_model'] is conversation_processing.ActionItemsExtraction
+    assert captured['feature'] == 'conversation_action_items.extract.shadow'
+    assert 'submit report by Friday' in captured['prompt']

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -13,6 +13,8 @@ from models.conversation import Conversation
 from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, ActionItemsExtraction, Event, Structured
 from .clients import get_llm, parser
+from utils.byok import has_byok_keys
+from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
 from utils.llm.conversation_folder import FolderAssignment, assign_conversation_to_folder, build_folders_context
 import logging
 
@@ -31,6 +33,13 @@ class DiscardConversation(BaseModel):
 
 class SpeakerIdMatch(BaseModel):
     speaker_id: int = Field(description="The speaker id assigned to the segment")
+
+
+def _invoke_gateway_unless_byok(prompt: str, output_model: type[BaseModel], *, feature: str) -> BaseModel | None:
+    if has_byok_keys():
+        record_chat_extraction_gateway_result(feature=feature, outcome='skipped', reason='byok')
+        return None
+    return invoke_chat_structured_gateway(prompt, output_model, feature=feature)
 
 
 def _word_count(text: str) -> int:
@@ -78,10 +87,7 @@ def should_discard_conversation(
                 "Generic filler words, acknowledgments, or incomplete thoughts in short conversations should be discarded."
             )
 
-    custom_parser = PydanticOutputParser(pydantic_object=DiscardConversation)
-    prompt = ChatPromptTemplate.from_messages(
-        [
-            '''You will receive a transcript, a series of photo descriptions from a wearable camera, or both. Your task is to decide if this content is meaningful enough to be saved as a memory.
+    prompt_template = '''You will receive a transcript, a series of photo descriptions from a wearable camera, or both. Your task is to decide if this content is meaningful enough to be saved as a memory.
 
 Task: Decide if the content should be saved as conversation summary.
 {duration_context}
@@ -110,19 +116,27 @@ Content:
 {full_context}
 
 {format_instructions}'''.replace(
-                '    ', ''
-            ).strip()
-        ]
+        '    ', ''
+    ).strip()
+    custom_parser = PydanticOutputParser(pydantic_object=DiscardConversation)
+    prompt_values = {
+        'full_context': full_context,
+        'duration_context': duration_context,
+        'format_instructions': custom_parser.get_format_instructions(),
+    }
+
+    gateway_response = _invoke_gateway_unless_byok(
+        prompt_template.format(**prompt_values),
+        DiscardConversation,
+        feature='conversation_discard.should_discard',
     )
+    if gateway_response is not None:
+        return gateway_response.discard
+
+    prompt = ChatPromptTemplate.from_messages([prompt_template])
     chain = prompt | get_llm('conv_discard') | custom_parser
     try:
-        response: DiscardConversation = chain.invoke(
-            {
-                'full_context': full_context,
-                'duration_context': duration_context,
-                'format_instructions': custom_parser.get_format_instructions(),
-            }
-        )
+        response: DiscardConversation = chain.invoke(prompt_values)
         return response.discard
 
     except Exception as e:
@@ -433,20 +447,25 @@ def extract_action_items(
         user_tz
     )
     current_time_local = current_time.astimezone(user_tz)
+    prompt_values = {
+        'conversation_context': conversation_context,
+        'format_instructions': action_items_parser.get_format_instructions(),
+        'language_code': language_code,
+        'response_language': response_language,
+        'started_at_local': started_at_local.replace(tzinfo=None).isoformat(),
+        'current_time_local': current_time_local.replace(tzinfo=None).isoformat(),
+        'tz': tz or 'UTC',
+        'existing_items_context': existing_items_context,
+    }
+
+    _invoke_gateway_unless_byok(
+        f'{instructions_text}\n\n{context_message.format(**prompt_values)}',
+        ActionItemsExtraction,
+        feature='conversation_action_items.extract.shadow',
+    )
 
     try:
-        response = chain.invoke(
-            {
-                'conversation_context': conversation_context,
-                'format_instructions': action_items_parser.get_format_instructions(),
-                'language_code': language_code,
-                'response_language': response_language,
-                'started_at_local': started_at_local.replace(tzinfo=None).isoformat(),
-                'current_time_local': current_time_local.replace(tzinfo=None).isoformat(),
-                'tz': tz or 'UTC',
-                'existing_items_context': existing_items_context,
-            }
-        )
+        response = chain.invoke(prompt_values)
 
         # Set created_at for action items if not already set
         now = current_time

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -8,7 +8,7 @@ description: "Architecture for Omi's internal LLM routing gateway, auto lanes, r
 
 > Status: v1 foundation implemented; first backend pilot is code-on by default with application-level fallback.
 >
-> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, local service URL configuration for backend callers, and a code-on `chat_extraction.requires_context` caller pilot with application-level fallback.
+> Implemented so far: separate FastAPI service skeleton, unauthenticated `/health`, service-authenticated `/ready`, service-authenticated `/v1/chat/completions`, repo-local config schemas/loader, checked-in `omi:auto:chat-structured` lane artifacts, internal service-auth helpers, request-level credential context helpers, typed gateway errors, OpenAI chat-completions request validation, route resolution for the v1 auto lane, the non-streaming provider executor, fake providers for deterministic tests, a live OpenAI-compatible provider adapter, local service URL configuration for backend callers, and code-on structured-output caller pilots for `chat_extraction.requires_context`, `conversation_discard.should_discard`, and `conversation_action_items.extract.shadow` with application-level fallback.
 
 ## Decision
 
@@ -537,6 +537,8 @@ Runtime fail-open means active route failure may use LKG only for failure classe
 - forwards supported OpenAI chat-completions controls such as `temperature`, `max_tokens`, `max_completion_tokens`, `seed`, `top_p`, penalties, `stop`, and `user`;
 - maps typed gateway exceptions to OpenAI-style error envelopes with `error.message`, `error.type`, `error.param`, and `error.code`;
 - rejects unknown auto lanes, bare provider model names, streaming, tools, unsupported capabilities, and unknown top-level request parameters before provider execution.
+
+Another real background caller is the conversation discard classifier in post-processing. It sends `conversation_discard.should_discard` through `omi:auto:chat-structured` and falls back to the legacy `conv_discard` LLM path if the gateway returns invalid output, times out, or fails. Action-item extraction also sends `conversation_action_items.extract.shadow` through the gateway as shadow traffic, then still uses the legacy `conv_action_items` result for product behavior. These routes give the rollout real backend-originated gateway traffic without adding latency to the foreground desktop chat path.
 
 The default provider registry includes the OpenAI-compatible adapter for the checked-in `openai` provider route. It is cached per process, closed during FastAPI lifespan shutdown, uses `OPENAI_API_KEY`, optional `OPENAI_BASE_URL`, and optional `OPENAI_MAX_RESPONSE_BYTES`, posts to `/chat/completions` with `httpx.AsyncClient`, and fails closed with `invalid_route_config` when the managed key is absent or rejected. Tests can still override the registry with fake providers.
 


### PR DESCRIPTION
## Summary
- route the conversation discard classifier through the LLM gateway first
- keep the existing conv_discard LLM path as fallback on gateway invalid output, timeout, or request failure
- document conversation_discard.should_discard as the first real background gateway caller

## Validation
- python -m pytest backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py -q
- python -m pytest backend/tests/unit/test_llm_gateway_executor.py backend/tests/unit/test_llm_gateway_openai_compatible.py backend/tests/unit/test_llm_gateway_config.py backend/tests/unit/test_llm_gateway_client_config.py backend/tests/unit/test_llm_gateway_auth.py -q
- python -m pytest backend/tests/unit/test_process_conversation_usage_context.py -q
- python -m py_compile backend/utils/llm/conversation_processing.py backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

