### PR TITLE
[codex] Speed up backend unit test CI

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-unit-tests.yml'
   pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-unit-tests.yml'
   workflow_dispatch:
 
 permissions:
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,6 +47,31 @@ jobs:
         working-directory: backend
         run: bash test-preflight.sh
 
+      - name: Select backend unit tests
+        id: select-tests
+        working-directory: backend
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > /tmp/backend-changed-files.txt
+            python scripts/select_backend_unit_tests.py \
+              --changed-files /tmp/backend-changed-files.txt \
+              --output /tmp/backend-unit-tests.txt \
+              --reason-output /tmp/backend-unit-tests-reason.txt
+          else
+            python scripts/select_backend_unit_tests.py \
+              --all \
+              --output /tmp/backend-unit-tests.txt \
+              --reason-output /tmp/backend-unit-tests-reason.txt
+          fi
+          echo "reason=$(cat /tmp/backend-unit-tests-reason.txt)" >> "$GITHUB_OUTPUT"
+          echo "count=$(wc -l < /tmp/backend-unit-tests.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
       - name: Run backend unit suite
         working-directory: backend
-        run: bash test.sh
+        env:
+          BACKEND_UNIT_TEST_FILE_LIST: /tmp/backend-unit-tests.txt
+          BACKEND_PYTEST_XDIST: auto
+          BACKEND_PYTEST_WORKERS: auto
+        run: |
+          echo "Selected ${{ steps.select-tests.outputs.count }} backend unit test files: ${{ steps.select-tests.outputs.reason }}"
+          bash test.sh

--- a/backend/pylock.macos-x86_64.toml
+++ b/backend/pylock.macos-x86_64.toml
@@ -277,6 +277,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981
 wheels = [{ url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", upload-time = 2024-06-20T11:30:28Z, size = 33521, hashes = { sha256 = "561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631" } }]
 
 [[packages]]
+name = "execnet"
+version = "2.1.2"
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", upload-time = 2025-11-12T09:56:37Z, size = 166622, hashes = { sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", upload-time = 2025-11-12T09:56:36Z, size = 40708, hashes = { sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec" } }]
+
+[[packages]]
 name = "executing"
 version = "2.0.1"
 sdist = { url = "https://files.pythonhosted.org/packages/08/41/85d2d28466fca93737592b7f3cc456d1cfd6bcd401beceeba17e8e792b50/executing-2.0.1.tar.gz", upload-time = 2023-10-29T10:17:13Z, size = 836501, hashes = { sha256 = "35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147" } }
@@ -1181,6 +1187,12 @@ name = "pytest-httpserver"
 version = "1.1.5"
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", upload-time = 2026-02-14T13:27:23Z, size = 70974, hashes = { sha256 = "dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", upload-time = 2026-02-14T13:27:22Z, size = 23330, hashes = { sha256 = "ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a" } }]
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", upload-time = 2025-07-01T13:30:59Z, size = 88069, hashes = { sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", upload-time = 2025-07-01T13:30:56Z, size = 46396, hashes = { sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88" } }]
 
 [[packages]]
 name = "python-dateutil"

--- a/backend/pylock.macos.toml
+++ b/backend/pylock.macos.toml
@@ -277,6 +277,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981
 wheels = [{ url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", upload-time = 2024-06-20T11:30:28Z, size = 33521, hashes = { sha256 = "561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631" } }]
 
 [[packages]]
+name = "execnet"
+version = "2.1.2"
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", upload-time = 2025-11-12T09:56:37Z, size = 166622, hashes = { sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", upload-time = 2025-11-12T09:56:36Z, size = 40708, hashes = { sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec" } }]
+
+[[packages]]
 name = "executing"
 version = "2.0.1"
 sdist = { url = "https://files.pythonhosted.org/packages/08/41/85d2d28466fca93737592b7f3cc456d1cfd6bcd401beceeba17e8e792b50/executing-2.0.1.tar.gz", upload-time = 2023-10-29T10:17:13Z, size = 836501, hashes = { sha256 = "35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147" } }
@@ -1164,6 +1170,12 @@ name = "pytest-httpserver"
 version = "1.1.5"
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", upload-time = 2026-02-14T13:27:23Z, size = 70974, hashes = { sha256 = "dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", upload-time = 2026-02-14T13:27:22Z, size = 23330, hashes = { sha256 = "ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a" } }]
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", upload-time = 2025-07-01T13:30:59Z, size = 88069, hashes = { sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", upload-time = 2025-07-01T13:30:56Z, size = 46396, hashes = { sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88" } }]
 
 [[packages]]
 name = "python-dateutil"

--- a/backend/pylock.toml
+++ b/backend/pylock.toml
@@ -275,6 +275,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981
 wheels = [{ url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", upload-time = 2024-06-20T11:30:28Z, size = 33521, hashes = { sha256 = "561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631" } }]
 
 [[packages]]
+name = "execnet"
+version = "2.1.2"
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", upload-time = 2025-11-12T09:56:37Z, size = 166622, hashes = { sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", upload-time = 2025-11-12T09:56:36Z, size = 40708, hashes = { sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec" } }]
+
+[[packages]]
 name = "executing"
 version = "2.0.1"
 sdist = { url = "https://files.pythonhosted.org/packages/08/41/85d2d28466fca93737592b7f3cc456d1cfd6bcd401beceeba17e8e792b50/executing-2.0.1.tar.gz", upload-time = 2023-10-29T10:17:13Z, size = 836501, hashes = { sha256 = "35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147" } }
@@ -1178,6 +1184,12 @@ name = "pytest-httpserver"
 version = "1.1.5"
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", upload-time = 2026-02-14T13:27:23Z, size = 70974, hashes = { sha256 = "dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", upload-time = 2026-02-14T13:27:22Z, size = 23330, hashes = { sha256 = "ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a" } }]
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", upload-time = 2025-07-01T13:30:59Z, size = 88069, hashes = { sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", upload-time = 2025-07-01T13:30:56Z, size = 46396, hashes = { sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88" } }]
 
 [[packages]]
 name = "python-dateutil"

--- a/backend/pylock.windows.toml
+++ b/backend/pylock.windows.toml
@@ -280,6 +280,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981
 wheels = [{ url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", upload-time = 2024-06-20T11:30:28Z, size = 33521, hashes = { sha256 = "561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631" } }]
 
 [[packages]]
+name = "execnet"
+version = "2.1.2"
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", upload-time = 2025-11-12T09:56:37Z, size = 166622, hashes = { sha256 = "63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", upload-time = 2025-11-12T09:56:36Z, size = 40708, hashes = { sha256 = "67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec" } }]
+
+[[packages]]
 name = "executing"
 version = "2.0.1"
 sdist = { url = "https://files.pythonhosted.org/packages/08/41/85d2d28466fca93737592b7f3cc456d1cfd6bcd401beceeba17e8e792b50/executing-2.0.1.tar.gz", upload-time = 2023-10-29T10:17:13Z, size = 836501, hashes = { sha256 = "35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147" } }
@@ -1172,6 +1178,12 @@ name = "pytest-httpserver"
 version = "1.1.5"
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", upload-time = 2026-02-14T13:27:23Z, size = 70974, hashes = { sha256 = "dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", upload-time = 2026-02-14T13:27:22Z, size = 23330, hashes = { sha256 = "ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a" } }]
+
+[[packages]]
+name = "pytest-xdist"
+version = "3.8.0"
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", upload-time = 2025-07-01T13:30:59Z, size = 88069, hashes = { sha256 = "7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", upload-time = 2025-07-01T13:30:56Z, size = 46396, hashes = { sha256 = "202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88" } }]
 
 [[packages]]
 name = "python-dateutil"

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -42,6 +42,7 @@ FULL_RUN_PATHS = (
 
 FULL_RUN_PREFIXES = (
     'backend/database/',
+    'backend/models/',
     'backend/testing/',
 )
 
@@ -102,16 +103,6 @@ AREA_TESTS = (
         ),
     ),
     (
-        ('backend/models/',),
-        (),
-        (
-            'tests/unit/test_*model*.py',
-            'tests/unit/test_*schema*.py',
-            'tests/unit/test_*validation*.py',
-            'tests/unit/test_request_validation_contracts.py',
-        ),
-    ),
-    (
         ('backend/routers/conversations', 'backend/services/conversations/', 'backend/utils/conversations'),
         (),
         (
@@ -147,7 +138,7 @@ AREA_TESTS = (
     (
         ('backend/routers/apps', 'backend/services/apps/', 'backend/utils/apps'),
         (),
-        ('tests/unit/test_apps_*.py', 'tests/unit/test_app_*.py'),
+        ('tests/unit/test_apps_*.py', 'tests/unit/test_app_*.py', 'tests/unit/test_create_persona_user_none.py'),
     ),
     (
         ('backend/routers/folders', 'backend/services/folders/', 'backend/utils/folders'),
@@ -213,7 +204,10 @@ def normalize_changed_path(path: str) -> str:
     path = path.strip()
     if not path:
         return ''
-    return path.replace('\\', '/').lstrip('./')
+    path = path.replace('\\', '/')
+    while path.startswith('./'):
+        path = path[2:]
+    return path
 
 
 def is_full_run_path(path: str) -> bool:

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Select backend unit tests for either a full run or a changed-file PR run."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+from pathlib import Path
+from pathlib import PurePosixPath
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+REPO_DIR = BACKEND_DIR.parent
+
+FULL_TEST_ROOTS = (
+    BACKEND_DIR / 'tests' / 'unit',
+    BACKEND_DIR / 'tests' / 'services',
+    BACKEND_DIR / 'tests' / 'routers',
+)
+FULL_TEST_GLOBS = (BACKEND_DIR / 'tests',)
+
+LEGACY_UNLISTED_TESTS = {
+    'tests/test_cache_manager.py',
+    'tests/unit/test_diarizer_dockerfile.py',
+    'tests/unit/test_lazy_conversation_processing.py',
+}
+
+FULL_RUN_PATHS = (
+    '.github/workflows/backend-unit-tests.yml',
+    'backend/pylock.toml',
+    'backend/pylock.macos.toml',
+    'backend/pylock.macos-x86_64.toml',
+    'backend/pylock.runtime.toml',
+    'backend/pylock.windows.toml',
+    'backend/pyproject.toml',
+    'backend/requirements.txt',
+    'backend/test-preflight.sh',
+    'backend/test.sh',
+    'backend/tests/conftest.py',
+    'backend/tests/unit/conftest.py',
+    'backend/scripts/select_backend_unit_tests.py',
+)
+
+FULL_RUN_PREFIXES = (
+    'backend/database/',
+    'backend/testing/',
+)
+
+FULL_RUN_GLOBS = (
+    'backend/*',
+    'backend/scripts/update-python-lock.sh',
+    'backend/scripts/sync-python-deps.sh',
+    'backend/utils/executors.py',
+    'backend/utils/log_sanitizer.py',
+    'backend/utils/http_client.py',
+    'backend/utils/auth.py',
+    'backend/utils/secrets.py',
+    'backend/utils/*.py',
+)
+
+AREA_TESTS = (
+    (
+        ('backend/llm_gateway/',),
+        (),
+        ('tests/unit/test_llm_gateway_*.py',),
+    ),
+    (
+        ('backend/mcp/', 'backend/routers/mcp'),
+        (),
+        ('tests/unit/test_mcp_*.py', 'tests/unit/test_oauth_callback_uid_guard.py'),
+    ),
+    (
+        ('backend/utils/stt/', 'backend/pusher/', 'backend/routers/transcribe', 'backend/routers/listen'),
+        (),
+        (
+            'tests/unit/test_*audio*.py',
+            'tests/unit/test_*listen*.py',
+            'tests/unit/test_*pusher*.py',
+            'tests/unit/test_*speaker*.py',
+            'tests/unit/test_*speech*.py',
+            'tests/unit/test_*stt*.py',
+            'tests/unit/test_*streaming*.py',
+            'tests/unit/test_*sync*.py',
+            'tests/unit/test_*transcribe*.py',
+            'tests/unit/test_*vad*.py',
+            'tests/unit/utils/test_listen_pusher_session.py',
+        ),
+    ),
+    (
+        ('backend/parakeet/',),
+        (),
+        ('tests/unit/test_parakeet_*.py',),
+    ),
+    (
+        ('backend/services/users/', 'backend/routers/users'),
+        (),
+        (
+            'tests/services/users/test_*.py',
+            'tests/routers/test_users.py',
+            'tests/unit/test_users_*.py',
+            'tests/unit/test_delete_account_*.py',
+            'tests/unit/test_claim_deletion_*.py',
+        ),
+    ),
+    (
+        ('backend/models/',),
+        (),
+        (
+            'tests/unit/test_*model*.py',
+            'tests/unit/test_*schema*.py',
+            'tests/unit/test_*validation*.py',
+            'tests/unit/test_request_validation_contracts.py',
+        ),
+    ),
+    (
+        ('backend/routers/conversations', 'backend/services/conversations/', 'backend/utils/conversations'),
+        (),
+        (
+            'tests/unit/test_conversation*.py',
+            'tests/unit/test_conversations*.py',
+            'tests/unit/test_folder_*.py',
+            'tests/unit/test_retrieval_*.py',
+        ),
+    ),
+    (
+        ('backend/routers/memories', 'backend/services/memories/', 'backend/utils/memories'),
+        (),
+        ('tests/unit/test_memories_*.py', 'tests/unit/test_memory_*.py'),
+    ),
+    (
+        ('backend/routers/action_items', 'backend/services/action_items/', 'backend/utils/action_items'),
+        (),
+        ('tests/unit/test_action_item*.py', 'tests/unit/test_dev_api_action_items_poison.py'),
+    ),
+    (
+        ('backend/routers/payment', 'backend/services/payment/', 'backend/utils/payments'),
+        (),
+        (
+            'tests/unit/test_payment_*.py',
+            'tests/unit/test_stripe_*.py',
+            'tests/unit/test_subscription_*.py',
+            'tests/unit/test_available_plans_resilience.py',
+            'tests/unit/test_trial_metadata.py',
+            'tests/unit/test_paywall_reconnect_gate.py',
+            'tests/unit/test_chat_quota.py',
+        ),
+    ),
+    (
+        ('backend/routers/apps', 'backend/services/apps/', 'backend/utils/apps'),
+        (),
+        ('tests/unit/test_apps_*.py', 'tests/unit/test_app_*.py'),
+    ),
+    (
+        ('backend/routers/folders', 'backend/services/folders/', 'backend/utils/folders'),
+        (),
+        ('tests/unit/test_folder_*.py',),
+    ),
+    (
+        ('backend/routers/developer', 'backend/services/developer/', 'backend/utils/developer'),
+        (),
+        ('tests/unit/test_dev_api_*.py', 'tests/unit/test_developer_*.py'),
+    ),
+    (
+        ('backend/routers/sync', 'backend/services/sync/', 'backend/utils/sync'),
+        (),
+        ('tests/unit/test_sync_*.py', 'tests/unit/test_audio_merge_tasks.py'),
+    ),
+    (
+        ('backend/routers/storage', 'backend/services/storage/', 'backend/utils/storage'),
+        (),
+        ('tests/unit/test_storage_*.py', 'tests/unit/test_file_upload*.py'),
+    ),
+    (
+        ('backend/routers/notifications', 'backend/services/notifications/', 'backend/utils/notifications'),
+        (),
+        ('tests/unit/test_*notification*.py', 'tests/unit/test_mentor_notifications.py'),
+    ),
+    (
+        ('backend/routers/twilio', 'backend/services/twilio/', 'backend/utils/twilio'),
+        (),
+        ('tests/unit/test_twilio_*.py', 'tests/unit/test_phone_*.py'),
+    ),
+    (
+        ('backend/routers/geocoding', 'backend/services/geocoding/', 'backend/utils/geocoding'),
+        (),
+        ('tests/unit/test_*geocoding*.py', 'tests/unit/test_location_maps_status_guard.py'),
+    ),
+    (
+        ('backend/routers/rate', 'backend/services/rate', 'backend/utils/rate'),
+        (),
+        ('tests/unit/test_rate_*.py',),
+    ),
+)
+
+
+def discover_all_tests() -> list[str]:
+    tests: set[Path] = set()
+    for root in FULL_TEST_ROOTS:
+        tests.update(root.rglob('test_*.py'))
+    for root in FULL_TEST_GLOBS:
+        tests.update(root.glob('test_*.py'))
+    return sorted(
+        test_path
+        for test_path in (_backend_relative(path) for path in tests if path.is_file())
+        if test_path not in LEGACY_UNLISTED_TESTS
+    )
+
+
+def _backend_relative(path: Path) -> str:
+    return path.relative_to(BACKEND_DIR).as_posix()
+
+
+def normalize_changed_path(path: str) -> str:
+    path = path.strip()
+    if not path:
+        return ''
+    return path.replace('\\', '/').lstrip('./')
+
+
+def is_full_run_path(path: str) -> bool:
+    if path in FULL_RUN_PATHS:
+        return True
+    if any(path.startswith(prefix) for prefix in FULL_RUN_PREFIXES):
+        return True
+    return any(path_matches(path, pattern) for pattern in FULL_RUN_GLOBS)
+
+
+def path_matches(path: str, pattern: str) -> bool:
+    return PurePosixPath(path).match(pattern)
+
+
+def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> tuple[list[str], str]:
+    changed_paths = [path for path in (normalize_changed_path(path) for path in changed_paths) if path]
+    if not changed_paths:
+        return all_tests, 'no changed paths were provided'
+
+    selected: set[str] = set()
+    backend_paths = [path for path in changed_paths if path.startswith('backend/')]
+    test_paths = [path for path in backend_paths if path.startswith('backend/tests/') and path.endswith('.py')]
+
+    for path in changed_paths:
+        if is_full_run_path(path):
+            return all_tests, f'{path} requires the full backend unit suite'
+
+    for path in test_paths:
+        backend_relative = path.removeprefix('backend/')
+        if backend_relative in all_tests:
+            selected.add(backend_relative)
+
+    for path in backend_paths:
+        for source_prefixes, source_globs, test_globs in AREA_TESTS:
+            if any(path.startswith(prefix) for prefix in source_prefixes) or any(
+                path_matches(path, pattern) for pattern in source_globs
+            ):
+                selected.update(match_tests(all_tests, test_globs))
+
+    if not backend_paths:
+        return [], 'no backend files changed'
+    if selected:
+        return sorted(selected), 'selected backend unit tests from changed paths'
+    return all_tests, 'backend changes did not match a narrow area'
+
+
+def match_tests(all_tests: list[str], test_globs: tuple[str, ...]) -> set[str]:
+    return {test for test in all_tests if any(fnmatch.fnmatch(test, pattern) for pattern in test_globs)}
+
+
+def read_lines(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def existing_tests(paths: list[str], all_tests: list[str]) -> list[str]:
+    all_test_set = set(all_tests)
+    missing = [path for path in paths if path not in all_test_set]
+    if missing:
+        missing_list = ', '.join(missing)
+        raise SystemExit(f'Selected backend unit tests do not exist: {missing_list}')
+    return sorted(dict.fromkeys(paths))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument('--all', action='store_true', help='print every backend unit test file')
+    mode.add_argument('--changed-files', type=Path, help='file containing repo-relative changed paths')
+    mode.add_argument('--from-test-list', type=Path, help='file containing backend-relative test paths')
+    parser.add_argument('--output', type=Path, help='write selected tests to this file instead of stdout')
+    parser.add_argument('--reason-output', type=Path, help='write the selection reason to this file')
+    args = parser.parse_args()
+
+    all_tests = discover_all_tests()
+    reason = 'full backend unit suite'
+    if args.all:
+        selected = all_tests
+    elif args.from_test_list:
+        selected = existing_tests(read_lines(args.from_test_list), all_tests)
+        reason = 'using provided backend unit test list'
+    else:
+        selected, reason = tests_for_changed_paths(read_lines(args.changed_files), all_tests)
+
+    output = '\n'.join(selected)
+    if output:
+        output += '\n'
+    if args.output:
+        args.output.write_text(output)
+    else:
+        print(output, end='')
+    if args.reason_output:
+        args.reason_output.write_text(reason + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/test-preflight.sh
+++ b/backend/test-preflight.sh
@@ -132,19 +132,12 @@ else
   bad "No unit test files found in tests/unit/"
 fi
 
-# Check if test.sh test files all exist
-missing_tests=()
-while IFS= read -r line; do
-  test_file=$(echo "$line" | awk '{print $2}')
-  if [[ ! -f "$test_file" ]]; then
-    missing_tests+=("$test_file")
-  fi
-done < <(grep -E '^(pytest|run_pytest) tests/' test.sh 2>/dev/null)
-
-if [[ ${#missing_tests[@]} -gt 0 ]]; then
-  bad "test.sh references missing files: ${missing_tests[*]}"
+# Check if the discovered full unit suite resolves cleanly.
+if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" scripts/select_backend_unit_tests.py --all >/tmp/backend-unit-tests-preflight.txt; then
+  selected_test_count=$(wc -l </tmp/backend-unit-tests-preflight.txt | tr -d ' ')
+  ok "$selected_test_count backend unit test files selected"
 else
-  ok "All test.sh references resolve to existing files"
+  bad "backend unit test selection failed"
 fi
 
 # ── Summary ──

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -6,286 +6,110 @@ cd "$ROOT_DIR"
 
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 
-failed_tests=()
+PYTHON_BIN="${PYTHON:-python3}"
+if ! "$PYTHON_BIN" -m pytest --version >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
 
-run_pytest() {
+read_test_file_list() {
+  local test_file_list="$1"
+  if [[ -n "$test_file_list" ]]; then
+    if [[ ! -f "$test_file_list" ]]; then
+      echo "ERROR: BACKEND_UNIT_TEST_FILE_LIST does not exist: $test_file_list" >&2
+      exit 1
+    fi
+    python scripts/select_backend_unit_tests.py --from-test-list "$test_file_list"
+  else
+    python scripts/select_backend_unit_tests.py --all
+  fi
+}
+
+pytest_args=(-v)
+if [[ "${BACKEND_PYTEST_XDIST:-auto}" != "0" ]]; then
+  if "$PYTHON_BIN" -c "import xdist" >/dev/null 2>&1; then
+    pytest_args+=("-n" "${BACKEND_PYTEST_WORKERS:-auto}" "--dist=loadfile")
+  else
+    echo "pytest-xdist not installed; running backend unit tests without parallel workers."
+  fi
+fi
+
+requires_process_isolation() {
   local test_path="$1"
+  grep -Eq 'sys[.]modules|importlib[.]reload|del sys[.]modules' "$test_path"
+}
+
+run_pytest_group() {
+  local label="$1"
   shift
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
 
   echo
   echo "----------------------------------------"
-  echo "Running $test_path"
+  echo "Running $label ($# files)"
   echo "----------------------------------------"
 
-  if ! pytest "$test_path" "$@"; then
+  if ! "$PYTHON_BIN" -m pytest "$@" "${pytest_args[@]}"; then
+    failed_tests+=("$label")
+  fi
+}
+
+run_isolated_pytest() {
+  local test_path="$1"
+
+  echo
+  echo "----------------------------------------"
+  echo "Running isolated $test_path"
+  echo "----------------------------------------"
+
+  if ! "$PYTHON_BIN" -m pytest "$test_path" -v; then
     failed_tests+=("$test_path")
   fi
 }
 
-finish_test_run() {
-  echo
-  echo "----------------------------------------"
-  if [[ ${#failed_tests[@]} -eq 0 ]]; then
-    echo "All backend tests passed."
-    exit 0
+unit_tests=()
+while IFS= read -r test_path; do
+  unit_tests+=("$test_path")
+done < <(read_test_file_list "${BACKEND_UNIT_TEST_FILE_LIST:-}")
+
+bulk_tests=()
+isolated_tests=()
+for test_path in "${unit_tests[@]}"; do
+  if requires_process_isolation "$test_path"; then
+    isolated_tests+=("$test_path")
+  else
+    bulk_tests+=("$test_path")
   fi
+done
 
-  echo "Backend test failures (${#failed_tests[@]}):"
-  printf '  - %s\n' "${failed_tests[@]}"
-  exit 1
-}
+failed_tests=()
 
-run_pytest tests/unit/test_transcript_segment.py -v
-run_pytest tests/unit/test_import_job_status_detail_enum.py -v
-run_pytest tests/unit/test_text_similarity.py -v
-run_pytest tests/unit/test_text_containment.py -v
-run_pytest tests/unit/test_speaker_sample.py -v
-run_pytest tests/unit/test_speaker_sample_migration.py -v
-run_pytest tests/unit/test_short_audio_embedding.py -v
-run_pytest tests/unit/test_users_add_sample_transaction.py -v
-run_pytest tests/unit/test_users_webhook_url_validation.py -v
-run_pytest tests/unit/test_users_missing_doc_guards.py -v
-run_pytest tests/unit/test_voice_message_language.py -v
-run_pytest tests/unit/test_speaker_assignment.py -v
-run_pytest tests/unit/test_speaker_id_pipeline.py -v
-run_pytest tests/unit/test_user_speaker_embedding.py -v
-run_pytest tests/unit/test_parakeet_diarization.py -v
-run_pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
-run_pytest tests/unit/test_parakeet_prerecorded.py -v
-run_pytest tests/unit/test_parakeet_nim.py -v
-run_pytest tests/unit/test_parakeet_stream_session.py -v
-run_pytest tests/unit/test_parakeet_gpu_worker.py -v
-run_pytest tests/unit/test_parakeet_batch_engine.py -v
-run_pytest tests/unit/test_parakeet_batch_routing.py -v
-run_pytest tests/unit/test_parakeet_builtin_embedding.py -v
-run_pytest tests/unit/test_parakeet_endpoints.py -v
-run_pytest tests/unit/test_audiobuffer_guard.py -v
-run_pytest tests/unit/test_memory_leak_buffers.py -v
-run_pytest tests/unit/test_hermetic_network.py -v
-run_pytest tests/unit/test_hermetic_network_collection_guard.py -v
-run_pytest tests/unit/test_mcp_search_memories.py -v
-run_pytest tests/unit/test_mcp_search_conversations_poison.py -v
-run_pytest tests/unit/test_mcp_memory_filters.py -v
-run_pytest tests/unit/test_mcp_client_tool_result.py -v
-run_pytest tests/unit/test_mcp_data_endpoints.py -v
-run_pytest tests/unit/test_mcp_oauth.py -v
-run_pytest tests/unit/test_mcp_action_item_writes.py -v
-run_pytest tests/unit/test_mcp_conversations_poison.py -v
-run_pytest tests/unit/test_mcp_profile_contact.py -v
-run_pytest tests/unit/test_memory_temporal_brain.py -v
-run_pytest tests/unit/test_memory_category_auto.py -v
-run_pytest tests/unit/test_memories_validation.py -v
-run_pytest tests/unit/test_memories_user_review.py -v
-run_pytest tests/unit/test_announcement_malformed_type.py -v
-run_pytest tests/unit/test_llm_gateway_service.py -v
-run_pytest tests/unit/test_llm_gateway_config.py -v
-run_pytest tests/unit/test_llm_gateway_auth.py -v
-run_pytest tests/unit/test_llm_gateway_credentials.py -v
-run_pytest tests/unit/test_llm_gateway_validator.py -v
-run_pytest tests/unit/test_llm_gateway_resolver.py -v
-run_pytest tests/unit/test_llm_gateway_executor.py -v
-run_pytest tests/unit/test_llm_gateway_openai_provider.py -v
-run_pytest tests/unit/test_llm_gateway_openai_compatible.py -v
-run_pytest tests/unit/test_llm_gateway_readiness.py -v
-run_pytest tests/unit/test_llm_gateway_client_config.py -v
-run_pytest tests/unit/test_llm_gateway_route_refs.py -v
-run_pytest tests/unit/test_llm_gateway_dependencies.py -v
-run_pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
-run_pytest tests/unit/test_backend_runtime_env_validator.py -v
-run_pytest tests/unit/test_llm_usage_tracker.py -v
-run_pytest tests/unit/test_llm_provider_plugin_structure.py -v
-run_pytest tests/unit/test_process_conversation_usage_context.py -v
-run_pytest tests/unit/test_high_priority_usage_tracking.py -v
-run_pytest tests/unit/test_new_usage_tracking_gaps.py -v
-run_pytest tests/unit/test_llm_usage_db.py -v
-run_pytest tests/unit/test_user_usage.py -v
-run_pytest tests/unit/test_llm_usage_endpoints.py -v
-run_pytest tests/unit/test_app_uid_keyerror.py -v
-run_pytest tests/unit/test_create_persona_user_none.py -v
-run_pytest tests/unit/test_daily_summary_race_condition.py -v
-run_pytest tests/unit/test_daily_summary_regenerate.py -v
-run_pytest tests/unit/test_chat_tools_messages.py -v
-run_pytest tests/unit/test_chat_tool_parameters_json.py -v
-run_pytest tests/unit/test_prompt_caching.py -v
-run_pytest tests/unit/test_mentor_notifications.py -v
-run_pytest tests/unit/test_proactive_notification_language.py -v
-run_pytest tests/unit/test_advice_update_missing_doc_guard.py -v
-run_pytest tests/unit/test_notification_token_cleanup.py -v
-run_pytest tests/unit/test_integration_notification_validation.py -v
-run_pytest tests/unit/test_conversations_to_string.py -v
-run_pytest tests/unit/test_location_maps_status_guard.py -v
-run_pytest tests/unit/test_conversation_render_factory.py -v
-run_pytest tests/unit/test_conversation_redact_enrich.py -v
-run_pytest tests/unit/test_retrieval_semantics.py -v
-run_pytest tests/unit/test_screen_activity_search_utc.py -v
-run_pytest tests/unit/test_conversation_tool_date_range_bound.py -v
-run_pytest tests/unit/test_retrieval_result_bounds.py -v
-run_pytest tests/unit/test_folder_name_enrichment.py -v
-run_pytest tests/unit/test_folder_conversations_malformed.py -v
-run_pytest tests/unit/test_conversations_count.py -v
-run_pytest tests/unit/test_conversations_date_range_validation.py -v
-run_pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
-run_pytest tests/unit/test_calendar_timezone.py -v
-run_pytest tests/unit/test_prompt_cache_optimization.py -v
-run_pytest tests/unit/test_prompt_cache_integration.py -v
-run_pytest tests/unit/test_firestore_cache.py -v
-run_pytest tests/unit/test_firestore_invariant_helpers.py -v
-run_pytest tests/unit/test_task_sharing.py -v
-run_pytest tests/unit/test_action_items_conversation_list_malformed.py -v
-run_pytest tests/unit/test_firmware_pagination.py -v
-run_pytest tests/unit/test_vad_gate.py -v
-run_pytest tests/unit/test_vad_onnx.py -v
-run_pytest tests/unit/test_log_sanitizer.py -v
-run_pytest tests/unit/test_hume_callback_malformed.py -v
-run_pytest tests/unit/test_file_upload_security.py -v
-run_pytest tests/unit/test_file_upload_endpoint_security.py -v
-run_pytest tests/unit/test_auth_redirect_uri.py -v
-run_pytest tests/unit/test_pusher_heartbeat.py -v
-run_pytest tests/unit/test_pusher_conversation_retry.py -v
-run_pytest tests/unit/utils/test_listen_pusher_session.py -v
-run_pytest tests/unit/test_listen_fallback_removal.py -v
-run_pytest tests/unit/test_desktop_updates.py -v
-run_pytest tests/unit/test_translation_optimization.py -v
-run_pytest tests/unit/test_translation_cost_optimization.py -v
-run_pytest tests/unit/test_translation_dedup_edge_cases.py -v
-run_pytest tests/unit/test_conversation_source_unknown.py -v
-run_pytest tests/unit/test_conversation_model_split.py -v
-run_pytest tests/unit/test_transcribe_conversation_cache.py -v
-run_pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
-run_pytest tests/unit/test_pusher_batch_upload.py -v
-run_pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
-run_pytest tests/unit/test_optional_audio_codecs.py -v
-run_pytest tests/unit/test_storage_opus_encoding.py -v
-run_pytest tests/unit/test_speech_profile_existence.py -v
-run_pytest tests/unit/test_speech_profile_wav_decode.py -v
-run_pytest tests/unit/test_storage_fanout_limits.py -v
-run_pytest tests/unit/test_deferred_blob_janitor.py -v
-run_pytest tests/unit/test_audio_merge_tasks.py -v
-run_pytest tests/unit/test_sync_playback_service.py -v
-run_pytest tests/unit/test_people_conversations_500s.py -v
-run_pytest tests/unit/test_import_jobs_malformed.py -v
-run_pytest tests/unit/test_firestore_read_ops_cache.py -v
-run_pytest tests/unit/test_ws_auth_handshake.py -v
-run_pytest tests/unit/test_streaming_deepgram_backoff.py -v
-run_pytest tests/unit/test_executors.py -v
-run_pytest tests/unit/test_task_integrations_async_offload.py -v
-run_pytest tests/unit/test_modulate_stt.py -v
-run_pytest tests/unit/test_batch_upload_storage.py -v
-run_pytest tests/unit/test_action_item_date_validation.py -v
-run_pytest tests/unit/test_action_items_date_range_validation.py -v
-run_pytest tests/unit/test_action_items_timezone.py -v
-run_pytest tests/unit/test_request_validation_contracts.py -v
-run_pytest tests/unit/test_conversation_structure_timezone.py -v
-run_pytest tests/unit/test_action_item_dedup.py -v
-run_pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
-run_pytest tests/unit/test_action_item_idempotency.py -v
-run_pytest tests/unit/test_goals_id_fallback.py -v
-run_pytest tests/unit/test_tools_router.py -v
-run_pytest tests/unit/test_kg_user_type_mismatch.py -v
-run_pytest tests/unit/test_kg_edge_id_sanitization.py -v
-run_pytest tests/unit/test_goal_extraction_batch.py -v
-run_pytest tests/unit/test_listen_pipeline.py -v
-run_pytest tests/unit/test_resample_pcm_divzero.py -v
-run_pytest tests/unit/test_fair_use_models.py -v
-run_pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
-run_pytest tests/unit/test_fair_use_engine.py -v
-run_pytest tests/unit/test_fair_use_classifier.py -v
-run_pytest tests/unit/test_fair_use_async.py -v
-run_pytest tests/unit/test_dg_usage_batch.py -v
-run_pytest tests/unit/test_billable_transcription_seconds.py -v
-run_pytest tests/unit/test_sync_fair_use_gate.py -v
-run_pytest tests/unit/test_sync_pcm_decode.py -v
-run_pytest tests/unit/test_sync_opus_decode.py -v
-run_pytest tests/unit/test_transcribe_lc3_optional.py -v
-run_pytest tests/unit/test_sync_silent_failure.py -v
-run_pytest tests/unit/test_sync_ordered_assignment.py -v
-run_pytest tests/unit/test_fair_use_free_tier.py -v
-run_pytest tests/unit/test_fair_use_upgrade.py -v
-run_pytest tests/unit/test_skip_classifier_restrict.py -v
-run_pytest tests/unit/test_timeout_middleware.py -v
-run_pytest tests/unit/test_pusher_circuit_breaker.py -v
-run_pytest tests/unit/test_pusher_ghost_connections.py -v
-run_pytest tests/unit/test_async_tasks.py -v
-run_pytest tests/unit/test_async_resource_correctness.py -v
-run_pytest tests/unit/test_lock_bypass_fixes.py -v
-run_pytest tests/unit/test_integration_malformed_records.py -v
-run_pytest tests/unit/test_oauth_callback_uid_guard.py -v
-run_pytest tests/unit/test_dev_api_lock_bypass.py -v
-run_pytest tests/unit/test_dev_api_folder_filters.py -v
-run_pytest tests/unit/test_dev_api_conversations_poison.py -v
-run_pytest tests/unit/test_developer_from_segments_idempotency.py -v
-run_pytest tests/unit/test_dev_api_memories_pagination.py -v
-run_pytest tests/unit/test_dev_api_action_items_poison.py -v
-run_pytest tests/unit/test_rate_limiting.py -v
-run_pytest tests/unit/test_rate_limit_json_failopen.py -v
-run_pytest tests/unit/test_memories_batch.py -v
-run_pytest tests/unit/test_memories_create.py -v
-run_pytest tests/unit/test_memories_pagination_clamp.py -v
-run_pytest tests/unit/test_sync_v2.py -v
-run_pytest tests/unit/test_sync_file_paths_filename_none.py -v
-run_pytest tests/unit/test_sync_cloud_tasks.py -v
-run_pytest tests/unit/test_sync_transcription_prefs.py -v
-run_pytest tests/unit/test_sync_record_usage.py -v
-run_pytest tests/unit/test_vision_stream_async.py -v
-run_pytest tests/unit/test_desktop_transcribe.py -v
-run_pytest tests/unit/test_desktop_migration.py -v
-run_pytest tests/unit/test_staged_tasks_batch_scores.py -v
-run_pytest tests/unit/test_staged_tasks_dedup.py -v
-run_pytest tests/unit/test_dg_start_guard.py -v
-run_pytest tests/unit/test_available_plans_resilience.py -v
-run_pytest tests/unit/test_subscription_restructure.py -v
-run_pytest tests/unit/test_chat_quota.py -v
-run_pytest tests/unit/test_voice_message_filename_none.py -v
-run_pytest tests/unit/test_subscription_plans.py -v
-run_pytest tests/unit/test_payment_available_plans_source.py -v
-run_pytest tests/unit/test_payment_reactivation_billing_date_utc.py -v
-run_pytest tests/unit/test_payment_promotion_codes.py -v
-run_pytest tests/unit/test_payment_connect_account_user_guard.py -v
-run_pytest tests/unit/test_stripe_webhook_none_guard.py -v
-run_pytest tests/unit/test_stripe_webhook_behavioral.py -v
-run_pytest tests/unit/test_voice_duration_limiter.py -v
-run_pytest tests/unit/test_async_webhooks.py -v
-run_pytest tests/unit/test_async_app_integrations.py -v
-run_pytest tests/unit/test_async_realtime_integrations_offload.py -v
-run_pytest tests/unit/test_async_geocoding.py -v
-run_pytest tests/unit/test_geocoding_cache.py -v
-run_pytest tests/unit/test_realtime_integrations_usage_tracking.py -v
-run_pytest tests/unit/test_async_auth.py -v
-run_pytest tests/unit/test_thread_join_elimination.py -v
-run_pytest tests/unit/test_async_http_infrastructure.py -v
-run_pytest tests/unit/test_clean_sweep_migrations.py -v
-run_pytest tests/unit/test_omi_qos_tiers.py -v
-run_pytest tests/unit/test_byok_security.py -v
-run_pytest tests/unit/test_paywall_reconnect_gate.py -v
-run_pytest tests/unit/test_trial_metadata.py -v
-run_pytest tests/unit/test_neo_desktop_grandfather.py -v
-run_pytest tests/unit/test_vertex_ai_system_role.py -v
-run_pytest tests/unit/test_tts.py -v
-run_pytest tests/unit/test_webhook_auto_disable.py -v
-run_pytest tests/unit/test_merge_validation.py -v
-run_pytest tests/unit/test_phone_calls.py -v
-run_pytest tests/unit/test_twilio_service.py -v
-run_pytest tests/unit/test_twilio_account_deletion.py -v
-run_pytest tests/unit/test_phone_verification_created_at.py -v
-run_pytest tests/unit/test_conversation_search_date_validation.py -v
-run_pytest tests/unit/test_conversation_events_bounds.py -v
-run_pytest tests/unit/test_conversation_hybrid_search.py -v
-run_pytest tests/unit/test_delete_account_stripe_cancel.py -v
-run_pytest tests/unit/test_delete_account_purge_storage.py -v
-run_pytest tests/unit/test_claim_deletion_wipe_txn.py -v
-run_pytest tests/services/users/test_account_deletion.py -v
-run_pytest tests/services/users/test_data_export.py -v
-run_pytest tests/routers/test_users.py -v
-run_pytest tests/unit/test_apps_review_reply_validation.py -v
-run_pytest tests/unit/test_apps_create_app_json.py -v
-run_pytest tests/unit/test_app_visibility_missing_doc_guard.py -v
+echo
+echo "----------------------------------------"
+if [[ ${#unit_tests[@]} -eq 0 ]]; then
+  echo "No backend unit tests selected."
+else
+  echo "Running ${#unit_tests[@]} backend unit test files"
+  echo "Bulk files: ${#bulk_tests[@]}"
+  echo "Isolated files: ${#isolated_tests[@]}"
+fi
+echo "----------------------------------------"
+
+if [[ ${#unit_tests[@]} -gt 0 ]]; then
+  run_pytest_group "bulk backend unit tests" "${bulk_tests[@]}"
+  for test_path in "${isolated_tests[@]}"; do
+    run_isolated_pytest "$test_path"
+  done
+fi
 
 # Optional fair-use integration tests require Redis and are intentionally outside
 # the deterministic unit signal.
 if [[ "${RUN_BACKEND_INTEGRATION_TESTS:-0}" == "1" ]]; then
   if command -v redis-cli >/dev/null 2>&1 && redis-cli ping >/dev/null 2>&1; then
-    run_pytest tests/integration/test_fair_use_live.py -v
-    run_pytest tests/integration/test_fair_use_api.py -v
+    if ! "$PYTHON_BIN" -m pytest tests/integration/test_fair_use_live.py tests/integration/test_fair_use_api.py -v; then
+      failed_tests+=("fair-use integration tests")
+    fi
   else
     echo "SKIP: fair-use integration tests (Redis not available)"
   fi
@@ -293,4 +117,13 @@ else
   echo "SKIP: fair-use integration tests (set RUN_BACKEND_INTEGRATION_TESTS=1 to enable)"
 fi
 
-finish_test_run
+echo
+echo "----------------------------------------"
+if [[ ${#failed_tests[@]} -eq 0 ]]; then
+  echo "All backend tests passed."
+  exit 0
+fi
+
+echo "Backend test failures (${#failed_tests[@]}):"
+printf '  - %s\n' "${failed_tests[@]}"
+exit 1

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -18,9 +18,9 @@ read_test_file_list() {
       echo "ERROR: BACKEND_UNIT_TEST_FILE_LIST does not exist: $test_file_list" >&2
       exit 1
     fi
-    python scripts/select_backend_unit_tests.py --from-test-list "$test_file_list"
+    "$PYTHON_BIN" scripts/select_backend_unit_tests.py --from-test-list "$test_file_list"
   else
-    python scripts/select_backend_unit_tests.py --all
+    "$PYTHON_BIN" scripts/select_backend_unit_tests.py --all
   fi
 }
 

--- a/backend/testing/e2e/requirements.txt
+++ b/backend/testing/e2e/requirements.txt
@@ -1,5 +1,6 @@
 pytest==8.4.1
 pytest-asyncio==1.3.0
+pytest-xdist==3.8.0
 fake-firestore==0.13.1
 fakeredis[lua]==2.36.2
 pytest-httpserver==1.1.5


### PR DESCRIPTION
## Summary
- add a conservative changed-file selector for backend unit tests
- skip the backend unit workflow entirely for PRs without backend or workflow changes
- run selected backend unit tests through a bulk-safe xdist phase plus per-file isolated phase for module-mocking tests
- add pytest-xdist to backend test dependencies and lockfiles

## Why
Backend unit CI was running the full historical file list for every backend PR. This keeps hermetic e2e behavior separate while letting unit CI run only tests relevant to touched areas, with full-suite fallback for shared or ambiguous changes.

## Validation
- `cd backend && PYTHON=.venv/bin/python bash test-preflight.sh`
- representative selector run for `backend/models/structured.py`: selected 12 backend unit files and passed
- `cd backend && PYTHON=.venv/bin/python BACKEND_PYTEST_XDIST=auto bash test.sh`: full backend unit suite passed, 244 selected files, 69 bulk files, 175 isolated files
- `git diff --check`
- `bash -n backend/test.sh`
- `python -m py_compile backend/scripts/select_backend_unit_tests.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

