### PR TITLE
Harden desktop tool surface drift checks

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2043,25 +2043,9 @@ workflows:
         script: |
           scripts/prepare-agent-runtime.sh --universal-node
 
-      - name: Test pi-mono-extension denylist classifier
+      - name: Test desktop tool surfaces
         script: |
-          # Run the pi-mono-extension unit tests so a `classifyBash()` /
-          # `classifyFileWrite()` / audit-log fail-safe regression fails the
-          # Mac app build before the tagged release is cut. The tests live
-          # in `pi-mono-extension/index.test.ts` and use node:test + the
-          # `--experimental-strip-types` flag that ships in Node 22+. We
-          # avoid a hard dependency on the codemagic runner's Node version
-          # by using `npx tsx` as a version-agnostic TypeScript loader that
-          # still delegates to node:test.
-          cd pi-mono-extension
-          npm ci --no-fund --no-audit
-          if node --experimental-strip-types --test index.test.ts; then
-            echo "pi-mono-extension tests passed (native Node --experimental-strip-types)"
-          else
-            echo "Falling back to npx tsx for older Node versions..."
-            npx --yes tsx@4.19.2 --test index.test.ts
-          fi
-          cd ..
+          scripts/test-tool-surfaces.sh
 
       - name: Prepare universal ffmpeg (arm64 + x86_64)
         script: |
@@ -2374,6 +2358,7 @@ workflows:
             mkdir -p "$APP_BUNDLE/Contents/Resources/agent/src/runtime"
             cp -f agent/src/runtime/control-tool-manifest.js "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
             cp -f agent/src/runtime/control-tool-manifest.ts "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
+            cp -f agent/src/runtime/node-tools.ts "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
             cp -f agent/src/runtime/omi-tool-manifest.ts "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
           else
             echo "ERROR: agent/dist not found"

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -10,9 +10,8 @@
 import { createInterface } from "readline";
 import { createConnection } from "net";
 import { readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
 import { isAgentControlToolName } from "./runtime/control-tools.js";
+import { loadSkillInstructions } from "./runtime/node-tools.js";
 import {
   buildToolAvailabilitySnapshot,
   mcpToolDefinitionsForAdapter,
@@ -361,27 +360,7 @@ async function handleJsonRpc(
         }
       } else if (toolName === "load_skill") {
         const name = (args.name as string || "").trim();
-        const workspace = process.env.OMI_WORKSPACE || "";
-        const candidates = [
-          workspace ? join(workspace, ".claude", "skills", name, "SKILL.md") : "",
-          join(homedir(), ".claude", "skills", name, "SKILL.md"),
-        ].filter(Boolean);
-
-        let content: string | null = null;
-        for (const filePath of candidates) {
-          try {
-            content = readFileSync(filePath, "utf8");
-            logErr(`load_skill: loaded '${name}' from ${filePath}`);
-            break;
-          } catch {
-            // not at this path, try next
-          }
-        }
-
-        // For dev-mode, prepend workspace path so Claude has that context
-        if (content && name === "dev-mode" && workspace) {
-          content = `Workspace: ${workspace}\n\n${content}`;
-        }
+        const content = await loadSkillInstructions(name);
 
         if (!isNotification) {
           send({
@@ -390,7 +369,7 @@ async function handleJsonRpc(
             result: {
               content: [{
                 type: "text",
-                text: content ?? `Skill '${name}' not found. Check the name matches one listed in <available_skills>.`,
+                text: content,
               }],
             },
           });

--- a/desktop/macos/agent/src/runtime/control-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/control-tool-manifest.ts
@@ -9,6 +9,14 @@ export interface AgentControlManifestProperty {
 
 export type AgentControlSurface = "desktopChat" | "realtimeHub";
 
+export interface AgentControlMcpInputSchemaOptions {
+  anyOf?: unknown[];
+  allOf?: unknown[];
+  oneOf?: unknown[];
+  if?: unknown;
+  then?: unknown;
+}
+
 export interface AgentControlManifestTool {
   name:
     | "list_agent_sessions"
@@ -28,7 +36,7 @@ export interface AgentControlManifestTool {
   timeoutClass: AgentControlTimeoutClass;
   properties: Record<string, AgentControlManifestProperty>;
   required: string[];
-  jsonSchemaOptions?: Record<string, unknown>;
+  mcpInputSchemaOptions?: AgentControlMcpInputSchemaOptions;
 }
 
 export const agentControlCapabilityManifest = [
@@ -139,7 +147,7 @@ Returns metadata and references only. It does not read arbitrary artifact conten
       limit: { type: "number", description: "Maximum artifacts to return. Default 50, max 200." },
     },
     required: [],
-    jsonSchemaOptions: {
+    mcpInputSchemaOptions: {
       anyOf: [
         { required: ["artifactId"] },
         { required: ["sessionId"] },
@@ -255,7 +263,7 @@ Supports call, spawn, and continue modes. Child context is intentionally minimal
       metadata: { type: "object", description: "Small structured metadata for the child run.", additionalProperties: true },
     },
     required: ["mode", "parentRunId", "objective"],
-    jsonSchemaOptions: {
+    mcpInputSchemaOptions: {
       allOf: [
         {
           if: { properties: { mode: { const: "continue" } }, required: ["mode"] },

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -10,8 +10,9 @@ const artifactRoleSchema = z.enum(["input", "result", "checkpoint", "tool_output
 const artifactLifecycleStateSchema = z.enum(["retained", "dismissed", "opened"]);
 const runModeSchema = z.enum(["ask", "act"]);
 const delegationModeSchema = z.enum(["call", "spawn", "continue"]);
+const strictObject = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict();
 
-const listAgentSessionsSchema = z.object({
+const listAgentSessionsSchema = strictObject({
   ownerId: z.string().min(1).optional(),
   status: sessionStatusSchema.optional(),
   surfaceKind: agentSurfaceKindSchema.optional(),
@@ -19,20 +20,20 @@ const listAgentSessionsSchema = z.object({
   beforeUpdatedAtMs: z.coerce.number().int().positive().optional(),
 });
 
-const getAgentRunSchema = z.object({
+const getAgentRunSchema = strictObject({
   runId: z.string().min(1),
   ownerId: z.string().min(1).optional(),
   includeEvents: z.boolean().default(true),
   eventLimit: z.coerce.number().int().positive().max(500).default(100),
 });
 
-const cancelAgentRunSchema = z.object({
+const cancelAgentRunSchema = strictObject({
   runId: z.string().min(1),
   ownerId: z.string().min(1).optional(),
 });
 
 const inspectAgentArtifactsSchema = z
-  .object({
+  .strictObject({
     artifactId: z.string().min(1).optional(),
     sessionId: z.string().min(1).optional(),
     runId: z.string().min(1).optional(),
@@ -45,7 +46,7 @@ const inspectAgentArtifactsSchema = z
     message: "Provide artifactId, sessionId, runId, or attemptId",
   });
 
-const updateAgentArtifactLifecycleSchema = z.object({
+const updateAgentArtifactLifecycleSchema = strictObject({
   artifactId: z.string().min(1),
   state: artifactLifecycleStateSchema,
   sessionId: z.string().min(1).optional(),
@@ -56,7 +57,7 @@ const updateAgentArtifactLifecycleSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 
-const sendAgentMessageSchema = z.object({
+const sendAgentMessageSchema = strictObject({
   sessionId: z.string().min(1),
   ownerId: z.string().min(1).optional(),
   prompt: z.string().min(1),
@@ -70,7 +71,7 @@ const sendAgentMessageSchema = z.object({
 });
 
 const delegateAgentSchema = z
-  .object({
+  .strictObject({
     mode: delegationModeSchema,
     parentRunId: z.string().min(1),
     objective: z.string().min(1),

--- a/desktop/macos/agent/src/runtime/node-tools.ts
+++ b/desktop/macos/agent/src/runtime/node-tools.ts
@@ -1,0 +1,46 @@
+import { readFile, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export function isSafeSkillName(name: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(name) && name !== "." && name !== ".." && !name.includes("..");
+}
+
+export async function loadSkillInstructions(name: string, workspace = process.env.OMI_WORKSPACE ?? ""): Promise<string> {
+  const trimmedName = name.trim();
+  if (!isSafeSkillName(trimmedName)) {
+    return "Invalid skill name. Use the exact skill name listed in available_skills.";
+  }
+
+  const roots = [
+    workspace ? resolve(workspace, ".claude", "skills") : "",
+    resolve(homedir(), ".claude", "skills"),
+  ].filter(Boolean);
+
+  let content: string | null = null;
+  for (const root of roots) {
+    let realRoot: string;
+    let realFilePath: string;
+    try {
+      realRoot = await realpath(root);
+      realFilePath = await realpath(resolve(root, trimmedName, "SKILL.md"));
+    } catch {
+      continue;
+    }
+    if (!realFilePath.startsWith(`${realRoot}/`)) {
+      continue;
+    }
+    try {
+      content = await readFile(realFilePath, "utf8");
+      break;
+    } catch {
+      // Try the next configured skill location.
+    }
+  }
+
+  if (content && trimmedName === "dev-mode" && workspace) {
+    return `Workspace: ${workspace}\n\n${content}`;
+  }
+
+  return content ?? `Skill '${trimmedName}' not found. Check the name matches one listed in <available_skills>.`;
+}

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -21,6 +21,9 @@ export interface OmiToolInputSchema {
   properties: Record<string, unknown>;
   required?: string[];
   additionalProperties?: boolean;
+}
+
+export interface OmiMcpToolInputSchema extends OmiToolInputSchema {
   anyOf?: unknown[];
   allOf?: unknown[];
   oneOf?: unknown[];
@@ -43,6 +46,7 @@ export interface OmiToolManifestEntry {
   promptGuidelines?: string[];
   latency: "fast local" | "fast network" | "async background";
   inputSchema: OmiToolInputSchema;
+  mcpInputSchema?: OmiMcpToolInputSchema;
   annotations: OmiToolAnnotations;
   timeoutClass: OmiToolTimeoutClass;
   executor: {
@@ -722,9 +726,13 @@ function controlEntry(tool: AgentControlManifestTool): OmiToolManifestEntry {
     latency: tool.latency,
     inputSchema: {
       ...agentControlInputSchema(tool),
-      ...tool.jsonSchemaOptions,
       additionalProperties: false,
     } as OmiToolInputSchema,
+    mcpInputSchema: {
+      ...agentControlInputSchema(tool),
+      ...tool.mcpInputSchemaOptions,
+      additionalProperties: false,
+    } as OmiMcpToolInputSchema,
     annotations: readOnlyLocal,
     timeoutClass: tool.timeoutClass,
     executor: { kind: "runtimeControl" },
@@ -767,11 +775,11 @@ export function toolNamesForAdapter(
 export function mcpToolDefinitionsForAdapter(
   adapterId: "omi-tools-stdio",
   context: OmiToolProjectionContext = {},
-): Array<{ name: string; description: string; inputSchema: OmiToolInputSchema }> {
+): Array<{ name: string; description: string; inputSchema: OmiMcpToolInputSchema }> {
   return toolsForAdapter(adapterId, context).map((tool) => ({
     name: tool.adapters[adapterId]?.adapterName ?? tool.name,
     description: tool.description,
-    inputSchema: tool.inputSchema,
+    inputSchema: tool.mcpInputSchema ?? tool.inputSchema,
   }));
 }
 

--- a/desktop/macos/agent/tests/codemagic-pi-mono-extension-ci.test.ts
+++ b/desktop/macos/agent/tests/codemagic-pi-mono-extension-ci.test.ts
@@ -2,17 +2,14 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("macOS release CI", () => {
-  it("installs pi-mono-extension dependencies before running extension tests", () => {
+  it("runs the shared desktop tool-surface guardrail before packaging", () => {
     const codemagic = readFileSync(new URL("../../../../codemagic.yaml", import.meta.url), "utf8");
-    const stepStart = codemagic.indexOf("name: Test pi-mono-extension denylist classifier");
+    const stepStart = codemagic.indexOf("name: Test desktop tool surfaces");
     expect(stepStart).toBeGreaterThanOrEqual(0);
 
     const step = codemagic.slice(stepStart, codemagic.indexOf("- name:", stepStart + 1));
-    expect(step).toContain("cd pi-mono-extension");
-    expect(step).toContain("npm ci --no-fund --no-audit");
-    expect(step.indexOf("npm ci --no-fund --no-audit")).toBeLessThan(
-      step.indexOf("node --experimental-strip-types --test index.test.ts")
-    );
+    expect(step).toContain("scripts/test-tool-surfaces.sh");
+    expect(stepStart).toBeLessThan(codemagic.indexOf("name: Prepare universal ffmpeg"));
   });
 
   it("bundles pi-mono-extension dependencies into release and local app resources", () => {
@@ -22,6 +19,7 @@ describe("macOS release CI", () => {
     for (const manifestFile of [
       "control-tool-manifest.js",
       "control-tool-manifest.ts",
+      "node-tools.ts",
       "omi-tool-manifest.ts",
     ]) {
       expect(codemagic).toContain(

--- a/desktop/macos/agent/tests/control-tools.test.ts
+++ b/desktop/macos/agent/tests/control-tools.test.ts
@@ -784,6 +784,25 @@ describe("agent control tools", () => {
     store.close();
   });
 
+  it("rejects extra top-level control tool keys to match advertised schemas", async () => {
+    const { store, kernel } = createKernelHarness(newDatabasePath());
+
+    const invalid = parseToolResult(
+      await handleAgentControlToolCall(ownerContext(kernel), "list_agent_sessions", {
+        unexpected: "drift",
+      }),
+    );
+
+    expect(invalid).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_tool_input",
+      },
+    });
+    expect(invalid.error.message).toContain("Unrecognized key");
+    store.close();
+  });
+
   it("filters persisted artifacts by session, run, attempt, and role", async () => {
     const { store, kernel } = createKernelHarness(newDatabasePath());
     const first = await kernel.executeRun(baseRunInput);

--- a/desktop/macos/agent/tests/node-tools.test.ts
+++ b/desktop/macos/agent/tests/node-tools.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isSafeSkillName, loadSkillInstructions } from "../src/runtime/node-tools.js";
+
+describe("node tool helpers", () => {
+  it("rejects traversal and path-like skill names", () => {
+    expect(isSafeSkillName("dev-mode")).toBe(true);
+    expect(isSafeSkillName("product_design.v1")).toBe(true);
+    expect(isSafeSkillName("../secrets")).toBe(false);
+    expect(isSafeSkillName("nested/skill")).toBe(false);
+    expect(isSafeSkillName("..")).toBe(false);
+    expect(isSafeSkillName("safe..looking")).toBe(false);
+  });
+
+  it("refuses symlink escapes from the configured skills root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omi-agent-skills-"));
+    const outside = await mkdtemp(join(tmpdir(), "omi-agent-skills-outside-"));
+    const skillName = "escape";
+
+    try {
+      await mkdir(join(root, ".claude", "skills"), { recursive: true });
+      await mkdir(join(outside, skillName), { recursive: true });
+      await writeFile(join(outside, skillName, "SKILL.md"), "secret instructions");
+      await symlink(join(outside, skillName), join(root, ".claude", "skills", skillName));
+
+      const result = await loadSkillInstructions(skillName, root);
+
+      expect(result).toBe("Skill 'escape' not found. Check the name matches one listed in <available_skills>.");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -113,6 +113,16 @@ describe("omi tool manifest", () => {
     ]);
   });
 
+  it("keeps MCP-only schema options from overriding base tool schema fields", () => {
+    for (const tool of toolsForAdapter("omi-tools-stdio")) {
+      const mcpTool = mcpToolDefinitionsForAdapter("omi-tools-stdio").find((candidate) => candidate.name === tool.name);
+      expect(mcpTool?.inputSchema.type).toBe(tool.inputSchema.type);
+      expect(mcpTool?.inputSchema.properties).toEqual(tool.inputSchema.properties);
+      expect(mcpTool?.inputSchema.required).toEqual(tool.inputSchema.required);
+      expect(mcpTool?.inputSchema.additionalProperties).toEqual(tool.inputSchema.additionalProperties);
+    }
+  });
+
   it("normalizes MCP-prefixed and explicit aliases", () => {
     expect(normalizeOmiToolName("omi-tools-stdio", "mcp__omi-tools__execute_sql")).toEqual({
       canonicalName: "execute_sql",

--- a/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
+++ b/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed Omi Beta desktop chat failing before answering when agent control tools are available."
+  "change": "Fixed Omi Beta desktop chat failing before answering when agent control tools are available"
 }

--- a/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
+++ b/desktop/macos/changelog/unreleased/20260628-pi-mono-chat-tools.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Omi Beta desktop chat failing before answering when agent control tools are available."
+}

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -35,7 +35,11 @@ import {
 } from "./index.ts";
 import type { ToolCallEvent } from "@mariozechner/pi-coding-agent";
 import { agentControlCapabilityManifest } from "../agent/src/runtime/control-tool-manifest.ts";
-import { toolNamesForAdapter } from "../agent/src/runtime/omi-tool-manifest.ts";
+import {
+  buildToolAvailabilitySnapshot,
+  toolNamesForAdapter,
+  toolsForAdapter,
+} from "../agent/src/runtime/omi-tool-manifest.ts";
 
 // ---------------------------------------------------------------------------
 // classifyBash — allow-by-default for normal dev commands
@@ -936,6 +940,52 @@ function createMockBridge(): { server: Server; sockPath: string } {
   return { server, sockPath };
 }
 
+function firstTypedSchema(schema: any): any {
+  if (schema?.type) return schema;
+  return schema?.anyOf?.find((candidate: any) => candidate.type) ?? {};
+}
+
+function normalizeCanonicalSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { type: schema.type };
+  if (schema.description !== undefined) normalized.description = schema.description;
+  if (schema.enum !== undefined) normalized.enum = schema.enum;
+  if (schema.type === "array" && schema.items && typeof schema.items === "object") {
+    normalized.items = normalizeCanonicalSchema(schema.items as Record<string, unknown>);
+  }
+  if (schema.type === "object") {
+    normalized.additionalProperties = schema.additionalProperties === true;
+    normalized.properties = Object.fromEntries(
+      Object.entries((schema.properties as Record<string, unknown>) ?? {}).map(([key, value]) => [
+        key,
+        normalizeCanonicalSchema(value as Record<string, unknown>),
+      ]),
+    );
+    normalized.required = Array.isArray(schema.required) ? [...schema.required].sort() : [];
+  }
+  return normalized;
+}
+
+function normalizeProjectedSchema(schema: any): Record<string, unknown> {
+  const typedSchema = firstTypedSchema(schema);
+  const normalized: Record<string, unknown> = { type: typedSchema.type };
+  if (typedSchema.description !== undefined) normalized.description = typedSchema.description;
+  if (typedSchema.enum !== undefined) normalized.enum = typedSchema.enum;
+  if (typedSchema.type === "array" && typedSchema.items) {
+    normalized.items = normalizeProjectedSchema(typedSchema.items);
+  }
+  if (typedSchema.type === "object") {
+    normalized.additionalProperties = typedSchema.additionalProperties === true;
+    normalized.properties = Object.fromEntries(
+      Object.entries(typedSchema.properties ?? {}).map(([key, value]) => [
+        key,
+        normalizeProjectedSchema(value),
+      ]),
+    );
+    normalized.required = Array.isArray(typedSchema.required) ? [...typedSchema.required].sort() : [];
+  }
+  return normalized;
+}
+
 test("OMI_TOOLS: exactly 26 tools defined via defineTool()", () => {
   assert.equal(OMI_TOOLS.length, 26);
 });
@@ -945,6 +995,35 @@ test("OMI_TOOLS: exact pi-mono projection from canonical manifest", () => {
     OMI_TOOLS.map((tool) => tool.name),
     toolNamesForAdapter("pi-mono"),
   );
+});
+
+test("OMI_TOOLS: all tools preserve canonical pi-mono projection metadata and schema shape", () => {
+  const canonicalTools = toolsForAdapter("pi-mono");
+
+  for (const canonicalTool of canonicalTools) {
+    const tool = OMI_TOOLS.find((candidate) => candidate.name === canonicalTool.name);
+    assert.ok(tool, `${canonicalTool.name} missing from OMI_TOOLS`);
+    assert.equal(tool!.label, canonicalTool.label, `${canonicalTool.name} label drifted`);
+    assert.equal(tool!.description, canonicalTool.description, `${canonicalTool.name} description drifted`);
+    assert.equal(tool!.promptSnippet, canonicalTool.promptSnippet, `${canonicalTool.name} promptSnippet drifted`);
+    assert.deepEqual(tool!.promptGuidelines ?? [], canonicalTool.promptGuidelines ?? [], `${canonicalTool.name} promptGuidelines drifted`);
+    assert.deepEqual(
+      [...((tool!.parameters as any).required ?? [])].sort(),
+      [...(canonicalTool.inputSchema.required ?? [])].sort(),
+      `${canonicalTool.name} required fields drifted`,
+    );
+
+    const projectedProperties = (tool!.parameters as any).properties ?? {};
+    for (const [propertyName, canonicalProperty] of Object.entries(canonicalTool.inputSchema.properties)) {
+      const property = projectedProperties[propertyName];
+      assert.ok(property, `${canonicalTool.name}.${propertyName} missing`);
+      assert.deepEqual(
+        normalizeProjectedSchema(property),
+        normalizeCanonicalSchema(canonicalProperty as Record<string, unknown>),
+        `${canonicalTool.name}.${propertyName} schema drifted`,
+      );
+    }
+  }
 });
 
 test("OMI_TOOLS: all tools have name, label, description, parameters, execute", () => {
@@ -984,7 +1063,7 @@ test("OMI_TOOLS: TypeBox schemas have additionalProperties=false", () => {
 });
 
 test("OMI_TOOLS: provider schemas do not advertise unsupported top-level composites", () => {
-  const unsupportedTopLevelKeys = ["anyOf", "allOf", "oneOf", "if", "then"] as const;
+  const unsupportedTopLevelKeys = ["anyOf", "allOf", "oneOf", "not", "if", "then"] as const;
   for (const tool of OMI_TOOLS) {
     const parameters = tool.parameters as any;
     for (const key of unsupportedTopLevelKeys) {
@@ -1111,6 +1190,51 @@ test("OMI_TOOLS: agent control tools match canonical capability manifest", () =>
       assert.equal(typedSchema.description, manifestProperty.description, `${manifestTool.name}.${propertyName} description drifted`);
       assert.deepEqual(typedSchema.enum, manifestProperty.enum, `${manifestTool.name}.${propertyName} enum drifted`);
     }
+  }
+});
+
+test("registerOmiTools: writes availability snapshot matching canonical pi-mono projection", async () => {
+  __resetOmiPipeForTest();
+  const { server, sockPath } = createMockBridge();
+  const dir = await mkdtemp(pathJoin(tmpdir(), "omi-pi-snapshot-success-"));
+  const snapshotPath = pathJoin(dir, "tools.json");
+  const previousPipe = process.env.OMI_BRIDGE_PIPE;
+  const previousSnapshotPath = process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH;
+  const registeredTools: string[] = [];
+
+  process.env.OMI_BRIDGE_PIPE = sockPath;
+  process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH = snapshotPath;
+
+  try {
+    await new Promise<void>((resolve) => server.listen(sockPath, resolve));
+    await __registerOmiToolsForTest({
+      registerTool(tool: { name: string }) {
+        registeredTools.push(tool.name);
+      },
+    } as any);
+
+    const snapshot = JSON.parse(await readFile(snapshotPath, "utf8"));
+    const expected = buildToolAvailabilitySnapshot("pi-mono");
+    assert.deepEqual(registeredTools, toolNamesForAdapter("pi-mono"));
+    assert.deepEqual(snapshot.advertisedToolNames, expected.advertisedToolNames);
+    assert.equal(snapshot.advertisedToolCount, expected.advertisedToolCount);
+    assert.deepEqual(snapshot.aliases, expected.aliases);
+    assert.deepEqual(snapshot.disabled, expected.disabled);
+  } finally {
+    __resetOmiPipeForTest();
+    if (previousPipe === undefined) {
+      delete process.env.OMI_BRIDGE_PIPE;
+    } else {
+      process.env.OMI_BRIDGE_PIPE = previousPipe;
+    }
+    if (previousSnapshotPath === undefined) {
+      delete process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH;
+    } else {
+      process.env.OMI_TOOL_AVAILABILITY_SNAPSHOT_PATH = previousSnapshotPath;
+    }
+    await rm(dir, { recursive: true, force: true });
+    server.close();
+    try { await unlink(sockPath); } catch {}
   }
 });
 

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -28,10 +28,11 @@ import {
   type ToolResultEvent,
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "@mariozechner/pi-ai";
-import { appendFile, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { createConnection, type Socket } from "node:net";
 import { dirname, join, resolve } from "node:path";
+import { isSafeSkillName, loadSkillInstructions } from "../agent/src/runtime/node-tools.ts";
 import {
   buildToolAvailabilitySnapshot,
   toolNamesForAdapter,
@@ -567,9 +568,7 @@ async function omiContextFileCorrelation(): Promise<Record<string, string | numb
 export const OMI_TOOL_TIMEOUT_MS = 30_000;
 export const OMI_LONG_CONTROL_TOOL_TIMEOUT_MS = 10 * 60_000;
 
-export function isSafeSkillName(name: string): boolean {
-  return /^[A-Za-z0-9._-]+$/.test(name) && name !== "." && name !== ".." && !name.includes("..");
-}
+export { isSafeSkillName };
 
 // ---------------------------------------------------------------------------
 // Omi tool definitions — pi-mono defineTool() with TypeBox schemas
@@ -584,14 +583,12 @@ function omiTool<T extends Parameters<typeof Type.Object>[0]>(spec: {
   promptGuidelines?: string[];
   properties: T;
   required: (keyof T)[];
-  schemaOptions?: Record<string, unknown>;
   timeoutMs?: number;
 }) {
   const parameters = Type.Object(
     spec.properties,
     { additionalProperties: false },
   );
-  Object.assign(parameters, spec.schemaOptions);
   const tool = defineTool({
     name: spec.name,
     label: spec.label,
@@ -664,17 +661,8 @@ function omiManifestTool(tool: OmiToolManifestEntry) {
     promptGuidelines: tool.promptGuidelines,
     properties: typeBoxPropertiesForInputSchema(tool.inputSchema),
     required: (tool.inputSchema.required ?? []) as never[],
-    schemaOptions: schemaOptionsForInputSchema(tool.inputSchema),
     timeoutMs: tool.timeoutClass === "long" ? OMI_LONG_CONTROL_TOOL_TIMEOUT_MS : OMI_TOOL_TIMEOUT_MS,
   });
-}
-
-function schemaOptionsForInputSchema(schema: OmiToolInputSchema): Record<string, unknown> {
-  const options: Record<string, unknown> = {};
-  // Provider-facing custom tool input schemas reject root-level composite
-  // keywords. Keep selector preconditions in runtime control validation.
-  void schema;
-  return options;
 }
 
 function loadSkillTool() {
@@ -697,39 +685,10 @@ function loadSkillTool() {
           details: undefined,
         };
       }
-      const workspace = process.env.OMI_WORKSPACE || "";
-      const roots = [
-        workspace ? resolve(workspace, ".claude", "skills") : "",
-        resolve(homedir(), ".claude", "skills"),
-      ].filter(Boolean);
-
-      let content: string | null = null;
-      for (const root of roots) {
-        let realRoot: string;
-        let realFilePath: string;
-        try {
-          realRoot = await realpath(root);
-          realFilePath = await realpath(resolve(root, name, "SKILL.md"));
-        } catch {
-          continue;
-        }
-        if (!realFilePath.startsWith(`${realRoot}/`)) {
-          continue;
-        }
-        try {
-          content = await readFile(realFilePath, "utf8");
-          break;
-        } catch {
-          // Try the next configured skill location.
-        }
-      }
-      if (content && name === "dev-mode" && workspace) {
-        content = `Workspace: ${workspace}\n\n${content}`;
-      }
       return {
         content: [{
           type: "text" as const,
-          text: content ?? `Skill '${name}' not found. Check the name matches one listed in <available_skills>.`,
+          text: await loadSkillInstructions(name),
         }],
         details: undefined,
       };

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -470,6 +470,7 @@ if [ -d "$AGENT_DIR/dist" ]; then
     mkdir -p "$APP_BUNDLE/Contents/Resources/agent/src/runtime"
     cp -f "$AGENT_DIR/src/runtime/control-tool-manifest.js" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
     cp -f "$AGENT_DIR/src/runtime/control-tool-manifest.ts" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
+    cp -f "$AGENT_DIR/src/runtime/node-tools.ts" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
     cp -f "$AGENT_DIR/src/runtime/omi-tool-manifest.ts" "$APP_BUNDLE/Contents/Resources/agent/src/runtime/"
 fi
 

--- a/desktop/macos/scripts/agent-logic-harness.sh
+++ b/desktop/macos/scripts/agent-logic-harness.sh
@@ -170,6 +170,10 @@ run_swift_focus() {
 
 run_agent_runtime_focus() {
   (
+    cd "$DESKTOP_DIR"
+    scripts/test-tool-surfaces.sh
+  )
+  (
     cd "$DESKTOP_DIR/agent"
     npm test -- --run \
       tests/codemagic-pi-mono-extension-ci.test.ts \

--- a/desktop/macos/scripts/prepare-agent-runtime.sh
+++ b/desktop/macos/scripts/prepare-agent-runtime.sh
@@ -182,6 +182,7 @@ validate_runtime_tree() {
   require_file "$AGENT_DIR/dist/patched-acp-entry.mjs"
   require_file "$AGENT_DIR/src/runtime/control-tool-manifest.js"
   require_file "$AGENT_DIR/src/runtime/control-tool-manifest.ts"
+  require_file "$AGENT_DIR/src/runtime/node-tools.ts"
   require_file "$AGENT_DIR/src/runtime/omi-tool-manifest.ts"
   require_file "$AGENT_DIR/node_modules/@mariozechner/pi-coding-agent/dist/cli.js"
   require_file "$AGENT_DIR/node_modules/@zed-industries/claude-agent-acp/dist/acp-agent.js"

--- a/desktop/macos/scripts/test-tool-surfaces.sh
+++ b/desktop/macos/scripts/test-tool-surfaces.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ensure_npm_deps() {
+  local dir="$1"
+  if [[ -d "$dir/node_modules" ]]; then
+    return
+  fi
+  (
+    cd "$dir"
+    npm ci --no-fund --no-audit
+  )
+}
+
+ensure_npm_deps "$DESKTOP_DIR/agent"
+(
+  cd "$DESKTOP_DIR/agent"
+  npm test -- --run \
+    tests/omi-tool-manifest.test.ts \
+    tests/control-tools.test.ts \
+    tests/node-tools.test.ts \
+    tests/codemagic-pi-mono-extension-ci.test.ts
+)
+
+ensure_npm_deps "$DESKTOP_DIR/pi-mono-extension"
+(
+  cd "$DESKTOP_DIR/pi-mono-extension"
+  node_bin="$DESKTOP_DIR/Desktop/Sources/Resources/node"
+  if [[ -x "$node_bin" ]]; then
+    "$node_bin" --experimental-strip-types --test index.test.ts
+  elif node --experimental-strip-types --test index.test.ts; then
+    echo "pi-mono-extension tests passed (native Node --experimental-strip-types)"
+  else
+    echo "Falling back to npx tsx for older Node versions..."
+    npx --yes tsx@4.19.2 --test index.test.ts
+  fi
+)

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -137,6 +137,18 @@ PY
   fi
 }
 
+check_desktop_tool_surfaces_if_needed() {
+  local file
+  for file in "${CHANGED_FILES[@]}"; do
+    case "$file" in
+      desktop/macos/agent/*|desktop/macos/agent/**/*|desktop/macos/pi-mono-extension/*|desktop/macos/pi-mono-extension/**/*|desktop/macos/run.sh|desktop/macos/scripts/prepare-agent-runtime.sh|desktop/macos/scripts/test-tool-surfaces.sh|codemagic.yaml)
+        desktop/macos/scripts/test-tool-surfaces.sh
+        return
+        ;;
+    esac
+  done
+}
+
 run_step check_merge_conflicts
 run_step python3 .github/scripts/desktop-changelog.py validate
 
@@ -149,6 +161,7 @@ else
 fi
 
 run_step python3 .github/scripts/check-desktop-prod-promotion-policy.py
+run_step check_desktop_tool_surfaces_if_needed
 run_step check_optional_formatters
 
 echo "Fast pre-push checks passed."


### PR DESCRIPTION
## Summary
- split provider-safe Omi tool schemas from MCP-only conditional schema metadata so pi-mono cannot advertise unsupported top-level composites again
- enforce the agent-control selector rules at runtime with stricter Zod validation and targeted tests
- centralize load_skill path validation, package the shared runtime file, and add a canonical desktop tool-surface guardrail script wired into CI, harnesses, and pre-push

## Root cause
The Omi Beta desktop chat failure was local to the pi-mono / Claude bridge tool registration path: agent control tools carried MCP-oriented top-level anyOf/allOf conditions into the provider-facing custom tool schema. The provider rejected that schema before answering. This is unrelated to the LLM gateway rollout; gateway logs showed no new chat/completion traffic for the failing path.

## Drift prevention
- pi-mono tests now compare every advertised tool against the canonical manifest projection and reject top-level anyOf/allOf/oneOf/not/if/then
- agent tests assert MCP-only schema options cannot override provider-safe base schema fields
- packaging tests require node-tools.ts in both run.sh and Codemagic bundle steps
- scripts/test-tool-surfaces.sh is now the single cheap guardrail used by Codemagic, the agent harness, and pre-push when desktop tool-surface files change

## Validation
- desktop/macos/scripts/test-tool-surfaces.sh
- npm run build (desktop/macos/agent)
- npm test (desktop/macos/agent)
- desktop/macos/scripts/agent-logic-harness.sh --node-only
- bash -n desktop/macos/scripts/test-tool-surfaces.sh scripts/pre-push desktop/macos/scripts/agent-logic-harness.sh
- python3 .github/scripts/desktop-changelog.py validate
- git diff --check origin/main..HEAD
- scripts/pre-push

Oracle consult: the successful compact consult found no must-fix design issues beyond preserving the runtime checks and guardrails added here. Earlier larger consult uploads timed out before producing reviewable feedback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

