### PR TITLE
Add backend runtime env validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Helm charts: `backend/charts/{backend-listen,pusher,diarizer,vad,deepgram-self-h
 - **backend-sync** (`main.py`, same image as backend) — Cloud Run service for `/v2/sync-local-files`. When `SYNC_DISPATCH_MODE=cloud_tasks`: stages raw audio in GCS, enqueues to Cloud Tasks queue `sync-jobs`, which POSTs `/v2/sync-jobs/run` (OIDC-verified, `utils/cloud_tasks.py`) to run decode→VAD→STT inside a request. Inline fallback when the flag is off, env is incomplete, BYOK headers are present, or enqueue fails. Audio playback merges (`/v1/sync/audio/*`) follow the same pattern via queue `audio-merge` building 30-day MP3 artifacts under `playback/` (`AUDIO_MERGE_DISPATCH_MODE`).
 - **notifications-job** (`modal/job.py`) — Cron job, reads Firestore/Redis, sends push notifications.
 
+Backend runtime env contract: keep `backend/deploy/runtime_env.yaml` aligned with GKE Helm values and Cloud Run runtime env; run `python backend/scripts/validate-backend-runtime-env.py --env <dev|prod>` after backend runtime env changes.
+
 Keep this map up to date. When adding, removing, or changing inter-service calls, update this section. If a PR changes audio streaming, transcription, conversation lifecycle, speaker identification, or the listen/pusher WebSocket protocol — update `docs/doc/developer/backend/listen_pusher_pipeline.mdx` in the same PR.
 
 ### App (Flutter)

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1,0 +1,117 @@
+schema_version: 1
+
+environments:
+  dev:
+    gcp_project: based-hardware-dev
+    region: us-central1
+    gke:
+      backend-listen:
+        values_file: backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+        env:
+          OMI_LLM_GATEWAY_URL:
+            value: http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080
+            category: service_discovery
+          OMI_LLM_GATEWAY_SERVICE_TOKEN:
+            secret:
+              name: dev-omi-backend-secrets
+              key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    cloud_run:
+      services:
+        backend:
+          env:
+            GOOGLE_CLOUD_PROJECT:
+              value: based-hardware
+            OMI_LLM_GATEWAY_URL:
+              value: http://172.16.63.232
+              category: service_discovery
+          secrets:
+            SERVICE_ACCOUNT_JSON:
+              secret: SERVICE_ACCOUNT_JSON
+              version: latest
+            ENCRYPTION_SECRET:
+              secret: ENCRYPTION_SECRET
+              version: latest
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+        backend-sync:
+          env:
+            GOOGLE_CLOUD_PROJECT:
+              value: based-hardware
+            OMI_LLM_GATEWAY_URL:
+              value: http://172.16.63.232
+              category: service_discovery
+          secrets:
+            SERVICE_ACCOUNT_JSON:
+              secret: SERVICE_ACCOUNT_JSON
+              version: latest
+            ENCRYPTION_SECRET:
+              secret: ENCRYPTION_SECRET
+              version: latest
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+        backend-integration:
+          env:
+            GOOGLE_CLOUD_PROJECT:
+              value: based-hardware
+            OMI_LLM_GATEWAY_URL:
+              value: http://172.16.63.232
+              category: service_discovery
+          secrets:
+            SERVICE_ACCOUNT_JSON:
+              secret: SERVICE_ACCOUNT_JSON
+              version: latest
+            ENCRYPTION_SECRET:
+              secret: ENCRYPTION_SECRET
+              version: latest
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+
+  prod:
+    gcp_project: based-hardware
+    region: us-central1
+    gke:
+      backend-listen:
+        values_file: backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+        env:
+          OMI_LLM_GATEWAY_URL:
+            value: http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080
+            category: service_discovery
+          OMI_LLM_GATEWAY_SERVICE_TOKEN:
+            secret:
+              name: prod-omi-backend-secrets
+              key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+    cloud_run:
+      services:
+        backend:
+          env:
+            OMI_LLM_GATEWAY_URL:
+              value: TBD_STABLE_PRIVATE_ENDPOINT
+              category: service_discovery
+              provisional: true
+          secrets:
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+        backend-sync:
+          env:
+            OMI_LLM_GATEWAY_URL:
+              value: TBD_STABLE_PRIVATE_ENDPOINT
+              category: service_discovery
+              provisional: true
+          secrets:
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+        backend-integration:
+          env:
+            OMI_LLM_GATEWAY_URL:
+              value: TBD_STABLE_PRIVATE_ENDPOINT
+              category: service_discovery
+              provisional: true
+          secrets:
+            OMI_LLM_GATEWAY_SERVICE_TOKEN:
+              secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / 'backend/deploy/runtime_env.yaml'
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    scope: str
+    message: str
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Validate backend runtime env manifests against checked-in GKE config and Cloud Run state.'
+    )
+    parser.add_argument('--env', choices=('dev', 'prod'), required=True)
+    parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        '--cloud-run-state',
+        type=Path,
+        help='Offline Cloud Run state JSON. Shape: {"services": {"backend": {"env": [...]} }}.',
+    )
+    parser.add_argument(
+        '--check-live-cloud-run',
+        action='store_true',
+        help='Fetch Cloud Run service state with gcloud and validate required env/secrets.',
+    )
+    parser.add_argument(
+        '--strict-provisional',
+        action='store_true',
+        help='Require provisional manifest values to match exactly. By default they only require presence.',
+    )
+    args = parser.parse_args()
+
+    errors = validate_runtime_env(
+        env=args.env,
+        manifest_path=args.manifest,
+        cloud_run_state_path=args.cloud_run_state,
+        check_live_cloud_run=args.check_live_cloud_run,
+        strict_provisional=args.strict_provisional,
+    )
+    for error in errors:
+        print(f'ERROR [{error.scope}]: {error.message}', file=sys.stderr)
+    if errors:
+        return 1
+    print(f'backend runtime env validation passed for {args.env}')
+    return 0
+
+
+def validate_runtime_env(
+    *,
+    env: str,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    cloud_run_state_path: Path | None = None,
+    check_live_cloud_run: bool = False,
+    strict_provisional: bool = False,
+) -> list[ValidationError]:
+    manifest = _load_yaml(manifest_path)
+    env_config = _get_env_config(manifest, env)
+    errors = _validate_manifest_shape(env_config, env)
+    if errors:
+        return errors
+
+    errors.extend(_validate_gke(env_config, strict_provisional=strict_provisional))
+
+    cloud_run_state = None
+    if cloud_run_state_path is not None:
+        cloud_run_state = _load_json(cloud_run_state_path)
+    elif check_live_cloud_run:
+        cloud_run_state = _fetch_live_cloud_run_state(env_config)
+
+    if cloud_run_state is not None:
+        errors.extend(_validate_cloud_run(env_config, cloud_run_state, strict_provisional=strict_provisional))
+    return errors
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = yaml.safe_load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f'{path} must contain a YAML mapping')
+    return loaded
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f'{path} must contain a JSON object')
+    return loaded
+
+
+def _get_env_config(manifest: dict[str, Any], env: str) -> dict[str, Any]:
+    environments = manifest.get('environments')
+    if not isinstance(environments, dict) or env not in environments:
+        raise ValueError(f'manifest has no environments.{env}')
+    env_config = environments[env]
+    if not isinstance(env_config, dict):
+        raise ValueError(f'environments.{env} must be a mapping')
+    return env_config
+
+
+def _validate_manifest_shape(env_config: dict[str, Any], env: str) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    for key in ('gcp_project', 'region', 'gke', 'cloud_run'):
+        if key not in env_config:
+            errors.append(ValidationError(env, f'missing {key}'))
+    cloud_run_services = env_config.get('cloud_run', {}).get('services')
+    if not isinstance(cloud_run_services, dict) or not cloud_run_services:
+        errors.append(ValidationError(env, 'cloud_run.services must be a non-empty mapping'))
+    return errors
+
+
+def _validate_gke(env_config: dict[str, Any], *, strict_provisional: bool) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    for service, service_config in env_config.get('gke', {}).items():
+        values_file = ROOT / service_config['values_file']
+        values = _load_yaml(values_file)
+        actual_env = _env_entries_by_name(values.get('env', []))
+        errors.extend(
+            _validate_env_entries(
+                scope=f'gke/{service}',
+                expected=service_config.get('env', {}),
+                actual=actual_env,
+                strict_provisional=strict_provisional,
+            )
+        )
+    return errors
+
+
+def _validate_cloud_run(
+    env_config: dict[str, Any],
+    cloud_run_state: dict[str, Any],
+    *,
+    strict_provisional: bool,
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    state_services = cloud_run_state.get('services')
+    if not isinstance(state_services, dict):
+        return [ValidationError('cloud_run', 'state must contain services mapping')]
+
+    for service, service_config in env_config['cloud_run']['services'].items():
+        service_state = state_services.get(service)
+        if not isinstance(service_state, dict):
+            errors.append(ValidationError(f'cloud_run/{service}', 'missing service state'))
+            continue
+        actual_env = _env_entries_by_name(service_state.get('env', []))
+        errors.extend(
+            _validate_env_entries(
+                scope=f'cloud_run/{service}',
+                expected=service_config.get('env', {}),
+                actual=actual_env,
+                strict_provisional=strict_provisional,
+            )
+        )
+        errors.extend(
+            _validate_cloud_run_secret_entries(
+                scope=f'cloud_run/{service}',
+                expected=service_config.get('secrets', {}),
+                actual=actual_env,
+            )
+        )
+    return errors
+
+
+def _validate_env_entries(
+    *,
+    scope: str,
+    expected: dict[str, Any],
+    actual: dict[str, dict[str, Any]],
+    strict_provisional: bool,
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    for name, expected_entry in expected.items():
+        actual_entry = actual.get(name)
+        if actual_entry is None:
+            errors.append(ValidationError(scope, f'missing env {name}'))
+            continue
+        if 'value' in expected_entry:
+            if expected_entry.get('provisional') and not strict_provisional:
+                if not _has_literal_value(actual_entry):
+                    errors.append(ValidationError(scope, f'env {name} must have a literal value'))
+                continue
+            actual_value = actual_entry.get('value')
+            expected_value = str(expected_entry['value'])
+            if actual_value != expected_value:
+                errors.append(ValidationError(scope, f'env {name} value mismatch: expected {expected_value!r}'))
+        elif 'secret' in expected_entry:
+            expected_secret = expected_entry['secret']
+            actual_secret = _secret_ref(actual_entry)
+            if actual_secret != expected_secret:
+                errors.append(ValidationError(scope, f'env {name} secret mismatch: expected {expected_secret!r}'))
+    return errors
+
+
+def _validate_cloud_run_secret_entries(
+    *,
+    scope: str,
+    expected: dict[str, Any],
+    actual: dict[str, dict[str, Any]],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    for name, expected_entry in expected.items():
+        actual_entry = actual.get(name)
+        if actual_entry is None:
+            errors.append(ValidationError(scope, f'missing secret binding {name}'))
+            continue
+        actual_secret = _cloud_run_secret_ref(actual_entry)
+        expected_secret = {
+            'secret': expected_entry['secret'],
+            'version': str(expected_entry.get('version', 'latest')),
+        }
+        if actual_secret != expected_secret:
+            errors.append(ValidationError(scope, f'secret binding {name} mismatch: expected {expected_secret!r}'))
+    return errors
+
+
+def _env_entries_by_name(raw_env: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw_env, list):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for entry in raw_env:
+        if isinstance(entry, dict) and isinstance(entry.get('name'), str):
+            result[entry['name']] = entry
+    return result
+
+
+def _has_literal_value(entry: dict[str, Any]) -> bool:
+    return entry.get('value') not in (None, '')
+
+
+def _secret_ref(entry: dict[str, Any]) -> dict[str, str] | None:
+    value_from = entry.get('valueFrom')
+    if not isinstance(value_from, dict):
+        return None
+    secret_ref = value_from.get('secretKeyRef')
+    if not isinstance(secret_ref, dict):
+        return None
+    name = secret_ref.get('name')
+    key = secret_ref.get('key')
+    if not isinstance(name, str) or not isinstance(key, str):
+        return None
+    return {'name': name, 'key': key}
+
+
+def _cloud_run_secret_ref(entry: dict[str, Any]) -> dict[str, str] | None:
+    value_from = entry.get('valueFrom')
+    if not isinstance(value_from, dict):
+        return None
+    secret_key_ref = value_from.get('secretKeyRef')
+    if isinstance(secret_key_ref, dict):
+        name = secret_key_ref.get('name')
+        version = secret_key_ref.get('key', 'latest')
+        if isinstance(name, str):
+            return {'secret': name, 'version': str(version)}
+    secret_ref = value_from.get('secretRef')
+    if isinstance(secret_ref, dict):
+        name = secret_ref.get('name')
+        version = secret_ref.get('version', 'latest')
+        if isinstance(name, str):
+            return {'secret': name, 'version': str(version)}
+    return None
+
+
+def _fetch_live_cloud_run_state(env_config: dict[str, Any]) -> dict[str, Any]:
+    services: dict[str, Any] = {}
+    project = env_config['gcp_project']
+    region = env_config['region']
+    for service in env_config['cloud_run']['services']:
+        command = [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            service,
+            f'--project={project}',
+            f'--region={region}',
+            '--format=json',
+        ]
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        service_state = json.loads(result.stdout)
+        services[service] = {
+            'env': service_state.get('spec', {})
+            .get('template', {})
+            .get('spec', {})
+            .get('containers', [{}])[0]
+            .get('env', [])
+        }
+    return {'services': services}
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -59,6 +59,7 @@ pytest tests/unit/test_llm_gateway_client_config.py -v
 pytest tests/unit/test_llm_gateway_route_refs.py -v
 pytest tests/unit/test_llm_gateway_dependencies.py -v
 pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
+pytest tests/unit/test_backend_runtime_env_validator.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_llm_provider_plugin_structure.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / 'scripts/validate-backend-runtime-env.py'
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location('validate_backend_runtime_env', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_yaml(path: Path, payload: dict) -> None:
+    with path.open('w', encoding='utf-8') as handle:
+        yaml.safe_dump(payload, handle, sort_keys=False)
+
+
+def test_repo_gke_values_match_manifest():
+    validator = load_validator()
+
+    errors = validator.validate_runtime_env(env='dev')
+
+    assert errors == []
+
+
+def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
+    validator = load_validator()
+    state_path = tmp_path / 'cloud_run_state.json'
+    state_path.write_text(
+        '''
+{
+  "services": {
+    "backend": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    },
+    "backend-sync": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    },
+    "backend-integration": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    }
+  }
+}
+''',
+        encoding='utf-8',
+    )
+
+    errors = validator.validate_runtime_env(env='dev', cloud_run_state_path=state_path)
+
+    assert [error.message for error in errors] == ['missing env OMI_LLM_GATEWAY_URL']
+    assert errors[0].scope == 'cloud_run/backend'
+
+
+def test_cloud_run_state_accepts_secret_bindings(tmp_path):
+    validator = load_validator()
+    state_path = tmp_path / 'cloud_run_state.json'
+    state_path.write_text(
+        '''
+{
+  "services": {
+    "backend": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    },
+    "backend-sync": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    },
+    "backend-integration": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    }
+  }
+}
+''',
+        encoding='utf-8',
+    )
+
+    errors = validator.validate_runtime_env(env='dev', cloud_run_state_path=state_path)
+
+    assert errors == []
+
+
+def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
+    validator = load_validator()
+    state_path = tmp_path / 'cloud_run_state.json'
+    state_path.write_text(
+        '''
+{
+  "services": {
+    "backend": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "1"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}
+      ]
+    },
+    "backend-sync": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}
+      ]
+    },
+    "backend-integration": {
+      "env": [
+        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
+        {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},
+        {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}
+      ]
+    }
+  }
+}
+''',
+        encoding='utf-8',
+    )
+
+    errors = validator.validate_runtime_env(env='dev', cloud_run_state_path=state_path)
+
+    assert len(errors) == 1
+    assert errors[0].scope == 'cloud_run/backend'
+    assert errors[0].message == (
+        "secret binding SERVICE_ACCOUNT_JSON mismatch: "
+        "expected {'secret': 'SERVICE_ACCOUNT_JSON', 'version': 'latest'}"
+    )
+
+
+def test_provisional_prod_endpoint_requires_presence_but_not_exact_value(tmp_path):
+    validator = load_validator()
+    values_file = tmp_path / 'prod_backend_listen.yaml'
+    write_yaml(
+        values_file,
+        {
+            'env': [
+                {
+                    'name': 'OMI_LLM_GATEWAY_URL',
+                    'value': 'http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080',
+                },
+                {
+                    'name': 'OMI_LLM_GATEWAY_SERVICE_TOKEN',
+                    'valueFrom': {
+                        'secretKeyRef': {
+                            'name': 'prod-omi-backend-secrets',
+                            'key': 'OMI_LLM_GATEWAY_SERVICE_TOKEN',
+                        }
+                    },
+                },
+            ]
+        },
+    )
+    manifest_path = tmp_path / 'runtime_env.yaml'
+    write_yaml(
+        manifest_path,
+        {
+            'schema_version': 1,
+            'environments': {
+                'prod': {
+                    'gcp_project': 'based-hardware',
+                    'region': 'us-central1',
+                    'gke': {
+                        'backend-listen': {
+                            'values_file': str(values_file),
+                            'env': {
+                                'OMI_LLM_GATEWAY_URL': {
+                                    'value': 'http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080'
+                                },
+                                'OMI_LLM_GATEWAY_SERVICE_TOKEN': {
+                                    'secret': {
+                                        'name': 'prod-omi-backend-secrets',
+                                        'key': 'OMI_LLM_GATEWAY_SERVICE_TOKEN',
+                                    }
+                                },
+                            },
+                        }
+                    },
+                    'cloud_run': {
+                        'services': {
+                            'backend': {
+                                'env': {
+                                    'OMI_LLM_GATEWAY_URL': {
+                                        'value': 'TBD_STABLE_PRIVATE_ENDPOINT',
+                                        'provisional': True,
+                                    }
+                                },
+                                'secrets': {
+                                    'OMI_LLM_GATEWAY_SERVICE_TOKEN': {
+                                        'secret': 'OMI_LLM_GATEWAY_SERVICE_TOKEN',
+                                        'version': 'latest',
+                                    }
+                                },
+                            }
+                        }
+                    },
+                }
+            },
+        },
+    )
+    state_path = tmp_path / 'cloud_run_state.json'
+    state_path.write_text(
+        '''
+{
+  "services": {
+    "backend": {
+      "env": [
+        {"name": "OMI_LLM_GATEWAY_URL", "value": "http://stable-private-endpoint"},
+        {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
+      ]
+    }
+  }
+}
+''',
+        encoding='utf-8',
+    )
+
+    errors = validator.validate_runtime_env(
+        env='prod',
+        manifest_path=manifest_path,
+        cloud_run_state_path=state_path,
+    )
+
+    assert errors == []

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -210,6 +210,27 @@ python backend/scripts/validate-llm-gateway-env.py \
   backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml
 ```
 
+Backend runtime env also has a cross-plane validator backed by
+`backend/deploy/runtime_env.yaml`. Run it without Cloud Run state to validate
+checked-in GKE config against the manifest:
+
+```bash
+python backend/scripts/validate-backend-runtime-env.py --env dev
+```
+
+Run it against live Cloud Run revisions before traffic shift when changing
+backend runtime env, secret bindings, or internal service discovery:
+
+```bash
+python backend/scripts/validate-backend-runtime-env.py --env dev --check-live-cloud-run
+```
+
+The manifest separates checked-in non-secret values, checked-in secret binding
+names, and platform-specific service discovery. Secret values stay in Secret
+Manager. Provisional values mark known migration gaps that require presence but
+do not yet have a final stable endpoint; use `--strict-provisional` once the
+endpoint is finalized.
+
 Post-deploy smoke check, from inside the GKE network or a pod with cluster DNS access:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `backend/deploy/runtime_env.yaml` as the first canonical backend runtime env manifest.
- Add `backend/scripts/validate-backend-runtime-env.py` to validate manifest entries against checked-in GKE Helm values and optional Cloud Run state/live revisions.
- Document the validator in the LLM Gateway docs and AGENTS, and include the focused unit test in `backend/test.sh`.

This is validator-first only. It does not render deploy config or change deploy behavior yet; follow-up rendering/generation work is tracked in #8517.

## Validation

- `cd backend && pytest tests/unit/test_backend_runtime_env_validator.py -q`
- `python -m py_compile backend/scripts/validate-backend-runtime-env.py`
- `python backend/scripts/validate-backend-runtime-env.py --env dev`
- `python backend/scripts/validate-backend-runtime-env.py --env prod`
- `python backend/scripts/validate-backend-runtime-env.py --env dev --check-live-cloud-run`
- `python backend/scripts/validate-llm-gateway-env.py backend/charts/backend-listen/dev_omi_backend_listen_values.yaml backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml`
- `python backend/scripts/validate-llm-gateway-env.py backend/charts/backend-listen/prod_omi_backend_listen_values.yaml backend/charts/llm-gateway/prod_omi_llm_gateway_values.yaml`
- `git diff --check`
- pre-push hooks passed

Known current drift, intentionally surfaced by the new command:

- `python backend/scripts/validate-backend-runtime-env.py --env prod --check-live-cloud-run` fails because prod Cloud Run `backend`, `backend-sync`, and `backend-integration` are missing `OMI_LLM_GATEWAY_URL` and `OMI_LLM_GATEWAY_SERVICE_TOKEN` bindings.

## Review

An independent subagent reviewed the uncommitted patch before this PR. It found one issue: Cloud Run secret validation compared only the secret name, not the version/key. This PR fixes that by modeling Cloud Run secret bindings as `{secret, version}` and defaulting expected versions to `latest`, with a regression test for old pinned versions.

Closes part of #8515.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

