### PR TITLE
fix: count CJK words in onboarding answer gate

### DIFF
--- a/backend/utils/onboarding.py
+++ b/backend/utils/onboarding.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Optional
 from utils.executors import llm_executor, run_blocking
 from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import track_usage, Features
+from utils.llm.conversation_processing import _word_count
 import logging
 
 logger = logging.getLogger(__name__)
@@ -167,7 +168,7 @@ class OnboardingHandler:
             transcript = self.current_transcript.strip()
 
             # Check with AI if enough content
-            word_count = len(transcript.split())
+            word_count = _word_count(transcript)
             answered = False
 
             if word_count >= 2:


### PR DESCRIPTION
### Problem

`OnboardingHandler._check_answer` decides whether a spoken answer has enough content before calling the LLM:

```py
word_count = len(transcript.split())
answered = False
if word_count >= 2:
    answered = await self._ai_check_answer(question, transcript)
```

`str.split()` returns 1 for CJK text that has no spaces, so a complete answer like `東京に住んでいます` ("I live in Tokyo") or `我在一家科技公司工作` counts as a single word and never reaches `_ai_check_answer`. The onboarding question stays marked unanswered for Japanese / Chinese / Korean speakers.

### Fix

Reuse the existing CJK-aware `_word_count` helper in `conversation_processing.py`, which `should_discard_conversation` already uses to avoid the exact same `split()` undercount (#7104, reported in #7065). English input is unchanged: `_word_count` falls back to `split()` when the text is not CJK-dominant.

### Verified

| input | old `split() >= 2` | new `_word_count >= 2` |
|---|---|---|
| `I am 25 years old` | pass | pass |
| `Tokyo` | reject | reject |
| `東京に住んでいます` | reject | pass |
| `我在一家科技公司工作` | reject | pass |

Same `unicodedata.east_asian_width` heuristic that already shipped in #7104, applied to the one other transcript word-count gate that was left using plain `split()`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

