### PR TITLE
fix(backend): unique migration prefix + un-shadow stripe_webhook (#8551)

### DIFF
--- a/backend/migrations/007_backfill_action_item_vectors.py
+++ b/backend/migrations/007_backfill_action_item_vectors.py
@@ -6,7 +6,7 @@ for each description, and upserts to Pinecone. Same approach as
 005_backfill_memory_vectors.py.
 
 Usage:
-    python 006_backfill_action_item_vectors.py [--dry-run] [--uid USER_ID] [--workers N]
+    python 007_backfill_action_item_vectors.py [--dry-run] [--uid USER_ID] [--workers N]
 
 Environment:
     GOOGLE_APPLICATION_CREDENTIALS: Path to Firebase service account key

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -987,7 +987,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
 
 
 @router.post('/v1/stripe/connect/webhook', tags=['v1', 'stripe', 'webhook'])
-async def stripe_webhook(request: Request, stripe_signature: str = Header(None)):
+async def stripe_connect_webhook(request: Request, stripe_signature: str = Header(None)):
     payload = await request.body()
 
     try:
@@ -1171,7 +1171,8 @@ def get_paypal_payment_details_endpoint(uid: str = Depends(auth.get_current_user
 @router.get("/v1/payments/success", response_class=HTMLResponse)
 def stripe_success(session_id: str = Query(...)):
     # The subscription is updated via webhook. This page is just for user feedback.
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Success</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1179,12 +1180,14 @@ def stripe_success(session_id: str = Query(...)):
                 <p>Your subscription is now active. You can close this window and return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.get("/v1/payments/cancel", response_class=HTMLResponse)
 def stripe_cancel():
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Cancelled</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1192,7 +1195,8 @@ def stripe_cancel():
                 <p>Your payment process was cancelled. You can return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.post('/v1/payments/customer-portal')
@@ -1225,7 +1229,8 @@ def create_customer_portal_endpoint(uid: str = Depends(auth.get_current_user_uid
 
 @router.get("/v1/payments/portal-return", response_class=HTMLResponse)
 def portal_return():
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
         <html>
             <head><title>Portal Complete</title></head>
             <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; flex-direction: column;">
@@ -1233,7 +1238,8 @@ def portal_return():
                 <p>Your payment settings have been updated. You can close this window and return to the app.</p>
             </body>
         </html>
-    """)
+    """
+    )
 
 
 @router.get("/v1/payment-methods/status")


### PR DESCRIPTION
Fixes #8551 — two latent backend correctness bugs, both small and unambiguous.

## Bug 1 — duplicate migration prefix `006_*`
`backend/migrations/006_auto_set_transcription_mode.py` and `006_backfill_action_item_vectors.py` shared a numeric prefix. Any prefix-keyed or "run 001..006" ops flow runs one and silently skips the other; even a glob+sort runner has non-deterministic ordering between the two.

**Root cause / safety:** migrations here are standalone scripts run manually by filename (`python 00N_*.py`) — there is no central runner, no applied-migrations tracking table, and no `LATEST_MIGRATION` constant or any other file referencing the filenames (verified by grep). So renaming is purely a hygiene fix with no runtime behavior change.

**Fix:** renamed the later-landed migration to `007_backfill_action_item_vectors.py` (action-item-vectors landed 2026-04-20 vs transcription-mode's 2026-03-24, per `git log --diff-filter=A`) and updated its docstring Usage line. Prefixes are now unique 001–007.

## Bug 2 — `stripe_webhook` defined twice in `routers/payment.py`
Lines 692 (`@router.post('/v1/stripe/webhook')`) and 990 (`@router.post('/v1/stripe/connect/webhook')`) both defined `async def stripe_webhook`. FastAPI is fine (distinct routes), but the second def shadows the first in the module namespace, so `from routers.payment import stripe_webhook` silently returns the *connect* handler — a footgun for imports, tests, mocks, and refactors.

**Fix:** renamed the connect handler to `stripe_connect_webhook`. The route decorators are unchanged, so FastAPI routing and webhook behavior are identical. The existing `tests/unit/test_stripe_webhook_*` suites locate the canonical first def via `source.index("async def stripe_webhook(...")` and are unaffected.

## Verification
- `python -m py_compile routers/payment.py migrations/007_backfill_action_item_vectors.py` — OK
- Namespace contract: only the canonical `/v1/stripe/webhook` keeps the `stripe_webhook` name; connect is now `stripe_connect_webhook`. No stray callers of either name in `routers/`, `utils/`, `database/`, `main.py`.
- black applied (pre-commit hook). No async-I/O changes.
- Zero runtime behavior change for either fix.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

