### PR TITLE
fix show Sync now button in import detail panel when connector is already connected

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -1589,13 +1589,13 @@ struct ImportConnectorSheet: View {
     private var primaryActionTitle: String {
         switch connector.id {
         case "calendar":
-            return model.isRunning ? "Importing…" : "Connect Calendar"
+            return model.isRunning ? "Importing…" : (snapshot.isConnected ? "Sync now" : "Connect Calendar")
         case "email":
-            return model.isRunning ? "Importing…" : "Connect Gmail"
+            return model.isRunning ? "Importing…" : (snapshot.isConnected ? "Sync now" : "Connect Gmail")
         case "apple-notes":
-            return model.isRunning ? "Importing…" : "Connect Apple Notes"
+            return model.isRunning ? "Importing…" : (snapshot.isConnected ? "Sync now" : "Connect Apple Notes")
         case "x":
-            return model.isRunning ? "Connecting…" : "Connect X"
+            return model.isRunning ? "Connecting…" : (snapshot.isConnected ? "Sync now" : "Connect X")
         case "local-files":
             return model.isRunning ? "Reindexing…" : "Reindex Local Files"
         default:

--- a/desktop/macos/changelog/unreleased/20260629-fix-gmail-connect-button-when-connected.json
+++ b/desktop/macos/changelog/unreleased/20260629-fix-gmail-connect-button-when-connected.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gmail import detail panel showing \"Connect Gmail\" button when Gmail is already connected"
+}


### PR DESCRIPTION
## Summary

- Fixed Gmail (and Calendar, Apple Notes, X) import detail panel always showing "Connect Gmail" even when already connected
- `primaryActionTitle` now checks `snapshot.isConnected` and returns "Sync now" for connected connectors, matching the list row button behavior

## Test plan

- [ ] Connect Gmail and open the import detail panel — button should show "Sync now" not "Connect Gmail"
- [ ] Unconnected connector should still show "Connect Gmail" / "Connect Calendar" etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

