### PR TITLE
Cap parakeet max batch size to 8 for auto attention mode

### DIFF
--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -110,6 +110,8 @@ env:
     value: "300"
   - name: PARAKEET_LOCAL_ATTN_CONTEXT
     value: "128,128"
+  - name: PARAKEET_MAX_BATCH_SIZE
+    value: "8"
   - name: PARAKEET_MAX_FILE_DURATION
     value: "3600"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL


### PR DESCRIPTION
## Summary
- Adds `PARAKEET_MAX_BATCH_SIZE=8` to prod parakeet Helm values
- Prevents VRAM exhaustion when auto attention mode disables torch.compile

## Context
Follow-up to PR #8486 (auto attention + 1h duration guard). Post-deploy monitoring detected a CUDA OOM at T+22min when a batch of 12 concurrent files exhausted ~93% VRAM. Auto mode disables torch.compile, which increases VRAM per batch item ~3x vs compiled mode. The default `max_batch_size=32` is too high for the uncompiled path.

**OOM event**: Single burst at 03:13 UTC, pod self-recovered in ~35s (0 restarts), 200+ successful requests after recovery. Batch size cap at 8 keeps estimated VRAM under ~70%.

## Test plan
- [ ] Verify Helm values render correctly (`helm template`)
- [ ] Deploy via `gcp_parakeet.yml` with Helm upgrade
- [ ] Confirm new pod has `PARAKEET_MAX_BATCH_SIZE=8` env var
- [ ] Monitor for zero OOMs under normal traffic
- [ ] zen to reproduce and validate on dev with burst testing

Fixes OOM observed in #8486 post-deploy monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

