### PR TITLE
fix(backend): run synchronous task-integration Firestore calls off the event loop in async handlers

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -13,6 +13,7 @@ import database.users as users_db
 import database.redis_db as redis_db
 from utils.other import endpoints as auth
 from utils.log_sanitizer import sanitize
+from utils.executors import db_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -389,7 +390,7 @@ async def refresh_oauth_token(
             if expires_in:
                 expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
                 updated_integration['expires_at'] = expires_at.isoformat()
-            users_db.set_task_integration(uid, app_key, updated_integration)
+            await run_blocking(db_executor, users_db.set_task_integration, uid, app_key, updated_integration)
             return updated_integration
         else:
             error_text = token_response.text
@@ -419,7 +420,7 @@ async def refresh_oauth_token(
                 if should_disconnect:
                     updated_integration = integration.copy()
                     updated_integration['connected'] = False
-                    users_db.set_task_integration(uid, app_key, updated_integration)
+                    await run_blocking(db_executor, users_db.set_task_integration, uid, app_key, updated_integration)
             raise HTTPException(status_code=401, detail=f"Failed to refresh {name} token")
     except HTTPException:
         raise
@@ -451,7 +452,7 @@ async def ensure_valid_oauth_token(
                 return await refresh_oauth_token(uid, app_key, integration, client=client)
             updated_integration = integration.copy()
             updated_integration['connected'] = False
-            users_db.set_task_integration(uid, app_key, updated_integration)
+            await run_blocking(db_executor, users_db.set_task_integration, uid, app_key, updated_integration)
             return updated_integration
     except Exception:
         if integration.get('refresh_token'):
@@ -556,7 +557,7 @@ async def _create_task_internal(
             else:
                 if response.status_code == 401:
                     integration['connected'] = False
-                    users_db.set_task_integration(uid, 'todoist', integration)
+                    await run_blocking(db_executor, users_db.set_task_integration, uid, 'todoist', integration)
                 return {
                     "success": False,
                     "error": f"Todoist API error: {response.status_code}",
@@ -682,7 +683,7 @@ async def create_task_via_integration(
     """Create a task in the specified integration using stored credentials."""
 
     # Get integration details
-    integration = users_db.get_task_integration(uid, app_key)
+    integration = await run_blocking(db_executor, users_db.get_task_integration, uid, app_key)
     if not integration or not integration.get('connected'):
         raise HTTPException(status_code=404, detail=f"Not connected to {app_key}")
 
@@ -729,7 +730,7 @@ async def create_task_via_integration(
 @router.get("/v1/task-integrations/asana/workspaces", tags=['task-integrations'])
 async def get_asana_workspaces(uid: str = Depends(auth.get_current_user_uid)):
     """Get user's Asana workspaces"""
-    data = users_db.get_task_integration(uid, 'asana')
+    data = await run_blocking(db_executor, users_db.get_task_integration, uid, 'asana')
 
     if not data:
         raise HTTPException(status_code=404, detail="Asana integration not found")
@@ -769,7 +770,7 @@ async def get_asana_workspaces(uid: str = Depends(auth.get_current_user_uid)):
 @router.get("/v1/task-integrations/asana/projects/{workspace_gid}", tags=['task-integrations'])
 async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_current_user_uid)):
     """Get projects in an Asana workspace"""
-    data = users_db.get_task_integration(uid, 'asana')
+    data = await run_blocking(db_executor, users_db.get_task_integration, uid, 'asana')
 
     if not data:
         raise HTTPException(status_code=404, detail="Asana integration not found")
@@ -809,7 +810,7 @@ async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_cur
 @router.get("/v1/task-integrations/clickup/teams", tags=['task-integrations'])
 async def get_clickup_teams(uid: str = Depends(auth.get_current_user_uid)):
     """Get user's ClickUp teams"""
-    data = users_db.get_task_integration(uid, 'clickup')
+    data = await run_blocking(db_executor, users_db.get_task_integration, uid, 'clickup')
 
     if not data:
         raise HTTPException(status_code=404, detail="ClickUp integration not found")
@@ -849,7 +850,7 @@ async def get_clickup_teams(uid: str = Depends(auth.get_current_user_uid)):
 @router.get("/v1/task-integrations/clickup/spaces/{team_id}", tags=['task-integrations'])
 async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_current_user_uid)):
     """Get spaces in a ClickUp team"""
-    data = users_db.get_task_integration(uid, 'clickup')
+    data = await run_blocking(db_executor, users_db.get_task_integration, uid, 'clickup')
 
     if not data:
         raise HTTPException(status_code=404, detail="ClickUp integration not found")
@@ -889,7 +890,7 @@ async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_current_u
 @router.get("/v1/task-integrations/clickup/lists/{space_id}", tags=['task-integrations'])
 async def get_clickup_lists(space_id: str, uid: str = Depends(auth.get_current_user_uid)):
     """Get lists in a ClickUp space"""
-    data = users_db.get_task_integration(uid, 'clickup')
+    data = await run_blocking(db_executor, users_db.get_task_integration, uid, 'clickup')
 
     if not data:
         raise HTTPException(status_code=404, detail="ClickUp integration not found")
@@ -1025,7 +1026,7 @@ async def handle_oauth_callback(
 
             # Store in Firebase
             try:
-                users_db.set_task_integration(uid, app_key, integration_data)
+                await run_blocking(db_executor, users_db.set_task_integration, uid, app_key, integration_data)
                 logger.info(f'{app_key}: Successfully stored tokens for user {uid}')
             except Exception as e:
                 logger.error(f'{app_key}: Error storing tokens in Firebase: {e}')

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -131,6 +131,7 @@ pytest tests/unit/test_firestore_read_ops_cache.py -v
 pytest tests/unit/test_ws_auth_handshake.py -v
 pytest tests/unit/test_streaming_deepgram_backoff.py -v
 pytest tests/unit/test_executors.py -v
+pytest tests/unit/test_task_integrations_async_offload.py -v
 pytest tests/unit/test_modulate_stt.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v

--- a/backend/tests/unit/test_task_integrations_async_offload.py
+++ b/backend/tests/unit/test_task_integrations_async_offload.py
@@ -27,7 +27,12 @@ def _async_funcs(tree):
 
 
 def test_run_blocking_is_imported():
-    assert "from utils.executors import db_executor, run_blocking" in SOURCE.read_text(encoding="utf-8")
+    # Semantic check (not an exact-string match) so import reordering or reformatting does not break it.
+    imported = set()
+    for node in ast.walk(_tree()):
+        if isinstance(node, ast.ImportFrom) and node.module == "utils.executors":
+            imported.update(alias.name for alias in node.names)
+    assert {"db_executor", "run_blocking"} <= imported
 
 
 def test_no_async_handler_calls_task_integration_db_directly():

--- a/backend/tests/unit/test_task_integrations_async_offload.py
+++ b/backend/tests/unit/test_task_integrations_async_offload.py
@@ -1,0 +1,60 @@
+"""Async task-integration handlers must not block the event loop on synchronous Firestore I/O.
+
+routers/task_integrations.py has async route handlers (create_task_via_integration, the asana/clickup
+readers, the OAuth token refresh/callback helpers) that called users_db.get_task_integration /
+set_task_integration directly. Those are synchronous Firestore reads/writes, so running them inside an
+`async def` blocks the event loop (health checks, HPA, all concurrent connections) per backend/AGENTS.md.
+The async-blocker linter does not catch database.* calls, only requests/time.sleep/Thread. These now go
+through `await run_blocking(db_executor, ...)`. The plain `def` endpoints (FastAPI runs them in a
+threadpool) keep calling the sync functions directly, which is correct.
+
+These are AST-level structural checks: the tool/router has a heavy import graph.
+"""
+
+import ast
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[2] / "routers" / "task_integrations.py"
+BLOCKING = {"get_task_integration", "set_task_integration", "delete_task_integration"}
+
+
+def _tree():
+    return ast.parse(SOURCE.read_text(encoding="utf-8"))
+
+
+def _async_funcs(tree):
+    return [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)]
+
+
+def test_run_blocking_is_imported():
+    assert "from utils.executors import db_executor, run_blocking" in SOURCE.read_text(encoding="utf-8")
+
+
+def test_no_async_handler_calls_task_integration_db_directly():
+    # In an async function, a direct call is `Call(func=users_db.<fn>)`. The offloaded form passes
+    # `users_db.<fn>` as a bare argument to run_blocking, so it is an Attribute, not a Call.
+    offenders = []
+    for fn in _async_funcs(_tree()):
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "users_db"
+                and node.func.attr in BLOCKING
+            ):
+                offenders.append((fn.name, node.func.attr, node.lineno))
+    assert (
+        not offenders
+    ), f"async handlers call sync task-integration Firestore directly (use run_blocking): {offenders}"
+
+
+def test_async_handlers_offload_task_integration_calls():
+    # Confirm the offloading is actually present (not just that the direct calls vanished).
+    wrapped = 0
+    for fn in _async_funcs(_tree()):
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "run_blocking":
+                if any(isinstance(a, ast.Attribute) and a.attr in BLOCKING for a in node.args):
+                    wrapped += 1
+    assert wrapped >= 11, f"expected at least 11 offloaded task-integration calls, found {wrapped}"


### PR DESCRIPTION
## Problem

Several `async def` route handlers in `routers/task_integrations.py` call the synchronous Firestore helpers `users_db.get_task_integration` / `set_task_integration` directly:

- `create_task_via_integration` (POST `/v1/task-integrations/{app_key}/tasks`)
- the Asana/ClickUp readers (`get_asana_workspaces`, `get_asana_projects`, `get_clickup_teams`, `get_clickup_spaces`, `get_clickup_lists`)
- the OAuth token helpers `refresh_oauth_token`, `ensure_valid_oauth_token`, `_create_task_internal`, and `handle_oauth_callback`

Those helpers do a synchronous Firestore `.get()` / `.set()`. Running a blocking call inside an `async def` blocks the event loop, which (per `backend/AGENTS.md`) freezes health checks, HPA scaling, and every other connection sharing the loop. The async-blocker linter (`scripts/lint_async_blockers.py`) does not catch this because it only flags `requests.*`, `time.sleep()`, and `Thread().start()`, not `database.*` calls.

The plain `def` endpoints in the same file (for example `get_task_integrations`, `save_task_integration`) are fine: FastAPI runs `def` handlers in a threadpool, so their synchronous Firestore calls do not block the loop. Those are left unchanged.

## Fix

Offload the synchronous task-integration Firestore reads and writes inside the async handlers to the database thread pool, following the project convention:

```python
integration = await run_blocking(db_executor, users_db.get_task_integration, uid, app_key)
```

All 11 such calls across the async handlers now go through `await run_blocking(db_executor, ...)`. No behavior changes; the calls just run off the event loop.

## Test

`tests/unit/test_task_integrations_async_offload.py` (registered in `test.sh`) is an AST-level structural check (the router has a heavy import graph). It asserts that `run_blocking`/`db_executor` are imported, that no `async def` in the file calls `users_db.get_task_integration` / `set_task_integration` / `delete_task_integration` directly (a direct call is an `ast.Call` on the helper; the offloaded form passes the helper to `run_blocking` as a bare argument), and that the offloading is actually present. All three fail against the previous code and pass with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

