### PR TITLE
[codex] Persist Windows OCR layout context

### DIFF
--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -59,9 +59,7 @@ function ensureColumn(d: Database.Database, table: string, col: string, decl: st
 // silently broke every INSERT. These tables are a derived cache with no user
 // data worth migrating, so recreating them is safe.
 function dropIfMissingColumn(d: Database.Database, table: string, col: string): void {
-  const exists = d
-    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")
-    .get(table)
+  const exists = d.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(table)
   if (!exists) return
   const cols = d.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
   if (!cols.some((c) => c.name === col)) d.exec(`DROP TABLE ${table}`)
@@ -268,7 +266,9 @@ export function getLocalConversation(id: string): LocalConversation | null {
 export function listLocalConversations(): LocalConversation[] {
   return timed('listLocalConversations', () => {
     const rows = get()
-      .prepare(`SELECT ${LOCAL_CONVERSATION_COLUMNS} FROM local_conversation ORDER BY created_at DESC`)
+      .prepare(
+        `SELECT ${LOCAL_CONVERSATION_COLUMNS} FROM local_conversation ORDER BY created_at DESC`
+      )
       .all() as LocalConversationRow[]
     return rows.map(mapLocalConversation)
   })
@@ -277,7 +277,6 @@ export function listLocalConversations(): LocalConversation[] {
 export function deleteLocalConversation(id: string): void {
   get().prepare('DELETE FROM local_conversation WHERE id = ?').run(id)
 }
-
 
 export function remapConversationId(fromId: string, toId: string): number {
   const r = get()
@@ -473,9 +472,7 @@ function getReadonly(): Database.Database {
 export function execSafeSelect(sql: string): KgSqlResult {
   const stmt = getReadonly().prepare(sql)
   const rows = stmt.all() as Record<string, unknown>[]
-  const columns = rows.length
-    ? Object.keys(rows[0])
-    : (stmt.columns().map((c) => c.name) ?? [])
+  const columns = rows.length ? Object.keys(rows[0]) : (stmt.columns().map((c) => c.name) ?? [])
   return { columns, rows }
 }
 
@@ -556,11 +553,7 @@ export function queryKgNodes(q: string, limit = 12): LocalKnowledgeGraph {
 
 // indexed_files whose filename/folder match q. Excludes apps (file_type
 // 'application') unless explicitly requested via fileType.
-export function searchIndexedFiles(
-  q: string,
-  fileType?: string,
-  limit = 20
-): IndexedFileRecord[] {
+export function searchIndexedFiles(q: string, fileType?: string, limit = 20): IndexedFileRecord[] {
   const like = `%${q}%`
   const cols =
     'path, filename, extension, file_type AS fileType, size_bytes AS sizeBytes, folder, depth, created_at AS createdAt, modified_at AS modifiedAt'
@@ -778,9 +771,10 @@ export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
 }
 
 export function rewindDayBounds(): { min: number; max: number } | null {
-  const row = get()
-    .prepare('SELECT MIN(ts) AS min, MAX(ts) AS max FROM rewind_frames')
-    .get() as { min: number | null; max: number | null }
+  const row = get().prepare('SELECT MIN(ts) AS min, MAX(ts) AS max FROM rewind_frames').get() as {
+    min: number | null
+    max: number | null
+  }
   return row.min == null || row.max == null ? null : { min: row.min, max: row.max }
 }
 

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -26,6 +26,8 @@ import type {
 import { perfMark } from '../../shared/perf'
 import { serializeOcrLinesForStorage } from '../rewind/ocrLayout'
 
+export type RewindFrameWithOcrLayout = RewindFrame & { ocrLinesJson: string | null }
+
 // Time a synchronous DB helper and emit a perf mark with its duration in ms.
 // Always-on (perfMark is a no-op unless OMI_PERF_LOG is set), so the bench can
 // measure DB read throughput without affecting normal runs.
@@ -722,6 +724,8 @@ export function clearLocalGraph(): void {
 // --- Rewind: screen-history timeline ---
 
 const REWIND_COLUMNS =
+  'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, image_path AS imagePath, width, height, indexed'
+const REWIND_INTERNAL_COLUMNS =
   'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, ocr_lines_json AS ocrLinesJson, image_path AS imagePath, width, height, indexed'
 
 export function insertRewindFrame(f: Omit<RewindFrame, 'id'>): number {
@@ -735,10 +739,27 @@ export function insertRewindFrame(f: Omit<RewindFrame, 'id'>): number {
 }
 
 export function listRewindFrames(from: number, to: number): RewindFrame[] {
-  return timed('listRewindFrames', () =>
-    get()
-      .prepare(`SELECT ${REWIND_COLUMNS} FROM rewind_frames WHERE ts BETWEEN ? AND ? ORDER BY ts`)
-      .all(from, to) as RewindFrame[]
+  return timed(
+    'listRewindFrames',
+    () =>
+      get()
+        .prepare(`SELECT ${REWIND_COLUMNS} FROM rewind_frames WHERE ts BETWEEN ? AND ? ORDER BY ts`)
+        .all(from, to) as RewindFrame[]
+  )
+}
+
+export function listRewindFramesWithOcrLayout(
+  from: number,
+  to: number
+): RewindFrameWithOcrLayout[] {
+  return timed(
+    'listRewindFramesWithOcrLayout',
+    () =>
+      get()
+        .prepare(
+          `SELECT ${REWIND_INTERNAL_COLUMNS} FROM rewind_frames WHERE ts BETWEEN ? AND ? ORDER BY ts`
+        )
+        .all(from, to) as RewindFrameWithOcrLayout[]
   )
 }
 

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -20,9 +20,11 @@ import type {
   OnboardingGraphNode,
   OnboardingGraphEdge,
   RewindFrame,
+  OcrLine,
   UsageCategory
 } from '../../shared/types'
 import { perfMark } from '../../shared/perf'
+import { serializeOcrLinesForStorage } from '../rewind/ocrLayout'
 
 // Time a synchronous DB helper and emit a perf mark with its duration in ms.
 // Always-on (perfMark is a no-op unless OMI_PERF_LOG is set), so the bench can
@@ -165,6 +167,7 @@ function get(): Database.Database {
       window_title TEXT NOT NULL DEFAULT '',
       process_name TEXT NOT NULL DEFAULT '',
       ocr_text TEXT NOT NULL DEFAULT '',
+      ocr_lines_json TEXT,
       image_path TEXT NOT NULL,
       width INTEGER NOT NULL DEFAULT 0,
       height INTEGER NOT NULL DEFAULT 0,
@@ -195,6 +198,9 @@ function get(): Database.Database {
   ensureColumn(db, 'local_kg_nodes', 'source_refs', 'TEXT')
   // Resolved .lnk target exe, for joining indexed apps to app_usage (additive).
   ensureColumn(db, 'indexed_files', 'target_path', 'TEXT')
+  // Optional OCR layout rows captured by the Windows helper. Kept separate from
+  // ocr_text so Rewind UI/search stay plain-text compatible.
+  ensureColumn(db, 'rewind_frames', 'ocr_lines_json', 'TEXT')
   return db
 }
 
@@ -716,7 +722,7 @@ export function clearLocalGraph(): void {
 // --- Rewind: screen-history timeline ---
 
 const REWIND_COLUMNS =
-  'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, image_path AS imagePath, width, height, indexed'
+  'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, ocr_lines_json AS ocrLinesJson, image_path AS imagePath, width, height, indexed'
 
 export function insertRewindFrame(f: Omit<RewindFrame, 'id'>): number {
   const r = get()
@@ -772,8 +778,10 @@ export function unindexedRewindFrames(limit = 20): RewindFrame[] {
     .all(limit) as RewindFrame[]
 }
 
-export function setRewindFrameOcr(id: number, ocrText: string): void {
-  get().prepare('UPDATE rewind_frames SET ocr_text = ?, indexed = 1 WHERE id = ?').run(ocrText, id)
+export function setRewindFrameOcr(id: number, ocrText: string, ocrLines?: OcrLine[]): void {
+  get()
+    .prepare('UPDATE rewind_frames SET ocr_text = ?, ocr_lines_json = ?, indexed = 1 WHERE id = ?')
+    .run(ocrText, serializeOcrLinesForStorage(ocrLines), id)
 }
 
 export function deleteRewindFramesOlderThan(cutoffTs: number): RewindFrame[] {

--- a/desktop/windows/src/main/ipc/dbRewindOcr.test.ts
+++ b/desktop/windows/src/main/ipc/dbRewindOcr.test.ts
@@ -40,15 +40,16 @@ vi.mock('better-sqlite3', () => ({
             ]
           }
           if (sql.includes('FROM rewind_frames WHERE ts BETWEEN')) {
-            return [
-              {
-                id: 7,
-                ...dbState.inserted,
-                ocrText: dbState.update?.[0] ?? '',
-                ocrLinesJson: dbState.update?.[1] ?? null,
-                indexed: 1
-              }
-            ]
+            const row: Record<string, unknown> = {
+              id: 7,
+              ...dbState.inserted,
+              ocrText: dbState.update?.[0] ?? '',
+              indexed: 1
+            }
+            if (sql.includes('ocr_lines_json AS ocrLinesJson')) {
+              row.ocrLinesJson = dbState.update?.[1] ?? null
+            }
+            return [row]
           }
           return []
         },
@@ -89,7 +90,12 @@ describe('rewind OCR db wiring', () => {
     dbState.inserted = null
     dbState.update = null
     vi.resetModules()
-    const { insertRewindFrame, listRewindFrames, setRewindFrameOcr } = await import('./db')
+    const {
+      insertRewindFrame,
+      listRewindFrames,
+      listRewindFramesWithOcrLayout,
+      setRewindFrameOcr
+    } = await import('./db')
 
     const id = insertRewindFrame(frame())
     setRewindFrameOcr(id, 'Hello world', [
@@ -101,7 +107,10 @@ describe('rewind OCR db wiring', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].ocrText).toBe('Hello world')
     expect(rows[0].indexed).toBe(1)
-    expect(JSON.parse(rows[0].ocrLinesJson ?? '[]')).toEqual([
+    expect('ocrLinesJson' in rows[0]).toBe(false)
+
+    const internalRows = listRewindFramesWithOcrLayout(0, 2000)
+    expect(JSON.parse(internalRows[0].ocrLinesJson ?? '[]')).toEqual([
       { text: 'Hello', x: 10, y: 10, w: 40, h: 12, confidence: 0.99 },
       { text: 'world', x: 56, y: 10, w: 40, h: 12, confidence: 0.98 }
     ])

--- a/desktop/windows/src/main/ipc/dbRewindOcr.test.ts
+++ b/desktop/windows/src/main/ipc/dbRewindOcr.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { RewindFrame } from '../../shared/types'
+
+const dbState = vi.hoisted(() => ({
+  inserted: null as Omit<RewindFrame, 'id'> | null,
+  update: null as [string, string | null, number] | null
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => 'test-user-data'
+  }
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: class FakeDatabase {
+    pragma(): null {
+      return null
+    }
+    exec(): this {
+      return this
+    }
+    prepare(sql: string): {
+      all: (...args: unknown[]) => unknown[]
+      get: (...args: unknown[]) => unknown
+      run: (...args: unknown[]) => { lastInsertRowid?: number; changes: number }
+      columns: () => { name: string }[]
+    } {
+      return {
+        all: () => {
+          if (sql.startsWith('PRAGMA table_info')) {
+            return [
+              { name: 'kind' },
+              { name: 'messages' },
+              { name: 'title' },
+              { name: 'summary' },
+              { name: 'id' },
+              { name: 'target_path' },
+              { name: 'ocr_lines_json' }
+            ]
+          }
+          if (sql.includes('FROM rewind_frames WHERE ts BETWEEN')) {
+            return [
+              {
+                id: 7,
+                ...dbState.inserted,
+                ocrText: dbState.update?.[0] ?? '',
+                ocrLinesJson: dbState.update?.[1] ?? null,
+                indexed: 1
+              }
+            ]
+          }
+          return []
+        },
+        get: () => undefined,
+        run: (...args: unknown[]) => {
+          if (sql.includes('INSERT INTO rewind_frames')) {
+            dbState.inserted = args[0] as Omit<RewindFrame, 'id'>
+            return { lastInsertRowid: 7, changes: 1 }
+          }
+          if (sql.includes('UPDATE rewind_frames SET ocr_text')) {
+            dbState.update = args as [string, string | null, number]
+          }
+          return { changes: 1 }
+        },
+        columns: () => []
+      }
+    }
+  }
+}))
+
+function frame(over: Partial<RewindFrame> = {}): Omit<RewindFrame, 'id'> {
+  return {
+    ts: 1000,
+    app: 'Code',
+    windowTitle: 'plan.md',
+    processName: 'Code.exe',
+    ocrText: '',
+    imagePath: 'frame.jpg',
+    width: 800,
+    height: 600,
+    indexed: 0,
+    ...over
+  }
+}
+
+describe('rewind OCR db wiring', () => {
+  it('persists OCR text and layout JSON on rewind frames', async () => {
+    dbState.inserted = null
+    dbState.update = null
+    vi.resetModules()
+    const { insertRewindFrame, listRewindFrames, setRewindFrameOcr } = await import('./db')
+
+    const id = insertRewindFrame(frame())
+    setRewindFrameOcr(id, 'Hello world', [
+      { text: 'Hello', x: 10, y: 10, w: 40, h: 12, confidence: 0.99 },
+      { text: 'world', x: 56, y: 10, w: 40, h: 12, confidence: 0.98 }
+    ])
+
+    const rows = listRewindFrames(0, 2000)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].ocrText).toBe('Hello world')
+    expect(rows[0].indexed).toBe(1)
+    expect(JSON.parse(rows[0].ocrLinesJson ?? '[]')).toEqual([
+      { text: 'Hello', x: 10, y: 10, w: 40, h: 12, confidence: 0.99 },
+      { text: 'world', x: 56, y: 10, w: 40, h: 12, confidence: 0.98 }
+    ])
+  })
+})

--- a/desktop/windows/src/main/ipc/screenSynth.ts
+++ b/desktop/windows/src/main/ipc/screenSynth.ts
@@ -7,6 +7,7 @@ import {
   advanceWatermark,
   recordRun
 } from '../screenSynth/state'
+import { buildOcrContextText } from '../rewind/ocrLayout'
 import type { ScreenFrameLite, ScreenSynthState, ScreenSynthRun } from '../../shared/types'
 
 export function registerScreenSynthHandlers(): void {
@@ -20,7 +21,11 @@ export function registerScreenSynthHandlers(): void {
       app: f.app,
       windowTitle: f.windowTitle,
       processName: f.processName,
-      ocrText: f.ocrText
+      ocrText: f.ocrText,
+      ocrContext: buildOcrContextText(f.ocrText, f.ocrLinesJson, {
+        width: f.width,
+        height: f.height
+      })
     }))
   })
   ipcMain.handle('screenSynth:getState', async () => getScreenSynthState())

--- a/desktop/windows/src/main/ipc/screenSynth.ts
+++ b/desktop/windows/src/main/ipc/screenSynth.ts
@@ -1,6 +1,6 @@
 // src/main/ipc/screenSynth.ts
 import { ipcMain } from 'electron'
-import { listRewindFrames } from './db'
+import { listRewindFramesWithOcrLayout } from './db'
 import {
   getScreenSynthState,
   updateScreenSynthState,
@@ -15,7 +15,7 @@ export function registerScreenSynthHandlers(): void {
   ipcMain.handle('screenSynth:framesSince', async (): Promise<ScreenFrameLite[]> => {
     const { watermarkTs } = getScreenSynthState()
     // +1 so we never re-emit the exact watermark frame.
-    const frames = listRewindFrames(watermarkTs + 1, Date.now())
+    const frames = listRewindFramesWithOcrLayout(watermarkTs + 1, Date.now())
     return frames.map((f) => ({
       ts: f.ts,
       app: f.app,

--- a/desktop/windows/src/main/rewind/captureService.ts
+++ b/desktop/windows/src/main/rewind/captureService.ts
@@ -58,7 +58,7 @@ async function refreshCurrentScreen(frameId: number, jpeg: Buffer): Promise<void
     const res = await helperProcess.ocr(jpeg)
     if (res.ok) {
       setCurrentScreen(res.fullText)
-      setRewindFrameOcr(frameId, res.fullText)
+      setRewindFrameOcr(frameId, res.fullText, res.lines)
     }
   } catch {
     /* best-effort: keep the last good cached value */

--- a/desktop/windows/src/main/rewind/ocrLayout.test.ts
+++ b/desktop/windows/src/main/rewind/ocrLayout.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildOcrContextText,
+  clusterOcrRows,
+  filterScreenChromeLines,
+  parseStoredOcrLines,
+  serializeOcrLayoutMarkdown,
+  serializeOcrLinesForStorage
+} from './ocrLayout'
+import type { OcrLine } from '../../shared/types'
+
+const line = (over: Partial<OcrLine>): OcrLine => ({
+  text: 'text',
+  x: 0,
+  y: 0,
+  w: 20,
+  h: 10,
+  confidence: 0.9,
+  ...over
+})
+
+describe('ocrLayout', () => {
+  it('clusters OCR lines into visual rows and orders each row left-to-right', () => {
+    const rows = clusterOcrRows([
+      line({ text: 'World', x: 35, y: 12 }),
+      line({ text: 'Hello', x: 10, y: 10 }),
+      line({ text: 'Second row', x: 10, y: 40, w: 80 })
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text).toBe('Hello World')
+    expect(rows[1].text).toBe('Second row')
+  })
+
+  it('splits visual rows when y coordinates differ by more than 10px', () => {
+    const rows = clusterOcrRows([
+      line({ text: 'First', x: 10, y: 100 }),
+      line({ text: 'same row', x: 35, y: 110 }),
+      line({ text: 'next row', x: 10, y: 111 })
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text).toBe('First same row')
+    expect(rows[1].text).toBe('next row')
+  })
+
+  it('filters likely menu and taskbar OCR before layout serialization', () => {
+    expect(
+      filterScreenChromeLines(
+        [
+          line({ text: 'File Edit View', y: 20 }),
+          line({ text: 'Document content', y: 120 }),
+          line({ text: 'Taskbar clock', y: 1050 })
+        ],
+        { width: 1920, height: 1080 }
+      ).map((l) => l.text)
+    ).toEqual(['Document content'])
+  })
+
+  it('serializes clustered rows as markdown with approximate screen positions', () => {
+    expect(
+      serializeOcrLayoutMarkdown(
+        [line({ text: 'File', x: 10, y: 50 }), line({ text: 'Edit', x: 80, y: 50 })],
+        { width: 200, height: 100 }
+      )
+    ).toBe('- top 50%, left 5%: File | Edit')
+  })
+
+  it('stores only valid OCR lines and tolerates bad stored JSON', () => {
+    const stored = serializeOcrLinesForStorage([
+      line({ text: 'Keep me', x: 1.4, y: 2.6 }),
+      line({ text: '   ' }),
+      line({ text: 'bad size', w: 0 })
+    ])
+
+    expect(stored).not.toBeNull()
+    expect(parseStoredOcrLines(stored)).toEqual([
+      { text: 'Keep me', x: 1, y: 3, w: 20, h: 10, confidence: 0.9 }
+    ])
+    expect(parseStoredOcrLines('{not json')).toEqual([])
+  })
+
+  it('falls back to plain OCR text when no stored layout is available', () => {
+    expect(buildOcrContextText('plain text', null)).toBe('plain text')
+  })
+})

--- a/desktop/windows/src/main/rewind/ocrLayout.test.ts
+++ b/desktop/windows/src/main/rewind/ocrLayout.test.ts
@@ -69,18 +69,50 @@ describe('ocrLayout', () => {
   it('stores only valid OCR lines and tolerates bad stored JSON', () => {
     const stored = serializeOcrLinesForStorage([
       line({ text: 'Keep me', x: 1.4, y: 2.6 }),
+      line({ text: 'Tiny but valid', x: 20, y: 20, w: 0.4, h: 0.4 }),
       line({ text: '   ' }),
       line({ text: 'bad size', w: 0 })
     ])
 
     expect(stored).not.toBeNull()
     expect(parseStoredOcrLines(stored)).toEqual([
-      { text: 'Keep me', x: 1, y: 3, w: 20, h: 10, confidence: 0.9 }
+      { text: 'Keep me', x: 1, y: 3, w: 20, h: 10, confidence: 0.9 },
+      { text: 'Tiny but valid', x: 20, y: 20, w: 1, h: 1, confidence: 0.9 }
     ])
     expect(parseStoredOcrLines('{not json')).toEqual([])
   })
 
   it('falls back to plain OCR text when no stored layout is available', () => {
     expect(buildOcrContextText('plain text', null)).toBe('plain text')
+  })
+
+  it('builds layout-aware context when stored lines cover the OCR text', () => {
+    const stored = serializeOcrLinesForStorage([
+      line({ text: 'Visible', x: 10, y: 50, w: 50 }),
+      line({ text: 'text', x: 70, y: 50, w: 40 })
+    ])
+
+    expect(
+      buildOcrContextText('Visible\ntext', stored, {
+        width: 200,
+        height: 100
+      })
+    ).toBe('- top 50%, left 5%: Visible text')
+  })
+
+  it('builds layout-aware context without dropping the full OCR text', () => {
+    const stored = serializeOcrLinesForStorage([
+      line({ text: 'Visible', x: 10, y: 50, w: 50 }),
+      line({ text: 'text', x: 70, y: 50, w: 40 })
+    ])
+
+    expect(
+      buildOcrContextText('Visible text\nExtra uncaptured text', stored, {
+        width: 200,
+        height: 100
+      })
+    ).toBe(
+      '- top 50%, left 5%: Visible text\n\nFull OCR text:\nVisible text\nExtra uncaptured text'
+    )
   })
 })

--- a/desktop/windows/src/main/rewind/ocrLayout.ts
+++ b/desktop/windows/src/main/rewind/ocrLayout.ts
@@ -25,6 +25,10 @@ function roundCoord(value: number): number {
   return Math.round(value)
 }
 
+function roundDimension(value: number): number {
+  return Math.max(1, Math.round(value))
+}
+
 export function normalizeOcrLines(lines: OcrLine[] | undefined): OcrLine[] {
   if (!Array.isArray(lines)) return []
   return lines
@@ -45,8 +49,8 @@ export function normalizeOcrLines(lines: OcrLine[] | undefined): OcrLine[] {
       text: line.text.trim(),
       x: roundCoord(line.x),
       y: roundCoord(line.y),
-      w: roundCoord(line.w),
-      h: roundCoord(line.h),
+      w: roundDimension(line.w),
+      h: roundDimension(line.h),
       confidence: finiteNumber(line.confidence) ? line.confidence : 0
     }))
 }
@@ -150,6 +154,17 @@ function rowLabel(row: OcrLayoutRow, size: FrameSize): string {
   return `top ${top}%, left ${left}%`
 }
 
+function normalizeTextForCoverage(text: string): string {
+  return text.trim().replace(/\s+/g, ' ')
+}
+
+function storedLinesCoverPlainText(lines: OcrLine[], plainText: string): boolean {
+  return (
+    normalizeTextForCoverage(lines.map((line) => line.text).join(' ')) ===
+    normalizeTextForCoverage(plainText)
+  )
+}
+
 export function serializeOcrLayoutMarkdown(lines: OcrLine[], size: FrameSize = {}): string {
   return clusterOcrRows(filterScreenChromeLines(lines, size))
     .map((row) => {
@@ -164,6 +179,10 @@ export function buildOcrContextText(
   ocrLinesJson: string | null | undefined,
   size: FrameSize = {}
 ): string {
-  const layout = serializeOcrLayoutMarkdown(parseStoredOcrLines(ocrLinesJson), size).trim()
-  return layout || ocrText.trim()
+  const plain = ocrText.trim()
+  const lines = parseStoredOcrLines(ocrLinesJson)
+  const layout = serializeOcrLayoutMarkdown(lines, size).trim()
+  if (!layout) return plain
+  if (!plain || storedLinesCoverPlainText(lines, plain)) return layout
+  return `${layout}\n\nFull OCR text:\n${plain}`
 }

--- a/desktop/windows/src/main/rewind/ocrLayout.ts
+++ b/desktop/windows/src/main/rewind/ocrLayout.ts
@@ -1,0 +1,169 @@
+import type { OcrLine } from '../../shared/types'
+
+const MAX_STORED_OCR_LINES = 200
+const ROW_CLUSTER_THRESHOLD_PX = 10
+const CHROME_EDGE_PX_AT_1080P = 40
+const REFERENCE_SCREEN_HEIGHT = 1080
+
+export type OcrLayoutRow = {
+  top: number
+  bottom: number
+  left: number
+  right: number
+  text: string
+  lines: OcrLine[]
+}
+
+type FrameSize = { width?: number; height?: number }
+type ClusterOptions = { rowThresholdPx?: number }
+
+function finiteNumber(value: number): boolean {
+  return Number.isFinite(value)
+}
+
+function roundCoord(value: number): number {
+  return Math.round(value)
+}
+
+export function normalizeOcrLines(lines: OcrLine[] | undefined): OcrLine[] {
+  if (!Array.isArray(lines)) return []
+  return lines
+    .filter((line) => {
+      const text = line.text?.trim()
+      return (
+        !!text &&
+        finiteNumber(line.x) &&
+        finiteNumber(line.y) &&
+        finiteNumber(line.w) &&
+        finiteNumber(line.h) &&
+        line.w > 0 &&
+        line.h > 0
+      )
+    })
+    .slice(0, MAX_STORED_OCR_LINES)
+    .map((line) => ({
+      text: line.text.trim(),
+      x: roundCoord(line.x),
+      y: roundCoord(line.y),
+      w: roundCoord(line.w),
+      h: roundCoord(line.h),
+      confidence: finiteNumber(line.confidence) ? line.confidence : 0
+    }))
+}
+
+export function serializeOcrLinesForStorage(lines: OcrLine[] | undefined): string | null {
+  const normalized = normalizeOcrLines(lines)
+  return normalized.length ? JSON.stringify(normalized) : null
+}
+
+export function parseStoredOcrLines(json: string | null | undefined): OcrLine[] {
+  if (!json) return []
+  try {
+    const parsed = JSON.parse(json)
+    return normalizeOcrLines(Array.isArray(parsed) ? (parsed as OcrLine[]) : undefined)
+  } catch {
+    return []
+  }
+}
+
+function sameRow(row: OcrLayoutRow, line: OcrLine, thresholdPx: number): boolean {
+  return Math.abs(row.top - line.y) <= thresholdPx
+}
+
+function joinRowText(lines: OcrLine[]): string {
+  const sorted = [...lines].sort((a, b) => a.x - b.x)
+  let out = ''
+  let previousRight = 0
+  for (const line of sorted) {
+    if (!out) {
+      out = line.text
+    } else {
+      const gap = line.x - previousRight
+      out += gap > Math.max(24, line.h * 2) ? ` | ${line.text}` : ` ${line.text}`
+    }
+    previousRight = Math.max(previousRight, line.x + line.w)
+  }
+  return out
+}
+
+export function clusterOcrRows(lines: OcrLine[], options: ClusterOptions = {}): OcrLayoutRow[] {
+  const thresholdPx = options.rowThresholdPx ?? ROW_CLUSTER_THRESHOLD_PX
+  const sorted = normalizeOcrLines(lines).sort((a, b) => a.y - b.y || a.x - b.x)
+  const rows: OcrLayoutRow[] = []
+
+  for (const line of sorted) {
+    const current = rows[rows.length - 1]
+    if (!current || !sameRow(current, line, thresholdPx)) {
+      rows.push({
+        top: line.y,
+        bottom: line.y + line.h,
+        left: line.x,
+        right: line.x + line.w,
+        text: line.text,
+        lines: [line]
+      })
+      continue
+    }
+
+    current.lines.push(line)
+    current.top = Math.min(current.top, line.y)
+    current.bottom = Math.max(current.bottom, line.y + line.h)
+    current.left = Math.min(current.left, line.x)
+    current.right = Math.max(current.right, line.x + line.w)
+    current.text = joinRowText(current.lines)
+  }
+
+  return rows.map((row) => ({
+    ...row,
+    lines: [...row.lines].sort((a, b) => a.x - b.x),
+    text: joinRowText(row.lines)
+  }))
+}
+
+function chromeEdgePx(size: FrameSize): number {
+  if (!size.height || size.height <= 0) return CHROME_EDGE_PX_AT_1080P
+  return Math.round((size.height / REFERENCE_SCREEN_HEIGHT) * CHROME_EDGE_PX_AT_1080P)
+}
+
+export function filterScreenChromeLines(lines: OcrLine[], size: FrameSize = {}): OcrLine[] {
+  const normalized = normalizeOcrLines(lines)
+  const topCutoff = chromeEdgePx(size)
+  const bottomCutoff = size.height && size.height > 0 ? size.height - topCutoff : null
+  return normalized.filter((line) => {
+    if (line.y < topCutoff) return false
+    if (bottomCutoff != null && line.y > bottomCutoff) return false
+    return true
+  })
+}
+
+function pct(value: number, total: number | undefined): number | null {
+  if (!total || total <= 0) return null
+  return Math.max(0, Math.min(100, Math.round((value / total) * 100)))
+}
+
+function rowLabel(row: OcrLayoutRow, size: FrameSize): string {
+  const top = pct(row.top, size.height)
+  const left = pct(row.left, size.width)
+  if (top == null && left == null) return ''
+  if (top == null) return `left ${left}%`
+  if (left == null) return `top ${top}%`
+  return `top ${top}%, left ${left}%`
+}
+
+export function serializeOcrLayoutMarkdown(lines: OcrLine[], size: FrameSize = {}): string {
+  return clusterOcrRows(filterScreenChromeLines(lines, size))
+    .map((row) => {
+      const label = rowLabel(row, size)
+      return label ? `- ${label}: ${row.text}` : `- ${row.text}`
+    })
+    .join('\n')
+}
+
+export function buildOcrContextText(
+  ocrText: string,
+  ocrLinesJson: string | null | undefined,
+  size: FrameSize = {}
+): string {
+  const layout = serializeOcrLayoutMarkdown(parseStoredOcrLines(ocrLinesJson), size).trim()
+  return layout || ocrText.trim()
+}

--- a/desktop/windows/src/main/rewind/ocrService.ts
+++ b/desktop/windows/src/main/rewind/ocrService.ts
@@ -23,7 +23,11 @@ async function backfill(): Promise<void> {
         continue
       }
       const result = await helperProcess.ocr(jpeg)
-      setRewindFrameOcr(f.id, result.ok ? result.fullText : '')
+      setRewindFrameOcr(
+        f.id,
+        result.ok ? result.fullText : '',
+        result.ok ? result.lines : undefined
+      )
     }
   } finally {
     running = false

--- a/desktop/windows/src/renderer/src/lib/screenGrouping.test.ts
+++ b/desktop/windows/src/renderer/src/lib/screenGrouping.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect } from 'vitest'
 import { groupFrames, budgetSegments, type ScreenSegment } from './screenGrouping'
+import type { ScreenFrameLite } from '../../../shared/types'
 
-const f = (ts: number, app: string, windowTitle: string, ocrText: string) => ({
+const f = (
+  ts: number,
+  app: string,
+  windowTitle: string,
+  ocrText: string,
+  over: Partial<ScreenFrameLite> = {}
+): ScreenFrameLite => ({
   ts,
   app,
   windowTitle,
   processName: app.toLowerCase() + '.exe',
-  ocrText
+  ocrText,
+  ...over
 })
 
 describe('groupFrames', () => {
@@ -25,6 +33,34 @@ describe('groupFrames', () => {
   })
   it('drops empty-OCR frames', () => {
     expect(groupFrames([f(1, 'Code', 'x', '   ')])).toEqual([])
+  })
+  it('uses layout-aware OCR context when present', () => {
+    const segs = groupFrames([
+      f(1, 'Code', 'plan.md', 'plain text', { ocrContext: '- top 10%, left 5%: layout text' })
+    ])
+    expect(segs[0].text).toBe('- top 10%, left 5%: layout text')
+  })
+  it('dedupes near-identical long OCR contexts at the same app/window', () => {
+    const segs = groupFrames([
+      f(
+        1,
+        'Code',
+        'plan.md',
+        'Project Alpha roadmap Q2 launch risk checklist owner Junius status green'
+      ),
+      f(
+        2,
+        'Code',
+        'plan.md',
+        'Project Alpha roadmap Q2 launch risk checklist owner Junius status green.'
+      ),
+      f(3, 'Code', 'plan.md', 'Now adding the Windows OCR layout serialization tests')
+    ])
+
+    expect(segs).toHaveLength(1)
+    expect(segs[0].text).toContain('status green')
+    expect(segs[0].text).not.toContain('status green.')
+    expect(segs[0].text).toContain('layout serialization tests')
   })
 })
 

--- a/desktop/windows/src/renderer/src/lib/screenGrouping.ts
+++ b/desktop/windows/src/renderer/src/lib/screenGrouping.ts
@@ -1,24 +1,24 @@
 // src/renderer/src/lib/screenGrouping.ts
 import type { ScreenFrameLite } from '../../../shared/types'
+import { isNearDuplicateText } from '../../../shared/textSimilarity'
 
 export type ScreenSegment = { app: string; windowTitle: string; text: string }
 
 // Group consecutive frames sharing app+window into one segment, concatenating
-// distinct OCR lines in order (drop exact consecutive duplicates and blanks).
+// distinct OCR contexts in order (drop near duplicates and blanks).
 export function groupFrames(frames: ScreenFrameLite[]): ScreenSegment[] {
   const out: ScreenSegment[] = []
-  let cur: { app: string; windowTitle: string; lines: string[]; seen: Set<string> } | null = null
+  let cur: { app: string; windowTitle: string; lines: string[] } | null = null
 
   for (const fr of frames) {
-    const text = (fr.ocrText ?? '').trim()
+    const text = (fr.ocrContext ?? fr.ocrText ?? '').trim()
     if (!text) continue
     const sameContext = cur && cur.app === fr.app && cur.windowTitle === fr.windowTitle
     if (!sameContext) {
       if (cur) out.push({ app: cur.app, windowTitle: cur.windowTitle, text: cur.lines.join('\n') })
-      cur = { app: fr.app, windowTitle: fr.windowTitle, lines: [], seen: new Set() }
+      cur = { app: fr.app, windowTitle: fr.windowTitle, lines: [] }
     }
-    if (cur && !cur.seen.has(text)) {
-      cur.seen.add(text)
+    if (cur && !cur.lines.some((line) => isNearDuplicateText(line, text))) {
       cur.lines.push(text)
     }
   }

--- a/desktop/windows/src/renderer/src/lib/screenRedact.test.ts
+++ b/desktop/windows/src/renderer/src/lib/screenRedact.test.ts
@@ -1,6 +1,12 @@
 // src/renderer/src/lib/screenRedact.test.ts
 import { describe, it, expect } from 'vitest'
-import { redact, isPrivateWindow, isDeniedContext, DEFAULT_DENYLIST, redactFrameFields } from './screenRedact'
+import {
+  redact,
+  isPrivateWindow,
+  isDeniedContext,
+  DEFAULT_DENYLIST,
+  redactFrameFields
+} from './screenRedact'
 
 describe('redact', () => {
   it('redacts emails, cards, ssn, tokens', () => {
@@ -24,9 +30,15 @@ describe('isPrivateWindow', () => {
 
 describe('isDeniedContext', () => {
   it('denies built-in sensitive contexts (case-insensitive); allows normal', () => {
-    expect(isDeniedContext({ app: '1Password', windowTitle: '', processName: '1password.exe' })).toBe(true)
-    expect(isDeniedContext({ app: 'Chrome', windowTitle: 'Chase - Log in', processName: 'chrome.exe' })).toBe(true)
-    expect(isDeniedContext({ app: 'Code', windowTitle: 'plan.md', processName: 'code.exe' })).toBe(false)
+    expect(
+      isDeniedContext({ app: '1Password', windowTitle: '', processName: '1password.exe' })
+    ).toBe(true)
+    expect(
+      isDeniedContext({ app: 'Chrome', windowTitle: 'Chase - Log in', processName: 'chrome.exe' })
+    ).toBe(true)
+    expect(isDeniedContext({ app: 'Code', windowTitle: 'plan.md', processName: 'code.exe' })).toBe(
+      false
+    )
     expect(DEFAULT_DENYLIST.length).toBeGreaterThan(0)
   })
 })
@@ -35,11 +47,13 @@ describe('redactFrameFields', () => {
   it('redacts both ocrText and windowTitle, preserving other fields', () => {
     const out = redactFrameFields({
       ocrText: 'email a@b.com',
+      ocrContext: '- top 5%: email a@b.com',
       windowTitle: 'Re: salary jane@acme.com - Outlook',
       app: 'Outlook',
       ts: 5
     })
     expect(out.ocrText).toBe('email [redacted]')
+    expect(out.ocrContext).toBe('- top 5%: email [redacted]')
     expect(out.windowTitle).toBe('Re: salary [redacted] - Outlook')
     expect(out.app).toBe('Outlook')
     expect(out.ts).toBe(5)

--- a/desktop/windows/src/renderer/src/lib/screenRedact.ts
+++ b/desktop/windows/src/renderer/src/lib/screenRedact.ts
@@ -1,8 +1,21 @@
 // src/renderer/src/lib/screenRedact.ts
 export const DEFAULT_DENYLIST: string[] = [
-  '1password', 'bitwarden', 'keepass', 'lastpass', 'dashlane',
-  'windows security', 'windows hello', 'log in', 'login', 'sign in',
-  'password', 'bank', 'chase', 'wells fargo', 'paypal', 'coinbase'
+  '1password',
+  'bitwarden',
+  'keepass',
+  'lastpass',
+  'dashlane',
+  'windows security',
+  'windows hello',
+  'log in',
+  'login',
+  'sign in',
+  'password',
+  'bank',
+  'chase',
+  'wells fargo',
+  'paypal',
+  'coinbase'
 ]
 
 const PRIVATE_MARKERS = ['incognito', 'inprivate', 'private browsing']
@@ -39,6 +52,13 @@ export function redact(text: string): string {
 // Redact the frame fields that get sent to the LLM — the OCR body AND the window
 // title (titles often carry emails/subjects/PII). Generic so it doesn't couple to
 // the RewindFrame type.
-export function redactFrameFields<T extends { ocrText: string; windowTitle: string }>(f: T): T {
-  return { ...f, ocrText: redact(f.ocrText), windowTitle: redact(f.windowTitle) }
+export function redactFrameFields<
+  T extends { ocrText: string; windowTitle: string; ocrContext?: string }
+>(f: T): T {
+  return {
+    ...f,
+    ocrText: redact(f.ocrText),
+    ocrContext: f.ocrContext ? redact(f.ocrContext) : f.ocrContext,
+    windowTitle: redact(f.windowTitle)
+  }
 }

--- a/desktop/windows/src/renderer/src/lib/screenSynthesis.ts
+++ b/desktop/windows/src/renderer/src/lib/screenSynthesis.ts
@@ -1,7 +1,7 @@
 // src/renderer/src/lib/screenSynthesis.ts
 import { omiApi } from './apiClient'
 import { generate } from './geminiClient'
-import { redact, isPrivateWindow, isDeniedContext } from './screenRedact'
+import { isPrivateWindow, isDeniedContext, redactFrameFields } from './screenRedact'
 import { groupFrames, budgetSegments } from './screenGrouping'
 import {
   buildScreenPrompt,
@@ -56,7 +56,7 @@ export async function runScreenSynthesisOnce(): Promise<number> {
     }
 
     // Redact on-device BEFORE building the prompt (nothing un-redacted leaves).
-    const redacted = allowed.map((f) => ({ ...f, ocrText: redact(f.ocrText) }))
+    const redacted = allowed.map(redactFrameFields)
     const segments = budgetSegments(groupFrames(redacted), PROMPT_BUDGET_CHARS)
     if (segments.length === 0) {
       await window.omi.screenSynthAdvanceWatermark(maxTs)

--- a/desktop/windows/src/shared/textSimilarity.test.ts
+++ b/desktop/windows/src/shared/textSimilarity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNearDuplicateText,
+  normalizeForTextSimilarity,
+  textSimilarityRatio
+} from './textSimilarity'
+
+describe('textSimilarity', () => {
+  it('normalizes case and whitespace', () => {
+    expect(normalizeForTextSimilarity('  Hello\nWORLD  ')).toBe('hello world')
+  })
+
+  it('treats long nearly-identical OCR text as a near duplicate', () => {
+    const a = 'Project Alpha roadmap Q2 launch risk checklist owner Junius status green'
+    const b = 'Project Alpha roadmap Q2 launch risk checklist owner Junius status green.'
+    expect(isNearDuplicateText(a, b)).toBe(true)
+    expect(textSimilarityRatio(a, b)).toBeGreaterThanOrEqual(0.92)
+  })
+
+  it('does not collapse short changed UI labels', () => {
+    expect(isNearDuplicateText('Open', 'Open file')).toBe(false)
+  })
+
+  it('does not collapse unrelated OCR text', () => {
+    const a = 'Project Alpha roadmap Q2 launch risk checklist owner Junius status green'
+    const b = 'Chrome search results for SQLite OCR clustering and markdown context'
+    expect(isNearDuplicateText(a, b)).toBe(false)
+  })
+})

--- a/desktop/windows/src/shared/textSimilarity.ts
+++ b/desktop/windows/src/shared/textSimilarity.ts
@@ -1,0 +1,42 @@
+const MIN_NEAR_DUPLICATE_CHARS = 32
+
+export function normalizeForTextSimilarity(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function bigramCounts(text: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (let i = 0; i < text.length - 1; i++) {
+    const gram = text.slice(i, i + 2)
+    counts.set(gram, (counts.get(gram) ?? 0) + 1)
+  }
+  return counts
+}
+
+export function textSimilarityRatio(a: string, b: string): number {
+  const left = normalizeForTextSimilarity(a)
+  const right = normalizeForTextSimilarity(b)
+  if (left === right) return 1
+  if (!left || !right) return 0
+
+  const maxLen = Math.max(left.length, right.length)
+  const minLen = Math.min(left.length, right.length)
+  if (maxLen < MIN_NEAR_DUPLICATE_CHARS) return 0
+  if (minLen / maxLen < 0.6) return 0
+
+  const leftCounts = bigramCounts(left)
+  const rightCounts = bigramCounts(right)
+  let overlap = 0
+  for (const [gram, count] of leftCounts) {
+    overlap += Math.min(count, rightCounts.get(gram) ?? 0)
+  }
+  return (2 * overlap) / Math.max(1, left.length + right.length - 2)
+}
+
+export function isNearDuplicateText(a: string, b: string, threshold = 0.92): boolean {
+  const left = normalizeForTextSimilarity(a)
+  const right = normalizeForTextSimilarity(b)
+  if (left === right) return true
+  if (Math.max(left.length, right.length) < MIN_NEAR_DUPLICATE_CHARS) return false
+  return textSimilarityRatio(left, right) >= threshold
+}

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -593,7 +593,6 @@ export type RewindFrame = {
   windowTitle: string
   processName: string
   ocrText: string
-  ocrLinesJson?: string | null
   imagePath: string
   width: number
   height: number

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -306,6 +306,8 @@ export type ScreenFrameLite = {
   windowTitle: string
   processName: string
   ocrText: string
+  /** Layout-aware OCR context for synthesis. Falls back to ocrText when absent. */
+  ocrContext?: string
 }
 
 // Persisted synthesis state (main owns it; default OFF / opt-in).
@@ -591,6 +593,7 @@ export type RewindFrame = {
   windowTitle: string
   processName: string
   ocrText: string
+  ocrLinesJson?: string | null
   imagePath: string
   width: number
   height: number


### PR DESCRIPTION
## Summary
- Rebased the Windows OCR layout context work onto current `main` (`45fe68b82f`).
- Persists OCR layout metadata for Windows Rewind frames so search/grouping can preserve spatial context.
- Adds text similarity helpers, OCR layout extraction tests, database coverage, grouping/redaction coverage, and a small Prettier follow-up for the rebased DB changes.

## Product invariants affected
- None. This PR only touches Windows desktop Rewind/OCR storage, grouping, redaction, and tests.

## Validation
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs install --frozen-lockfile --ignore-scripts`
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs exec vitest run src/main/ipc/dbRewindOcr.test.ts src/main/rewind/ocrLayout.test.ts src/renderer/src/lib/screenGrouping.test.ts src/renderer/src/lib/screenRedact.test.ts src/shared/textSimilarity.test.ts` -> 23 passed
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs exec prettier --check <changed Windows files>`
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs run typecheck:node`
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs run typecheck:web`

Note: local Windows validation uses the pnpm Corepack entry directly because this machine does not expose a `pnpm` shim on `PATH`. Install was run with `--ignore-scripts` to avoid native Electron rebuild noise while validating these TypeScript-only changes.
