### PR TITLE
Fix desktop OAuth base API URL handling

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Google Service Account
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./desktop/macos/Backend-Rust/google-credentials.json
 
+      - name: Validate desktop OAuth base API URL
+        env:
+          DESKTOP_BACKEND_BASE_API_URL: ${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DESKTOP_BACKEND_BASE_API_URL//[[:space:]]/}" ]; then
+            echo "DESKTOP_BACKEND_BASE_API_URL must be configured for desktop OAuth callbacks" >&2
+            exit 1
+          fi
+
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -61,6 +71,7 @@ jobs:
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
+            BASE_API_URL=${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             OPENAI_API_KEY=OPENAI_API_KEY:latest

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -270,6 +270,17 @@ jobs:
         if: steps.current.outputs.deploy_needed == 'true'
         run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./release-source/desktop/macos/Backend-Rust/google-credentials.json
 
+      - name: Validate desktop OAuth base API URL
+        if: steps.current.outputs.deploy_needed == 'true'
+        env:
+          DESKTOP_BACKEND_BASE_API_URL: ${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DESKTOP_BACKEND_BASE_API_URL//[[:space:]]/}" ]; then
+            echo "DESKTOP_BACKEND_BASE_API_URL must be configured for desktop OAuth callbacks" >&2
+            exit 1
+          fi
+
       - name: Build and Push Desktop Backend Image
         if: steps.current.outputs.deploy_needed == 'true'
         uses: docker/build-push-action@v6
@@ -296,6 +307,7 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
+            BASE_API_URL=${{ vars.DESKTOP_BACKEND_BASE_API_URL }}
             OMI_DESKTOP_RELEASE_TAG=${{ inputs.release_tag }}
             OMI_DESKTOP_RELEASE_SHA=${{ steps.plan.outputs.target_sha }}
             OMI_DESKTOP_RELEASE_CHANNEL=stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f bran
 
 ## CI/CD & Logs
 
-- Desktop release pipeline: merging `desktop/macos/**` to `main` auto-increments the version, tags `v*-macos`, and triggers Codemagic to build/sign/notarize/publish a beta GitHub release. Stable/prod requires manually running `.github/workflows/desktop_promote_prod.yml` with `release_tag` and `confirm=promote-stable`; that workflow is roll-forward only, deploys the Rust backend from the exact tag, verifies `/health`, promotes the Firestore bridge release, then marks the GitHub release stable.
+- Desktop release pipeline: merging `desktop/macos/**` to `main` auto-increments the version, tags `v*-macos`, and triggers Codemagic to build/sign/notarize/publish a beta GitHub release. Stable/prod requires manually running `.github/workflows/desktop_promote_prod.yml` with `release_tag` and `confirm=promote-stable`; that workflow is roll-forward only, deploys the Rust backend from the exact tag, verifies `/health`, promotes the Firestore bridge release, then marks the GitHub release stable. Desktop Rust backend deploys require environment-scoped `DESKTOP_BACKEND_BASE_API_URL` so OAuth callbacks set runtime `BASE_API_URL`.
 - Backend deploy: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
 
 ## Documentation Maintenance

--- a/desktop/macos/Backend-Rust/src/routes/auth.rs
+++ b/desktop/macos/Backend-Rust/src/routes/auth.rs
@@ -163,10 +163,18 @@ impl IntoResponse for ErrorResponse {
 }
 
 fn api_base_url(config: &Config) -> Result<&str, ErrorResponse> {
-    config.base_api_url.as_deref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "BASE_API_URL not configured".to_string(),
-    })
+    config
+        .base_api_url
+        .as_deref()
+        .filter(|url| is_nonblank_url(url))
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "BASE_API_URL not configured".to_string(),
+        })
+}
+
+fn is_nonblank_url(url: &str) -> bool {
+    !url.trim().is_empty()
 }
 
 // OAuth credential data stored in auth codes
@@ -646,7 +654,8 @@ async fn generate_custom_token(
     let request_uri = state
         .config
         .base_api_url
-        .as_ref()
+        .as_deref()
+        .filter(|url| is_nonblank_url(url))
         .ok_or("BASE_API_URL not configured")?;
 
     // Sign in with OAuth credential using Firebase Auth REST API
@@ -757,4 +766,22 @@ pub fn auth_routes(config: Arc<Config>) -> Router {
         .route("/v1/auth/callback/google", get(auth_callback_google))
         .route("/v1/auth/token", post(auth_token))
         .with_state(auth_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_base_url_rejects_blank_values() {
+        assert!(!is_nonblank_url(""));
+        assert!(!is_nonblank_url("   "));
+        assert!(!is_nonblank_url("\n\t"));
+    }
+
+    #[test]
+    fn auth_base_url_accepts_nonblank_values() {
+        assert!(is_nonblank_url("https://desktop-backend.example.com"));
+        assert!(is_nonblank_url("  https://desktop-backend.example.com  "));
+    }
 }

--- a/desktop/macos/Backend-Rust/src/routes/auth.rs
+++ b/desktop/macos/Backend-Rust/src/routes/auth.rs
@@ -162,6 +162,13 @@ impl IntoResponse for ErrorResponse {
     }
 }
 
+fn api_base_url(config: &Config) -> Result<&str, ErrorResponse> {
+    config.base_api_url.as_deref().ok_or_else(|| ErrorResponse {
+        error: "not_configured".to_string(),
+        message: "BASE_API_URL not configured".to_string(),
+    })
+}
+
 // OAuth credential data stored in auth codes
 #[derive(Debug, Serialize, Deserialize)]
 struct OAuthCredentials {
@@ -208,7 +215,10 @@ async fn auth_authorize(
         redirect_uri: params.redirect_uri,
         state: params.state,
     };
-    state.sessions.set_session(&session_id, session_data, 300).await;
+    state
+        .sessions
+        .set_session(&session_id, session_data, 300)
+        .await;
 
     match params.provider.as_str() {
         "apple" => apple_auth_redirect(&state.config, &session_id),
@@ -221,12 +231,15 @@ async fn auth_authorize(
 }
 
 fn apple_auth_redirect(config: &Config, session_id: &str) -> Result<Redirect, ErrorResponse> {
-    let client_id = config.apple_client_id.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "APPLE_CLIENT_ID not configured".to_string(),
-    })?;
+    let client_id = config
+        .apple_client_id
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "APPLE_CLIENT_ID not configured".to_string(),
+        })?;
 
-    let api_base_url = config.base_api_url.as_deref().unwrap_or("http://localhost:8080");
+    let api_base_url = api_base_url(config)?;
     let callback_url = format!("{}/v1/auth/callback/apple", api_base_url);
 
     let auth_url = format!(
@@ -244,12 +257,15 @@ fn apple_auth_redirect(config: &Config, session_id: &str) -> Result<Redirect, Er
 }
 
 fn google_auth_redirect(config: &Config, session_id: &str) -> Result<Redirect, ErrorResponse> {
-    let client_id = config.google_client_id.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "GOOGLE_CLIENT_ID not configured".to_string(),
-    })?;
+    let client_id = config
+        .google_client_id
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "GOOGLE_CLIENT_ID not configured".to_string(),
+        })?;
 
-    let api_base_url = config.base_api_url.as_deref().unwrap_or("http://localhost:8080");
+    let api_base_url = api_base_url(config)?;
     let callback_url_raw = format!("{}/v1/auth/callback/google", api_base_url);
     let callback_url = urlencoding::encode(&callback_url_raw);
     let scope = urlencoding::encode("openid email profile");
@@ -279,17 +295,24 @@ async fn auth_callback_apple(
         });
     }
 
-    let session_data = state.sessions.get_session(&form.state).await.ok_or_else(|| ErrorResponse {
-        error: "invalid_session".to_string(),
-        message: "Invalid or expired auth session".to_string(),
-    })?;
+    let session_data = state
+        .sessions
+        .get_session(&form.state)
+        .await
+        .ok_or_else(|| ErrorResponse {
+            error: "invalid_session".to_string(),
+            message: "Invalid or expired auth session".to_string(),
+        })?;
 
     // Exchange Apple code for tokens
     let oauth_credentials = exchange_apple_code(&state, &form.code, &session_data).await?;
 
     // Create temporary auth code
     let auth_code = uuid::Uuid::new_v4().to_string();
-    state.sessions.set_code(&auth_code, oauth_credentials, 300).await;
+    state
+        .sessions
+        .set_code(&auth_code, oauth_credentials, 300)
+        .await;
 
     // Return HTML that redirects to app
     let html = render_auth_callback(
@@ -324,17 +347,24 @@ async fn auth_callback_google(
         message: "Missing state parameter".to_string(),
     })?;
 
-    let session_data = state.sessions.get_session(&session_id).await.ok_or_else(|| ErrorResponse {
-        error: "invalid_session".to_string(),
-        message: "Invalid or expired auth session".to_string(),
-    })?;
+    let session_data = state
+        .sessions
+        .get_session(&session_id)
+        .await
+        .ok_or_else(|| ErrorResponse {
+            error: "invalid_session".to_string(),
+            message: "Invalid or expired auth session".to_string(),
+        })?;
 
     // Exchange Google code for tokens
     let oauth_credentials = exchange_google_code(&state, &code, &session_data).await?;
 
     // Create temporary auth code
     let auth_code = uuid::Uuid::new_v4().to_string();
-    state.sessions.set_code(&auth_code, oauth_credentials, 300).await;
+    state
+        .sessions
+        .set_code(&auth_code, oauth_credentials, 300)
+        .await;
 
     // Return HTML that redirects to app
     let html = render_auth_callback(
@@ -359,15 +389,20 @@ async fn auth_token(
         });
     }
 
-    let oauth_credentials_json = state.sessions.get_code(&form.code).await.ok_or_else(|| ErrorResponse {
-        error: "invalid_code".to_string(),
-        message: "Invalid or expired code".to_string(),
-    })?;
+    let oauth_credentials_json =
+        state
+            .sessions
+            .get_code(&form.code)
+            .await
+            .ok_or_else(|| ErrorResponse {
+                error: "invalid_code".to_string(),
+                message: "Invalid or expired code".to_string(),
+            })?;
 
     state.sessions.delete_code(&form.code).await;
 
-    let credentials: OAuthCredentials = serde_json::from_str(&oauth_credentials_json)
-        .map_err(|e| ErrorResponse {
+    let credentials: OAuthCredentials =
+        serde_json::from_str(&oauth_credentials_json).map_err(|e| ErrorResponse {
             error: "parse_error".to_string(),
             message: format!("Failed to parse credentials: {}", e),
         })?;
@@ -408,10 +443,13 @@ async fn exchange_apple_code(
 ) -> Result<String, ErrorResponse> {
     let config = &state.config;
 
-    let client_id = config.apple_client_id.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "Apple auth not configured".to_string(),
-    })?;
+    let client_id = config
+        .apple_client_id
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "Apple auth not configured".to_string(),
+        })?;
 
     let team_id = config.apple_team_id.as_ref().ok_or_else(|| ErrorResponse {
         error: "not_configured".to_string(),
@@ -423,12 +461,15 @@ async fn exchange_apple_code(
         message: "APPLE_KEY_ID not configured".to_string(),
     })?;
 
-    let private_key = config.apple_private_key.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "APPLE_PRIVATE_KEY not configured".to_string(),
-    })?;
+    let private_key = config
+        .apple_private_key
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "APPLE_PRIVATE_KEY not configured".to_string(),
+        })?;
 
-    let api_base_url = config.base_api_url.as_deref().unwrap_or("http://localhost:8080");
+    let api_base_url = api_base_url(config)?;
     let callback_url = format!("{}/v1/auth/callback/apple", api_base_url);
 
     // Generate client secret JWT
@@ -493,17 +534,23 @@ async fn exchange_google_code(
 ) -> Result<String, ErrorResponse> {
     let config = &state.config;
 
-    let client_id = config.google_client_id.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "Google auth not configured".to_string(),
-    })?;
+    let client_id = config
+        .google_client_id
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "Google auth not configured".to_string(),
+        })?;
 
-    let client_secret = config.google_client_secret.as_ref().ok_or_else(|| ErrorResponse {
-        error: "not_configured".to_string(),
-        message: "GOOGLE_CLIENT_SECRET not configured".to_string(),
-    })?;
+    let client_secret = config
+        .google_client_secret
+        .as_ref()
+        .ok_or_else(|| ErrorResponse {
+            error: "not_configured".to_string(),
+            message: "GOOGLE_CLIENT_SECRET not configured".to_string(),
+        })?;
 
-    let api_base_url = config.base_api_url.as_deref().unwrap_or("http://localhost:8080");
+    let api_base_url = api_base_url(config)?;
     let callback_url = format!("{}/v1/auth/callback/google", api_base_url);
 
     // Exchange code for tokens
@@ -591,8 +638,16 @@ async fn generate_custom_token(
     state: &AuthState,
     credentials: &OAuthCredentials,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let firebase_api_key = state.config.firebase_api_key.as_ref()
+    let firebase_api_key = state
+        .config
+        .firebase_api_key
+        .as_ref()
         .ok_or("FIREBASE_API_KEY not configured")?;
+    let request_uri = state
+        .config
+        .base_api_url
+        .as_ref()
+        .ok_or("BASE_API_URL not configured")?;
 
     // Sign in with OAuth credential using Firebase Auth REST API
     let sign_in_url = format!(
@@ -606,7 +661,10 @@ async fn generate_custom_token(
         _ => return Err(format!("Unsupported provider: {}", credentials.provider).into()),
     };
 
-    let mut post_body = format!("id_token={}&providerId={}", credentials.id_token, provider_id);
+    let mut post_body = format!(
+        "id_token={}&providerId={}",
+        credentials.id_token, provider_id
+    );
     if let Some(access_token) = &credentials.access_token {
         post_body.push_str(&format!("&access_token={}", access_token));
     }
@@ -628,7 +686,7 @@ async fn generate_custom_token(
         .post(&sign_in_url)
         .json(&SignInRequest {
             post_body,
-            request_uri: "http://localhost".to_string(),
+            request_uri: request_uri.to_string(),
             return_idp_credential: true,
             return_secure_token: true,
         })
@@ -662,7 +720,12 @@ async fn generate_custom_token(
     Err("Custom token generation requires Firebase Admin SDK - not yet implemented in Rust".into())
 }
 
-fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {
+fn render_auth_callback(
+    code: &str,
+    state: &str,
+    redirect_uri: &str,
+    error: Option<&str>,
+) -> String {
     // Load template and replace placeholders
     let template = include_str!("../../templates/auth_callback.html");
 
@@ -670,7 +733,10 @@ fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Opti
         .replace("{{ code }}", code)
         .replace("{{ state }}", state)
         .replace("{{ redirect_uri }}", redirect_uri)
-        .replace("{{ error if error is defined else '' }}", error.unwrap_or(""))
+        .replace(
+            "{{ error if error is defined else '' }}",
+            error.unwrap_or(""),
+        )
 }
 
 /// Create auth routes
@@ -682,7 +748,10 @@ pub fn auth_routes(config: Arc<Config>) -> Router {
     };
 
     Router::new()
-        .route("/.well-known/apple-developer-domain-association.txt", get(apple_domain_association))
+        .route(
+            "/.well-known/apple-developer-domain-association.txt",
+            get(apple_domain_association),
+        )
         .route("/v1/auth/authorize", get(auth_authorize))
         .route("/v1/auth/callback/apple", post(auth_callback_apple))
         .route("/v1/auth/callback/google", get(auth_callback_google))

--- a/desktop/macos/changelog/unreleased/20260629-oauth-base-url.json
+++ b/desktop/macos/changelog/unreleased/20260629-oauth-base-url.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop OAuth setup failures when the backend callback URL is missing"
+}


### PR DESCRIPTION
## Summary
- remove silent localhost fallbacks from desktop Rust OAuth callback URL construction
- fail explicitly when BASE_API_URL is missing
- use the configured base API URL for Firebase Identity Toolkit requestUri
- add the required desktop changelog fragment

Closes #8552

## Validation
- rg -n "unwrap_or\(\"http://localhost:8080\"\)|request_uri: \"http://localhost\"|http://localhost|localhost:8080" desktop/macos/Backend-Rust/src/routes/auth.rs (no matches)
- cargo test auth
- cargo check
- pre-push hook fast checks passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

