### PR TITLE
fix(app): resource leaks + defensive guards (capture/sync/STT/widgets)

### DIFF
--- a/app/lib/pages/apps/app_detail/widgets/add_review_widget.dart
+++ b/app/lib/pages/apps/app_detail/widgets/add_review_widget.dart
@@ -74,6 +74,12 @@ class _AddReviewWidgetState extends State<AddReviewWidget> {
   }
 
   @override
+  void dispose() {
+    reviewController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,

--- a/app/lib/pages/conversation_detail/test_prompts.dart
+++ b/app/lib/pages/conversation_detail/test_prompts.dart
@@ -18,6 +18,12 @@ class _TestPromptsPageState extends State<TestPromptsPage> {
   String result = '';
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.primary,

--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -138,6 +138,12 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final peopleProvider = context.watch<PeopleProvider>();
     final people = peopleProvider.people;

--- a/app/lib/pages/onboarding/name/name_widget.dart
+++ b/app/lib/pages/onboarding/name/name_widget.dart
@@ -31,6 +31,13 @@ class _NameWidgetState extends State<NameWidget> {
   }
 
   @override
+  void dispose() {
+    nameController.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: [

--- a/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
+++ b/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
@@ -262,6 +262,12 @@ class _PrimaryLanguageWidgetState extends State<PrimaryLanguageWidget> {
   }
 
   @override
+  void dispose() {
+    _languageScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: [

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -634,79 +634,83 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
   Future<void> _importConfig() async {
     final controller = TextEditingController();
 
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: const Color(0xFF1A1A1A),
-        title: Text(context.l10n.importConfiguration, style: const TextStyle(color: Colors.white, fontSize: 18)),
-        content: SizedBox(
-          width: double.maxFinite,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(context.l10n.pasteJsonConfig, style: TextStyle(color: Colors.grey.shade400, fontSize: 14)),
-              const SizedBox(height: 12),
-              Container(
-                height: 200,
-                decoration: BoxDecoration(
-                  color: const Color(0xFF0D0D0D),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.grey.shade800),
-                ),
-                child: TextField(
-                  controller: controller,
-                  maxLines: null,
-                  expands: true,
-                  style: const TextStyle(color: Colors.white, fontFamily: 'monospace', fontSize: 12),
-                  decoration: InputDecoration(
-                    hintText: context.l10n.transcriptionJsonPlaceholder,
-                    hintStyle: TextStyle(color: Colors.grey.shade700),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.all(12),
+    try {
+      final result = await showDialog<String>(
+        context: context,
+        builder: (context) => AlertDialog(
+          backgroundColor: const Color(0xFF1A1A1A),
+          title: Text(context.l10n.importConfiguration, style: const TextStyle(color: Colors.white, fontSize: 18)),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(context.l10n.pasteJsonConfig, style: TextStyle(color: Colors.grey.shade400, fontSize: 14)),
+                const SizedBox(height: 12),
+                Container(
+                  height: 200,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF0D0D0D),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.grey.shade800),
                   ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  Icon(Icons.info_outline, size: 14, color: Colors.grey.shade600),
-                  const SizedBox(width: 6),
-                  Expanded(
-                    child: Text(
-                      context.l10n.addApiKeyAfterImport,
-                      style: TextStyle(color: Colors.grey.shade600, fontSize: 11),
+                  child: TextField(
+                    controller: controller,
+                    maxLines: null,
+                    expands: true,
+                    style: const TextStyle(color: Colors.white, fontFamily: 'monospace', fontSize: 12),
+                    decoration: InputDecoration(
+                      hintText: context.l10n.transcriptionJsonPlaceholder,
+                      hintStyle: TextStyle(color: Colors.grey.shade700),
+                      border: InputBorder.none,
+                      contentPadding: const EdgeInsets.all(12),
                     ),
                   ),
-                ],
-              ),
-            ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(Icons.info_outline, size: 14, color: Colors.grey.shade600),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        context.l10n.addApiKeyAfterImport,
+                        style: TextStyle(color: Colors.grey.shade600, fontSize: 11),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(context.l10n.cancel, style: TextStyle(color: Colors.grey.shade400)),
+            ),
+            TextButton(
+              onPressed: () async {
+                final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+                if (clipboardData?.text != null) {
+                  controller.text = clipboardData!.text!;
+                }
+              },
+              child: Text(context.l10n.paste, style: const TextStyle(color: Colors.white)),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, controller.text),
+              child: Text(context.l10n.import, style: const TextStyle(color: Colors.white)),
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(context.l10n.cancel, style: TextStyle(color: Colors.grey.shade400)),
-          ),
-          TextButton(
-            onPressed: () async {
-              final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
-              if (clipboardData?.text != null) {
-                controller.text = clipboardData!.text!;
-              }
-            },
-            child: Text(context.l10n.paste, style: const TextStyle(color: Colors.white)),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: Text(context.l10n.import, style: const TextStyle(color: Colors.white)),
-          ),
-        ],
-      ),
-    );
+      );
 
-    if (result != null && result.isNotEmpty) {
-      _parseAndApplyConfig(result);
+      if (result != null && result.isNotEmpty) {
+        _parseAndApplyConfig(result);
+      }
+    } finally {
+      controller.dispose();
     }
   }
 

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1326,6 +1326,7 @@ class CaptureProvider extends ChangeNotifier
   Future _closeBleStream({bool disableNativeBackground = false}) async {
     await _bleBytesStream?.cancel();
     await _blePhotoStream?.cancel();
+    await _bleButtonStream?.cancel();
     _stopMetricsTracking();
     if (disableNativeBackground) {
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
@@ -1346,6 +1347,7 @@ class CaptureProvider extends ChangeNotifier
   void dispose() {
     _bleBytesStream?.cancel();
     _blePhotoStream?.cancel();
+    _bleButtonStream?.cancel();
     _socket?.unsubscribe(this);
     _keepAliveTimer?.cancel();
     _inProgressConversationRefreshTimer?.cancel();

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -129,6 +129,8 @@ class MemoriesProvider extends ChangeNotifier {
 
   /// Set the connectivity provider to listen for connection changes
   void setConnectivityProvider(ConnectivityProvider provider) {
+    if (identical(_connectivityProvider, provider)) return;
+    _connectivityProvider?.removeListener(_onConnectivityChanged);
     _connectivityProvider = provider;
     _connectivityProvider?.addListener(_onConnectivityChanged);
   }

--- a/app/lib/services/sockets/pure_streaming_stt.dart
+++ b/app/lib/services/sockets/pure_streaming_stt.dart
@@ -324,24 +324,31 @@ class GeminiStreamingSttSocket implements IPureSocket {
       _frameBuffer.clear();
       _bufferedBytes = 0;
 
-      Uint8List pcmData = combined;
+      Uint8List? pcmData = combined;
       if (transcoder != null) {
         try {
           pcmData = transcoder!.transcodeFrames([combined]);
-        } catch (_) {}
+        } catch (e) {
+          // Don't ship un-transcoded bytes tagged as PCM — that produces a corrupted stream.
+          // Skip only the tail send; teardown below must still run.
+          CustomSttLogService.instance.error('GeminiStreaming', 'Transcode error (flush): $e');
+          pcmData = null;
+        }
       }
 
-      final realtimeInput = {
-        'realtimeInput': {
-          'mediaChunks': [
-            {'mimeType': 'audio/pcm;rate=$sampleRate', 'data': base64Encode(pcmData)},
-          ],
-        },
-      };
+      if (pcmData != null) {
+        final realtimeInput = {
+          'realtimeInput': {
+            'mediaChunks': [
+              {'mimeType': 'audio/pcm;rate=$sampleRate', 'data': base64Encode(pcmData)},
+            ],
+          },
+        };
 
-      try {
-        _channel!.sink.add(jsonEncode(realtimeInput));
-      } catch (_) {}
+        try {
+          _channel!.sink.add(jsonEncode(realtimeInput));
+        } catch (_) {}
+      }
     }
 
     await Future.delayed(const Duration(milliseconds: 500));

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -256,7 +256,9 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
   @override
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
     _cancelRequested = false;
-    var walToSync = _wals.where((w) => w == wal).toList().first;
+    final matches = _wals.where((w) => w == wal).toList();
+    if (matches.isEmpty) return null;
+    final walToSync = matches.first;
 
     walToSync.isSyncing = true;
     walToSync.syncStartedAt = DateTime.now();

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -729,7 +729,12 @@ class LocalWalSyncImpl implements LocalWalSync {
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
     await _flush();
 
-    var walToSync = _wals.where((w) => w == wal).toList().first;
+    final matches = _wals.where((w) => w == wal).toList();
+    if (matches.isEmpty) {
+      DebugLogManager.logInfo('Single WAL upload skipped — WAL no longer tracked', {'walId': wal.id});
+      return null;
+    }
+    final walToSync = matches.first;
 
     var resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
 

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -1,5 +1,7 @@
+import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -7,6 +9,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
+import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
@@ -35,6 +38,13 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return Directory.systemTemp.path;
+        return null;
+      },
+    );
 
     listener = _MockListener();
     sync = LocalWalSyncImpl(listener);
@@ -377,6 +387,28 @@ void main() {
       // No firmware header in stored data
       expect(chunk[0].length, 3);
       expect(chunk[0][0], 0xAA); // First byte is audio, not header
+    });
+  });
+
+  group('syncWal — orphan WAL guard', () {
+    // A WAL the user taps "sync" on may already be gone from `_wals` (a
+    // concurrent delete/reload). Previously `.first` on the empty match list
+    // threw an uncaught StateError; the guard now bails out to null instead.
+    test('LocalWalSyncImpl.syncWal returns null when the WAL is not tracked', () async {
+      final orphan = Wal(timerStart: 123, codec: BleAudioCodec.opus, seconds: 10);
+
+      final result = await sync.syncWal(wal: orphan);
+
+      expect(result, isNull);
+    });
+
+    test('FlashPageWalSyncImpl.syncWal returns null when the WAL is not tracked', () async {
+      final flashSync = FlashPageWalSyncImpl(listener);
+      final orphan = Wal(timerStart: 456, codec: BleAudioCodec.opus, seconds: 10);
+
+      final result = await flashSync.syncWal(wal: orphan);
+
+      expect(result, isNull);
     });
   });
 }


### PR DESCRIPTION
## What

A robustness batch from the app audit — fixes resource leaks and adds defensive guards. Behavior-preserving except where it fixes a defect.

### Resource leaks
- **`capture_provider.dart`** — `_bleButtonStream` (a BLE button-characteristic subscription) was never cancelled in `_closeBleStream()` / `dispose()`, only on reassignment. Now cancelled in both.
- **6 widgets** — added missing `dispose()` for `TextEditingController` / `FocusNode` / `ScrollController`: `name_widget`, `name_speaker_sheet`, `add_review_widget`, `primary_language_widget`, `test_prompts`; `transcription_settings` `_importConfig` now disposes the dialog controller via `try/finally`.
- **`memories_provider.dart`** — `setConnectivityProvider` re-added a listener on every `ProxyProvider.update` (per network flap) without removing the old one. Now removes-before-add with an `identical()` no-op guard.

### Defensive guards (fix latent crashes / corruption)
- **`local_wal_sync.dart` + `flash_page_wal_sync.dart`** — `syncWal` did `.where(..).toList().first`, throwing an uncaught `StateError` when the user synced a WAL already removed from the list. Now an `isEmpty` guard returns `null` (callers already null-check).
- **`pure_streaming_stt.dart`** — Gemini disconnect tail-flush shipped un-transcoded Opus bytes tagged as PCM on transcode failure (corrupted stream). Now skips **only the send** and still runs teardown.

## Verification (Flutter 3.41.9 / Dart 3.11.5)
- **Tests:** added orphan-WAL guard tests for both `LocalWalSyncImpl` and `FlashPageWalSyncImpl` (with a path_provider mock); they fail against the old `.first` code. **Full suite: 585 pass.**
- **Build:** clean `flutter build apk --release --flavor dev` ✅ (full AOT compile).
- **Review:** independent 3-lens review (regression / lifecycle / edge-cases). It caught a real regression — an earlier version of the Gemini fix used `return`, which skipped `disconnect()`'s teardown (`sink.close()` / `onClosed()`) and would have leaked the socket. **Fixed** (skip only the send) and re-verified; the other 11 changes drew zero concerns.

## Not included
The transcript-drop race (`capture_provider.dart:2183`) is held for a separate PR — it needs a careful single-flight fix, not a one-liner.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

