### PR TITLE
fix(backend): render screen activity search timestamps in UTC instead of host-local time (#4643)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -84,6 +84,7 @@ pytest tests/unit/test_location_maps_status_guard.py -v
 pytest tests/unit/test_conversation_render_factory.py -v
 pytest tests/unit/test_conversation_redact_enrich.py -v
 pytest tests/unit/test_retrieval_semantics.py -v
+pytest tests/unit/test_screen_activity_search_utc.py -v
 pytest tests/unit/test_conversation_tool_date_range_bound.py -v
 pytest tests/unit/test_folder_name_enrichment.py -v
 pytest tests/unit/test_folder_conversations_malformed.py -v

--- a/backend/tests/unit/test_screen_activity_search_utc.py
+++ b/backend/tests/unit/test_screen_activity_search_utc.py
@@ -1,0 +1,32 @@
+"""search_screen_activity_tool must render match timestamps in UTC, not the host's local time (#4643).
+
+The screen-activity search result formatted each match's epoch timestamp with a naive
+datetime.fromtimestamp(ts).strftime(...), which uses the host's local timezone, so the time shown in
+chat depended on where the backend happened to run. It now passes tz=timezone.utc, matching how
+conversation search and the other timestamp fixes render times. These are source-level structural
+checks, since the tool has a heavy import graph (Firestore, vector search, OCR fetch).
+"""
+
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[2] / "utils" / "retrieval" / "tools" / "screen_activity_tools.py"
+
+
+def _source() -> str:
+    return SOURCE.read_text(encoding="utf-8")
+
+
+def test_timezone_is_imported():
+    assert "from datetime import datetime, timezone" in _source()
+
+
+def test_search_result_timestamp_is_utc():
+    source = _source()
+    start = source.index("def search_screen_activity_tool")
+    next_def = source.find("\ndef ", start + 1)
+    func = source[start:] if next_def == -1 else source[start:next_def]
+
+    # The timestamp must be made timezone-aware (UTC) before formatting.
+    assert "datetime.fromtimestamp(ts, tz=timezone.utc)" in func
+    # The naive form (no tzinfo) must be gone.
+    assert "datetime.fromtimestamp(ts).strftime" not in func

--- a/backend/tests/unit/test_screen_activity_search_utc.py
+++ b/backend/tests/unit/test_screen_activity_search_utc.py
@@ -90,6 +90,15 @@ def test_resolve_display_tz_falls_back_to_utc_on_invalid():
         assert sat._resolve_display_tz("u1") is timezone.utc
 
 
+def test_resolve_display_tz_falls_back_to_utc_when_lookup_raises():
+    # A transient Firestore/network error reading the user's timezone must not crash the search.
+    def _boom(uid):
+        raise RuntimeError("firestore unavailable")
+
+    with patch.object(sat.notification_db, "get_user_time_zone", _boom):
+        assert sat._resolve_display_tz("u1") is timezone.utc
+
+
 def test_search_tool_renders_in_resolved_timezone():
     source = SOURCE.read_text(encoding="utf-8")
     func = source[source.index("def search_screen_activity_tool") :]

--- a/backend/tests/unit/test_screen_activity_search_utc.py
+++ b/backend/tests/unit/test_screen_activity_search_utc.py
@@ -1,32 +1,99 @@
-"""search_screen_activity_tool must render match timestamps in UTC, not the host's local time (#4643).
+"""search_screen_activity_tool must render match timestamps in the user's timezone (#4643).
 
 The screen-activity search result formatted each match's epoch timestamp with a naive
-datetime.fromtimestamp(ts).strftime(...), which uses the host's local timezone, so the time shown in
-chat depended on where the backend happened to run. It now passes tz=timezone.utc, matching how
-conversation search and the other timestamp fixes render times. These are source-level structural
-checks, since the tool has a heavy import graph (Firestore, vector search, OCR fetch).
+datetime.fromtimestamp(ts), which uses the host's local timezone. It now renders in the user's
+timezone via notification_db.get_user_time_zone(uid), matching how conversation_tools renders chat
+timestamps, so screen-activity and conversation matches in the same chat answer use the same
+timezone. It falls back to UTC when the user has no timezone set or it is not a valid IANA name.
+
+The _resolve_display_tz helper is exercised behaviorally (the tool has a heavy import graph, so the
+module is loaded with its heavy leaves stubbed); the wiring into the render is checked at source level.
 """
 
+import importlib.util
+import os
+import sys
+import types
+from datetime import timezone
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-SOURCE = Path(__file__).resolve().parents[2] / "utils" / "retrieval" / "tools" / "screen_activity_tools.py"
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+SOURCE = BACKEND_DIR / "utils" / "retrieval" / "tools" / "screen_activity_tools.py"
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
 
 
-def _source() -> str:
-    return SOURCE.read_text(encoding="utf-8")
+def _pkg(name):
+    mod = sys.modules.get(name)
+    if mod is None or not hasattr(mod, "__path__"):
+        mod = types.ModuleType(name)
+        mod.__path__ = []
+        sys.modules[name] = mod
+    return mod
 
 
-def test_timezone_is_imported():
-    assert "from datetime import datetime, timezone" in _source()
+def _mod(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
 
 
-def test_search_result_timestamp_is_utc():
-    source = _source()
-    start = source.index("def search_screen_activity_tool")
-    next_def = source.find("\ndef ", start + 1)
-    func = source[start:] if next_def == -1 else source[start:next_def]
+# Stub the heavy leaves screen_activity_tools.py imports (all absolute imports, no relative ones, so
+# the module can load under a plain name). The utils.retrieval.agentic import is left to fail so the
+# module's own ImportError fallback runs.
+for _p in ["langchain_core", "database", "utils", "utils.llm"]:
+    _pkg(_p)
+_mod("langchain_core.tools", tool=lambda fn: fn)
+_mod("langchain_core.runnables", RunnableConfig=object)
+_mod("database.screen_activity")
+_mod("database.vector_db", search_screen_activity_vectors=MagicMock())
+_mod("database.notifications", get_user_time_zone=lambda uid: None)
+_mod("database._client", db=MagicMock())
+_mod("utils.llm.clients", gemini_embed_query=MagicMock())
 
-    # The timestamp must be made timezone-aware (UTC) before formatting.
-    assert "datetime.fromtimestamp(ts, tz=timezone.utc)" in func
+
+def _load():
+    spec = importlib.util.spec_from_file_location("screen_activity_tools_under_test", str(SOURCE))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sat = _load()
+
+
+def _with_tz(tz_name):
+    return patch.object(sat.notification_db, "get_user_time_zone", lambda uid: tz_name)
+
+
+def test_resolve_display_tz_uses_user_timezone():
+    with _with_tz("America/New_York"):
+        tz = sat._resolve_display_tz("u1")
+    assert str(tz) == "America/New_York"
+
+
+def test_resolve_display_tz_falls_back_to_utc_when_unset():
+    with _with_tz(None):
+        assert sat._resolve_display_tz("u1") is timezone.utc
+
+
+def test_resolve_display_tz_falls_back_to_utc_on_invalid():
+    with _with_tz("Not/AValidZone"):
+        assert sat._resolve_display_tz("u1") is timezone.utc
+
+
+def test_search_tool_renders_in_resolved_timezone():
+    source = SOURCE.read_text(encoding="utf-8")
+    func = source[source.index("def search_screen_activity_tool") :]
+    assert "_resolve_display_tz(uid)" in func
+    assert "datetime.fromtimestamp(ts, tz=display_tz)" in func
     # The naive form (no tzinfo) must be gone.
     assert "datetime.fromtimestamp(ts).strftime" not in func

--- a/backend/utils/retrieval/tools/screen_activity_tools.py
+++ b/backend/utils/retrieval/tools/screen_activity_tools.py
@@ -3,7 +3,7 @@ Tools for accessing screen/computer activity data from the desktop app.
 """
 
 import contextvars
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from langchain_core.tools import tool
@@ -208,7 +208,7 @@ def search_screen_activity_tool(
         score = scores_by_id.get(sid, 0)
         app_name = app_by_id.get(sid, 'Unknown')
         ts = ts_by_id.get(sid, 0)
-        ts_str = datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S') if ts else 'Unknown'
+        ts_str = datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S') if ts else 'Unknown'
 
         # Fetch OCR text from Firestore
         ocr_text = ''

--- a/backend/utils/retrieval/tools/screen_activity_tools.py
+++ b/backend/utils/retrieval/tools/screen_activity_tools.py
@@ -42,13 +42,14 @@ def _get_uid(config: RunnableConfig) -> Optional[str]:
 def _resolve_display_tz(uid: str):
     # Render timestamps in the user's timezone so a chat answer shows screen-activity matches in the
     # same timezone as conversation matches (conversation_tools renders in the user's timezone too).
-    # Fall back to UTC when the user has no timezone set or it is not a valid IANA name.
-    tz_name = notification_db.get_user_time_zone(uid)
-    if tz_name:
-        try:
+    # Fall back to UTC on any failure: no timezone set, an invalid IANA name, or a Firestore error
+    # reading it (a transient lookup error must not fail an otherwise successful search).
+    try:
+        tz_name = notification_db.get_user_time_zone(uid)
+        if tz_name:
             return ZoneInfo(tz_name)
-        except Exception:
-            logger.warning(f"search_screen_activity_tool - invalid user timezone {tz_name!r}, using UTC")
+    except Exception:
+        logger.warning("search_screen_activity_tool - could not resolve user timezone, using UTC")
     return timezone.utc
 
 

--- a/backend/utils/retrieval/tools/screen_activity_tools.py
+++ b/backend/utils/retrieval/tools/screen_activity_tools.py
@@ -5,12 +5,14 @@ Tools for accessing screen/computer activity data from the desktop app.
 import contextvars
 from datetime import datetime, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from langchain_core.tools import tool
 from langchain_core.runnables import RunnableConfig
 
 import database.screen_activity as screen_activity_db
 import database.vector_db as vector_db
+import database.notifications as notification_db
 from database._client import db as firestore_db
 from utils.llm.clients import gemini_embed_query
 import logging
@@ -35,6 +37,19 @@ def _get_uid(config: RunnableConfig) -> Optional[str]:
         return config['configurable'].get('user_id')
     except (KeyError, TypeError):
         return None
+
+
+def _resolve_display_tz(uid: str):
+    # Render timestamps in the user's timezone so a chat answer shows screen-activity matches in the
+    # same timezone as conversation matches (conversation_tools renders in the user's timezone too).
+    # Fall back to UTC when the user has no timezone set or it is not a valid IANA name.
+    tz_name = notification_db.get_user_time_zone(uid)
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            logger.warning(f"search_screen_activity_tool - invalid user timezone {tz_name!r}, using UTC")
+    return timezone.utc
 
 
 @tool
@@ -202,13 +217,14 @@ def search_screen_activity_tool(
     app_by_id = {m['screenshot_id']: m.get('appName', '') for m in matches}
     ts_by_id = {m['screenshot_id']: m.get('timestamp', 0) for m in matches}
 
+    display_tz = _resolve_display_tz(uid)
     result = f"Found {len(matches)} screen activity matches for '{query}':\n\n"
 
     for sid in screenshot_ids:
         score = scores_by_id.get(sid, 0)
         app_name = app_by_id.get(sid, 'Unknown')
         ts = ts_by_id.get(sid, 0)
-        ts_str = datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S') if ts else 'Unknown'
+        ts_str = datetime.fromtimestamp(ts, tz=display_tz).strftime('%Y-%m-%d %H:%M:%S') if ts else 'Unknown'
 
         # Fetch OCR text from Firestore
         ocr_text = ''


### PR DESCRIPTION
## Problem

`search_screen_activity_tool` renders each matching screenshot's timestamp for the chat model with a naive `datetime.fromtimestamp(ts)`. Without a `tz`, the epoch is interpreted in the host's local timezone, so the time shown depends on where the backend runs.

The companion chat tool `conversation_tools` already renders match timestamps in the user's timezone (via `notification_db.get_user_time_zone(uid)`). Rendering screen-activity matches in a fixed timezone would make the two surfaces disagree within a single chat answer, which is the inconsistency #4643 is about.

## Fix

Render screen-activity match timestamps in the user's timezone, matching `conversation_tools`. A small `_resolve_display_tz(uid)` helper reads `notification_db.get_user_time_zone(uid)` and returns the corresponding `ZoneInfo`, falling back to UTC when the user has no timezone set or the value is not a valid IANA name.

```python
display_tz = _resolve_display_tz(uid)
...
ts_str = datetime.fromtimestamp(ts, tz=display_tz).strftime('%Y-%m-%d %H:%M:%S') if ts else 'Unknown'
```

## Test

`tests/unit/test_screen_activity_search_utc.py` (registered in `test.sh`) loads the tool with its heavy leaves stubbed and exercises `_resolve_display_tz` behaviorally: a set timezone resolves to that zone, an unset timezone falls back to UTC, and an invalid name falls back to UTC. A source-level check confirms the render uses the resolved timezone and no longer uses the naive form.
