### PR TITLE
[codex] Make notch mode automatic

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -159,7 +159,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private var frameAnimationToken: Int = 0
 
     private var notchModeEnabled: Bool {
-        ShortcutSettings.shared.notchModeEnabled && Self.screenHasCameraHousing(screenForPlacement)
+        Self.screenHasCameraHousing(screenForPlacement)
     }
     var usesNotchIslandForCurrentScreen: Bool { notchModeEnabled }
     private var screenForPlacement: NSScreen? {
@@ -253,8 +253,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         contentRect: NSRect, styleMask style: NSWindow.StyleMask,
         backing backingStoreType: NSWindow.BackingStoreType = .buffered, defer flag: Bool = false
     ) {
-        let initialSize = ShortcutSettings.shared.notchModeEnabled
-            && FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first)
+        let initialSize = FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first)
             ? NSSize(
                 width: FloatingControlBarWindow.notchHiddenCenterWidth(for: NSScreen.main ?? NSScreen.screens.first)
                     + FloatingControlBarWindow.notchCompactSideWidth * 2,
@@ -274,8 +273,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
-        self.level = ShortcutSettings.shared.notchModeEnabled
-            && FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first) ? .statusBar : .floating
+        self.level = FloatingControlBarWindow.screenHasCameraHousing(NSScreen.main ?? NSScreen.screens.first)
+            ? .statusBar
+            : .floating
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.isMovableByWindowBackground = false
         self.acceptsMouseMovedEvents = true
@@ -755,8 +755,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         let currentVisible = currentScreen?.visibleFrame ?? .zero
         let targetVisible = targetScreen.visibleFrame
 
-        let targetUsesNotchIsland = ShortcutSettings.shared.notchModeEnabled
-            && Self.screenHasCameraHousing(targetScreen)
+        let targetUsesNotchIsland = Self.screenHasCameraHousing(targetScreen)
 
         if targetUsesNotchIsland {
             growOutFromNotch(on: targetScreen)
@@ -1543,9 +1542,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
 
     private var topInsetForPillFallback: CGFloat {
-        ShortcutSettings.shared.notchModeEnabled
-            ? Self.topInsetWhenNotchModeFallsBackToPill
-            : Self.topInset
+        Self.topInsetWhenNotchModeFallsBackToPill
     }
 
     /// Center the bar near the top of the main screen.
@@ -1556,7 +1553,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             self.center()
             return
         }
-        if ShortcutSettings.shared.notchModeEnabled && Self.screenHasCameraHousing(screen) {
+        if Self.screenHasCameraHousing(screen) {
             let targetFrame = frameForCurrentState(on: screen, usesNotchIsland: true)
             self.setFrame(targetFrame, display: true, animate: false)
             log("FloatingControlBarWindow: centered notch island at \(targetFrame.origin) on screen \(screen.frame)")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -325,11 +325,6 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(solidBackground, forKey: "shortcut_solidBackground") }
     }
 
-    /// When true, the floating bar anchors to the top-center notch area and blends into it.
-    @Published var notchModeEnabled: Bool {
-        didSet { UserDefaults.standard.set(notchModeEnabled, forKey: "shortcut_notchModeEnabled") }
-    }
-
     /// When true, push-to-talk plays start/end sounds.
     @Published var pttSoundsEnabled: Bool {
         didSet { UserDefaults.standard.set(pttSoundsEnabled, forKey: "shortcut_pttSoundsEnabled") }
@@ -544,7 +539,6 @@ class ShortcutSettings: ObservableObject {
         self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
-        self.notchModeEnabled = UserDefaults.standard.object(forKey: "shortcut_notchModeEnabled") as? Bool ?? true
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
         self.pttMuteSystemAudio = UserDefaults.standard.object(forKey: "shortcut_pttMuteSystemAudio") as? Bool ?? true
         self.selectedModel = ModelQoS.Claude.sanitizedSelection(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -2475,28 +2475,6 @@ struct SettingsContentView: View {
         }
       }
 
-      settingsCard(settingId: "floatingbar.notch") {
-        HStack(spacing: 16) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Notch Mode")
-              .scaledFont(size: 16, weight: .semibold)
-              .foregroundColor(OmiColors.textPrimary)
-            Text("Anchor the floating bar around the MacBook notch with agents on the left and voice controls on the right.")
-              .scaledFont(size: 13)
-              .foregroundColor(OmiColors.textSecondary)
-          }
-          Spacer()
-          Toggle("", isOn: $shortcutSettings.notchModeEnabled)
-            .toggleStyle(.switch)
-            .tint(.accentColor)
-            .onChange(of: shortcutSettings.notchModeEnabled) { _, _ in
-              if FloatingControlBarManager.shared.isEnabled {
-                FloatingControlBarManager.shared.show()
-              }
-            }
-        }
-      }
-
       settingsCard(settingId: "floatingbar.draggable") {
         HStack(spacing: 16) {
           VStack(alignment: .leading, spacing: 4) {

--- a/desktop/macos/changelog/unreleased/20260629-floating-bar-notch-default.json
+++ b/desktop/macos/changelog/unreleased/20260629-floating-bar-notch-default.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made the floating bar use Notch Mode automatically on Macs with a notch"
+}


### PR DESCRIPTION
## Summary
- Removed the user-facing Notch Mode toggle from Floating Bar settings
- Stopped reading/writing the old `shortcut_notchModeEnabled` preference
- Made notch island rendering automatic when the active screen reports a camera housing, with compact pill fallback otherwise
- Added a desktop changelog fragment

## Root Cause
Some users could miss the new notch UI because the old persisted Notch Mode preference could remain disabled. Separately, the runtime still depends on macOS reporting a camera housing for the active display, so external/non-notch displays continue to use the compact pill.

## Validation
- `git diff --check`
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`
- Pre-push hooks: desktop changelog validation, prod promotion policy, tool surface checks, optional formatters

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

