### PR TITLE
fix(plugins): point omi-twitter-app Procfile at main_simple:app (#8553)

### DIFF
--- a/plugins/omi-twitter-app/Procfile
+++ b/plugins/omi-twitter-app/Procfile
@@ -1,2 +1,2 @@
-web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}
+web: uvicorn main_simple:app --host 0.0.0.0 --port ${PORT:-8000}
 


### PR DESCRIPTION
## Bug
`plugins/omi-twitter-app/Procfile` runs:
```
web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}
```
but there is **no `main.py`** in that directory — the only module is `main_simple.py`, which defines the FastAPI app:
```
$ ls plugins/omi-twitter-app/main*.py
plugins/omi-twitter-app/main_simple.py
$ grep -n '^app =' plugins/omi-twitter-app/main_simple.py
20:app = FastAPI(
```
So the plugin fails to boot on Railway/Heroku with a `ModuleNotFoundError: No module named 'main'` the moment uvicorn tries to import the `app` symbol.

## Root cause
The Procfile module path (`main`) does not match the actual module filename (`main_simple`).

## Fix
Point uvicorn at the module that actually exposes `app`: `main_simple:app`. One line, no logic change.

## Canonical-plugin note
The adjacent `plugins/omi-twitter-chat-tools-app/` is a **separate, complete** plugin (its own `main.py`, `Procfile`, `db.py`, `models.py`, `railway.toml`). They are not duplicates of each other, so neither is deleted here — `omi-twitter-app` is the lightweight "simple" variant and only its Procfile was wrong.

## Verification
- `python3 -m py_compile main_simple.py` → OK
- `app = FastAPI(...)` confirmed present in `main_simple.py` (line 20), so `main_simple:app` resolves.

Resolves #8553.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

