### PR TITLE
test(app): fix stale ring_protocol + AudioWavePainter boundary tests

### DIFF
--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -208,18 +208,21 @@ void main() {
       expect(frames, isEmpty);
     });
 
-    test('parses a frame that exactly fills the buffer (boundary)', () {
-      // [size=2][0xAA, 0xBB] — buffer length 3, frame ends at last byte.
-      // Boundary check must be > (not >=) for this to parse.
+    test('drops a frame that would end exactly at the buffer boundary (firmware overflow guard)', () {
+      // [size=2][0xAA, 0xBB] — the frame would end exactly at audio.length.
+      // The firmware (transport.c:write_to_storage) never writes a frame ending
+      // exactly at the last byte: a size byte at the boundary with no room for
+      // its frame is an overflow artifact, and the bytes after it are stale from
+      // a previous write. The parser's >= guard drops it; parsing the stale
+      // region as opus otherwise yields OpusException -4 "corrupted stream".
       final frames = RingProtocol.parseAudioPayload([2, 0xAA, 0xBB]);
-      expect(frames.length, 1);
-      expect(frames[0], [0xAA, 0xBB]);
+      expect(frames, isEmpty);
     });
 
-    test('parses tightly-packed frames with no trailing padding (440B exactly)', () {
-      // 40 frames of [size=10][10B] = 40 * 11 = 440 bytes — the last frame
-      // ends precisely at audio.length. With >=, the last frame is silently
-      // dropped; with > it's preserved.
+    test('drops the boundary-aligned last frame in tightly-packed input (440B exactly)', () {
+      // 40 frames of [size=10][10B] = 40 * 11 = 440 bytes — the 40th frame would
+      // end precisely at audio.length. The firmware never emits such a frame, so
+      // the >= boundary guard drops it: 39 frames survive, the last being #38.
       final audio = <int>[];
       for (int i = 0; i < 40; i++) {
         audio.add(10);
@@ -227,8 +230,8 @@ void main() {
       }
       expect(audio.length, 440);
       final frames = RingProtocol.parseAudioPayload(audio);
-      expect(frames.length, 40);
-      expect(frames.last, List.filled(10, 39 & 0xFF));
+      expect(frames.length, 39);
+      expect(frames.last, List.filled(10, 38 & 0xFF));
     });
   });
 

--- a/app/test/widgets/audio_wave_painter_test.dart
+++ b/app/test/widgets/audio_wave_painter_test.dart
@@ -21,32 +21,32 @@ void main() {
       expect(painter1.shouldRepaint(painter2), true);
     });
 
-    test('shouldRepaint returns true when level differs by more than 0.01', () {
+    test('shouldRepaint returns true when level differs by more than 0.005', () {
       final painter1 = AudioWavePainter(levels: [0.5, 0.6, 0.7]);
       final painter2 = AudioWavePainter(levels: [0.5, 0.65, 0.7]);
 
       expect(painter1.shouldRepaint(painter2), true);
     });
 
-    test('shouldRepaint returns false when level differs by 0.01 or less', () {
+    test('shouldRepaint returns false when level differs by less than 0.005', () {
       final painter1 = AudioWavePainter(levels: [0.5, 0.6, 0.7]);
-      final painter2 = AudioWavePainter(levels: [0.5, 0.605, 0.7]);
+      final painter2 = AudioWavePainter(levels: [0.5, 0.604, 0.7]); // ~0.004 diff - below threshold
 
       expect(painter1.shouldRepaint(painter2), false);
     });
 
-    // Boundary tests for the 0.01 threshold (implementation uses > 0.01, not >=)
-    // Note: Floating point precision means 0.51 - 0.5 = 0.010000000000000009, not exactly 0.01
-    test('shouldRepaint returns true when level differs by clearly more than 0.01', () {
+    // Boundary tests for the 0.005 threshold (implementation uses > 0.005, not >=).
+    // Note: floating point precision means 0.505 - 0.5 = 0.005000000000000004, not exactly 0.005.
+    test('shouldRepaint returns true when level differs by clearly more than 0.005', () {
       final painter1 = AudioWavePainter(levels: [0.5, 0.6, 0.7]);
       final painter2 = AudioWavePainter(levels: [0.5, 0.62, 0.7]); // 0.02 diff - clearly above threshold
 
       expect(painter1.shouldRepaint(painter2), true);
     });
 
-    test('shouldRepaint returns false when level differs by clearly less than 0.01', () {
+    test('shouldRepaint returns false when level differs by clearly less than 0.005', () {
       final painter1 = AudioWavePainter(levels: [0.5, 0.6, 0.7]);
-      final painter2 = AudioWavePainter(levels: [0.5, 0.605, 0.7]); // 0.005 diff - clearly below threshold
+      final painter2 = AudioWavePainter(levels: [0.5, 0.602, 0.7]); // 0.002 diff - clearly below threshold
 
       expect(painter1.shouldRepaint(painter2), false);
     });
@@ -58,11 +58,11 @@ void main() {
       expect(painter1.shouldRepaint(painter2), true);
     });
 
-    test('shouldRepaint with 0.01 boundary affected by floating point precision', () {
-      // Due to floating point: 0.51 - 0.5 = 0.010000000000000009 > 0.01
-      // This documents the actual behavior - slight imprecision at boundary
+    test('shouldRepaint at the 0.005 boundary is affected by floating point precision', () {
+      // Due to floating point: 0.505 - 0.5 = 0.005000000000000004 > 0.005
+      // This documents the actual behavior - slight imprecision at the boundary.
       final painter1 = AudioWavePainter(levels: [0.5, 0.5, 0.5]);
-      final painter2 = AudioWavePainter(levels: [0.5, 0.51, 0.5]);
+      final painter2 = AudioWavePainter(levels: [0.5, 0.505, 0.5]);
       // Because of floating point, this returns true (repaint triggered)
       expect(painter1.shouldRepaint(painter2), true);
     });


### PR DESCRIPTION
## What

Fixes the 4 remaining pre-existing test failures (surfaced during the Flutter 3.41.9 upgrade). Both are **stale tests that drifted from intentional code changes** — the fix is in the tests; **no shipping code changed**.

### `ring_protocol_test.dart` — 2 failures
The boundary tests asserted that a frame ending *exactly* at the buffer end is preserved (a `>` boundary check). That behavior was **deliberately reverted** in `4c3a0dd93` ("parseAudioPayload boundary uses `>=` to match firmware overflow"):

> The firmware's `transport.c:write_to_storage` overflows when a frame won't fit; at the boundary it writes a trailing size byte without its frame and the bytes after it are stale… Our parser's `>` check let that stale region be consumed as a valid opus frame, producing OpusException -4 "corrupted stream"… the firmware never writes a frame ending exactly at byte 439, so the "preserve boundary-aligned frame" rationale for `>` was a fiction.

The tests came from the **earlier, reverted** `1b989734a` and were never updated. **`>=` is correct** — reverting it would reintroduce the playback corruption. Updated the two tests to assert the boundary-aligned frame is **dropped** (with the firmware rationale in comments). `ring_protocol.dart` is untouched.

### `audio_wave_painter_test.dart` — 2 failures
`AudioWavePainter.shouldRepaint` has shipped with a `> 0.005` threshold since `468758b1a` (Apr 26, painter redesign), but the tests still assumed `> 0.01`. Their "false" cases used a `0.005` diff, which floats *just above* `0.005` (`0.605 - 0.6 = 0.005000…04`) → repaint → fail. Updated the below-threshold cases to use clearly-below-`0.005` diffs and refreshed names/comments. Painter code untouched.

> Note: the `0.01 → 0.005` change in `468758b1a` was an undocumented part of a rendering-fix commit (the original `0.01` was introduced "to reduce battery drain" in `b8a44ffbb`). This PR keeps the shipping `0.005` and aligns the tests. If the `0.01` (fewer repaints) was actually intended, that's a one-line code change worth a separate look — flagging rather than silently picking.

## Verification (Flutter 3.41.9 / Dart 3.11.5)
- `flutter analyze` on both files: **0 errors**
- The 2 files: **43 tests pass**
- **Full suite: 583 pass, 0 failures** (was 579 pass / 4 fail before this PR)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

