### PR TITLE
fix(backend): reject inverted date ranges in the conversations list and count endpoints with 400

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -169,6 +169,13 @@ def reprocess_conversation(
     return processed_conversation
 
 
+def _ensure_aware(value: datetime) -> datetime:
+    # FastAPI parses a query datetime as naive or timezone-aware depending on whether the client
+    # included a UTC offset. Normalize to timezone-aware (UTC) so comparing the two ends of a date
+    # range never raises TypeError on mixed awareness (which would surface as a 500).
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
 @router.get(
     '/v1/conversations',
     response_model=List[Conversation],
@@ -189,6 +196,8 @@ def get_conversations(
     starred: Optional[bool] = Query(None, description="Filter by starred status"),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):
+        raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
     logger.info(f'get_conversations {uid} {limit} {offset} {statuses} {folder_id} {starred}')
     # force convos statuses to processing, completed on the empty filter
     if len(statuses) == 0:
@@ -220,6 +229,8 @@ def get_conversations_count(
     starred: Optional[bool] = Query(None, description="Filter by starred status"),
     uid: str = Depends(auth.get_current_user_uid),
 ):
+    if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):
+        raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
     status_list = [s.strip() for s in statuses.split(',') if s.strip()] if statuses else []
     count = conversations_db.get_conversations_count(
         uid,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -88,6 +88,7 @@ pytest tests/unit/test_conversation_tool_date_range_bound.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v
 pytest tests/unit/test_conversations_count.py -v
+pytest tests/unit/test_conversations_date_range_validation.py -v
 pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
 pytest tests/unit/test_prompt_cache_optimization.py -v
 pytest tests/unit/test_prompt_cache_integration.py -v

--- a/backend/tests/unit/test_conversations_date_range_validation.py
+++ b/backend/tests/unit/test_conversations_date_range_validation.py
@@ -1,0 +1,244 @@
+"""GET /v1/conversations and /v1/conversations/count must reject an inverted date range.
+
+Both endpoints accept start_date/end_date filters and forward them straight to Firestore inequality
+filters (created_at >= start, created_at <= end). FastAPI Query() cannot validate one parameter
+against another, so an inverted range (start > end) was passed through: Firestore then applies a
+contradictory pair of filters and returns an empty list / a count of zero, so the caller cannot tell
+a malformed request apart from a genuinely empty result. Both endpoints now validate start <= end
+and return 400 first.
+
+The comparison also normalizes timezone awareness first: FastAPI parses a query datetime as naive or
+aware depending on whether the client included an offset, and comparing a naive against an aware
+datetime raises TypeError (a 500). The endpoints normalize both bounds to UTC before comparing.
+
+This mounts the conversations router with its heavy dependencies stubbed (same harness as the other
+router unit tests) and calls the handlers directly.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'ulid',
+    'pinecone',
+    'typesense',
+    'database._client',
+    'database.conversations',
+    'database.action_items',
+    'database.memories',
+    'database.redis_db',
+    'database.users',
+    'database.vector_db',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'firebase_admin.credentials',
+    'firebase_admin.firestore',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'utils.other.endpoints',
+    'utils.other.storage',
+    'utils.conversations.factory',
+    'utils.conversations.render',
+    'utils.conversations.process_conversation',
+    'utils.conversations.search',
+    'utils.conversations.calendar_linking',
+    'utils.conversations.calendar_utils',
+    'utils.conversations.location',
+    'utils.llm.conversation_processing',
+    'utils.speaker_identification',
+    'utils.app_integrations',
+    'utils.retrieval.tools.calendar_tools',
+    'utils.retrieval.tools.google_utils',
+]
+
+_MISSING = object()
+_saved_modules = {}
+_saved_parent_attrs = {}
+
+
+def _save_module_for_restore(name):
+    if name not in _saved_modules:
+        _saved_modules[name] = sys.modules.get(name, _MISSING)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        key = (parent_name, attr)
+        if key not in _saved_parent_attrs:
+            previous_attr = parent.__dict__.get(attr, _MISSING) if parent is not None else _MISSING
+            _saved_parent_attrs[key] = (parent, previous_attr)
+
+
+def _register_module(name, module):
+    _save_module_for_restore(name)
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, _AutoMockModule):
+            parent = _AutoMockModule(parent_name)
+            _register_module(parent_name, parent)
+        setattr(parent, attr, module)
+    return module
+
+
+def _remove_module_for_fresh_import(name):
+    _save_module_for_restore(name)
+    sys.modules.pop(name, None)
+    if '.' in name:
+        parent_name, attr = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            parent.__dict__.pop(attr, None)
+
+
+def _restore_stubbed_modules():
+    for name in sorted(_saved_modules, key=lambda item: item.count('.'), reverse=True):
+        previous = _saved_modules[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (_parent_name, attr), (parent, previous_attr) in _saved_parent_attrs.items():
+        if parent is None:
+            continue
+        if previous_attr is _MISSING:
+            parent.__dict__.pop(attr, None)
+        else:
+            setattr(parent, attr, previous_attr)
+    _saved_modules.clear()
+    _saved_parent_attrs.clear()
+
+
+# Import the real, lightweight utils submodules the router needs at module level BEFORE stubbing, so
+# they stay cached as the real modules. The stub loop replaces sys.modules['utils'] with an AutoMock
+# (a side effect of stubbing utils.other.*); we re-pin the real utils package afterward.
+import utils as _real_utils_pkg  # noqa: E402
+import utils.executors  # noqa: E402,F401
+import utils.conversations  # noqa: E402,F401
+import utils.conversations.factory  # noqa: E402,F401
+
+_save_module_for_restore('utils')
+
+for _mod_name in _stubs:
+    _register_module(_mod_name, _AutoMockModule(_mod_name))
+
+sys.modules['utils'] = _real_utils_pkg
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# utils.other.endpoints exposes the auth dependencies used in route signatures; FastAPI builds the
+# dependants at decoration time, so it needs real callables.
+_endpoints = ModuleType('utils.other.endpoints')
+
+
+def _fake_get_current_user_uid():  # pragma: no cover - dependency stand-in
+    return 'test-uid'
+
+
+def _fake_with_rate_limit(dependency, _policy):  # pragma: no cover - returns wrapped dependency
+    return dependency
+
+
+_endpoints.get_current_user_uid = _fake_get_current_user_uid
+_endpoints.with_rate_limit = _fake_with_rate_limit
+_endpoints.get_user = MagicMock()
+_register_module('utils.other.endpoints', _endpoints)
+
+from fastapi import HTTPException  # noqa: E402
+
+_remove_module_for_fresh_import('routers.conversations')
+_remove_module_for_fresh_import('routers')
+try:
+    from routers import conversations as conv  # noqa: E402
+finally:
+    _restore_stubbed_modules()
+
+
+def _call_list(**overrides):
+    kwargs = dict(
+        limit=100,
+        offset=0,
+        statuses="processing,completed",
+        include_discarded=True,
+        start_date=None,
+        end_date=None,
+        folder_id=None,
+        starred=None,
+        uid='u1',
+    )
+    kwargs.update(overrides)
+    return conv.get_conversations(**kwargs)
+
+
+def _call_count(**overrides):
+    kwargs = dict(
+        statuses=None,
+        include_discarded=False,
+        start_date=None,
+        end_date=None,
+        folder_id=None,
+        starred=None,
+        uid='u1',
+    )
+    kwargs.update(overrides)
+    return conv.get_conversations_count(**kwargs)
+
+
+def test_inverted_range_list_returns_400():
+    with pytest.raises(HTTPException) as exc:
+        _call_list(start_date=datetime(2024, 12, 31), end_date=datetime(2024, 1, 1))
+    assert exc.value.status_code == 400
+
+
+def test_inverted_range_count_returns_400():
+    with pytest.raises(HTTPException) as exc:
+        _call_count(start_date=datetime(2024, 12, 31), end_date=datetime(2024, 1, 1))
+    assert exc.value.status_code == 400
+
+
+def test_mixed_timezone_awareness_inverted_returns_400():
+    # A naive bound compared against an aware bound must still yield a clean 400, not a TypeError 500.
+    with pytest.raises(HTTPException) as exc:
+        _call_list(start_date=datetime(2024, 12, 31), end_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert exc.value.status_code == 400
+
+
+def test_equal_dates_are_allowed():
+    same = datetime(2024, 6, 1)
+    with patch.object(conv.conversations_db, 'get_conversations_count', return_value=0):
+        result = _call_count(start_date=same, end_date=same)
+    assert result == {'count': 0}
+
+
+def test_valid_range_passes_through():
+    with patch.object(conv.conversations_db, 'get_conversations_count', return_value=0):
+        result = _call_count(start_date=datetime(2024, 1, 1), end_date=datetime(2024, 12, 31, tzinfo=timezone.utc))
+    assert result == {'count': 0}


### PR DESCRIPTION
## Problem

`GET /v1/conversations` and `GET /v1/conversations/count` both accept `start_date`/`end_date` filters and forward them straight into Firestore inequality filters (`created_at >= start`, `created_at <= end`).

FastAPI `Query()` validates each parameter on its own but cannot compare one parameter against another, so an inverted range (for example `start_date` after `end_date`) was passed through unchecked. Firestore then applies a contradictory pair of filters and returns an empty list, or a count of zero, so the caller cannot tell a malformed request apart from a genuinely empty result.

This is the same class of fix as the action-items list endpoint in #8578.

## Fix

Validate `start_date <= end_date` in both endpoints before the database call and return 400 when start is after end.

The bounds are normalized to UTC before comparing. FastAPI parses a query datetime as naive or timezone-aware depending on whether the client included an offset, and comparing a naive against an aware datetime raises `TypeError` (a 500). A small `_ensure_aware` helper assumes UTC for a naive value so the comparison is always well defined and a mixed-format request still gets a clean 400.

Equal endpoints stay valid (the ranges are inclusive). Requests with only one side of a range, or with no date filters, are unaffected.

## Test

`tests/unit/test_conversations_date_range_validation.py` (registered in `test.sh`) mounts the conversations router with its heavy dependencies stubbed (the same harness as the other router unit tests) and calls the handlers directly. It checks that an inverted range on both the list and count endpoints returns 400, that a mixed naive/aware inverted range also returns 400 instead of raising TypeError, that an equal-date range is allowed, and that a normal range passes through. The three inverted checks fail against the previous unguarded code and pass with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

