### PR TITLE
Wire dev Cloud Run backend to LLM gateway

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -67,8 +67,13 @@ jobs:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+          flags: >-
+            --network=omi-dev-vpc-1
+            --subnet=omi-us-central1-dev-vpc-1-subnet-1
+            --vpc-egress=private-ranges-only
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
+            OMI_LLM_GATEWAY_URL=http://172.16.63.232
           secrets: |
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
@@ -92,8 +97,13 @@ jobs:
           service: ${{ env.SERVICE }}-sync
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+          flags: >-
+            --network=omi-dev-vpc-1
+            --subnet=omi-us-central1-dev-vpc-1-subnet-1
+            --vpc-egress=private-ranges-only
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
+            OMI_LLM_GATEWAY_URL=http://172.16.63.232
           secrets: |
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
@@ -124,8 +134,13 @@ jobs:
           service: ${{ env.SERVICE }}-integration
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+          flags: >-
+            --network=omi-dev-vpc-1
+            --subnet=omi-us-central1-dev-vpc-1-subnet-1
+            --vpc-egress=private-ranges-only
           env_vars: |
             GOOGLE_CLOUD_PROJECT=based-hardware
+            OMI_LLM_GATEWAY_URL=http://172.16.63.232
           secrets: |
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest

--- a/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
@@ -34,7 +34,24 @@ podLabels: {}
 
 service:
   type: ClusterIP
+  backendConfig: dev-llm-gateway-backend-config
   port: 8080
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "dev-llm-gateway-backend-config"}'
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: "gce-internal"
+    kubernetes.io/ingress.regional-static-ip-name: "dev-llm-gateway-ilb-ip-address"
+    kubernetes.io/ingress.allow-http: "true"
+  hosts:
+    - paths:
+        - path: /
+          pathType: Prefix
+  tls: []
 
 env:
   - name: OMI_LLM_GATEWAY_PROD

--- a/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
+++ b/backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml
@@ -34,7 +34,11 @@ podLabels: {}
 
 service:
   type: ClusterIP
+  backendConfig: ""
   port: 8080
+
+ingress:
+  enabled: false
 
 env:
   - name: OMI_LLM_GATEWAY_PROD

--- a/backend/charts/llm-gateway/templates/backendconfig.yaml
+++ b/backend/charts/llm-gateway/templates/backendconfig.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.service.backendConfig -}}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ .Values.service.backendConfig }}
+spec:
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    port: {{ .Values.service.port }}
+    type: HTTP
+    requestPath: /health
+{{- end }}

--- a/backend/charts/llm-gateway/templates/ingress.yaml
+++ b/backend/charts/llm-gateway/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.ingress .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - {{- with .host }}
+      host: {{ . | quote }}
+      {{- end }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "llm-gateway.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/backend/charts/llm-gateway/templates/service.yaml
+++ b/backend/charts/llm-gateway/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "llm-gateway.fullname" . }}
   labels:
     {{- include "llm-gateway.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
## Summary
- expose dev llm-gateway through a private GKE internal ingress on reserved IP 172.16.63.232
- add BackendConfig health checks so the ingress uses /health instead of /
- set OMI_LLM_GATEWAY_URL for dev Cloud Run backend services in auto-dev deploys
- keep prod llm-gateway ingress disabled

## Live dev actions already applied
- reserved dev internal IP dev-llm-gateway-ilb-ip-address at 172.16.63.232
- applied dev llm-gateway Service/Ingress/BackendConfig
- verified the GCE ingress backend is HEALTHY
- updated dev Cloud Run services backend, backend-sync, and backend-integration with OMI_LLM_GATEWAY_URL=http://172.16.63.232

## Validation
- PyYAML parsed edited workflow and values files
- git diff --check passed
- pre-push hooks passed
- in-cluster curl to http://172.16.63.232/health returned 200 OK

## Notes
OMI_LLM_GATEWAY_SERVICE_TOKEN is a secret and remains synced via Secret Manager. OMI_LLM_GATEWAY_URL is non-secret runtime config; this PR makes that config explicit for dev Cloud Run instead of relying only on the GKE backend-listen Helm values.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

