### PR TITLE
[codex] Explain Windows Rewind search matches

### DIFF
--- a/desktop/windows/src/main/rewind/rewindGrouping.test.ts
+++ b/desktop/windows/src/main/rewind/rewindGrouping.test.ts
@@ -53,6 +53,17 @@ describe('groupFrames', () => {
     expect(groups[0].matchSnippet).toContain('Window title:')
     expect(groups[0].matchSnippet.toLowerCase()).toContain('notion')
   })
+  it('prefers OCR matches over shared metadata matches in the same group', () => {
+    const groups = groupFrames(
+      [
+        frame({ id: 1, ts: 0, windowTitle: 'Slack - general', ocrText: 'daily notes' }),
+        frame({ id: 2, ts: 10, windowTitle: 'Slack - general', ocrText: 'slack launch checklist' })
+      ],
+      'slack'
+    )
+    expect(groups[0].representative.id).toBe(2)
+    expect(groups[0].matchSnippet).not.toContain('Window title:')
+  })
   it('uses app matches when OCR and window title do not explain the search hit', () => {
     const groups = groupFrames(
       [frame({ id: 1, app: 'Slack.exe', windowTitle: 'general', ocrText: 'team update' })],

--- a/desktop/windows/src/main/rewind/rewindGrouping.test.ts
+++ b/desktop/windows/src/main/rewind/rewindGrouping.test.ts
@@ -44,4 +44,21 @@ describe('groupFrames', () => {
     expect(groups[0].representative.id).toBe(2)
     expect(groups[0].matchSnippet.toLowerCase()).toContain('world')
   })
+  it('uses window-title matches when OCR text does not explain the search hit', () => {
+    const groups = groupFrames(
+      [frame({ id: 1, windowTitle: 'Project plan - Notion', ocrText: 'status notes' })],
+      'notion'
+    )
+    expect(groups[0].representative.id).toBe(1)
+    expect(groups[0].matchSnippet).toContain('Window title:')
+    expect(groups[0].matchSnippet.toLowerCase()).toContain('notion')
+  })
+  it('uses app matches when OCR and window title do not explain the search hit', () => {
+    const groups = groupFrames(
+      [frame({ id: 1, app: 'Slack.exe', windowTitle: 'general', ocrText: 'team update' })],
+      'slack'
+    )
+    expect(groups[0].matchSnippet).toContain('App:')
+    expect(groups[0].matchSnippet.toLowerCase()).toContain('slack')
+  })
 })

--- a/desktop/windows/src/main/rewind/rewindGrouping.ts
+++ b/desktop/windows/src/main/rewind/rewindGrouping.ts
@@ -14,12 +14,12 @@ function includesQuery(text: string, query: string): boolean {
   return text.toLowerCase().includes(query.toLowerCase())
 }
 
-function frameMatchesQuery(f: RewindFrame, query: string): boolean {
-  return (
-    includesQuery(f.ocrText, query) ||
-    includesQuery(f.windowTitle, query) ||
-    includesQuery(f.app, query)
-  )
+function frameOcrMatchesQuery(f: RewindFrame, query: string): boolean {
+  return includesQuery(f.ocrText, query)
+}
+
+function frameMetadataMatchesQuery(f: RewindFrame, query: string): boolean {
+  return includesQuery(f.windowTitle, query) || includesQuery(f.app, query)
 }
 
 function buildMatchSnippet(f: RewindFrame, query: string): string {
@@ -43,7 +43,10 @@ export function groupFrames(frames: RewindFrame[], query: string): RewindSearchG
     if (current.length === 0) return
     const first = current[0]
     const last = current[current.length - 1]
-    const rep = current.find((f) => frameMatchesQuery(f, query)) ?? last
+    const rep =
+      current.find((f) => frameOcrMatchesQuery(f, query)) ??
+      current.find((f) => frameMetadataMatchesQuery(f, query)) ??
+      last
     groups.push({
       id: `${first.app}-${first.ts}`,
       app: first.app,

--- a/desktop/windows/src/main/rewind/rewindGrouping.ts
+++ b/desktop/windows/src/main/rewind/rewindGrouping.ts
@@ -10,6 +10,25 @@ function snippet(text: string, query: string): string {
   return (start > 0 ? '…' : '') + text.slice(start, idx + query.length + 30).trim() + '…'
 }
 
+function includesQuery(text: string, query: string): boolean {
+  return text.toLowerCase().includes(query.toLowerCase())
+}
+
+function frameMatchesQuery(f: RewindFrame, query: string): boolean {
+  return (
+    includesQuery(f.ocrText, query) ||
+    includesQuery(f.windowTitle, query) ||
+    includesQuery(f.app, query)
+  )
+}
+
+function buildMatchSnippet(f: RewindFrame, query: string): string {
+  if (includesQuery(f.ocrText, query)) return snippet(f.ocrText, query)
+  if (includesQuery(f.windowTitle, query)) return `Window title: ${snippet(f.windowTitle, query)}`
+  if (includesQuery(f.app, query)) return `App: ${snippet(f.app, query)}`
+  return snippet(f.ocrText, query)
+}
+
 /**
  * Cluster a flat frame list into groups: consecutive frames within
  * GROUP_WINDOW_MS of the group's start that share the same app + window title.
@@ -24,7 +43,7 @@ export function groupFrames(frames: RewindFrame[], query: string): RewindSearchG
     if (current.length === 0) return
     const first = current[0]
     const last = current[current.length - 1]
-    const rep = current.find((f) => f.ocrText.toLowerCase().includes(query.toLowerCase())) ?? last
+    const rep = current.find((f) => frameMatchesQuery(f, query)) ?? last
     groups.push({
       id: `${first.app}-${first.ts}`,
       app: first.app,
@@ -33,7 +52,7 @@ export function groupFrames(frames: RewindFrame[], query: string): RewindSearchG
       endTs: last.ts,
       frames: [...current],
       representative: rep,
-      matchSnippet: snippet(rep.ocrText, query)
+      matchSnippet: buildMatchSnippet(rep, query)
     })
     current = []
   }


### PR DESCRIPTION
## Summary
- Rebased the Windows Rewind search snippets PR onto current `main` (`45fe68b82f`).
- Keeps OCR-derived Rewind search representatives explainable by carrying the matched snippet context through grouping.
- Preserves the prior representative-selection behavior while preferring OCR matches when they explain the search hit.

## Product invariants affected
- None. This PR only touches Windows desktop Rewind grouping logic and tests.

## Validation
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs install --frozen-lockfile --ignore-scripts`
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs exec vitest run src/main/rewind/rewindGrouping.test.ts` -> 6 passed
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs exec prettier --check src/main/rewind/rewindGrouping.ts src/main/rewind/rewindGrouping.test.ts`
- `node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\11.6.0\dist\pnpm.mjs run typecheck:node`

Note: local Windows validation uses the pnpm Corepack entry directly because this machine does not expose a `pnpm` shim on `PATH`.
