### PR TITLE
fix(backend): serve path-suffixed MCP OAuth protected-resource metadata (#8506)

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -455,8 +455,7 @@ MCP_TOOLS = [
 ]
 
 
-@router.get("/.well-known/oauth-protected-resource", tags=["mcp"])
-def oauth_protected_resource_metadata():
+def _protected_resource_metadata():
     return {
         "resource": MCP_RESOURCE_URL,
         "authorization_servers": [MCP_AUTHORIZATION_SERVER_URL],
@@ -464,6 +463,19 @@ def oauth_protected_resource_metadata():
         "bearer_methods_supported": ["header"],
         "resource_documentation": "https://docs.omi.me/doc/developer/mcp/setup",
     }
+
+
+@router.get("/.well-known/oauth-protected-resource", tags=["mcp"])
+def oauth_protected_resource_metadata():
+    return _protected_resource_metadata()
+
+
+# RFC 9728: clients derive the metadata URL by inserting the resource path after the
+# well-known prefix. ChatGPT's verifier probes the path-suffixed variant for the MCP
+# resource (https://api.omi.me/v1/mcp/sse), so serve the same document there too.
+@router.get("/.well-known/oauth-protected-resource/v1/mcp/sse", tags=["mcp"])
+def oauth_protected_resource_metadata_for_resource():
+    return _protected_resource_metadata()
 
 
 @router.get("/.well-known/oauth-authorization-server", tags=["mcp"])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -38,6 +38,7 @@ pytest tests/unit/test_mcp_client_tool_result.py -v
 pytest tests/unit/test_mcp_data_endpoints.py -v
 pytest tests/unit/test_mcp_conversations_poison.py -v
 pytest tests/unit/test_mcp_profile_contact.py -v
+pytest tests/unit/test_mcp_oauth_metadata.py -v
 pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_memory_category_auto.py -v
 pytest tests/unit/test_memories_validation.py -v

--- a/backend/tests/unit/test_mcp_oauth_metadata.py
+++ b/backend/tests/unit/test_mcp_oauth_metadata.py
@@ -1,0 +1,133 @@
+"""Unit tests for MCP OAuth Protected Resource Metadata discovery (RFC 9728).
+
+ChatGPT Apps' verifier probes the path-suffixed metadata URL for the submitted
+MCP resource (https://api.omi.me/v1/mcp/sse), i.e.
+`/.well-known/oauth-protected-resource/v1/mcp/sse`. Issue #8506: that route 404'd
+while only the root `/.well-known/oauth-protected-resource` was served, blocking
+the ChatGPT Apps OAuth review. These tests assert the alias serves the same
+metadata document and that the canonical resource identifier is correct.
+
+Heavy deps are stubbed following the pattern in test_mcp_data_endpoints.py.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if not isinstance(module, ModuleType):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [path]
+    if '.' in name:
+        parent_name, child_name = name.rsplit('.', 1)
+        parent = sys.modules.setdefault(parent_name, ModuleType(parent_name))
+        setattr(parent, child_name, module)
+    return module
+
+
+_ensure_package_path('utils', os.path.join(_BACKEND_DIR, 'utils'))
+_ensure_package_path('utils.retrieval', os.path.join(_BACKEND_DIR, 'utils', 'retrieval'))
+_ensure_package_path('models', os.path.join(_BACKEND_DIR, 'models'))
+
+_stubs = [
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.screen_activity',
+    'database.x_posts',
+    'database.fair_use',
+    'database.auth',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google',
+    'google.cloud',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'utils.other.storage',
+    'utils.other.endpoints',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.render',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.log_sanitizer',
+    'utils.executors',
+    'dependencies',
+]
+for mod_name in _stubs:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = _AutoMockModule(mod_name)
+
+if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
+sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
+sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
+sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+
+from routers import mcp_sse as sse  # noqa: E402
+
+
+def test_root_and_path_suffixed_metadata_are_identical():
+    root = sse.oauth_protected_resource_metadata()
+    suffixed = sse.oauth_protected_resource_metadata_for_resource()
+    assert root == suffixed
+
+
+def test_resource_identifier_is_canonical():
+    meta = sse.oauth_protected_resource_metadata_for_resource()
+    assert meta['resource'] == 'https://api.omi.me/v1/mcp/sse'
+    assert meta['authorization_servers'] == ['https://api.omi.me']
+    assert meta['bearer_methods_supported'] == ['header']
+
+
+def test_path_suffixed_route_is_registered():
+    paths = {getattr(r, 'path', None) for r in sse.router.routes}
+    assert '/.well-known/oauth-protected-resource' in paths
+    assert '/.well-known/oauth-protected-resource/v1/mcp/sse' in paths


### PR DESCRIPTION
## Bug (#8506)

ChatGPT Apps review rejected the Omi MCP app at the OAuth/sign-in step. Prod logs show ChatGPT's verifier probing the **path-suffixed** OAuth Protected Resource Metadata URL for the submitted MCP resource and getting a 404:

```
404 GET https://api.omi.me/.well-known/oauth-protected-resource/v1/mcp/sse
200 GET https://api.omi.me/.well-known/oauth-protected-resource
```

The submitted MCP resource is `https://api.omi.me/v1/mcp/sse`. The credentials/account are fine (issue confirms the full token + tool flow works) — the blocker is metadata discovery.

## Root cause

`backend/routers/mcp_sse.py` only served the **root** `/.well-known/oauth-protected-resource`. Per **RFC 9728**, a client derives the metadata URL by inserting the resource's path after the well-known prefix, i.e. `/.well-known/oauth-protected-resource/v1/mcp/sse`. That route didn't exist → 404 → ChatGPT's verifier failed discovery.

## Fix

- Extract the metadata document into a small `_protected_resource_metadata()` helper.
- Keep the existing root route serving it.
- Add an alias route `GET /.well-known/oauth-protected-resource/v1/mcp/sse` returning the **same** document.

This is a pure public-discovery metadata route — no change to token validation, credential handling, or signing. The deeper OAuth-flow hardening items raised in the issue's audit (real authorization-code flow, PKCE enforcement, redirect-URI allowlisting, scope enforcement, RFC-shaped `/token` responses) touch the credential/token path and are intentionally **left for a human-owned change** — out of this watchdog's scope.

## Tests

New `backend/tests/unit/test_mcp_oauth_metadata.py` (registered in `test.sh`):
- root and path-suffixed endpoints return identical metadata,
- canonical `resource` == `https://api.omi.me/v1/mcp/sse`,
- both routes are registered.

`py_compile` + `scripts/lint_async_blockers.py` clean; pre-commit black clean. Runtime UNVERIFIED locally (no fastapi/pytest in this env); CI runs the suite.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

