### PR TITLE
[codex] Keep update relaunches quiet when backgrounded

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -211,6 +211,9 @@ struct OMIApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   static var openMainWindow: (() -> Void)?
+  private static var appIsActive = false
+  private static var mainWindowIsKey = false
+  private static var lastMainWindowForegroundAt: Date?
 
   private var sentryHeartbeatTimer: Timer?
   private var globalHotkeyMonitor: Any?
@@ -247,14 +250,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
     log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
+    let restoreMainWindowAfterUpdateRelaunch = UpdateRelaunchWindowPolicy.consumePendingRelaunch()
+    if let restoreMainWindowAfterUpdateRelaunch {
+      log(
+        "AppDelegate: Sparkle update relaunch detected; restoreMainWindow=\(restoreMainWindowAfterUpdateRelaunch)"
+      )
+    }
 
     // Refresh the "Auto" realtime-voice model pick from Artificial Analysis (daily, cached).
     AutoModelSelector.shared.refreshIfStale()
 
     // After a Sparkle update, show a small "what's new" card in the corner of the
     // main window once. Delayed so the window/overlay exist to render it.
-    DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-      WhatsNewToast.shared.presentIfUpdated()
+    if restoreMainWindowAfterUpdateRelaunch != false {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+        WhatsNewToast.shared.presentIfUpdated()
+      }
     }
 
     // Proactive notifications are now OFF by default for everyone. Run the one-time
@@ -533,21 +544,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Start Sentry heartbeat timer (every 5 minutes) to capture breadcrumbs periodically
     startSentryHeartbeat()
+    startForegroundTracking()
 
-    // Activate app and show main window after a brief delay
+    // Apply initial main-window policy after SwiftUI has created the window.
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
       log("AppDelegate: Checking windows after 0.2s delay, count=\(NSApp.windows.count)")
-      NSApp.activate()
+      let shouldSuppressMainWindow = restoreMainWindowAfterUpdateRelaunch == false
+      if !shouldSuppressMainWindow {
+        NSApp.activate()
+      }
       var foundOmiWindow = false
       for window in NSApp.windows {
         log("AppDelegate: Window title='\(window.title)', isVisible=\(window.isVisible)")
-        if window.title.hasPrefix("Omi") {
+        if Self.isMainOmiWindow(window) {
           foundOmiWindow = true
-          window.makeKeyAndOrderFront(nil)
           window.appearance = NSAppearance(named: .darkAqua)
           // Ensure fullscreen always creates a dedicated Space
           window.collectionBehavior.insert(.fullScreenPrimary)
-          log("AppDelegate: Main window shown on launch")
+          if shouldSuppressMainWindow {
+            window.orderOut(nil)
+            log("AppDelegate: Main window suppressed after background update relaunch")
+          } else {
+            window.makeKeyAndOrderFront(nil)
+            log("AppDelegate: Main window shown on launch")
+          }
         }
       }
       if !foundOmiWindow {
@@ -570,6 +590,77 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       }
       log("Sentry: Session heartbeat captured")
     }
+  }
+
+  private func startForegroundTracking() {
+    Self.recordForegroundState()
+
+    let center = NotificationCenter.default
+    windowObservers.append(
+      center.addObserver(
+        forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+      ) { _ in
+        Self.recordForegroundState()
+      })
+    windowObservers.append(
+      center.addObserver(
+        forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
+      ) { _ in
+        Self.recordForegroundState()
+      })
+    windowObservers.append(
+      center.addObserver(
+        forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+      ) { _ in
+        Self.recordForegroundState()
+      })
+    windowObservers.append(
+      center.addObserver(
+        forName: NSWindow.didResignKeyNotification, object: nil, queue: .main
+      ) { _ in
+        Self.recordForegroundState()
+      })
+  }
+
+  static func shouldRestoreMainWindowAfterUpdateRelaunch() -> Bool {
+    let readState = {
+      Self.recordForegroundState()
+      return UpdateRelaunchWindowPolicy.shouldRestoreMainWindow(
+        appIsActive: appIsActive,
+        frontmostBundleMatches: frontmostApplicationMatchesBundle(),
+        mainWindowIsKey: mainWindowIsKey,
+        lastMainWindowForegroundAt: lastMainWindowForegroundAt
+      )
+    }
+
+    if Thread.isMainThread {
+      return readState()
+    }
+
+    return DispatchQueue.main.sync(execute: readState)
+  }
+
+  private static func recordForegroundState(now: Date = Date()) {
+    appIsActive = NSApp.isActive
+    mainWindowIsKey = NSApp.keyWindow.map(isMainOmiWindow) ?? false
+
+    if UpdateRelaunchWindowPolicy.shouldRestoreMainWindow(
+      appIsActive: appIsActive,
+      frontmostBundleMatches: frontmostApplicationMatchesBundle(),
+      mainWindowIsKey: mainWindowIsKey,
+      lastMainWindowForegroundAt: nil,
+      now: now
+    ) {
+      lastMainWindowForegroundAt = now
+    }
+  }
+
+  private static func frontmostApplicationMatchesBundle() -> Bool {
+    NSWorkspace.shared.frontmostApplication?.bundleIdentifier == Bundle.main.bundleIdentifier
+  }
+
+  private static func isMainOmiWindow(_ window: NSWindow) -> Bool {
+    window.title.lowercased().hasPrefix("omi")
   }
 
   /// Strip com.apple.provenance extended attributes from our own bundle.

--- a/desktop/macos/Desktop/Sources/UpdateRelaunchWindowPolicy.swift
+++ b/desktop/macos/Desktop/Sources/UpdateRelaunchWindowPolicy.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct UpdateRelaunchWindowPolicy {
+  static let foregroundGraceInterval: TimeInterval = 30
+
+  private static let pendingRelaunchKey = "sparkleUpdateRelaunchPending"
+  private static let restoreMainWindowKey = "sparkleUpdateRelaunchRestoreMainWindow"
+
+  static func shouldRestoreMainWindow(
+    appIsActive: Bool,
+    frontmostBundleMatches: Bool,
+    mainWindowIsKey: Bool,
+    lastMainWindowForegroundAt: Date?,
+    now: Date = Date(),
+    foregroundGraceInterval: TimeInterval = foregroundGraceInterval
+  ) -> Bool {
+    if appIsActive && frontmostBundleMatches && mainWindowIsKey {
+      return true
+    }
+
+    guard let lastMainWindowForegroundAt else {
+      return false
+    }
+
+    return now.timeIntervalSince(lastMainWindowForegroundAt) <= foregroundGraceInterval
+  }
+
+  static func markPendingRelaunch(restoreMainWindow: Bool, defaults: UserDefaults = .standard) {
+    defaults.set(true, forKey: pendingRelaunchKey)
+    defaults.set(restoreMainWindow, forKey: restoreMainWindowKey)
+    defaults.synchronize()
+  }
+
+  static func consumePendingRelaunch(defaults: UserDefaults = .standard) -> Bool? {
+    guard defaults.bool(forKey: pendingRelaunchKey) else {
+      return nil
+    }
+
+    let restoreMainWindow = defaults.bool(forKey: restoreMainWindowKey)
+    defaults.removeObject(forKey: pendingRelaunchKey)
+    defaults.removeObject(forKey: restoreMainWindowKey)
+    defaults.synchronize()
+    return restoreMainWindow
+  }
+}

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -182,6 +182,11 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
   func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
     let version = item.displayVersionString
     logSync("Sparkle: Installing update v\(version)")
+    let restoreMainWindow = AppDelegate.shouldRestoreMainWindowAfterUpdateRelaunch()
+    UpdateRelaunchWindowPolicy.markPendingRelaunch(restoreMainWindow: restoreMainWindow)
+    logSync(
+      "Sparkle: Next launch will \(restoreMainWindow ? "restore" : "suppress") the main window after update"
+    )
     Task { @MainActor in
       AnalyticsManager.shared.updateInstalled(version: version)
       self.viewModel?.updateAvailable = false

--- a/desktop/macos/Desktop/Tests/UpdateRelaunchWindowPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateRelaunchWindowPolicyTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+final class UpdateRelaunchWindowPolicyTests: XCTestCase {
+  func testRestoresWhenMainWindowIsCurrentlyForeground() {
+    XCTAssertTrue(
+      UpdateRelaunchWindowPolicy.shouldRestoreMainWindow(
+        appIsActive: true,
+        frontmostBundleMatches: true,
+        mainWindowIsKey: true,
+        lastMainWindowForegroundAt: nil
+      ))
+  }
+
+  func testSuppressesWhenAppWasNotRecentlyForeground() {
+    let now = Date()
+
+    XCTAssertFalse(
+      UpdateRelaunchWindowPolicy.shouldRestoreMainWindow(
+        appIsActive: false,
+        frontmostBundleMatches: false,
+        mainWindowIsKey: false,
+        lastMainWindowForegroundAt: now.addingTimeInterval(-31),
+        now: now,
+        foregroundGraceInterval: 30
+      ))
+  }
+
+  func testRestoresWhenSparkleTemporarilyTookFocusFromForegroundWindow() {
+    let now = Date()
+
+    XCTAssertTrue(
+      UpdateRelaunchWindowPolicy.shouldRestoreMainWindow(
+        appIsActive: false,
+        frontmostBundleMatches: false,
+        mainWindowIsKey: false,
+        lastMainWindowForegroundAt: now.addingTimeInterval(-5),
+        now: now,
+        foregroundGraceInterval: 30
+      ))
+  }
+
+  func testPendingRelaunchMarkerIsConsumedOnce() {
+    let suiteName = "UpdateRelaunchWindowPolicyTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    UpdateRelaunchWindowPolicy.markPendingRelaunch(restoreMainWindow: false, defaults: defaults)
+
+    XCTAssertEqual(
+      UpdateRelaunchWindowPolicy.consumePendingRelaunch(defaults: defaults),
+      false
+    )
+    XCTAssertNil(UpdateRelaunchWindowPolicy.consumePendingRelaunch(defaults: defaults))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260628-quiet-update-relaunch.json
+++ b/desktop/macos/changelog/unreleased/20260628-quiet-update-relaunch.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved automatic updates so the main window only reopens when omi was already in the foreground"
+}


### PR DESCRIPTION
## Summary

- Record whether the main Omi window was foregrounded when Sparkle begins installing an update.
- On the post-update relaunch, restore the main window only if it was foregrounded or very recently foregrounded; otherwise keep the app/menu-bar process alive and order the main window out.
- Add focused policy tests and a desktop changelog fragment.

## Validation

- `xcrun swift test --package-path desktop/macos/Desktop --filter UpdateRelaunchWindowPolicyTests`
- `xcrun swift build -c debug --package-path Desktop`
- Launched named bundle `omi-quiet-update` with the update-relaunch marker set to suppress the window; verified automation bridge stayed alive and logs showed `restoreMainWindow=false` plus `Main window suppressed after background update relaunch`.
- Pre-push checks passed, including desktop changelog validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

