### PR TITLE
Fix desktop conversation finalization state machine

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -5,7 +5,7 @@ import zlib
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Dict, Any
 
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import AlreadyExists, Conflict, NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -170,6 +170,24 @@ def upsert_conversation(uid: str, conversation_data: dict):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_data['id'])
     conversation_ref.set(conversation_data)
+
+
+@set_data_protection_level(data_arg_name='conversation_data')
+@prepare_for_write(data_arg_name='conversation_data', prepare_func=_prepare_conversation_for_write)
+def create_conversation_if_absent(uid: str, conversation_data: dict) -> bool:
+    """Atomically create a conversation document if it does not already exist."""
+    if 'audio_base64_url' in conversation_data:
+        del conversation_data['audio_base64_url']
+    if 'photos' in conversation_data:
+        del conversation_data['photos']
+
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_data['id'])
+    try:
+        conversation_ref.create(conversation_data)
+        return True
+    except (AlreadyExists, Conflict):
+        return False
 
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
@@ -741,6 +759,35 @@ def update_conversation_status(uid: str, conversation_id: str, status: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'status': status})
+
+
+def claim_conversation_status(
+    uid: str,
+    conversation_id: str,
+    expected_status: ConversationStatus,
+    claimed_status: ConversationStatus,
+    extra_updates: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Atomically transition a conversation status when the current status matches."""
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+    transaction = db.transaction()
+
+    @firestore.transactional
+    def _claim(transaction):
+        snapshot = conversation_ref.get(transaction=transaction)
+        if not snapshot.exists:
+            raise NotFound(f'Conversation {conversation_id} not found')
+        current = snapshot.to_dict() or {}
+        if current.get('status') != expected_status.value:
+            return False
+        updates = {'status': claimed_status.value}
+        if extra_updates:
+            updates.update(extra_updates)
+        transaction.update(conversation_ref, updates)
+        return True
+
+    return _claim(transaction)
 
 
 def set_conversation_as_discarded(uid: str, conversation_id: str):

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -143,6 +143,47 @@ def process_in_progress_conversation(
     return CreateConversationResponse(conversation=conversation, messages=messages)
 
 
+@router.post(
+    '/v1/conversations/{conversation_id}/finalize', response_model=CreateConversationResponse, tags=['conversations']
+)
+def finalize_conversation(
+    conversation_id: str,
+    request: ProcessConversationRequest = None,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "conversations:create")),
+):
+    """Finalize exactly one backend conversation.
+
+    Unlike POST /v1/conversations, this does not operate on the user's Redis
+    "current in-progress" pointer, so desktop retry/rotation cannot accidentally
+    finalize a newer recording.
+    """
+    conversation = _get_valid_conversation_by_id(uid, conversation_id)
+    conversation = deserialize_conversation(conversation)
+
+    if request and request.calendar_meeting_context:
+        if not conversation.external_data:
+            conversation.external_data = {}
+        conversation.external_data['calendar_meeting_context'] = request.calendar_meeting_context.dict()
+
+    if conversation.status != ConversationStatus.in_progress:
+        return CreateConversationResponse(conversation=conversation, messages=[])
+
+    current_in_progress_id = redis_db.get_in_progress_conversation_id(uid)
+    if current_in_progress_id == conversation_id:
+        redis_db.remove_in_progress_conversation_id(uid)
+
+    geolocation = redis_db.get_cached_user_geolocation(uid)
+    if geolocation:
+        geolocation = Geolocation(**geolocation)
+        conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
+
+    conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
+    conversation = process_conversation(uid, conversation.language, conversation, force_process=True)
+    messages = asyncio.run(trigger_external_integrations(uid, conversation))
+
+    return CreateConversationResponse(conversation=conversation, messages=messages)
+
+
 @router.post('/v1/conversations/{conversation_id}/reprocess', response_model=Conversation, tags=['conversations'])
 def reprocess_conversation(
     conversation_id: str,

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -160,13 +160,28 @@ def finalize_conversation(
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = deserialize_conversation(conversation)
 
+    if conversation.status != ConversationStatus.in_progress:
+        return CreateConversationResponse(conversation=conversation, messages=[])
+
+    claim_updates = {}
     if request and request.calendar_meeting_context:
         if not conversation.external_data:
             conversation.external_data = {}
         conversation.external_data['calendar_meeting_context'] = request.calendar_meeting_context.dict()
+        claim_updates['external_data'] = conversation.external_data
 
-    if conversation.status != ConversationStatus.in_progress:
-        return CreateConversationResponse(conversation=conversation, messages=[])
+    if not conversations_db.claim_conversation_status(
+        uid,
+        conversation.id,
+        ConversationStatus.in_progress,
+        ConversationStatus.processing,
+        extra_updates=claim_updates or None,
+    ):
+        latest = _get_valid_conversation_by_id(uid, conversation_id)
+        latest = deserialize_conversation(latest)
+        return CreateConversationResponse(conversation=latest, messages=[])
+
+    conversation.status = ConversationStatus.processing
 
     current_in_progress_id = redis_db.get_in_progress_conversation_id(uid)
     if current_in_progress_id == conversation_id:
@@ -177,7 +192,6 @@ def finalize_conversation(
         geolocation = Geolocation(**geolocation)
         conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
 
-    conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
     conversation = process_conversation(uid, conversation.language, conversation, force_process=True)
     if conversation.status:
         conversations_db.update_conversation_status(uid, conversation.id, conversation.status)

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -179,6 +179,8 @@ def finalize_conversation(
 
     conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
     conversation = process_conversation(uid, conversation.language, conversation, force_process=True)
+    if conversation.status:
+        conversations_db.update_conversation_status(uid, conversation.id, conversation.status)
     messages = asyncio.run(trigger_external_integrations(uid, conversation))
 
     return CreateConversationResponse(conversation=conversation, messages=messages)

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
 
 import database.folders as folders_db
 import database.memories as memories_db
@@ -18,13 +18,18 @@ from database.vector_db import upsert_memory_vectors_batch
 
 from models.folder import Folder
 from models.memories import MemoryCategory, Memory, MemoryDB
-from models.conversation import CreateConversation, ExternalIntegrationCreateConversation
+from models.conversation import (
+    Conversation as OmiConversation,
+    CreateConversation,
+    ExternalIntegrationCreateConversation,
+)
 from models.conversation_enums import (
     CategoryEnum,
     ConversationSource,
     ExternalIntegrationConversationSource,
 )
 from models.geolocation import Geolocation
+from models.structured import Structured
 from utils.conversations.render import populate_speaker_names, populate_folder_names
 from utils.dev_cache import invalidate_developer_cache
 from models.transcript_segment import TranscriptSegment
@@ -52,6 +57,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6fdb3fd13')
 
 
 # ******************************************************
@@ -835,6 +842,13 @@ class CreateConversationFromTranscriptRequest(BaseModel):
     transcript_segments: List[DevTranscriptSegment] = Field(
         description="List of transcript segments with speaker and timing info", min_length=1, max_length=500
     )
+    client_session_id: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices('client_session_id', 'client_conversation_id', 'session_id', 'client_id'),
+        min_length=1,
+        max_length=200,
+        description="Stable client-generated session ID. When provided, retries return the same conversation ID.",
+    )
     source: Optional[ConversationSource] = Field(
         default=ConversationSource.external_integration,
         description="Source of the conversation (e.g., omi, friend, openglass, phone, external_integration)",
@@ -845,6 +859,16 @@ class CreateConversationFromTranscriptRequest(BaseModel):
     )
     language: Optional[str] = Field(default='en', description="Language code (ISO 639-1, e.g., 'en', 'es', 'fr')")
     geolocation: Optional[Geolocation] = Field(default=None, description="Geolocation where conversation occurred")
+
+    @field_validator('client_session_id')
+    @classmethod
+    def normalize_client_session_id(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError('client_session_id cannot be empty')
+        return value
 
 
 @router.get("/v1/dev/user/folders", response_model=List[Folder], tags=["developer"])
@@ -1049,6 +1073,21 @@ def get_conversation_endpoint(
     return conversation
 
 
+def _from_segments_conversation_id(uid: str, client_session_id: str) -> str:
+    return str(uuid.uuid5(_FROM_SEGMENTS_CONVERSATION_NAMESPACE, f'{uid}\0{client_session_id}'))
+
+
+def _conversation_response_from_data(conversation: dict) -> ConversationResponse:
+    status = conversation.get('status') or 'completed'
+    if hasattr(status, 'value'):
+        status = status.value
+    return ConversationResponse(
+        id=conversation['id'],
+        status=status,
+        discarded=bool(conversation.get('discarded', False)),
+    )
+
+
 def _create_conversation_from_segments(
     uid: str, request: CreateConversationFromTranscriptRequest
 ) -> ConversationResponse:
@@ -1117,15 +1156,44 @@ def _create_conversation_from_segments(
     # Source defaults
     source = request.source or ConversationSource.external_integration
 
+    conversation_id = None
+    if request.client_session_id:
+        conversation_id = _from_segments_conversation_id(uid, request.client_session_id)
+        existing_conversation = conversations_db.get_conversation(uid, conversation_id)
+        if existing_conversation:
+            logger.info(
+                "from-segments idempotency hit for uid=%s client_session_id=%s conversation_id=%s",
+                uid,
+                request.client_session_id,
+                conversation_id,
+            )
+            return _conversation_response_from_data(existing_conversation)
+
     # Create conversation object with transcript segments
-    create_conversation_obj = CreateConversation(
-        transcript_segments=transcript_segments,
-        started_at=started_at,
-        finished_at=finished_at,
-        language=language_code,
-        geolocation=geolocation,
-        source=source,
-    )
+    if conversation_id:
+        create_conversation_obj = OmiConversation(
+            id=conversation_id,
+            created_at=started_at,
+            transcript_segments=transcript_segments,
+            started_at=started_at,
+            finished_at=finished_at,
+            language=language_code,
+            geolocation=geolocation,
+            source=source,
+            structured=Structured(),
+            external_data={
+                'from_segments_client_session_id': request.client_session_id,
+            },
+        )
+    else:
+        create_conversation_obj = CreateConversation(
+            transcript_segments=transcript_segments,
+            started_at=started_at,
+            finished_at=finished_at,
+            language=language_code,
+            geolocation=geolocation,
+            source=source,
+        )
 
     # Process conversation
     conversation = process_conversation(uid, language_code, create_conversation_obj)

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1197,6 +1197,14 @@ def _create_conversation_from_segments(
 
     # Process conversation
     conversation = process_conversation(uid, language_code, create_conversation_obj)
+    if request.client_session_id and not conversations_db.get_conversation(uid, conversation.id):
+        logger.info(
+            "from-segments idempotency persisted returned conversation uid=%s client_session_id=%s conversation_id=%s",
+            uid,
+            request.client_session_id,
+            conversation.id,
+        )
+        conversations_db.upsert_conversation(uid, conversation.dict())
 
     return ConversationResponse(
         id=conversation.id,

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -26,6 +26,7 @@ from models.conversation import (
 from models.conversation_enums import (
     CategoryEnum,
     ConversationSource,
+    ConversationStatus,
     ExternalIntegrationConversationSource,
 )
 from models.geolocation import Geolocation
@@ -57,6 +58,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+FROM_SEGMENTS_CLAIM_STALE_AFTER = timedelta(minutes=15)
 
 _FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6fdb3fd13')
 
@@ -1077,6 +1079,20 @@ def _from_segments_conversation_id(uid: str, client_session_id: str) -> str:
     return str(uuid.uuid5(_FROM_SEGMENTS_CONVERSATION_NAMESPACE, f'{uid}\0{client_session_id}'))
 
 
+def _is_stale_from_segments_claim(conversation: dict, client_session_id: str, now: datetime) -> bool:
+    external_data = conversation.get('external_data') or {}
+    if external_data.get('from_segments_client_session_id') != client_session_id:
+        return False
+    if conversation.get('status') != ConversationStatus.processing.value:
+        return False
+    claimed_at = external_data.get('from_segments_claimed_at')
+    if not isinstance(claimed_at, datetime):
+        return False
+    if claimed_at.tzinfo is None:
+        claimed_at = claimed_at.replace(tzinfo=timezone.utc)
+    return now - claimed_at > FROM_SEGMENTS_CLAIM_STALE_AFTER
+
+
 def _conversation_response_from_data(conversation: dict) -> ConversationResponse:
     status = conversation.get('status') or 'completed'
     if hasattr(status, 'value'):
@@ -1161,13 +1177,24 @@ def _create_conversation_from_segments(
         conversation_id = _from_segments_conversation_id(uid, request.client_session_id)
         existing_conversation = conversations_db.get_conversation(uid, conversation_id)
         if existing_conversation:
-            logger.info(
-                "from-segments idempotency hit for uid=%s client_session_id=%s conversation_id=%s",
-                uid,
-                request.client_session_id,
-                conversation_id,
-            )
-            return _conversation_response_from_data(existing_conversation)
+            if _is_stale_from_segments_claim(
+                existing_conversation, request.client_session_id, datetime.now(timezone.utc)
+            ):
+                logger.warning(
+                    "from-segments idempotency stale claim for uid=%s client_session_id=%s conversation_id=%s; retrying",
+                    uid,
+                    request.client_session_id,
+                    conversation_id,
+                )
+                conversations_db.delete_conversation(uid, conversation_id)
+            else:
+                logger.info(
+                    "from-segments idempotency hit for uid=%s client_session_id=%s conversation_id=%s",
+                    uid,
+                    request.client_session_id,
+                    conversation_id,
+                )
+                return _conversation_response_from_data(existing_conversation)
 
     # Create conversation object with transcript segments
     if conversation_id:
@@ -1183,8 +1210,21 @@ def _create_conversation_from_segments(
             structured=Structured(),
             external_data={
                 'from_segments_client_session_id': request.client_session_id,
+                'from_segments_claimed_at': datetime.now(timezone.utc),
             },
+            status=ConversationStatus.processing,
         )
+        if not conversations_db.create_conversation_if_absent(uid, create_conversation_obj.dict()):
+            existing_conversation = conversations_db.get_conversation(uid, conversation_id)
+            if existing_conversation:
+                logger.info(
+                    "from-segments idempotency concurrent hit for uid=%s client_session_id=%s conversation_id=%s",
+                    uid,
+                    request.client_session_id,
+                    conversation_id,
+                )
+                return _conversation_response_from_data(existing_conversation)
+            raise HTTPException(status_code=409, detail="Conversation creation already in progress")
     else:
         create_conversation_obj = CreateConversation(
             transcript_segments=transcript_segments,
@@ -1196,8 +1236,13 @@ def _create_conversation_from_segments(
         )
 
     # Process conversation
-    conversation = process_conversation(uid, language_code, create_conversation_obj)
-    if request.client_session_id and not conversations_db.get_conversation(uid, conversation.id):
+    try:
+        conversation = process_conversation(uid, language_code, create_conversation_obj)
+    except Exception:
+        if request.client_session_id and conversation_id:
+            conversations_db.delete_conversation(uid, conversation_id)
+        raise
+    if request.client_session_id:
         logger.info(
             "from-segments idempotency persisted returned conversation uid=%s client_session_id=%s conversation_id=%s",
             uid,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -174,6 +174,7 @@ pytest tests/unit/test_oauth_callback_uid_guard.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v
 pytest tests/unit/test_dev_api_conversations_poison.py -v
+pytest tests/unit/test_developer_from_segments_idempotency.py -v
 pytest tests/unit/test_dev_api_memories_pagination.py -v
 pytest tests/unit/test_dev_api_action_items_poison.py -v
 pytest tests/unit/test_rate_limiting.py -v

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -10,7 +10,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
@@ -261,7 +261,10 @@ def test_finalize_conversation_processes_target_id_and_clears_matching_redis_poi
         response = conv.finalize_conversation('conv-1', uid='test-uid')
 
     remove_pointer.assert_called_once_with('test-uid')
-    update_status.assert_called_once_with('test-uid', 'conv-1', ConversationStatus.processing)
+    assert update_status.call_args_list == [
+        call('test-uid', 'conv-1', ConversationStatus.processing),
+        call('test-uid', 'conv-1', ConversationStatus.completed),
+    ]
     process.assert_called_once_with('test-uid', 'en', target, force_process=True)
     assert response.conversation.id == 'conv-1'
     assert response.conversation.status == ConversationStatus.completed

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -10,7 +10,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
@@ -251,6 +251,7 @@ def test_finalize_conversation_processes_target_id_and_clears_matching_redis_poi
     with (
         patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
         patch.object(conv, 'deserialize_conversation', return_value=target),
+        patch.object(conv.conversations_db, 'claim_conversation_status', return_value=True) as claim_status,
         patch.object(conv.redis_db, 'get_in_progress_conversation_id', return_value='conv-1'),
         patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
         patch.object(conv.redis_db, 'get_cached_user_geolocation', return_value=None),
@@ -260,11 +261,15 @@ def test_finalize_conversation_processes_target_id_and_clears_matching_redis_poi
     ):
         response = conv.finalize_conversation('conv-1', uid='test-uid')
 
+    claim_status.assert_called_once_with(
+        'test-uid',
+        'conv-1',
+        ConversationStatus.in_progress,
+        ConversationStatus.processing,
+        extra_updates=None,
+    )
     remove_pointer.assert_called_once_with('test-uid')
-    assert update_status.call_args_list == [
-        call('test-uid', 'conv-1', ConversationStatus.processing),
-        call('test-uid', 'conv-1', ConversationStatus.completed),
-    ]
+    update_status.assert_called_once_with('test-uid', 'conv-1', ConversationStatus.completed)
     process.assert_called_once_with('test-uid', 'en', target, force_process=True)
     assert response.conversation.id == 'conv-1'
     assert response.conversation.status == ConversationStatus.completed
@@ -277,6 +282,7 @@ def test_finalize_conversation_does_not_clear_different_redis_pointer():
     with (
         patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
         patch.object(conv, 'deserialize_conversation', return_value=target),
+        patch.object(conv.conversations_db, 'claim_conversation_status', return_value=True),
         patch.object(conv.redis_db, 'get_in_progress_conversation_id', return_value='newer-conv'),
         patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
         patch.object(conv.redis_db, 'get_cached_user_geolocation', return_value=None),
@@ -287,6 +293,31 @@ def test_finalize_conversation_does_not_clear_different_redis_pointer():
         conv.finalize_conversation('conv-1', uid='test-uid')
 
     remove_pointer.assert_not_called()
+
+
+def test_finalize_conversation_claim_loser_returns_latest_without_side_effects():
+    target = _conversation(status=ConversationStatus.in_progress)
+    latest = _conversation(status=ConversationStatus.processing)
+
+    with (
+        patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
+        patch.object(conv, 'deserialize_conversation', side_effect=[target, latest]),
+        patch.object(conv.conversations_db, 'claim_conversation_status', return_value=False) as claim_status,
+        patch.object(conv.redis_db, 'get_in_progress_conversation_id') as get_pointer,
+        patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
+        patch.object(conv.conversations_db, 'update_conversation_status') as update_status,
+        patch.object(conv, 'process_conversation') as process,
+        patch.object(conv, 'trigger_external_integrations', AsyncMock(return_value=[])) as integrations,
+    ):
+        response = conv.finalize_conversation('conv-1', uid='test-uid')
+
+    claim_status.assert_called_once()
+    get_pointer.assert_not_called()
+    remove_pointer.assert_not_called()
+    update_status.assert_not_called()
+    process.assert_not_called()
+    integrations.assert_not_called()
+    assert response.conversation.status == ConversationStatus.processing
 
 
 def test_finalize_conversation_is_noop_for_completed_conversation():

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -8,8 +8,9 @@ The handler now catches it and returns HTTP 400. These tests mount the conversat
 
 import os
 import sys
+from datetime import datetime, timezone
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault(
@@ -151,6 +152,9 @@ _register_module('utils.other.endpoints', _endpoints)
 
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
+from models.conversation import Conversation  # noqa: E402
+from models.conversation_enums import ConversationStatus  # noqa: E402
+from models.structured import Structured  # noqa: E402
 
 _remove_module_for_fresh_import('routers.conversations')
 _remove_module_for_fresh_import('routers')
@@ -225,3 +229,78 @@ def test_user_speaker_does_not_require_person_record():
     assert resp.status_code == 200
     mock_get_person.assert_not_called()
     assert mock_search.call_args.kwargs['speaker_id'] == 'user'
+
+
+def _conversation(conversation_id='conv-1', status=ConversationStatus.in_progress):
+    return Conversation(
+        id=conversation_id,
+        created_at=datetime.now(timezone.utc),
+        started_at=datetime.now(timezone.utc),
+        finished_at=datetime.now(timezone.utc),
+        language='en',
+        structured=Structured(),
+        transcript_segments=[],
+        status=status,
+    )
+
+
+def test_finalize_conversation_processes_target_id_and_clears_matching_redis_pointer():
+    target = _conversation()
+    processed = _conversation(status=ConversationStatus.completed)
+
+    with (
+        patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
+        patch.object(conv, 'deserialize_conversation', return_value=target),
+        patch.object(conv.redis_db, 'get_in_progress_conversation_id', return_value='conv-1'),
+        patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
+        patch.object(conv.redis_db, 'get_cached_user_geolocation', return_value=None),
+        patch.object(conv.conversations_db, 'update_conversation_status') as update_status,
+        patch.object(conv, 'process_conversation', return_value=processed) as process,
+        patch.object(conv, 'trigger_external_integrations', AsyncMock(return_value=[])),
+    ):
+        response = conv.finalize_conversation('conv-1', uid='test-uid')
+
+    remove_pointer.assert_called_once_with('test-uid')
+    update_status.assert_called_once_with('test-uid', 'conv-1', ConversationStatus.processing)
+    process.assert_called_once_with('test-uid', 'en', target, force_process=True)
+    assert response.conversation.id == 'conv-1'
+    assert response.conversation.status == ConversationStatus.completed
+
+
+def test_finalize_conversation_does_not_clear_different_redis_pointer():
+    target = _conversation()
+    processed = _conversation(status=ConversationStatus.completed)
+
+    with (
+        patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
+        patch.object(conv, 'deserialize_conversation', return_value=target),
+        patch.object(conv.redis_db, 'get_in_progress_conversation_id', return_value='newer-conv'),
+        patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
+        patch.object(conv.redis_db, 'get_cached_user_geolocation', return_value=None),
+        patch.object(conv.conversations_db, 'update_conversation_status'),
+        patch.object(conv, 'process_conversation', return_value=processed),
+        patch.object(conv, 'trigger_external_integrations', AsyncMock(return_value=[])),
+    ):
+        conv.finalize_conversation('conv-1', uid='test-uid')
+
+    remove_pointer.assert_not_called()
+
+
+def test_finalize_conversation_is_noop_for_completed_conversation():
+    completed = _conversation(status=ConversationStatus.completed)
+
+    with (
+        patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),
+        patch.object(conv, 'deserialize_conversation', return_value=completed),
+        patch.object(conv.redis_db, 'get_in_progress_conversation_id') as get_pointer,
+        patch.object(conv.redis_db, 'remove_in_progress_conversation_id') as remove_pointer,
+        patch.object(conv.conversations_db, 'update_conversation_status') as update_status,
+        patch.object(conv, 'process_conversation') as process,
+    ):
+        response = conv.finalize_conversation('conv-1', uid='test-uid')
+
+    get_pointer.assert_not_called()
+    remove_pointer.assert_not_called()
+    update_status.assert_not_called()
+    process.assert_not_called()
+    assert response.conversation.status == ConversationStatus.completed

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -189,6 +189,8 @@ def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
 def test_client_session_id_uses_stable_conversation_id(monkeypatch):
     captured = {}
     monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    upsert = MagicMock()
+    monkeypatch.setattr(conversations_db, 'upsert_conversation', upsert)
 
     def _process(uid, language, conversation):
         captured['conversation'] = conversation
@@ -204,7 +206,31 @@ def test_client_session_id_uses_stable_conversation_id(monkeypatch):
     assert isinstance(captured['conversation'], Conversation)
     assert captured['conversation'].id == expected_id
     assert captured['conversation'].external_data == {'from_segments_client_session_id': 'local-session-1'}
-    conversations_db.get_conversation.assert_called_once_with('uid1', expected_id)
+    assert conversations_db.get_conversation.call_args_list == [
+        call('uid1', expected_id),
+        call('uid1', expected_id),
+    ]
+    upsert.assert_called_once()
+
+
+def test_client_session_id_persists_when_processor_returns_without_saving(monkeypatch):
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(side_effect=[None, None]))
+    upsert = MagicMock()
+    monkeypatch.setattr(conversations_db, 'upsert_conversation', upsert)
+
+    def _process(_uid, _language, conversation):
+        conversation.status = ConversationStatus.completed
+        return conversation
+
+    monkeypatch.setattr(developer, 'process_conversation', _process)
+
+    response = developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+
+    assert response.id == expected_id
+    upsert.assert_called_once()
+    assert upsert.call_args.args[0] == 'uid1'
+    assert upsert.call_args.args[1]['id'] == expected_id
 
 
 def test_client_session_id_retry_returns_existing_without_processing(monkeypatch):

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -1,9 +1,9 @@
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -177,6 +177,7 @@ def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
         )
 
     monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock())
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock())
     monkeypatch.setattr(developer, 'process_conversation', _process)
 
     response = developer._create_conversation_from_segments('uid1', _request())
@@ -184,11 +185,14 @@ def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
     assert response.id == 'random-process-id'
     assert isinstance(captured['conversation'], CreateConversation)
     conversations_db.get_conversation.assert_not_called()
+    conversations_db.create_conversation_if_absent.assert_not_called()
 
 
 def test_client_session_id_uses_stable_conversation_id(monkeypatch):
     captured = {}
     monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    claim = MagicMock(return_value=True)
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', claim)
     upsert = MagicMock()
     monkeypatch.setattr(conversations_db, 'upsert_conversation', upsert)
 
@@ -205,17 +209,21 @@ def test_client_session_id_uses_stable_conversation_id(monkeypatch):
     assert response.id == expected_id
     assert isinstance(captured['conversation'], Conversation)
     assert captured['conversation'].id == expected_id
-    assert captured['conversation'].external_data == {'from_segments_client_session_id': 'local-session-1'}
-    assert conversations_db.get_conversation.call_args_list == [
-        call('uid1', expected_id),
-        call('uid1', expected_id),
-    ]
+    assert captured['conversation'].external_data['from_segments_client_session_id'] == 'local-session-1'
+    assert isinstance(captured['conversation'].external_data['from_segments_claimed_at'], datetime)
+    assert captured['conversation'].status == ConversationStatus.completed
+    conversations_db.get_conversation.assert_called_once_with('uid1', expected_id)
+    claim.assert_called_once()
+    assert claim.call_args.args[0] == 'uid1'
+    assert claim.call_args.args[1]['id'] == expected_id
+    assert claim.call_args.args[1]['status'] == ConversationStatus.processing
     upsert.assert_called_once()
 
 
 def test_client_session_id_persists_when_processor_returns_without_saving(monkeypatch):
     expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
-    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(side_effect=[None, None]))
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock(return_value=True))
     upsert = MagicMock()
     monkeypatch.setattr(conversations_db, 'upsert_conversation', upsert)
 
@@ -249,6 +257,80 @@ def test_client_session_id_retry_returns_existing_without_processing(monkeypatch
     assert response.status == 'processing'
     assert response.discarded is False
     process.assert_not_called()
+
+
+def test_client_session_id_concurrent_claim_loser_returns_existing_without_processing(monkeypatch):
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+    monkeypatch.setattr(
+        conversations_db,
+        'get_conversation',
+        MagicMock(side_effect=[None, {'id': expected_id, 'status': 'processing', 'discarded': False}]),
+    )
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock(return_value=False))
+    process = MagicMock()
+    monkeypatch.setattr(developer, 'process_conversation', process)
+
+    response = developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+
+    assert response.id == expected_id
+    assert response.status == 'processing'
+    process.assert_not_called()
+
+
+def test_client_session_id_stale_claim_is_deleted_and_reprocessed(monkeypatch):
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+    stale_claim = {
+        'id': expected_id,
+        'status': 'processing',
+        'discarded': False,
+        'external_data': {
+            'from_segments_client_session_id': 'local-session-1',
+            'from_segments_claimed_at': datetime.now(timezone.utc) - timedelta(minutes=30),
+        },
+    }
+    delete = MagicMock()
+    process = MagicMock(side_effect=lambda _uid, _language, conversation: conversation)
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=stale_claim))
+    monkeypatch.setattr(conversations_db, 'delete_conversation', delete)
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock(return_value=True))
+    monkeypatch.setattr(conversations_db, 'upsert_conversation', MagicMock())
+    monkeypatch.setattr(developer, 'process_conversation', process)
+
+    response = developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+
+    assert response.id == expected_id
+    delete.assert_called_once_with('uid1', expected_id)
+    process.assert_called_once()
+
+
+def test_client_session_id_claim_is_released_when_processing_fails(monkeypatch):
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+    delete = MagicMock()
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock(return_value=True))
+    monkeypatch.setattr(conversations_db, 'delete_conversation', delete)
+    monkeypatch.setattr(developer, 'process_conversation', MagicMock(side_effect=RuntimeError('boom')))
+
+    try:
+        developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError('expected processing failure')
+
+    delete.assert_called_once_with('uid1', expected_id)
+
+
+def test_client_session_id_atomic_claim_winner_processes_once(monkeypatch):
+    process = MagicMock(side_effect=lambda _uid, _language, conversation: conversation)
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    monkeypatch.setattr(conversations_db, 'create_conversation_if_absent', MagicMock(return_value=True))
+    monkeypatch.setattr(conversations_db, 'upsert_conversation', MagicMock())
+    monkeypatch.setattr(developer, 'process_conversation', process)
+
+    developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+
+    process.assert_called_once()
 
 
 def test_client_session_id_aliases_and_trimming():

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -1,0 +1,233 @@
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _ensure_package_path(name, path):
+    module = sys.modules.get(name)
+    if module is None or not hasattr(module, '__path__'):
+        module = ModuleType(name)
+        sys.modules[name] = module
+    module.__path__ = [str(path)]
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _drop_stale_module(name, expected_file):
+    module = sys.modules.get(name)
+    if module is None:
+        return
+    module_file = getattr(module, '__file__', None)
+    try:
+        module_path = Path(module_file).resolve() if module_file else None
+    except TypeError:
+        module_path = None
+    if module_path == expected_file.resolve():
+        return
+    sys.modules.pop(name, None)
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, attr_name, None) is module:
+            delattr(parent, attr_name)
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.knowledge_graph',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.storage',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.location',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.llm.knowledge_graph',
+]
+for _mod_name in _stubs:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _AutoMockModule(_mod_name)
+
+sys.modules['database._client'].document_id_from_seed = MagicMock(return_value='memory-id')
+sys.modules['database.vector_db'].upsert_memory_vectors_batch = MagicMock()
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['utils.apps'].update_personas_async = MagicMock()
+
+_endpoints = sys.modules.get('utils.other.endpoints')
+if _endpoints is None:
+    _endpoints = ModuleType('utils.other.endpoints')
+    sys.modules['utils.other.endpoints'] = _endpoints
+_endpoints.get_current_user_uid = lambda: 'uid1'
+_endpoints.with_rate_limit = lambda dependency, _policy: dependency
+_endpoints.get_user = MagicMock()
+
+_ensure_package_path('models', BACKEND_DIR / 'models')
+_ensure_package_path('routers', BACKEND_DIR / 'routers')
+_ensure_package_path('utils', BACKEND_DIR / 'utils')
+_ensure_package_path('utils.conversations', BACKEND_DIR / 'utils' / 'conversations')
+_drop_stale_module('models.conversation', BACKEND_DIR / 'models' / 'conversation.py')
+_drop_stale_module('models.conversation_enums', BACKEND_DIR / 'models' / 'conversation_enums.py')
+_drop_stale_module('models.dev_api_key', BACKEND_DIR / 'models' / 'dev_api_key.py')
+_drop_stale_module('models.folder', BACKEND_DIR / 'models' / 'folder.py')
+_drop_stale_module('models.geolocation', BACKEND_DIR / 'models' / 'geolocation.py')
+_drop_stale_module('models.memories', BACKEND_DIR / 'models' / 'memories.py')
+_drop_stale_module('models.structured', BACKEND_DIR / 'models' / 'structured.py')
+_drop_stale_module('models.transcript_segment', BACKEND_DIR / 'models' / 'transcript_segment.py')
+_drop_stale_module('routers.developer', BACKEND_DIR / 'routers' / 'developer.py')
+_drop_stale_module('utils.conversations.render', BACKEND_DIR / 'utils' / 'conversations' / 'render.py')
+
+import database.conversations as conversations_db  # noqa: E402
+import routers.developer as developer  # noqa: E402
+from models.conversation import Conversation, CreateConversation  # noqa: E402
+from models.conversation_enums import ConversationStatus  # noqa: E402
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _segment():
+    return {'text': 'hello world', 'speaker': 'SPEAKER_00', 'is_user': True, 'start': 0.0, 'end': 1.5}
+
+
+def _request(**overrides):
+    data = {
+        'transcript_segments': [_segment()],
+        'source': 'desktop',
+        'started_at': NOW,
+        'finished_at': NOW.replace(second=2),
+        'language': 'en',
+    }
+    data.update(overrides)
+    return developer.CreateConversationFromTranscriptRequest.model_validate(data)
+
+
+def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
+    captured = {}
+
+    def _process(uid, language, conversation):
+        captured['uid'] = uid
+        captured['language'] = language
+        captured['conversation'] = conversation
+        return Conversation(
+            id='random-process-id',
+            created_at=NOW,
+            started_at=conversation.started_at,
+            finished_at=conversation.finished_at,
+            source=conversation.source,
+            language=conversation.language,
+            structured={},
+            transcript_segments=conversation.transcript_segments,
+            status=ConversationStatus.completed,
+        )
+
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock())
+    monkeypatch.setattr(developer, 'process_conversation', _process)
+
+    response = developer._create_conversation_from_segments('uid1', _request())
+
+    assert response.id == 'random-process-id'
+    assert isinstance(captured['conversation'], CreateConversation)
+    conversations_db.get_conversation.assert_not_called()
+
+
+def test_client_session_id_uses_stable_conversation_id(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+
+    def _process(uid, language, conversation):
+        captured['conversation'] = conversation
+        conversation.status = ConversationStatus.completed
+        return conversation
+
+    monkeypatch.setattr(developer, 'process_conversation', _process)
+
+    response = developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-1'))
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+
+    assert response.id == expected_id
+    assert isinstance(captured['conversation'], Conversation)
+    assert captured['conversation'].id == expected_id
+    assert captured['conversation'].external_data == {'from_segments_client_session_id': 'local-session-1'}
+    conversations_db.get_conversation.assert_called_once_with('uid1', expected_id)
+
+
+def test_client_session_id_retry_returns_existing_without_processing(monkeypatch):
+    expected_id = developer._from_segments_conversation_id('uid1', 'local-session-1')
+    monkeypatch.setattr(
+        conversations_db,
+        'get_conversation',
+        MagicMock(return_value={'id': expected_id, 'status': 'processing', 'discarded': False}),
+    )
+    process = MagicMock()
+    monkeypatch.setattr(developer, 'process_conversation', process)
+
+    response = developer._create_conversation_from_segments('uid1', _request(session_id='local-session-1'))
+
+    assert response.id == expected_id
+    assert response.status == 'processing'
+    assert response.discarded is False
+    process.assert_not_called()
+
+
+def test_client_session_id_aliases_and_trimming():
+    request = _request(client_id='  local-client-1  ')
+    desktop_request = _request(client_conversation_id='local-conversation-1')
+
+    assert request.client_session_id == 'local-client-1'
+    assert desktop_request.client_session_id == 'local-conversation-1'

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -1428,6 +1428,19 @@ extension APIClient {
       return nil
     }
   }
+
+  /// Finalize a specific backend conversation id. This avoids the global Redis-backed
+  /// force-process endpoint, which can act on a newer in-progress recording after rotation.
+  func finalizeConversation(id conversationId: String) async throws -> ServerConversation {
+    struct EmptyBody: Encodable {}
+
+    let response: ForceProcessConversationResponse = try await post(
+      "v1/conversations/\(conversationId)/finalize",
+      body: EmptyBody(),
+      customBaseURL: nil
+    )
+    return response.conversation
+  }
 }
 
 // MARK: - Create Conversation From Segments (on-device transcription upload)
@@ -1450,6 +1463,7 @@ extension APIClient {
     let started_at: String?  // ISO8601
     let finished_at: String?  // ISO8601
     let language: String
+    let client_conversation_id: String?
   }
 
   struct CreateConversationFromSegmentsResponse: Decodable {

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -648,8 +648,17 @@ class AppState: ObservableObject {
       Task { @MainActor in
         if self.isTranscribing {
           log("App terminating - stopping transcription (backend handles conversation)")
+          let sessionId = self.currentSessionId
           self.stopAudioCapture()
-          self.clearTranscriptionState()
+          if let sessionId {
+            try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)
+          }
+          self.clearTranscriptionState(
+            finalizationReason: .userStop,
+            runFinalizer: false,
+            allowCloudForceProcess: false,
+            finishSession: false
+          )
         }
       }
     }
@@ -665,8 +674,17 @@ class AppState: ObservableObject {
         self.wasTranscribingBeforeSleep = self.isTranscribing
         if self.isTranscribing {
           log("Computer sleeping - stopping transcription (backend handles conversation)")
+          let sessionId = self.currentSessionId
           self.stopAudioCapture()
-          self.clearTranscriptionState()
+          if let sessionId {
+            try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)
+          }
+          self.clearTranscriptionState(
+            finalizationReason: .userStop,
+            runFinalizer: false,
+            allowCloudForceProcess: false,
+            finishSession: false
+          )
         }
         // Flush final sync changes before sleep
         await AgentSyncService.shared.stop()
@@ -1728,7 +1746,8 @@ class AppState: ObservableObject {
             source: currentConversationSource.rawValue,
             language: effectiveLanguage,
             timezone: TimeZone.current.identifier,
-            inputDeviceName: recordingInputDeviceName
+            inputDeviceName: recordingInputDeviceName,
+            finalizationStrategy: useLocalSTT ? .localSegments : .cloudReconcile
           )
           await MainActor.run {
             self.currentSessionId = sessionId
@@ -1765,9 +1784,27 @@ class AppState: ObservableObject {
         Task { @MainActor in
           guard let self = self, self.isTranscribing else { return }
           log("Transcription: 4-hour limit reached - restarting session")
-          // Stop and restart (WebSocket close triggers backend conversation processing)
+          let sessionId = self.currentSessionId
+          // Stop, durably queue finalization, and restart.
           self.stopAudioCapture()
-          self.clearTranscriptionState()
+          if let sessionId {
+            try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
+          }
+          self.clearTranscriptionState(
+            finalizationReason: .maxDurationRotation,
+            runFinalizer: false,
+            allowCloudForceProcess: false,
+            finishSession: false
+          )
+          if let sessionId {
+            Task {
+              await ConversationFinalizationService.shared.finalizeSession(
+                id: sessionId,
+                reason: .maxDurationRotation,
+                allowCloudForceProcess: false
+              )
+            }
+          }
           self.startTranscription()
         }
       }
@@ -2122,27 +2159,26 @@ class AppState: ObservableObject {
       let sys = localSystemService
       localMicService = nil
       localSystemService = nil
-      let uploadSessionId = currentSessionId
       Task { @MainActor in
         self.stopAudioCapture()
         await mic?.finish()
         await sys?.finish()
-        self.clearTranscriptionState()
+        self.clearTranscriptionState(finalizationReason: .userStop, allowCloudForceProcess: false)
         self.silentMicFallbackInProgress = false
-        // Upload the on-device transcript so the conversation syncs + gets memories/summaries.
-        if let uploadSessionId { await self.uploadLocalSession(uploadSessionId) }
       }
       return
     }
 
     // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil)
     let capturedSessionId = currentSessionId
-    let capturedStartTime = recordingStartTime
-    let capturedBackendConversationId = currentBackendConversationId
     let generationAtStop = recordingGeneration
 
     stopAudioCapture()
-    clearTranscriptionState()
+    clearTranscriptionState(
+      finalizationReason: .userStop,
+      runFinalizer: false,
+      allowCloudForceProcess: false
+    )
     silentMicFallbackInProgress = false
 
     // After WS close, the Python backend processes the conversation automatically.
@@ -2159,50 +2195,12 @@ class AppState: ObservableObject {
         return
       }
 
-      do {
-        if let conversation = try await APIClient.shared.forceProcessConversation() {
-          // Prefer the exact backend conversation id announced by /v4/listen; fall back to
-          // timestamp/source matching for older backend sessions that did not emit the event.
-          if let sessionId = capturedSessionId,
-             let backendConversationId = capturedBackendConversationId,
-             DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
-               id: conversation.id,
-               boundBackendId: backendConversationId,
-               status: conversation.status,
-               source: conversation.source) {
-            try? await TranscriptionStorage.shared.markSessionCompleted(
-              id: sessionId, backendId: conversation.id)
-            log("Transcription: Force-processed bound conversation \(conversation.id), session \(sessionId) completed")
-          } else if let sessionId = capturedSessionId, let startTime = capturedStartTime,
-                    capturedBackendConversationId == nil,
-                    DesktopConversationMatchPolicy.matchesDesktopConversation(
-              startedAt: conversation.startedAt,
-              source: conversation.source,
-              sessionStartedAt: startTime) {
-            try? await TranscriptionStorage.shared.markSessionCompleted(
-              id: sessionId, backendId: conversation.id)
-            log("Transcription: Force-processed conversation \(conversation.id), session \(sessionId) completed")
-          } else if let sessionId = capturedSessionId, let startTime = capturedStartTime {
-            // Force-process returned a different conversation — fall back to reconciliation
-            log("Transcription: Force-processed conversation \(conversation.id) does not match session \(sessionId), reconciling by timestamp")
-            await reconcileSession(
-              sessionId: sessionId,
-              startTime: startTime,
-              backendConversationId: capturedBackendConversationId)
-          }
-        } else {
-          // 404: No in-progress conversation — WS close handler already processed it.
-          // Reconcile by exact backend id when available, otherwise by timestamp/source.
-          if let sessionId = capturedSessionId, let startTime = capturedStartTime {
-            await reconcileSession(
-              sessionId: sessionId,
-              startTime: startTime,
-              backendConversationId: capturedBackendConversationId)
-          }
-        }
-      } catch {
-        // Other error — leave session as pendingUpload for retry service to reconcile
-        logError("Transcription: Force-process failed, retry service will reconcile", error: error)
+      if let sessionId = capturedSessionId {
+        await ConversationFinalizationService.shared.finalizeSession(
+          id: sessionId,
+          reason: .userStop,
+          allowCloudForceProcess: true
+        )
       }
 
       await loadConversations()
@@ -2265,122 +2263,6 @@ class AppState: ObservableObject {
     }
   }
 
-  /// Reconcile a local session by checking if a matching conversation exists on the backend.
-  /// If found, marks the session as completed. Otherwise leaves it as pendingUpload for retry.
-  private func reconcileSession(
-    sessionId: Int64,
-    startTime: Date,
-    backendConversationId: String? = nil
-  ) async {
-    do {
-      if let backendConversationId, !backendConversationId.isEmpty {
-        do {
-          let conversation = try await APIClient.shared.getConversation(id: backendConversationId)
-          guard DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
-            id: conversation.id,
-            boundBackendId: backendConversationId,
-            status: conversation.status,
-            source: conversation.source
-          ) else {
-            log("Transcription: Exact backend conversation \(backendConversationId) is not a completed desktop session; falling back to timestamp")
-            throw APIError.invalidResponse
-          }
-          try await TranscriptionStorage.shared.markSessionCompleted(
-            id: sessionId, backendId: conversation.id)
-          log("Transcription: Reconciled session \(sessionId) by exact backend conversation \(conversation.id)")
-          return
-        } catch {
-          logError("Transcription: Exact backend conversation reconciliation failed for session \(sessionId), falling back to timestamp", error: error)
-        }
-      }
-
-      let conversations = try await APIClient.shared.getConversations(
-        limit: 5,
-        includeDiscarded: true,
-        startDate: startTime.addingTimeInterval(-5),
-        endDate: Date().addingTimeInterval(5)
-      )
-      if let match = conversations.first(where: { conv in
-        DesktopConversationMatchPolicy.matchesDesktopConversation(
-          startedAt: conv.startedAt,
-          source: conv.source,
-          sessionStartedAt: startTime)
-      }) {
-        try await TranscriptionStorage.shared.markSessionCompleted(
-          id: sessionId, backendId: match.id)
-        log("Transcription: Reconciled session \(sessionId) → backend conversation \(match.id)")
-      } else {
-        log("Transcription: No matching backend conversation found for session \(sessionId), leaving for retry")
-      }
-    } catch {
-      logError("Transcription: Reconciliation failed for session \(sessionId)", error: error)
-    }
-  }
-
-  /// Upload a finished on-device (Parakeet) conversation to the backend so it is persisted,
-  /// processed (memories/summaries), and synced to every device — the same result a cloud
-  /// conversation gets, but the transcript was produced locally. On success, marks the local
-  /// session completed with the returned backend conversation id.
-  private func uploadLocalSession(_ sessionId: Int64) async {
-    // Segment DB writes are scheduled fire-and-forget by handleBackendSegments — let them drain
-    // so the upload includes the final tail segments.
-    try? await Task.sleep(nanoseconds: 1_000_000_000)
-    do {
-      guard let bundle = try await TranscriptionStorage.shared.getSessionWithSegments(id: sessionId)
-      else { return }
-      let session = bundle.session
-      guard !bundle.segments.isEmpty else {
-        log("Transcription: Local session \(sessionId) has no segments — nothing to upload")
-        return
-      }
-
-      let raw: [APIClient.UploadSegment] = bundle.segments.map { seg in
-        APIClient.UploadSegment(
-          text: seg.text,
-          speaker: seg.speakerLabel ?? String(format: "SPEAKER_%02d", seg.speaker),
-          speaker_id: seg.speaker,
-          is_user: seg.isUser,
-          person_id: seg.personId,
-          start: seg.startTime,
-          end: seg.endTime
-        )
-      }
-      // Merge consecutive same-speaker segments to stay under the backend's 500-segment cap
-      // (Parakeet emits ~1 segment per 10s window).
-      var merged: [APIClient.UploadSegment] = []
-      for seg in raw {
-        if let last = merged.last, last.speaker_id == seg.speaker_id {
-          merged[merged.count - 1] = APIClient.UploadSegment(
-            text: last.text + " " + seg.text, speaker: last.speaker, speaker_id: last.speaker_id,
-            is_user: last.is_user, person_id: last.person_id, start: last.start, end: seg.end)
-        } else {
-          merged.append(seg)
-        }
-      }
-      if merged.count > 500 {
-        log("Transcription: Local session \(sessionId) has \(merged.count) segments (>500), truncating")
-        merged = Array(merged.prefix(500))
-      }
-
-      let iso = ISO8601DateFormatter()
-      let request = APIClient.CreateConversationFromSegmentsRequest(
-        transcript_segments: merged,
-        source: "desktop",
-        started_at: iso.string(from: session.startedAt),
-        finished_at: session.finishedAt.map { iso.string(from: $0) },
-        language: session.language
-      )
-      let response = try await APIClient.shared.createConversationFromSegments(request)
-      try? await TranscriptionStorage.shared.markSessionCompleted(
-        id: sessionId, backendId: response.id)
-      log(
-        "Transcription: Uploaded on-device session \(sessionId) → backend conversation \(response.id) (\(merged.count) segments)"
-      )
-    } catch {
-      logError("Transcription: Failed to upload on-device session \(sessionId)", error: error)
-    }
-  }
-
   /// Finish the current conversation and keep recording for a new one.
   /// Disconnects the WebSocket (triggers backend conversation processing) then reconnects.
   func finishConversation() async -> FinishConversationResult {
@@ -2395,6 +2277,8 @@ class AppState: ObservableObject {
     // may arrive on the new WebSocket after currentSessionId and recordingStartTime have changed.
     finishedSessionId = currentSessionId
     finishedRecordingStartTime = recordingStartTime
+    let finishedUsesLocalSTT = useLocalSTT
+    let sessionToFinalize = currentSessionId
 
     // Local mode: flush both Parakeet instances' final tails to the CURRENT session BEFORE we
     // rotate currentSessionId, so the last sub-window words attach to THIS conversation rather
@@ -2403,28 +2287,23 @@ class AppState: ObservableObject {
     if useLocalSTT {
       await localMicService?.finish()
       await localSystemService?.finish()
+    } else {
+      // Close the cloud stream before marking the old local session finished, so no late
+      // WebSocket segments can be persisted after the finalization snapshot starts.
+      transcriptionService?.stop()
+      transcriptionService = nil
     }
 
     // Mark current DB session as finished before stopping
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)
-    if let sessionId = currentSessionId {
+    if let sessionId = sessionToFinalize {
       do {
-        try await TranscriptionStorage.shared.finishSession(id: sessionId)
+        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .finishAndContinue)
         log("Transcription: Finished DB session \(sessionId) before reconnect")
       } catch {
         logError("Transcription: Failed to finish DB session \(sessionId)", error: error)
       }
     }
-
-    // Local mode: upload the just-finished on-device conversation to the backend (async) so it
-    // syncs + gets memories/summaries while we keep recording the next conversation.
-    if useLocalSTT, let uploadSessionId = finishedSessionId {
-      Task { await self.uploadLocalSession(uploadSessionId) }
-    }
-
-    // Stop the transcription service (closes WebSocket, triggers backend conversation processing)
-    transcriptionService?.stop()
-    transcriptionService = nil
 
     // Clear currentSessionId BEFORE reconnecting — any segments arriving on the new WebSocket
     // must not be persisted against the finished session. They'll be buffered in memory until
@@ -2452,6 +2331,16 @@ class AppState: ObservableObject {
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
 
+    if let sessionId = sessionToFinalize {
+      Task {
+        await ConversationFinalizationService.shared.finalizeSession(
+          id: sessionId,
+          reason: .finishAndContinue,
+          allowCloudForceProcess: !finishedUsesLocalSTT
+        )
+      }
+    }
+
     // Restart the 4-hour max recording timer
     maxRecordingTimer?.invalidate()
     maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: maxRecordingDuration, repeats: false)
@@ -2459,8 +2348,26 @@ class AppState: ObservableObject {
       Task { @MainActor in
         guard let self = self, self.isTranscribing else { return }
         log("Transcription: 4-hour limit reached — stopping and restarting")
+        let sessionId = self.currentSessionId
         self.stopAudioCapture()
-        self.clearTranscriptionState()
+        if let sessionId {
+          try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
+        }
+        self.clearTranscriptionState(
+          finalizationReason: .maxDurationRotation,
+          runFinalizer: false,
+          allowCloudForceProcess: false,
+          finishSession: false
+        )
+        if let sessionId {
+          Task {
+            await ConversationFinalizationService.shared.finalizeSession(
+              id: sessionId,
+              reason: .maxDurationRotation,
+              allowCloudForceProcess: false
+            )
+          }
+        }
         self.startTranscription()
       }
     }
@@ -2522,7 +2429,8 @@ class AppState: ObservableObject {
           source: currentConversationSource.rawValue,
           language: lang,
           timezone: TimeZone.current.identifier,
-          inputDeviceName: recordingInputDeviceName
+          inputDeviceName: recordingInputDeviceName,
+          finalizationStrategy: useLocalSTT ? .localSegments : .cloudReconcile
         )
         await MainActor.run {
           self.currentSessionId = sessionId
@@ -2614,7 +2522,12 @@ class AppState: ObservableObject {
   }
 
   /// Clear transcription state after saving
-  private func clearTranscriptionState() {
+  private func clearTranscriptionState(
+    finalizationReason: TranscriptionFinalizationReason = .userStop,
+    runFinalizer: Bool = true,
+    allowCloudForceProcess: Bool = false,
+    finishSession: Bool = true
+  ) {
     log(
       "Transcription: Final segments count: \(totalSegmentCount) (in-memory: \(speakerSegments.count)), words: \(totalWordCount)"
     )
@@ -2623,11 +2536,18 @@ class AppState: ObservableObject {
     LiveNotesMonitor.shared.endSession()
 
     // Mark DB session as finished (pending upload / crash recovery)
-    if let sessionId = currentSessionId {
+    if finishSession, let sessionId = currentSessionId {
       Task {
         do {
-          try await TranscriptionStorage.shared.finishSession(id: sessionId)
+          try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: finalizationReason)
           log("Transcription: Finished DB session \(sessionId)")
+          if runFinalizer {
+            await ConversationFinalizationService.shared.finalizeSession(
+              id: sessionId,
+              reason: finalizationReason,
+              allowCloudForceProcess: allowCloudForceProcess
+            )
+          }
         } catch {
           logError("Transcription: Failed to finish DB session \(sessionId)", error: error)
         }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -1785,8 +1785,19 @@ class AppState: ObservableObject {
           guard let self = self, self.isTranscribing else { return }
           log("Transcription: 4-hour limit reached - restarting session")
           let sessionId = self.currentSessionId
+          let wasLocalSTT = self.useLocalSTT
+          let mic = self.localMicService
+          let sys = self.localSystemService
+          if wasLocalSTT {
+            self.localMicService = nil
+            self.localSystemService = nil
+          }
           // Stop, durably queue finalization, and restart.
           self.stopAudioCapture()
+          if wasLocalSTT {
+            await mic?.finish()
+            await sys?.finish()
+          }
           if let sessionId {
             try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
           }
@@ -2349,7 +2360,18 @@ class AppState: ObservableObject {
         guard let self = self, self.isTranscribing else { return }
         log("Transcription: 4-hour limit reached — stopping and restarting")
         let sessionId = self.currentSessionId
+        let wasLocalSTT = self.useLocalSTT
+        let mic = self.localMicService
+        let sys = self.localSystemService
+        if wasLocalSTT {
+          self.localMicService = nil
+          self.localSystemService = nil
+        }
         self.stopAudioCapture()
+        if wasLocalSTT {
+          await mic?.finish()
+          await sys?.finish()
+        }
         if let sessionId {
           try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
         }

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+actor ConversationFinalizationService {
+  static let shared = ConversationFinalizationService()
+
+  private let maxRetries = 5
+
+  private init() {}
+
+  func finalizeSession(
+    id sessionId: Int64,
+    reason: TranscriptionFinalizationReason,
+    allowCloudForceProcess: Bool = false
+  ) async {
+    do {
+      guard let session = try await TranscriptionStorage.shared.getSession(id: sessionId) else {
+        return
+      }
+      await finalizeSession(session, reason: reason, allowCloudForceProcess: allowCloudForceProcess)
+    } catch {
+      logError("ConversationFinalization: Failed to load session \(sessionId)", error: error)
+    }
+  }
+
+  func recoverPendingFinalizations() async {
+    do {
+      let sessions = try await TranscriptionStorage.shared.getSessionsNeedingFinalization(maxRetries: maxRetries)
+      if !sessions.isEmpty {
+      log("ConversationFinalization: Recovering \(sessions.count) pending sessions")
+      }
+      for session in sessions where session.isReadyForRetry() || session.status != .failed {
+        await finalizeSession(
+          session,
+          reason: .retry,
+          allowCloudForceProcess: session.backendId?.isEmpty == false
+        )
+      }
+    } catch {
+      logError("ConversationFinalization: Recovery failed", error: error)
+    }
+  }
+
+  private func finalizeSession(
+    _ session: TranscriptionSessionRecord,
+    reason: TranscriptionFinalizationReason,
+    allowCloudForceProcess: Bool
+  ) async {
+    guard let sessionId = session.id else { return }
+    guard session.status != .completed && !session.backendSynced else { return }
+
+    let strategy = session.finalizationStrategy ?? defaultStrategy(for: session)
+    log(
+      "ConversationFinalization: Finalizing session \(sessionId) strategy=\(strategy.rawValue) reason=\(reason.rawValue)"
+    )
+
+    do {
+      guard try await TranscriptionStorage.shared.markSessionUploading(id: sessionId) else {
+        return
+      }
+      switch strategy {
+      case .localSegments:
+        try await uploadLocalSegments(sessionId: sessionId)
+      case .cloudReconcile:
+        try await finalizeCloudSession(session: session, allowForceProcess: allowCloudForceProcess)
+      }
+    } catch {
+      await markRetryableFailure(sessionId: sessionId, error: error)
+    }
+  }
+
+  private func defaultStrategy(for session: TranscriptionSessionRecord) -> TranscriptionFinalizationStrategy {
+    if session.backendId?.isEmpty == false {
+      return .cloudReconcile
+    }
+    return session.source == ConversationSource.desktop.rawValue ? .localSegments : .cloudReconcile
+  }
+
+  private func uploadLocalSegments(sessionId: Int64) async throws {
+    guard let bundle = try await TranscriptionStorage.shared.getSessionWithSegments(id: sessionId) else {
+      throw TranscriptionStorageError.sessionNotFound
+    }
+    guard !bundle.segments.isEmpty else {
+      log("ConversationFinalization: Deleting empty local session \(sessionId)")
+      try await TranscriptionStorage.shared.deleteSession(id: sessionId)
+      return
+    }
+
+    var merged: [APIClient.UploadSegment] = []
+    for seg in bundle.segments {
+      let upload = APIClient.UploadSegment(
+        text: seg.text,
+        speaker: seg.speakerLabel ?? String(format: "SPEAKER_%02d", seg.speaker),
+        speaker_id: seg.speaker,
+        is_user: seg.isUser,
+        person_id: seg.personId,
+        start: seg.startTime,
+        end: seg.endTime
+      )
+      if let last = merged.last,
+         last.speaker_id == upload.speaker_id,
+         last.speaker == upload.speaker,
+         last.is_user == upload.is_user,
+         last.person_id == upload.person_id {
+        merged[merged.count - 1] = APIClient.UploadSegment(
+          text: last.text + " " + upload.text,
+          speaker: last.speaker,
+          speaker_id: last.speaker_id,
+          is_user: last.is_user,
+          person_id: last.person_id,
+          start: last.start,
+          end: upload.end
+        )
+      } else {
+        merged.append(upload)
+      }
+    }
+
+    if merged.count > 500 {
+      throw TranscriptionStorageError.invalidState(
+        "Local session has \(merged.count) merged segments, exceeding backend limit"
+      )
+    }
+
+    let iso = ISO8601DateFormatter()
+    let request = APIClient.CreateConversationFromSegmentsRequest(
+      transcript_segments: merged,
+      source: "desktop",
+      started_at: iso.string(from: bundle.session.startedAt),
+      finished_at: bundle.session.finishedAt.map { iso.string(from: $0) },
+      language: bundle.session.language,
+      client_conversation_id: localClientConversationId(session: bundle.session, sessionId: sessionId)
+    )
+    let response = try await APIClient.shared.createConversationFromSegments(request)
+    let status = LocalConversationStatus(rawValue: response.status) ?? .processing
+    let completed = try await TranscriptionStorage.shared.markSessionCompleted(
+      id: sessionId,
+      backendId: response.id,
+      conversationStatus: status
+    )
+    if completed {
+      log("ConversationFinalization: Uploaded local session \(sessionId) -> backend conversation \(response.id)")
+    }
+  }
+
+  private func finalizeCloudSession(
+    session: TranscriptionSessionRecord,
+    allowForceProcess: Bool
+  ) async throws {
+    guard let sessionId = session.id else { return }
+
+    if let backendId = session.backendId, !backendId.isEmpty {
+      let conversation: ServerConversation
+      if allowForceProcess {
+        conversation = try await APIClient.shared.finalizeConversation(id: backendId)
+      } else {
+        conversation = try await APIClient.shared.getConversation(id: backendId)
+      }
+      if DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+        id: conversation.id,
+        boundBackendId: backendId,
+        status: conversation.status,
+        source: conversation.source
+      ) {
+        let status = LocalConversationStatus(rawValue: conversation.status.rawValue) ?? .processing
+        try await TranscriptionStorage.shared.markSessionCompleted(
+          id: sessionId,
+          backendId: conversation.id,
+          conversationStatus: status
+        )
+        log("ConversationFinalization: Finalized cloud session \(sessionId) by backend id \(conversation.id)")
+        return
+      }
+      throw TranscriptionStorageError.invalidState("Bound backend conversation is not completed")
+    }
+
+    if allowForceProcess, let conversation = try await APIClient.shared.forceProcessConversation() {
+      if DesktopConversationMatchPolicy.matchesDesktopConversation(
+        startedAt: conversation.startedAt,
+        source: conversation.source,
+        sessionStartedAt: session.startedAt
+      ) {
+        let status = LocalConversationStatus(rawValue: conversation.status.rawValue) ?? .processing
+        try await TranscriptionStorage.shared.markSessionCompleted(
+          id: sessionId,
+          backendId: conversation.id,
+          conversationStatus: status
+        )
+        log("ConversationFinalization: Force-processed unbound cloud session \(sessionId) -> \(conversation.id)")
+        return
+      }
+    }
+
+    let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
+    let existing = try await APIClient.shared.getConversations(
+      limit: 5,
+      includeDiscarded: true,
+      startDate: session.startedAt.addingTimeInterval(-5),
+      endDate: finishedAt.addingTimeInterval(5)
+    )
+    if let match = existing.first(where: { conv in
+      DesktopConversationMatchPolicy.matchesDesktopConversation(
+        startedAt: conv.startedAt,
+        source: conv.source,
+        sessionStartedAt: session.startedAt
+      )
+    }) {
+      let status = LocalConversationStatus(rawValue: match.status.rawValue) ?? .processing
+      try await TranscriptionStorage.shared.markSessionCompleted(
+        id: sessionId,
+        backendId: match.id,
+        conversationStatus: status
+      )
+      log("ConversationFinalization: Reconciled cloud session \(sessionId) by timestamp \(match.id)")
+      return
+    }
+
+    throw TranscriptionStorageError.invalidState("No matching backend conversation found")
+  }
+
+  private func markRetryableFailure(sessionId: Int64, error: Error) async {
+    let message = error.localizedDescription
+    do {
+      try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
+      try await TranscriptionStorage.shared.markSessionFailed(id: sessionId, error: message)
+    } catch {
+      logError("ConversationFinalization: Failed to record finalization failure for session \(sessionId)", error: error)
+    }
+  }
+
+  private func localClientConversationId(session: TranscriptionSessionRecord, sessionId: Int64) -> String {
+    let startedAtMs = Int64((session.startedAt.timeIntervalSince1970 * 1000).rounded())
+    return "macos-local-\(sessionId)-\(startedAtMs)"
+  }
+}

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -115,15 +115,16 @@ actor ConversationFinalizationService {
       }
     }
 
-    if merged.count > 500 {
-      throw TranscriptionStorageError.invalidState(
-        "Local session has \(merged.count) merged segments, exceeding backend limit"
+    let uploadSegments = Self.compactSegmentsForBackendLimit(merged)
+    if uploadSegments.count != merged.count {
+      log(
+        "ConversationFinalization: Compacted local session \(sessionId) from \(merged.count) to \(uploadSegments.count) segments for backend upload"
       )
     }
 
     let iso = ISO8601DateFormatter()
     let request = APIClient.CreateConversationFromSegmentsRequest(
-      transcript_segments: merged,
+      transcript_segments: uploadSegments,
       source: "desktop",
       started_at: iso.string(from: bundle.session.startedAt),
       finished_at: bundle.session.finishedAt.map { iso.string(from: $0) },
@@ -140,6 +141,41 @@ actor ConversationFinalizationService {
     if completed {
       log("ConversationFinalization: Uploaded local session \(sessionId) -> backend conversation \(response.id)")
     }
+  }
+
+  static func compactSegmentsForBackendLimit(
+    _ segments: [APIClient.UploadSegment],
+    maxSegments: Int = 500
+  ) -> [APIClient.UploadSegment] {
+    guard maxSegments > 0, segments.count > maxSegments else { return segments }
+
+    var compacted: [APIClient.UploadSegment] = []
+    compacted.reserveCapacity(maxSegments)
+    for index in 0..<maxSegments {
+      let startIndex = index * segments.count / maxSegments
+      let endIndex = (index + 1) * segments.count / maxSegments
+      let group = Array(segments[startIndex..<endIndex])
+      guard let first = group.first, let last = group.last else { continue }
+
+      let sameSpeaker = group.allSatisfy { segment in
+        segment.speaker == first.speaker
+          && segment.speaker_id == first.speaker_id
+          && segment.is_user == first.is_user
+          && segment.person_id == first.person_id
+      }
+      compacted.append(
+        APIClient.UploadSegment(
+          text: group.map(\.text).joined(separator: " "),
+          speaker: sameSpeaker ? first.speaker : "MIXED",
+          speaker_id: sameSpeaker ? first.speaker_id : nil,
+          is_user: sameSpeaker ? first.is_user : false,
+          person_id: sameSpeaker ? first.person_id : nil,
+          start: first.start,
+          end: last.end
+        )
+      )
+    }
+    return compacted
   }
 
   private func finalizeCloudSession(

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -1298,6 +1298,15 @@ actor RewindDatabase {
             try db.create(index: "idx_segments_session", on: "transcription_segments", columns: ["sessionId"])
         }
 
+        migrator.registerMigration("addTranscriptionFinalizationMetadata") { db in
+            try db.alter(table: "transcription_sessions") { t in
+                t.add(column: "finalizationStrategy", .text)
+                t.add(column: "finalizationReason", .text)
+                t.add(column: "finalizationStartedAt", .datetime)
+                t.add(column: "finalizationCompletedAt", .datetime)
+            }
+        }
+
         // Migration 11: Create live_notes table for AI-generated notes during recording
         migrator.registerMigration("createLiveNotes") { db in
             try db.create(table: "live_notes") { t in

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -373,7 +373,7 @@ extension TranscriptionSessionRecord {
             finalizationStrategy: nil,
             finalizationReason: nil,
             finalizationStartedAt: nil,
-            finalizationCompletedAt: conversation.finishedAt ?? Date(),
+            finalizationCompletedAt: localStatus == .completed ? (conversation.finishedAt ?? Date()) : nil,
             title: conversation.structured.title,
             overview: conversation.structured.overview,
             emoji: conversation.structured.emoji,

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -12,6 +12,19 @@ enum TranscriptionSessionStatus: String, Codable, CaseIterable {
     case failed = "failed"
 }
 
+enum TranscriptionFinalizationStrategy: String, Codable, CaseIterable {
+    case localSegments = "local_segments"
+    case cloudReconcile = "cloud_reconcile"
+}
+
+enum TranscriptionFinalizationReason: String, Codable, CaseIterable {
+    case userStop = "user_stop"
+    case finishAndContinue = "finish_and_continue"
+    case maxDurationRotation = "max_duration_rotation"
+    case crashRecovery = "crash_recovery"
+    case retry = "retry"
+}
+
 /// Conversation processing status (from backend)
 /// Matches ConversationStatus in APIClient.swift
 enum LocalConversationStatus: String, Codable, CaseIterable {
@@ -42,6 +55,10 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
     var backendSynced: Bool
     var createdAt: Date
     var updatedAt: Date
+    var finalizationStrategy: TranscriptionFinalizationStrategy?
+    var finalizationReason: TranscriptionFinalizationReason?
+    var finalizationStartedAt: Date?
+    var finalizationCompletedAt: Date?
 
     // MARK: - Structured Data (from ServerConversation.Structured)
     var title: String?
@@ -83,6 +100,10 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
         backendSynced: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
+        finalizationStrategy: TranscriptionFinalizationStrategy? = nil,
+        finalizationReason: TranscriptionFinalizationReason? = nil,
+        finalizationStartedAt: Date? = nil,
+        finalizationCompletedAt: Date? = nil,
         // Structured data
         title: String? = nil,
         overview: String? = nil,
@@ -116,6 +137,10 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
         self.backendSynced = backendSynced
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.finalizationStrategy = finalizationStrategy
+        self.finalizationReason = finalizationReason
+        self.finalizationStartedAt = finalizationStartedAt
+        self.finalizationCompletedAt = finalizationCompletedAt
         // Structured data
         self.title = title
         self.overview = overview
@@ -345,6 +370,10 @@ extension TranscriptionSessionRecord {
             backendSynced: true,
             createdAt: conversation.createdAt,
             updatedAt: Date(),
+            finalizationStrategy: nil,
+            finalizationReason: nil,
+            finalizationStartedAt: nil,
+            finalizationCompletedAt: conversation.finishedAt ?? Date(),
             title: conversation.structured.title,
             overview: conversation.structured.overview,
             emoji: conversation.structured.emoji,

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -49,7 +49,8 @@ actor TranscriptionStorage {
         source: String,
         language: String = "en",
         timezone: String = "UTC",
-        inputDeviceName: String? = nil
+        inputDeviceName: String? = nil,
+        finalizationStrategy: TranscriptionFinalizationStrategy = .cloudReconcile
     ) async throws -> Int64 {
         let db = try await ensureInitialized()
 
@@ -59,7 +60,8 @@ actor TranscriptionStorage {
             language: language,
             timezone: timezone,
             inputDeviceName: inputDeviceName,
-            status: .recording
+            status: .recording,
+            finalizationStrategy: finalizationStrategy
         )
 
         let record = try await db.write { database in
@@ -71,7 +73,11 @@ actor TranscriptionStorage {
     }
 
     /// Mark session as finished (recording complete, ready for upload/reconciliation)
-    func finishSession(id: Int64) async throws {
+    func finishSession(
+        id: Int64,
+        strategy: TranscriptionFinalizationStrategy? = nil,
+        reason: TranscriptionFinalizationReason = .userStop
+    ) async throws {
         let db = try await ensureInitialized()
 
         let didFinish = try await db.write { database -> Bool in
@@ -86,6 +92,16 @@ actor TranscriptionStorage {
 
             record.finishedAt = Date()
             record.status = .pendingUpload
+            if let strategy {
+                record.finalizationStrategy = strategy
+            } else if record.finalizationStrategy == nil {
+                record.finalizationStrategy =
+                    (record.backendId?.isEmpty == false) ? .cloudReconcile :
+                    (record.source == ConversationSource.desktop.rawValue ? .localSegments : .cloudReconcile)
+            }
+            record.finalizationReason = reason
+            record.finalizationStartedAt = nil
+            record.finalizationCompletedAt = nil
             record.updatedAt = Date()
             try record.update(database)
             return true
@@ -126,37 +142,70 @@ actor TranscriptionStorage {
     }
 
     /// Mark session as currently uploading
-    func markSessionUploading(id: Int64) async throws {
-        try await updateSessionStatus(id: id, status: .uploading)
+    @discardableResult
+    func markSessionUploading(id: Int64) async throws -> Bool {
+        let db = try await ensureInitialized()
+
+        let claimed = try await db.write { database -> Bool in
+            guard var record = try TranscriptionSessionRecord.fetchOne(database, key: id) else {
+                throw TranscriptionStorageError.sessionNotFound
+            }
+
+            guard record.status != .completed && !record.backendSynced else {
+                log("TranscriptionStorage: Skipping markSessionUploading for completed backend-synced session \(id)")
+                return false
+            }
+
+            record.status = .uploading
+            record.finalizationStartedAt = Date()
+            record.updatedAt = Date()
+            try record.update(database)
+            return true
+        }
+
+        if claimed {
+            log("TranscriptionStorage: Marked session \(id) finalization in progress")
+        }
+        return claimed
     }
 
     /// Mark session as completed (uploaded successfully)
-    func markSessionCompleted(id: Int64, backendId: String) async throws {
+    @discardableResult
+    func markSessionCompleted(
+        id: Int64,
+        backendId: String,
+        conversationStatus: LocalConversationStatus = .completed
+    ) async throws -> Bool {
         let db = try await ensureInitialized()
 
-        try await db.write { database in
+        let completed = try await db.write { database -> Bool in
             guard var record = try TranscriptionSessionRecord.fetchOne(database, key: id) else {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
             guard record.canAcceptCompletion(backendId: backendId) else {
                 log("TranscriptionStorage: Skipping conflicting completion for session \(id) (existing: \(record.backendId ?? "nil"), incoming: \(backendId))")
-                return
+                return false
             }
 
             let completedAt = Date()
             record.status = .completed
-            record.conversationStatus = .completed
+            record.conversationStatus = conversationStatus
             record.finishedAt = record.finishedAt ?? completedAt
             record.backendId = backendId
             record.backendSynced = true
             record.retryCount = 0
             record.lastError = nil
+            record.finalizationCompletedAt = completedAt
             record.updatedAt = completedAt
             try record.update(database)
+            return true
         }
 
-        log("TranscriptionStorage: Completed session \(id) (backendId: \(backendId))")
+        if completed {
+            log("TranscriptionStorage: Completed session \(id) (backendId: \(backendId))")
+        }
+        return completed
     }
 
     /// Mark session as failed with error.
@@ -567,6 +616,24 @@ actor TranscriptionStorage {
                 .filter(Column("retryCount") < maxRetries)
                 .filter(Column("backendSynced") == false)
                 .order(Column("updatedAt").asc)
+                .fetchAll(database)
+        }
+    }
+
+    /// Get all unfinished sessions that should be finalized or retried by the canonical finalizer.
+    func getSessionsNeedingFinalization(maxRetries: Int = 5, uploadingStaleAfter seconds: TimeInterval = 300) async throws -> [TranscriptionSessionRecord] {
+        let db = try await ensureInitialized()
+        let uploadingCutoff = Date().addingTimeInterval(-seconds)
+
+        return try await db.read { database in
+            try TranscriptionSessionRecord
+                .filter(Column("backendSynced") == false)
+                .filter(
+                    Column("status") == TranscriptionSessionStatus.pendingUpload.rawValue ||
+                    (Column("status") == TranscriptionSessionStatus.uploading.rawValue && Column("updatedAt") < uploadingCutoff) ||
+                    (Column("status") == TranscriptionSessionStatus.failed.rawValue && Column("retryCount") < maxRetries)
+                )
+                .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -151,14 +151,21 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
+            let now = Date()
+            let staleUploadingCutoff = now.addingTimeInterval(-300)
+            guard record.status != .uploading || record.updatedAt < staleUploadingCutoff else {
+                log("TranscriptionStorage: Skipping markSessionUploading for in-progress session \(id)")
+                return false
+            }
+
             guard record.status != .completed && !record.backendSynced else {
                 log("TranscriptionStorage: Skipping markSessionUploading for completed backend-synced session \(id)")
                 return false
             }
 
             record.status = .uploading
-            record.finalizationStartedAt = Date()
-            record.updatedAt = Date()
+            record.finalizationStartedAt = now
+            record.updatedAt = now
             try record.update(database)
             return true
         }

--- a/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionRetryService.swift
@@ -8,7 +8,6 @@ class TranscriptionRetryService {
     private var retryTimer: Timer?
     private var isProcessing = false
     private let retryInterval: TimeInterval = 60  // Check every 60 seconds
-    private let maxRetries = 5
     private var consecutiveDBFailures = 0
     private let maxConsecutiveDBFailures = 3
 
@@ -65,41 +64,12 @@ class TranscriptionRetryService {
                     } else {
                         // Mark as pending upload so it will be retried
                         log("TranscriptionRetryService: Marking crashed session \(session.id!) as pending upload (\(segmentCount) segments)")
-                        try await TranscriptionStorage.shared.finishSession(id: session.id!)
+                        try await TranscriptionStorage.shared.finishSession(id: session.id!, reason: .crashRecovery)
                     }
                 }
             }
 
-            // Now process any pending sessions
-            let pendingSessions = try await TranscriptionStorage.shared.getPendingUploadSessions()
-            if !pendingSessions.isEmpty {
-                log("TranscriptionRetryService: Found \(pendingSessions.count) pending sessions to reconcile")
-                for session in pendingSessions {
-                    await reconcileSession(session)
-                }
-            }
-
-            // Recover sessions stuck in 'uploading' (app quit/crash during upload, or markSessionCompleted failed)
-            let stuckUploadingSessions = try await TranscriptionStorage.shared.getStuckUploadingSessions(olderThan: 300)
-            if !stuckUploadingSessions.isEmpty {
-                log("TranscriptionRetryService: Found \(stuckUploadingSessions.count) stuck uploading sessions")
-                for session in stuckUploadingSessions {
-                    await recoverStuckSession(session)
-                }
-            }
-
-            // Also check for failed sessions that can be retried
-            let failedSessions = try await TranscriptionStorage.shared.getFailedSessions(maxRetries: maxRetries)
-            if !failedSessions.isEmpty {
-                log("TranscriptionRetryService: Found \(failedSessions.count) failed sessions to retry")
-                for session in failedSessions {
-                    if session.isReadyForRetry() {
-                        await reconcileSession(session)
-                    } else {
-                        log("TranscriptionRetryService: Session \(session.id!) not ready for retry (backoff)")
-                    }
-                }
-            }
+            await ConversationFinalizationService.shared.recoverPendingFinalizations()
 
             // Log stats
             let stats = try await TranscriptionStorage.shared.getStats()
@@ -125,27 +95,9 @@ class TranscriptionRetryService {
         defer { isProcessing = false }
 
         do {
-            // Get pending sessions
-            let pendingSessions = try await TranscriptionStorage.shared.getPendingUploadSessions()
+            _ = try await TranscriptionStorage.shared.getStats()
             consecutiveDBFailures = 0 // DB query succeeded, reset counter
-
-            for session in pendingSessions {
-                await reconcileSession(session)
-            }
-
-            // Recover sessions stuck in 'uploading' for more than 5 minutes
-            let stuckSessions = try await TranscriptionStorage.shared.getStuckUploadingSessions(olderThan: 300)
-            for session in stuckSessions {
-                await recoverStuckSession(session)
-            }
-
-            // Get failed sessions that are ready for retry
-            let failedSessions = try await TranscriptionStorage.shared.getFailedSessions(maxRetries: maxRetries)
-            for session in failedSessions {
-                if session.isReadyForRetry() {
-                    await reconcileSession(session)
-                }
-            }
+            await ConversationFinalizationService.shared.recoverPendingFinalizations()
 
         } catch {
             consecutiveDBFailures += 1
@@ -157,127 +109,6 @@ class TranscriptionRetryService {
             } else {
                 logError("TranscriptionRetryService: Queue processing failed (\(consecutiveDBFailures)/\(maxConsecutiveDBFailures))", error: error)
             }
-        }
-    }
-
-    // MARK: - Stuck Session Recovery
-
-    /// Recover a session stuck in 'uploading' — check if backend already has it before re-uploading
-    private func recoverStuckSession(_ session: TranscriptionSessionRecord) async {
-        guard let sessionId = session.id else { return }
-
-        log("TranscriptionRetryService: Recovering stuck session \(sessionId)")
-
-        // Check if the backend already has a conversation for this time window
-        // (upload succeeded but markSessionCompleted failed silently)
-        do {
-            let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
-            let existing = try await APIClient.shared.getConversations(
-                limit: 5,
-                startDate: session.startedAt.addingTimeInterval(-2),
-                endDate: finishedAt.addingTimeInterval(2)
-            )
-
-            // Look for a desktop conversation with matching started_at/finished_at
-            if let match = existing.first(where: { conv in
-                guard let convStarted = conv.startedAt, let convFinished = conv.finishedAt else { return false }
-                guard conv.source == .desktop else { return false }
-                return abs(convStarted.timeIntervalSince(session.startedAt)) < 5
-                    && abs(convFinished.timeIntervalSince(finishedAt)) < 5
-            }) {
-                log("TranscriptionRetryService: Session \(sessionId) already exists on backend as \(match.id), marking completed")
-                try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: match.id)
-                return
-            }
-        } catch {
-            log("TranscriptionRetryService: Could not check backend for session \(sessionId), will re-upload: \(error.localizedDescription)")
-        }
-
-        // No match found — mark as pending so it gets re-uploaded
-        log("TranscriptionRetryService: Session \(sessionId) not found on backend, marking as pending upload")
-        do {
-            try await TranscriptionStorage.shared.finishSession(id: sessionId)
-        } catch {
-            logError("TranscriptionRetryService: Failed to mark session \(sessionId) as pending", error: error)
-        }
-    }
-
-    // MARK: - Reconciliation
-
-    /// Reconcile a pending session with the backend.
-    /// Since /v4/listen stores segments in Firestore as they stream, the backend already has the
-    /// conversation data. We just need to find the matching backend conversation and mark local
-    /// session as completed. No segment re-upload needed.
-    private func reconcileSession(_ session: TranscriptionSessionRecord) async {
-        guard let sessionId = session.id else { return }
-
-        log("TranscriptionRetryService: Reconciling session \(sessionId) (retryCount: \(session.retryCount))")
-
-        do {
-            if let backendId = session.backendId, !backendId.isEmpty {
-                do {
-                    let conversation = try await APIClient.shared.getConversation(id: backendId)
-                    guard DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
-                        id: conversation.id,
-                        boundBackendId: backendId,
-                        status: conversation.status,
-                        source: conversation.source
-                    ) else {
-                        if conversation.status == .inProgress {
-                            log("TranscriptionRetryService: Backend conversation \(backendId) is still in progress, will retry")
-                            try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
-                            try await TranscriptionStorage.shared.markSessionFailed(
-                                id: sessionId, error: "Bound backend conversation is still in progress")
-                            return
-                        }
-                        log("TranscriptionRetryService: Backend conversation \(backendId) is not a completed desktop session, falling back to timestamp")
-                        throw APIError.invalidResponse
-                    }
-                    log("TranscriptionRetryService: Session \(sessionId) found by exact backend id \(conversation.id), marking completed")
-                    try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: conversation.id)
-                    return
-                } catch {
-                    logError("TranscriptionRetryService: Exact backend id lookup failed for session \(sessionId), falling back to timestamp", error: error)
-                }
-            }
-
-            // Check if backend already has a conversation for this time window
-            let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
-            if let existing = try? await APIClient.shared.getConversations(
-                limit: 5,
-                includeDiscarded: true,
-                startDate: session.startedAt.addingTimeInterval(-5),
-                endDate: finishedAt.addingTimeInterval(5)
-            ), let match = existing.first(where: { conv in
-                DesktopConversationMatchPolicy.matchesDesktopConversation(
-                    startedAt: conv.startedAt,
-                    source: conv.source,
-                    sessionStartedAt: session.startedAt
-                )
-            }) {
-                log("TranscriptionRetryService: Session \(sessionId) found on backend as \(match.id), marking completed")
-                try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: match.id)
-                return
-            }
-
-            // No matching conversation found on backend.
-            // Do NOT call force-process here — it acts on the user's current in-progress
-            // conversation which may belong to another device or a new recording session.
-            // Force-process is only safe immediately after stopping (in AppState.stopTranscription).
-            // The retry service only reconciles by timestamp; if no match exists yet, retry later.
-            log("TranscriptionRetryService: No backend match for session \(sessionId), will retry")
-            try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
-            try await TranscriptionStorage.shared.markSessionFailed(
-                id: sessionId, error: "No matching desktop conversation found on backend")
-
-            // Fire error event after all retries exhausted
-            if session.retryCount + 1 >= maxRetries {
-                await AnalyticsManager.shared.recordingError(
-                    error: "Session \(sessionId) could not be reconciled after \(maxRetries) attempts")
-            }
-
-        } catch {
-            logError("TranscriptionRetryService: Reconciliation failed for session \(sessionId)", error: error)
         }
     }
 

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -159,6 +159,31 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         )
     }
 
+    func testFreshUploadingSessionCannotBeReclaimedImmediately() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .userStop
+        )
+
+        let firstClaim = try await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
+        let secondClaim = try await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
+
+        XCTAssertTrue(firstClaim)
+        XCTAssertFalse(secondClaim)
+    }
+
+    func testProcessingServerConversationDoesNotStampFinalizationCompletedAt() async throws {
+        let conversation = makeServerConversation(status: .processing)
+
+        let sessionId = try await TranscriptionStorage.shared.syncServerConversation(conversation)
+        let session = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let unwrappedSession = try XCTUnwrap(session)
+
+        XCTAssertEqual(unwrappedSession.conversationStatus, .processing)
+        XCTAssertNil(unwrappedSession.finalizationCompletedAt)
+    }
+
     func testEmptyLocalSegmentsSessionIsDiscardedInsteadOfRetriedForever() async throws {
         let sessionId = try await TranscriptionStorage.shared.startSession(
             source: "desktop",
@@ -176,5 +201,38 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
 
         let session = try await TranscriptionStorage.shared.getSession(id: sessionId)
         XCTAssertNil(session)
+    }
+
+    private func makeServerConversation(status: ConversationStatus) -> ServerConversation {
+        let createdAt = Date(timeIntervalSince1970: 1_000)
+        return ServerConversation(
+            id: "server-\(status.rawValue)",
+            createdAt: createdAt,
+            startedAt: createdAt,
+            finishedAt: createdAt.addingTimeInterval(60),
+            structured: Structured(
+                title: "Title",
+                overview: "Overview",
+                emoji: "chat",
+                category: "other",
+                actionItems: [],
+                events: []
+            ),
+            transcriptSegments: [],
+            transcriptSegmentsIncluded: true,
+            geolocation: nil,
+            photos: [],
+            appsResults: [],
+            source: .desktop,
+            language: "en",
+            status: status,
+            discarded: false,
+            deleted: false,
+            isLocked: false,
+            starred: false,
+            folderId: nil,
+            inputDeviceName: nil,
+            deferred: false
+        )
     }
 }

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Omi_Computer
+
+final class TranscriptionFinalizationStateMachineTests: XCTestCase {
+    private var testUserId: String!
+    private var userDir: URL?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testUserId = "transcription-finalization-test-\(UUID().uuidString)"
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        RewindDatabase.currentUserId = testUserId
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        userDir = appSupport
+            .appendingPathComponent("Omi", isDirectory: true)
+            .appendingPathComponent(testUserId, isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        RewindDatabase.currentUserId = nil
+        if let userDir {
+            try? FileManager.default.removeItem(at: userDir)
+        }
+        try await super.tearDown()
+    }
+
+    func testFinalizationStrategyReasonAndTimestampsPersistAcrossStorageReopen() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .localSegments
+        )
+
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .finishAndContinue
+        )
+        try await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
+
+        let uploadingSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let uploading = try XCTUnwrap(uploadingSession)
+        XCTAssertEqual(uploading.status, .uploading)
+        XCTAssertEqual(uploading.finalizationStrategy, .localSegments)
+        XCTAssertEqual(uploading.finalizationReason, .finishAndContinue)
+        XCTAssertNotNil(uploading.finishedAt)
+        XCTAssertNotNil(uploading.finalizationStartedAt)
+        XCTAssertNil(uploading.finalizationCompletedAt)
+
+        try await TranscriptionStorage.shared.markSessionCompleted(
+            id: sessionId,
+            backendId: "backend-finalized"
+        )
+
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        try await RewindDatabase.shared.initialize()
+
+        let completedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let completed = try XCTUnwrap(completedSession)
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertEqual(completed.backendId, "backend-finalized")
+        XCTAssertTrue(completed.backendSynced)
+        XCTAssertEqual(completed.finalizationStrategy, .localSegments)
+        XCTAssertEqual(completed.finalizationReason, .finishAndContinue)
+        XCTAssertNotNil(completed.finalizationStartedAt)
+        XCTAssertNotNil(completed.finalizationCompletedAt)
+    }
+
+    func testFinishSessionDefaultsStrategyAndStoresReason() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .userStop
+        )
+
+        let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let session = try XCTUnwrap(storedSession)
+        XCTAssertEqual(session.status, .pendingUpload)
+        XCTAssertEqual(session.finalizationStrategy, .cloudReconcile)
+        XCTAssertEqual(session.finalizationReason, .userStop)
+        XCTAssertNil(session.finalizationStartedAt)
+        XCTAssertNil(session.finalizationCompletedAt)
+    }
+
+    func testSessionsNeedingFinalizationIncludesRetryableWorkOnly() async throws {
+        let recordingId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+
+        let pendingId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: pendingId,
+            reason: .userStop
+        )
+
+        let failedRetryableId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: failedRetryableId,
+            reason: .retry
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(
+            id: failedRetryableId,
+            error: "transient finalization failure"
+        )
+
+        let failedExhaustedId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: failedExhaustedId,
+            reason: .retry
+        )
+        try await TranscriptionStorage.shared.markSessionFailed(
+            id: failedExhaustedId,
+            error: "exhausted finalization failure"
+        )
+        for _ in 0..<5 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: failedExhaustedId)
+        }
+
+        let completedId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: completedId,
+            reason: .userStop
+        )
+        try await TranscriptionStorage.shared.markSessionCompleted(
+            id: completedId,
+            backendId: "backend-completed"
+        )
+
+        let needingFinalization = try await TranscriptionStorage.shared.getSessionsNeedingFinalization()
+        let ids = Set(needingFinalization.compactMap(\.id))
+
+        XCTAssertTrue(ids.contains(pendingId))
+        XCTAssertTrue(ids.contains(failedRetryableId))
+        XCTAssertFalse(ids.contains(recordingId))
+        XCTAssertFalse(ids.contains(failedExhaustedId))
+        XCTAssertFalse(ids.contains(completedId))
+    }
+
+    func testFreshUploadingSessionWaitsForStaleRecoveryWindow() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .userStop
+        )
+        try await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
+
+        let needingFinalization = try await TranscriptionStorage.shared.getSessionsNeedingFinalization(
+            uploadingStaleAfter: 300
+        )
+
+        XCTAssertFalse(
+            needingFinalization.contains { $0.id == sessionId },
+            "Fresh uploading sessions should not be retried until the stale recovery window expires"
+        )
+    }
+
+    func testEmptyLocalSegmentsSessionIsDiscardedInsteadOfRetriedForever() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .localSegments
+        )
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .userStop
+        )
+
+        await ConversationFinalizationService.shared.finalizeSession(
+            id: sessionId,
+            reason: .userStop
+        )
+
+        let session = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        XCTAssertNil(session)
+    }
+}

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -203,6 +203,52 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         XCTAssertNil(session)
     }
 
+    func testCompactsOversizedLocalUploadWithoutDroppingText() {
+        let segments = (0..<750).map { index in
+            APIClient.UploadSegment(
+                text: "segment-\(index)",
+                speaker: index.isMultiple(of: 2) ? "SPEAKER_00" : "SPEAKER_01",
+                speaker_id: index.isMultiple(of: 2) ? 0 : 1,
+                is_user: index.isMultiple(of: 2),
+                person_id: nil,
+                start: Double(index),
+                end: Double(index) + 0.5
+            )
+        }
+
+        let compacted = ConversationFinalizationService.compactSegmentsForBackendLimit(segments)
+
+        XCTAssertEqual(compacted.count, 500)
+        XCTAssertEqual(compacted.first?.start, 0)
+        XCTAssertEqual(compacted.last?.end, 749.5)
+        let compactedText = compacted.map(\.text).joined(separator: " ")
+        for index in 0..<750 {
+            XCTAssertTrue(compactedText.contains("segment-\(index)"))
+        }
+        XCTAssertTrue(compacted.contains { $0.speaker == "MIXED" })
+    }
+
+    func testCompactionLeavesBackendSizedUploadsUnchanged() {
+        let segments = (0..<3).map { index in
+            APIClient.UploadSegment(
+                text: "segment-\(index)",
+                speaker: "SPEAKER_00",
+                speaker_id: 0,
+                is_user: true,
+                person_id: "person-1",
+                start: Double(index),
+                end: Double(index) + 0.5
+            )
+        }
+
+        let compacted = ConversationFinalizationService.compactSegmentsForBackendLimit(segments)
+
+        XCTAssertEqual(compacted.count, segments.count)
+        XCTAssertEqual(compacted.map(\.text), segments.map(\.text))
+        XCTAssertEqual(compacted.map(\.speaker), segments.map(\.speaker))
+        XCTAssertEqual(compacted.map(\.person_id), segments.map(\.person_id))
+    }
+
     private func makeServerConversation(status: ConversationStatus) -> ServerConversation {
         let createdAt = Date(timeIntervalSince1970: 1_000)
         return ServerConversation(

--- a/desktop/macos/Desktop/Tests/TranscriptionStorageRecoveryTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionStorageRecoveryTests.swift
@@ -52,7 +52,7 @@ final class TranscriptionStorageRecoveryTests: XCTestCase {
             id: sessionId,
             backendId: "backend-conversation-pending"
         )
-        try await TranscriptionStorage.shared.finishSession(id: sessionId)
+        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .crashRecovery)
 
         let pending = try await TranscriptionStorage.shared.getPendingUploadSessions()
 

--- a/desktop/macos/changelog/unreleased/20260629-conversation-finalization-state-machine.json
+++ b/desktop/macos/changelog/unreleased/20260629-conversation-finalization-state-machine.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop conversations so local transcription sessions are finalized and retried through one durable path"
+}


### PR DESCRIPTION
## Summary
- add a desktop conversation finalization coordinator for local segment upload, cloud targeted finalize/reconcile, retry, and crash recovery
- make local from-segments creation idempotent with stable client session IDs
- add targeted backend conversation finalization by ID to avoid global Redis current-conversation races
- add desktop finalization metadata, tests, and changelog fragment

## Verification
- cd backend && pytest tests/unit/test_developer_from_segments_idempotency.py tests/unit/test_conversation_search_date_validation.py -q
- cd desktop/macos && xcrun swift test --package-path Desktop --filter TranscriptionFinalizationStateMachineTests
- cd desktop/macos && xcrun swift test --package-path Desktop --filter TranscriptionStorageRecoveryTests
- cd desktop/macos && xcrun swift build -c debug --package-path Desktop
- git diff --check
- pre-push checks passed

## Notes
- The gitignored collaboration spec remains local at .dev/collaboration/conversation-finalization-state-machine.md.
- Known follow-up: backend from-segments idempotency is deterministic but not an atomic processing-side-effect claim under concurrent duplicate requests; the spec documents the ledger/transaction follow-up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

