### PR TITLE
[codex] Separate LLM extraction contracts

### DIFF
--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -123,6 +123,10 @@ def _select_serving_route(resolved_route: ResolvedRoute) -> RouteArtifact:
     return resolved_route.last_known_good_route
 
 
+def selected_serving_route_artifact_id(resolved_route: ResolvedRoute) -> str:
+    return _select_serving_route(resolved_route).route_artifact_id
+
+
 def _is_route_eligible_to_serve(route: RouteArtifact, validated_request: ValidatedChatCompletionRequest) -> bool:
     """Whether a route should receive live traffic based on rollout stage and percent."""
     if route.rollout.stage in (RolloutStage.SHADOW, RolloutStage.DISABLED):

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -13,7 +13,7 @@ from llm_gateway.gateway.errors import (
     GatewayErrorCode,
     GatewayInvalidRequestError,
 )
-from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
+from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion, selected_serving_route_artifact_id
 from llm_gateway.gateway.metrics import observe_error, observe_success, time_request
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
@@ -43,7 +43,7 @@ async def create_chat_completion(
                 lambda: observe_error(
                     started_at,
                     lane_id=resolved_route.lane.lane_id,
-                    route_artifact_id=resolved_route.active_route.route_artifact_id,
+                    route_artifact_id=selected_serving_route_artifact_id(resolved_route),
                     error=exc,
                 )
             )

--- a/backend/models/structured.py
+++ b/backend/models/structured.py
@@ -10,7 +10,7 @@ if _SDK_SRC.exists() and str(_SDK_SRC) not in sys.path:
     sys.path.insert(0, str(_SDK_SRC))
 
 try:
-    from omi_plugin_sdk.models import ActionItem, ActionItemsExtraction, Event, Structured
+    from omi_plugin_sdk.models import ActionItem, Event, Structured
 except ModuleNotFoundError:
     from models.conversation_enums import CategoryEnum
 
@@ -73,11 +73,6 @@ except ModuleNotFoundError:
                 ]
             )
 
-    class ActionItemsExtraction(BaseModel):
-        action_items: List[ActionItem] = Field(
-            description='A list of action items from the conversation', default_factory=list
-        )
-
     class Structured(BaseModel):
         title: str = Field(description='A title/name for this conversation', default='')
         overview: str = Field(
@@ -118,4 +113,4 @@ except ModuleNotFoundError:
             return result.strip()
 
 
-__all__ = ['ActionItem', 'ActionItemsExtraction', 'Event', 'Structured']
+__all__ = ['ActionItem', 'Event', 'Structured']

--- a/backend/models/structured_extraction.py
+++ b/backend/models/structured_extraction.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from models.conversation_enums import CategoryEnum
+from models.structured import ActionItem, Event, Structured
+
+
+class ExtractedActionItem(BaseModel):
+    description: str = Field(description="The action item to be completed")
+    due_at: Optional[datetime] = Field(default=None, description="When the action item is due")
+
+    def to_action_item(self) -> ActionItem:
+        return ActionItem(description=self.description, due_at=self.due_at)
+
+
+class ActionItemsExtraction(BaseModel):
+    action_items: List[ExtractedActionItem] = Field(
+        description="A list of action items from the conversation",
+        default=[],
+    )
+
+    def to_action_items(self) -> List[ActionItem]:
+        return [item.to_action_item() for item in self.action_items]
+
+
+class ExtractedEvent(BaseModel):
+    title: str = Field(description="The title of the event")
+    description: str = Field(description="A brief description of the event", default='')
+    start: datetime = Field(description="The start date and time of the event")
+    duration: int = Field(description="The duration of the event in minutes", default=30)
+
+    def to_event(self) -> Event:
+        return Event(
+            title=self.title,
+            description=self.description,
+            start=self.start,
+            duration=self.duration,
+            created=False,
+        )
+
+
+class StructuredExtraction(BaseModel):
+    title: str = Field(description="A title/name for this conversation", default='')
+    overview: str = Field(
+        description="A brief overview of the conversation, highlighting the key details from it",
+        default='',
+    )
+    emoji: str = Field(description="An emoji to represent the conversation", default='🧠')
+    category: CategoryEnum = Field(description="A category for this conversation", default=CategoryEnum.other)
+    action_items: List[ExtractedActionItem] = Field(
+        description="A list of action items from the conversation",
+        default=[],
+    )
+    events: List[ExtractedEvent] = Field(
+        description="A list of events extracted from the conversation, that the user must have on his calendar.",
+        default=[],
+    )
+
+    @field_validator('category', mode='before')
+    @classmethod
+    def set_category_default_on_error(cls, v: any) -> 'CategoryEnum':
+        if isinstance(v, CategoryEnum):
+            return v
+        try:
+            return CategoryEnum(v)
+        except ValueError:
+            return CategoryEnum.other
+
+    def to_structured(self) -> Structured:
+        return Structured(
+            title=self.title,
+            overview=self.overview,
+            emoji=self.emoji,
+            category=self.category,
+            action_items=[item.to_action_item() for item in self.action_items],
+            events=[event.to_event() for event in self.events],
+        )

--- a/backend/models/structured_extraction.py
+++ b/backend/models/structured_extraction.py
@@ -31,6 +31,13 @@ class ExtractedEvent(BaseModel):
     start: datetime = Field(description="The start date and time of the event")
     duration: int = Field(description="The duration of the event in minutes", default=30)
 
+    @field_validator('duration')
+    @classmethod
+    def duration_must_be_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError('duration must be a positive number of minutes')
+        return v
+
     def to_event(self) -> Event:
         return Event(
             title=self.title,

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -72,6 +72,16 @@ def _load_module_from_file(module_name, file_path):
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies
 # ---------------------------------------------------------------------------
+for importable_mod_name in [
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+]:
+    try:
+        importlib.import_module(importable_mod_name)
+    except Exception:
+        pass
+
 for mod_name in [
     "firebase_admin",
     "firebase_admin.firestore",
@@ -111,7 +121,8 @@ action_items_db.update_action_item = MagicMock(return_value=True)
 # Stub database.notifications (action_item_tools imports get_user_time_zone for tz rendering)
 notifications_db = _stub_module("database.notifications")
 notifications_db.get_user_time_zone = MagicMock(return_value="UTC")
-_stub_package("database")
+if "database" not in sys.modules:
+    importlib.import_module("database")
 
 # Stub notifications
 notif_mod = _stub_module("utils.notifications")
@@ -120,12 +131,14 @@ notif_mod.send_action_item_created_notification = MagicMock()
 notif_mod.send_action_item_data_message = MagicMock()
 notif_mod.sync_action_item_reminder = MagicMock()
 
-byok_mod = _stub_module("utils.byok")
-byok_mod.has_byok_keys = MagicMock(return_value=False)
+if "utils.byok" not in sys.modules:
+    byok_mod = _stub_module("utils.byok")
+    byok_mod.has_byok_keys = MagicMock(return_value=False)
 
-gateway_mod = _stub_module("utils.llm.gateway_client")
-gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
-gateway_mod.record_chat_extraction_gateway_result = MagicMock()
+if "utils.llm.gateway_client" not in sys.modules:
+    gateway_mod = _stub_module("utils.llm.gateway_client")
+    gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
+    gateway_mod.record_chat_extraction_gateway_result = MagicMock()
 
 # Stub langchain
 langchain_core = _stub_package("langchain_core")
@@ -422,15 +435,15 @@ class TestExtractActionItemsPostValidation:
 
     def test_clears_past_due_dates_from_extraction(self):
         """Due dates more than 1 day in the past should be cleared after extraction."""
-        from models.structured import ActionItem, ActionItemsExtraction
+        from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem
 
         past_due = datetime(2025, 9, 15, 10, 0, tzinfo=timezone.utc)
         future_due = datetime.now(timezone.utc) + timedelta(days=3)
 
         mock_response = ActionItemsExtraction(
             action_items=[
-                ActionItem(description="Past task", due_at=past_due),
-                ActionItem(description="Future task", due_at=future_due),
+                ExtractedActionItem(description="Past task", due_at=past_due),
+                ExtractedActionItem(description="Future task", due_at=future_due),
             ]
         )
 
@@ -473,7 +486,7 @@ class TestExtractActionItemsPostValidation:
 
     def test_passes_current_time_to_invoke(self):
         """extract_action_items should pass current_time in the invoke payload."""
-        from models.structured import ActionItemsExtraction
+        from models.structured_extraction import ActionItemsExtraction
 
         mock_response = ActionItemsExtraction(action_items=[])
         mock_chain = MagicMock()
@@ -515,9 +528,11 @@ class TestExtractActionItemsPostValidation:
 
     def test_preserves_none_due_dates(self):
         """Action items with no due date should remain unchanged."""
-        from models.structured import ActionItem, ActionItemsExtraction
+        from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem
 
-        mock_response = ActionItemsExtraction(action_items=[ActionItem(description="No due date task", due_at=None)])
+        mock_response = ActionItemsExtraction(
+            action_items=[ExtractedActionItem(description="No due date task", due_at=None)]
+        )
         mock_chain = MagicMock()
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)
@@ -556,11 +571,11 @@ class TestExtractActionItemsPostValidation:
 
     def test_preserves_due_date_within_grace_boundary(self):
         """Due date 23h ago should be preserved (within 1-day grace window)."""
-        from models.structured import ActionItem, ActionItemsExtraction
+        from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem
 
         boundary_due = datetime.now(timezone.utc) - timedelta(hours=23)
         mock_response = ActionItemsExtraction(
-            action_items=[ActionItem(description="Boundary task", due_at=boundary_due)]
+            action_items=[ExtractedActionItem(description="Boundary task", due_at=boundary_due)]
         )
         mock_chain = MagicMock()
         mock_chain.invoke.return_value = mock_response
@@ -609,9 +624,9 @@ class TestActionItemTimezoneConversion:
         return ZoneInfo(key)
 
     def _run(self, due_at, tz):
-        from models.structured import ActionItem, ActionItemsExtraction
+        from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem
 
-        mock_response = ActionItemsExtraction(action_items=[ActionItem(description="Task", due_at=due_at)])
+        mock_response = ActionItemsExtraction(action_items=[ExtractedActionItem(description="Task", due_at=due_at)])
         mock_chain = MagicMock()
         mock_chain.invoke.return_value = mock_response
         mock_chain.__or__ = MagicMock(return_value=mock_chain)

--- a/backend/tests/unit/test_conversation_model_split.py
+++ b/backend/tests/unit/test_conversation_model_split.py
@@ -55,7 +55,6 @@ class TestReExportsRemoved:
 
         reexport_symbols = [
             'ActionItem',
-            'ActionItemsExtraction',
             'AudioFile',
             'CalendarMeetingContext',
             'CategoryEnum',
@@ -81,7 +80,8 @@ class TestReExportsRemoved:
     def test_canonical_imports_work(self):
         """All moved symbols import from their canonical modules."""
         from models.conversation_enums import CategoryEnum, ConversationSource, ConversationStatus
-        from models.structured import Structured, ActionItem, Event, ActionItemsExtraction
+        from models.structured import Structured, ActionItem, Event
+        from models.structured_extraction import ActionItemsExtraction
         from models.audio_file import AudioFile
         from models.calendar_context import CalendarMeetingContext, MeetingParticipant
         from models.conversation_photo import ConversationPhoto

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -43,6 +43,7 @@ sys.modules.setdefault('utils.llm.clients', clients_stub)
 from utils import byok
 from utils.llm import chat, gateway_client
 from utils.llm import conversation_processing
+from models.structured_extraction import ActionItemsExtraction
 
 
 class FakeParser:
@@ -214,6 +215,34 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
     assert captured['json']['messages'] == [{'role': 'user', 'content': 'classified prompt'}]
     assert captured['json']['response_format']['type'] == 'json_schema'
     assert captured['json']['response_format']['json_schema']['schema']['properties']['value']['type'] == 'boolean'
+
+
+def test_strict_schema_normalizes_action_item_extraction_for_openai():
+    schema = gateway_client._strict_model_json_schema(ActionItemsExtraction)
+
+    assert schema['additionalProperties'] is False
+    assert schema['required'] == ['action_items']
+
+    action_item_schema = schema['$defs']['ExtractedActionItem']
+    assert action_item_schema['additionalProperties'] is False
+    assert action_item_schema['required'] == ['description', 'due_at']
+    assert 'default' not in action_item_schema['properties']['due_at']
+    assert {'type': 'null'} in action_item_schema['properties']['due_at']['anyOf']
+
+
+def test_strict_schema_removes_defaults_recursively():
+    schema = gateway_client._strict_model_json_schema(ActionItemsExtraction)
+
+    def walk(node):
+        if isinstance(node, dict):
+            assert 'default' not in node
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(schema)
 
 
 def test_chat_structured_gateway_records_success_metric(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -11,7 +11,7 @@ from llm_gateway.gateway.errors import (
     GatewayInvalidRouteConfigError,
     GatewayProviderFailureError,
 )
-from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion
+from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion, selected_serving_route_artifact_id
 from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure, fake_success_response
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
 from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutPolicy, RolloutStage
@@ -335,6 +335,7 @@ async def test_shadow_active_route_serves_lkg_not_active():
     assert result.selected_model == 'gpt-4.1-mini'
     assert result.used_lkg
     assert provider.calls[0].request['model'] == 'gpt-4.1-mini'
+    assert selected_serving_route_artifact_id(resolved) == LKG_ROUTE
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -55,12 +55,12 @@ def test_chat_completions_forwards_action_item_extraction_strict_schema(monkeypa
     monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
     provider = FakeChatCompletionProvider()
     app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
-    request = _chat_structured_payload(
-        'Extract action items.',
-        ActionItemsExtraction,
-        feature='conversation_action_items.extract.shadow',
-    )
     try:
+        request = _chat_structured_payload(
+            'Extract action items.',
+            ActionItemsExtraction,
+            feature='conversation_action_items.extract.shadow',
+        )
         response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -6,6 +6,8 @@ from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import FakeChatCompletionProvider
 from llm_gateway.main import app
 from llm_gateway.routers import dependencies
+from models.structured_extraction import ActionItemsExtraction
+from utils.llm.gateway_client import _chat_structured_payload
 
 LANE_ID = 'omi:auto:chat-structured'
 
@@ -47,6 +49,29 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request
+
+
+def test_chat_completions_forwards_action_item_extraction_strict_schema(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    provider = FakeChatCompletionProvider()
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    request = _chat_structured_payload(
+        'Extract action items.',
+        ActionItemsExtraction,
+        feature='conversation_action_items.extract.shadow',
+    )
+    try:
+        response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    forwarded_schema = provider.calls[0].request['response_format']['json_schema']['schema']
+    assert forwarded_schema['required'] == ['action_items']
+    action_item_schema = forwarded_schema['$defs']['ExtractedActionItem']
+    assert action_item_schema['additionalProperties'] is False
+    assert action_item_schema['required'] == ['description', 'due_at']
+    assert 'default' not in action_item_schema['properties']['due_at']
 
 
 def test_chat_completions_rejects_unknown_auto_lane(monkeypatch):

--- a/backend/tests/unit/test_memories_validation.py
+++ b/backend/tests/unit/test_memories_validation.py
@@ -3,12 +3,18 @@ Tests for memories validation filtering logic.
 Regression test for issue #4501: ResponseValidationError after KeyError fix.
 """
 
-import pytest
+import os
 import sys
+
+import pytest
+from types import ModuleType
 from datetime import datetime, timezone
 from pydantic import BaseModel, ValidationError, Field
 from typing import Optional, List
 from enum import Enum
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 class MemoryCategory(str, Enum):
@@ -236,12 +242,64 @@ class TestMemoryValidationFiltering:
 
 class TestExtractedMemoryValidation:
     def _ensure_memory_model_dependencies(self):
+        os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-key-for-unit-tests')
+
+        models = sys.modules.setdefault('models', ModuleType('models'))
+        models.__path__ = [str(BACKEND_DIR / 'models')]
+
+        database = sys.modules.setdefault('database', ModuleType('database'))
+        if not hasattr(database, '__path__'):
+            database.__path__ = []
+
         client = sys.modules.get('database._client')
-        if client is not None and not hasattr(client, 'document_id_from_seed'):
+        if client is None:
+            client = ModuleType('database._client')
+            sys.modules['database._client'] = client
+            database._client = client
+        if not hasattr(client, 'document_id_from_seed'):
             client.document_id_from_seed = lambda value: f'id-{value}'
+
         users = sys.modules.get('database.users')
-        if users is not None and not hasattr(users, 'get_user_language_preference'):
+        if users is None:
+            users = ModuleType('database.users')
+            sys.modules['database.users'] = users
+            database.users = users
+        if not hasattr(users, 'get_user_language_preference'):
             users.get_user_language_preference = lambda uid: 'en'
+
+        llm_usage = sys.modules.get('database.llm_usage')
+        if llm_usage is None:
+            llm_usage = ModuleType('database.llm_usage')
+            sys.modules['database.llm_usage'] = llm_usage
+            database.llm_usage = llm_usage
+        if not hasattr(llm_usage, 'record_llm_usage'):
+            llm_usage.record_llm_usage = lambda *args, **kwargs: None
+
+        tiktoken = sys.modules.get('tiktoken')
+        if tiktoken is None:
+            tiktoken = ModuleType('tiktoken')
+            tiktoken.encoding_for_model = lambda model: type(
+                'Encoding', (), {'encode': lambda self, text: list(text)}
+            )()
+            sys.modules['tiktoken'] = tiktoken
+
+        prompts = sys.modules.get('utils.prompts')
+        if prompts is None:
+            prompts = ModuleType('utils.prompts')
+            prompts.extract_memories_prompt = object()
+            prompts.extract_learnings_prompt = object()
+            prompts.extract_memories_text_content_prompt = object()
+            sys.modules['utils.prompts'] = prompts
+
+        llms_memory = sys.modules.get('utils.llms.memory')
+        if llms_memory is None:
+            llms = sys.modules.setdefault('utils.llms', ModuleType('utils.llms'))
+            if not hasattr(llms, '__path__'):
+                llms.__path__ = []
+            llms_memory = ModuleType('utils.llms.memory')
+            llms_memory.get_prompt_memories = lambda uid: ('Test User', '')
+            sys.modules['utils.llms.memory'] = llms_memory
+            llms.memory = llms_memory
 
     def test_unknown_llm_category_defaults_to_interesting(self):
         self._ensure_memory_model_dependencies()

--- a/backend/tests/unit/test_memories_validation.py
+++ b/backend/tests/unit/test_memories_validation.py
@@ -4,6 +4,7 @@ Regression test for issue #4501: ResponseValidationError after KeyError fix.
 """
 
 import pytest
+import sys
 from datetime import datetime, timezone
 from pydantic import BaseModel, ValidationError, Field
 from typing import Optional, List
@@ -231,3 +232,33 @@ class TestMemoryValidationFiltering:
 
         assert len(valid_memories) == 1
         assert valid_memories[0].id == 'valid'
+
+
+class TestExtractedMemoryValidation:
+    def _ensure_memory_model_dependencies(self):
+        client = sys.modules.get('database._client')
+        if client is not None and not hasattr(client, 'document_id_from_seed'):
+            client.document_id_from_seed = lambda value: f'id-{value}'
+        users = sys.modules.get('database.users')
+        if users is not None and not hasattr(users, 'get_user_language_preference'):
+            users.get_user_language_preference = lambda uid: 'en'
+
+    def test_unknown_llm_category_defaults_to_interesting(self):
+        self._ensure_memory_model_dependencies()
+        from models.memories import MemoryCategory
+        from utils.llm.memories import ExtractedMemory
+
+        extracted = ExtractedMemory(content='User likes short meetings', category='unexpected_llm_category')
+
+        assert extracted.category == MemoryCategory.interesting
+        assert extracted.to_memory().category == MemoryCategory.interesting
+
+    def test_legacy_llm_category_maps_to_current_category(self):
+        self._ensure_memory_model_dependencies()
+        from models.memories import MemoryCategory
+        from utils.llm.memories import ExtractedMemory
+
+        extracted = ExtractedMemory(content='User likes coffee', category='hobbies')
+
+        assert extracted.category == MemoryCategory.system
+        assert extracted.to_memory().category == MemoryCategory.system

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -106,7 +106,6 @@ _install_module('langchain_core.output_parsers', PydanticOutputParser=_PydanticO
 _install_module('langchain_openai', ChatOpenAI=_ChatOpenAI, OpenAIEmbeddings=_OpenAIEmbeddings)
 _install_module('langchain_google_genai', ChatGoogleGenerativeAI=_ChatGoogleGenerativeAI)
 _install_module('tiktoken', encoding_for_model=MagicMock(return_value=_Encoding()))
-_install_module('models.structured', Structured=MagicMock())
 _install_module('utils.byok', get_byok_key=MagicMock(return_value=None))
 
 _HEAVY_MOCKS = {
@@ -169,6 +168,7 @@ def _clients_subprocess_script(assertion: str) -> str:
         "    'database',",
         "    'database._client',",
         "    'database.llm_usage',",
+        "    'models.structured_extraction',",
         "]:",
         "    sys.modules.setdefault(module_name, MagicMock())",
         "os.environ['OPENAI_API_KEY'] = 'sk-test'",

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -51,7 +51,11 @@ def _drop_module_if_missing_attrs(module_name, required_attrs):
 _drop_module_if_missing_attrs("models.conversation_enums", ("CategoryEnum",))
 _drop_module_if_missing_attrs(
     "models.structured",
-    ("ActionItem", "ActionItemsExtraction", "Event", "Structured"),
+    ("ActionItem", "Event", "Structured"),
+)
+_drop_module_if_missing_attrs(
+    "models.structured_extraction",
+    ("ActionItemsExtraction", "StructuredExtraction"),
 )
 
 _conversation_processing_stub = sys.modules.get("utils.llm.conversation_processing")

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -11,7 +11,7 @@ from langchain_core.output_parsers import PydanticOutputParser
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
 
-from models.structured import Structured
+from models.structured_extraction import StructuredExtraction
 from utils.byok import get_byok_key
 from utils.llm.model_config import (
     MODEL_QOS_PROFILES,
@@ -368,7 +368,7 @@ embeddings = _OpenAIEmbeddingsProxy(
     default=_embeddings_default,
     ctor_kwargs={},
 )
-parser = PydanticOutputParser(pydantic_object=Structured)
+parser = PydanticOutputParser(pydantic_object=StructuredExtraction)
 
 encoding = tiktoken.encoding_for_model('gpt-4')
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -11,7 +11,8 @@ from models.app import App
 from models.calendar_context import CalendarMeetingContext
 from models.conversation import Conversation
 from models.conversation_photo import ConversationPhoto
-from models.structured import ActionItem, ActionItemsExtraction, Event, Structured
+from models.structured import ActionItem, Event, Structured
+from models.structured_extraction import ActionItemsExtraction, StructuredExtraction
 from .clients import get_llm, parser
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
@@ -49,6 +50,16 @@ def _word_count(text: str) -> int:
     if cjk_chars > len(text) * 0.3:
         return cjk_chars // 2
     return len(text.split())
+
+
+def _coerce_action_items(response: ActionItemsExtraction) -> List[ActionItem]:
+    return response.to_action_items()
+
+
+def _coerce_structured(response: Structured | StructuredExtraction) -> Structured:
+    if isinstance(response, StructuredExtraction):
+        return response.to_structured()
+    return response
 
 
 def should_discard_conversation(
@@ -466,10 +477,11 @@ def extract_action_items(
 
     try:
         response = chain.invoke(prompt_values)
+        action_items = _coerce_action_items(response)
 
         # Set created_at for action items if not already set
         now = current_time
-        for action_item in response.action_items or []:
+        for action_item in action_items:
             if action_item.created_at is None:
                 action_item.created_at = now
             # The LLM returns naive LOCAL time; convert to UTC deterministically (and normalize any
@@ -485,7 +497,7 @@ def extract_action_items(
                     )
                     action_item.due_at = None
 
-        return response.action_items or []
+        return action_items
 
     except Exception as e:
         logger.error(f'Error extracting action items: {e}')
@@ -574,15 +586,17 @@ def get_transcript_structure(
     prompt = ChatPromptTemplate.from_messages([('system', instructions_text), ('system', context_message)])
     chain = prompt | get_llm('conv_structure', cache_key='omi-transcript-structure') | parser
 
-    response = chain.invoke(
-        {
-            'conversation_context': conversation_context,
-            'format_instructions': parser.get_format_instructions(),
-            'language_code': language_code,
-            'response_language': response_language,
-            'started_at': _local_started_at_iso(started_at, tz),
-            'tz': tz or 'UTC',
-        }
+    response = _coerce_structured(
+        chain.invoke(
+            {
+                'conversation_context': conversation_context,
+                'format_instructions': parser.get_format_instructions(),
+                'language_code': language_code,
+                'response_language': response_language,
+                'started_at': _local_started_at_iso(started_at, tz),
+                'tz': tz or 'UTC',
+            }
+        )
     )
 
     for event in response.events or []:
@@ -658,16 +672,18 @@ def get_reprocess_transcript_structure(
     prompt = ChatPromptTemplate.from_messages([('system', prompt_text)])
     chain = prompt | get_llm('conv_structure', cache_key='omi-transcript-structure') | parser
 
-    response = chain.invoke(
-        {
-            'full_context': full_context,
-            'title': title,
-            'format_instructions': parser.get_format_instructions(),
-            'language_code': language_code,
-            'response_language': response_language,
-            'started_at': _local_started_at_iso(started_at, tz),
-            'tz': tz or 'UTC',
-        }
+    response = _coerce_structured(
+        chain.invoke(
+            {
+                'full_context': full_context,
+                'title': title,
+                'format_instructions': parser.get_format_instructions(),
+                'language_code': language_code,
+                'response_language': response_language,
+                'started_at': _local_started_at_iso(started_at, tz),
+                'tz': tz or 'UTC',
+            }
+        )
     )
 
     for event in response.events or []:

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -11,6 +11,7 @@ import database.users as users_db
 from models.conversation import Conversation
 from models.daily_summary_payload import DailySummaryPayload
 from models.structured import Structured
+from models.structured_extraction import StructuredExtraction
 from models.other import Person
 from utils.conversations.render import conversations_to_string
 from utils.llm.clients import get_llm, parser
@@ -20,6 +21,12 @@ from utils.log_sanitizer import sanitize, sanitize_validation_error
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_structured(response: Structured | StructuredExtraction) -> Structured:
+    if isinstance(response, StructuredExtraction):
+        return response.to_structured()
+    return response
 
 
 def _basic_daily_summary(
@@ -77,16 +84,18 @@ def get_message_structure(
     prompt = ChatPromptTemplate.from_messages([('system', prompt_text)])
     chain = prompt | get_llm('external_structure') | parser
 
-    response = chain.invoke(
-        {
-            'language_code': language_code,
-            'response_language': response_language,
-            'started_at': started_at.isoformat(),
-            'tz': tz,
-            'text': text,
-            'text_source_spec': text_source_spec if text_source_spec else 'Messaging App',
-            'format_instructions': parser.get_format_instructions(),
-        }
+    response = _coerce_structured(
+        chain.invoke(
+            {
+                'language_code': language_code,
+                'response_language': response_language,
+                'started_at': started_at.isoformat(),
+                'tz': tz,
+                'text': text,
+                'text_source_spec': text_source_spec if text_source_spec else 'Messaging App',
+                'format_instructions': parser.get_format_instructions(),
+            }
+        )
     )
 
     for event in response.events or []:
@@ -114,7 +123,9 @@ def summarize_experience_text(text: str, text_source_spec: str = None) -> Struct
       Text: ```{text}```
       '''.replace('    ', '').strip()
 
-    response = get_llm('external_structure').with_structured_output(Structured).invoke(prompt)
+    response = _coerce_structured(
+        get_llm('external_structure').with_structured_output(StructuredExtraction).invoke(prompt)
+    )
 
     # Set created_at for action items if not already set
     for action_item in response.action_items or []:

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -136,39 +136,42 @@ def _chat_structured_payload(prompt: str, output_model: type[BaseModel], *, feat
 def _strict_model_json_schema(output_model: type[BaseModel]) -> dict:
     """Generate a strict-compatible JSON Schema for OpenAI Structured Outputs.
 
-    OpenAI requires every object schema to include ``additionalProperties: false``
-    when ``strict`` mode is set. Pydantic's ``model_json_schema()`` does not add
-    that by default, so we inject it recursively for all ``type: object`` schemas.
+    OpenAI strict structured outputs require every object schema to disallow
+    additional properties and mark every declared property as required. Pydantic
+    emits defaults for optional/domain fields; strip those from provider schemas
+    and represent optional values through their nullable type instead.
     """
     schema = output_model.model_json_schema()
-    _enforce_additional_properties_false(schema)
+    _normalize_strict_schema(schema)
     return schema
 
 
-def _enforce_additional_properties_false(schema: dict) -> None:
-    """Recursively add ``additionalProperties: false`` to all object schemas."""
+def _normalize_strict_schema(schema: dict) -> None:
+    """Recursively normalize a Pydantic JSON schema for strict provider output."""
     if not isinstance(schema, dict):
         return
-    if schema.get('type') == 'object' and 'additionalProperties' not in schema:
+    schema.pop('default', None)
+    if schema.get('type') == 'object':
         schema['additionalProperties'] = False
+    properties = schema.get('properties')
+    if isinstance(properties, dict):
+        schema['required'] = list(properties.keys())
+        for prop_schema in properties.values():
+            _normalize_strict_schema(prop_schema)
     # Recurse into nested schemas under $defs, properties, items, etc.
     for key in ('$defs', 'definitions'):
         defs = schema.get(key)
         if isinstance(defs, dict):
             for def_schema in defs.values():
-                _enforce_additional_properties_false(def_schema)
-    properties = schema.get('properties')
-    if isinstance(properties, dict):
-        for prop_schema in properties.values():
-            _enforce_additional_properties_false(prop_schema)
+                _normalize_strict_schema(def_schema)
     items = schema.get('items')
     if isinstance(items, dict):
-        _enforce_additional_properties_false(items)
+        _normalize_strict_schema(items)
     for ref_key in ('anyOf', 'oneOf', 'allOf'):
         alternatives = schema.get(ref_key)
         if isinstance(alternatives, list):
             for alt_schema in alternatives:
-                _enforce_additional_properties_false(alt_schema)
+                _normalize_strict_schema(alt_schema)
 
 
 def _extract_choice_content(response_body: object) -> object:

--- a/backend/utils/llm/memories.py
+++ b/backend/utils/llm/memories.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple
 
 from langchain_core.output_parsers import PydanticOutputParser
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from database import users as users_db
 from models.memories import Memory, MemoryCategory
@@ -24,20 +24,54 @@ def _get_language_instruction(uid: str, language: Optional[str] = None) -> str:
     return 'Write all extracted memories/learnings in English.'
 
 
+class ExtractedMemory(BaseModel):
+    content: str = Field(description="The content of the memory")
+    category: MemoryCategory = Field(description="The category of the memory", default=MemoryCategory.interesting)
+    tags: List[str] = Field(description="The tags of the memory and learning", default=[])
+    headline: Optional[str] = Field(description="Short headline for notification preview (max 5 words)", default=None)
+
+    @field_validator('category', mode='before')
+    @classmethod
+    def set_category_default_on_error(cls, v: object) -> MemoryCategory | str:
+        if isinstance(v, MemoryCategory):
+            return v
+        if isinstance(v, str):
+            if v in {'interesting', 'system', 'manual', 'workflow'}:
+                return v
+            if v in LEGACY_TO_NEW_CATEGORY:
+                return LEGACY_TO_NEW_CATEGORY[v]
+        return MemoryCategory.interesting
+
+    def to_memory(self) -> Memory:
+        return Memory(
+            content=self.content,
+            category=self.category,
+            visibility='private',
+            tags=self.tags,
+            headline=self.headline,
+        )
+
+
 class Memories(BaseModel):
-    facts: List[Memory] = Field(
+    facts: List[ExtractedMemory] = Field(
         min_items=0,
         max_items=2,
         description="List of **new** memories. Maximum 2 per conversation.",
         default=[],
     )
 
+    def to_memories(self) -> List[Memory]:
+        return [fact.to_memory() for fact in self.facts]
+
 
 class MemoriesByTexts(BaseModel):
-    facts: List[Memory] = Field(
+    facts: List[ExtractedMemory] = Field(
         description="List of **new** facts. If any",
         default=[],
     )
+
+    def to_memories(self) -> List[Memory]:
+        return [fact.to_memory() for fact in self.facts]
 
 
 # Map for converting legacy categories to new format
@@ -93,11 +127,12 @@ def new_memories_extractor(
         )
 
         # Ensure all new memories use the new category format
-        for memory in response.facts:
+        memories = response.to_memories()
+        for memory in memories:
             if isinstance(memory.category, str) and memory.category in LEGACY_TO_NEW_CATEGORY:
                 memory.category = LEGACY_TO_NEW_CATEGORY[memory.category]
 
-        return response.facts
+        return memories
     except Exception as e:
         logger.error(f'Error extracting new facts: {e}')
         return []
@@ -123,7 +158,7 @@ def extract_memories_from_text(
     try:
         parser = PydanticOutputParser(pydantic_object=MemoriesByTexts)
         chain = extract_memories_text_content_prompt | get_llm('memories') | parser
-        response: Memories = chain.invoke(
+        response: MemoriesByTexts = chain.invoke(
             {
                 'user_name': user_name,
                 'text_content': text,
@@ -135,11 +170,12 @@ def extract_memories_from_text(
         )
 
         # Ensure all new memories use the new category format
-        for memory in response.facts:
+        memories = response.to_memories()
+        for memory in memories:
             if isinstance(memory.category, str) and memory.category in LEGACY_TO_NEW_CATEGORY:
                 memory.category = LEGACY_TO_NEW_CATEGORY[memory.category]
 
-        return response.facts
+        return memories
     except Exception as e:
         logger.error(f'Error extracting facts from {text_source}: {e}')
         return []


### PR DESCRIPTION
## Summary
- add LLM-facing extraction DTOs for conversation structure, action items, and memories so provider contracts no longer expose persisted/domain models
- harden llm-gateway strict JSON schema generation for OpenAI structured outputs by requiring all object properties, stripping defaults, and normalizing nested schemas
- label gateway error metrics with the route that actually serves traffic under shadow/LKG routing
- fix related test-module stubs so combined focused tests do not mutate shared imports during collection

## Root cause
Action-item extraction reused the persisted `ActionItem` model as a strict provider schema. Server-owned default fields such as `completed` were omitted from Pydantic `required`, causing OpenAI strict structured outputs to reject the schema before the gateway call could succeed organically.

Closes #8600

## Validation
- `backend/.venv/bin/python -m pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py tests/unit/test_llm_gateway_openai_compatible.py tests/unit/test_llm_gateway_executor.py tests/unit/test_action_item_date_validation.py tests/unit/test_conversation_model_split.py tests/unit/test_prompt_caching.py tests/unit/test_memories_validation.py -q` → 162 passed
- `backend/.venv/bin/python -m py_compile backend/models/structured.py backend/models/structured_extraction.py backend/utils/llm/gateway_client.py backend/utils/llm/conversation_processing.py backend/utils/llm/external_integrations.py backend/utils/llm/memories.py backend/llm_gateway/gateway/executor.py backend/llm_gateway/routers/openai_compatible.py`
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py` → selected blocking findings: 0
- `backend/test-preflight.sh` → 10 passed, 11 optional warnings, 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

