### PR TITLE
Fix dev backend-listen auto deploy rollout

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -44,13 +44,18 @@ jobs:
       - name: Google Service Account
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
 
+      - name: Compute short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./backend/Dockerfile
           push: true
-          tags: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+          tags: |
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ env.SHORT_SHA }}
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
@@ -107,7 +112,11 @@ jobs:
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install \
             ${{ vars.ENV }}-omi-backend-listen \
             ./backend/charts/backend-listen \
-            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml
+            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            --set image.tag=${{ env.SHORT_SHA }}
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status \
+            deploy/${{ vars.ENV }}-omi-backend-listen \
+            --timeout=300s
 
       - name: Deploy ${{ env.SERVICE }}-integration to Cloud Run
         id: deploy-backend-integration
@@ -124,4 +133,3 @@ jobs:
 
       - name: Show Output
         run: echo "Backend deployed to development environment"
-


### PR DESCRIPTION
## Summary
- tag backend auto-dev images with both latest and the merge short SHA
- deploy dev backend-listen with the immutable short-SHA tag so Helm changes the pod template
- wait for the GKE backend-listen rollout to complete before marking the workflow successful

## Why
The auto-dev workflow pushed backend:latest but deployed backend-listen without overriding the chart default tag of latest. Kubernetes saw no Deployment template change, so the existing pod kept running the old image digest even though the workflow succeeded.

## Validation
- Parsed .github/workflows/gcp_backend_auto_dev.yml with PyYAML
- Pre-push hooks passed

## Rollout test
After this merges, the Auto Deploy Backend to Development workflow should create a new backend-listen ReplicaSet using image tag  for the merge commit. Then we can verify the pod image tag/digest and scrape llm_gateway_chat_extraction metrics.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

