### PR TITLE
fix(backend): guard database/users.py getters against a missing user document (return defaults instead of 500)

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -130,7 +130,7 @@ def get_user_profile(uid: str) -> dict:
 
 def get_user_store_recording_permission(uid: str):
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('store_recording_permission', False)
 
 
@@ -142,7 +142,7 @@ def set_user_store_recording_permission(uid: str, value: bool):
 def get_user_private_cloud_sync_enabled(uid: str) -> bool:
     """Check if user has private cloud sync enabled."""
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('private_cloud_sync_enabled', True)
 
 
@@ -1012,7 +1012,7 @@ def set_chat_message_rating_score(
 
 def get_stripe_connect_account_id(uid: str):
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('stripe_account_id', None)
 
 
@@ -1028,7 +1028,7 @@ def set_paypal_payment_details(uid: str, data: dict):
 
 def get_paypal_payment_details(uid: str):
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('paypal_details', None)
 
 
@@ -1039,7 +1039,7 @@ def set_default_payment_method(uid: str, payment_method_id: str):
 
 def get_default_payment_method(uid: str):
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('default_payment_method', None)
 
 
@@ -1244,7 +1244,7 @@ def get_existing_user_subscription(uid: str) -> Optional[Subscription]:
 def get_user_training_data_opt_in(uid: str) -> Optional[dict]:
     """Get user's training data opt-in status."""
     user_ref = db.collection('users').document(uid)
-    user_data = user_ref.get().to_dict()
+    user_data = user_ref.get().to_dict() or {}
     return user_data.get('training_data_opt_in', None)
 
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -39,6 +39,7 @@ from database.users import (
     get_default_payment_method,
     set_default_payment_method,
     get_paypal_payment_details,
+    get_user_profile,
 )
 from utils import stripe as stripe_utils
 from utils.apps import find_app_subscription, get_is_user_paid_app, paid_app, set_user_app_sub_customer_id
@@ -1026,6 +1027,11 @@ def create_connect_account_endpoint(
         if account_id:
             account = refresh_connect_account_link(account_id)
         else:
+            # Require a real user record before creating a Stripe Connect account, so a UID that is
+            # valid in auth but missing from Firestore surfaces as a 404 rather than leaving an
+            # orphaned Stripe account (cubic on #8567).
+            if not get_user_profile(uid):
+                raise HTTPException(status_code=404, detail="User not found")
             if country is None or country.strip() == "":
                 raise HTTPException(status_code=400, detail="Country is required")
             account = create_connect_account(uid, country)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -200,6 +200,7 @@ pytest tests/unit/test_voice_message_filename_none.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
 pytest tests/unit/test_payment_promotion_codes.py -v
+pytest tests/unit/test_payment_connect_account_user_guard.py -v
 pytest tests/unit/test_stripe_webhook_none_guard.py -v
 pytest tests/unit/test_stripe_webhook_behavioral.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -15,6 +15,7 @@ pytest tests/unit/test_speaker_sample_migration.py -v
 pytest tests/unit/test_short_audio_embedding.py -v
 pytest tests/unit/test_users_add_sample_transaction.py -v
 pytest tests/unit/test_users_webhook_url_validation.py -v
+pytest tests/unit/test_users_missing_doc_guards.py -v
 pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v

--- a/backend/tests/unit/test_payment_connect_account_user_guard.py
+++ b/backend/tests/unit/test_payment_connect_account_user_guard.py
@@ -1,0 +1,38 @@
+"""The Stripe connect-account endpoint must block creation for a missing user (#8567).
+
+Guarding the database/users.py getters made get_stripe_connect_account_id return None for a missing
+user document instead of raising. On its own that let create_connect_account_endpoint fall through
+to creating a Stripe Connect account for a UID with no Firestore record, leaving an orphaned billing
+account (cubic on #8567). The endpoint now verifies the user exists and returns 404 before any Stripe
+side effect. These are source-level structural checks, matching the other payment endpoint tests
+(routers/payment.py has a heavy import graph).
+"""
+
+from pathlib import Path
+
+PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+
+
+def _source() -> str:
+    return PAYMENT_SOURCE.read_text(encoding="utf-8")
+
+
+def test_get_user_profile_is_imported_in_payment():
+    assert "get_user_profile" in _source()
+
+
+def test_connect_account_creation_checks_user_before_creating():
+    source = _source()
+    start = source.index("def create_connect_account_endpoint")
+    end = source.index("\ndef ", start + 1)
+    endpoint = source[start:end]
+
+    # The missing-user guard and its 404 must be present in this endpoint.
+    assert "get_user_profile(uid)" in endpoint
+    assert "User not found" in endpoint
+
+    # The guard must run BEFORE the Stripe account is created, so a non-existent user never produces
+    # an orphaned Stripe Connect account.
+    guard_pos = endpoint.index("User not found")
+    create_pos = endpoint.index("create_connect_account(uid")
+    assert guard_pos < create_pos, "user-existence guard must run before Stripe account creation"

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -1,0 +1,120 @@
+"""Tests that user-document getters in database/users.py fail soft on a missing user doc.
+
+Several simple getters did `user_ref.get().to_dict().get(field)`. When the user document does not
+exist, `.to_dict()` returns None, so `.get(field)` raised AttributeError, surfacing as a 500 on
+authenticated endpoints (store-recording permission, private-cloud-sync, the Stripe/PayPal/default
+payment-method getters, training-data opt-in) and in conversation post-processing. A UID can be
+valid in auth but missing from Firestore (new user before doc creation, mid-deletion, or a data
+race). These getters now use the file's existing `.to_dict() or {}` guard so a missing doc yields
+the same default as a missing field instead of crashing. These cover the pure getter behavior.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _pkg(name):
+    mod = sys.modules.get(name)
+    if mod is None or not hasattr(mod, "__path__"):
+        mod = types.ModuleType(name)
+        mod.__path__ = []
+        sys.modules[name] = mod
+    return mod
+
+
+def _mod(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+# Stub the heavy leaves database/users.py imports so the real module loads; the @transactional /
+# CachePolicy module-level constructs become harmless mocks. None are exercised by the getters here.
+for _p in ["google", "google.cloud", "database", "models", "utils"]:
+    _pkg(_p)
+_mod("google.cloud.firestore", SERVER_TIMESTAMP=MagicMock())
+_mod("google.cloud.firestore_v1", FieldFilter=MagicMock(), transactional=lambda fn: fn)
+_mod("database._client", db=MagicMock(), document_id_from_seed=lambda seed: "id")
+_mod("database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock())
+_mod("database.redis_db", try_acquire_user_platform_write_lock=MagicMock())
+_mod(
+    "models.users",
+    Subscription=MagicMock(),
+    PlanLimits=MagicMock(),
+    PlanType=MagicMock(),
+    SubscriptionStatus=MagicMock(),
+)
+_mod("utils.subscription", get_default_basic_subscription=MagicMock())
+
+
+def _load():
+    # Load under the real package-qualified name so the module's `from ._client import ...` relative
+    # import resolves against the stubbed `database` package above.
+    spec = importlib.util.spec_from_file_location("database.users", str(BACKEND_DIR / "database" / "users.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["database.users"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+users = _load()
+
+
+def _db_for(to_dict_result):
+    """A db whose users/<uid> document get().to_dict() returns the given value (None = missing doc)."""
+    snapshot = MagicMock()
+    snapshot.to_dict.return_value = to_dict_result
+    db = MagicMock()
+    db.collection.return_value.document.return_value.get.return_value = snapshot
+    return db
+
+
+# (getter name, field key, default when missing, a present value)
+CASES = [
+    ("get_user_store_recording_permission", "store_recording_permission", False, True),
+    ("get_user_private_cloud_sync_enabled", "private_cloud_sync_enabled", True, False),
+    ("get_stripe_connect_account_id", "stripe_account_id", None, "acct_123"),
+    ("get_paypal_payment_details", "paypal_details", None, {"email": "x@y.z"}),
+    ("get_default_payment_method", "default_payment_method", None, "pm_123"),
+    ("get_user_training_data_opt_in", "training_data_opt_in", None, {"opt_in": True}),
+]
+
+
+@pytest.mark.parametrize("fn,field,default,present", CASES)
+def test_missing_user_doc_returns_default_not_crash(fn, field, default, present):
+    # to_dict() is None when the user document does not exist; the getter must return the default
+    # rather than raising AttributeError (which previously became a 500).
+    func = getattr(users, fn)
+    with patch.object(users, "db", _db_for(None)):
+        assert func("uid-without-doc") == default
+
+
+@pytest.mark.parametrize("fn,field,default,present", CASES)
+def test_existing_user_doc_returns_field_value(fn, field, default, present):
+    # Happy path is unchanged: a present field is returned as-is.
+    func = getattr(users, fn)
+    with patch.object(users, "db", _db_for({field: present})):
+        assert func("uid") == present
+
+
+@pytest.mark.parametrize("fn,field,default,present", CASES)
+def test_doc_present_but_field_absent_returns_default(fn, field, default, present):
+    # A doc that exists but lacks the field still yields the default (also unchanged behavior).
+    func = getattr(users, fn)
+    with patch.object(users, "db", _db_for({"unrelated": 1})):
+        assert func("uid") == default


### PR DESCRIPTION
## What

Several getters in `database/users.py` read a user field with `user_ref.get().to_dict().get(field)`. When the user document does not exist, `.to_dict()` returns `None`, so `.get(field)` raises `AttributeError: 'NoneType' object has no attribute 'get'`, which surfaces as a 500.

A UID can be valid in the auth system but missing from Firestore (a new user before the doc is created, a user mid-deletion, or a data race), so these are reachable on authenticated paths:

- `get_user_store_recording_permission` (GET /v1/users/store-recording-permission, and conversation post-processing)
- `get_user_private_cloud_sync_enabled` (/v2/sync-local-files)
- `get_stripe_connect_account_id`, `get_paypal_payment_details`, `get_default_payment_method` (payment endpoints)
- `get_user_training_data_opt_in` (training-data opt-in endpoint)

The same file already guards this case in `get_stripe_customer_id`, `get_ai_user_profile`, and others (and uses `.to_dict() or {}` at a couple of spots), so these six were just inconsistent.

## How

Apply the file's existing `.to_dict() or {}` guard to the six getters. A missing document now yields the same default as a missing field (False / True / None) instead of crashing. There is no behavior change when the document exists.

## Testing

New pure unit test `tests/unit/test_users_missing_doc_guards.py` (registered in test.sh) loads `database/users.py` with its heavy leaves stubbed and, for each of the six getters, asserts: a missing document returns the default without raising (the regression), a present field is returned unchanged, and a document missing the field returns the default. All 18 pass. black and the async blocker lint are clean.

## Update (after review)

Guarding `get_stripe_connect_account_id` alone would let `create_connect_account_endpoint` proceed to create a Stripe Connect account for a UID with no Firestore record (a `None` return reads as "no existing account"), leaving an orphaned billing account. The getter guards are kept, and the endpoint now calls `get_user_profile(uid)` and returns 404 `User not found` before `create_connect_account` runs, so a missing user surfaces as a clean error instead of an orphaned account. Added `tests/unit/test_payment_connect_account_user_guard.py` (source-level, matching the other payment endpoint tests) asserting the user check runs before account creation.
