### PR TITLE
fix(app): remove leftover DEBUG/PII print() calls from the auth flow

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -167,18 +167,13 @@ Future _init() async {
     }
   }
 
-  // DEBUG: Log Firebase Auth state before getIdToken
-  print('DEBUG main: Before getIdToken - currentUser=${FirebaseAuth.instance.currentUser?.uid}');
   bool isAuth = (await AuthService.instance.getIdToken()) != null;
-  print('DEBUG main: After getIdToken - isAuth=$isAuth, currentUser=${FirebaseAuth.instance.currentUser?.uid}');
   if (isAuth) {
     PlatformManager.instance.analytics.identify();
     // Restore onboarding state from server if not already set locally
     // This handles the case where cached credentials are used on startup
     if (!SharedPreferencesUtil().onboardingCompleted) {
-      print('DEBUG main: Restoring onboarding state from server...');
       await AuthService.instance.restoreOnboardingState();
-      print('DEBUG main: After restore - onboardingCompleted=${SharedPreferencesUtil().onboardingCompleted}');
     }
   }
   initOpus(await opus_flutter.load());

--- a/app/lib/pages/onboarding/custom_auth/signin.dart
+++ b/app/lib/pages/onboarding/custom_auth/signin.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import 'package:omi/utils/l10n_extensions.dart';
@@ -44,11 +42,6 @@ class CustomAuthSignUpState extends State<CustomAuthSignUp> {
   void _submitForm() {
     if (_formKey.currentState!.validate()) {
       // Form is valid, proceed further
-      Map<String, String> formData = {'email': _emailController.text, 'password': _passwordController.text};
-
-      String jsonString = jsonEncode(formData);
-      print(jsonString);
-
       // You can show a success message or navigate to another page here
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.signInSuccess)));
     }

--- a/app/lib/pages/onboarding/custom_auth/signup.dart
+++ b/app/lib/pages/onboarding/custom_auth/signup.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import 'package:omi/utils/l10n_extensions.dart';
@@ -62,15 +60,6 @@ class CustomAuthSignUpState extends State<CustomAuthSignUp> {
   void _submitForm() {
     if (_formKey.currentState!.validate()) {
       // Form is valid, proceed further
-      Map<String, String> formData = {
-        'name': _nameController.text,
-        'email': _emailController.text,
-        'password': _passwordController.text,
-      };
-
-      String jsonString = jsonEncode(formData);
-      print(jsonString);
-
       // You can show a success message or navigate to another page here
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.signUpSuccess)));
     }

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -102,9 +102,7 @@ class AuthenticationProvider extends BaseProvider {
                 'Failed to sign in with Google, please try again.',
           );
         }
-      } catch (e, stackTrace) {
-        print('DEBUG_AUTH: OAuth Google sign in error: $e');
-        print('DEBUG_AUTH: Stack trace: $stackTrace');
+      } catch (e) {
         Logger.debug('OAuth Google sign in error: $e');
         AppSnackbar.showSnackbarError(
           globalNavigatorKey.currentContext?.l10n.authenticationFailed ?? 'Authentication failed. Please try again.',
@@ -271,7 +269,7 @@ class AuthenticationProvider extends BaseProvider {
         rethrow;
       }
     } catch (e) {
-      print('Error linking with Apple: $e');
+      Logger.debug('Error linking with Apple: $e');
       AppSnackbar.showSnackbarError(
         globalNavigatorKey.currentContext?.l10n.authFailedToLinkApple ?? 'Failed to link with Apple, please try again.',
       );

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -17,7 +17,6 @@ import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
-import 'package:omi/utils/logger.dart';
 
 class AuthService {
   static final AuthService _instance = AuthService._internal();
@@ -36,40 +35,25 @@ class AuthService {
 
   /// Google Sign In using the standard google_sign_in package (iOS, Android)
   Future<UserCredential?> signInWithGoogleMobile() async {
-    print('DEBUG_AUTH: Using standard Google Sign In for mobile');
-
     // Trigger the authentication flow
     final GoogleSignInAccount? googleUser = await GoogleSignIn(scopes: ['profile', 'email']).signIn();
-    print('DEBUG_AUTH: Google User: $googleUser');
 
     // Obtain the auth details from the request
     final GoogleSignInAuthentication? googleAuth = await googleUser?.authentication;
-    print(
-      'DEBUG_AUTH: Google Auth accessToken=${googleAuth?.accessToken != null}, idToken=${googleAuth?.idToken != null}',
-    );
     if (googleAuth == null) {
-      print('DEBUG_AUTH: Failed - googleAuth is NULL');
       return null;
     }
 
     // Create a new credential
     if (googleAuth.accessToken == null && googleAuth.idToken == null) {
-      print('DEBUG_AUTH: Failed - accessToken and idToken are both NULL');
       return null;
     }
     final credential = GoogleAuthProvider.credential(accessToken: googleAuth.accessToken, idToken: googleAuth.idToken);
 
     // Once signed in, return the UserCredential
-    try {
-      print('DEBUG_AUTH: Calling signInWithCredential...');
-      var result = await FirebaseAuth.instance.signInWithCredential(credential);
-      print('DEBUG_AUTH: signInWithCredential SUCCESS - uid=${result.user?.uid}');
-      await _updateUserPreferences(result, 'google');
-      return result;
-    } catch (e) {
-      print('DEBUG_AUTH: signInWithCredential FAILED: $e');
-      rethrow;
-    }
+    final result = await FirebaseAuth.instance.signInWithCredential(credential);
+    await _updateUserPreferences(result, 'google');
+    return result;
   }
 
   /// Generates a cryptographically secure random nonce, to be included in a
@@ -465,12 +449,9 @@ class AuthService {
 
   Future<void> _restoreOnboardingState() async {
     try {
-      print('DEBUG _restoreOnboardingState: fetching from server...');
       final state = await getUserOnboardingState();
-      print('DEBUG _restoreOnboardingState: got state=$state');
       if (state != null) {
         if (state['completed'] == true) {
-          print('DEBUG _restoreOnboardingState: setting onboardingCompleted=true');
           SharedPreferencesUtil().onboardingCompleted = true;
         }
         final acquisitionSource = state['acquisition_source'] as String? ?? '';
@@ -483,12 +464,9 @@ class AuthService {
           SharedPreferencesUtil().userPrimaryLanguage = serverLanguage;
           SharedPreferencesUtil().hasSetPrimaryLanguage = true;
         }
-        print(
-          'DEBUG _restoreOnboardingState: done, onboardingCompleted=${SharedPreferencesUtil().onboardingCompleted}',
-        );
       }
     } catch (e) {
-      print('DEBUG _restoreOnboardingState: error=$e');
+      Logger.debug('restoreOnboardingState failed: $e');
     }
   }
 


### PR DESCRIPTION
## What

Removes leftover debug `print()` calls in the auth/startup flow that write user PII to device console logs (and **run in release builds** — `print` is not stripped by Flutter).

| File | Removed |
|------|---------|
| `services/auth_service.dart` | 9 `DEBUG_AUTH` prints in `signInWithGoogleMobile` (Firebase UID, full `GoogleSignInAccount`, token flags, raw exception) + 5 `DEBUG _restoreOnboardingState` prints (onboarding state). Restore error now via `Logger.debug`. Also removed a duplicate `logger.dart` import. |
| `main.dart` | 4 `DEBUG main` startup prints (Firebase UID) |
| `providers/auth_provider.dart` | 2 `DEBUG_AUTH` prints; Apple-link error routed through `Logger.debug` |
| `custom_auth/signin.dart` + `signup.dart` | dead `print(jsonString)` dumping **plaintext email + password** (forms are unreferenced scaffolding, but removed regardless; dropped the now-unused `dart:convert`) |

No behavior change — pure removal of debug logging (the `signInWithGoogleMobile` try/catch only printed-then-rethrew, so it was collapsed).

## Verification (Flutter 3.41.9)
- `flutter analyze` on all 5 files: **0 errors, 0 `avoid_print`** (the 2 remaining lints are pre-existing and unrelated — an unused `material.dart` import and a private-type-in-public-API hint).
- All touched auth files are now `print()`-free.

Scope note: this targets the auth-flow PII/debug prints. The broader ~100 raw `print()`→`Logger` sweep across the app is tracked separately.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

