### PR TITLE
fix(backend): return 404 instead of 500 when advice is deleted during update

### DIFF
--- a/backend/database/advice.py
+++ b/backend/database/advice.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
+from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
 
@@ -75,8 +76,15 @@ def update_advice(uid: str, advice_id: str, is_read: bool = None, is_dismissed: 
         updates['is_read'] = is_read
     if is_dismissed is not None:
         updates['is_dismissed'] = is_dismissed
-    ref.update(updates)
+    try:
+        ref.update(updates)
+    except NotFound:
+        # The advice was deleted between the existence check and the update.
+        return None
     result = ref.get().to_dict()
+    if result is None:
+        # The advice was deleted between the update and the re-read.
+        return None
     result['id'] = advice_id
     return result
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -77,6 +77,7 @@ pytest tests/unit/test_chat_tool_parameters_json.py -v
 pytest tests/unit/test_prompt_caching.py -v
 pytest tests/unit/test_mentor_notifications.py -v
 pytest tests/unit/test_proactive_notification_language.py -v
+pytest tests/unit/test_advice_update_missing_doc_guard.py -v
 pytest tests/unit/test_notification_token_cleanup.py -v
 pytest tests/unit/test_integration_notification_validation.py -v
 pytest tests/unit/test_conversations_to_string.py -v

--- a/backend/tests/unit/test_advice_update_missing_doc_guard.py
+++ b/backend/tests/unit/test_advice_update_missing_doc_guard.py
@@ -1,0 +1,117 @@
+"""update_advice must return None (404) when the advice is deleted mid-update, not crash with a 500.
+
+PATCH /v1/advice/{advice_id} -> update_advice checks the document exists, applies the update, then
+re-reads it to return the fresh value. Two concurrent-deletion windows turned that into a 500:
+  1. Deleted between the existence check and ref.update(...) -> Firestore update() raises NotFound.
+  2. Deleted between the update and the re-read -> ref.get().to_dict() is None, so result['id'] = ...
+     raised TypeError.
+The router treats a None return as a 404, so both races should yield 404, not an unhandled 500. The
+function now returns None in both cases. These cover the pure database-function behavior.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _pkg(name):
+    mod = sys.modules.get(name)
+    if mod is None or not hasattr(mod, "__path__"):
+        mod = types.ModuleType(name)
+        mod.__path__ = []
+        sys.modules[name] = mod
+    return mod
+
+
+def _mod(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+class _NotFound(Exception):
+    """Stand-in for google.api_core.exceptions.NotFound."""
+
+
+# Stub the heavy leaves database/advice.py imports so the real module loads.
+for _p in ["google", "google.cloud", "google.api_core", "database"]:
+    _pkg(_p)
+_mod("google.api_core.exceptions", NotFound=_NotFound)
+_mod("google.cloud.firestore", SERVER_TIMESTAMP=MagicMock(), Query=MagicMock())
+_mod("google.cloud.firestore_v1.base_query", FieldFilter=MagicMock())
+_mod("database._client", db=MagicMock())
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("database.advice", str(BACKEND_DIR / "database" / "advice.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["database.advice"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+advice = _load()
+
+
+def _snap(exists, data=None):
+    snap = MagicMock()
+    snap.exists = exists
+    snap.to_dict.return_value = data
+    return snap
+
+
+def _wire(get_results, update_exc=None):
+    """A mocked advice collection whose document().get() yields the given snapshots in order."""
+    ref = MagicMock()
+    ref.get.side_effect = list(get_results)
+    if update_exc is not None:
+        ref.update.side_effect = update_exc
+    col = MagicMock()
+    col.document.return_value = ref
+    return col, ref
+
+
+def test_missing_advice_returns_none():
+    # The existing existence check: a UID/advice_id with no document returns None (404), no update.
+    col, ref = _wire([_snap(False)])
+    with patch.object(advice, "_user_col", return_value=col):
+        assert advice.update_advice("u", "adv1", is_read=True) is None
+    ref.update.assert_not_called()
+
+
+def test_deleted_before_update_returns_none():
+    # Deleted between the existence check and the update: Firestore update() raises NotFound, which
+    # must become a None return (404), not a propagated 500.
+    col, ref = _wire([_snap(True)], update_exc=_NotFound)
+    with patch.object(advice, "_user_col", return_value=col):
+        assert advice.update_advice("u", "adv1", is_read=True) is None
+
+
+def test_deleted_after_update_returns_none():
+    # Deleted between the update and the re-read: to_dict() is None, which must become a None return
+    # instead of a TypeError on result['id'].
+    col, ref = _wire([_snap(True), _snap(False, None)])
+    with patch.object(advice, "_user_col", return_value=col):
+        assert advice.update_advice("u", "adv1", is_dismissed=True) is None
+
+
+def test_happy_path_returns_dict_with_id():
+    col, ref = _wire([_snap(True), _snap(True, {"text": "hi", "is_read": False})])
+    with patch.object(advice, "_user_col", return_value=col):
+        result = advice.update_advice("u", "adv1", is_read=True)
+    assert result["id"] == "adv1"
+    assert result["text"] == "hi"


### PR DESCRIPTION
## Problem

`update_advice` (behind `PATCH /v1/advice/{advice_id}`) checks the advice document exists, applies the update, then re-reads the document to return the fresh value:

```python
snap = ref.get()
if not snap.exists:
    return None
...
ref.update(updates)
result = ref.get().to_dict()
result['id'] = advice_id
return result
```

If the advice is deleted concurrently, two windows turn a 404 into a 500:

1. Deleted between the existence check and `ref.update(...)`: Firestore `update()` requires the document to exist, so it raises `NotFound`, which propagated as an unhandled 500.
2. Deleted between the update and the re-read: `ref.get().to_dict()` returns None, so `result['id'] = advice_id` raised `TypeError: 'NoneType' object does not support item assignment`.

The router maps a None return to a 404 (`Advice not found`), so both races should surface as a clean 404 rather than a 500.

## Fix

Treat a concurrent deletion as "not found" in both windows: catch `NotFound` from the update and return None, and return None when the re-read yields no document.

```python
try:
    ref.update(updates)
except NotFound:
    return None
result = ref.get().to_dict()
if result is None:
    return None
result['id'] = advice_id
return result
```

The normal update path is unchanged.

## Test

`tests/unit/test_advice_update_missing_doc_guard.py` (registered in `test.sh`) loads `database/advice.py` with its heavy leaves stubbed and drives `update_advice` with a mocked Firestore reference. It covers the existing missing-document path, deletion before the update (update raises `NotFound`), deletion after the update (re-read returns None), and the normal path returning the updated document with its id. The two race cases fail against the previous code (a propagated `NotFound` and a `TypeError`) and pass with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

