### PR TITLE
[codex] Add CI architecture guardrails

### DIFF
--- a/.github/scripts/check_arch_guardrails.py
+++ b/.github/scripts/check_arch_guardrails.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Advisory architecture guardrails for changed files.
+
+Warns on large changed files and long functions, then exits 0. This script is
+intentionally stdlib-only so it can run early in CI without setup steps.
+"""
+
+import argparse
+import ast
+import os
+import re
+from pathlib import Path
+
+
+SOURCE_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".dart",
+    ".h",
+    ".hpp",
+    ".js",
+    ".jsx",
+    ".kt",
+    ".m",
+    ".mm",
+    ".py",
+    ".rs",
+    ".swift",
+    ".ts",
+    ".tsx",
+}
+SKIP_SUFFIXES = (
+    ".gen.dart",
+    ".g.dart",
+    ".lock",
+    ".min.js",
+)
+SKIP_PARTS = {
+    ".git",
+    ".next",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "target",
+}
+BRACE_FUNCTION_RE = re.compile(
+    r"""
+    ^\s*
+    (?:
+      (?:public|private|internal|fileprivate|open|static|async|export|default|mutating|override|final|inline)\s+
+    )*
+    (?:
+      func\s+\w+|
+      function\s+\w+|
+      async\s+function\s+\w+|
+      fn\s+\w+|
+      [A-Za-z_][\w:<>\[\]\?&\*\s]+\s+[A-Za-z_]\w*\s*\([^;]*\)
+    )
+    [^{;]*\{
+    """,
+    re.VERBOSE,
+)
+
+
+def source_file(path):
+    if path.suffix not in SOURCE_EXTENSIONS:
+        return False
+    if path.name.endswith(SKIP_SUFFIXES):
+        return False
+    return not any(part in SKIP_PARTS for part in path.parts)
+
+
+def annotation_escape(value):
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_warning(path, line, title, message):
+    print(
+        f"::warning file={annotation_escape(path)},line={line},title={annotation_escape(title)}::"
+        f"{annotation_escape(message)}"
+    )
+
+
+def read_changed_files(path):
+    changed = []
+    with path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            raw_path = raw_line.strip()
+            if raw_path:
+                changed.append(Path(raw_path))
+    return changed
+
+
+def python_functions(path, source):
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    functions = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end_line = getattr(node, "end_lineno", node.lineno)
+        functions.append((node.name, node.lineno, end_line, end_line - node.lineno + 1))
+    return functions
+
+
+def brace_functions(path, lines):
+    functions = []
+    in_function = None
+    brace_depth = 0
+
+    for index, line in enumerate(lines, start=1):
+        if in_function is None:
+            if not BRACE_FUNCTION_RE.search(line):
+                continue
+            in_function = {
+                "name": line.strip().split("{", 1)[0].strip()[:80] or path.name,
+                "line": index,
+            }
+            brace_depth = line.count("{") - line.count("}")
+            if brace_depth <= 0:
+                functions.append((in_function["name"], index, index, 1))
+                in_function = None
+            continue
+
+        brace_depth += line.count("{") - line.count("}")
+        if brace_depth <= 0:
+            start = in_function["line"]
+            functions.append((in_function["name"], start, index, index - start + 1))
+            in_function = None
+
+    return functions
+
+
+def long_functions(path, source, line_threshold):
+    if path.suffix == ".py":
+        functions = python_functions(path, source)
+    else:
+        functions = brace_functions(path, source.splitlines())
+    return [item for item in functions if item[3] > line_threshold]
+
+
+def write_summary(warnings, file_threshold, function_threshold):
+    lines = [
+        "## Architecture guardrails",
+        "",
+        f"Advisory thresholds: files over {file_threshold} lines, functions over {function_threshold} lines.",
+        "",
+    ]
+    if not warnings:
+        lines.append("No advisory architecture warnings for changed files.")
+    else:
+        lines.append("| Type | Location | Detail |")
+        lines.append("| --- | --- | --- |")
+        for warning in warnings:
+            lines.append(f"| {warning['type']} | {warning['location']} | {warning['detail']} |")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+            handle.write("\n")
+    else:
+        print("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Warn on large changed files and long functions")
+    parser.add_argument("--changed-files", default="/tmp/changed-files.txt", type=Path)
+    parser.add_argument("--file-lines", default=800, type=int)
+    parser.add_argument("--function-lines", default=150, type=int)
+    args = parser.parse_args()
+
+    warnings = []
+    if not args.changed_files.exists():
+        write_summary(warnings, args.file_lines, args.function_lines)
+        return 0
+
+    for path in read_changed_files(args.changed_files):
+        if not path.exists() or not path.is_file() or not source_file(path):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        line_count = source.count("\n") + (0 if source.endswith("\n") or not source else 1)
+        if line_count > args.file_lines:
+            message = f"{path} is {line_count} lines; consider splitting files over {args.file_lines} lines."
+            emit_warning(path, 1, "Large changed file", message)
+            warnings.append({"type": "File size", "location": f"{path}:1", "detail": f"{line_count} lines"})
+
+        for name, start, _end, length in long_functions(path, source, args.function_lines):
+            message = (
+                f"{name} is {length} lines; consider extracting focused helpers over " f"{args.function_lines} lines."
+            )
+            emit_warning(path, start, "Long function", message)
+            warnings.append({"type": "Function length", "location": f"{path}:{start}", "detail": message})
+
+    write_summary(warnings, args.file_lines, args.function_lines)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
           FILES=$(git diff --name-only --diff-filter=ACM "$DIFF_BASE"...HEAD)
           echo "$FILES"
           echo "$FILES" > /tmp/changed-files.txt
+          echo "diff_base=$DIFF_BASE" >> $GITHUB_OUTPUT
           echo "has_dart=$(echo "$FILES" | grep -q '\.dart$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_python=$(echo "$FILES" | grep -q 'backend/.*\.py$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_arb=$(echo "$FILES" | grep -q '\.arb$' && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -34,6 +35,7 @@ jobs:
           echo "has_frontend=$(echo "$FILES" | grep -q '^web/frontend/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_workflows=$(echo "$FILES" | grep -qE '^\.github/workflows/.*\.ya?ml$|^\.github/actionlint\.ya?ml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_backend_async_gate=$(echo "$FILES" | grep -qE '^backend/.*\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
           echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -52,6 +54,9 @@ jobs:
             echo "FAIL: unresolved merge conflict markers found in changed files"
             exit 1
           fi
+
+      - name: Architecture guardrail warnings
+        run: python3 .github/scripts/check_arch_guardrails.py --changed-files /tmp/changed-files.txt
 
       - name: Check desktop changelog data
         run: python3 .github/scripts/desktop-changelog.py validate
@@ -110,6 +115,14 @@ jobs:
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs black --check --line-length 120 --skip-string-normalization
           fi
+
+      - name: Check backend async blockers
+        if: steps.changed.outputs.has_backend_async_gate == 'true'
+        run: |
+          python3 backend/scripts/scan_async_blockers.py \
+            --dirs backend/routers backend/utils \
+            --diff-base "${{ steps.changed.outputs.diff_base }}" \
+            --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def
 
       # -- ARB --
       - name: Check ARB formatting

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -175,7 +175,7 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     4. **Long-running coordinators need async orchestration or sized pools.** If a coordinator holds a thread pool slot for >10s, it must either use async coordination (`asyncio.create_task` + `await run_blocking(...)`) or run on a pool sized for `hold_time × peak_concurrency`. Prefer async coordination for any coordinator with hold time >60s — thread slots occupied by sleeping coordinators waste memory and starve other work.
   - **Audit command:** `grep -rn '\.result()' --include="*.py" | grep -v tests/ | grep -v __pycache__` — every hit must be a leaf operation or a coordinator on a different pool from its children.
   - **Pool observability:** `get_executor_metrics()` returns active count, queue depth, and utilization % for all pools. `log_executor_health()` runs every 60s, warns when any pool exceeds 70% utilization. Wired in `main.py` startup event.
-- **Lane 3 — Lint**: `python scripts/lint_async_blockers.py` catches `requests.*`, `time.sleep()`, `Thread().start()` in async code. Run before committing.
+- **Lane 3 — Lint**: `python scripts/scan_async_blockers.py --dirs backend/routers backend/utils` catches blocking calls in async routes and helpers. Run before committing.
 - **Shutdown**: `close_all_clients()` + `shutdown_executors()` wired in `main.py` and `pusher/main.py`.
 
 ## WebSocket Concurrency (Long-Lived Connections)

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -175,7 +175,7 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     4. **Long-running coordinators need async orchestration or sized pools.** If a coordinator holds a thread pool slot for >10s, it must either use async coordination (`asyncio.create_task` + `await run_blocking(...)`) or run on a pool sized for `hold_time × peak_concurrency`. Prefer async coordination for any coordinator with hold time >60s — thread slots occupied by sleeping coordinators waste memory and starve other work.
   - **Audit command:** `grep -rn '\.result()' --include="*.py" | grep -v tests/ | grep -v __pycache__` — every hit must be a leaf operation or a coordinator on a different pool from its children.
   - **Pool observability:** `get_executor_metrics()` returns active count, queue depth, and utilization % for all pools. `log_executor_health()` runs every 60s, warns when any pool exceeds 70% utilization. Wired in `main.py` startup event.
-- **Lane 3 — Lint**: `python scripts/scan_async_blockers.py --dirs backend/routers backend/utils` catches blocking calls in async routes and helpers. Run before committing.
+- **Lane 3 — Lint**: `python scripts/scan_async_blockers.py --dirs routers utils` catches blocking calls in async routes and helpers. Run from `backend/` before committing. From the repository root, use `python backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils`.
 - **Shutdown**: `close_all_clients()` + `shutdown_executors()` wired in `main.py` and `pusher/main.py`.
 
 ## WebSocket Concurrency (Long-Lived Connections)

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -192,7 +192,10 @@ def collect_py_files(dirs):
 
 
 def _line_span(node):
-    return node.lineno, getattr(node, "end_lineno", node.lineno)
+    start_line = node.lineno
+    if node.decorator_list:
+        start_line = min(dec.lineno for dec in node.decorator_list)
+    return start_line, getattr(node, "end_lineno", node.lineno)
 
 
 def scan_dirs(dirs):
@@ -307,8 +310,8 @@ def _diff_paths(dirs):
     return [_normalize_path(d.rstrip("/")) for d in dirs]
 
 
-def changed_line_ranges(diff_base, dirs):
-    """Return changed new-file line ranges keyed by repo-relative path."""
+def changed_scope(diff_base, dirs):
+    """Return changed line ranges and import-changed files for diff-scoped failures."""
     cmd = [
         "git",
         "diff",
@@ -320,6 +323,7 @@ def changed_line_ranges(diff_base, dirs):
     ]
     proc = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE)
     ranges_by_file = {}
+    import_changed_files = set()
     current_file = None
     hunk_re = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
@@ -328,22 +332,33 @@ def changed_line_ranges(diff_base, dirs):
             current_file = line.removeprefix("+++ b/")
             ranges_by_file.setdefault(current_file, [])
             continue
-        if current_file is None or not line.startswith("@@"):
+        if current_file is None:
             continue
-        match = hunk_re.match(line)
-        if not match:
+        if line.startswith("@@"):
+            match = hunk_re.match(line)
+            if not match:
+                continue
+            start = int(match.group(1))
+            count = int(match.group(2) or "1")
+            if count == 0:
+                continue
+            ranges_by_file[current_file].append((start, start + count - 1))
             continue
-        start = int(match.group(1))
-        count = int(match.group(2) or "1")
-        if count == 0:
+        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
             continue
-        ranges_by_file[current_file].append((start, start + count - 1))
+        changed_source = line[1:].strip()
+        if changed_source.startswith(("import ", "from ")):
+            import_changed_files.add(current_file)
 
-    return ranges_by_file
+    return {"ranges": ranges_by_file, "import_changed_files": import_changed_files}
 
 
-def finding_touches_changed_lines(finding, changed_ranges):
-    file_ranges = changed_ranges.get(_normalize_path(finding["file"]), [])
+def finding_in_changed_scope(finding, scope):
+    file_path = _normalize_path(finding["file"])
+    if file_path in scope["import_changed_files"]:
+        return True
+
+    file_ranges = scope["ranges"].get(file_path, [])
     if not file_ranges:
         return False
     start = finding["line"]
@@ -353,7 +368,7 @@ def finding_touches_changed_lines(finding, changed_ranges):
 
 def _finding_qualifies(category, finding):
     if category == "no_await_should_be_def":
-        return finding.get("all_calls_are_blocking", False)
+        return bool(finding.get("all_blocking"))
     return True
 
 
@@ -372,13 +387,13 @@ def normalize_fail_on(values):
     return tuple(dict.fromkeys(categories))
 
 
-def selected_failures(results, fail_on, changed_ranges=None):
+def selected_failures(results, fail_on, scope=None):
     failures = []
     for category in fail_on:
         for finding in results.get(category, []):
             if not _finding_qualifies(category, finding):
                 continue
-            if changed_ranges is not None and not finding_touches_changed_lines(finding, changed_ranges):
+            if scope is not None and not finding_in_changed_scope(finding, scope):
                 continue
             failures.append((category, finding))
     return failures
@@ -464,8 +479,8 @@ def main():
     parser.add_argument(
         "--diff-base",
         help=(
-            "Only fail findings whose function line range intersects lines changed since this git ref. "
-            "The full report is still printed."
+            "Only fail findings whose function/decorator line range intersects lines changed since this git ref, "
+            "or findings in files with changed imports. The full report is still printed."
         ),
     )
     args = parser.parse_args()
@@ -477,17 +492,21 @@ def main():
             sys.exit(2)
 
     results = scan_dirs(args.dirs)
-    changed_ranges = changed_line_ranges(args.diff_base, args.dirs) if args.diff_base else None
-    failures = selected_failures(results, fail_on, changed_ranges)
+    scope = changed_scope(args.diff_base, args.dirs) if args.diff_base else None
+    failures = selected_failures(results, fail_on, scope)
 
     if args.json:
         json.dump(results, sys.stdout, indent=2)
         print()
     else:
         print_report(results)
-        scope = f"changed function ranges since {args.diff_base}" if args.diff_base else "all scanned functions"
+        scope_label = (
+            f"changed function/decorator ranges and import-changed files since {args.diff_base}"
+            if args.diff_base
+            else "all scanned functions"
+        )
         print(f"Fail-on policy: {', '.join(fail_on) if fail_on else '(none)'}")
-        print(f"Fail-on scope: {scope}")
+        print(f"Fail-on scope: {scope_label}")
         print(f"Selected blocking findings: {len(failures)}")
         for category, finding in failures:
             label = finding.get("endpoint") or finding.get("function") or "async def"

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -15,13 +15,30 @@ as arguments to these wrappers).
 
 Usage:
   python3 scan_async_blockers.py [--dirs backend/routers backend/utils] [--json]
+  python3 scan_async_blockers.py --diff-base origin/main --fail-on high_network_io,mixed_await_sync_db
 
 Exit codes:
-  0 = clean (no HIGH findings)
-  1 = HIGH findings present
+  0 = clean for the selected fail-on policy
+  1 = selected fail-on findings present
 """
 
-import ast, os, sys, json, argparse
+import argparse
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+
+DEFAULT_FAIL_ON = ("high_network_io",)
+FAIL_ON_CATEGORIES = (
+    "high_network_io",
+    "async_helpers_with_blocking",
+    "time_sleep",
+    "mixed_await_sync_db",
+    "no_await_should_be_def",
+    "medium_file_io",
+)
 
 
 def get_db_imports(source):
@@ -53,8 +70,13 @@ def get_storage_imports(source):
     return names
 
 
+def _walk_body(node):
+    for stmt in node.body:
+        yield from ast.walk(stmt)
+
+
 def has_await(node):
-    for child in ast.walk(node):
+    for child in _walk_body(node):
         if isinstance(child, ast.Await):
             return True
     return False
@@ -118,16 +140,18 @@ def scan_async_function(node, db_names, db_module_aliases, storage_names):
     file_io = []
     network_io = []
     sleeps = []
+    body_call_lines = set()
 
     offloaded = _get_offloaded_lines(node)
     nested = _collect_nested_func_lines(node)
 
-    for child in ast.walk(node):
+    for child in _walk_body(node):
         if not isinstance(child, ast.Call):
             continue
         line = child.lineno
         if line in offloaded or line in nested:
             continue
+        body_call_lines.add(line)
         if isinstance(child.func, ast.Name):
             if child.func.id in db_names:
                 db_calls.append({"line": line, "call": child.func.id})
@@ -154,7 +178,7 @@ def scan_async_function(node, db_names, db_module_aliases, storage_names):
             ):
                 network_io.append({"line": line, "call": "creds.refresh() [sync HTTP]"})
 
-    return db_calls, file_io, network_io, sleeps
+    return db_calls, file_io, network_io, sleeps, body_call_lines
 
 
 def collect_py_files(dirs):
@@ -165,6 +189,10 @@ def collect_py_files(dirs):
                 if fname.endswith('.py') and fname != '__init__.py':
                     files.append(os.path.join(root, fname))
     return sorted(files)
+
+
+def _line_span(node):
+    return node.lineno, getattr(node, "end_lineno", node.lineno)
 
 
 def scan_dirs(dirs):
@@ -205,16 +233,20 @@ def scan_dirs(dirs):
                 continue
 
             is_endpoint = any('router' in ast.dump(d).lower() for d in node.decorator_list)
-            db_calls, file_io, network_io, sleeps = scan_async_function(
+            db_calls, file_io, network_io, sleeps, body_call_lines = scan_async_function(
                 node, db_names, db_module_aliases, storage_names
             )
             endpoint_has_await = has_await(node)
+            start_line, end_line = _line_span(node)
+            blocking_call_lines = {call["line"] for call in db_calls + file_io + network_io + sleeps}
+            all_calls_are_blocking = bool(body_call_lines) and body_call_lines <= blocking_call_lines
 
             if is_endpoint:
                 method, path = get_route_info(node.decorator_list)
                 entry = {
                     "file": fpath,
-                    "line": node.lineno,
+                    "line": start_line,
+                    "end_line": end_line,
                     "endpoint": node.name,
                     "method": method,
                     "path": path,
@@ -229,7 +261,12 @@ def scan_dirs(dirs):
                     results["time_sleep"].append({**entry, "calls": sleeps})
                 if not endpoint_has_await:
                     results["no_await_should_be_def"].append(
-                        {**entry, "db_calls": db_calls, "all_blocking": db_calls + file_io + network_io}
+                        {
+                            **entry,
+                            "db_calls": db_calls,
+                            "all_blocking": db_calls + file_io + network_io + sleeps,
+                            "all_calls_are_blocking": all_calls_are_blocking,
+                        }
                     )
                 elif db_calls:
                     results["mixed_await_sync_db"].append({**entry, "db_calls": db_calls})
@@ -238,7 +275,8 @@ def scan_dirs(dirs):
                     results["async_helpers_with_blocking"].append(
                         {
                             "file": fpath,
-                            "line": node.lineno,
+                            "line": start_line,
+                            "end_line": end_line,
                             "function": node.name,
                             "network_io": network_io,
                             "file_io": file_io,
@@ -259,6 +297,91 @@ def scan_dirs(dirs):
         "async_helpers_with_blocking": len(results["async_helpers_with_blocking"]),
     }
     return results
+
+
+def _normalize_path(path):
+    return path.replace(os.sep, "/")
+
+
+def _diff_paths(dirs):
+    return [_normalize_path(d.rstrip("/")) for d in dirs]
+
+
+def changed_line_ranges(diff_base, dirs):
+    """Return changed new-file line ranges keyed by repo-relative path."""
+    cmd = [
+        "git",
+        "diff",
+        "--unified=0",
+        "--diff-filter=ACM",
+        f"{diff_base}...HEAD",
+        "--",
+        *_diff_paths(dirs),
+    ]
+    proc = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE)
+    ranges_by_file = {}
+    current_file = None
+    hunk_re = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+    for line in proc.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line.removeprefix("+++ b/")
+            ranges_by_file.setdefault(current_file, [])
+            continue
+        if current_file is None or not line.startswith("@@"):
+            continue
+        match = hunk_re.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        if count == 0:
+            continue
+        ranges_by_file[current_file].append((start, start + count - 1))
+
+    return ranges_by_file
+
+
+def finding_touches_changed_lines(finding, changed_ranges):
+    file_ranges = changed_ranges.get(_normalize_path(finding["file"]), [])
+    if not file_ranges:
+        return False
+    start = finding["line"]
+    end = finding.get("end_line", start)
+    return any(start <= changed_end and end >= changed_start for changed_start, changed_end in file_ranges)
+
+
+def _finding_qualifies(category, finding):
+    if category == "no_await_should_be_def":
+        return finding.get("all_calls_are_blocking", False)
+    return True
+
+
+def normalize_fail_on(values):
+    categories = []
+    for value in values:
+        for category in value.split(","):
+            category = category.strip()
+            if category:
+                categories.append(category)
+    unknown = sorted(set(categories) - set(FAIL_ON_CATEGORIES))
+    if unknown:
+        print(f"Error: unknown --fail-on categories: {', '.join(unknown)}", file=sys.stderr)
+        print(f"Valid categories: {', '.join(FAIL_ON_CATEGORIES)}", file=sys.stderr)
+        sys.exit(2)
+    return tuple(dict.fromkeys(categories))
+
+
+def selected_failures(results, fail_on, changed_ranges=None):
+    failures = []
+    for category in fail_on:
+        for finding in results.get(category, []):
+            if not _finding_qualifies(category, finding):
+                continue
+            if changed_ranges is not None and not finding_touches_changed_lines(finding, changed_ranges):
+                continue
+            failures.append((category, finding))
+    return failures
 
 
 def print_report(results):
@@ -327,7 +450,26 @@ def main():
         help="Directories to scan (default: backend/routers backend/utils)",
     )
     parser.add_argument("--json", action="store_true", help="Output JSON instead of text")
+    parser.add_argument(
+        "--fail-on",
+        action="append",
+        default=None,
+        metavar="CATEGORY[,CATEGORY...]",
+        help=(
+            "Finding categories that should make the scanner exit 1. "
+            f"Valid categories: {', '.join(FAIL_ON_CATEGORIES)}. "
+            f"Default: {','.join(DEFAULT_FAIL_ON)}"
+        ),
+    )
+    parser.add_argument(
+        "--diff-base",
+        help=(
+            "Only fail findings whose function line range intersects lines changed since this git ref. "
+            "The full report is still printed."
+        ),
+    )
     args = parser.parse_args()
+    fail_on = normalize_fail_on(args.fail_on or [",".join(DEFAULT_FAIL_ON)])
 
     for d in args.dirs:
         if not os.path.isdir(d):
@@ -335,15 +477,23 @@ def main():
             sys.exit(2)
 
     results = scan_dirs(args.dirs)
+    changed_ranges = changed_line_ranges(args.diff_base, args.dirs) if args.diff_base else None
+    failures = selected_failures(results, fail_on, changed_ranges)
 
     if args.json:
         json.dump(results, sys.stdout, indent=2)
         print()
     else:
         print_report(results)
+        scope = f"changed function ranges since {args.diff_base}" if args.diff_base else "all scanned functions"
+        print(f"Fail-on policy: {', '.join(fail_on) if fail_on else '(none)'}")
+        print(f"Fail-on scope: {scope}")
+        print(f"Selected blocking findings: {len(failures)}")
+        for category, finding in failures:
+            label = finding.get("endpoint") or finding.get("function") or "async def"
+            print(f"  {category}: {finding['file']}:{finding['line']} | {label}")
 
-    has_high = results["summary"]["high_network_io"] > 0
-    sys.exit(1 if has_high else 0)
+    sys.exit(1 if failures else 0)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -316,7 +316,7 @@ def changed_scope(diff_base, dirs):
         "git",
         "diff",
         "--unified=0",
-        "--diff-filter=ACM",
+        "--diff-filter=ACMR",
         f"{diff_base}...HEAD",
         "--",
         *_diff_paths(dirs),
@@ -341,6 +341,13 @@ def changed_scope(diff_base, dirs):
             start = int(match.group(1))
             count = int(match.group(2) or "1")
             if count == 0:
+                # Deletion-only hunks have an empty new-side range (for example
+                # ``+42,0``). Keep the adjacent post-delete line in scope so
+                # diff-scoped fail-on checks still catch regressions caused by
+                # removing an await/offload inside an otherwise unchanged async
+                # function.
+                start = max(start, 1)
+                ranges_by_file[current_file].append((start, start))
                 continue
             ranges_by_file[current_file].append((start, start + count - 1))
             continue
@@ -367,8 +374,6 @@ def finding_in_changed_scope(finding, scope):
 
 
 def _finding_qualifies(category, finding):
-    if category == "no_await_should_be_def":
-        return bool(finding.get("all_blocking"))
     return True
 
 

--- a/backend/tests/unit/test_async_resource_correctness.py
+++ b/backend/tests/unit/test_async_resource_correctness.py
@@ -224,6 +224,70 @@ async def helper():
     tree = ast.parse(source)
     node = next(n for n in tree.body if getattr(n, "name", None) == "helper")
 
-    _db, file_io, _network, _sleeps = scanner.scan_async_function(node, set(), set(), set())
+    _db, file_io, _network, _sleeps, _body_call_lines = scanner.scan_async_function(node, set(), set(), set())
 
     assert file_io == []
+
+
+def test_scan_async_blockers_keeps_deletion_only_hunks_in_changed_scope(monkeypatch):
+    scanner = _load_module(
+        "scan_async_blockers_diff_scope_for_test", BACKEND_DIR / "scripts" / "scan_async_blockers.py"
+    )
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured["cmd"] = args[0]
+        return types.SimpleNamespace(stdout="""
+diff --git a/backend/routers/example.py b/backend/routers/example.py
+index 1111111..2222222 100644
+--- a/backend/routers/example.py
++++ b/backend/routers/example.py
+@@ -42 +42,0 @@ async def endpoint():
+-    await run_blocking(db_executor, expensive_sync_call)
+diff --git a/backend/routers/old_name.py b/backend/routers/new_name.py
+similarity index 96%
+rename from backend/routers/old_name.py
+rename to backend/routers/new_name.py
+--- a/backend/routers/old_name.py
++++ b/backend/routers/new_name.py
+@@ -10 +10 @@ async def renamed_endpoint():
+-    await old_call()
++    await new_call()
+""")
+
+    monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+
+    scope = scanner.changed_scope("origin/main", ["backend/routers"])
+
+    assert "--diff-filter=ACMR" in captured["cmd"]
+    assert scope["ranges"]["backend/routers/example.py"] == [(42, 42)]
+    assert scope["ranges"]["backend/routers/new_name.py"] == [(10, 10)]
+    assert scanner.finding_in_changed_scope(
+        {"file": "backend/routers/example.py", "line": 40, "end_line": 45},
+        scope,
+    )
+
+
+def test_scan_async_blockers_honors_no_await_fail_on_without_blocking_calls():
+    scanner = _load_module("scan_async_blockers_fail_on_for_test", BACKEND_DIR / "scripts" / "scan_async_blockers.py")
+
+    results = {
+        "no_await_should_be_def": [
+            {
+                "file": "backend/routers/example.py",
+                "line": 12,
+                "end_line": 16,
+                "endpoint": "endpoint",
+                "method": "GET",
+                "path": "/example",
+                "has_await": False,
+                "db_calls": [],
+                "all_blocking": [],
+                "all_calls_are_blocking": False,
+            }
+        ]
+    }
+
+    assert scanner.selected_failures(results, ("no_await_should_be_def",)) == [
+        ("no_await_should_be_def", results["no_await_should_be_def"][0])
+    ]


### PR DESCRIPTION
## Summary
- Adds advisory architecture guardrails for large changed files and long functions in the existing lint workflow.
- Promotes the backend async-blocker scanner into CI for backend changes.
- Adds explicit `--fail-on` and diff-scoped enforcement to avoid blocking unrelated legacy findings.
- Fixes stale backend docs to reference `scan_async_blockers.py`.

## Validation
- `python3 -m py_compile .github/scripts/check_arch_guardrails.py backend/scripts/scan_async_blockers.py` passed.
- `python3 .github/scripts/check_arch_guardrails.py --changed-files /tmp/wave1-8548-review-files.txt` passed and remains advisory.
- `python3 backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils --diff-base origin/main --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def` passed with 0 selected findings.
- `python3 -m black --check --line-length 120 --skip-string-normalization .github/scripts/check_arch_guardrails.py backend/scripts/scan_async_blockers.py` passed.
- `git diff --check origin/main...HEAD` passed.
- Worker ran `actionlint -shellcheck "" .github/workflows/lint.yml` successfully.
- Pre-implementation and pre-PR Oracle reviews completed; P2 findings were addressed.

Closes #8548


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

