### PR TITLE
fix(backend): consume task-integration OAuth state atomically with GETDEL (replay hardening)

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -116,13 +116,14 @@ def validate_and_consume_oauth_state(state_token: Optional[str]) -> Optional[Dic
         return None
 
     state_key = f"oauth_state:{state_token}"
-    state_data_str = redis_db.r.get(state_key)
+    # Atomic get-and-delete: an OAuth state is single-use, so consuming it must be one operation.
+    # A separate GET then DELETE lets two concurrent callbacks carrying the same state both read the
+    # value before either delete runs, weakening replay protection. GETDEL removes it atomically, so
+    # only one caller ever receives the value.
+    state_data_str = redis_db.r.getdel(state_key)
 
     if not state_data_str:
         return None
-
-    # Delete immediately to prevent replay
-    redis_db.r.delete(state_key)
 
     try:
         state_data = ast.literal_eval(state_data_str.decode() if isinstance(state_data_str, bytes) else state_data_str)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -169,6 +169,7 @@ run_pytest tests/unit/test_ws_auth_handshake.py -v
 run_pytest tests/unit/test_streaming_deepgram_backoff.py -v
 run_pytest tests/unit/test_executors.py -v
 run_pytest tests/unit/test_task_integrations_async_offload.py -v
+run_pytest tests/unit/test_task_integrations_oauth_atomic.py -v
 run_pytest tests/unit/test_modulate_stt.py -v
 run_pytest tests/unit/test_batch_upload_storage.py -v
 run_pytest tests/unit/test_action_item_date_validation.py -v

--- a/backend/tests/unit/test_task_integrations_oauth_atomic.py
+++ b/backend/tests/unit/test_task_integrations_oauth_atomic.py
@@ -1,0 +1,126 @@
+"""task_integrations.validate_and_consume_oauth_state must consume an OAuth state atomically.
+
+Same single-use requirement as the routers/integrations.py copy: a separate GET then DELETE lets two
+concurrent callbacks carrying the same state both read the value before either delete runs, which
+weakens replay protection. It now uses an atomic Redis GETDEL, so only one caller receives the value
+and a second consume of the same state returns None. (This handler parses the stored value with
+ast.literal_eval, so the fixture stores a Python repr rather than JSON.)
+
+routers/task_integrations.py has a heavy import graph, so it is imported under a stub finder that
+auto-mocks those namespaces (keeping models/fastapi/pydantic real), then the helper is called
+directly with the redis client patched.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot()
+_clear()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import task_integrations as ti
+finally:
+    sys.meta_path.remove(_finder)
+    _restore(_snap)
+
+
+def test_consume_uses_atomic_getdel_not_get_then_delete():
+    fake_r = MagicMock()
+    fake_r.getdel.return_value = repr({'uid': 'u1', 'app_key': 'a1'}).encode()
+    with patch.object(ti.redis_db, 'r', fake_r):
+        result = ti.validate_and_consume_oauth_state('tok')
+
+    assert result == {'uid': 'u1', 'app_key': 'a1'}
+    fake_r.getdel.assert_called_once_with('oauth_state:tok')
+    fake_r.get.assert_not_called()
+    fake_r.delete.assert_not_called()
+
+
+def test_consume_is_single_use():
+    store = {'oauth_state:tok': repr({'uid': 'u1', 'app_key': 'a1'}).encode()}
+    fake_r = MagicMock()
+    fake_r.getdel.side_effect = lambda key: store.pop(key, None)
+
+    with patch.object(ti.redis_db, 'r', fake_r):
+        first = ti.validate_and_consume_oauth_state('tok')
+        second = ti.validate_and_consume_oauth_state('tok')
+
+    assert first == {'uid': 'u1', 'app_key': 'a1'}
+    assert second is None


### PR DESCRIPTION
## Summary
The Todoist / Microsoft Tasks OAuth callback consumes its single-use state token with a separate Redis `GET` then `DELETE`. Two concurrent callbacks carrying the same state can both read the value before either delete runs, weakening the replay / single-use protection on the callback. This is the same hardening just applied to the chat OAuth callback in #8593, in the second copy of `validate_and_consume_oauth_state`.

## Root cause
`validate_and_consume_oauth_state` in `routers/task_integrations.py` does `redis_db.r.get(state_key)` and then `redis_db.r.delete(state_key)` as two operations. The consume runs in a worker thread (the handler offloads it), so two requests with the same state can interleave: both `GET` the value before either `DELETE`, and both consume it.

## Fix
Consume the state with an atomic `redis_db.r.getdel(state_key)` (Redis GETDEL), so the get-and-delete is a single operation and only one caller ever receives the value. The `ast.literal_eval` parse is unchanged.

## Testing
Added `tests/unit/test_task_integrations_oauth_atomic.py` (registered in `test.sh`): one test asserts the consume is a single `GETDEL` (not a separate `GET` + `DELETE`), and one drives two consumes of the same state and confirms only the first succeeds. Red-proven against the current head (both fail without the fix). black clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

