### PR TITLE
test(app): fix pre-existing test drift (env fakes + DeviceType.frame)

### DIFF
--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -13,6 +13,7 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/env/env.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/app_globals.dart';
 import 'package:omi/providers/capture_provider.dart';
@@ -66,6 +67,35 @@ TranscriptSegment _segment(String id, String text) {
 BtDevice _device({required String id, required DeviceType type, String name = 'TestDevice'}) =>
     BtDevice(id: id, name: name, type: type, rssi: -50);
 
+/// Minimal EnvFields stub so Env-backed code paths (e.g. native BLE stream
+/// config reading Env.apiBaseUrl) don't hit a LateInitializationError.
+class _TestEnvFields implements EnvFields {
+  @override
+  String? get openAIAPIKey => null;
+  @override
+  String? get posthogApiKey => null;
+  @override
+  String? get apiBaseUrl => null;
+  @override
+  String? get googleMapsApiKey => null;
+  @override
+  String? get intercomAppId => null;
+  @override
+  String? get intercomIOSApiKey => null;
+  @override
+  String? get intercomAndroidApiKey => null;
+  @override
+  String? get googleClientId => null;
+  @override
+  String? get googleClientSecret => null;
+  @override
+  bool? get useWebAuth => false;
+  @override
+  bool? get useAuthCustomToken => false;
+  @override
+  String? get stagingApiUrl => null;
+}
+
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -79,6 +109,11 @@ void main() {
       },
     );
     ConnectivityPlatform.instance = _TestConnectivityPlatform();
+    try {
+      Env.init(_TestEnvFields());
+    } catch (_) {
+      // Env._instance is late final — ignore if already initialized in this isolate.
+    }
     try {
       await ServiceManager.init();
     } catch (_) {
@@ -638,13 +673,6 @@ void main() {
       provider.dispose();
     });
 
-    test('returns false for Frame', () {
-      final provider = CaptureProvider();
-      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
-      expect(provider.hasNativeBleAudioRoute, isFalse);
-      provider.dispose();
-    });
-
     test('returns false for Limitless', () {
       final provider = CaptureProvider();
       provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.limitless));
@@ -685,7 +713,7 @@ void main() {
       expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
       expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
       expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
-      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isNull);
+      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isEmpty);
       provider.dispose();
     });
 
@@ -743,17 +771,6 @@ void main() {
     test('enable rejects for device with no native route (Fieldy)', () async {
       final provider = CaptureProvider();
       provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.fieldy));
-
-      final result = await provider.setBackgroundModeEnabled(true);
-
-      expect(result, isFalse);
-      expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
-      provider.dispose();
-    });
-
-    test('enable rejects for device with no native route (Frame)', () async {
-      final provider = CaptureProvider();
-      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
 
       final result = await provider.setBackgroundModeEnabled(true);
 
@@ -874,7 +891,7 @@ void main() {
       expect(SharedPreferencesUtil().backgroundModeEnabled, isFalse);
       expect(SharedPreferencesUtil().getBool('nativeBleStreamingEnabled'), isFalse);
       expect(SharedPreferencesUtil().getBool('nativeBleForegroundReady'), isFalse);
-      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isNull);
+      expect(SharedPreferencesUtil().getString('nativeBleStreamConfig'), isEmpty);
       provider.dispose();
     });
 
@@ -917,7 +934,7 @@ void main() {
 
     test('switching from no-route device to Omi gains route', () {
       final provider = CaptureProvider();
-      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.frame));
+      provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.fieldy));
       expect(provider.hasNativeBleAudioRoute, isFalse);
 
       provider.updateRecordingDevice(_device(id: '11:22:33:44:55:66', type: DeviceType.omi));

--- a/app/test/unit/env_empty_staging_test.dart
+++ b/app/test/unit/env_empty_staging_test.dart
@@ -10,11 +10,9 @@ class _EmptyStagingEnvFields implements EnvFields {
   @override
   String? get openAIAPIKey => null;
   @override
-  String? get mixpanelProjectToken => null;
+  String? get posthogApiKey => null;
   @override
   String? get apiBaseUrl => 'https://api.prod.example.com/';
-  @override
-  String? get growthbookApiKey => null;
   @override
   String? get googleMapsApiKey => null;
   @override

--- a/app/test/unit/env_staging_test.dart
+++ b/app/test/unit/env_staging_test.dart
@@ -10,11 +10,9 @@ class _StagingEnvFields implements EnvFields {
   @override
   String? get openAIAPIKey => null;
   @override
-  String? get mixpanelProjectToken => null;
+  String? get posthogApiKey => null;
   @override
   String? get apiBaseUrl => 'https://api.prod.example.com/';
-  @override
-  String? get growthbookApiKey => null;
   @override
   String? get googleMapsApiKey => null;
   @override

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -11,11 +11,9 @@ class _TestEnvFields implements EnvFields {
   @override
   String? get openAIAPIKey => null;
   @override
-  String? get mixpanelProjectToken => null;
+  String? get posthogApiKey => null;
   @override
   String? get apiBaseUrl => 'https://api.prod.example.com/';
-  @override
-  String? get growthbookApiKey => null;
   @override
   String? get googleMapsApiKey => null;
   @override


### PR DESCRIPTION
## What

Fixes pre-existing test failures that had drifted from the app code. These were surfaced while verifying the Flutter 3.41.9 upgrade (#8581) but are **independent of it** — they fail on `main` today.

### Env fakes out of sync with `EnvFields` (3 files)
`lib/env/env.dart` swapped Mixpanel → PostHog: dropped `mixpanelProjectToken` + `growthbookApiKey`, added `posthogApiKey`. The test fakes in `env_test.dart`, `env_staging_test.dart`, `env_empty_staging_test.dart` were stale, causing:
- **error** `Missing concrete implementation of 'getter EnvFields.posthogApiKey'`
- 2× **warning** `override_on_non_overriding_member` (the removed getters)

Fix: rename `mixpanelProjectToken`→`posthogApiKey`, drop `growthbookApiKey` → fakes now match the interface exactly.

### `DeviceType.frame` removed (`capture_provider_test.dart`)
`frame` was removed from the `DeviceType` enum (commit `ecb30e1cb`). Three tests still referenced it → **error** `There's no constant named 'frame' in 'DeviceType'`, which meant the **entire file failed to compile and never ran**.

Fixes:
- Dropped the 2 redundant "no native route" cases for Frame (that path is already covered by `bee`/`fieldy`/`limitless`/`plaud`).
- Switched the unique "switching from no-route device to Omi gains route" case to `fieldy`.

Once the file compiled, it exposed two further latent bugs in tests that had never executed:
- **`Env` never initialized** → `LateInitializationError` on `omi`-route paths reading `Env.apiBaseUrl`. Added an `Env.init(stub)` in `setUpAll`.
- **Wrong assertion** — `SharedPreferencesUtil.getString` returns a non-nullable `String` defaulting to `''`, so a cleared `nativeBleStreamConfig` is `''`, not `null`. Changed `isNull` → `isEmpty` (2 spots).

## Verification (Flutter 3.41.9 / Dart 3.11.5)
- `flutter analyze` on the 4 files: **0 errors** (was 6).
- `flutter test` on the 4 files: **72 tests pass** (was: 6 compile errors + 10 runtime failures).

## Out of scope
The full suite still has **4 unrelated pre-existing logic failures** in files this PR doesn't touch — `audio_wave_painter_test` (`shouldRepaint` 0.01 epsilon boundary) and `ring_protocol_test` (off-by-one buffer boundary). Both are SDK-version-independent pure-Dart logic and need their own investigation; left for a separate fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

