### PR TITLE
Fix Flutter root theme purple accent

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -291,8 +291,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
-            CaptureProvider>(
+        ChangeNotifierProxyProvider4<
+          ConversationProvider,
+          MessageProvider,
+          PeopleProvider,
+          UsageProvider,
+          CaptureProvider
+        >(
           create: (context) => CaptureProvider(),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) =>
               (previous?..updateProviderInstances(conversation, message, people, usage)) ?? CaptureProvider(),
@@ -365,7 +370,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               useMaterial3: false,
               colorScheme: const ColorScheme.dark(
                 primary: Colors.black,
-                secondary: Colors.deepPurple,
+                secondary: Colors.white,
                 surface: Colors.black38,
               ),
               snackBarTheme: const SnackBarThemeData(
@@ -380,7 +385,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               ),
               textSelectionTheme: const TextSelectionThemeData(
                 cursorColor: Colors.white,
-                selectionColor: Colors.deepPurple,
+                selectionColor: Colors.white24,
                 selectionHandleColor: Colors.white,
               ),
               cupertinoOverrideTheme: const CupertinoThemeData(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -291,13 +291,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<
-          ConversationProvider,
-          MessageProvider,
-          PeopleProvider,
-          UsageProvider,
-          CaptureProvider
-        >(
+        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
+            CaptureProvider>(
           create: (context) => CaptureProvider(),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) =>
               (previous?..updateProviderInstances(conversation, message, people, usage)) ?? CaptureProvider(),
@@ -370,7 +365,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               useMaterial3: false,
               colorScheme: const ColorScheme.dark(
                 primary: Colors.black,
-                secondary: Colors.white,
+                secondary: Color(0xFF35343B),
                 surface: Colors.black38,
               ),
               snackBarTheme: const SnackBarThemeData(


### PR DESCRIPTION
## Summary
- Replace the root Flutter Material theme `Colors.deepPurple` accent with existing neutral white theme colors in `app/lib/main.dart`.
- Keep the broader purple sweep out of scope for this quick-fix PR; this only addresses the two root theme references requested in #8555.

## Validation
- `dart format --line-length 120 app/lib/main.dart`
- `grep -n "deepPurple\|Colors.purple" app/lib/main.dart` -> no matches
- Push pre-checks passed, including `dart format --set-exit-if-changed` for the touched Dart file.

Note: Flutter analyzer/tests were not run because `flutter` is not installed on this worktree PATH and `.dart_tool` is absent. Dart format reported the existing missing `package:flutter_lints/flutter.yaml` package-resolution warning, but completed successfully.

Closes #8555

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

