### PR TITLE
Fix floating bar shortcut display

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -3,6 +3,12 @@ import Combine
 import MarkdownUI
 import SwiftUI
 
+enum ShortcutHintLayout {
+    static func visibleTokens(for keys: [String]) -> [String] {
+        keys
+    }
+}
+
 /// Main floating control bar SwiftUI view composing all sub-views.
 struct FloatingControlBarView: View {
     @EnvironmentObject var state: FloatingControlBarState
@@ -412,7 +418,7 @@ struct FloatingControlBarView: View {
     }
 
     private func notchShortcutKeys(_ keys: [String]) -> some View {
-        ForEach(keys.prefix(2), id: \.self) { key in
+        ForEach(ShortcutHintLayout.visibleTokens(for: keys), id: \.self) { key in
             Text(key)
                 .scaledFont(size: 8, weight: .medium)
                 .foregroundStyle(.white.opacity(0.75))
@@ -423,6 +429,7 @@ struct FloatingControlBarView: View {
                 .background(Color.white.opacity(0.12))
                 .cornerRadius(3)
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private var notchChromeHeight: CGFloat {

--- a/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
@@ -20,4 +20,11 @@ final class ShortcutSettingsTests: XCTestCase {
             ]
         )
     }
+
+    func testAskOmiCommandShiftReturnShowsEveryShortcutToken() {
+        let tokens = ShortcutSettings.askOmiCommandShiftReturnShortcut.displayTokens
+
+        XCTAssertEqual(tokens, ["⇧", "⌘", "↩"])
+        XCTAssertEqual(ShortcutHintLayout.visibleTokens(for: tokens), tokens)
+    }
 }

--- a/desktop/macos/changelog/unreleased/20260629-floating-shortcut-display.json
+++ b/desktop/macos/changelog/unreleased/20260629-floating-shortcut-display.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the floating bar hover menu hiding the final key in longer Ask Omi shortcuts"
+}


### PR DESCRIPTION
## Summary
- Remove the two-token cap from the notch hover shortcut renderer so longer Ask Omi shortcuts show every key
- Keep shortcut chips horizontally fixed so SwiftUI does not compress the full token sequence away
- Add a regression test for Cmd+Shift+Return and a desktop changelog fragment

## Root cause
The notch hover row rendered shortcut chips with `keys.prefix(2)`, so Cmd+Shift+Return displayed only `⇧` and `⌘` and dropped the Return key.

## Verification
- `make setup`
- `xcrun swift test --package-path Desktop --filter ShortcutSettingsTests`
- `xcrun swift build -c debug --package-path Desktop`
- Launched named bundle `com.omi.omi-shortcut-display` with Ask Omi shortcut set to Cmd+Shift+Return; AX full-tree hover check exposed: `Omi Chat, Ask, ⇧, ⌘, ↩, ⌥`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

