### PR TITLE
[codex] Add realtime calendar event tool

### DIFF
--- a/backend/routers/tools.py
+++ b/backend/routers/tools.py
@@ -17,10 +17,11 @@ Endpoints:
 """
 
 import logging
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 import database.vector_db as vector_db
 from utils.other.endpoints import get_current_user_uid, with_rate_limit
@@ -82,11 +83,18 @@ class UpdateActionItemRequest(BaseModel):
 
 class CreateCalendarEventRequest(BaseModel):
     title: str = Field(description="Event title")
-    start_time: str = Field(description="ISO date/time with timezone")
-    end_time: str = Field(description="ISO date/time with timezone")
+    start_time: datetime = Field(description="ISO date/time with timezone")
+    end_time: datetime = Field(description="ISO date/time with timezone")
     description: Optional[str] = Field(default=None, description="Event description")
     location: Optional[str] = Field(default=None, description="Event location")
     attendees: Optional[str] = Field(default=None, description="Comma-separated attendee names or email addresses")
+
+    @field_validator('start_time', 'end_time')
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError('datetime must include timezone')
+        return value
 
 
 # --------------- conversation endpoints ---------------
@@ -258,12 +266,16 @@ async def create_calendar_event(
     result = await create_calendar_event_tool.ainvoke(
         {
             "title": body.title,
-            "start_time": body.start_time,
-            "end_time": body.end_time,
+            "start_time": body.start_time.isoformat(),
+            "end_time": body.end_time.isoformat(),
             "description": body.description,
             "location": body.location,
             "attendees": body.attendees,
         },
         config={"configurable": {"user_id": uid}},
     )
-    return _ok("create_calendar_event", result)
+    return {
+        "tool_name": "create_calendar_event",
+        "result_text": result,
+        "is_error": not result.startswith("✅ Successfully created calendar event:"),
+    }

--- a/backend/routers/tools.py
+++ b/backend/routers/tools.py
@@ -13,6 +13,7 @@ Endpoints:
 - GET   /v1/tools/action-items           — list action items
 - POST  /v1/tools/action-items           — create action item
 - PATCH /v1/tools/action-items/{id}      — update action item
+- POST  /v1/tools/calendar-events        — create calendar event
 """
 
 import logging
@@ -31,6 +32,7 @@ from utils.retrieval.tool_services.action_items import (
     create_action_item_text,
     update_action_item_text,
 )
+from utils.retrieval.tools.calendar_tools import create_calendar_event_tool
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +78,15 @@ class UpdateActionItemRequest(BaseModel):
     completed: Optional[bool] = Field(default=None)
     description: Optional[str] = Field(default=None)
     due_at: Optional[str] = Field(default=None, description="ISO date with timezone")
+
+
+class CreateCalendarEventRequest(BaseModel):
+    title: str = Field(description="Event title")
+    start_time: str = Field(description="ISO date/time with timezone")
+    end_time: str = Field(description="ISO date/time with timezone")
+    description: Optional[str] = Field(default=None, description="Event description")
+    location: Optional[str] = Field(default=None, description="Event location")
+    attendees: Optional[str] = Field(default=None, description="Comma-separated attendee names or email addresses")
 
 
 # --------------- conversation endpoints ---------------
@@ -234,3 +245,25 @@ def update_action_item(
         due_at=body.due_at,
     )
     return _ok("update_action_item", result)
+
+
+# --------------- calendar endpoints ---------------
+
+
+@router.post("/v1/tools/calendar-events", response_model=ToolResponse)
+async def create_calendar_event(
+    body: CreateCalendarEventRequest,
+    uid: str = Depends(with_rate_limit(get_current_user_uid, "tools:mutate")),
+):
+    result = await create_calendar_event_tool.ainvoke(
+        {
+            "title": body.title,
+            "start_time": body.start_time,
+            "end_time": body.end_time,
+            "description": body.description,
+            "location": body.location,
+            "attendees": body.attendees,
+        },
+        config={"configurable": {"user_id": uid}},
+    )
+    return _ok("create_calendar_event", result)

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -128,8 +128,22 @@ notif_mod.sync_action_item_reminder = MagicMock()
 _stub_package("utils")
 _stub_package("utils.conversations")
 _stub_package("utils.retrieval")
+_stub_package("utils.retrieval.tools")
 _stub_package("utils.retrieval.tool_services")
 _stub_package("utils.other")
+
+
+class FakeCalendarEventTool:
+    def __init__(self):
+        self.calls = []
+
+    async def ainvoke(self, tool_input, config=None):
+        self.calls.append((tool_input, config))
+        return f"✅ Successfully created calendar event: {tool_input['title']}"
+
+
+calendar_tools_mod = _stub_module("utils.retrieval.tools.calendar_tools")
+calendar_tools_mod.create_calendar_event_tool = FakeCalendarEventTool()
 
 # Stub render and factory modules
 render_mod = _stub_module("utils.conversations.render")
@@ -568,6 +582,7 @@ class TestUpdateActionItemText:
         action_items_db.get_action_item.reset_mock()
         action_items_db.update_action_item.reset_mock()
         action_items_db.update_action_item.return_value = True
+        calendar_tools_mod.create_calendar_event_tool.calls.clear()
         notif_mod.send_action_item_completed_notification.reset_mock()
 
     def test_empty_id_rejected(self):
@@ -731,6 +746,30 @@ class TestRouterEndpoints:
         body = resp.json()
         assert body["tool_name"] == "update_action_item"
         assert "completed" in body["result_text"].lower()
+
+    def test_create_calendar_event_endpoint(self):
+        resp = self.client.post(
+            "/v1/tools/calendar-events",
+            json={
+                "title": "Design review",
+                "start_time": "2026-06-28T14:00:00-04:00",
+                "end_time": "2026-06-28T15:00:00-04:00",
+                "location": "Zoom",
+                "attendees": "sam@example.com",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tool_name"] == "create_calendar_event"
+        assert "Design review" in body["result_text"]
+
+        tool_input, config = calendar_tools_mod.create_calendar_event_tool.calls[-1]
+        assert tool_input["title"] == "Design review"
+        assert tool_input["start_time"] == "2026-06-28T14:00:00-04:00"
+        assert tool_input["end_time"] == "2026-06-28T15:00:00-04:00"
+        assert tool_input["location"] == "Zoom"
+        assert tool_input["attendees"] == "sam@example.com"
+        assert config == {"configurable": {"user_id": "test-uid"}}
 
     def test_get_conversations_query_params(self):
         """Query params are forwarded correctly to the service."""

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -136,9 +136,14 @@ _stub_package("utils.other")
 class FakeCalendarEventTool:
     def __init__(self):
         self.calls = []
+        self.next_result = None
 
     async def ainvoke(self, tool_input, config=None):
         self.calls.append((tool_input, config))
+        if self.next_result is not None:
+            result = self.next_result
+            self.next_result = None
+            return result
         return f"✅ Successfully created calendar event: {tool_input['title']}"
 
 
@@ -693,6 +698,8 @@ class TestRouterEndpoints:
         action_items_db.create_action_item.return_value = "test-item-id"
         action_items_db.update_action_item.reset_mock()
         action_items_db.update_action_item.return_value = True
+        calendar_tools_mod.create_calendar_event_tool.calls.clear()
+        calendar_tools_mod.create_calendar_event_tool.next_result = None
 
     def test_get_conversations_endpoint(self):
         resp = self.client.get("/v1/tools/conversations")
@@ -762,6 +769,7 @@ class TestRouterEndpoints:
         body = resp.json()
         assert body["tool_name"] == "create_calendar_event"
         assert "Design review" in body["result_text"]
+        assert body["is_error"] is False
 
         tool_input, config = calendar_tools_mod.create_calendar_event_tool.calls[-1]
         assert tool_input["title"] == "Design review"
@@ -770,6 +778,44 @@ class TestRouterEndpoints:
         assert tool_input["location"] == "Zoom"
         assert tool_input["attendees"] == "sam@example.com"
         assert config == {"configurable": {"user_id": "test-uid"}}
+
+    def test_create_calendar_event_rejects_malformed_datetimes(self):
+        resp = self.client.post(
+            "/v1/tools/calendar-events",
+            json={
+                "title": "Design review",
+                "start_time": "tomorrow at 2",
+                "end_time": "2026-06-28T15:00:00-04:00",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_create_calendar_event_requires_timezone(self):
+        resp = self.client.post(
+            "/v1/tools/calendar-events",
+            json={
+                "title": "Design review",
+                "start_time": "2026-06-28T14:00:00",
+                "end_time": "2026-06-28T15:00:00-04:00",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_create_calendar_event_marks_calendar_tool_failures_as_errors(self):
+        calendar_tools_mod.create_calendar_event_tool.next_result = "Google Calendar is not connected."
+        resp = self.client.post(
+            "/v1/tools/calendar-events",
+            json={
+                "title": "Design review",
+                "start_time": "2026-06-28T14:00:00-04:00",
+                "end_time": "2026-06-28T15:00:00-04:00",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tool_name"] == "create_calendar_event"
+        assert body["result_text"] == "Google Calendar is not connected."
+        assert body["is_error"] is True
 
     def test_get_conversations_query_params(self):
         """Query params are forwarded correctly to the service."""

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -19,6 +19,7 @@ from models.calendar_mutation import (
     format_deleted_calendar_events,
 )
 from utils.http_client import get_auth_client
+from utils.executors import db_executor, run_blocking
 from utils.retrieval.tools.integration_base import (
     ensure_capped,
     parse_iso_with_tz,
@@ -484,7 +485,9 @@ async def get_calendar_events_tool(
     Returns:
         Formatted list of calendar events with their details.
     """
-    uid, integration, access_token, access_err = prepare_access(
+    uid, integration, access_token, access_err = await run_blocking(
+        db_executor,
+        prepare_access,
         config,
         'google_calendar',
         'Google Calendar',
@@ -781,7 +784,9 @@ async def create_calendar_event_tool(
         f"start_time: {start_time}, end_time: {end_time}, location: {location}"
     )
 
-    uid, integration, access_token, access_err = prepare_access(
+    uid, integration, access_token, access_err = await run_blocking(
+        db_executor,
+        prepare_access,
         config,
         'google_calendar',
         'Google Calendar',

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -5102,6 +5102,24 @@ extension APIClient {
     }
   }
 
+  struct CreateCalendarEventRequest: Encodable {
+    let title: String
+    let startTime: String
+    let endTime: String
+    let description: String?
+    let location: String?
+    let attendees: String?
+
+    enum CodingKeys: String, CodingKey {
+      case title
+      case startTime = "start_time"
+      case endTime = "end_time"
+      case description
+      case location
+      case attendees
+    }
+  }
+
   /// Percent-encode a date string for use in query parameters.
   /// `.urlQueryAllowed` does not encode `+`, but servers decode `+` as space in query strings.
   /// This encodes `+` as `%2B` so timezone offsets like `+07:00` survive round-trip.
@@ -5186,6 +5204,25 @@ extension APIClient {
   ) async throws -> ToolResponse {
     let body = UpdateActionItemRequest(completed: completed, description: description, dueAt: dueAt)
     return try await patch("v1/tools/action-items/\(id)", body: body, customBaseURL: nil)
+  }
+
+  func toolCreateCalendarEvent(
+    title: String,
+    startTime: String,
+    endTime: String,
+    description: String? = nil,
+    location: String? = nil,
+    attendees: String? = nil
+  ) async throws -> ToolResponse {
+    let body = CreateCalendarEventRequest(
+      title: title,
+      startTime: startTime,
+      endTime: endTime,
+      description: description,
+      location: location,
+      attendees: attendees
+    )
+    return try await post("v1/tools/calendar-events", body: body, customBaseURL: nil)
   }
 
   // MARK: - X (Twitter) Connector

--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -126,6 +126,17 @@ enum DesktopCapabilityRegistry {
         "Find the task first, then update the matching id. Do not guess task ids."
       ]),
     Capability(
+      toolName: "create_calendar_event",
+      title: "Create Calendar Event",
+      latency: .fastNetwork,
+      surfaces: [.realtimeHub],
+      summary: "Create a new Google Calendar event.",
+      bullets: [
+        "Use when the user asks to add, create, schedule, or put a specific event on their calendar.",
+        "Pass title, start_time, and end_time as ISO-8601 strings with timezone; include location, description, and attendees when provided.",
+        "Use spawn_agent for multi-step calendar work such as finding availability or coordinating with people."
+      ]),
+    Capability(
       toolName: "complete_task",
       title: "Complete Task",
       latency: .fastLocal,
@@ -397,6 +408,7 @@ enum DesktopCapabilityRegistry {
     """
     Omi capability model:
     - You can read Omi data quickly with fast tools: tasks, memories, conversations, daily recaps, and screen history.
+    - You can create a straightforward calendar event with create_calendar_event when the user gives the event details.
     - You can inspect your local task-chat agents/subagents and floating agent pills with get_task_agent_status. If the user asks about your subagents, background agents, running agents, finished agents, or task-agent errors/timeouts, call it before answering.
     - You can inspect and stop canonical Omi-managed agent sessions/runs with list_agent_sessions, get_agent_run, and cancel_agent_run. Use these for agents created in chat, PTT/realtime, task chat, or any other Omi surface when a canonical run id is available.
     - You can inspect canonical agent output references with inspect_agent_artifacts and mark artifact metadata with update_agent_artifact_lifecycle.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -907,6 +907,39 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
           id: id, completed: completed, description: newDescription, dueAt: dueAt
         ).resultText
       }
+    case .createCalendarEvent:
+      let title = (arguments["title"] as? String)?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      guard !title.isEmpty else {
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name, output: "No calendar event title was given.")
+        return
+      }
+      guard let startTime = arguments["start_time"] as? String, !startTime.isEmpty else {
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name, output: "No calendar event start time was given.")
+        return
+      }
+      guard let endTime = arguments["end_time"] as? String, !endTime.isEmpty else {
+        sendToolResultIfCurrent(
+          source: source, callId: callId, name: name, output: "No calendar event end time was given.")
+        return
+      }
+      runToolAndSpeak(
+        source: source,
+        callId: callId, name: name, detail: "\"\(title.prefix(60))\"",
+        emptyText: "Calendar event created.",
+        errorText: "Could not create the calendar event right now."
+      ) {
+        try await APIClient.shared.toolCreateCalendarEvent(
+          title: title,
+          startTime: startTime,
+          endTime: endTime,
+          description: arguments["description"] as? String,
+          location: arguments["location"] as? String,
+          attendees: arguments["attendees"] as? String
+        ).resultText
+      }
     case .spawnAgent:
       let brief = arg("brief")
       let title = (arguments["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -140,6 +140,7 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .searchScreenHistory: stub = "Found it: yesterday afternoon you were reading the launch doc in Safari."
     case .createActionItem: stub = "Created task: Example task."
     case .updateActionItem: stub = "Updated the task."
+    case .createCalendarEvent: stub = "Created calendar event: Example event."
     case .spawnAgent: stub = "Started a background agent."
     case .screenshot: stub = "Screen captured."
     case .pointClick: stub = "Clicked."

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -7,7 +7,7 @@ import Foundation
 // declared to both providers (OpenAI Realtime `tools`, Gemini `functionDeclarations`);
 // `RealtimeHubController` executes them by calling EXISTING app code / endpoints.
 // Reads (get_tasks, get_memories, search_memories, search_conversations) and simple
-// writes (create_action_item, update_action_item) run synchronously and speak their
+// writes (create_action_item, update_action_item, create_calendar_event) run synchronously and speak their
 // result; multi-step / other-app work still goes to spawn_agent.
 
 enum HubTool: String {
@@ -60,6 +60,8 @@ enum HubTool: String {
   case createActionItem = "create_action_item"
   /// Update an existing task (mark done, change text/due). Needs the task id from get_tasks.
   case updateActionItem = "update_action_item"
+  /// Create a Google Calendar event through the backend calendar tool.
+  case createCalendarEvent = "create_calendar_event"
   /// Capture the user's screen so the model can see what they're looking at.
   case screenshot = "screenshot"
   /// Click at on-screen coordinates (local).
@@ -85,8 +87,9 @@ enum RealtimeHubTools {
     (get_tasks), what Omi knows about them / their memories & facts (get_memories, \
     search_memories), their past conversations (search_conversations), what they DID on \
     their Mac (get_daily_recap), and their on-screen history (search_screen_history) — and \
-    you can make simple task changes (create_action_item, update_action_item). For anything in \
-    their OTHER apps (calendar, notes, emails, messages, files, reminders, browser) or any \
+    you can make simple task changes (create_action_item, update_action_item) and create a \
+    straightforward calendar event (create_calendar_event). For anything else in their OTHER \
+    apps (notes, emails, messages, files, reminders, browser, or multi-step calendar work) or any \
     multi-step "do X for me" work, use spawn_agent — it hands the request to a background \
     agent that has those tools and can act in the user's apps.
 
@@ -145,7 +148,13 @@ enum RealtimeHubTools {
     call create_action_item with a clear `description` (and `due_at` if a time was given), \
     then confirm out loud. CHANGE an existing task (mark done, edit, reschedule): first \
     call get_tasks to get the matching task's id, then call update_action_item with that id.
-    - DOING something for the user in their OTHER apps (calendar, notes, emails, messages, \
+    - ADD a calendar event / schedule a specific meeting ("put lunch on my calendar", \
+    "schedule demo review tomorrow 2-3pm"): call create_calendar_event with `title`, \
+    `start_time`, and `end_time` as ISO-8601 strings WITH timezone. Include `attendees`, \
+    `location`, and `description` only if the user provided them. If the user gives no end time, \
+    choose a reasonable duration from context (usually 30 minutes for meetings, 1 hour otherwise) \
+    rather than spawning an agent just to ask.
+    - DOING something else for the user in their OTHER apps (notes, emails, messages, \
     files, browser) or any multi-step work — create/send/open/edit/search/schedule/automate/ \
     "do X for me": you CANNOT do these yourself. You MUST actually EMIT the spawn_agent \
     function call (with a clear, self-contained `brief` and a short `title`). That function \
@@ -485,6 +494,36 @@ enum RealtimeHubTools {
             "due_at": ["type": "string", "description": "New ISO-8601 due date/time, if rescheduling."],
           ],
           "required": ["id"],
+        ],
+      ],
+      [
+        "type": "function",
+        "name": HubTool.createCalendarEvent.rawValue,
+        "description":
+          "Create a Google Calendar event for the user. Use for simple calendar requests like "
+          + "'put this on my calendar', 'schedule lunch tomorrow', or 'create an event'. Requires "
+          + "start_time and end_time as ISO-8601 strings with timezone. Use spawn_agent instead "
+          + "for multi-step scheduling, finding availability, rescheduling, deleting, or coordinating with people.",
+        "parameters": [
+          "type": "object",
+          "properties": [
+            "title": ["type": "string", "description": "Event title."],
+            "start_time": [
+              "type": "string",
+              "description": "Event start time in ISO-8601 with timezone, e.g. 2026-06-28T14:00:00-04:00.",
+            ],
+            "end_time": [
+              "type": "string",
+              "description": "Event end time in ISO-8601 with timezone, e.g. 2026-06-28T15:00:00-04:00.",
+            ],
+            "description": ["type": "string", "description": "Optional event description."],
+            "location": ["type": "string", "description": "Optional event location."],
+            "attendees": [
+              "type": "string",
+              "description": "Optional comma-separated attendee names or email addresses.",
+            ],
+          ],
+          "required": ["title", "start_time", "end_time"],
         ],
       ],
       [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -69,6 +69,24 @@ enum HubTool: String {
 }
 
 enum RealtimeHubTools {
+  private static func currentCalendarContext(now: Date = Date(), timeZone: TimeZone = .current) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withColonSeparatorInTimeZone]
+    formatter.timeZone = timeZone
+    let offset = timeZone.secondsFromGMT(for: now)
+    let sign = offset >= 0 ? "+" : "-"
+    let absOffset = abs(offset)
+    let hours = absOffset / 3600
+    let minutes = (absOffset % 3600) / 60
+    return String(
+      format: "Current local datetime: %@. Current timezone: %@ (UTC%@%02d:%02d).",
+      formatter.string(from: now),
+      timeZone.identifier,
+      sign,
+      hours,
+      minutes
+    )
+  }
 
   static func systemInstruction(aboutUser: String) -> String {
     """
@@ -80,6 +98,8 @@ enum RealtimeHubTools {
     Reply in the same language the user is speaking.
 
     \(aboutUser)
+
+    \(currentCalendarContext())
 
     \(DesktopCapabilityRegistry.realtimeSelfModelPrompt)
 
@@ -153,7 +173,8 @@ enum RealtimeHubTools {
     `start_time`, and `end_time` as ISO-8601 strings WITH timezone. Include `attendees`, \
     `location`, and `description` only if the user provided them. If the user gives no end time, \
     choose a reasonable duration from context (usually 30 minutes for meetings, 1 hour otherwise) \
-    rather than spawning an agent just to ask.
+    rather than spawning an agent just to ask. Resolve relative dates like "today", "tomorrow", \
+    and weekdays from the current local datetime/timezone above.
     - DOING something else for the user in their OTHER apps (notes, emails, messages, \
     files, browser) or any multi-step work — create/send/open/edit/search/schedule/automate/ \
     "do X for me": you CANNOT do these yourself. You MUST actually EMIT the spawn_agent \

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1676,7 +1676,11 @@ class ChatToolExecutor {
         return resp.resultText
 
       case "create_calendar_event":
-        guard let title = args["title"] as? String, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let rawTitle = args["title"] as? String else {
+          return "Error: title is required"
+        }
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else {
           return "Error: title is required"
         }
         guard let startTime = args["start_time"] as? String, !startTime.isEmpty else {

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -169,6 +169,8 @@ class ChatToolExecutor {
       return await executeBackendTool(toolCall)
     case "update_action_item":
       return await executeBackendTool(toolCall)
+    case "create_calendar_event":
+      return await executeBackendTool(toolCall)
 
     default:
       return "Unknown tool: \(toolCall.name)"
@@ -1670,6 +1672,30 @@ class ChatToolExecutor {
           completed: args["completed"] as? Bool,
           description: args["description"] as? String,
           dueAt: validatedUpdateDueAt
+        )
+        return resp.resultText
+
+      case "create_calendar_event":
+        guard let title = args["title"] as? String, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+          return "Error: title is required"
+        }
+        guard let startTime = args["start_time"] as? String, !startTime.isEmpty else {
+          return "Error: start_time is required"
+        }
+        guard let endTime = args["end_time"] as? String, !endTime.isEmpty else {
+          return "Error: end_time is required"
+        }
+        let validatedStart = validateISODate(startTime, paramName: "start_time")
+        if let error = validatedStart.error { return error }
+        let validatedEnd = validateISODate(endTime, paramName: "end_time")
+        if let error = validatedEnd.error { return error }
+        let resp = try await api.toolCreateCalendarEvent(
+          title: title,
+          startTime: validatedStart.valid ?? startTime,
+          endTime: validatedEnd.valid ?? endTime,
+          description: args["description"] as? String,
+          location: args["location"] as? String,
+          attendees: args["attendees"] as? String
         )
         return resp.resultText
 

--- a/desktop/macos/Desktop/Tests/CreateCalendarEventToolTests.swift
+++ b/desktop/macos/Desktop/Tests/CreateCalendarEventToolTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Omi_Computer
+
+final class CreateCalendarEventToolTests: XCTestCase {
+    func testCreateCalendarEventIsHandledByExecutor() async {
+        let toolCall = ToolCall(
+            name: "create_calendar_event",
+            arguments: [
+                "title": "Design review",
+                "start_time": "2026-06-28T14:00:00-04:00"
+            ],
+            thoughtSignature: nil
+        )
+
+        let result = await ChatToolExecutor.execute(toolCall)
+
+        XCTAssertFalse(result.hasPrefix("Unknown tool"), "create_calendar_event must be handled directly")
+        XCTAssertEqual(result, "Error: end_time is required")
+    }
+
+    func testCreateCalendarEventRequiresTimezoneDates() async {
+        let toolCall = ToolCall(
+            name: "create_calendar_event",
+            arguments: [
+                "title": "Design review",
+                "start_time": "2026-06-28T14:00:00",
+                "end_time": "2026-06-28T15:00:00-04:00"
+            ],
+            thoughtSignature: nil
+        )
+
+        let result = await ChatToolExecutor.execute(toolCall)
+
+        XCTAssertTrue(result.contains("start_time must be ISO format with timezone offset"))
+    }
+}

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -18,6 +18,7 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertTrue(instr.contains("subagents"))
         XCTAssertTrue(instr.contains("get_daily_recap"))
         XCTAssertTrue(instr.contains("ask_higher_model"))
+        XCTAssertTrue(instr.contains("create_calendar_event"))
         XCTAssertTrue(instr.contains("ANSWER YOURSELF"))
     }
 
@@ -40,6 +41,21 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertNotNil(manageTool)
         XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("dismiss"))
         XCTAssertTrue((manageTool?["description"] as? String ?? "").contains("clear completed"))
+    }
+
+    func testRealtimeCreateCalendarEventToolIsExposedWithRequiredArguments() {
+        let tools = RealtimeHubTools.openAITools
+        let calendarTool = tools.first { ($0["name"] as? String) == HubTool.createCalendarEvent.rawValue }
+        XCTAssertNotNil(calendarTool)
+        XCTAssertTrue((calendarTool?["description"] as? String ?? "").contains("Google Calendar"))
+
+        let parameters = calendarTool?["parameters"] as? [String: Any]
+        let properties = parameters?["properties"] as? [String: Any]
+        XCTAssertNotNil(properties?["title"])
+        XCTAssertNotNil(properties?["start_time"])
+        XCTAssertNotNil(properties?["end_time"])
+        XCTAssertNotNil(properties?["attendees"])
+        XCTAssertEqual(parameters?["required"] as? [String], ["title", "start_time", "end_time"])
     }
 
     func testRealtimeCanonicalAgentControlToolsAreExposed() {

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -19,6 +19,9 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertTrue(instr.contains("get_daily_recap"))
         XCTAssertTrue(instr.contains("ask_higher_model"))
         XCTAssertTrue(instr.contains("create_calendar_event"))
+        XCTAssertTrue(instr.contains("Current local datetime:"))
+        XCTAssertTrue(instr.contains("Current timezone:"))
+        XCTAssertTrue(instr.contains("Resolve relative dates"))
         XCTAssertTrue(instr.contains("ANSWER YOURSELF"))
     }
 

--- a/desktop/macos/changelog/unreleased/20260628-realtime-calendar-event-tool.json
+++ b/desktop/macos/changelog/unreleased/20260628-realtime-calendar-event-tool.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added direct calendar event creation for realtime voice requests"
+}


### PR DESCRIPTION
## Summary

Adds a direct `create_calendar_event` path for realtime voice/calendar requests so straightforward event creation no longer has to route through `spawn_agent`.

## Root Cause

The production failure was triggered before any calendar API call: the realtime hub delegated a deterministic calendar-create request to `spawn_agent`, and the spawned agent advertised a provider-invalid tool schema to Anthropic/pi-mono. That made the whole background task fail immediately with a schema 400.

## Changes

- Adds `POST /v1/tools/calendar-events` to the backend tools router, backed by the existing calendar LangChain tool.
- Adds macOS API client support for the new endpoint.
- Exposes `create_calendar_event` in realtime hub tools and capability registry.
- Handles the tool in the realtime controller and chat tool executor.
- Adds backend and Swift tests plus a desktop changelog fragment.

## Validation

- `cd backend && python -m pytest tests/unit/test_tools_router.py -q`
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter "HubSystemInstructionTests|CreateCalendarEventToolTests"`
- `python backend/scripts/scan_async_blockers.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

