### PR TITLE
[codex] Add deferred-work marker policy

### DIFF
--- a/.github/scripts/deferred-work-marker-count.py
+++ b/.github/scripts/deferred-work-marker-count.py
@@ -25,6 +25,7 @@ EXCLUDED_DIR_NAMES = {
 }
 
 NORMALIZED_EXCLUDED_DIR_NAMES = {
+    ".pio",
     "Generated",
     "generated",
     "vendor",
@@ -108,7 +109,7 @@ def count_markers(root: Path, raw: bool) -> tuple[dict[str, int], dict[str, int]
         except UnicodeDecodeError:
             try:
                 text = path.read_text(encoding="latin-1")
-            except UnicodeDecodeError:
+            except OSError:
                 continue
         except OSError:
             continue

--- a/.github/scripts/deferred-work-marker-count.py
+++ b/.github/scripts/deferred-work-marker-count.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 
 MARKERS = ("TO" "DO", "FIX" "ME", "HA" "CK")
-MARKER_RE = re.compile(r"\b(" + "|".join(MARKERS) + r")\b")
+MARKER_RE = re.compile(r"\b(" + "|".join(MARKERS) + r")\b", re.IGNORECASE)
 
 EXCLUDED_DIR_NAMES = {
     ".build",
@@ -119,7 +119,7 @@ def count_markers(root: Path, raw: bool) -> tuple[dict[str, int], dict[str, int]
 
         file_counts[relative_path] = len(matches)
         for marker in matches:
-            marker_counts[marker] += 1
+            marker_counts[marker.upper()] += 1
 
     return marker_counts, file_counts
 

--- a/.github/scripts/deferred-work-marker-count.py
+++ b/.github/scripts/deferred-work-marker-count.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Count explicit deferred-work markers in repository text files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+MARKERS = ("TO" "DO", "FIX" "ME", "HA" "CK")
+MARKER_RE = re.compile(r"\b(" + "|".join(MARKERS) + r")\b")
+
+EXCLUDED_DIR_NAMES = {
+    ".build",
+    ".dart_tool",
+    ".git",
+    ".next",
+    ".pub-cache",
+    "build",
+    "DerivedData",
+    "node_modules",
+    "Pods",
+    "target",
+}
+
+NORMALIZED_EXCLUDED_DIR_NAMES = {
+    "Generated",
+    "generated",
+    "vendor",
+}
+
+NORMALIZED_EXCLUDED_PREFIXES = (
+    ".github/workflows/",
+    "app/lib/l10n/",
+    "backend/charts/deepgram-self-hosted/nova-3/charts/",
+    "omi/firmware/devkit/src/lib/opus-1.2.1/",
+    "omi/firmware/omi/src/lib/core/lib/opus-1.2.1/",
+)
+
+NORMALIZED_EXCLUDED_SUFFIXES = (
+    ".g.dart",
+    ".gen.dart",
+    "Package.resolved",
+    "package-lock.json",
+    "pubspec.lock",
+)
+
+NORMALIZED_EXCLUDED_FILES = {
+    ".github/scripts/deferred-work-marker-count.py",
+    "AGENTS.md",
+    "CLAUDE.md",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="Repository root to scan.")
+    parser.add_argument("--raw", action="store_true", help="Include generated, vendored, policy, and workflow files.")
+    parser.add_argument(
+        "--format",
+        choices=("plain", "github-summary"),
+        default="plain",
+        help="Output format.",
+    )
+    return parser.parse_args()
+
+
+def is_binary(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return b"\0" in handle.read(4096)
+    except OSError:
+        return True
+
+
+def excluded_by_normalized_policy(relative_path: str) -> bool:
+    if any(part in NORMALIZED_EXCLUDED_DIR_NAMES for part in Path(relative_path).parts):
+        return True
+    if relative_path in NORMALIZED_EXCLUDED_FILES:
+        return True
+    if relative_path.endswith(NORMALIZED_EXCLUDED_SUFFIXES):
+        return True
+    return relative_path.startswith(NORMALIZED_EXCLUDED_PREFIXES)
+
+
+def iter_files(root: Path, raw: bool):
+    for dirpath, dirnames, filenames in os.walk(root):
+        current = Path(dirpath)
+        dirnames[:] = [name for name in dirnames if name not in EXCLUDED_DIR_NAMES]
+        for filename in filenames:
+            path = current / filename
+            relative_path = path.relative_to(root).as_posix()
+            if not raw and excluded_by_normalized_policy(relative_path):
+                continue
+            if is_binary(path):
+                continue
+            yield path, relative_path
+
+
+def count_markers(root: Path, raw: bool) -> tuple[dict[str, int], dict[str, int]]:
+    marker_counts = {marker: 0 for marker in MARKERS}
+    file_counts: dict[str, int] = {}
+
+    for path, relative_path in iter_files(root, raw):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            try:
+                text = path.read_text(encoding="latin-1")
+            except UnicodeDecodeError:
+                continue
+        except OSError:
+            continue
+
+        matches = MARKER_RE.findall(text)
+        if not matches:
+            continue
+
+        file_counts[relative_path] = len(matches)
+        for marker in matches:
+            marker_counts[marker] += 1
+
+    return marker_counts, file_counts
+
+
+def print_plain(marker_counts: dict[str, int], file_counts: dict[str, int], raw: bool) -> None:
+    label = "raw" if raw else "normalized"
+    total = sum(marker_counts.values())
+    print(f"{label} total: {total}")
+    for marker in MARKERS:
+        print(f"{marker}: {marker_counts[marker]}")
+    print(f"files: {len(file_counts)}")
+
+
+def print_github_summary(marker_counts: dict[str, int], file_counts: dict[str, int], raw: bool) -> None:
+    label = "Raw" if raw else "Normalized"
+    total = sum(marker_counts.values())
+    print(f"### {label} deferred-work marker count")
+    print()
+    print("| Marker | Count |")
+    print("| --- | ---: |")
+    for marker in MARKERS:
+        print(f"| `{marker}` | {marker_counts[marker]} |")
+    print(f"| **Total** | **{total}** |")
+    print()
+    print(f"Files with markers: {len(file_counts)}")
+    if not raw:
+        print()
+        print("Normalized count excludes generated, vendored, build, lock, policy, and workflow files.")
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    marker_counts, file_counts = count_markers(root, args.raw)
+
+    if args.format == "github-summary":
+        print_github_summary(marker_counts, file_counts, args.raw)
+    else:
+        print_plain(marker_counts, file_counts, args.raw)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
 
+      - name: Summarize deferred-work markers
+        continue-on-error: true
+        run: python3 .github/scripts/deferred-work-marker-count.py --format github-summary >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check GitHub Actions workflows
         if: steps.changed.outputs.has_workflows == 'true'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ These rules apply to every AI agent working in this repository. This file is the
 
 - **Never use purple.** Purple is off-brand — do not use it anywhere in the UI (icons, accents, glows, hover states, gradients). Use white/neutral for accent icons and primary actions.
 
+### Deferred Work Markers
+
+- New `TODO`, `FIXME`, and `HACK` comments must reference a tracking issue or be resolved before merge.
+- Existing markers are legacy debt; only delete or annotate them when the owner and next action are clear.
+
 ### Backend (Python)
 
 - **No in-function imports** — all imports at module top level.

--- a/app/lib/pages/processing_conversations/page.dart
+++ b/app/lib/pages/processing_conversations/page.dart
@@ -40,12 +40,6 @@ class _ProcessingConversationPageState extends State<ProcessingConversationPage>
   Widget build(BuildContext context) {
     return Consumer<ConversationProvider>(
       builder: (context, provider, child) {
-        // Track memory // FIXME
-        // if (widget.memory.status == ServerProcessingMemoryStatus.done &&
-        //     provider.memories.firstWhereOrNull((e) => e.id == widget.memory.memoryId) != null) {
-        //   _pushNewMemory(context, provider.memories.firstWhereOrNull((e) => e.id == widget.memory.memoryId));
-        // }
-
         // Conversation source
         var convoSource = widget.conversation.source;
         bool hasPhotos = (widget.conversation.photos ?? []).isNotEmpty;

--- a/app/lib/pages/processing_conversations/page.dart
+++ b/app/lib/pages/processing_conversations/page.dart
@@ -43,6 +43,14 @@ class _ProcessingConversationPageState extends State<ProcessingConversationPage>
         // Conversation source
         var convoSource = widget.conversation.source;
         bool hasPhotos = (widget.conversation.photos ?? []).isNotEmpty;
+        String contentTabLabel;
+        if (convoSource == ConversationSource.openglass) {
+          contentTabLabel = context.l10n.photos;
+        } else if (convoSource == ConversationSource.screenpipe) {
+          contentTabLabel = context.l10n.rawData;
+        } else {
+          contentTabLabel = context.l10n.content;
+        }
 
         return PopScope(
           canPop: true,
@@ -81,13 +89,7 @@ class _ProcessingConversationPageState extends State<ProcessingConversationPage>
                   controller: _controller,
                   labelStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18),
                   tabs: [
-                    Tab(
-                      text: convoSource == ConversationSource.openglass
-                          ? context.l10n.photos
-                          : convoSource == ConversationSource.screenpipe
-                          ? context.l10n.rawData
-                          : context.l10n.content,
-                    ),
+                    Tab(text: contentTabLabel),
                     Tab(text: context.l10n.summary),
                   ],
                   indicator: BoxDecoration(color: Colors.transparent, borderRadius: BorderRadius.circular(16)),

--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -61,8 +61,6 @@ class NotificationUtil {
   }
 
   static void _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
-    // Always ensure that all plugins was initialized
-    // TODO: for what?
     WidgetsFlutterBinding.ensureInitialized();
 
     String? navigateTo;
@@ -75,9 +73,7 @@ class NotificationUtil {
     }
 
     globalNavigatorKey.currentState?.pushReplacement(
-      MaterialPageRoute(
-        builder: (context) => HomePageWrapper(navigateToRoute: navigateTo),
-      ),
+      MaterialPageRoute(builder: (context) => HomePageWrapper(navigateToRoute: navigateTo)),
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds a root policy requiring new `TODO`, `FIXME`, and `HACK` comments to be resolved or linked to tracking issues.
- Adds a reusable deferred-work marker counter with raw and normalized modes.
- Surfaces a non-blocking marker count in the lint workflow summary.
- Removes two stale deferred-work comments from Flutter code.

## Validation
- `black --line-length 120 --skip-string-normalization .github/scripts/deferred-work-marker-count.py` passed.
- `python3 -m py_compile .github/scripts/deferred-work-marker-count.py` passed.
- `python3 .github/scripts/deferred-work-marker-count.py --raw` passed.
- `python3 .github/scripts/deferred-work-marker-count.py` passed.
- `python3 .github/scripts/deferred-work-marker-count.py --format github-summary` passed.
- `git diff --check` passed.
- Commit hook ran during commit.

Counts at HEAD:
- Raw: 969 total across 247 files.
- Normalized: 265 total across 148 files.

Closes #8549


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

