### PR TITLE
Fix backend router layering

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -38,19 +38,19 @@ from models.chat import (
     MessageConversation,
     FileChat,
 )
-from routers.sync import retrieve_file_paths, decode_files_to_wav
 from utils.apps import get_available_app_by_id
 from utils.conversation_helpers import extract_memory_ids
 from utils.chat import (
+    acquire_chat_session,
+    initial_message_util,
     process_voice_message_segment,
     process_voice_message_segment_stream,
     resolve_voice_message_language,
     transcribe_voice_message_segment,
     transcribe_pcm_bytes,
 )
+from utils.sync.files import retrieve_file_paths, decode_files_to_wav
 from utils.stt.streaming import process_audio_dg, get_stt_service_for_language
-from utils.llm.persona import initial_persona_chat_message
-from utils.llm.chat import initial_chat_message
 from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
@@ -113,14 +113,6 @@ def filter_messages(messages, app_id):
         collected.append(message)
     logger.info(f'filter_messages output: {len(collected)}')
     return collected
-
-
-def acquire_chat_session(uid: str, app_id: Optional[str] = None):
-    chat_session = chat_db.get_chat_session(uid, app_id=app_id)
-    if chat_session is None:
-        cs = ChatSession(id=str(uuid.uuid4()), created_at=datetime.now(timezone.utc), plugin_id=app_id)
-        chat_session = chat_db.add_chat_session(uid, cs.dict())
-    return chat_session
 
 
 def _build_quota_exceeded_reply(
@@ -381,55 +373,6 @@ def clear_chat_messages(
         chat_db.delete_chat_session(uid, chat_session_id)
 
     return initial_message_util(uid, compat_app_id)
-
-
-def initial_message_util(uid: str, app_id: Optional[str] = None, chat_session_id: Optional[str] = None):
-    logger.info(f'initial_message_util {app_id}')
-
-    # init chat session — use provided session_id if available, otherwise acquire by app_id
-    if chat_session_id:
-        chat_session = chat_db.get_chat_session_by_id(uid, chat_session_id)
-        if chat_session is None:
-            raise HTTPException(status_code=404, detail='Chat session not found')
-    else:
-        chat_session = acquire_chat_session(uid, app_id=app_id)
-
-    # Load previous messages — session-scoped when session_id is provided, app-scoped otherwise
-    if chat_session_id:
-        prev_messages = list(reversed(chat_db.get_messages(uid, limit=5, chat_session_id=chat_session_id)))
-    else:
-        prev_messages = list(reversed(chat_db.get_messages(uid, limit=5, app_id=app_id)))
-    logger.info(f'initial_message_util returned {len(prev_messages)} prev messages for {app_id}')
-
-    app = get_available_app_by_id(app_id, uid)
-    app = App(**app) if app else None
-
-    # persona
-    text: str
-    if app and app.is_a_persona():
-        text = initial_persona_chat_message(uid, app, prev_messages)
-    else:
-        prev_messages_str = ''
-        if prev_messages:
-            prev_messages_str = 'Previous conversation history:\n'
-            prev_messages_str += Message.get_messages_as_string([Message(**msg) for msg in prev_messages])
-        logger.info(f'initial_message_util {len(prev_messages_str)} {app_id}')
-        text = initial_chat_message(uid, app, prev_messages_str)
-
-    ai_message = Message(
-        id=str(uuid.uuid4()),
-        text=text,
-        created_at=datetime.now(timezone.utc),
-        sender='ai',
-        app_id=app_id,
-        from_external_integration=False,
-        type='text',
-        memories_id=[],
-        chat_session_id=chat_session['id'],
-    )
-    chat_db.add_message(uid, ai_message.dict())
-    chat_db.add_message_to_chat_session(uid, chat_session['id'], ai_message.id)
-    return ai_message
 
 
 @router.post('/v2/initial-message', tags=['chat'], response_model=Message)

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel, Field
 
 import database.chat as chat_db
 from database.users import set_chat_message_rating_score
+from utils.chat import initial_message_util
+from utils.llm.clients import get_llm
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -194,11 +196,9 @@ def create_initial_message(
 ):
     """Generate an initial greeting message for a chat session.
 
-    Delegates to the existing initial_message_util in routers/chat.py which
+    Delegates to the shared chat helper which
     handles persona detection, previous message context, and LLM generation.
     """
-    from routers.chat import initial_message_util
-
     ai_message = initial_message_util(uid, request.app_id, chat_session_id=request.session_id)
     return {'message': ai_message.text, 'message_id': ai_message.id}
 
@@ -209,8 +209,6 @@ def generate_session_title(
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "chat:initial")),
 ):
     """Generate a title for a chat session based on its messages."""
-    from utils.llm.clients import get_llm
-
     conversation = '\n'.join(f"{m.sender}: {m.text}" for m in request.messages[:10])
     prompt = (
         "Generate a short, descriptive title (max 6 words) for this chat conversation. "

--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -1,14 +1,11 @@
-import os
 import re
 from typing import Optional, Tuple, List, Dict
 
-import httpx
 from fastapi import APIRouter, HTTPException
 from enum import Enum
 import ast
 
-from database.redis_db import get_generic_cache, set_generic_cache
-from utils.log_sanitizer import sanitize
+from utils.github_releases import get_omi_github_releases, extract_key_value_pairs
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,7 +26,6 @@ FIRMWARE_TAG_PATTERN = re.compile(
     r'^(?:Omi_CV1|Omi_DK2|OmiGlass|OpenGlass|Friend)_v[0-9]+(?:\.[0-9]+){1,2}$',
     re.IGNORECASE,
 )
-MAX_PAGES = 20  # Safety cap to prevent runaway pagination
 
 
 # Device Model Number
@@ -56,103 +52,6 @@ def _get_device_by_model_number(device_model: str):
         return DeviceModel.OMI_CV1
 
     return None
-
-
-async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Pattern] = None) -> Optional[List[Dict]]:
-    """Fetch releases from GitHub API with caching.
-
-    When tag_filter is provided, paginates through all pages and returns only
-    releases whose tag_name matches the filter. Without tag_filter, returns
-    the first page of releases unfiltered (sufficient for desktop releases
-    which are always recent).
-
-    Resilience: if GitHub returns errors or an empty list during an upstream
-    outage, we fall back to a longer-lived "last known good" cache so the
-    macos.omi.me download endpoint keeps serving the previous DMG link.
-    """
-
-    lkg_key = f"{cache_key}:lkg"
-
-    # Check cache first (use `is not None` so cached empty list is a hit)
-    cached_releases = get_generic_cache(cache_key)
-    if cached_releases is not None:
-        return cached_releases
-
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}",
-    }
-
-    collected: List[Dict] = []
-    fetch_failed = False
-
-    try:
-        page = 1
-        async with httpx.AsyncClient() as client:
-            while page <= MAX_PAGES:
-                url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
-                response = await client.get(url, headers=headers)
-                if response.status_code != 200:
-                    logger.error(
-                        "Error fetching GitHub releases page %d: %d %s",
-                        page,
-                        response.status_code,
-                        sanitize(response.text),
-                    )
-                    fetch_failed = True
-                    break
-
-                page_releases = response.json()
-                if not page_releases:
-                    break
-
-                if tag_filter:
-                    for release in page_releases:
-                        tag_name = release.get("tag_name", "")
-                        if tag_filter.match(tag_name):
-                            collected.append(release)
-                else:
-                    collected.extend(page_releases)
-
-                # Without filter, single page is enough (desktop releases are recent)
-                if not tag_filter:
-                    break
-
-                # Stop if this was the last page
-                if len(page_releases) < 100:
-                    break
-
-                page += 1
-    except Exception as exc:
-        logger.exception("Exception fetching GitHub releases: %s", sanitize(str(exc)))
-        fetch_failed = True
-
-    # If the live fetch failed or returned nothing, prefer the last-known-good
-    # cache over an empty response. Re-cache LKG under the short key with a
-    # short TTL (60s) so we retry GitHub soon without hammering it.
-    if fetch_failed or not collected:
-        last_known_good = get_generic_cache(lkg_key)
-        if last_known_good:
-            logger.warning(
-                "GitHub releases fetch %s; serving last-known-good cache for %s",
-                "failed" if fetch_failed else "returned empty",
-                cache_key,
-            )
-            set_generic_cache(cache_key, last_known_good, ttl=60)
-            return last_known_good
-
-        # No fallback — short-cache the empty result so we don't hammer
-        # GitHub, but use a shorter TTL than the success path (5min) so
-        # recovery is faster once GitHub is back.
-        set_generic_cache(cache_key, collected, ttl=60)
-        return collected
-
-    # Live fetch succeeded with data: refresh both caches. The LKG TTL is
-    # 24h so it survives multi-hour GitHub outages.
-    set_generic_cache(cache_key, collected, ttl=300)
-    set_generic_cache(lkg_key, collected, ttl=86400)
-    return collected
 
 
 def _parse_firmware_version(version_str: Optional[str]) -> Optional[Tuple[int, ...]]:
@@ -352,38 +251,3 @@ async def get_stable_version(device_model: str):
 
     candidates.sort(key=lambda r: r.get("published_at", ""), reverse=True)
     return _extract_firmware_response(device, candidates[0])
-
-
-def extract_key_value_pairs(markdown_content):
-    if not markdown_content:
-        return {}
-
-    key_value_pattern = re.compile(r'<!-- KEY_VALUE_START\s*(.*?)\s*KEY_VALUE_END -->', re.DOTALL)
-    key_value_match = key_value_pattern.search(markdown_content)
-
-    if not key_value_match:
-        return {}
-
-    key_value_string = key_value_match.group(1).strip()
-    lines = key_value_string.split('\n')
-    key_value_map = {}
-
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-
-        # Use split with maxsplit=1 to handle values containing colons
-        parts = line.split(':', 1)
-        if len(parts) == 2:
-            key = parts[0].strip()
-            value = parts[1].strip()
-
-            if key == 'ota_update_steps':
-                key_value_map[key] = [step.strip() for step in value.split(',') if step.strip()]
-            elif key == 'changelog':
-                key_value_map[key] = [item.strip() for item in value.split('|') if item.strip()]
-            else:
-                key_value_map[key] = value
-
-    return key_value_map

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -19,12 +19,12 @@ import models.integrations as integration_models
 import models.conversation as conversation_models
 from models.conversation import SearchRequest
 from models.app import App
-from routers.conversations import process_conversation, trigger_external_integrations
+from utils.app_integrations import send_app_notification, trigger_external_integrations
 from utils.conversations.location import get_google_maps_location
 from utils.conversations.render import redact_conversation_for_integration
 from utils.conversations.memories import process_external_integration_memory
+from utils.conversations.process_conversation import process_conversation
 from utils.conversations.search import search_conversations
-from utils.app_integrations import send_app_notification
 from utils.other.endpoints import check_rate_limit_inline
 from utils.executors import run_blocking, db_executor, postprocess_executor, critical_executor
 import logging

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3,9 +3,7 @@ import contextlib
 import io
 import logging
 import os
-import re
 import shutil
-import struct
 import threading
 import time
 import uuid as _uuid
@@ -29,13 +27,6 @@ from utils.executors import (
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, Header, Request, Response
 from fastapi.responses import JSONResponse
 
-try:
-    from opuslib import Decoder
-except Exception as e:
-    Decoder = None
-    _OPUS_IMPORT_ERROR = e
-else:
-    _OPUS_IMPORT_ERROR = None
 from pydub import AudioSegment
 
 from database import conversations as conversations_db
@@ -86,8 +77,8 @@ from utils.cloud_tasks import (
 )
 from utils.http_client import _get_semaphore
 from utils.log_sanitizer import sanitize
-from utils.request_validation import parse_sync_filename_timestamp
 from utils.sync import playback as sync_playback
+from utils.sync.files import decode_files_to_wav, get_timestamp_from_path, get_wav_duration, retrieve_file_paths
 from utils.stt.pre_recorded import postprocess_words, prerecorded
 from utils.stt.vad import vad_is_empty
 from utils.fair_use import (
@@ -119,15 +110,6 @@ AUDIO_SAMPLE_RATE = 16000
 _V1_DEPRECATION_HEADERS = {'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'}
 
 router = APIRouter()
-
-
-def _get_opus_decoder_class():
-    if Decoder is None:
-        raise RuntimeError(
-            'Opus sync decoding requires opuslib and the native libopus library. '
-            'Install the OS-level Opus package before processing .opus sync files.'
-        ) from _OPUS_IMPORT_ERROR
-    return Decoder
 
 
 def _hard_restriction_headers(retry_after: int | None, base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
@@ -229,204 +211,6 @@ def download_audio_file_endpoint(
 # **********************************************
 # ************ SYNC LOCAL FILES ****************
 # **********************************************
-
-
-def decode_opus_file_to_wav(opus_file_path, wav_file_path, sample_rate=16000, channels=1, frame_size: int = 160):
-    """Decode an Opus file with length-prefixed frames to WAV format.
-
-    Writes directly to WAV file to avoid accumulating all PCM data in memory.
-    """
-    if not os.path.exists(opus_file_path):
-        logger.warning(f"File not found: {sanitize(opus_file_path)}")
-        return False
-
-    decoder = _get_opus_decoder_class()(sample_rate, channels)
-    frame_count = 0
-
-    try:
-        with open(opus_file_path, 'rb') as f, wave.open(wav_file_path, 'wb') as wav_file:
-            wav_file.setnchannels(channels)
-            wav_file.setsampwidth(2)  # 16-bit audio
-            wav_file.setframerate(sample_rate)
-
-            while True:
-                length_bytes = f.read(4)
-                if not length_bytes:
-                    logger.info("End of file reached.")
-                    break
-                if len(length_bytes) < 4:
-                    logger.info("Incomplete length prefix at the end of the file.")
-                    break
-
-                frame_length = struct.unpack('<I', length_bytes)[0]
-                opus_data = f.read(frame_length)
-                if len(opus_data) < frame_length:
-                    logger.error(f"Unexpected end of file at frame {frame_count}.")
-                    break
-                try:
-                    pcm_frame = decoder.decode(opus_data, frame_size=frame_size)
-                    wav_file.writeframes(pcm_frame)  # Write directly to file
-                    frame_count += 1
-                except Exception as e:
-                    logger.error(f"Error decoding frame {frame_count}: {e}")
-                    # Skip this frame instead of breaking the entire decode loop
-                    continue
-
-        if frame_count > 0:
-            logger.info(f"Decoded audio saved to {sanitize(wav_file_path)}")
-            return True
-        else:
-            logger.info("No PCM data was decoded.")
-            # Clean up empty/invalid wav file
-            if os.path.exists(wav_file_path):
-                os.remove(wav_file_path)
-            return False
-    except Exception as e:
-        logger.error(f"Error during decode: {e}")
-        # Clean up on error
-        if os.path.exists(wav_file_path):
-            os.remove(wav_file_path)
-        return False
-
-
-def get_timestamp_from_path(path: str):
-    return parse_sync_filename_timestamp(path)
-
-
-def retrieve_file_paths(files: List[UploadFile], uid: str):
-    directory = f'syncing/{uid}/'
-    os.makedirs(directory, exist_ok=True)
-    paths = []
-    for file in files:
-        filename = file.filename
-        # Validate the file is .bin and contains a _$timestamp.bin, if not, 400 bad request
-        if not filename:
-            raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
-        if not filename.endswith('.bin'):
-            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
-        if '_' not in filename:
-            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, missing timestamp")
-        try:
-            timestamp = get_timestamp_from_path(filename)
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
-
-        path = f"{directory}{filename}"
-        try:
-            with open(path, "wb") as buffer:
-                shutil.copyfileobj(file.file, buffer)
-            paths.append(path)
-        except Exception as e:
-            if os.path.exists(path):
-                os.remove(path)
-            raise HTTPException(status_code=500, detail=f"Failed to write file {filename}: {str(e)}")
-    return paths
-
-
-def get_wav_duration(wav_path: str) -> float:
-    """Get WAV file duration without loading entire file into memory."""
-    try:
-        with wave.open(wav_path, 'rb') as wav_file:
-            frames = wav_file.getnframes()
-            rate = wav_file.getframerate()
-            return frames / float(rate)
-    except Exception as e:
-        logger.error(f"Error reading WAV duration: {e}")
-        return 0.0
-
-
-def decode_pcm_file_to_wav(pcm_file_path, wav_file_path, sample_rate=16000, channels=1, sample_width=2):
-    """Decode a length-prefixed PCM .bin file to WAV.
-
-    The file format is: [4-byte uint32 frame_length][frame_bytes] repeated.
-    Each frame contains raw PCM samples (no encoding).
-    sample_width: 2 for pcm16, 1 for pcm8.
-    """
-    try:
-        pcm_data = bytearray()
-        with open(pcm_file_path, 'rb') as f:
-            while True:
-                length_bytes = f.read(4)
-                if not length_bytes or len(length_bytes) < 4:
-                    break
-                frame_length = struct.unpack('<I', length_bytes)[0]
-                if frame_length == 0 or frame_length > 65536:
-                    logger.warning(f"PCM decode: suspicious frame length {frame_length}, skipping rest")
-                    break
-                frame_data = f.read(frame_length)
-                if len(frame_data) < frame_length:
-                    break
-                pcm_data.extend(frame_data)
-
-        if not pcm_data:
-            logger.info(f"PCM decode: no data in {pcm_file_path}")
-            return False
-
-        wav_data = sync_playback.pcm_to_wav(
-            bytes(pcm_data), sample_rate=sample_rate, channels=channels, sample_width=sample_width
-        )
-        with open(wav_file_path, 'wb') as f:
-            f.write(wav_data)
-        return True
-    except Exception as e:
-        logger.error(f"PCM decode failed for {pcm_file_path}: {e}")
-        return False
-
-
-def _is_pcm_codec(filename: str) -> bool:
-    """Check if the filename indicates a PCM codec (pcm8 or pcm16)."""
-    return '_pcm16_' in filename or '_pcm8_' in filename
-
-
-def decode_files_to_wav(files_path: List[str]):
-    wav_files = []
-    for path in files_path:
-        wav_path = path.replace('.bin', '.wav')
-        filename = os.path.basename(path)
-        frame_size = 160  # Default frame size
-        match = re.search(r'_fs(\d+)', filename)
-        if match:
-            try:
-                frame_size = int(match.group(1))
-                logger.info(f"Found frame size {frame_size} in filename: {filename}")
-            except ValueError:
-                logger.error(f"Invalid frame size format in filename: {filename}, using default {frame_size}")
-
-        # Detect codec from filename: PCM files need different decoding than Opus
-        if _is_pcm_codec(filename):
-            # Parse sample rate from filename: audio_{device}_{codec}_{sampleRate}_{channel}_...
-            sample_rate_match = re.search(r'_pcm(?:8|16)_(\d+)_', filename)
-            sample_rate = (
-                int(sample_rate_match.group(1)) if sample_rate_match else (16000 if '_pcm16_' in filename else 8000)
-            )
-            sample_width = 1 if '_pcm8_' in filename else 2
-            success = decode_pcm_file_to_wav(path, wav_path, sample_rate=sample_rate, sample_width=sample_width)
-        else:
-            success = decode_opus_file_to_wav(path, wav_path, frame_size=frame_size)
-
-        if not success:
-            # Clean up .bin file even on decode failure
-            if os.path.exists(path):
-                os.remove(path)
-            continue
-
-        # Always remove .bin file after decode attempt
-        if os.path.exists(path):
-            os.remove(path)
-
-        # Check duration without loading entire file into memory
-        duration = get_wav_duration(wav_path)
-        if duration == 0:
-            # Invalid WAV file
-            if os.path.exists(wav_path):
-                os.remove(wav_path)
-            raise HTTPException(status_code=400, detail=f"Invalid file format {path}")
-
-        if duration < 1:
-            os.remove(wav_path)
-            continue
-        wav_files.append(wav_path)
-    return wav_files
 
 
 # Max length of a single VAD segment / STT transcribe request. Bounds GPU memory on the

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -6,8 +6,8 @@ from xml.sax.saxutils import escape as xml_escape
 from fastapi import APIRouter, HTTPException, Header, Query
 from fastapi.responses import RedirectResponse, Response, HTMLResponse
 
-from routers.firmware import get_omi_github_releases, extract_key_value_pairs
 from database.redis_db import delete_generic_cache
+from utils.github_releases import get_omi_github_releases, extract_key_value_pairs
 
 router = APIRouter()
 

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -1673,9 +1673,7 @@ class TestInitialMessageEndpoint:
         mock_msg.text = 'Hello! How can I help?'
         mock_msg.id = 'msg-123'
 
-        with patch.dict(
-            'sys.modules', {'routers.chat': MagicMock(initial_message_util=MagicMock(return_value=mock_msg))}
-        ):
+        with patch('routers.chat_sessions.initial_message_util', return_value=mock_msg):
             result = create_initial_message(InitialMessageRequest(session_id='s1', app_id='app1'), uid='u1')
 
         assert result == {'message': 'Hello! How can I help?', 'message_id': 'msg-123'}
@@ -1688,7 +1686,7 @@ class TestInitialMessageEndpoint:
         mock_msg.id = 'msg-456'
         mock_util = MagicMock(return_value=mock_msg)
 
-        with patch.dict('sys.modules', {'routers.chat': MagicMock(initial_message_util=mock_util)}):
+        with patch('routers.chat_sessions.initial_message_util', mock_util):
             create_initial_message(InitialMessageRequest(session_id='s1'), uid='u1')
             mock_util.assert_called_once_with('u1', None, chat_session_id='s1')
 
@@ -1700,7 +1698,7 @@ class TestInitialMessageEndpoint:
         mock_msg.id = 'msg-789'
         mock_util = MagicMock(return_value=mock_msg)
 
-        with patch.dict('sys.modules', {'routers.chat': MagicMock(initial_message_util=mock_util)}):
+        with patch('routers.chat_sessions.initial_message_util', mock_util):
             create_initial_message(InitialMessageRequest(session_id='sess-42', app_id='myapp'), uid='u1')
             mock_util.assert_called_once_with('u1', 'myapp', chat_session_id='sess-42')
 

--- a/backend/tests/unit/test_firmware_pagination.py
+++ b/backend/tests/unit/test_firmware_pagination.py
@@ -108,7 +108,7 @@ class TestPagination:
 
         with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
             'utils.github_releases.set_generic_cache'
-        ) as mock_set_cache, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ) as mock_set_cache, patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -143,7 +143,7 @@ class TestPagination:
 
         with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
             'utils.github_releases.set_generic_cache'
-        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -153,6 +153,46 @@ class TestPagination:
         assert len(result) == 100
         # Should only have made 1 API call (no pagination)
         assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_omits_authorization_header_without_github_token(self):
+        """Public release fetches must not send Bearer None when GITHUB_TOKEN is unset."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _desktop_releases(1)
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
+            'os.environ', {}, clear=True
+        ):
+            await get_omi_github_releases("test_key")
+
+        headers = mock_client.get.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_adds_authorization_header_with_github_token(self):
+        """Configured tokens are still used for authenticated GitHub release fetches."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _desktop_releases(1)
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
+            'os.environ', {'GITHUB_TOKEN': 'test-token'}
+        ):
+            await get_omi_github_releases("test_key")
+
+        headers = mock_client.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer test-token"
 
     @pytest.mark.asyncio
     async def test_pagination_safety_cap(self):
@@ -170,7 +210,7 @@ class TestPagination:
 
         with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
             'utils.github_releases.set_generic_cache'
-        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -206,7 +246,7 @@ class TestCacheBehavior:
 
         with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
             'utils.github_releases.set_generic_cache'
-        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ) as mock_set, patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -245,7 +285,7 @@ class TestLastKnownGoodFallback:
 
         with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
             'utils.github_releases.set_generic_cache'
-        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ) as mock_set, patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -277,7 +317,7 @@ class TestLastKnownGoodFallback:
 
         with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
             'utils.github_releases.set_generic_cache'
-        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -300,7 +340,7 @@ class TestLastKnownGoodFallback:
 
         with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
             'utils.github_releases.set_generic_cache'
-        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ), patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -324,7 +364,7 @@ class TestLastKnownGoodFallback:
 
         with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
             'utils.github_releases.set_generic_cache'
-        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        ) as mock_set, patch('utils.github_releases.get_web_fetch_client', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 

--- a/backend/tests/unit/test_firmware_pagination.py
+++ b/backend/tests/unit/test_firmware_pagination.py
@@ -24,11 +24,13 @@ sys.modules.setdefault('google.auth', MagicMock())
 sys.modules.setdefault('google.auth.transport.requests', MagicMock())
 
 from routers.firmware import (
-    get_omi_github_releases,
     FIRMWARE_TAG_PATTERN,
-    MAX_PAGES,
-    _parse_firmware_version,
     _find_candidate_releases,
+    _parse_firmware_version,
+)
+from utils.github_releases import (
+    get_omi_github_releases,
+    MAX_PAGES,
 )
 
 
@@ -104,9 +106,9 @@ class TestPagination:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
-            'routers.firmware.set_generic_cache'
-        ) as mock_set_cache, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ) as mock_set_cache, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -139,9 +141,9 @@ class TestPagination:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
-            'routers.firmware.set_generic_cache'
-        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -166,9 +168,9 @@ class TestPagination:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
-            'routers.firmware.set_generic_cache'
-        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -184,7 +186,7 @@ class TestCacheBehavior:
     @pytest.mark.asyncio
     async def test_cached_empty_list_is_cache_hit(self):
         """An empty list in cache should NOT trigger a re-fetch."""
-        with patch('routers.firmware.get_generic_cache', return_value=[]) as mock_get:
+        with patch('utils.github_releases.get_generic_cache', return_value=[]) as mock_get:
             result = await get_omi_github_releases("test_key", tag_filter=FIRMWARE_TAG_PATTERN)
 
         assert result == []
@@ -202,9 +204,9 @@ class TestCacheBehavior:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
-            'routers.firmware.set_generic_cache'
-        ) as mock_set, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -241,9 +243,9 @@ class TestLastKnownGoodFallback:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
-            'routers.firmware.set_generic_cache'
-        ) as mock_set, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
+            'utils.github_releases.set_generic_cache'
+        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -273,9 +275,9 @@ class TestLastKnownGoodFallback:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
-            'routers.firmware.set_generic_cache'
-        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -296,9 +298,9 @@ class TestLastKnownGoodFallback:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
-            'routers.firmware.set_generic_cache'
-        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', side_effect=fake_get), patch(
+            'utils.github_releases.set_generic_cache'
+        ), patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 
@@ -320,9 +322,9 @@ class TestLastKnownGoodFallback:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
-            'routers.firmware.set_generic_cache'
-        ) as mock_set, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+        with patch('utils.github_releases.get_generic_cache', return_value=None), patch(
+            'utils.github_releases.set_generic_cache'
+        ) as mock_set, patch('utils.github_releases.httpx.AsyncClient', return_value=mock_client), patch.dict(
             'os.environ', {'GITHUB_TOKEN': 'test-token'}
         ):
 

--- a/backend/tests/unit/test_optional_audio_codecs.py
+++ b/backend/tests/unit/test_optional_audio_codecs.py
@@ -40,6 +40,9 @@ def _drop_module(name: str):
     sys.modules.pop(name, None)
     parent_name, _, attr = name.rpartition(".")
     parent = sys.modules.get(parent_name)
+    if parent is not None and not hasattr(parent, "__path__"):
+        sys.modules.pop(parent_name, None)
+        return
     if parent is not None and hasattr(parent, attr):
         delattr(parent, attr)
 
@@ -156,18 +159,18 @@ def test_storage_import_defers_missing_native_opus(monkeypatch):
 
 
 def test_sync_import_defers_missing_native_opus(monkeypatch, tmp_path):
-    captured_sync = _capture_module("routers.sync")
+    captured_sync_files = _capture_module("utils.sync.files")
     _install_sync_import_stubs(monkeypatch)
     monkeypatch.setitem(sys.modules, "opuslib", None)
     try:
-        _drop_module("routers.sync")
+        _drop_module("utils.sync.files")
 
-        sync = importlib.import_module("routers.sync")
+        sync_files = importlib.import_module("utils.sync.files")
         opus_path = tmp_path / "audio.opus"
         opus_path.write_bytes(b"\x00\x00\x00\x00")
 
-        assert sync.Decoder is None
+        assert sync_files.Decoder is None
         with pytest.raises(RuntimeError, match=MISSING_OPUS_MESSAGE):
-            sync.decode_opus_file_to_wav(str(opus_path), str(tmp_path / "audio.wav"))
+            sync_files.decode_opus_file_to_wav(str(opus_path), str(tmp_path / "audio.wav"))
     finally:
-        _restore_module("routers.sync", captured_sync)
+        _restore_module("utils.sync.files", captured_sync_files)

--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -215,12 +215,8 @@ sys.modules['utils.log_sanitizer'].sanitize_pii = lambda x: x
 
 _remove_python_multipart_stub = _install_python_multipart_stub()
 try:
-    from routers.sync import (  # noqa: E402
-        decode_opus_file_to_wav,
-        decode_files_to_wav,
-        _merge_and_cap_vad_segments,
-        MAX_VAD_SEGMENT_SECONDS,
-    )
+    from routers.sync import _merge_and_cap_vad_segments, MAX_VAD_SEGMENT_SECONDS  # noqa: E402
+    from utils.sync.files import decode_files_to_wav, decode_opus_file_to_wav  # noqa: E402
 finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)
@@ -283,7 +279,7 @@ class TestDecodeOpusFileToWav:
     def test_valid_file_returns_true_and_creates_wav(self):
         """All frames decode → True, WAV file created."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -296,7 +292,7 @@ class TestDecodeOpusFileToWav:
     def test_correct_frame_count_in_wav(self):
         """Five decoded frames of 160 samples each → 800 WAV frames."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -317,7 +313,7 @@ class TestDecodeOpusFileToWav:
         After the fix (continue), frames 0-1 and 3-4 are decoded → True.
         """
         klass, _ = _failing_decoder(fail_on={2})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -331,7 +327,7 @@ class TestDecodeOpusFileToWav:
     def test_first_frame_corrupt_rest_valid(self):
         """Frame 0 is corrupt → skipped, frames 1-4 decoded → True."""
         klass, _ = _failing_decoder(fail_on={0})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -345,7 +341,7 @@ class TestDecodeOpusFileToWav:
     def test_last_frame_corrupt_prior_frames_preserved(self):
         """Frame 4 is corrupt → skipped, frames 0-3 decoded → True."""
         klass, _ = _failing_decoder(fail_on={4})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -359,7 +355,7 @@ class TestDecodeOpusFileToWav:
     def test_multiple_non_contiguous_corrupt_frames_skipped(self):
         """Frames 1 and 3 corrupt → both skipped, frames 0, 2, 4 decoded → True."""
         klass, _ = _failing_decoder(fail_on={1, 3})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -375,7 +371,7 @@ class TestDecodeOpusFileToWav:
     def test_all_frames_corrupt_returns_false(self):
         """Every frame raises → frame_count stays 0 → False, no WAV created."""
         klass, _ = _failing_decoder(fail_on={0, 1, 2, 3, 4})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -388,7 +384,7 @@ class TestDecodeOpusFileToWav:
     def test_all_corrupt_single_frame_file_returns_false(self):
         """File with one frame that fails → False."""
         klass, _ = _failing_decoder(fail_on={0})
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME])
@@ -403,7 +399,7 @@ class TestDecodeOpusFileToWav:
     def test_empty_file_returns_false(self):
         """Zero-byte file → no frames → False."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'empty.bin')
             wav_path = os.path.join(d, 'empty.wav')
             open(bin_path, 'wb').close()  # touch
@@ -415,7 +411,7 @@ class TestDecodeOpusFileToWav:
     def test_file_not_found_returns_false(self):
         """Non-existent input path → False without exception."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             result = decode_opus_file_to_wav(
                 os.path.join(d, 'missing.bin'),
                 os.path.join(d, 'missing.wav'),
@@ -427,7 +423,7 @@ class TestDecodeOpusFileToWav:
     def test_truncated_frame_data_stops_cleanly(self):
         """Length prefix says N bytes but file ends early → break, prior frames kept."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'truncated.bin')
             wav_path = os.path.join(d, 'truncated.wav')
             with open(bin_path, 'wb') as f:
@@ -447,7 +443,7 @@ class TestDecodeOpusFileToWav:
     def test_truncated_frame_as_first_entry_returns_false(self):
         """Truncated data with no prior valid frames → False."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'trunc_first.bin')
             wav_path = os.path.join(d, 'trunc_first.wav')
             with open(bin_path, 'wb') as f:
@@ -462,7 +458,7 @@ class TestDecodeOpusFileToWav:
     def test_incomplete_length_prefix_at_eof_stops_cleanly(self):
         """Only 2 bytes remain for the 4-byte length prefix → break, prior frames kept."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'partial_prefix.bin')
             wav_path = os.path.join(d, 'partial_prefix.wav')
             with open(bin_path, 'wb') as f:
@@ -479,7 +475,7 @@ class TestDecodeOpusFileToWav:
     def test_gigantic_length_prefix_treated_as_truncation(self):
         """0xFFFFFFFF frame length → read returns far fewer bytes → truncation break → prior frames kept."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'giant_prefix.bin')
             wav_path = os.path.join(d, 'giant_prefix.wav')
             with open(bin_path, 'wb') as f:
@@ -518,7 +514,7 @@ class TestDecodeFilesToWavOpus:
     def test_valid_opus_file_included_in_output(self):
         """Valid Opus file with > 1 s of audio → wav path included."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = self._opus_filename(d)
             self._write_valid_opus_bin(bin_path)
 
@@ -531,7 +527,7 @@ class TestDecodeFilesToWavOpus:
     def test_frame_size_parsed_from_filename(self):
         """_fs320 in filename → frame_size=320 passed to decoder."""
         klass, instance = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             # fs320 filename
             bin_path = os.path.join(d, f'audio_omi_opus_16000_1_fs320_1710000000.bin')
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * self.ENOUGH_FRAMES)
@@ -547,7 +543,7 @@ class TestDecodeFilesToWavOpus:
     def test_all_corrupt_frames_file_excluded_from_output(self):
         """Decode returns False → wav not included, bin cleaned up."""
         klass, _ = _failing_decoder(fail_on=set(range(self.ENOUGH_FRAMES)))
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = self._opus_filename(d)
             self._write_valid_opus_bin(bin_path)
 
@@ -559,7 +555,7 @@ class TestDecodeFilesToWavOpus:
     def test_bin_file_deleted_after_successful_decode(self):
         """Successful decode → .bin removed (not left as an orphan)."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = self._opus_filename(d)
             self._write_valid_opus_bin(bin_path)
 
@@ -572,7 +568,7 @@ class TestDecodeFilesToWavOpus:
     def test_too_short_audio_excluded(self):
         """< 1 s of decoded audio → excluded from output, wav cleaned up."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = self._opus_filename(d)
             # 5 frames × 160 samples = 800 samples = 0.05 s → below 1 s threshold
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 5)
@@ -586,7 +582,7 @@ class TestDecodeFilesToWavOpus:
     def test_exactly_one_second_included(self):
         """Exactly 1.0 s decoded (100 frames × 160 samples at 16 kHz) → included."""
         klass, _ = _good_decoder()
-        with tempfile.TemporaryDirectory() as d, patch('routers.sync.Decoder', klass):
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = self._opus_filename(d)
             # 100 frames × 160 samples / 16000 Hz = 1.0 s
             _write_opus_bin(bin_path, [FAKE_OPUS_FRAME] * 100)
@@ -617,7 +613,7 @@ class TestDecodeFilesToWavOpus:
                     inst.decode.side_effect = Exception("corrupt")
                 return inst
 
-            with patch('routers.sync.Decoder', side_effect=_make_instance):
+            with patch('utils.sync.files.Decoder', side_effect=_make_instance):
                 self._write_valid_opus_bin(valid_bin)
                 _write_opus_bin(corrupt_bin, [FAKE_OPUS_FRAME] * 5)
 

--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -13,12 +13,14 @@ Each scenario corresponds to a real-world sticky-pending failure mode.
 """
 
 import importlib.util
+import io
 import os
 import struct
 import sys
 import tempfile
 import wave
 from types import ModuleType
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -216,7 +218,12 @@ sys.modules['utils.log_sanitizer'].sanitize_pii = lambda x: x
 _remove_python_multipart_stub = _install_python_multipart_stub()
 try:
     from routers.sync import _merge_and_cap_vad_segments, MAX_VAD_SEGMENT_SECONDS  # noqa: E402
-    from utils.sync.files import decode_files_to_wav, decode_opus_file_to_wav  # noqa: E402
+    from utils.sync.files import (  # noqa: E402
+        MAX_SYNC_FRAME_BYTES,
+        decode_files_to_wav,
+        decode_opus_file_to_wav,
+        retrieve_file_paths,
+    )
 finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)
@@ -472,9 +479,9 @@ class TestDecodeOpusFileToWav:
             with wave.open(wav_path, 'rb') as wf:
                 assert wf.getnframes() == 160
 
-    def test_gigantic_length_prefix_treated_as_truncation(self):
-        """0xFFFFFFFF frame length → read returns far fewer bytes → truncation break → prior frames kept."""
-        klass, _ = _good_decoder()
+    def test_gigantic_length_prefix_rejected_before_read(self):
+        """0xFFFFFFFF frame length → reject before attempting a huge read, prior frames kept."""
+        klass, instance = _good_decoder()
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'giant_prefix.bin')
             wav_path = os.path.join(d, 'giant_prefix.wav')
@@ -482,13 +489,65 @@ class TestDecodeOpusFileToWav:
                 f.write(struct.pack('<I', len(FAKE_OPUS_FRAME)))
                 f.write(FAKE_OPUS_FRAME)
                 f.write(struct.pack('<I', 0xFFFFFFFF))  # 4 GB claimed
-                f.write(b'\xaa' * 20)  # Only 20 bytes available
+                f.write(b'\xaa' * 20)  # Must not be read as a frame
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
             assert result is True
+            assert instance.decode.call_count == 1
             with wave.open(wav_path, 'rb') as wf:
                 assert wf.getnframes() == 160
+
+    def test_frame_length_above_cap_rejected_before_read(self):
+        """Malformed Opus frame lengths use the same cap as PCM decoding."""
+        klass, instance = _good_decoder()
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
+            bin_path = os.path.join(d, 'over_cap.bin')
+            wav_path = os.path.join(d, 'over_cap.wav')
+            with open(bin_path, 'wb') as f:
+                f.write(struct.pack('<I', len(FAKE_OPUS_FRAME)))
+                f.write(FAKE_OPUS_FRAME)
+                f.write(struct.pack('<I', MAX_SYNC_FRAME_BYTES + 1))
+                f.write(b'\xaa' * 20)
+
+            result = decode_opus_file_to_wav(bin_path, wav_path)
+
+            assert result is True
+            assert instance.decode.call_count == 1
+
+
+class TestRetrieveFilePaths:
+    """Upload path validation for shared sync file helpers."""
+
+    class _Upload:
+        def __init__(self, filename: str):
+            self.filename = filename
+            self.file = io.BytesIO(b'payload')
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../audio_omi_opus_16000_1_fs160_1710000000.bin",
+            "nested/audio_omi_opus_16000_1_fs160_1710000000.bin",
+            "nested\\audio_omi_opus_16000_1_fs160_1710000000.bin",
+        ],
+    )
+    def test_rejects_path_separator_filenames(self, filename, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(Exception) as exc_info:
+            retrieve_file_paths(cast(list, [self._Upload(filename)]), "u1")
+
+        assert getattr(exc_info.value, "status_code", None) == 400
+        assert not (tmp_path / "audio_omi_opus_16000_1_fs160_1710000000.bin").exists()
+
+    def test_valid_filename_stays_under_uid_directory(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        paths = retrieve_file_paths(cast(list, [self._Upload("audio_omi_opus_16000_1_fs160_1710000000.bin")]), "u1")
+
+        assert paths == [os.path.join("syncing/u1", "audio_omi_opus_16000_1_fs160_1710000000.bin")]
+        assert (tmp_path / paths[0]).read_bytes() == b'payload'
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_sync_pcm_decode.py
+++ b/backend/tests/unit/test_sync_pcm_decode.py
@@ -200,7 +200,7 @@ if not hasattr(sys.modules.setdefault('google.cloud', MagicMock()), 'tasks_v2'):
 
 _remove_python_multipart_stub = _install_python_multipart_stub()
 try:
-    from routers.sync import _is_pcm_codec, decode_pcm_file_to_wav, decode_files_to_wav
+    from utils.sync.files import _is_pcm_codec, decode_pcm_file_to_wav, decode_files_to_wav
 finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -3,16 +3,21 @@ import uuid
 from datetime import datetime, timezone
 from typing import AsyncGenerator, List, Optional, Tuple
 
+from fastapi import HTTPException
+
 import database.chat as chat_db
 import database.notifications as notification_db
 import database.users as user_db
 from database.apps import record_app_usage
+from models.app import App, UsageHistoryType
 from models.chat import ChatSession, Message, ResponseMessage, MessageConversation
 from models.notification_message import NotificationMessage
-from utils.conversations.factory import deserialize_conversation
-from models.app import UsageHistoryType
 from models.transcript_segment import TranscriptSegment
+from utils.apps import get_available_app_by_id
 from utils.conversation_helpers import extract_memory_ids
+from utils.conversations.factory import deserialize_conversation
+from utils.llm.chat import initial_chat_message
+from utils.llm.persona import initial_persona_chat_message
 from utils.notifications import send_notification
 from utils.other.storage import get_syncing_file_temporal_signed_url, schedule_syncing_temporal_file_deletion
 from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream
@@ -26,6 +31,62 @@ from utils.llm.usage_tracker import track_usage, set_usage_context, reset_usage_
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def acquire_chat_session(uid: str, app_id: Optional[str] = None):
+    chat_session = chat_db.get_chat_session(uid, app_id=app_id)
+    if chat_session is None:
+        cs = ChatSession(id=str(uuid.uuid4()), created_at=datetime.now(timezone.utc), plugin_id=app_id)
+        chat_session = chat_db.add_chat_session(uid, cs.dict())
+    return chat_session
+
+
+def initial_message_util(uid: str, app_id: Optional[str] = None, chat_session_id: Optional[str] = None):
+    logger.info(f'initial_message_util {app_id}')
+
+    # init chat session — use provided session_id if available, otherwise acquire by app_id
+    if chat_session_id:
+        chat_session = chat_db.get_chat_session_by_id(uid, chat_session_id)
+        if chat_session is None:
+            raise HTTPException(status_code=404, detail='Chat session not found')
+    else:
+        chat_session = acquire_chat_session(uid, app_id=app_id)
+
+    # Load previous messages — session-scoped when session_id is provided, app-scoped otherwise
+    if chat_session_id:
+        prev_messages = list(reversed(chat_db.get_messages(uid, limit=5, chat_session_id=chat_session_id)))
+    else:
+        prev_messages = list(reversed(chat_db.get_messages(uid, limit=5, app_id=app_id)))
+    logger.info(f'initial_message_util returned {len(prev_messages)} prev messages for {app_id}')
+
+    app = get_available_app_by_id(app_id, uid)
+    app = App(**app) if app else None
+
+    text: str
+    if app and app.is_a_persona():
+        text = initial_persona_chat_message(uid, app, prev_messages)
+    else:
+        prev_messages_str = ''
+        if prev_messages:
+            prev_messages_str = 'Previous conversation history:\n'
+            prev_messages_str += Message.get_messages_as_string([Message(**msg) for msg in prev_messages])
+        logger.info(f'initial_message_util {len(prev_messages_str)} {app_id}')
+        text = initial_chat_message(uid, app, prev_messages_str)
+
+    ai_message = Message(
+        id=str(uuid.uuid4()),
+        text=text,
+        created_at=datetime.now(timezone.utc),
+        sender='ai',
+        app_id=app_id,
+        from_external_integration=False,
+        type='text',
+        memories_id=[],
+        chat_session_id=chat_session['id'],
+    )
+    chat_db.add_message(uid, ai_message.dict())
+    chat_db.add_message_to_chat_session(uid, chat_session['id'], ai_message.id)
+    return ai_message
 
 
 def resolve_voice_message_language(uid: str, request_language: Optional[str]) -> str:

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -64,7 +64,7 @@ def initial_message_util(uid: str, app_id: Optional[str] = None, chat_session_id
 
     text: str
     if app and app.is_a_persona():
-        text = initial_persona_chat_message(uid, app, prev_messages)
+        text = initial_persona_chat_message(uid, app, [Message(**msg) for msg in prev_messages])
     else:
         prev_messages_str = ''
         if prev_messages:

--- a/backend/utils/github_releases.py
+++ b/backend/utils/github_releases.py
@@ -1,0 +1,133 @@
+import logging
+import os
+import re
+from typing import Dict, List, Optional
+
+import httpx
+
+from database.redis_db import get_generic_cache, set_generic_cache
+from utils.log_sanitizer import sanitize
+
+logger = logging.getLogger(__name__)
+
+MAX_PAGES = 20  # Safety cap to prevent runaway pagination
+
+
+async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Pattern] = None) -> Optional[List[Dict]]:
+    """Fetch releases from GitHub API with caching.
+
+    When tag_filter is provided, paginates through all pages and returns only
+    releases whose tag_name matches the filter. Without tag_filter, returns
+    the first page of releases unfiltered (sufficient for desktop releases
+    which are always recent).
+
+    Resilience: if GitHub returns errors or an empty list during an upstream
+    outage, we fall back to a longer-lived "last known good" cache so the
+    macos.omi.me download endpoint keeps serving the previous DMG link.
+    """
+
+    lkg_key = f"{cache_key}:lkg"
+
+    cached_releases = get_generic_cache(cache_key)
+    if cached_releases is not None:
+        return cached_releases
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}",
+    }
+
+    collected: List[Dict] = []
+    fetch_failed = False
+
+    try:
+        page = 1
+        async with httpx.AsyncClient() as client:
+            while page <= MAX_PAGES:
+                url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
+                response = await client.get(url, headers=headers)
+                if response.status_code != 200:
+                    logger.error(
+                        "Error fetching GitHub releases page %d: %d %s",
+                        page,
+                        response.status_code,
+                        sanitize(response.text),
+                    )
+                    fetch_failed = True
+                    break
+
+                page_releases = response.json()
+                if not page_releases:
+                    break
+
+                if tag_filter:
+                    for release in page_releases:
+                        tag_name = release.get("tag_name", "")
+                        if tag_filter.match(tag_name):
+                            collected.append(release)
+                else:
+                    collected.extend(page_releases)
+
+                if not tag_filter:
+                    break
+
+                if len(page_releases) < 100:
+                    break
+
+                page += 1
+    except Exception as exc:
+        logger.exception("Exception fetching GitHub releases: %s", sanitize(str(exc)))
+        fetch_failed = True
+
+    if fetch_failed or not collected:
+        last_known_good = get_generic_cache(lkg_key)
+        if last_known_good:
+            logger.warning(
+                "GitHub releases fetch %s; serving last-known-good cache for %s",
+                "failed" if fetch_failed else "returned empty",
+                cache_key,
+            )
+            set_generic_cache(cache_key, last_known_good, ttl=60)
+            return last_known_good
+
+        set_generic_cache(cache_key, collected, ttl=60)
+        return collected
+
+    set_generic_cache(cache_key, collected, ttl=300)
+    set_generic_cache(lkg_key, collected, ttl=86400)
+    return collected
+
+
+def extract_key_value_pairs(markdown_content):
+    if not markdown_content:
+        return {}
+
+    key_value_pattern = re.compile(r'<!-- KEY_VALUE_START\s*(.*?)\s*KEY_VALUE_END -->', re.DOTALL)
+    key_value_match = key_value_pattern.search(markdown_content)
+
+    if not key_value_match:
+        return {}
+
+    key_value_string = key_value_match.group(1).strip()
+    lines = key_value_string.split('\n')
+    key_value_map = {}
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split(':', 1)
+        if len(parts) == 2:
+            key = parts[0].strip()
+            value = parts[1].strip()
+
+            if key == 'ota_update_steps':
+                key_value_map[key] = [step.strip() for step in value.split(',') if step.strip()]
+            elif key == 'changelog':
+                key_value_map[key] = [item.strip() for item in value.split('|') if item.strip()]
+            else:
+                key_value_map[key] = value
+
+    return key_value_map

--- a/backend/utils/github_releases.py
+++ b/backend/utils/github_releases.py
@@ -3,9 +3,9 @@ import os
 import re
 from typing import Dict, List, Optional
 
-import httpx
-
 from database.redis_db import get_generic_cache, set_generic_cache
+from utils.executors import db_executor, run_blocking
+from utils.http_client import get_web_fetch_client
 from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
@@ -28,74 +28,76 @@ async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Patter
 
     lkg_key = f"{cache_key}:lkg"
 
-    cached_releases = get_generic_cache(cache_key)
+    cached_releases = await run_blocking(db_executor, get_generic_cache, cache_key)
     if cached_releases is not None:
         return cached_releases
 
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}",
     }
+    github_token = os.getenv('GITHUB_TOKEN')
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
 
     collected: List[Dict] = []
     fetch_failed = False
 
     try:
         page = 1
-        async with httpx.AsyncClient() as client:
-            while page <= MAX_PAGES:
-                url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
-                response = await client.get(url, headers=headers)
-                if response.status_code != 200:
-                    logger.error(
-                        "Error fetching GitHub releases page %d: %d %s",
-                        page,
-                        response.status_code,
-                        sanitize(response.text),
-                    )
-                    fetch_failed = True
-                    break
+        client = get_web_fetch_client()
+        while page <= MAX_PAGES:
+            url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
+            response = await client.get(url, headers=headers)
+            if response.status_code != 200:
+                logger.error(
+                    "Error fetching GitHub releases page %d: %d %s",
+                    page,
+                    response.status_code,
+                    sanitize(response.text),
+                )
+                fetch_failed = True
+                break
 
-                page_releases = response.json()
-                if not page_releases:
-                    break
+            page_releases = response.json()
+            if not page_releases:
+                break
 
-                if tag_filter:
-                    for release in page_releases:
-                        tag_name = release.get("tag_name", "")
-                        if tag_filter.match(tag_name):
-                            collected.append(release)
-                else:
-                    collected.extend(page_releases)
+            if tag_filter:
+                for release in page_releases:
+                    tag_name = release.get("tag_name", "")
+                    if tag_filter.match(tag_name):
+                        collected.append(release)
+            else:
+                collected.extend(page_releases)
 
-                if not tag_filter:
-                    break
+            if not tag_filter:
+                break
 
-                if len(page_releases) < 100:
-                    break
+            if len(page_releases) < 100:
+                break
 
-                page += 1
+            page += 1
     except Exception as exc:
         logger.exception("Exception fetching GitHub releases: %s", sanitize(str(exc)))
         fetch_failed = True
 
     if fetch_failed or not collected:
-        last_known_good = get_generic_cache(lkg_key)
+        last_known_good = await run_blocking(db_executor, get_generic_cache, lkg_key)
         if last_known_good:
             logger.warning(
                 "GitHub releases fetch %s; serving last-known-good cache for %s",
                 "failed" if fetch_failed else "returned empty",
                 cache_key,
             )
-            set_generic_cache(cache_key, last_known_good, ttl=60)
+            await run_blocking(db_executor, set_generic_cache, cache_key, last_known_good, ttl=60)
             return last_known_good
 
-        set_generic_cache(cache_key, collected, ttl=60)
+        await run_blocking(db_executor, set_generic_cache, cache_key, collected, ttl=60)
         return collected
 
-    set_generic_cache(cache_key, collected, ttl=300)
-    set_generic_cache(lkg_key, collected, ttl=86400)
+    await run_blocking(db_executor, set_generic_cache, cache_key, collected, ttl=300)
+    await run_blocking(db_executor, set_generic_cache, lkg_key, collected, ttl=86400)
     return collected
 
 

--- a/backend/utils/sync/files.py
+++ b/backend/utils/sync/files.py
@@ -1,0 +1,220 @@
+import logging
+import os
+import re
+import shutil
+import struct
+import wave
+from typing import List
+
+from fastapi import HTTPException, UploadFile
+
+from utils.log_sanitizer import sanitize
+from utils.request_validation import parse_sync_filename_timestamp
+from utils.sync import playback as sync_playback
+
+try:
+    from opuslib import Decoder
+except Exception as e:
+    Decoder = None
+    _OPUS_IMPORT_ERROR = e
+else:
+    _OPUS_IMPORT_ERROR = None
+
+logger = logging.getLogger(__name__)
+
+
+def _get_opus_decoder_class():
+    if Decoder is None:
+        raise RuntimeError(
+            'Opus sync decoding requires opuslib and the native libopus library. '
+            'Install the OS-level Opus package before processing .opus sync files.'
+        ) from _OPUS_IMPORT_ERROR
+    return Decoder
+
+
+def decode_opus_file_to_wav(opus_file_path, wav_file_path, sample_rate=16000, channels=1, frame_size: int = 160):
+    """Decode an Opus file with length-prefixed frames to WAV format.
+
+    Writes directly to WAV file to avoid accumulating all PCM data in memory.
+    """
+    if not os.path.exists(opus_file_path):
+        logger.warning(f"File not found: {sanitize(opus_file_path)}")
+        return False
+
+    decoder = _get_opus_decoder_class()(sample_rate, channels)
+    frame_count = 0
+
+    try:
+        with open(opus_file_path, 'rb') as f, wave.open(wav_file_path, 'wb') as wav_file:
+            wav_file.setnchannels(channels)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+
+            while True:
+                length_bytes = f.read(4)
+                if not length_bytes:
+                    logger.info("End of file reached.")
+                    break
+                if len(length_bytes) < 4:
+                    logger.info("Incomplete length prefix at the end of the file.")
+                    break
+
+                frame_length = struct.unpack('<I', length_bytes)[0]
+                opus_data = f.read(frame_length)
+                if len(opus_data) < frame_length:
+                    logger.error(f"Unexpected end of file at frame {frame_count}.")
+                    break
+                try:
+                    pcm_frame = decoder.decode(opus_data, frame_size=frame_size)
+                    wav_file.writeframes(pcm_frame)
+                    frame_count += 1
+                except Exception as e:
+                    logger.error(f"Error decoding frame {frame_count}: {e}")
+                    continue
+
+        if frame_count > 0:
+            logger.info(f"Decoded audio saved to {sanitize(wav_file_path)}")
+            return True
+
+        logger.info("No PCM data was decoded.")
+        if os.path.exists(wav_file_path):
+            os.remove(wav_file_path)
+        return False
+    except Exception as e:
+        logger.error(f"Error during decode: {e}")
+        if os.path.exists(wav_file_path):
+            os.remove(wav_file_path)
+        return False
+
+
+def get_timestamp_from_path(path: str):
+    return parse_sync_filename_timestamp(path)
+
+
+def retrieve_file_paths(files: List[UploadFile], uid: str):
+    directory = f'syncing/{uid}/'
+    os.makedirs(directory, exist_ok=True)
+    paths = []
+    for file in files:
+        filename = file.filename
+        if not filename:
+            raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
+        if not filename.endswith('.bin'):
+            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
+        if '_' not in filename:
+            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, missing timestamp")
+        try:
+            get_timestamp_from_path(filename)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
+
+        path = f"{directory}{filename}"
+        try:
+            with open(path, "wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
+            paths.append(path)
+        except Exception as e:
+            if os.path.exists(path):
+                os.remove(path)
+            raise HTTPException(status_code=500, detail=f"Failed to write file {filename}: {str(e)}")
+    return paths
+
+
+def get_wav_duration(wav_path: str) -> float:
+    """Get WAV file duration without loading entire file into memory."""
+    try:
+        with wave.open(wav_path, 'rb') as wav_file:
+            frames = wav_file.getnframes()
+            rate = wav_file.getframerate()
+            return frames / float(rate)
+    except Exception as e:
+        logger.error(f"Error reading WAV duration: {e}")
+        return 0.0
+
+
+def decode_pcm_file_to_wav(pcm_file_path, wav_file_path, sample_rate=16000, channels=1, sample_width=2):
+    """Decode a length-prefixed PCM .bin file to WAV.
+
+    The file format is: [4-byte uint32 frame_length][frame_bytes] repeated.
+    Each frame contains raw PCM samples (no encoding).
+    sample_width: 2 for pcm16, 1 for pcm8.
+    """
+    try:
+        pcm_data = bytearray()
+        with open(pcm_file_path, 'rb') as f:
+            while True:
+                length_bytes = f.read(4)
+                if not length_bytes or len(length_bytes) < 4:
+                    break
+                frame_length = struct.unpack('<I', length_bytes)[0]
+                if frame_length == 0 or frame_length > 65536:
+                    logger.warning(f"PCM decode: suspicious frame length {frame_length}, skipping rest")
+                    break
+                frame_data = f.read(frame_length)
+                if len(frame_data) < frame_length:
+                    break
+                pcm_data.extend(frame_data)
+
+        if not pcm_data:
+            logger.info(f"PCM decode: no data in {pcm_file_path}")
+            return False
+
+        wav_data = sync_playback.pcm_to_wav(
+            bytes(pcm_data), sample_rate=sample_rate, channels=channels, sample_width=sample_width
+        )
+        with open(wav_file_path, 'wb') as f:
+            f.write(wav_data)
+        return True
+    except Exception as e:
+        logger.error(f"PCM decode failed for {pcm_file_path}: {e}")
+        return False
+
+
+def _is_pcm_codec(filename: str) -> bool:
+    """Check if the filename indicates a PCM codec (pcm8 or pcm16)."""
+    return '_pcm16_' in filename or '_pcm8_' in filename
+
+
+def decode_files_to_wav(files_path: List[str]):
+    wav_files = []
+    for path in files_path:
+        wav_path = path.replace('.bin', '.wav')
+        filename = os.path.basename(path)
+        frame_size = 160
+        match = re.search(r'_fs(\d+)', filename)
+        if match:
+            try:
+                frame_size = int(match.group(1))
+                logger.info(f"Found frame size {frame_size} in filename: {filename}")
+            except ValueError:
+                logger.error(f"Invalid frame size format in filename: {filename}, using default {frame_size}")
+
+        if _is_pcm_codec(filename):
+            sample_rate_match = re.search(r'_pcm(?:8|16)_(\d+)_', filename)
+            sample_rate = (
+                int(sample_rate_match.group(1)) if sample_rate_match else (16000 if '_pcm16_' in filename else 8000)
+            )
+            sample_width = 1 if '_pcm8_' in filename else 2
+            success = decode_pcm_file_to_wav(path, wav_path, sample_rate=sample_rate, sample_width=sample_width)
+        else:
+            success = decode_opus_file_to_wav(path, wav_path, frame_size=frame_size)
+
+        if not success:
+            if os.path.exists(path):
+                os.remove(path)
+            continue
+
+        if os.path.exists(path):
+            os.remove(path)
+
+        duration = get_wav_duration(wav_path)
+        if duration == 0:
+            if os.path.exists(wav_path):
+                os.remove(wav_path)
+            raise HTTPException(status_code=400, detail=f"Invalid file format {path}")
+
+        if duration < 1:
+            os.remove(wav_path)
+            continue
+        wav_files.append(wav_path)
+    return wav_files

--- a/backend/utils/sync/files.py
+++ b/backend/utils/sync/files.py
@@ -22,6 +22,8 @@ else:
 
 logger = logging.getLogger(__name__)
 
+MAX_SYNC_FRAME_BYTES = 65536
+
 
 def _get_opus_decoder_class():
     if Decoder is None:
@@ -60,6 +62,9 @@ def decode_opus_file_to_wav(opus_file_path, wav_file_path, sample_rate=16000, ch
                     break
 
                 frame_length = struct.unpack('<I', length_bytes)[0]
+                if frame_length == 0 or frame_length > MAX_SYNC_FRAME_BYTES:
+                    logger.warning(f"Opus decode: suspicious frame length {frame_length}, skipping rest")
+                    break
                 opus_data = f.read(frame_length)
                 if len(opus_data) < frame_length:
                     logger.error(f"Unexpected end of file at frame {frame_count}.")
@@ -99,6 +104,10 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
         filename = file.filename
         if not filename:
             raise HTTPException(status_code=400, detail='Uploaded file is missing a filename')
+        if os.path.basename(filename) != filename or '/' in filename or '\\' in filename:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid file format {filename}, path separators are not allowed"
+            )
         if not filename.endswith('.bin'):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")
         if '_' not in filename:
@@ -108,7 +117,7 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        path = f"{directory}{filename}"
+        path = os.path.join(directory, filename)
         try:
             with open(path, "wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)
@@ -147,7 +156,7 @@ def decode_pcm_file_to_wav(pcm_file_path, wav_file_path, sample_rate=16000, chan
                 if not length_bytes or len(length_bytes) < 4:
                     break
                 frame_length = struct.unpack('<I', length_bytes)[0]
-                if frame_length == 0 or frame_length > 65536:
+                if frame_length == 0 or frame_length > MAX_SYNC_FRAME_BYTES:
                     logger.warning(f"PCM decode: suspicious frame length {frame_length}, skipping rest")
                     break
                 frame_data = f.read(frame_length)


### PR DESCRIPTION
## Summary
- Move shared GitHub release fetching and KEY_VALUE parsing from firmware router into utils.github_releases.
- Move sync upload/decode helpers from routers.sync into utils.sync.files and update chat/sync callers.
- Move shared initial chat message/session helper into utils.chat and update chat session caller.
- Replace integration router imports from routers.conversations with existing utils-layer helpers.

Closes #8556

## Validation
- grep -rn "^from routers\." backend/routers/ # zero hits
- python3 -m black --line-length 120 --skip-string-normalization backend/routers/chat.py backend/routers/chat_sessions.py backend/routers/firmware.py backend/routers/integration.py backend/routers/sync.py backend/routers/updates.py backend/utils/chat.py backend/utils/github_releases.py backend/utils/sync/files.py backend/tests/unit/test_firmware_pagination.py backend/tests/unit/test_desktop_migration.py backend/tests/unit/test_sync_opus_decode.py backend/tests/unit/test_sync_pcm_decode.py
- python3 -m compileall -q backend/routers/chat.py backend/routers/chat_sessions.py backend/routers/firmware.py backend/routers/integration.py backend/routers/sync.py backend/routers/updates.py backend/utils/chat.py backend/utils/github_releases.py backend/utils/sync/files.py backend/tests/unit/test_firmware_pagination.py backend/tests/unit/test_desktop_migration.py backend/tests/unit/test_sync_opus_decode.py backend/tests/unit/test_sync_pcm_decode.py
- ENCRYPTION_SECRET=... OPENAI_API_KEY=sk-dummy TYPESENSE_API_KEY=dummy TYPESENSE_HOST=localhost TYPESENSE_HOST_PORT=8108 python3 - <<'PY' ... import affected routers/utils ... PY
- ENCRYPTION_SECRET=... OPENAI_API_KEY=sk-dummy python3 -m pytest backend/tests/unit/test_firmware_pagination.py backend/tests/unit/test_desktop_updates.py -q # 94 passed
- ENCRYPTION_SECRET=... OPENAI_API_KEY=sk-dummy python3 -m pytest backend/tests/unit/test_sync_pcm_decode.py backend/tests/unit/test_sync_opus_decode.py -q # 51 passed, 1 existing deprecation warning

## Note
- backend/tests/unit/test_desktop_migration.py::TestInitialMessageEndpoint still does not collect in this local harness because the test stubs database.redis_db without r before reaching these endpoint tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

