### PR TITLE
fix(backend): reject inverted date ranges in GET /v1/action-items with 400

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -274,6 +274,13 @@ def create_action_item(request: CreateActionItemRequest, uid: str = Depends(auth
     return ActionItemResponse(**action_item)
 
 
+def _ensure_aware(value: datetime) -> datetime:
+    # FastAPI parses a query datetime as naive or timezone-aware depending on whether the client
+    # included a UTC offset. Normalize to timezone-aware (UTC) so comparing the two ends of a date
+    # range never raises TypeError on mixed awareness (which would surface as a 500).
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
 @router.get("/v1/action-items", tags=['action-items'])
 def get_action_items(
     limit: int = Query(50, ge=1, le=500, description="Maximum number of action items to return"),
@@ -287,9 +294,13 @@ def get_action_items(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     """Get action items for the current user."""
-    if start_date is not None and end_date is not None and start_date > end_date:
+    if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):
         raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
-    if due_start_date is not None and due_end_date is not None and due_start_date > due_end_date:
+    if (
+        due_start_date is not None
+        and due_end_date is not None
+        and _ensure_aware(due_start_date) > _ensure_aware(due_end_date)
+    ):
         raise HTTPException(status_code=400, detail="due_start_date must be earlier than or equal to due_end_date")
 
     action_items = action_items_db.get_action_items(

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -287,6 +287,11 @@ def get_action_items(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     """Get action items for the current user."""
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
+    if due_start_date is not None and due_end_date is not None and due_start_date > due_end_date:
+        raise HTTPException(status_code=400, detail="due_start_date must be earlier than or equal to due_end_date")
+
     action_items = action_items_db.get_action_items(
         uid=uid,
         conversation_id=conversation_id,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -134,6 +134,7 @@ pytest tests/unit/test_executors.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_action_items_date_range_validation.py -v
 pytest tests/unit/test_action_items_timezone.py -v
 pytest tests/unit/test_request_validation_contracts.py -v
 pytest tests/unit/test_conversation_structure_timezone.py -v

--- a/backend/tests/unit/test_action_items_date_range_validation.py
+++ b/backend/tests/unit/test_action_items_date_range_validation.py
@@ -1,0 +1,188 @@
+"""GET /v1/action-items must reject an inverted date range instead of silently returning nothing.
+
+get_action_items accepts start_date/end_date (created_at) and due_start_date/due_end_date (due_at)
+filters and forwards them straight to Firestore inequality filters. FastAPI Query() cannot validate
+one parameter against another, so an inverted range (start > end) was passed through unguarded:
+Firestore then applies conflicting `>=` and `<=` filters and returns an empty list, so the caller
+gets "no action items" and cannot tell a bad request apart from a genuinely empty result. The
+endpoint now validates start <= end for both pairs and returns 400 first.
+
+This mounts the action-items router with its heavy dependencies stubbed (same harness as the other
+router unit tests) and calls the handler directly.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'database.action_items',
+    'database.conversations',
+    'database.redis_db',
+    'database.vector_db',
+    'utils.users',
+    'utils.notifications',
+    'utils.task_sync',
+]
+
+_MISSING = object()
+_saved_modules = {}
+_saved_parent_attrs = {}
+
+
+def _save_module_for_restore(name):
+    if name not in _saved_modules:
+        _saved_modules[name] = sys.modules.get(name, _MISSING)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        key = (parent_name, attr)
+        if key not in _saved_parent_attrs:
+            previous_attr = parent.__dict__.get(attr, _MISSING) if parent is not None else _MISSING
+            _saved_parent_attrs[key] = (parent, previous_attr)
+
+
+def _register_module(name, module):
+    _save_module_for_restore(name)
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, _AutoMockModule):
+            parent = _AutoMockModule(parent_name)
+            _register_module(parent_name, parent)
+        setattr(parent, attr, module)
+    return module
+
+
+def _remove_module_for_fresh_import(name):
+    _save_module_for_restore(name)
+    sys.modules.pop(name, None)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            parent.__dict__.pop(attr, None)
+
+
+def _restore_stubbed_modules():
+    for name in sorted(_saved_modules, key=lambda item: item.count('.'), reverse=True):
+        previous = _saved_modules[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (_parent_name, attr), (parent, previous_attr) in _saved_parent_attrs.items():
+        if parent is None:
+            continue
+        if previous_attr is _MISSING:
+            parent.__dict__.pop(attr, None)
+        else:
+            setattr(parent, attr, previous_attr)
+    _saved_modules.clear()
+    _saved_parent_attrs.clear()
+
+
+# Import the real, lightweight utils submodule the router needs at module level
+# (utils.executors line 6) BEFORE stubbing, so it stays cached as the real module. The stub loop
+# replaces sys.modules['utils'] with an AutoMock (a side effect of stubbing utils.users etc.); we
+# re-pin the real utils package afterward so `from utils.executors import ...` resolves the real one.
+import utils as _real_utils_pkg  # noqa: E402
+import utils.executors  # noqa: E402,F401
+
+_save_module_for_restore('utils')
+
+for _mod_name in _stubs:
+    _register_module(_mod_name, _AutoMockModule(_mod_name))
+
+# Re-pin the real utils package so its real submodule (executors) loads.
+sys.modules['utils'] = _real_utils_pkg
+
+# utils.other.endpoints exposes the auth dependency used in route signatures; FastAPI builds the
+# dependant at decoration time, so it needs a real callable, not a MagicMock.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_register_module('utils.other.endpoints', _endpoints)
+
+from fastapi import HTTPException  # noqa: E402
+
+_remove_module_for_fresh_import('routers.action_items')
+_remove_module_for_fresh_import('routers')
+try:
+    from routers import action_items as ai  # noqa: E402
+finally:
+    _restore_stubbed_modules()
+
+
+def _call(**overrides):
+    kwargs = dict(
+        limit=50,
+        offset=0,
+        completed=None,
+        conversation_id=None,
+        start_date=None,
+        end_date=None,
+        due_start_date=None,
+        due_end_date=None,
+        uid='u1',
+    )
+    kwargs.update(overrides)
+    return ai.get_action_items(**kwargs)
+
+
+def test_inverted_created_date_range_returns_400():
+    with pytest.raises(HTTPException) as exc:
+        _call(start_date=datetime(2024, 12, 31), end_date=datetime(2024, 1, 1))
+    assert exc.value.status_code == 400
+
+
+def test_inverted_due_date_range_returns_400():
+    with pytest.raises(HTTPException) as exc:
+        _call(due_start_date=datetime(2024, 12, 31), due_end_date=datetime(2024, 1, 1))
+    assert exc.value.status_code == 400
+
+
+def test_equal_dates_are_allowed():
+    # An inclusive range where start == end is valid and must not be rejected.
+    same = datetime(2024, 6, 1)
+    with patch.object(ai.action_items_db, 'get_action_items', return_value=[]):
+        result = _call(start_date=same, end_date=same)
+    assert result == {"action_items": [], "has_more": False}
+
+
+def test_valid_range_passes_through():
+    with patch.object(ai.action_items_db, 'get_action_items', return_value=[]):
+        result = _call(start_date=datetime(2024, 1, 1), end_date=datetime(2024, 12, 31))
+    assert result == {"action_items": [], "has_more": False}

--- a/backend/tests/unit/test_action_items_date_range_validation.py
+++ b/backend/tests/unit/test_action_items_date_range_validation.py
@@ -15,7 +15,7 @@ import os
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -185,4 +185,20 @@ def test_equal_dates_are_allowed():
 def test_valid_range_passes_through():
     with patch.object(ai.action_items_db, 'get_action_items', return_value=[]):
         result = _call(start_date=datetime(2024, 1, 1), end_date=datetime(2024, 12, 31))
+    assert result == {"action_items": [], "has_more": False}
+
+
+def test_mixed_timezone_awareness_inverted_returns_400():
+    # FastAPI parses one bound as naive and the other as timezone-aware when the client only adds an
+    # offset to one of them. Comparing those directly raises TypeError (a 500); the endpoint must
+    # normalize and still return a clean 400 for an inverted range.
+    with pytest.raises(HTTPException) as exc:
+        _call(start_date=datetime(2024, 12, 31), end_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert exc.value.status_code == 400
+
+
+def test_mixed_timezone_awareness_valid_passes():
+    # A valid range with mixed awareness must not raise TypeError either.
+    with patch.object(ai.action_items_db, 'get_action_items', return_value=[]):
+        result = _call(start_date=datetime(2024, 1, 1), end_date=datetime(2024, 12, 31, tzinfo=timezone.utc))
     assert result == {"action_items": [], "has_more": False}


### PR DESCRIPTION
## Problem

`GET /v1/action-items` accepts two pairs of date-range filters: `start_date`/`end_date` (filtering on `created_at`) and `due_start_date`/`due_end_date` (filtering on `due_at`). They flow straight into Firestore inequality filters.

FastAPI `Query()` validates each parameter on its own but cannot compare one parameter against another, so an inverted range (for example `start_date` after `end_date`) was passed through unchecked. Firestore then applies a contradictory pair of filters (`created_at >= later AND created_at <= earlier`) and returns an empty list. The caller gets "no action items" and cannot tell a malformed request apart from a genuinely empty result.

## Fix

Validate both pairs in the endpoint before the database call and return 400 when start is after end:

- `start_date` must be earlier than or equal to `end_date`
- `due_start_date` must be earlier than or equal to `due_end_date`

Equal endpoints stay valid (the ranges are inclusive). Requests with only one side of a range, or with no date filters, are unaffected.

## Test

`tests/unit/test_action_items_date_range_validation.py` (registered in `test.sh`) mounts the action-items router with its heavy dependencies stubbed (the same harness as the other router unit tests) and calls the handler directly. It checks that an inverted created-range and an inverted due-range each return 400, that an equal-date range is allowed, and that a normal range passes through. The two inverted-range checks fail against the previous unguarded code and pass with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

