### PR TITLE
Fix Omi Beta chat control tool schemas

### DIFF
--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -767,6 +767,23 @@ describe("agent control tools", () => {
     store.close();
   });
 
+  it("validates artifact inspection selectors before control tool dispatch", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath());
+
+    const invalid = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "inspect_agent_artifacts", {}),
+    );
+
+    expect(invalid).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_tool_input",
+      },
+    });
+    expect(invalid.error.message).toContain("artifactId, sessionId, runId, or attemptId");
+    store.close();
+  });
+
   it("filters persisted artifacts by session, run, attempt, and role", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     const first = await kernel.executeRun(baseRunInput);

--- a/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
+++ b/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Omi Beta desktop chat failing before answering when agent control tools are available."
+}

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -983,10 +983,13 @@ test("OMI_TOOLS: TypeBox schemas have additionalProperties=false", () => {
   }
 });
 
-test("OMI_TOOLS: provider schemas do not invent top-level oneOf", () => {
+test("OMI_TOOLS: provider schemas do not advertise unsupported top-level composites", () => {
+  const unsupportedTopLevelKeys = ["anyOf", "allOf", "oneOf", "if", "then"] as const;
   for (const tool of OMI_TOOLS) {
     const parameters = tool.parameters as any;
-    assert.equal(parameters.oneOf, undefined, `${tool.name} has top-level oneOf`);
+    for (const key of unsupportedTopLevelKeys) {
+      assert.equal(parameters[key], undefined, `${tool.name} has top-level ${key}`);
+    }
   }
 });
 
@@ -1037,23 +1040,18 @@ test("OMI_TOOLS: top-level schemas keep the object contract", () => {
   }
 });
 
-test("OMI_TOOLS: agent control schemas preserve top-level composite preconditions", () => {
+test("OMI_TOOLS: agent control schemas keep runtime precondition guidance without top-level composites", () => {
   const inspectArtifacts = OMI_TOOLS.find((tool) => tool.name === "inspect_agent_artifacts");
-  assert.deepEqual((inspectArtifacts?.parameters as any).anyOf, [
-    { required: ["artifactId"] },
-    { required: ["sessionId"] },
-    { required: ["runId"] },
-    { required: ["attemptId"] },
-  ]);
+  assert.equal((inspectArtifacts?.parameters as any).anyOf, undefined);
   assert.match(inspectArtifacts?.description ?? "", /session, run, or attempt/);
+  assert.ok(
+    inspectArtifacts?.promptGuidelines?.some((guideline) =>
+      guideline.includes("get_agent_run")
+    ),
+  );
 
   const delegateAgent = OMI_TOOLS.find((tool) => tool.name === "delegate_agent");
-  assert.deepEqual((delegateAgent?.parameters as any).allOf, [
-    {
-      if: { properties: { mode: { const: "continue" } }, required: ["mode"] },
-      then: { required: ["childSessionId"] },
-    },
-  ]);
+  assert.equal((delegateAgent?.parameters as any).allOf, undefined);
   assert.ok(
     delegateAgent?.promptGuidelines?.some((guideline) =>
       guideline.includes("Use call for a structured child result")
@@ -1101,8 +1099,8 @@ test("OMI_TOOLS: agent control tools match canonical capability manifest", () =>
       [...manifestTool.required].sort(),
       `${manifestTool.name} required fields drifted`
     );
-    assert.deepEqual((tool!.parameters as any).anyOf, manifestTool.jsonSchemaOptions?.anyOf, `${manifestTool.name} anyOf drifted`);
-    assert.deepEqual((tool!.parameters as any).allOf, manifestTool.jsonSchemaOptions?.allOf, `${manifestTool.name} allOf drifted`);
+    assert.equal((tool!.parameters as any).anyOf, undefined, `${manifestTool.name} should not advertise top-level anyOf`);
+    assert.equal((tool!.parameters as any).allOf, undefined, `${manifestTool.name} should not advertise top-level allOf`);
 
     for (const [propertyName, manifestProperty] of Object.entries(manifestTool.properties)) {
       const property = (tool!.parameters as any).properties[propertyName];

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -671,10 +671,9 @@ function omiManifestTool(tool: OmiToolManifestEntry) {
 
 function schemaOptionsForInputSchema(schema: OmiToolInputSchema): Record<string, unknown> {
   const options: Record<string, unknown> = {};
-  for (const key of ["anyOf", "allOf", "oneOf", "if", "then"] as const) {
-    const value = schema[key];
-    if (value !== undefined) options[key] = value;
-  }
+  // Provider-facing custom tool input schemas reject root-level composite
+  // keywords. Keep selector preconditions in runtime control validation.
+  void schema;
   return options;
 }
 


### PR DESCRIPTION
## Summary
- Stop pi-mono from advertising root-level `anyOf`/`allOf`/`oneOf`/`if`/`then` in Omi custom tool schemas.
- Keep the agent-control selector rules in runtime validation, including missing artifact selectors and `delegate_agent` continue-mode `childSessionId`.
- Add a desktop changelog fragment for the Beta chat failure.

## Root Cause
Omi Beta desktop chat registers Omi tools through the pi-mono extension, which projects the canonical Omi tool manifest into TypeBox `parameters`. The canonical control manifest includes root-level schema combinators for `inspect_agent_artifacts` and `delegate_agent`; pi-mono copied those onto provider-facing custom tool schemas. The provider rejects top-level `oneOf`/`allOf`/`anyOf`, so chat failed before an answer. This path is local pi-mono/Claude bridge tool registration, not LLM gateway traffic.

## Validation
- `npm test` in `desktop/macos/pi-mono-extension`
- `npm test -- --run tests/control-tools.test.ts tests/omi-tool-manifest.test.ts` in `desktop/macos/agent`
- `npm test` in `desktop/macos/agent`
- `npm run build` in `desktop/macos/agent`
- `python3 .github/scripts/desktop-changelog.py validate`
- pre-push hook fast checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

