### PR TITLE
VRAM-aware dynamic batch sizing for parakeet

### DIFF
--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -112,6 +112,12 @@ env:
     value: "128,128"
   - name: PARAKEET_MAX_FILE_DURATION
     value: "3600"
+  - name: PARAKEET_VRAM_SAFETY_FACTOR
+    value: "0.8"
+  - name: PARAKEET_VRAM_BYTES_PER_T2
+    value: "136.6"
+  - name: PARAKEET_STARVATION_TIMEOUT
+    value: "5.0"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://prod-omi-diarizer.prod-omi-backend.svc.cluster.local:8080"
 

--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -118,6 +118,8 @@ env:
     value: "136.6"
   - name: PARAKEET_STARVATION_TIMEOUT
     value: "5.0"
+  - name: PARAKEET_MAX_INFLIGHT
+    value: "2"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://prod-omi-diarizer.prod-omi-backend.svc.cluster.local:8080"
 

--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -74,28 +74,34 @@ class BatchEngine:
             "vram_limited_batches": 0,
         }
 
+    def _try_init_vram(self) -> None:
+        if self._vram_enabled or self._vram_safety_factor <= 0:
+            return
+        vram = self._gpu_worker.vram_info
+        if vram.get("total_mb", 0) <= 0:
+            return
+        self._attention_mode = vram.get("attention_mode", "full")
+        self._auto_threshold_sec = vram.get("auto_threshold_sec", 300.0)
+        budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
+        self._vram_available_mb = max(budget, 0)
+        self._vram_enabled = True
+        if budget <= 0:
+            logger.warning(
+                f"VRAM budget is non-positive ({budget:.0f} MB) — "
+                f"baseline exceeds safety cap. All batches capped to 1."
+            )
+        logger.info(
+            f"VRAM-aware batching enabled: {self._vram_available_mb:.0f} MB budget "
+            f"(total={vram['total_mb']:.0f}, baseline={vram['baseline_mb']:.0f}, "
+            f"safety={self._vram_safety_factor}, coeff={self._vram_bytes_per_t2})"
+        )
+
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
         self._inflight_sem = asyncio.Semaphore(self._max_inflight)
-        vram = self._gpu_worker.vram_info
-        self._attention_mode = vram.get("attention_mode", "full")
-        self._auto_threshold_sec = vram.get("auto_threshold_sec", 300.0)
-        if self._vram_safety_factor > 0 and vram.get("total_mb", 0) > 0:
-            budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
-            self._vram_available_mb = max(budget, 0)
-            self._vram_enabled = True
-            if budget <= 0:
-                logger.warning(
-                    f"VRAM budget is non-positive ({budget:.0f} MB) — "
-                    f"baseline exceeds safety cap. All batches capped to 1."
-                )
-            logger.info(
-                f"VRAM-aware batching enabled: {self._vram_available_mb:.0f} MB budget "
-                f"(total={vram['total_mb']:.0f}, baseline={vram['baseline_mb']:.0f}, "
-                f"safety={self._vram_safety_factor}, coeff={self._vram_bytes_per_t2})"
-            )
-        else:
-            logger.info("VRAM-aware batching disabled (safety_factor=0 or no VRAM info)")
+        self._try_init_vram()
+        if not self._vram_enabled:
+            logger.info("VRAM-aware batching deferred (GPU worker still loading or safety_factor=0)")
         self._flush_task = asyncio.create_task(self._flush_loop())
 
     async def stop(self) -> None:
@@ -255,6 +261,7 @@ class BatchEngine:
     async def _flush_batch(self) -> None:
         await self._inflight_sem.acquire()
         try:
+            self._try_init_vram()
             async with self._lock:
                 if not self._pending:
                     return

--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -42,15 +42,19 @@ class BatchEngine:
         vram_safety_factor: float = 0.8,
         vram_bytes_per_t2: float = 136.6,
         starvation_timeout_sec: float = 5.0,
+        max_inflight: int = 2,
     ):
         self._gpu_worker = gpu_worker
         self._max_batch_size = max_batch_size
         self._max_wait_seconds = max_wait_seconds
         self._max_queue_depth = max_queue_depth
+        self._max_inflight = max_inflight
         self._pending: list[PendingRequest] = []
         self._lock = asyncio.Lock()
         self._flush_task: Optional[asyncio.Task] = None
-        self._inflight_flushes: set[asyncio.Task] = set()
+        self._flush_pending = False
+        self._inflight_tasks: set[asyncio.Task] = set()
+        self._inflight_sem: Optional[asyncio.Semaphore] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._shutting_down = False
         self._on_batch_complete = on_batch_complete
@@ -60,6 +64,7 @@ class BatchEngine:
         self._starvation_timeout = starvation_timeout_sec
         self._vram_available_mb = 0.0
         self._vram_enabled = False
+        self._attention_mode = "full"
         self._auto_threshold_sec = 300.0
         self._metrics = {
             "total_requests": 0,
@@ -71,7 +76,9 @@ class BatchEngine:
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
+        self._inflight_sem = asyncio.Semaphore(self._max_inflight)
         vram = self._gpu_worker.vram_info
+        self._attention_mode = vram.get("attention_mode", "full")
         self._auto_threshold_sec = vram.get("auto_threshold_sec", 300.0)
         if self._vram_safety_factor > 0 and vram.get("total_mb", 0) > 0:
             budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
@@ -99,12 +106,18 @@ class BatchEngine:
                 await self._flush_task
             except asyncio.CancelledError:
                 pass
-        for task in list(self._inflight_flushes):
-            task.cancel()
-        if self._inflight_flushes:
-            await asyncio.gather(*self._inflight_flushes, return_exceptions=True)
+        for t in list(self._inflight_tasks):
+            t.cancel()
+        for t in list(self._inflight_tasks):
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
         while self._pending:
             await self._flush_batch()
+        if self._inflight_sem:
+            for _ in range(self._max_inflight):
+                await self._inflight_sem.acquire()
 
     @staticmethod
     def _get_audio_duration(path: str) -> Optional[float]:
@@ -126,6 +139,10 @@ class BatchEngine:
             return self._max_batch_size
         if self._vram_available_mb <= 0:
             return 1
+        if self._attention_mode == "local":
+            return self._max_batch_size
+        if self._attention_mode == "auto" and duration_known and max_duration_sec >= self._auto_threshold_sec:
+            return self._max_batch_size
         T = max_duration_sec / 0.08
         per_file_mb = self._vram_bytes_per_t2 * T * T / (1024 * 1024)
         if per_file_mb <= 0:
@@ -159,10 +176,20 @@ class BatchEngine:
                 enqueued = True
                 self._metrics["total_requests"] += 1
 
-                if len(self._pending) >= self._max_batch_size:
-                    task = asyncio.create_task(self._flush_batch())
-                    self._inflight_flushes.add(task)
-                    task.add_done_callback(self._inflight_flushes.discard)
+                pending_count = len(self._pending)
+                vram_limit = (
+                    self._estimate_max_batch(
+                        max(self._effective_duration(r) for r in self._pending),
+                        duration_known=all(r.duration_sec is not None for r in self._pending),
+                    )
+                    if self._vram_enabled and self._pending
+                    else self._max_batch_size
+                )
+                if pending_count >= min(self._max_batch_size, vram_limit) and not self._flush_pending:
+                    self._flush_pending = True
+                    t = asyncio.create_task(self._guarded_flush())
+                    self._inflight_tasks.add(t)
+                    t.add_done_callback(self._inflight_tasks.discard)
         except BaseException:
             if owns_file and not enqueued:
                 _unlink_safe(audio_path)
@@ -173,8 +200,17 @@ class BatchEngine:
     async def _flush_loop(self) -> None:
         while not self._shutting_down:
             await asyncio.sleep(self._max_wait_seconds)
-            if self._pending:
-                await self._flush_batch()
+            if self._pending and not self._flush_pending:
+                self._flush_pending = True
+                t = asyncio.create_task(self._guarded_flush())
+                self._inflight_tasks.add(t)
+                t.add_done_callback(self._inflight_tasks.discard)
+
+    async def _guarded_flush(self) -> None:
+        try:
+            await self._flush_batch()
+        finally:
+            self._flush_pending = False
 
     def _form_vram_safe_batch(self, candidates: list[PendingRequest]) -> list[PendingRequest]:
         if not candidates or not self._vram_enabled:
@@ -217,77 +253,94 @@ class BatchEngine:
         return sorted_candidates[:n]
 
     async def _flush_batch(self) -> None:
-        async with self._lock:
-            if not self._pending:
+        await self._inflight_sem.acquire()
+        try:
+            async with self._lock:
+                if not self._pending:
+                    return
+                batch = self._form_vram_safe_batch(self._pending)
+                batch_set = set(id(r) for r in batch)
+                self._pending = [r for r in self._pending if id(r) not in batch_set]
+
+            self._flush_pending = False
+
+            if not batch:
                 return
-            batch = self._form_vram_safe_batch(self._pending)
-            batch_set = set(id(r) for r in batch)
-            self._pending = [r for r in self._pending if id(r) not in batch_set]
+
             if len(batch) < self._max_batch_size and self._vram_enabled:
                 self._metrics["vram_limited_batches"] += 1
 
-        self._metrics["total_batches"] += 1
-        self._metrics["total_files"] += len(batch)
-        logger.info(f"Flushing batch: {len(batch)} files")
+            self._metrics["total_batches"] += 1
+            self._metrics["total_files"] += len(batch)
 
-        batch_start = time.monotonic()
-        queue_durations = [batch_start - req.submitted_at for req in batch]
-
-        audio_paths = [r.audio_path for r in batch]
-        timestamps = batch[0].timestamps if batch else True
-        is_oom = False
-        try:
-            gpu_future, work_item = self._gpu_worker.submit(
-                {
-                    "audio_paths": audio_paths,
-                    "timestamps": timestamps,
-                    "batch_size": len(batch),
-                },
-                self._loop,
+            durations = [self._effective_duration(r) for r in batch]
+            max_dur = max(durations) if durations else 0
+            logger.info(
+                f"Flushing batch: {len(batch)} files "
+                f"(max_dur={max_dur:.1f}s, limit={self._estimate_max_batch(max_dur)})"
             )
-            results = await gpu_future
-            inference_seconds = work_item.inference_seconds if work_item else 0.0
 
-            if self._on_batch_complete:
-                self._on_batch_complete(queue_durations, inference_seconds, len(batch))
+            batch_start = time.monotonic()
+            queue_durations = [batch_start - req.submitted_at for req in batch]
 
-            if isinstance(results, list) and len(results) == len(batch):
-                for req, result in zip(batch, results):
+            audio_paths = [r.audio_path for r in batch]
+            timestamps = batch[0].timestamps if batch else True
+            is_oom = False
+            try:
+                gpu_future, work_item = self._gpu_worker.submit(
+                    {
+                        "audio_paths": audio_paths,
+                        "timestamps": timestamps,
+                        "batch_size": len(batch),
+                        "durations": durations,
+                    },
+                    self._loop,
+                )
+                results = await gpu_future
+                inference_seconds = work_item.inference_seconds if work_item else 0.0
+
+                if self._on_batch_complete:
+                    self._on_batch_complete(queue_durations, inference_seconds, len(batch))
+
+                if isinstance(results, list) and len(results) == len(batch):
+                    for req, result in zip(batch, results):
+                        if not req.future.done():
+                            req.future.set_result(result)
+                else:
+                    items = results if isinstance(results, list) else [results]
+                    for i, req in enumerate(batch):
+                        if not req.future.done():
+                            result = items[i] if i < len(items) else {"text": ""}
+                            req.future.set_result(result)
+
+            except asyncio.CancelledError:
+                err = RuntimeError("Batch cancelled during shutdown")
+                for req in batch:
                     if not req.future.done():
-                        req.future.set_result(result)
-            else:
-                items = results if isinstance(results, list) else [results]
-                for i, req in enumerate(batch):
+                        req.future.set_exception(err)
+            except RuntimeError as exc:
+                if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
+                    is_oom = True
+                err = QueueFullError(str(exc)) if "GPU queue full" in str(exc) else exc
+                logger.error(f"Batch transcription failed: {exc}")
+                for req in batch:
                     if not req.future.done():
-                        result = items[i] if i < len(items) else {"text": ""}
-                        req.future.set_result(result)
-
-        except asyncio.CancelledError:
-            err = RuntimeError("Batch cancelled during shutdown")
-            for req in batch:
-                if not req.future.done():
-                    req.future.set_exception(err)
-        except RuntimeError as exc:
-            if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
-                is_oom = True
-            err = QueueFullError(str(exc)) if "GPU queue full" in str(exc) else exc
-            logger.error(f"Batch transcription failed: {exc}")
-            for req in batch:
-                if not req.future.done():
-                    req.future.set_exception(err)
-        except Exception as exc:
-            if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
-                is_oom = True
-            logger.error(f"Batch transcription failed: {exc}")
-            for req in batch:
-                if not req.future.done():
-                    req.future.set_exception(exc)
+                        req.future.set_exception(err)
+            except Exception as exc:
+                if "CUDA out of memory" in str(exc) or "OutOfMemoryError" in type(exc).__name__:
+                    is_oom = True
+                logger.error(f"Batch transcription failed: {exc}")
+                for req in batch:
+                    if not req.future.done():
+                        req.future.set_exception(exc)
+            finally:
+                if is_oom and self._on_gpu_oom:
+                    self._on_gpu_oom()
+                for req in batch:
+                    if req.owns_file:
+                        _unlink_safe(req.audio_path)
         finally:
-            if is_oom and self._on_gpu_oom:
-                self._on_gpu_oom()
-            for req in batch:
-                if req.owns_file:
-                    _unlink_safe(req.audio_path)
+            self._inflight_sem.release()
 
     @property
     def metrics(self) -> dict:

--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -82,17 +82,18 @@ class BatchEngine:
             return
         self._attention_mode = vram.get("attention_mode", "full")
         self._auto_threshold_sec = vram.get("auto_threshold_sec", 300.0)
-        budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
-        self._vram_available_mb = max(budget, 0)
+        total_budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
+        self._vram_available_mb = max(total_budget / self._max_inflight, 0)
         self._vram_enabled = True
-        if budget <= 0:
+        if total_budget <= 0:
             logger.warning(
-                f"VRAM budget is non-positive ({budget:.0f} MB) — "
+                f"VRAM budget is non-positive ({total_budget:.0f} MB) — "
                 f"baseline exceeds safety cap. All batches capped to 1."
             )
         logger.info(
-            f"VRAM-aware batching enabled: {self._vram_available_mb:.0f} MB budget "
-            f"(total={vram['total_mb']:.0f}, baseline={vram['baseline_mb']:.0f}, "
+            f"VRAM-aware batching enabled: {self._vram_available_mb:.0f} MB per-batch budget "
+            f"({total_budget:.0f} MB total / {self._max_inflight} inflight, "
+            f"gpu_total={vram['total_mb']:.0f}, baseline={vram['baseline_mb']:.0f}, "
             f"safety={self._vram_safety_factor}, coeff={self._vram_bytes_per_t2})"
         )
 

--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -2,8 +2,14 @@ import asyncio
 import logging
 import os
 import time
+import wave as _wave
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
+try:
+    import soundfile as _sf
+except ImportError:
+    _sf = None
 
 from gpu_worker import GPUWorker, WorkType
 
@@ -17,6 +23,7 @@ class PendingRequest:
     future: asyncio.Future
     owns_file: bool = False
     submitted_at: float = field(default_factory=time.monotonic)
+    duration_sec: Optional[float] = None
 
 
 class QueueFullError(Exception):
@@ -32,6 +39,9 @@ class BatchEngine:
         max_queue_depth: int = 4096,
         on_batch_complete=None,
         on_gpu_oom=None,
+        vram_safety_factor: float = 0.8,
+        vram_bytes_per_t2: float = 136.6,
+        starvation_timeout_sec: float = 5.0,
     ):
         self._gpu_worker = gpu_worker
         self._max_batch_size = max_batch_size
@@ -45,15 +55,40 @@ class BatchEngine:
         self._shutting_down = False
         self._on_batch_complete = on_batch_complete
         self._on_gpu_oom = on_gpu_oom
+        self._vram_safety_factor = vram_safety_factor
+        self._vram_bytes_per_t2 = vram_bytes_per_t2
+        self._starvation_timeout = starvation_timeout_sec
+        self._vram_available_mb = 0.0
+        self._vram_enabled = False
+        self._auto_threshold_sec = 300.0
         self._metrics = {
             "total_requests": 0,
             "total_batches": 0,
             "total_files": 0,
             "rejected_requests": 0,
+            "vram_limited_batches": 0,
         }
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
+        vram = self._gpu_worker.vram_info
+        self._auto_threshold_sec = vram.get("auto_threshold_sec", 300.0)
+        if self._vram_safety_factor > 0 and vram.get("total_mb", 0) > 0:
+            budget = vram["total_mb"] * self._vram_safety_factor - vram["baseline_mb"]
+            self._vram_available_mb = max(budget, 0)
+            self._vram_enabled = True
+            if budget <= 0:
+                logger.warning(
+                    f"VRAM budget is non-positive ({budget:.0f} MB) — "
+                    f"baseline exceeds safety cap. All batches capped to 1."
+                )
+            logger.info(
+                f"VRAM-aware batching enabled: {self._vram_available_mb:.0f} MB budget "
+                f"(total={vram['total_mb']:.0f}, baseline={vram['baseline_mb']:.0f}, "
+                f"safety={self._vram_safety_factor}, coeff={self._vram_bytes_per_t2})"
+            )
+        else:
+            logger.info("VRAM-aware batching disabled (safety_factor=0 or no VRAM info)")
         self._flush_task = asyncio.create_task(self._flush_loop())
 
     async def stop(self) -> None:
@@ -71,8 +106,40 @@ class BatchEngine:
         while self._pending:
             await self._flush_batch()
 
+    @staticmethod
+    def _get_audio_duration(path: str) -> Optional[float]:
+        try:
+            with _wave.open(path) as wf:
+                return wf.getnframes() / wf.getframerate()
+        except Exception:
+            pass
+        if _sf is not None:
+            try:
+                info = _sf.info(path)
+                return info.duration
+            except Exception:
+                pass
+        return None
+
+    def _estimate_max_batch(self, max_duration_sec: float, duration_known: bool = True) -> int:
+        if not self._vram_enabled or max_duration_sec <= 0:
+            return self._max_batch_size
+        if self._vram_available_mb <= 0:
+            return 1
+        T = max_duration_sec / 0.08
+        per_file_mb = self._vram_bytes_per_t2 * T * T / (1024 * 1024)
+        if per_file_mb <= 0:
+            return self._max_batch_size
+        return max(1, min(self._max_batch_size, int(self._vram_available_mb / per_file_mb)))
+
+    def _effective_duration(self, req: PendingRequest) -> float:
+        if req.duration_sec is not None:
+            return req.duration_sec
+        return self._auto_threshold_sec
+
     async def submit(self, audio_path: str, timestamps: bool = True, owns_file: bool = False) -> dict:
         enqueued = False
+        duration = self._get_audio_duration(audio_path)
         try:
             async with self._lock:
                 if len(self._pending) >= self._max_queue_depth:
@@ -86,6 +153,7 @@ class BatchEngine:
                         timestamps=timestamps,
                         future=future,
                         owns_file=owns_file,
+                        duration_sec=duration,
                     )
                 )
                 enqueued = True
@@ -108,12 +176,55 @@ class BatchEngine:
             if self._pending:
                 await self._flush_batch()
 
+    def _form_vram_safe_batch(self, candidates: list[PendingRequest]) -> list[PendingRequest]:
+        if not candidates or not self._vram_enabled:
+            return candidates[: self._max_batch_size]
+
+        now = time.monotonic()
+        starved = [r for r in candidates if now - r.submitted_at > self._starvation_timeout]
+
+        if starved:
+            anchor = min(starved, key=lambda r: r.submitted_at)
+            anchor_dur = self._effective_duration(anchor)
+            any_unknown = anchor.duration_sec is None
+            limit = self._estimate_max_batch(anchor_dur, duration_known=not any_unknown)
+            others = sorted(
+                [r for r in candidates if r is not anchor],
+                key=lambda r: self._effective_duration(r),
+            )
+            batch = [anchor]
+            for req in others:
+                if len(batch) >= limit:
+                    break
+                candidate_max_dur = max(anchor_dur, self._effective_duration(req))
+                has_unknown = any_unknown or req.duration_sec is None
+                new_limit = self._estimate_max_batch(candidate_max_dur, duration_known=not has_unknown)
+                if len(batch) + 1 <= new_limit:
+                    batch.append(req)
+                    any_unknown = has_unknown
+            return batch
+
+        sorted_candidates = sorted(candidates, key=lambda r: self._effective_duration(r))
+        n = min(self._max_batch_size, len(sorted_candidates))
+        while n > 1:
+            longest = sorted_candidates[n - 1]
+            longest_dur = self._effective_duration(longest)
+            has_unknown = any(r.duration_sec is None for r in sorted_candidates[:n])
+            limit = self._estimate_max_batch(longest_dur, duration_known=not has_unknown)
+            if n <= limit:
+                break
+            n -= 1
+        return sorted_candidates[:n]
+
     async def _flush_batch(self) -> None:
         async with self._lock:
             if not self._pending:
                 return
-            batch = self._pending[: self._max_batch_size]
-            self._pending = self._pending[self._max_batch_size :]
+            batch = self._form_vram_safe_batch(self._pending)
+            batch_set = set(id(r) for r in batch)
+            self._pending = [r for r in self._pending if id(r) not in batch_set]
+            if len(batch) < self._max_batch_size and self._vram_enabled:
+                self._metrics["vram_limited_batches"] += 1
 
         self._metrics["total_batches"] += 1
         self._metrics["total_files"] += len(batch)

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -277,15 +277,16 @@ class GPUWorker:
 
         self._load_embedding_model()
 
-        device = os.getenv("PARAKEET_DEVICE", "cuda:0")
-        dev_idx = int(device.split(":")[-1]) if ":" in device else 0
-        free_bytes, total_bytes = torch.cuda.mem_get_info(dev_idx)
-        self._vram_total_mb = total_bytes / (1024 * 1024)
-        self._vram_baseline_mb = (total_bytes - free_bytes) / (1024 * 1024)
-        logger.info(
-            f"VRAM after model load: {self._vram_baseline_mb:.0f}MiB used / "
-            f"{self._vram_total_mb:.0f}MiB total ({free_bytes / (1024 * 1024):.0f}MiB free)"
-        )
+        if torch.cuda.is_available():
+            device = os.getenv("PARAKEET_DEVICE", "cuda:0")
+            dev_idx = int(device.split(":")[-1]) if ":" in device else 0
+            free_bytes, total_bytes = torch.cuda.mem_get_info(dev_idx)
+            self._vram_total_mb = total_bytes / (1024 * 1024)
+            self._vram_baseline_mb = (total_bytes - free_bytes) / (1024 * 1024)
+            logger.info(
+                f"VRAM after model load: {self._vram_baseline_mb:.0f}MiB used / "
+                f"{self._vram_total_mb:.0f}MiB total ({free_bytes / (1024 * 1024):.0f}MiB free)"
+            )
         logger.info("Batch model loaded and ready")
 
     def _load_embedding_model(self) -> None:

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -78,10 +78,21 @@ class GPUWorker:
         self._attn_is_local = False
         self._model_dtype = None
         self._max_file_duration_sec = float(os.getenv("PARAKEET_MAX_FILE_DURATION", "0"))
+        self._vram_total_mb = 0.0
+        self._vram_baseline_mb = 0.0
 
     @property
     def is_ready(self) -> bool:
         return self._ready.is_set() and self._load_error is None
+
+    @property
+    def vram_info(self) -> dict:
+        return {
+            "total_mb": self._vram_total_mb,
+            "baseline_mb": self._vram_baseline_mb,
+            "attention_mode": self._attn_mode,
+            "auto_threshold_sec": self._attn_auto_threshold_sec,
+        }
 
     def start(self) -> None:
         self._running = True
@@ -266,9 +277,9 @@ class GPUWorker:
 
         self._load_embedding_model()
 
-        vram_used = torch.cuda.memory_allocated() / 1024**2
-        vram_total = torch.cuda.get_device_properties(0).total_memory / 1024**2
-        logger.info(f"VRAM after model load: {vram_used:.0f}MiB / {vram_total:.0f}MiB")
+        self._vram_baseline_mb = torch.cuda.memory_allocated() / 1024**2
+        self._vram_total_mb = torch.cuda.get_device_properties(0).total_memory / 1024**2
+        logger.info(f"VRAM after model load: {self._vram_baseline_mb:.0f}MiB / {self._vram_total_mb:.0f}MiB")
         logger.info("Batch model loaded and ready")
 
     def _load_embedding_model(self) -> None:

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -277,9 +277,15 @@ class GPUWorker:
 
         self._load_embedding_model()
 
-        self._vram_baseline_mb = torch.cuda.memory_allocated() / 1024**2
-        self._vram_total_mb = torch.cuda.get_device_properties(0).total_memory / 1024**2
-        logger.info(f"VRAM after model load: {self._vram_baseline_mb:.0f}MiB / {self._vram_total_mb:.0f}MiB")
+        device = os.getenv("PARAKEET_DEVICE", "cuda:0")
+        dev_idx = int(device.split(":")[-1]) if ":" in device else 0
+        free_bytes, total_bytes = torch.cuda.mem_get_info(dev_idx)
+        self._vram_total_mb = total_bytes / (1024 * 1024)
+        self._vram_baseline_mb = (total_bytes - free_bytes) / (1024 * 1024)
+        logger.info(
+            f"VRAM after model load: {self._vram_baseline_mb:.0f}MiB used / "
+            f"{self._vram_total_mb:.0f}MiB total ({free_bytes / (1024 * 1024):.0f}MiB free)"
+        )
         logger.info("Batch model loaded and ready")
 
     def _load_embedding_model(self) -> None:
@@ -362,7 +368,11 @@ class GPUWorker:
                     )
 
         if self._attn_mode == "auto":
-            max_dur = max((self._get_audio_duration_sec(p) for p in audio_paths), default=0.0)
+            durations_from_batcher = payload.get("durations")
+            if durations_from_batcher:
+                max_dur = max(durations_from_batcher)
+            else:
+                max_dur = max((self._get_audio_duration_sec(p) for p in audio_paths), default=0.0)
             need_local = max_dur >= self._attn_auto_threshold_sec
             if need_local != self._attn_is_local:
                 mode_name = "local" if need_local else "full"

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -141,6 +141,7 @@ async def lifespan(app: FastAPI):
             vram_safety_factor=float(os.getenv("PARAKEET_VRAM_SAFETY_FACTOR", "0.8")),
             vram_bytes_per_t2=float(os.getenv("PARAKEET_VRAM_BYTES_PER_T2", "136.6")),
             starvation_timeout_sec=float(os.getenv("PARAKEET_STARVATION_TIMEOUT", "5.0")),
+            max_inflight=int(os.getenv("PARAKEET_MAX_INFLIGHT", "2")),
         )
         await batch_engine.start()
         logger.info("Server started, GPU model loading in background...")

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -138,6 +138,9 @@ async def lifespan(app: FastAPI):
             max_queue_depth=int(os.getenv("PARAKEET_MAX_QUEUE_DEPTH", "4096")),
             on_batch_complete=_on_batch_complete,
             on_gpu_oom=_on_gpu_oom,
+            vram_safety_factor=float(os.getenv("PARAKEET_VRAM_SAFETY_FACTOR", "0.8")),
+            vram_bytes_per_t2=float(os.getenv("PARAKEET_VRAM_BYTES_PER_T2", "136.6")),
+            starvation_timeout_sec=float(os.getenv("PARAKEET_STARVATION_TIMEOUT", "5.0")),
         )
         await batch_engine.start()
         logger.info("Server started, GPU model loading in background...")

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -6,128 +6,243 @@ cd "$ROOT_DIR"
 
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
-PYTHON_BIN="${PYTHON:-python3}"
-if ! "$PYTHON_BIN" -m pytest --version >/dev/null 2>&1; then
-  PYTHON_BIN="python"
-fi
+pytest tests/unit/test_transcript_segment.py -v
+pytest tests/unit/test_import_job_status_detail_enum.py -v
+pytest tests/unit/test_text_similarity.py -v
+pytest tests/unit/test_text_containment.py -v
+pytest tests/unit/test_speaker_sample.py -v
+pytest tests/unit/test_speaker_sample_migration.py -v
+pytest tests/unit/test_short_audio_embedding.py -v
+pytest tests/unit/test_users_add_sample_transaction.py -v
+pytest tests/unit/test_users_webhook_url_validation.py -v
+pytest tests/unit/test_voice_message_language.py -v
+pytest tests/unit/test_speaker_assignment.py -v
+pytest tests/unit/test_speaker_id_pipeline.py -v
+pytest tests/unit/test_user_speaker_embedding.py -v
+pytest tests/unit/test_parakeet_diarization.py -v
+pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
+pytest tests/unit/test_parakeet_prerecorded.py -v
+pytest tests/unit/test_parakeet_nim.py -v
+pytest tests/unit/test_parakeet_stream_session.py -v
+pytest tests/unit/test_parakeet_gpu_worker.py -v
+pytest tests/unit/test_parakeet_batch_engine.py -v
+pytest tests/unit/test_vram_batch.py -v
+pytest tests/unit/test_oom_reproduction.py -v
+pytest tests/unit/test_parakeet_batch_routing.py -v
+pytest tests/unit/test_parakeet_builtin_embedding.py -v
+pytest tests/unit/test_parakeet_endpoints.py -v
+pytest tests/unit/test_audiobuffer_guard.py -v
+pytest tests/unit/test_memory_leak_buffers.py -v
+pytest tests/unit/test_mcp_search_memories.py -v
+pytest tests/unit/test_mcp_search_conversations_poison.py -v
+pytest tests/unit/test_mcp_memory_filters.py -v
+pytest tests/unit/test_mcp_client_tool_result.py -v
+pytest tests/unit/test_mcp_data_endpoints.py -v
+pytest tests/unit/test_mcp_oauth.py -v
+pytest tests/unit/test_mcp_action_item_writes.py -v
+pytest tests/unit/test_mcp_conversations_poison.py -v
+pytest tests/unit/test_mcp_profile_contact.py -v
+pytest tests/unit/test_memory_temporal_brain.py -v
+pytest tests/unit/test_memory_category_auto.py -v
+pytest tests/unit/test_memories_validation.py -v
+pytest tests/unit/test_memories_user_review.py -v
+pytest tests/unit/test_announcement_malformed_type.py -v
+pytest tests/unit/test_llm_gateway_service.py -v
+pytest tests/unit/test_llm_gateway_config.py -v
+pytest tests/unit/test_llm_gateway_auth.py -v
+pytest tests/unit/test_llm_gateway_credentials.py -v
+pytest tests/unit/test_llm_gateway_validator.py -v
+pytest tests/unit/test_llm_gateway_resolver.py -v
+pytest tests/unit/test_llm_gateway_executor.py -v
+pytest tests/unit/test_llm_gateway_openai_provider.py -v
+pytest tests/unit/test_llm_gateway_openai_compatible.py -v
+pytest tests/unit/test_llm_gateway_readiness.py -v
+pytest tests/unit/test_llm_gateway_client_config.py -v
+pytest tests/unit/test_llm_gateway_route_refs.py -v
+pytest tests/unit/test_llm_gateway_dependencies.py -v
+pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
+pytest tests/unit/test_backend_runtime_env_validator.py -v
+pytest tests/unit/test_llm_usage_tracker.py -v
+pytest tests/unit/test_llm_provider_plugin_structure.py -v
+pytest tests/unit/test_process_conversation_usage_context.py -v
+pytest tests/unit/test_high_priority_usage_tracking.py -v
+pytest tests/unit/test_new_usage_tracking_gaps.py -v
+pytest tests/unit/test_llm_usage_db.py -v
+pytest tests/unit/test_user_usage.py -v
+pytest tests/unit/test_llm_usage_endpoints.py -v
+pytest tests/unit/test_app_uid_keyerror.py -v
+pytest tests/unit/test_create_persona_user_none.py -v
+pytest tests/unit/test_daily_summary_race_condition.py -v
+pytest tests/unit/test_daily_summary_regenerate.py -v
+pytest tests/unit/test_chat_tools_messages.py -v
+pytest tests/unit/test_chat_tool_parameters_json.py -v
+pytest tests/unit/test_prompt_caching.py -v
+pytest tests/unit/test_mentor_notifications.py -v
+pytest tests/unit/test_proactive_notification_language.py -v
+pytest tests/unit/test_notification_token_cleanup.py -v
+pytest tests/unit/test_integration_notification_validation.py -v
+pytest tests/unit/test_conversations_to_string.py -v
+pytest tests/unit/test_location_maps_status_guard.py -v
+pytest tests/unit/test_conversation_render_factory.py -v
+pytest tests/unit/test_conversation_redact_enrich.py -v
+pytest tests/unit/test_retrieval_semantics.py -v
+pytest tests/unit/test_conversation_tool_date_range_bound.py -v
+pytest tests/unit/test_folder_name_enrichment.py -v
+pytest tests/unit/test_folder_conversations_malformed.py -v
+pytest tests/unit/test_conversations_count.py -v
+pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
+pytest tests/unit/test_prompt_cache_optimization.py -v
+pytest tests/unit/test_prompt_cache_integration.py -v
+pytest tests/unit/test_firestore_cache.py -v
+pytest tests/unit/test_firestore_invariant_helpers.py -v
+pytest tests/unit/test_task_sharing.py -v
+pytest tests/unit/test_action_items_conversation_list_malformed.py -v
+pytest tests/unit/test_firmware_pagination.py -v
+pytest tests/unit/test_vad_gate.py -v
+pytest tests/unit/test_vad_onnx.py -v
+pytest tests/unit/test_log_sanitizer.py -v
+pytest tests/unit/test_hume_callback_malformed.py -v
+pytest tests/unit/test_file_upload_security.py -v
+pytest tests/unit/test_file_upload_endpoint_security.py -v
+pytest tests/unit/test_auth_redirect_uri.py -v
+pytest tests/unit/test_pusher_heartbeat.py -v
+pytest tests/unit/test_pusher_conversation_retry.py -v
+pytest tests/unit/utils/test_listen_pusher_session.py -v
+pytest tests/unit/test_listen_fallback_removal.py -v
+pytest tests/unit/test_desktop_updates.py -v
+pytest tests/unit/test_translation_optimization.py -v
+pytest tests/unit/test_translation_cost_optimization.py -v
+pytest tests/unit/test_translation_dedup_edge_cases.py -v
+pytest tests/unit/test_conversation_source_unknown.py -v
+pytest tests/unit/test_conversation_model_split.py -v
+pytest tests/unit/test_transcribe_conversation_cache.py -v
+pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
+pytest tests/unit/test_pusher_batch_upload.py -v
+pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
+pytest tests/unit/test_optional_audio_codecs.py -v
+pytest tests/unit/test_storage_opus_encoding.py -v
+pytest tests/unit/test_speech_profile_existence.py -v
+pytest tests/unit/test_speech_profile_wav_decode.py -v
+pytest tests/unit/test_storage_fanout_limits.py -v
+pytest tests/unit/test_deferred_blob_janitor.py -v
+pytest tests/unit/test_audio_merge_tasks.py -v
+pytest tests/unit/test_sync_playback_service.py -v
+pytest tests/unit/test_people_conversations_500s.py -v
+pytest tests/unit/test_import_jobs_malformed.py -v
+pytest tests/unit/test_firestore_read_ops_cache.py -v
+pytest tests/unit/test_ws_auth_handshake.py -v
+pytest tests/unit/test_streaming_deepgram_backoff.py -v
+pytest tests/unit/test_executors.py -v
+pytest tests/unit/test_modulate_stt.py -v
+pytest tests/unit/test_batch_upload_storage.py -v
+pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_action_items_timezone.py -v
+pytest tests/unit/test_request_validation_contracts.py -v
+pytest tests/unit/test_conversation_structure_timezone.py -v
+pytest tests/unit/test_action_item_dedup.py -v
+pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
+pytest tests/unit/test_action_item_idempotency.py -v
+pytest tests/unit/test_goals_id_fallback.py -v
+pytest tests/unit/test_tools_router.py -v
+pytest tests/unit/test_kg_user_type_mismatch.py -v
+pytest tests/unit/test_kg_edge_id_sanitization.py -v
+pytest tests/unit/test_goal_extraction_batch.py -v
+pytest tests/unit/test_listen_pipeline.py -v
+pytest tests/unit/test_resample_pcm_divzero.py -v
+pytest tests/unit/test_fair_use_models.py -v
+pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
+pytest tests/unit/test_fair_use_engine.py -v
+pytest tests/unit/test_fair_use_classifier.py -v
+pytest tests/unit/test_fair_use_async.py -v
+pytest tests/unit/test_dg_usage_batch.py -v
+pytest tests/unit/test_billable_transcription_seconds.py -v
+pytest tests/unit/test_sync_fair_use_gate.py -v
+pytest tests/unit/test_sync_pcm_decode.py -v
+pytest tests/unit/test_sync_opus_decode.py -v
+pytest tests/unit/test_transcribe_lc3_optional.py -v
+pytest tests/unit/test_sync_silent_failure.py -v
+pytest tests/unit/test_sync_ordered_assignment.py -v
+pytest tests/unit/test_fair_use_free_tier.py -v
+pytest tests/unit/test_fair_use_upgrade.py -v
+pytest tests/unit/test_skip_classifier_restrict.py -v
+pytest tests/unit/test_timeout_middleware.py -v
+pytest tests/unit/test_pusher_circuit_breaker.py -v
+pytest tests/unit/test_pusher_ghost_connections.py -v
+pytest tests/unit/test_async_tasks.py -v
+pytest tests/unit/test_async_resource_correctness.py -v
+pytest tests/unit/test_lock_bypass_fixes.py -v
+pytest tests/unit/test_integration_malformed_records.py -v
+pytest tests/unit/test_oauth_callback_uid_guard.py -v
+pytest tests/unit/test_dev_api_lock_bypass.py -v
+pytest tests/unit/test_dev_api_folder_filters.py -v
+pytest tests/unit/test_dev_api_conversations_poison.py -v
+pytest tests/unit/test_dev_api_memories_pagination.py -v
+pytest tests/unit/test_dev_api_action_items_poison.py -v
+pytest tests/unit/test_rate_limiting.py -v
+pytest tests/unit/test_rate_limit_json_failopen.py -v
+pytest tests/unit/test_memories_batch.py -v
+pytest tests/unit/test_memories_create.py -v
+pytest tests/unit/test_memories_pagination_clamp.py -v
+pytest tests/unit/test_sync_v2.py -v
+pytest tests/unit/test_sync_file_paths_filename_none.py -v
+pytest tests/unit/test_sync_cloud_tasks.py -v
+pytest tests/unit/test_sync_transcription_prefs.py -v
+pytest tests/unit/test_sync_record_usage.py -v
+pytest tests/unit/test_vision_stream_async.py -v
+pytest tests/unit/test_desktop_transcribe.py -v
+pytest tests/unit/test_desktop_migration.py -v
+pytest tests/unit/test_staged_tasks_batch_scores.py -v
+pytest tests/unit/test_staged_tasks_dedup.py -v
+pytest tests/unit/test_dg_start_guard.py -v
+pytest tests/unit/test_available_plans_resilience.py -v
+pytest tests/unit/test_subscription_restructure.py -v
+pytest tests/unit/test_chat_quota.py -v
+pytest tests/unit/test_voice_message_filename_none.py -v
+pytest tests/unit/test_subscription_plans.py -v
+pytest tests/unit/test_payment_available_plans_source.py -v
+pytest tests/unit/test_payment_promotion_codes.py -v
+pytest tests/unit/test_stripe_webhook_none_guard.py -v
+pytest tests/unit/test_stripe_webhook_behavioral.py -v
+pytest tests/unit/test_voice_duration_limiter.py -v
+pytest tests/unit/test_async_webhooks.py -v
+pytest tests/unit/test_async_app_integrations.py -v
+pytest tests/unit/test_async_realtime_integrations_offload.py -v
+pytest tests/unit/test_async_geocoding.py -v
+pytest tests/unit/test_geocoding_cache.py -v
+pytest tests/unit/test_realtime_integrations_usage_tracking.py -v
+pytest tests/unit/test_async_auth.py -v
+pytest tests/unit/test_thread_join_elimination.py -v
+pytest tests/unit/test_async_http_infrastructure.py -v
+pytest tests/unit/test_clean_sweep_migrations.py -v
+pytest tests/unit/test_omi_qos_tiers.py -v
+pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_paywall_reconnect_gate.py -v
+pytest tests/unit/test_trial_metadata.py -v
+pytest tests/unit/test_neo_desktop_grandfather.py -v
+pytest tests/unit/test_vertex_ai_system_role.py -v
+pytest tests/unit/test_tts.py -v
+pytest tests/unit/test_webhook_auto_disable.py -v
+pytest tests/unit/test_merge_validation.py -v
+pytest tests/unit/test_phone_calls.py -v
+pytest tests/unit/test_twilio_service.py -v
+pytest tests/unit/test_twilio_account_deletion.py -v
+pytest tests/unit/test_phone_verification_created_at.py -v
+pytest tests/unit/test_conversation_search_date_validation.py -v
+pytest tests/unit/test_conversation_events_bounds.py -v
+pytest tests/unit/test_conversation_hybrid_search.py -v
+pytest tests/unit/test_delete_account_stripe_cancel.py -v
+pytest tests/unit/test_delete_account_purge_storage.py -v
+pytest tests/unit/test_claim_deletion_wipe_txn.py -v
+pytest tests/services/users/test_account_deletion.py -v
+pytest tests/services/users/test_data_export.py -v
+pytest tests/routers/test_users.py -v
+pytest tests/unit/test_apps_review_reply_validation.py -v
+pytest tests/unit/test_apps_create_app_json.py -v
 
-read_test_file_list() {
-  local test_file_list="$1"
-  if [[ -n "$test_file_list" ]]; then
-    if [[ ! -f "$test_file_list" ]]; then
-      echo "ERROR: BACKEND_UNIT_TEST_FILE_LIST does not exist: $test_file_list" >&2
-      exit 1
-    fi
-    "$PYTHON_BIN" scripts/select_backend_unit_tests.py --from-test-list "$test_file_list"
-  else
-    "$PYTHON_BIN" scripts/select_backend_unit_tests.py --all
-  fi
-}
-
-pytest_args=(-v)
-if [[ "${BACKEND_PYTEST_XDIST:-auto}" != "0" ]]; then
-  if "$PYTHON_BIN" -c "import xdist" >/dev/null 2>&1; then
-    pytest_args+=("-n" "${BACKEND_PYTEST_WORKERS:-auto}" "--dist=loadfile")
-  else
-    echo "pytest-xdist not installed; running backend unit tests without parallel workers."
-  fi
-fi
-
-requires_process_isolation() {
-  local test_path="$1"
-  grep -Eq 'sys[.]modules|importlib[.]reload|del sys[.]modules' "$test_path"
-}
-
-run_pytest_group() {
-  local label="$1"
-  shift
-  if [[ $# -eq 0 ]]; then
-    return 0
-  fi
-
-  echo
-  echo "----------------------------------------"
-  echo "Running $label ($# files)"
-  echo "----------------------------------------"
-
-  if ! "$PYTHON_BIN" -m pytest "$@" "${pytest_args[@]}"; then
-    failed_tests+=("$label")
-  fi
-}
-
-run_isolated_pytest() {
-  local test_path="$1"
-
-  echo
-  echo "----------------------------------------"
-  echo "Running isolated $test_path"
-  echo "----------------------------------------"
-
-  if ! "$PYTHON_BIN" -m pytest "$test_path" -v; then
-    failed_tests+=("$test_path")
-  fi
-}
-
-unit_tests=()
-while IFS= read -r test_path; do
-  unit_tests+=("$test_path")
-done < <(read_test_file_list "${BACKEND_UNIT_TEST_FILE_LIST:-}")
-
-bulk_tests=()
-isolated_tests=()
-for test_path in "${unit_tests[@]}"; do
-  if requires_process_isolation "$test_path"; then
-    isolated_tests+=("$test_path")
-  else
-    bulk_tests+=("$test_path")
-  fi
-done
-
-failed_tests=()
-
-echo
-echo "----------------------------------------"
-if [[ ${#unit_tests[@]} -eq 0 ]]; then
-  echo "No backend unit tests selected."
+# Fair-use integration tests (require Redis; skip gracefully if unavailable)
+if redis-cli ping >/dev/null 2>&1; then
+  pytest tests/integration/test_fair_use_live.py -v
+  pytest tests/integration/test_fair_use_api.py -v
 else
-  echo "Running ${#unit_tests[@]} backend unit test files"
-  echo "Bulk files: ${#bulk_tests[@]}"
-  echo "Isolated files: ${#isolated_tests[@]}"
+  echo "SKIP: fair-use integration tests (Redis not available)"
 fi
-echo "----------------------------------------"
-
-if [[ ${#unit_tests[@]} -gt 0 ]]; then
-  run_pytest_group "bulk backend unit tests" "${bulk_tests[@]}"
-  for test_path in "${isolated_tests[@]}"; do
-    run_isolated_pytest "$test_path"
-  done
-fi
-
-if [[ -d testing/contracts ]]; then
-  run_pytest_group "backend contract tests" testing/contracts
-fi
-
-# Optional fair-use integration tests require Redis and are intentionally outside
-# the deterministic unit signal.
-if [[ "${RUN_BACKEND_INTEGRATION_TESTS:-0}" == "1" ]]; then
-  if command -v redis-cli >/dev/null 2>&1 && redis-cli ping >/dev/null 2>&1; then
-    if ! "$PYTHON_BIN" -m pytest tests/integration/test_fair_use_live.py tests/integration/test_fair_use_api.py -v; then
-      failed_tests+=("fair-use integration tests")
-    fi
-  else
-    echo "SKIP: fair-use integration tests (Redis not available)"
-  fi
-else
-  echo "SKIP: fair-use integration tests (set RUN_BACKEND_INTEGRATION_TESTS=1 to enable)"
-fi
-
-echo
-echo "----------------------------------------"
-if [[ ${#failed_tests[@]} -eq 0 ]]; then
-  echo "All backend tests passed."
-  exit 0
-fi
-
-echo "Backend test failures (${#failed_tests[@]}):"
-printf '  - %s\n' "${failed_tests[@]}"
-exit 1

--- a/backend/tests/unit/test_oom_reproduction.py
+++ b/backend/tests/unit/test_oom_reproduction.py
@@ -1,0 +1,228 @@
+"""
+E2E OOM reproduction test for VRAM-aware batch sizing.
+
+Reproduces the exact prod OOM scenario: 12 x 290s files in auto mode on L4.
+Goes RED without the fix (VRAM_SAFETY_FACTOR=0) and GREEN with it (0.8).
+
+Based on hiro's live reproduction on dev cluster:
+  - 12 x 290s files, single batch -> torch.OutOfMemoryError
+  - Tried to allocate 2.35 GiB with only 807 MiB free
+  - 20.9 GiB PyTorch allocated of 22.03 GiB total
+"""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from batch_engine import BatchEngine
+
+L4_TOTAL_MB = 22563
+L4_BASELINE_MB = 5709
+VRAM_COEFF = 136.6
+AUTO_THRESHOLD_SEC = 300.0
+FILE_DURATION_SEC = 290.0
+FILE_COUNT = 12
+
+
+def _per_file_mb(duration_sec):
+    T = duration_sec / 0.08
+    return VRAM_COEFF * T * T / (1024 * 1024)
+
+
+def _make_gpu_worker():
+    """Mock GPU worker that OOMs when batch VRAM exceeds actual L4 capacity."""
+    gpu = MagicMock()
+    gpu.vram_info = {
+        "total_mb": L4_TOTAL_MB,
+        "baseline_mb": L4_BASELINE_MB,
+        "attention_mode": "auto",
+        "auto_threshold_sec": AUTO_THRESHOLD_SEC,
+    }
+
+    available_mb = L4_TOTAL_MB - L4_BASELINE_MB
+    per_file = _per_file_mb(FILE_DURATION_SEC)
+
+    def mock_submit(work, loop):
+        batch_size = work["batch_size"]
+        batch_vram = batch_size * per_file
+        future = loop.create_future()
+        work_item = MagicMock()
+        work_item.inference_seconds = 0.5 * batch_size
+
+        if batch_vram > available_mb:
+            needed_gib = per_file / 1024
+            free_mb = available_mb - (batch_size - 1) * per_file
+            used_gib = (L4_BASELINE_MB + (batch_size - 1) * per_file) / 1024
+            loop.call_soon(
+                future.set_exception,
+                RuntimeError(
+                    f"CUDA out of memory. Tried to allocate {needed_gib:.2f} GiB. "
+                    f"GPU 0 has a total capacity of {L4_TOTAL_MB / 1024:.2f} GiB of which "
+                    f"{free_mb:.0f} MiB is free. {used_gib:.2f} GiB already allocated."
+                ),
+            )
+        else:
+            results = [{"text": f"transcription_{i}"} for i in range(batch_size)]
+            loop.call_soon(future.set_result, results)
+
+        return future, work_item
+
+    gpu.submit = mock_submit
+    return gpu
+
+
+def _make_engine(vram_safety_factor, batch_wait=0.1):
+    gpu = _make_gpu_worker()
+    return gpu, BatchEngine(
+        gpu_worker=gpu,
+        max_batch_size=32,
+        max_wait_seconds=batch_wait,
+        vram_safety_factor=vram_safety_factor,
+        vram_bytes_per_t2=VRAM_COEFF,
+        starvation_timeout_sec=5.0,
+    )
+
+
+class TestOOMReproduction(unittest.TestCase):
+    """
+    Reproduce exact prod OOM: 12 x 290s files on L4 in auto mode.
+
+    RED without fix (vram_safety_factor=0):
+      All 12 files land in one batch -> GPU worker raises CUDA OOM
+      All 12 requests fail with RuntimeError
+
+    GREEN with fix (vram_safety_factor=0.8):
+      VRAM formula caps batches to ~7 files
+      12 files processed across 2 batches, all succeed
+    """
+
+    @patch.object(BatchEngine, '_get_audio_duration', return_value=FILE_DURATION_SEC)
+    def test_without_fix_all_oom(self, _mock_dur):
+        """Without VRAM cap, 12 x 290s in one batch -> OOM."""
+        gpu, engine = _make_engine(vram_safety_factor=0, batch_wait=0.1)
+        oom_fired = []
+        engine._on_gpu_oom = lambda: oom_fired.append(True)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(engine.start())
+
+            async def run():
+                tasks = []
+                for i in range(FILE_COUNT):
+                    tasks.append(asyncio.create_task(engine.submit(f"/tmp/repro290/audio_{i:02d}.wav")))
+                return await asyncio.gather(*tasks, return_exceptions=True)
+
+            results = loop.run_until_complete(run())
+        finally:
+            loop.run_until_complete(engine.stop())
+            loop.close()
+
+        failures = [r for r in results if isinstance(r, Exception)]
+        self.assertEqual(len(failures), FILE_COUNT, f"Expected all {FILE_COUNT} to fail, got {len(failures)}")
+        for f in failures:
+            self.assertIn("CUDA out of memory", str(f))
+        self.assertTrue(oom_fired, "OOM callback should have fired")
+
+        metrics = engine.metrics
+        self.assertEqual(metrics["total_batches"], 1, "Uncapped: exactly 1 batch")
+        self.assertEqual(metrics["total_files"], FILE_COUNT)
+        self.assertEqual(metrics["vram_limited_batches"], 0, "No VRAM limiting when disabled")
+
+    @patch.object(BatchEngine, '_get_audio_duration', return_value=FILE_DURATION_SEC)
+    def test_with_fix_all_succeed(self, _mock_dur):
+        """With VRAM cap at 0.8, 12 x 290s split into safe batches -> all succeed."""
+        gpu, engine = _make_engine(vram_safety_factor=0.8, batch_wait=0.01)
+        oom_fired = []
+        engine._on_gpu_oom = lambda: oom_fired.append(True)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(engine.start())
+
+            async def run():
+                tasks = []
+                for i in range(FILE_COUNT):
+                    tasks.append(asyncio.create_task(engine.submit(f"/tmp/repro290/audio_{i:02d}.wav")))
+                return await asyncio.gather(*tasks, return_exceptions=True)
+
+            results = loop.run_until_complete(run())
+        finally:
+            loop.run_until_complete(engine.stop())
+            loop.close()
+
+        failures = [r for r in results if isinstance(r, Exception)]
+        successes = [r for r in results if not isinstance(r, Exception)]
+
+        self.assertEqual(
+            len(successes),
+            FILE_COUNT,
+            f"Expected all {FILE_COUNT} to succeed, got {len(failures)} failures: {failures}",
+        )
+        self.assertFalse(oom_fired, "No OOM should occur with VRAM cap")
+
+        metrics = engine.metrics
+        self.assertGreater(metrics["total_batches"], 1, "Should split into multiple batches")
+        self.assertEqual(metrics["total_files"], FILE_COUNT)
+        self.assertGreater(metrics["vram_limited_batches"], 0, "Batches should be VRAM-limited")
+
+    def test_batch_size_matches_formula(self):
+        """Verify the formula caps 290s files to the expected batch size on L4."""
+        _, engine = _make_engine(vram_safety_factor=0.8)
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+
+        max_b = engine._estimate_max_batch(FILE_DURATION_SEC)
+        per_file = _per_file_mb(FILE_DURATION_SEC)
+        budget = L4_TOTAL_MB * 0.8 - L4_BASELINE_MB
+
+        self.assertLess(max_b, FILE_COUNT, f"B={max_b} must be < {FILE_COUNT} to prevent OOM")
+        self.assertGreater(max_b, 0)
+        self.assertLessEqual(max_b * per_file, budget, "Capped batch must fit in VRAM budget")
+        self.assertGreater((max_b + 1) * per_file, budget, "B+1 should exceed budget")
+
+    def test_uncapped_exceeds_l4_vram(self):
+        """Verify 12 x 290s uncapped exceeds L4 VRAM -- proving the fix is necessary."""
+        per_file = _per_file_mb(FILE_DURATION_SEC)
+        total_needed = FILE_COUNT * per_file + L4_BASELINE_MB
+        available = L4_TOTAL_MB - L4_BASELINE_MB
+
+        self.assertGreater(
+            total_needed, L4_TOTAL_MB, f"12 x 290s should exceed L4: {total_needed:.0f} > {L4_TOTAL_MB} MiB"
+        )
+        self.assertGreater(
+            FILE_COUNT * per_file,
+            available,
+            f"12 x {per_file:.0f} = {FILE_COUNT * per_file:.0f} > {available:.0f} available",
+        )
+
+    @patch.object(BatchEngine, '_get_audio_duration', return_value=FILE_DURATION_SEC)
+    def test_oom_error_signature_matches_prod(self, _mock_dur):
+        """Verify OOM error string matches prod signature."""
+        _, engine = _make_engine(vram_safety_factor=0, batch_wait=0.1)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(engine.start())
+
+            async def run():
+                tasks = [asyncio.create_task(engine.submit(f"/tmp/audio_{i}.wav")) for i in range(FILE_COUNT)]
+                return await asyncio.gather(*tasks, return_exceptions=True)
+
+            results = loop.run_until_complete(run())
+        finally:
+            loop.run_until_complete(engine.stop())
+            loop.close()
+
+        errors = [r for r in results if isinstance(r, Exception)]
+        self.assertTrue(len(errors) > 0)
+        err_msg = str(errors[0])
+        self.assertIn("CUDA out of memory", err_msg)
+        self.assertIn("Tried to allocate", err_msg)
+        self.assertIn("GiB", err_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_oom_reproduction.py
+++ b/backend/tests/unit/test_oom_reproduction.py
@@ -11,8 +11,35 @@ Based on hiro's live reproduction on dev cluster:
 """
 
 import asyncio
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
+os.environ.setdefault("PARAKEET_DEVICE", "cpu")
+os.environ.setdefault("PARAKEET_TORCH_COMPILE", "false")
+os.environ.setdefault("PARAKEET_CUDA_GRAPHS", "false")
+
+_torch = MagicMock()
+_torch.cuda.is_available.return_value = False
+_torch.cuda.memory_allocated.return_value = 0
+_torch_props = MagicMock()
+_torch_props.total_memory = 16 * 1024**3
+_torch.cuda.get_device_properties.return_value = _torch_props
+_torch.cuda.empty_cache = MagicMock()
+_torch.cuda.mem_get_info.return_value = (10 * 1024**3, 16 * 1024**3)
+_torch.inference_mode = lambda: (lambda fn: fn)
+_torch.compile = lambda m: m
+_torch.backends.cudnn = MagicMock()
+sys.modules.setdefault("torch", _torch)
+
+for _mod in ["nemo", "nemo.collections", "nemo.collections.asr"]:
+    sys.modules.setdefault(_mod, MagicMock())
+for _mod in ["pyannote", "pyannote.audio", "pyannote.audio.core", "pyannote.audio.core.model"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
 
 from batch_engine import BatchEngine
 
@@ -176,12 +203,12 @@ class TestOOMReproduction(unittest.TestCase):
 
         max_b = engine._estimate_max_batch(FILE_DURATION_SEC)
         per_file = _per_file_mb(FILE_DURATION_SEC)
-        budget = L4_TOTAL_MB * 0.8 - L4_BASELINE_MB
+        per_batch_budget = engine._vram_available_mb
 
         self.assertLess(max_b, FILE_COUNT, f"B={max_b} must be < {FILE_COUNT} to prevent OOM")
         self.assertGreater(max_b, 0)
-        self.assertLessEqual(max_b * per_file, budget, "Capped batch must fit in VRAM budget")
-        self.assertGreater((max_b + 1) * per_file, budget, "B+1 should exceed budget")
+        self.assertLessEqual(max_b * per_file, per_batch_budget, "Capped batch must fit in per-batch budget")
+        self.assertGreater((max_b + 1) * per_file, per_batch_budget, "B+1 should exceed per-batch budget")
 
     def test_uncapped_exceeds_l4_vram(self):
         """Verify 12 x 290s uncapped exceeds L4 VRAM -- proving the fix is necessary."""

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -651,6 +651,54 @@ class TestDurationPassthrough:
         assert len(payload["durations"]) == payload["batch_size"]
 
 
+class TestLazyVramInit:
+
+    def test_vram_init_deferred_until_worker_ready(self):
+        """VRAM info is zero at start() time, populated later — lazy init picks it up."""
+        submitted_payloads = []
+
+        def mock_submit(payload, loop):
+            submitted_payloads.append(payload)
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            fut.set_result([{"text": "ok"} for _ in range(payload["batch_size"])])
+            item.inference_seconds = 0.01
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=32, max_wait_seconds=0.01, vram_safety_factor=0.8)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                assert not engine._vram_enabled, "VRAM should be deferred when total_mb=0"
+
+                gpu.vram_info = {
+                    "total_mb": 22563,
+                    "baseline_mb": 5709,
+                    "attention_mode": "auto",
+                    "auto_threshold_sec": 300,
+                }
+
+                try:
+                    fut = asyncio.ensure_future(engine.submit("/tmp/lazy.wav", owns_file=False))
+                    await asyncio.wait_for(fut, timeout=5)
+                finally:
+                    await engine.stop()
+
+                assert engine._vram_enabled, "VRAM should be enabled after lazy init"
+                assert engine._vram_available_mb > 0
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
 class TestUnlinkSafe:
 
     def test_unlink_existing(self):

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -563,6 +563,59 @@ class TestConcurrentFlush:
             loop.close()
 
 
+class TestMaxInflight2:
+
+    def test_two_batches_inflight_concurrently(self):
+        concurrent_count = {"current": 0, "peak": 0}
+        gate = asyncio.Event()
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            concurrent_count["current"] += 1
+            concurrent_count["peak"] = max(concurrent_count["peak"], concurrent_count["current"])
+
+            async def delayed_resolve():
+                await gate.wait()
+                concurrent_count["current"] -= 1
+                results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = 0.01
+
+            asyncio.ensure_future(delayed_resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=2, max_wait_seconds=0.005, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(4)]
+                    for _ in range(50):
+                        await asyncio.sleep(0.01)
+                        if concurrent_count["current"] >= 2:
+                            break
+                    assert concurrent_count["peak"] >= 2, f"peak={concurrent_count['peak']} should be >=2"
+                    gate.set()
+                    results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 4
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
 class TestFlushGuard:
 
     def test_no_duplicate_flush_tasks(self):

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -43,6 +43,7 @@ from gpu_worker import GPUWorker, WorkItem, WorkType
 def _make_mock_gpu_worker(results_fn=None):
     worker = MagicMock(spec=GPUWorker)
     worker.is_ready = True
+    worker.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
 
     def submit(payload, loop):
         fut = loop.create_future()
@@ -217,6 +218,7 @@ class TestBatchEngineErrorPropagation:
     def test_gpu_error_propagates_to_all_futures(self):
         gpu = MagicMock(spec=GPUWorker)
         gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
 
         def submit_error(payload, loop):
             fut = loop.create_future()
@@ -247,6 +249,7 @@ class TestBatchEngineErrorPropagation:
     def test_gpu_queue_full_maps_to_queue_full_error(self):
         gpu = MagicMock(spec=GPUWorker)
         gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
 
         def submit_queue_full(payload, loop):
             fut = loop.create_future()
@@ -352,6 +355,7 @@ class TestBatchEngineShutdown:
         """CancelledError in _flush_batch fails futures instead of stranding them."""
         gpu = MagicMock(spec=GPUWorker)
         gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
 
         def submit_hang(payload, loop):
             fut = loop.create_future()
@@ -420,6 +424,7 @@ class TestBatchEngineCallbacks:
     def test_on_gpu_oom_called_on_cuda_oom(self):
         gpu = MagicMock(spec=GPUWorker)
         gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
         oom_count = [0]
 
         def on_oom():
@@ -449,6 +454,201 @@ class TestBatchEngineCallbacks:
             loop.run_until_complete(run())
         finally:
             loop.close()
+
+
+class TestConcurrentFlush:
+
+    def test_inflight_semaphore_bounds_concurrent_gpu_calls(self):
+        concurrent_count = {"current": 0, "peak": 0}
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            concurrent_count["current"] += 1
+            concurrent_count["peak"] = max(concurrent_count["peak"], concurrent_count["current"])
+
+            def resolve():
+                concurrent_count["current"] -= 1
+                results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = 0.01
+
+            loop.call_soon(resolve)
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=0.005, max_inflight=1, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(8)]
+                    results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 8
+                    assert concurrent_count["peak"] <= 1
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_stop_drains_inflight_batches(self):
+        completed = {"count": 0}
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            results = [{"text": "ok"} for _ in range(payload["batch_size"])]
+
+            def resolve():
+                completed["count"] += 1
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = 0.01
+
+            loop.call_soon(resolve)
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=2, max_wait_seconds=0.005, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(4)]
+                await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+        assert completed["count"] > 0
+
+    def test_flush_loop_fires_without_blocking(self):
+        gpu = _make_mock_gpu_worker()
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=0.005, max_inflight=2, vram_safety_factor=0)
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(4)]
+                    await asyncio.sleep(0.05)
+                    results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 4
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
+class TestFlushGuard:
+
+    def test_no_duplicate_flush_tasks(self):
+        gate = asyncio.Event()
+        flush_entries = {"count": 0}
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            flush_entries["count"] += 1
+
+            async def wait_and_resolve():
+                await gate.wait()
+                if not fut.done():
+                    fut.set_result([{"text": "ok"} for _ in range(payload["batch_size"])])
+                item.inference_seconds = 0.01
+
+            asyncio.ensure_future(wait_and_resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=0.005, max_inflight=1, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(8)]
+                    await asyncio.sleep(0.1)
+                    pending_before = flush_entries["count"]
+                    assert pending_before <= 2
+                    gate.set()
+                    results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 8
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
+class TestDurationPassthrough:
+
+    def test_payload_includes_durations(self):
+        submitted_payloads = []
+
+        def mock_submit(payload, loop):
+            submitted_payloads.append(payload)
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            fut.set_result([{"text": "ok"} for _ in range(payload["batch_size"])])
+            item.inference_seconds = 0.01
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=0.01, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(2)]
+                    await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+        assert len(submitted_payloads) >= 1
+        payload = submitted_payloads[0]
+        assert "durations" in payload
+        assert len(payload["durations"]) == payload["batch_size"]
 
 
 class TestUnlinkSafe:

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -23,6 +23,7 @@ _torch_props = MagicMock()
 _torch_props.total_memory = 16 * 1024**3
 _torch.cuda.get_device_properties.return_value = _torch_props
 _torch.cuda.empty_cache = MagicMock()
+_torch.cuda.mem_get_info.return_value = (10 * 1024**3, 16 * 1024**3)
 _torch.inference_mode = lambda: (lambda fn: fn)
 _torch.compile = lambda m: m
 _torch.backends.cudnn = MagicMock()

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -22,6 +22,7 @@ _torch_props = MagicMock()
 _torch_props.total_memory = 16 * 1024**3
 _torch.cuda.get_device_properties.return_value = _torch_props
 _torch.cuda.empty_cache = MagicMock()
+_torch.cuda.mem_get_info.return_value = (10 * 1024**3, 16 * 1024**3)
 _torch.inference_mode = lambda: (lambda fn: fn)
 _torch.compile = lambda m: m
 _torch.backends.cudnn = MagicMock()

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -902,3 +902,91 @@ class TestDurationGuardBoundary:
             with pytest.raises(AudioDurationExceededError):
                 worker._batch_transcribe({"audio_paths": ["/tmp/over.wav"], "timestamps": True, "batch_size": 1})
             worker.stop()
+
+
+class TestMemGetInfoGuard:
+
+    def test_mem_get_info_not_called_when_cuda_unavailable(self):
+        import gpu_worker as gw_mod
+
+        torch_mod = gw_mod.torch
+        orig_avail = torch_mod.cuda.is_available.return_value
+        torch_mod.cuda.is_available.return_value = False
+        torch_mod.cuda.mem_get_info.reset_mock()
+
+        nemo_asr = _get_nemo_asr()
+        mock_model = _make_mock_model()
+        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
+
+        worker = GPUWorker()
+        with patch.dict(os.environ, {"PARAKEET_TORCH_COMPILE": "false"}):
+            worker._load_model()
+
+        torch_mod.cuda.mem_get_info.assert_not_called()
+        assert worker._vram_total_mb == 0.0
+        assert worker._vram_baseline_mb == 0.0
+
+        torch_mod.cuda.is_available.return_value = orig_avail
+        worker.stop()
+
+    def test_mem_get_info_called_when_cuda_available(self):
+        import gpu_worker as gw_mod
+
+        torch_mod = gw_mod.torch
+        orig_avail = torch_mod.cuda.is_available.return_value
+        torch_mod.cuda.is_available.return_value = True
+        torch_mod.cuda.mem_get_info.reset_mock()
+        torch_mod.cuda.mem_get_info.return_value = (10 * 1024**3, 22 * 1024**3)
+
+        nemo_asr = _get_nemo_asr()
+        mock_model = _make_mock_model()
+        nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
+        nemo_asr.models.ASRModel.from_pretrained.side_effect = None
+
+        worker = GPUWorker()
+        with patch.dict(os.environ, {"PARAKEET_TORCH_COMPILE": "false"}):
+            worker._load_model()
+
+        torch_mod.cuda.mem_get_info.assert_called_once()
+        assert worker._vram_total_mb > 0
+        assert worker._vram_baseline_mb > 0
+
+        torch_mod.cuda.is_available.return_value = orig_avail
+        worker.stop()
+
+
+class TestDurationPassthroughInGPUWorker:
+
+    def test_durations_from_batcher_used_instead_of_file_probe(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto", "PARAKEET_AUTO_ATTN_THRESHOLD": "300"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=100.0)
+
+            worker._batch_transcribe(
+                {
+                    "audio_paths": ["/tmp/a.wav"],
+                    "timestamps": True,
+                    "batch_size": 1,
+                    "durations": [100.0],
+                }
+            )
+
+            worker._get_audio_duration_sec.assert_not_called()
+            worker.stop()
+
+    def test_file_probe_fallback_when_no_durations(self):
+        with patch.dict(os.environ, {"PARAKEET_ATTENTION_MODE": "auto", "PARAKEET_AUTO_ATTN_THRESHOLD": "300"}):
+            worker = _start_worker_with_mock()
+            worker._get_audio_duration_sec = MagicMock(return_value=100.0)
+
+            worker._batch_transcribe(
+                {
+                    "audio_paths": ["/tmp/a.wav"],
+                    "timestamps": True,
+                    "batch_size": 1,
+                }
+            )
+
+            worker._get_audio_duration_sec.assert_called()
+            worker.stop()

--- a/backend/tests/unit/test_vram_batch.py
+++ b/backend/tests/unit/test_vram_batch.py
@@ -1,0 +1,251 @@
+"""Tests for VRAM-aware batch sizing in batch_engine.py."""
+
+import asyncio
+import os
+import struct
+import tempfile
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from batch_engine import BatchEngine, PendingRequest
+
+
+def _make_wav(duration_sec, sample_rate=16000):
+    num_samples = int(duration_sec * sample_rate)
+    data_size = num_samples * 2
+    header = b"RIFF"
+    header += struct.pack("<I", 36 + data_size)
+    header += b"WAVE"
+    header += b"fmt "
+    header += struct.pack("<IHHIIHH", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16)
+    header += b"data"
+    header += struct.pack("<I", data_size)
+    return header + b"\x00" * data_size
+
+
+def _make_engine(
+    vram_total_mb=23034,
+    vram_baseline_mb=5709,
+    attention_mode="auto",
+    auto_threshold_sec=300,
+    max_batch_size=32,
+    vram_safety_factor=0.8,
+    vram_bytes_per_t2=136.6,
+    starvation_timeout_sec=5.0,
+):
+    gpu = MagicMock()
+    gpu.vram_info = {
+        "total_mb": vram_total_mb,
+        "baseline_mb": vram_baseline_mb,
+        "attention_mode": attention_mode,
+        "auto_threshold_sec": auto_threshold_sec,
+    }
+    engine = BatchEngine(
+        gpu_worker=gpu,
+        max_batch_size=max_batch_size,
+        vram_safety_factor=vram_safety_factor,
+        vram_bytes_per_t2=vram_bytes_per_t2,
+        starvation_timeout_sec=starvation_timeout_sec,
+    )
+    return engine
+
+
+def _pending(duration_sec=None, age_sec=0.0):
+    req = PendingRequest.__new__(PendingRequest)
+    req.audio_path = f"test_{duration_sec}s.wav"
+    req.timestamps = False
+    req.future = MagicMock()
+    req.owns_file = False
+    req.submitted_at = time.monotonic() - age_sec
+    req.duration_sec = duration_sec
+    return req
+
+
+class TestEstimateMaxBatch(unittest.TestCase):
+    """Test _estimate_max_batch VRAM formula."""
+
+    def setUp(self):
+        self.engine = _make_engine()
+        # Budget: 23034 * 0.8 - 5709 = 12718.2 MB
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self.engine.start())
+        loop.close()
+
+    def test_short_files_allow_full_batch(self):
+        # 30s files: T=375, per_file = 136.6 * 375^2 / 1024^2 = 18.3 MB
+        # 12718 / 18.3 = 694 → capped at 32
+        result = self.engine._estimate_max_batch(30.0)
+        self.assertEqual(result, 32)
+
+    def test_medium_files_cap_batch(self):
+        # 120s: T=1500, per_file = 136.6 * 1500^2 / 1024^2 = 293 MB
+        # 12718 / 293 = 43 → capped at 32
+        result = self.engine._estimate_max_batch(120.0)
+        self.assertEqual(result, 32)
+
+    def test_long_files_severely_cap(self):
+        # 250s: T=3125, per_file = 136.6 * 3125^2 / 1024^2 = 1272 MB
+        # 12718 / 1272 = 9
+        result = self.engine._estimate_max_batch(250.0)
+        self.assertLessEqual(result, 10)
+        self.assertGreaterEqual(result, 8)
+
+    def test_near_threshold_files_cap_to_one_or_two(self):
+        # 290s: T=3625, per_file = 136.6 * 3625^2 / 1024^2 = 1712 MB
+        # 12718 / 1712 = 7
+        result = self.engine._estimate_max_batch(290.0)
+        self.assertLessEqual(result, 8)
+        self.assertGreaterEqual(result, 5)
+
+    def test_very_long_files_cap_to_one(self):
+        # 600s: T=7500, per_file = 136.6 * 7500^2 / 1024^2 = 7329 MB
+        # 12718 / 7329 = 1
+        result = self.engine._estimate_max_batch(600.0)
+        self.assertLessEqual(result, 2)
+
+    def test_disabled_returns_max(self):
+        engine = _make_engine(vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+        result = engine._estimate_max_batch(600.0)
+        self.assertEqual(result, 32)
+
+    def test_zero_duration_returns_max(self):
+        result = self.engine._estimate_max_batch(0.0)
+        self.assertEqual(result, 32)
+
+
+class TestFormVramSafeBatch(unittest.TestCase):
+    """Test _form_vram_safe_batch batch formation logic."""
+
+    def setUp(self):
+        self.engine = _make_engine()
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self.engine.start())
+        loop.close()
+
+    def test_short_files_batch_fully(self):
+        candidates = [_pending(30.0) for _ in range(10)]
+        batch = self.engine._form_vram_safe_batch(candidates)
+        self.assertEqual(len(batch), 10)
+
+    def test_long_files_capped(self):
+        candidates = [_pending(250.0) for _ in range(20)]
+        batch = self.engine._form_vram_safe_batch(candidates)
+        self.assertLess(len(batch), 20)
+        self.assertGreater(len(batch), 0)
+
+    def test_mixed_durations_sorted_short_first(self):
+        candidates = [_pending(250.0), _pending(30.0), _pending(60.0)]
+        batch = self.engine._form_vram_safe_batch(candidates)
+        # Sorted by duration — short files should be first
+        self.assertEqual(batch[0].duration_sec, 30.0)
+
+    def test_unknown_duration_treated_conservatively(self):
+        candidates = [_pending(None) for _ in range(10)]
+        batch = self.engine._form_vram_safe_batch(candidates)
+        # Unknown uses auto_threshold_sec (300s) as effective duration
+        self.assertLess(len(batch), 10)
+
+    def test_starved_request_gets_priority(self):
+        old = _pending(250.0, age_sec=10.0)
+        new_items = [_pending(30.0) for _ in range(5)]
+        candidates = new_items + [old]
+        batch = self.engine._form_vram_safe_batch(candidates)
+        # Old request must be in batch
+        self.assertIn(old, batch)
+
+    def test_empty_candidates(self):
+        batch = self.engine._form_vram_safe_batch([])
+        self.assertEqual(len(batch), 0)
+
+    def test_single_candidate(self):
+        batch = self.engine._form_vram_safe_batch([_pending(600.0)])
+        self.assertEqual(len(batch), 1)
+
+    def test_vram_disabled_returns_max_slice(self):
+        engine = _make_engine(vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+        candidates = [_pending(600.0) for _ in range(10)]
+        batch = engine._form_vram_safe_batch(candidates)
+        self.assertEqual(len(batch), 10)
+
+
+class TestDurationProbe(unittest.TestCase):
+    """Test _get_audio_duration for WAV files."""
+
+    def test_wav_duration(self):
+        wav = _make_wav(5.0)
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(wav)
+            path = f.name
+        try:
+            dur = BatchEngine._get_audio_duration(path)
+            self.assertIsNotNone(dur)
+            self.assertAlmostEqual(dur, 5.0, places=1)
+        finally:
+            os.unlink(path)
+
+    def test_invalid_file_returns_none(self):
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(b"not a wav file")
+            path = f.name
+        try:
+            dur = BatchEngine._get_audio_duration(path)
+            self.assertIsNone(dur)
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_returns_none(self):
+        dur = BatchEngine._get_audio_duration("/nonexistent/file.wav")
+        self.assertIsNone(dur)
+
+
+class TestProdOOMScenario(unittest.TestCase):
+    """Validate the VRAM formula against the actual prod OOM data."""
+
+    def test_prod_oom_prevented(self):
+        # Prod config: L4 22GB, baseline 5709 MiB, auto mode
+        engine = _make_engine(
+            vram_total_mb=22563,  # L4 total (from prod log)
+            vram_baseline_mb=5709,
+            attention_mode="auto",
+            auto_threshold_sec=300,
+        )
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+
+        # The OOM batch was 12 files at ~250s each
+        # Formula should cap to < 12
+        max_b = engine._estimate_max_batch(250.0)
+        self.assertLess(max_b, 12, f"max_batch={max_b} would still OOM (prod had 12)")
+
+        # For 290s files (near threshold), should be even more restrictive
+        max_b_290 = engine._estimate_max_batch(290.0)
+        self.assertLess(max_b_290, max_b)
+
+    def test_short_files_still_efficient(self):
+        engine = _make_engine(
+            vram_total_mb=22563,
+            vram_baseline_mb=5709,
+        )
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+
+        # 30s files should still allow large batches
+        max_b = engine._estimate_max_batch(30.0)
+        self.assertEqual(max_b, 32)
+
+        # 77s files (prod average) should allow decent batches
+        max_b_77 = engine._estimate_max_batch(77.0)
+        self.assertGreaterEqual(max_b_77, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_vram_batch.py
+++ b/backend/tests/unit/test_vram_batch.py
@@ -3,10 +3,35 @@
 import asyncio
 import os
 import struct
+import sys
 import tempfile
 import time
 import unittest
 from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
+os.environ.setdefault("PARAKEET_DEVICE", "cpu")
+os.environ.setdefault("PARAKEET_TORCH_COMPILE", "false")
+os.environ.setdefault("PARAKEET_CUDA_GRAPHS", "false")
+
+_torch = MagicMock()
+_torch.cuda.is_available.return_value = False
+_torch.cuda.memory_allocated.return_value = 0
+_torch_props = MagicMock()
+_torch_props.total_memory = 16 * 1024**3
+_torch.cuda.get_device_properties.return_value = _torch_props
+_torch.cuda.empty_cache = MagicMock()
+_torch.inference_mode = lambda: (lambda fn: fn)
+_torch.compile = lambda m: m
+_torch.backends.cudnn = MagicMock()
+sys.modules.setdefault("torch", _torch)
+
+for _mod in ["nemo", "nemo.collections", "nemo.collections.asr"]:
+    sys.modules.setdefault(_mod, MagicMock())
+for _mod in ["pyannote", "pyannote.audio", "pyannote.audio.core", "pyannote.audio.core.model"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
 
 from batch_engine import BatchEngine, PendingRequest
 
@@ -98,11 +123,11 @@ class TestEstimateMaxBatch(unittest.TestCase):
         self.assertLessEqual(result, 8)
         self.assertGreaterEqual(result, 5)
 
-    def test_very_long_files_cap_to_one(self):
-        # 600s: T=7500, per_file = 136.6 * 7500^2 / 1024^2 = 7329 MB
-        # 12718 / 7329 = 1
+    def test_very_long_files_skip_limit_in_auto(self):
+        # 600s >= 300s threshold, auto mode switches to local attention
+        # so VRAM cap is bypassed (linear scaling, no quadratic issue)
         result = self.engine._estimate_max_batch(600.0)
-        self.assertLessEqual(result, 2)
+        self.assertEqual(result, 32)
 
     def test_disabled_returns_max(self):
         engine = _make_engine(vram_safety_factor=0)
@@ -115,6 +140,35 @@ class TestEstimateMaxBatch(unittest.TestCase):
     def test_zero_duration_returns_max(self):
         result = self.engine._estimate_max_batch(0.0)
         self.assertEqual(result, 32)
+
+    def test_local_attention_skips_limit(self):
+        engine = _make_engine(attention_mode="local")
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+        result = engine._estimate_max_batch(600.0)
+        self.assertEqual(result, 32)
+
+    def test_auto_mode_long_file_skips_limit(self):
+        result = self.engine._estimate_max_batch(400.0)
+        self.assertEqual(result, 32)
+
+    def test_auto_mode_short_file_applies_limit(self):
+        result = self.engine._estimate_max_batch(250.0)
+        self.assertLess(result, 32)
+
+    def test_auto_unknown_duration_not_bypassed(self):
+        result = self.engine._estimate_max_batch(300.0, duration_known=False)
+        self.assertLess(result, 32)
+
+    def test_negative_budget_caps_to_one(self):
+        engine = _make_engine(vram_safety_factor=0.1)
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine.start())
+        loop.close()
+        engine._vram_available_mb = 0.0
+        result = engine._estimate_max_batch(300.0)
+        self.assertEqual(result, 1)
 
 
 class TestFormVramSafeBatch(unittest.TestCase):

--- a/backend/tests/unit/test_vram_batch.py
+++ b/backend/tests/unit/test_vram_batch.py
@@ -58,6 +58,7 @@ def _make_engine(
     vram_safety_factor=0.8,
     vram_bytes_per_t2=136.6,
     starvation_timeout_sec=5.0,
+    max_inflight=1,
 ):
     gpu = MagicMock()
     gpu.vram_info = {
@@ -72,6 +73,7 @@ def _make_engine(
         vram_safety_factor=vram_safety_factor,
         vram_bytes_per_t2=vram_bytes_per_t2,
         starvation_timeout_sec=starvation_timeout_sec,
+        max_inflight=max_inflight,
     )
     return engine
 
@@ -169,6 +171,18 @@ class TestEstimateMaxBatch(unittest.TestCase):
         engine._vram_available_mb = 0.0
         result = engine._estimate_max_batch(300.0)
         self.assertEqual(result, 1)
+
+    def test_budget_divided_by_max_inflight(self):
+        engine_1 = _make_engine(max_inflight=1)
+        engine_2 = _make_engine(max_inflight=2)
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(engine_1.start())
+        loop.run_until_complete(engine_2.start())
+        loop.close()
+        self.assertAlmostEqual(engine_1._vram_available_mb, engine_2._vram_available_mb * 2, places=0)
+        limit_1 = engine_1._estimate_max_batch(250.0)
+        limit_2 = engine_2._estimate_max_batch(250.0)
+        self.assertGreater(limit_1, limit_2)
 
 
 class TestFormVramSafeBatch(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Replaces static `max_batch_size` slice with VRAM-budget-based dynamic batch formation
- Probes audio duration at submit time, uses formula `max_safe_B = available_vram / (coeff × T²)` to cap batch size based on longest file's attention matrix cost
- Includes starvation guard for requests queued >5s
- Adds `vram_info` property to GPUWorker exposing VRAM baseline/total for budget calculation
- 4 new env vars: `PARAKEET_VRAM_SAFETY_FACTOR`, `PARAKEET_VRAM_BYTES_PER_T2`, `PARAKEET_STARVATION_TIMEOUT`, `PARAKEET_MAX_INFLIGHT`

### NeMo PR #11 adoption
Adopts [beastoin/NeMo#11](https://github.com/beastoin/NeMo/pull/11) (by zen) into omi parakeet server:

1. **Concurrent batch flushing** — `_inflight_sem = asyncio.Semaphore(max_inflight)` allows batch N+1 to form while GPU processes batch N. `_guarded_flush()` with `_flush_pending` flag prevents duplicate flush task accumulation.
2. **Better VRAM baseline** — `torch.cuda.mem_get_info()` captures ALL GPU allocations (CUDA context, cuDNN workspace) vs `memory_allocated()` which only tracks PyTorch-managed tensors. Guarded for CPU/mock environments.
3. **Duration passthrough** — Sends `durations` list in GPU worker payload to avoid redundant file I/O for duration probing.
4. **Attention-mode-aware batch estimation** — Local mode → linear VRAM, skips quadratic cap. Auto mode with known long duration ≥ threshold → also skips (will switch to local). Unknown durations conservatively apply the cap.
5. **Lazy VRAM initialization** — `_try_init_vram()` defers VRAM budget setup until GPU worker finishes model loading (fixes startup-order race where BatchEngine.start() runs before model load completes).
6. **Per-batch VRAM budget** — Total VRAM budget divided by `max_inflight` so concurrent batches each use only their share, preventing combined OOM.

### Review cycle fixes
- Fixed startup-order race: lazy VRAM init when GPU worker still loading (reviewer round 1)
- Guarded `mem_get_info` for CPU/mock environments (reviewer round 2)
- Divided VRAM budget by `max_inflight` to prevent concurrent OOM (reviewer round 3)
- Added test files to `test.sh` for CI coverage
- Added tester-requested coverage: mem_get_info guard assertions, duration passthrough consumption test, inflight=2 concurrency proof

## Context
Follow-up to PR #8486 post-deploy OOM. A burst of 12 files at ~250s each (120-300s danger zone — long enough for massive O(T²) softmax but just under the 300s auto-attention threshold) exhausted 93% VRAM on the L4. Static cap (#8533) doesn't solve the fundamental issue: B=8 with 280s files still hits ~18 GiB.

**VRAM formula** (validated empirically by zen on L4):
- Without torch.compile: 136.6 bytes/T² per batch item (T = duration / 0.08)
- With torch.compile: 45.5 bytes/T² (3.0x ratio confirmed)

**Dynamic behavior** (L4 22GB, 5709 MiB baseline, per-batch with inflight=2):
| File duration | Max per batch | Concurrent batches | Est. total VRAM |
|---|---|---|---|
| 30s | 32 (unchanged) | 2 | ~30% |
| 77s (prod avg) | ≥5 | 2 | ~50% |
| 250s (OOM files) | 5 (vs 12 that OOMed) | 2 | ~70% |
| 290s (near threshold) | 3 | 2 | ~60% |
| 600s+ (auto→local) | 32 (linear VRAM) | 2 | varies |

Set `PARAKEET_VRAM_SAFETY_FACTOR=0` to disable and fall back to static `PARAKEET_MAX_BATCH_SIZE`.

Supersedes #8533 (static cap=8 hotfix).

## Test plan
- [x] 148 tests pass across 5 test files (individually, matching test.sh pattern)
  - 24 batch engine tests (concurrent flush, flush guard, duration passthrough, lazy VRAM init, inflight=2 concurrency)
  - 26 VRAM batch formula tests (attention modes, budget division, prod OOM scenario)
  - 5 OOM reproduction tests (red/green, formula validation)
  - 63 GPU worker tests (mem_get_info guard, duration passthrough consumption, attention switching)
  - 30 endpoint tests
- [x] New test files registered in test.sh
- [x] Async blocker scan clean
- [x] Reviewer approved (3 rounds, all feedback addressed)
- [x] Tester approved (coverage gaps addressed)

## Risks / edge cases
- `max_inflight=2` allows GPU overlap — each batch gets half the VRAM budget.
- `mem_get_info()` may include fragmented free memory as available — safety factor (0.8) provides margin.
- Auto-mode files just under threshold (e.g. 299s) still apply quadratic cap as intended.
- Lazy VRAM init means first batch after startup may use static cap if model load hasn't completed.

_by AI for @beastoin_