### PR TITLE
fix(backend): format the subscription reactivation billing date in UTC (#4643)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import Request, Header, HTTPException, APIRouter, Depends, Query
 from google.api_core.exceptions import NotFound as FirestoreNotFound
@@ -203,7 +203,9 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
                 users_db.update_user_subscription(uid, current_subscription.dict())
 
                 # Calculate next billing date
-                next_billing = datetime.fromtimestamp(stripe_sub_dict['current_period_end']).strftime('%B %d, %Y')
+                next_billing = datetime.fromtimestamp(stripe_sub_dict['current_period_end'], tz=timezone.utc).strftime(
+                    '%B %d, %Y'
+                )
 
                 return {
                     "status": "reactivated",

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -198,6 +198,7 @@ pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_voice_message_filename_none.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
+pytest tests/unit/test_payment_reactivation_billing_date_utc.py -v
 pytest tests/unit/test_payment_promotion_codes.py -v
 pytest tests/unit/test_stripe_webhook_none_guard.py -v
 pytest tests/unit/test_stripe_webhook_behavioral.py -v

--- a/backend/tests/unit/test_payment_reactivation_billing_date_utc.py
+++ b/backend/tests/unit/test_payment_reactivation_billing_date_utc.py
@@ -1,0 +1,37 @@
+"""The subscription-reactivation billing date must be formatted timezone-aware (#4643).
+
+_try_reactivate_subscription rendered Stripe's current_period_end (a Unix epoch) with a naive
+datetime.fromtimestamp(...).strftime(...), so the user-facing "your plan will automatically renew
+on <date>" message used the server's local timezone instead of UTC. The rest of the codebase formats
+this same Stripe current_period_end field with tz=timezone.utc (utils/subscription.py,
+database/users.py), so on a non-UTC host the reactivation message could show the wrong day. The
+reactivation path now matches. These are source-level structural checks, matching the other payment
+endpoint tests (routers/payment.py has a heavy import graph).
+"""
+
+from pathlib import Path
+
+PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+
+
+def _source() -> str:
+    return PAYMENT_SOURCE.read_text(encoding="utf-8")
+
+
+def test_timezone_is_imported_in_payment():
+    assert "from datetime import datetime, timezone" in _source()
+
+
+def test_reactivation_billing_date_is_timezone_aware():
+    source = _source()
+    start = source.index("def _try_reactivate_subscription")
+    end = source.index("\ndef ", start + 1)
+    func = source[start:end]
+
+    # The billing-date formatting must pass tz=timezone.utc, matching how the same Stripe
+    # current_period_end field is rendered elsewhere (utils/subscription.py, database/users.py).
+    assert "current_period_end" in func
+    assert "tz=timezone.utc" in func
+
+    # The naive single-line form (fromtimestamp on current_period_end with no tz) must be gone.
+    assert "datetime.fromtimestamp(stripe_sub_dict['current_period_end']).strftime" not in func


### PR DESCRIPTION
## Problem

When a user reactivates a subscription that was scheduled to cancel, the confirmation message tells them when their plan renews:

"Your subscription has been reactivated! No charge now - your plan will automatically renew on {next_billing}."

`_try_reactivate_subscription` in `routers/payment.py` built that date from Stripe's `current_period_end` (a Unix epoch) with a naive `datetime.fromtimestamp(...)`, which interprets the timestamp in the host's local timezone. On any host not running in UTC the rendered day can be off by one.

## Fix

Pass `tz=timezone.utc` to `datetime.fromtimestamp(...)` so the date is computed in UTC. This matches how the same Stripe `current_period_end` field is already formatted elsewhere in the codebase (`utils/subscription.py`, `database/users.py`).

Only the displayed date string changes. The raw epoch is still returned unchanged as `next_billing_date`, so no caller that relies on the numeric value is affected.

## Test

`tests/unit/test_payment_reactivation_billing_date_utc.py` (registered in `test.sh`) is a source-level structural check, matching the other payment tests since `routers/payment.py` has a heavy import graph. It verifies `timezone` is imported and that the reactivation billing date is formatted with `tz=timezone.utc`. It fails against the previous naive code and passes with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

