### PR TITLE
[codex] Escape Windows Rewind search wildcards

### DIFF
--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -3,6 +3,7 @@ import { app } from 'electron'
 import { basename, join } from 'path'
 import { categorize } from '../usage/category'
 import { isNewLocalDay } from '../usage/usageDay'
+import { buildRewindSearchQuery } from '../rewind/rewindSearchQuery'
 import type {
   AppUsageRecord,
   ChatMessage,
@@ -737,14 +738,15 @@ export function listRewindFrames(from: number, to: number): RewindFrame[] {
 
 export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
   return timed('searchRewindFrames', () => {
-    const like = `%${query}%`
+    const search = buildRewindSearchQuery(query)
+    if (!search) return []
     return get()
       .prepare(
         `SELECT ${REWIND_COLUMNS} FROM rewind_frames
-       WHERE ocr_text LIKE ? OR window_title LIKE ? OR app LIKE ?
+       WHERE ${search.where}
        ORDER BY ts DESC LIMIT ?`
       )
-      .all(like, like, like, limit) as RewindFrame[]
+      .all(...search.params, limit) as RewindFrame[]
   })
 }
 

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
@@ -26,6 +26,11 @@ describe('rewindSearchQuery', () => {
     expect(tokenizeRewindSearchQuery(huge)).toEqual(['a'.repeat(REWIND_SEARCH_QUERY_CHAR_LIMIT)])
   })
 
+  it('does not let leading whitespace consume the query text cap', () => {
+    const padded = `${' '.repeat(REWIND_SEARCH_QUERY_CHAR_LIMIT + 20)}visual studio`
+    expect(tokenizeRewindSearchQuery(padded)).toEqual(['visual', 'studio'])
+  })
+
   it('escapes LIKE wildcards and the escape character itself', () => {
     expect(escapeRewindSearchLikeToken('100%_done\\today')).toBe('100\\%\\_done\\\\today')
   })

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRewindSearchQuery,
+  escapeRewindSearchLikeToken,
+  REWIND_SEARCH_TOKEN_LIMIT,
+  tokenizeRewindSearchQuery
+} from './rewindSearchQuery'
+
+describe('rewindSearchQuery', () => {
+  it('normalizes whitespace and caps the number of SQL terms', () => {
+    expect(tokenizeRewindSearchQuery('  visual   studio  code ')).toEqual([
+      'visual',
+      'studio',
+      'code'
+    ])
+
+    const many = Array.from({ length: REWIND_SEARCH_TOKEN_LIMIT + 3 }, (_, i) => `term${i}`).join(
+      ' '
+    )
+    expect(tokenizeRewindSearchQuery(many)).toHaveLength(REWIND_SEARCH_TOKEN_LIMIT)
+  })
+
+  it('escapes LIKE wildcards and the escape character itself', () => {
+    expect(escapeRewindSearchLikeToken('100%_done\\today')).toBe('100\\%\\_done\\\\today')
+  })
+
+  it('builds an all-token search across OCR text, app, and window title', () => {
+    const sql = buildRewindSearchQuery('visual studio')
+
+    expect(sql?.where).toBe(
+      "(ocr_text LIKE ? ESCAPE '\\' OR window_title LIKE ? ESCAPE '\\' OR app LIKE ? ESCAPE '\\') AND (ocr_text LIKE ? ESCAPE '\\' OR window_title LIKE ? ESCAPE '\\' OR app LIKE ? ESCAPE '\\')"
+    )
+    expect(sql?.params).toEqual(Array(3).fill('%visual%').concat(Array(3).fill('%studio%')))
+  })
+
+  it('treats percent and underscore as literal search characters', () => {
+    const sql = buildRewindSearchQuery('100% done_')
+
+    expect(sql?.params).toEqual(Array(3).fill('%100\\%%').concat(Array(3).fill('%done\\_%')))
+  })
+
+  it('returns null for an empty query', () => {
+    expect(buildRewindSearchQuery('   ')).toBeNull()
+  })
+})

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildRewindSearchQuery,
   escapeRewindSearchLikeToken,
+  REWIND_SEARCH_QUERY_CHAR_LIMIT,
   REWIND_SEARCH_TOKEN_LIMIT,
   tokenizeRewindSearchQuery
 } from './rewindSearchQuery'
@@ -18,6 +19,11 @@ describe('rewindSearchQuery', () => {
       ' '
     )
     expect(tokenizeRewindSearchQuery(many)).toHaveLength(REWIND_SEARCH_TOKEN_LIMIT)
+  })
+
+  it('limits scanned query text before tokenizing large inputs', () => {
+    const huge = `${'a'.repeat(REWIND_SEARCH_QUERY_CHAR_LIMIT + 20)} tail`
+    expect(tokenizeRewindSearchQuery(huge)).toEqual(['a'.repeat(REWIND_SEARCH_QUERY_CHAR_LIMIT)])
   })
 
   it('escapes LIKE wildcards and the escape character itself', () => {

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.ts
@@ -1,0 +1,33 @@
+const SEARCH_FIELDS = ['ocr_text', 'window_title', 'app'] as const
+
+export const REWIND_SEARCH_TOKEN_LIMIT = 8
+
+export type RewindSearchSql = {
+  where: string
+  params: string[]
+}
+
+export function tokenizeRewindSearchQuery(query: string): string[] {
+  return query.trim().split(/\s+/).filter(Boolean).slice(0, REWIND_SEARCH_TOKEN_LIMIT)
+}
+
+export function escapeRewindSearchLikeToken(token: string): string {
+  return token.replace(/[\\%_]/g, (ch) => `\\${ch}`)
+}
+
+export function buildRewindSearchQuery(query: string): RewindSearchSql | null {
+  const tokens = tokenizeRewindSearchQuery(query)
+  if (tokens.length === 0) return null
+
+  const params: string[] = []
+  const clauses = tokens.map((token) => {
+    const pattern = `%${escapeRewindSearchLikeToken(token)}%`
+    SEARCH_FIELDS.forEach(() => params.push(pattern))
+    return `(${SEARCH_FIELDS.map((field) => `${field} LIKE ? ESCAPE '\\'`).join(' OR ')})`
+  })
+
+  return {
+    where: clauses.join(' AND '),
+    params
+  }
+}

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.ts
@@ -10,8 +10,8 @@ export type RewindSearchSql = {
 
 export function tokenizeRewindSearchQuery(query: string): string[] {
   return query
-    .slice(0, REWIND_SEARCH_QUERY_CHAR_LIMIT)
     .trim()
+    .slice(0, REWIND_SEARCH_QUERY_CHAR_LIMIT)
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, REWIND_SEARCH_TOKEN_LIMIT)

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.ts
@@ -1,6 +1,7 @@
 const SEARCH_FIELDS = ['ocr_text', 'window_title', 'app'] as const
 
 export const REWIND_SEARCH_TOKEN_LIMIT = 8
+export const REWIND_SEARCH_QUERY_CHAR_LIMIT = 512
 
 export type RewindSearchSql = {
   where: string
@@ -8,7 +9,12 @@ export type RewindSearchSql = {
 }
 
 export function tokenizeRewindSearchQuery(query: string): string[] {
-  return query.trim().split(/\s+/).filter(Boolean).slice(0, REWIND_SEARCH_TOKEN_LIMIT)
+  return query
+    .slice(0, REWIND_SEARCH_QUERY_CHAR_LIMIT)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, REWIND_SEARCH_TOKEN_LIMIT)
 }
 
 export function escapeRewindSearchLikeToken(token: string): string {


### PR DESCRIPTION
## Summary
- Escape SQLite LIKE wildcard characters in Windows Rewind search terms so `%`, `_`, and backslashes are treated as literal user input.
- Split whitespace-separated Rewind queries into capped tokens and require every token to match OCR text, window title, or app name.
- Trim before applying the pre-tokenization character cap so leading/trailing whitespace cannot consume the scan budget or erase valid search terms.
- Add focused unit coverage for tokenization, input-size capping, leading-whitespace capping, LIKE escaping, empty queries, and generated SQL params.

## Review follow-up
- Addressed cubic feedback that the character cap must run after `.trim()` but before `.split()`.

## Refresh
- Rebased on `main` at `b781d91767ac96a20f2305614eb50c7744a8a6c3`.
- Current head: `dcb92038f0ece15575743f75f42e1e7c493e3fdc`.
- GitHub currently reports this PR as mergeable.

## Tests
- `npm run test -- src/main/rewind/rewindSearchQuery.test.ts src/main/rewind/rewindGrouping.test.ts` -> 2 files, 10 tests passed
- `npm run typecheck` -> passed
- targeted `npx eslint --quiet` on changed Windows files -> no errors
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `scripts/pre-commit` with `PYTHONUTF8=1` -> passed
- `scripts/pre-push` with `PYTHONUTF8=1` -> passed