### PR TITLE
Fix Twitter plugin Procfile entrypoint

### DIFF
--- a/plugins/omi-twitter-app/Procfile
+++ b/plugins/omi-twitter-app/Procfile
@@ -1,2 +1,1 @@
-web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}
-
+web: uvicorn main_simple:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- Updated plugins/omi-twitter-app/Procfile to run uvicorn main_simple:app.
- main_simple.py is the module that defines the FastAPI app, and plugins/omi-twitter-app/railway.toml already points at main_simple:app.

## Canonical plugin note
- plugins/omi-twitter-chat-tools-app has its own main.py and matching Procfile/Railway config.
- I did not find a repo-level marker that clearly identifies either plugins/omi-twitter-app or plugins/omi-twitter-chat-tools-app as canonical, so this PR stays scoped to the boot fix for plugins/omi-twitter-app.

## Validation
- make setup
- python3 -c "import main_simple; from fastapi import FastAPI; assert isinstance(main_simple.app, FastAPI); print(type(main_simple.app).__name__)" failed in the ambient environment because tweepy was not installed.
- /tmp/omi-twitter-app-8553-venv/bin/python -m pip install -r requirements.txt
- OPENAI_API_KEY=dummy /tmp/omi-twitter-app-8553-venv/bin/python -c "import main_simple; from fastapi import FastAPI; assert isinstance(main_simple.app, FastAPI); print(type(main_simple.app).__name__)" -> FastAPI
- OPENAI_API_KEY=dummy /tmp/omi-twitter-app-8553-venv/bin/python -c "from uvicorn.importer import import_from_string; app = import_from_string('main_simple:app'); print(type(app).__name__)" -> FastAPI
- git diff --check

Closes #8553

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

