### PR TITLE
Allow email login for MCP OAuth review

### DIFF
--- a/backend/templates/mcp_oauth_authorize.html
+++ b/backend/templates/mcp_oauth_authorize.html
@@ -114,7 +114,7 @@
         firebase.initializeApp(firebaseConfig);
 
         let idToken = null;
-        const signInOptions = [firebase.auth.GoogleAuthProvider.PROVIDER_ID];
+        const signInOptions = [firebase.auth.EmailAuthProvider.PROVIDER_ID, firebase.auth.GoogleAuthProvider.PROVIDER_ID];
         if (/Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
             signInOptions.push('apple.com');
         }


### PR DESCRIPTION
## Summary
- Adds Email/Password as a FirebaseUI sign-in option on the hosted MCP OAuth consent page.
- Keeps Google sign-in and the existing Apple-on-Apple-platforms behavior intact.
- Enables deterministic ChatGPT app review using the seeded Omi review account instead of requiring Google/Apple setup.

## Validation
- `PYTHONPATH=backend pytest -q backend/tests/unit/test_mcp_oauth.py backend/tests/unit/test_mcp_data_endpoints.py`
- `git diff --check origin/main..HEAD`
- Verified Firebase email/password sign-in for `chatgpt-review@omi.me` succeeds.
- Seeded review account data in prod Firebase/Firestore/Pinecone and verified both seeded vector searches return rank 0:
  - memory id `review-weekly-planning-mondays`
  - conversation id `review-fundraising-may-2026`
- Verified dev OAuth authorize/token exchange succeeds with the review account.

## Production rollout note
Production currently still needs a backend deployment before reviewer traffic will work. The current production endpoint returns `405 Method Not Allowed` for `POST https://api.omi.me/authorize`, which indicates the merged MCP OAuth backend code is not live there yet. After this PR is merged, deploy prod and repeat the production OAuth smoke test before resubmitting the ChatGPT app.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

