### PR TITLE
Harden backend CI/CD image tags and rollout checks

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,13 @@
+# GitHub Workflow Agent Guide
+
+These rules apply to GitHub Actions workflows and custom actions under `.github/`.
+
+## CI/CD Deploy Safety
+
+- Use immutable image tags for deploys. Build and push the short SHA tag, then deploy that exact tag.
+- Do not deploy Cloud Run services from an untagged image path; use `image:...:${SHORT_SHA}` so revisions show the source commit.
+- Do not let Helm chart-only deploys reset GKE workloads to `latest`. Preserve the currently deployed immutable tag or require an explicit tag input.
+- Every GKE Deployment deploy must wait for rollout completion with `kubectl rollout status ... --timeout=...` and fail on timeout.
+- For chart-only backend-listen deploys, fail if the current deployed image tag is missing or `latest`; use the backend deploy workflow to establish an immutable tag first.
+- Keep rollout checks close to the deploy step they verify, especially for `backend-listen`, `pusher`, `agent-proxy`, `llm-gateway`, `parakeet`, `diarizer`, and `vad`.
+- When editing workflows, keep `actionlint` coverage in CI so YAML and GitHub expression mistakes fail before merge.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-m
+
+config-variables: null

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -68,7 +68,8 @@ jobs:
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
 
       - name: Compute short SHA
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+        id: image-tag
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
@@ -78,7 +79,7 @@ jobs:
           push: true
           tags: |
             gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
-            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ env.SHORT_SHA }}
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
@@ -88,7 +89,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
       - name: Deploy ${{ env.SERVICE }}-sync to Cloud Run
         id: deploy-backend-sync
@@ -96,7 +97,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}-sync
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v2
@@ -109,7 +110,8 @@ jobs:
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen ./backend/charts/backend-listen \
             -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
-            --set image.tag=${{ env.SHORT_SHA }}
+            --set image.tag=${{ steps.image-tag.outputs.short_sha }}
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
 
       - name: Deploy ${{ env.SERVICE }}-integration to Cloud Run
         id: deploy-backend-integration
@@ -117,7 +119,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}-integration
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
       # Mirror every secret declared in the backend-secrets chart into the
       # three Cloud Run revisions (additive). GKE picks them up via the helm
@@ -133,7 +135,7 @@ jobs:
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output
-        run: echo ${{ steps.deploy.outputs.url }}
+        run: echo ${{ steps.deploy-backend.outputs.url }}
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_backend_agent_proxy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Deploy Agent Proxy to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-agent-proxy ./backend/charts/agent-proxy -f ./backend/charts/agent-proxy/${{ vars.ENV }}_omi_agent_proxy_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s
 
       - name: Show Output
         run: echo "Agent proxy deployed to ${{ github.event.inputs.environment }}"

--- a/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Deploy Agent Proxy to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-agent-proxy ./backend/charts/agent-proxy -f ./backend/charts/agent-proxy/${{ vars.ENV }}_omi_agent_proxy_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s
 
       - name: Show Output
         run: echo "Agent proxy deployed to development environment"

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -45,7 +45,8 @@ jobs:
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
 
       - name: Compute short SHA
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+        id: image-tag
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
@@ -55,7 +56,7 @@ jobs:
           push: true
           tags: |
             gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
-            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ env.SHORT_SHA }}
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
           cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
 
@@ -65,7 +66,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
           secrets: |
@@ -90,7 +91,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}-sync
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
           secrets: |
@@ -113,10 +114,8 @@ jobs:
             ${{ vars.ENV }}-omi-backend-listen \
             ./backend/charts/backend-listen \
             -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
-            --set image.tag=${{ env.SHORT_SHA }}
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status \
-            deploy/${{ vars.ENV }}-omi-backend-listen \
-            --timeout=300s
+            --set image.tag=${{ steps.image-tag.outputs.short_sha }}
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
 
       - name: Deploy ${{ env.SERVICE }}-integration to Cloud Run
         id: deploy-backend-integration
@@ -124,7 +123,7 @@ jobs:
         with:
           service: ${{ env.SERVICE }}-integration
           region: ${{ env.REGION }}
-          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
           secrets: |

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -65,6 +65,17 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: Resolve deployed backend-listen image tag
+        run: |
+          IMAGE="$(kubectl -n ${{ vars.ENV }}-omi-backend get deploy/${{ vars.ENV }}-omi-backend-listen -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          TAG="${IMAGE##*:}"
+          if [[ -z "$TAG" || "$TAG" == "$IMAGE" || "$TAG" == "latest" ]]; then
+            echo "backend-listen is not currently pinned to an immutable image tag: ${IMAGE:-<missing>}" >&2
+            echo "Run the backend deploy workflow first so chart-only upgrades preserve a short-SHA image tag." >&2
+            exit 1
+          fi
+          echo "BACKEND_LISTEN_IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
+
       - name: Helm diff (dry run)
         run: |
           echo "=== Current release values ==="
@@ -74,6 +85,7 @@ jobs:
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen \
             ./backend/charts/backend-listen \
             -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            --set "image.tag=${BACKEND_LISTEN_IMAGE_TAG}" \
             --dry-run
 
       # The ExternalSecret resource (which tells external-secrets which GCP
@@ -97,7 +109,8 @@ jobs:
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen \
             ./backend/charts/backend-listen \
-            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml
+            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            --set "image.tag=${BACKEND_LISTEN_IMAGE_TAG}"
 
       - name: Verify rollout
         run: |

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -167,6 +167,7 @@ jobs:
             fi
           else
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+            kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s
           fi
 
       - name: Smoke LLM Gateway
@@ -229,7 +230,7 @@ jobs:
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output
-        run: echo ${{ steps.deploy.outputs.url }}
+        run: echo "${{ env.SERVICE }} deployed to ${{ github.event.inputs.environment }}"
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s
 
       - name: Show Output
         run: echo "Pusher deployed to development environment"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
           echo "has_firmware=$(echo "$FILES" | grep -qE '^(omi|omiGlass)/.*\.(c|cpp|cc|cxx|h|hpp)$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_frontend=$(echo "$FILES" | grep -q '^web/frontend/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_workflows=$(echo "$FILES" | grep -qE '^\.github/workflows/.*\.ya?ml$|^\.github/actionlint\.ya?ml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
           echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -70,6 +71,15 @@ jobs:
 
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
+
+      - name: Check GitHub Actions workflows
+        if: steps.changed.outputs.has_workflows == 'true'
+        run: |
+          GOBIN=/tmp/actionlint-bin go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          FILES=$(grep -E '^\.github/workflows/.*\.ya?ml$' /tmp/changed-files.txt || true)
+          if [ -n "$FILES" ]; then
+            /tmp/actionlint-bin/actionlint -shellcheck "" $FILES
+          fi
 
       # -- Dart --
       - name: Setup Flutter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,12 +236,12 @@ Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format man
 - Before starting work, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 - Always commit to the current branch — never switch branches mid-task. Always work in a git worktree for code changes (`git worktree add`).
 - Never push directly to `main`. Land changes through PRs only. Never squash-merge — use a regular merge.
-- Make individual commits per file, not bulk commits.
+- Make individual commits per feature or testable surface, not per file or unrelated bulk changes.
 - If push fails (remote ahead): `git pull --rebase && git push`.
 - Never push or create PRs unless explicitly asked — commit locally by default.
 
 ### RELEASE Command
-Create a branch from `main`, individual commits per file, push and open a PR, merge without squash, then switch back to `main` and pull.
+Create a branch from `main`, make individual commits per feature or testable surface, push and open a PR, merge without squash, then switch back to `main` and pull.
 
 ### RELEASEWITHBACKEND Command
 Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.


### PR DESCRIPTION
## Summary
- add `.github/AGENTS.md` with CI/CD deploy-safety rules for future workflow edits
- update repo Git guidance to commit by feature or testable surface instead of by file
- deploy backend Cloud Run revisions and backend-listen GKE pods from the short-SHA image tag
- preserve the currently deployed backend-listen image tag during chart-only upgrades instead of falling back to `latest`
- add missing GKE rollout waits for backend-listen, pusher, and agent-proxy deploy workflows
- add actionlint coverage for changed GitHub Actions workflows

Fixes #8510

## Validation
- `git diff --check origin/main..HEAD`
- Ruby YAML parse for edited workflow/config files
- `/tmp/codex-actionlint-bin/actionlint -shellcheck "" .github/workflows/gcp_backend.yml .github/workflows/gcp_backend_auto_dev.yml .github/workflows/gcp_backend_listen_helm.yml .github/workflows/gcp_backend_pusher.yml .github/workflows/gcp_backend_pusher_auto_deploy.yml .github/workflows/gcp_backend_agent_proxy.yml .github/workflows/gcp_backend_agent_proxy_auto_deploy.yml .github/workflows/lint.yml`
- pre-push hooks passed
- GitHub `Lint & Format Check` passed on run `28335077420`