### PR TITLE
fix(backend): bound the get_memories chat tool result to prevent context overflow (#4927)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -84,6 +84,7 @@ pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_retrieval_semantics.py -v
 pytest tests/unit/test_conversation_tool_date_range_bound.py -v
+pytest tests/unit/test_retrieval_result_bounds.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v

--- a/backend/tests/unit/test_retrieval_result_bounds.py
+++ b/backend/tests/unit/test_retrieval_result_bounds.py
@@ -55,21 +55,23 @@ class TestCapItemsForLlm:
 
 class TestBoundedResult:
     def test_truncated_appends_summarize_and_narrow_note(self):
-        out = rb.bounded_result("User Memories (500 total):\n- a fact", 500, True, noun="memories")
-        assert "500 memories" in out
+        out = rb.bounded_result("User Memories (300 shown):\n- a fact", True, noun="memories")
+        # No definitive total is claimed (the page length is not the true total); it says more may exist.
+        assert "more may exist" in out
+        assert "most relevant memories" in out
         assert "Summarize what is shown" in out
-        assert "narrow" in out
+        assert "narrower" in out
 
     def test_not_truncated_short_result_unchanged(self):
-        body = "User Memories (3 total):\n- a fact"
-        assert rb.bounded_result(body, 3, False, noun="memories") == body
+        body = "User Memories (3 shown):\n- a fact"
+        assert rb.bounded_result(body, False, noun="memories") == body
 
     def test_oversized_result_is_clipped_to_budget_with_note(self):
         big = "x" * (rb.MAX_RESULT_CHARS + 5000)
-        out = rb.bounded_result(big, 1000, False, noun="memories")
+        out = rb.bounded_result(big, False, noun="memories")
         assert len(out) <= rb.MAX_RESULT_CHARS + 400  # budget plus the appended note
         assert "Summarize what is shown" in out
 
     def test_default_noun(self):
-        out = rb.bounded_result("body", 10, True)
-        assert "10 results" in out
+        out = rb.bounded_result("body", True)
+        assert "most relevant results" in out

--- a/backend/tests/unit/test_retrieval_result_bounds.py
+++ b/backend/tests/unit/test_retrieval_result_bounds.py
@@ -1,0 +1,75 @@
+"""Tests for bounding agentic retrieval tool results (issue #4927).
+
+A broad chat question can match a huge set ("what do you know about me" -> every memory), and
+formatting all of it into one tool result floods the chat model's context so it freezes or
+refuses. get_memories_tool now bounds its result via these shared helpers (the same fix already
+applied to the conversations tool). These cover the pure bounding helpers directly.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _load(module_name, rel_path):
+    # result_bounds.py imports nothing heavy, so load it directly without triggering the
+    # utils.retrieval.tools package __init__ (which pulls in every tool's dependencies).
+    spec = importlib.util.spec_from_file_location(module_name, str(BACKEND_DIR / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rb = _load("result_bounds_under_test", "utils/retrieval/tools/result_bounds.py")
+
+
+class TestCapItemsForLlm:
+    def test_caps_to_max_and_flags_truncation(self):
+        capped, total, truncated = rb.cap_items_for_llm(list(range(500)), 300)
+        assert total == 500
+        assert truncated is True
+        assert capped == list(range(300))  # most-relevant-first order preserved
+
+    def test_under_cap_is_untouched(self):
+        capped, total, truncated = rb.cap_items_for_llm(list(range(50)), 300)
+        assert capped == list(range(50)) and total == 50 and truncated is False
+
+    def test_exactly_at_cap_is_not_truncated(self):
+        capped, total, truncated = rb.cap_items_for_llm(list(range(300)), 300)
+        assert truncated is False and len(capped) == 300
+
+    def test_empty_list(self):
+        assert rb.cap_items_for_llm([], 300) == ([], 0, False)
+
+
+class TestBoundedResult:
+    def test_truncated_appends_summarize_and_narrow_note(self):
+        out = rb.bounded_result("User Memories (500 total):\n- a fact", 500, True, noun="memories")
+        assert "500 memories" in out
+        assert "Summarize what is shown" in out
+        assert "narrow" in out
+
+    def test_not_truncated_short_result_unchanged(self):
+        body = "User Memories (3 total):\n- a fact"
+        assert rb.bounded_result(body, 3, False, noun="memories") == body
+
+    def test_oversized_result_is_clipped_to_budget_with_note(self):
+        big = "x" * (rb.MAX_RESULT_CHARS + 5000)
+        out = rb.bounded_result(big, 1000, False, noun="memories")
+        assert len(out) <= rb.MAX_RESULT_CHARS + 400  # budget plus the appended note
+        assert "Summarize what is shown" in out
+
+    def test_default_noun(self):
+        out = rb.bounded_result("body", 10, True)
+        assert "10 results" in out

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -13,9 +13,15 @@ import database.memories as memory_db
 import database.vector_db as vector_db
 from models.memories import MemoryDB
 from utils.retrieval.hybrid import rrf_rerank
+from utils.retrieval.tools.result_bounds import cap_items_for_llm, bounded_result
 import logging
 
 logger = logging.getLogger(__name__)
+
+# A broad question ("what do you know about me") can match every memory a user has. Formatting
+# all of them floods the chat model's context, so it freezes or refuses (#4927). Bound how many
+# are handed to the model at once; the most recent are kept.
+MAX_MEMORIES_FOR_LLM = 300
 
 # Import agent_config_context for fallback config access
 try:
@@ -58,26 +64,15 @@ def get_memories_tool(
     - Questions like "when did X happen?", "what happened at Y?", "when did I get Z?"
 
     Memory retrieval guidance - choosing the right limit:
-    - **CRITICAL**: For ANY question asking about basic personal information (name, age, location, background, etc.) or multiple personal facts together, you MUST use limit=5000 to get ALL memories
-    - **For GENERAL COMPREHENSIVE questions, you MUST use limit=5000** to get ALL memories
-    - **For specific questions about a single narrow topic, you can use limit=50-200**
-    - Examples when you MUST use limit=5000:
-      * "what do you know about me"
-      * "tell me about myself"
-      * "what's my name, age, and location"
-      * "who am I"
-      * "what's my profile"
-      * "what's my age"
-      * "where do I live"
-      * "tell me everything"
-      * "what are all my interests"
-      * Any question asking for multiple personal facts together
-    - Examples when limit=50-200 is acceptable:
-      * "what conversations did I have about Python"
-      * "what do I know about machine learning"
-      * Questions about a specific narrow topic
-    - **Ask user for confirmation** before fetching 500+ memories for very broad analysis, as it may take longer
-    - **Maximum limit is 5000 per call** - use pagination (offset parameter) if more are needed
+    - For broad questions about the user ("what do you know about me", "tell me about myself",
+      "who am I", "what are all my interests"), use a high limit (e.g. 300) to get a comprehensive
+      set of facts.
+    - For specific questions about a single narrow topic ("what do I know about machine learning"),
+      use limit=50-200.
+    - For a very large memory bank the result is automatically capped to the most relevant memories
+      so it cannot overflow context; summarize what is returned and offer to narrow to a specific
+      topic if the user needs more.
+    - Use the offset parameter to page through additional memories when needed.
 
     Args:
         limit: Number of memories to retrieve (default: 50, recommended: 50-200, max per call: 5000)
@@ -160,12 +155,13 @@ def get_memories_tool(
     if memories:
         memories = [m for m in memories if not m.get('is_locked', False)]
 
-    memories_count = len(memories) if memories else 0
-    logger.info(f"📊 get_memories_tool - found {memories_count} memories")
-
-    # Log warning if large number of memories retrieved
-    if memories_count >= 500:
-        logger.info(f"⚠️ Large number of memories retrieved ({memories_count}). Consider if all are needed.")
+    # Bound how many memories are formatted for the chat model so a broad question cannot flood
+    # its context and freeze it (#4927). The DB returns newest-first, so this keeps the most recent.
+    memories, total_found, results_truncated = cap_items_for_llm(memories or [], MAX_MEMORIES_FOR_LLM)
+    logger.info(
+        f"📊 get_memories_tool - found {total_found} memories"
+        + (f" (formatting the most recent {len(memories)})" if results_truncated else "")
+    )
 
     if not memories:
         date_info = ""
@@ -193,10 +189,10 @@ def get_memories_tool(
         return "Error: Could not parse memories data"
 
     # Format memories using the Memory model's string formatter
-    result = f"User Memories ({len(memory_objects)} total):\n\n"
+    result = f"User Memories ({total_found} total):\n\n"
     result += MemoryDB.get_memories_as_str(memory_objects)
 
-    return result.strip()
+    return bounded_result(result.strip(), total_found, results_truncated, noun="memories")
 
 
 @tool

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -157,10 +157,14 @@ def get_memories_tool(
 
     # Bound how many memories are formatted for the chat model so a broad question cannot flood
     # its context and freeze it (#4927). The DB returns newest-first, so this keeps the most recent.
-    memories, total_found, results_truncated = cap_items_for_llm(memories or [], MAX_MEMORIES_FOR_LLM)
+    # A full DB page (len >= limit) means more memories likely exist beyond it, so flag that too so
+    # the note is not silently dropped when the model requested a small limit (cubic on #8527).
+    db_page = memories or []
+    more_in_db = len(db_page) >= limit
+    memories, page_count, capped = cap_items_for_llm(db_page, MAX_MEMORIES_FOR_LLM)
+    results_truncated = capped or more_in_db
     logger.info(
-        f"📊 get_memories_tool - found {total_found} memories"
-        + (f" (formatting the most recent {len(memories)})" if results_truncated else "")
+        f"📊 get_memories_tool - page {page_count} memories, showing {len(memories)}, truncated={results_truncated}"
     )
 
     if not memories:
@@ -188,11 +192,12 @@ def get_memories_tool(
     if not memory_objects:
         return "Error: Could not parse memories data"
 
-    # Format memories using the Memory model's string formatter
-    result = f"User Memories ({total_found} total):\n\n"
+    # Format memories using the Memory model's string formatter. Label the count as "shown" rather
+    # than "total": it is the displayed page, which may be a subset of all the user's memories.
+    result = f"User Memories ({len(memory_objects)} shown):\n\n"
     result += MemoryDB.get_memories_as_str(memory_objects)
 
-    return bounded_result(result.strip(), total_found, results_truncated, noun="memories")
+    return bounded_result(result.strip(), results_truncated, noun="memories")
 
 
 @tool

--- a/backend/utils/retrieval/tools/result_bounds.py
+++ b/backend/utils/retrieval/tools/result_bounds.py
@@ -24,16 +24,20 @@ def cap_items_for_llm(items: list, max_items: int):
     return list(items), total_found, False
 
 
-def bounded_result(result: str, total_found: int, truncated: bool, noun: str = "results") -> str:
+def bounded_result(result: str, truncated: bool, noun: str = "results") -> str:
     """Apply a hard character budget and, when the set was truncated, append a note telling the
-    model to summarize what it has and to offer to narrow, so it answers instead of freezing."""
+    model to summarize what it has and to offer to narrow, so it answers instead of freezing.
+
+    The note deliberately does not state a total count: callers may pass an already-paginated
+    page whose length is not the true total, so claiming a total would mislead (cubic on #8527).
+    """
     if len(result) > MAX_RESULT_CHARS:
         result = result[:MAX_RESULT_CHARS]
         truncated = True
     if truncated:
         result += (
-            f"\n\n[This query matched {total_found} {noun}; only the most relevant are shown to stay "
-            f"within limits. Summarize what is shown and tell the user they can ask about a narrower "
-            f"topic or date range for complete detail.]"
+            f"\n\n[Only the most relevant {noun} are shown here to stay within limits; more may exist. "
+            f"Summarize what is shown and tell the user they can ask about a narrower topic or date range, "
+            f"or page with the offset, for the rest.]"
         )
     return result

--- a/backend/utils/retrieval/tools/result_bounds.py
+++ b/backend/utils/retrieval/tools/result_bounds.py
@@ -1,0 +1,39 @@
+"""Shared size bounds for agentic retrieval tool results.
+
+A chat tool that formats every matched row into one string can flood the model's context when
+a broad query matches a huge set ("what do you know about me" pulls every memory; "analyze my
+last 30 days" pulls every conversation). The oversized tool result then makes the model freeze
+or refuse with "that's quite a bit of information to process at once" (issue #4927). These
+helpers cap the row count and the raw character size, and append a note telling the model to
+summarize what it has and offer to narrow.
+"""
+
+MAX_RESULT_CHARS = 60000
+
+
+def cap_items_for_llm(items: list, max_items: int):
+    """Keep at most ``max_items`` rows for the chat model.
+
+    Callers pass rows already ordered most-relevant- or most-recent-first, so this keeps the
+    ones that matter. Returns ``(capped_list, total_found, truncated)`` where ``truncated`` is
+    True when some rows were dropped.
+    """
+    total_found = len(items)
+    if total_found > max_items:
+        return items[:max_items], total_found, True
+    return list(items), total_found, False
+
+
+def bounded_result(result: str, total_found: int, truncated: bool, noun: str = "results") -> str:
+    """Apply a hard character budget and, when the set was truncated, append a note telling the
+    model to summarize what it has and to offer to narrow, so it answers instead of freezing."""
+    if len(result) > MAX_RESULT_CHARS:
+        result = result[:MAX_RESULT_CHARS]
+        truncated = True
+    if truncated:
+        result += (
+            f"\n\n[This query matched {total_found} {noun}; only the most relevant are shown to stay "
+            f"within limits. Summarize what is shown and tell the user they can ask about a narrower "
+            f"topic or date range for complete detail.]"
+        )
+    return result


### PR DESCRIPTION
## Summary

Follow-up to the merged #8503. That PR bounded the conversations chat tool so a wide date range could not flood the chat model and freeze it; get_memories_tool has the same unbounded-result problem and the same failure. Asking a broad question like "what do you know about me" can match every memory a user has, and the tool formats all of them into one result, which overflows the chat model's context so it freezes or refuses with "that's quite a bit of information to process at once" (#4927). This bounds the memory tool the same way.

## Root cause

utils/retrieval/tools/memory_tools.py get_memories_tool fetches and formats memories into a single string. Its docstring tells the model to do exactly the wrong thing for broad questions: "For ANY question asking about basic personal information ... you MUST use limit=5000 to get ALL memories." For a user with thousands of memories that produces a result far larger than the chat context can hold, so the model never answers. (search_memories_tool is already bounded at limit 20, so it is fine.)

## Fix

- Added utils/retrieval/tools/result_bounds.py with two small reusable helpers: cap_items_for_llm(items, max_items) keeps at most max_items rows (most relevant first) and reports the true total, and bounded_result applies a hard character budget (60000) and, when the set was truncated, appends a note telling the model to summarize what it has and offer to narrow. This is the same bounding pattern #8503 introduced inline for the conversations tool, factored into a shared helper other tools can adopt.
- get_memories_tool now caps the memories it formats to the 300 most recent before building the result and applies the character budget, so the tool result can never overflow context. The header still reports the true total.
- Rewrote the limit guidance in the docstring so it no longer instructs the model to fetch all 5000 memories, and explains that very large memory banks are capped to the most relevant.

The effect: instead of freezing, the chat answers from a comprehensive but bounded set of memories and tells the user it can narrow further. The change is additive and only affects the very large memory bank case (most users have far fewer than 300 memories, so nothing changes for them).

## Testing

- New tests/unit/test_retrieval_result_bounds.py (8 tests): cap_items_for_llm (caps to the most relevant, reports the total, leaves small sets and the exact-boundary case untouched, handles empty) and bounded_result (appends the summarize-and-narrow note when truncated with the right count and noun, leaves a small untruncated result unchanged, clips an oversized result to the budget). Registered in test.sh.
- Proven red against the absence of the helper (the suite fails to collect without it), green after.
- Verified the retrieval-tool importer tests (test_lock_bypass_fixes, test_prompt_cache_integration) fail identically with and without this change, confirming the local failures are pre-existing environment issues, not a regression.

Refs #4927.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

