### PR TITLE
feat(ui): adopt OmiButton across the app (style-preserving migration)

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3064,5 +3064,6 @@
     "deviceOnboardingIntroSubtitle": "جولة سريعة وعملية على كل ما يمكن أن يفعله جهاز Omi.",
     "deviceOnboardingIntroDuration": "حوالي دقيقة واحدة",
     "jumpToLatestMessage": "الانتقال إلى أحدث رسالة",
-    "latest": "الأحدث"
+    "latest": "الأحدث",
+    "flashFirmware": "تحديث البرنامج الثابت"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Хуткі практычны агляд усяго, што ўмее ваш Omi.",
     "deviceOnboardingIntroDuration": "Каля 1 хвіліны",
     "jumpToLatestMessage": "Перайсці да апошняга паведамлення",
-    "latest": "Апошні"
+    "latest": "Апошні",
+    "flashFirmware": "Усталяваць прашыўку"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3066,5 +3066,6 @@
     "deviceOnboardingIntroSubtitle": "Бърза практическа обиколка на всичко, което вашият Omi може да прави.",
     "deviceOnboardingIntroDuration": "Около 1 минута",
     "jumpToLatestMessage": "Отиди до последното съобщение",
-    "latest": "Последно"
+    "latest": "Последно",
+    "flashFirmware": "Инсталирай фърмуера"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "আপনার Omi যা যা করতে পারে তার একটি দ্রুত, হাতে-কলমে ভ্রমণ।",
     "deviceOnboardingIntroDuration": "প্রায় ১ মিনিট",
     "jumpToLatestMessage": "সর্বশেষ বার্তায় যান",
-    "latest": "সর্বশেষ"
+    "latest": "সর্বশেষ",
+    "flashFirmware": "ফার্মওয়্যার ফ্ল্যাশ করুন"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Brz, praktičan obilazak svega što vaš Omi može.",
     "deviceOnboardingIntroDuration": "Oko 1 minute",
     "jumpToLatestMessage": "Idi na najnoviju poruku",
-    "latest": "Najnovije"
+    "latest": "Najnovije",
+    "flashFirmware": "Instaliraj firmver"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3066,5 +3066,6 @@
     "deviceOnboardingIntroSubtitle": "Un recorregut ràpid i pràctic per tot el que pot fer el teu Omi.",
     "deviceOnboardingIntroDuration": "Aproximadament 1 minut",
     "jumpToLatestMessage": "Vés a l'últim missatge",
-    "latest": "Últim"
+    "latest": "Últim",
+    "flashFirmware": "Grava el microprogramari"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3066,5 +3066,6 @@
     "deviceOnboardingIntroSubtitle": "Rychlá praktická prohlídka všeho, co váš Omi umí.",
     "deviceOnboardingIntroDuration": "Přibližně 1 minuta",
     "jumpToLatestMessage": "Přejít na nejnovější zprávu",
-    "latest": "Nejnovější"
+    "latest": "Nejnovější",
+    "flashFirmware": "Nahrát firmware"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3106,5 +3106,6 @@
     "deviceOnboardingIntroSubtitle": "En hurtig, praktisk rundvisning i alt, hvad din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minut",
     "jumpToLatestMessage": "Gå til nyeste besked",
-    "latest": "Nyeste"
+    "latest": "Nyeste",
+    "flashFirmware": "Flash firmware"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3065,5 +3065,6 @@
     "deviceOnboardingIntroSubtitle": "Ein kurzer, praktischer Rundgang durch alles, was dein Omi kann.",
     "deviceOnboardingIntroDuration": "Etwa 1 Minute",
     "jumpToLatestMessage": "Zur neuesten Nachricht springen",
-    "latest": "Neueste"
+    "latest": "Neueste",
+    "flashFirmware": "Firmware flashen"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Μια γρήγορη, πρακτική περιήγηση σε όλα όσα μπορεί να κάνει το Omi σας.",
     "deviceOnboardingIntroDuration": "Περίπου 1 λεπτό",
     "jumpToLatestMessage": "Μετάβαση στο πιο πρόσφατο μήνυμα",
-    "latest": "Πρόσφατο"
+    "latest": "Πρόσφατο",
+    "flashFirmware": "Εγκατάσταση firmware"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11210,5 +11210,9 @@
     "latest": "Latest",
     "@latest": {
         "description": "Visible label for the jump-to-latest button in chat"
+    },
+    "flashFirmware": "Flash Firmware",
+    "@flashFirmware": {
+        "description": "Button on the manual firmware flash page (developer settings)"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3098,5 +3098,6 @@
     "deviceOnboardingIntroSubtitle": "Un recorrido rápido y práctico por todo lo que tu Omi puede hacer.",
     "deviceOnboardingIntroDuration": "Aproximadamente 1 minuto",
     "jumpToLatestMessage": "Ir al mensaje más reciente",
-    "latest": "Más reciente"
+    "latest": "Más reciente",
+    "flashFirmware": "Flashear firmware"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Kiire ja praktiline ülevaade kõigest, mida sinu Omi suudab.",
     "deviceOnboardingIntroDuration": "Umbes 1 minut",
     "jumpToLatestMessage": "Hüppa uusima sõnumi juurde",
-    "latest": "Uusim"
+    "latest": "Uusim",
+    "flashFirmware": "Installi püsivara"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "یک گشت سریع و کاربردی در همه‌ی کارهایی که Omi شما می‌تواند انجام دهد.",
     "deviceOnboardingIntroDuration": "حدود ۱ دقیقه",
     "jumpToLatestMessage": "پرش به آخرین پیام",
-    "latest": "آخرین"
+    "latest": "آخرین",
+    "flashFirmware": "فلش کردن میان‌افزار"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Nopea ja käytännönläheinen kierros kaikkeen, mitä Omisi osaa.",
     "deviceOnboardingIntroDuration": "Noin 1 minuutti",
     "jumpToLatestMessage": "Siirry uusimpaan viestiin",
-    "latest": "Uusin"
+    "latest": "Uusin",
+    "flashFirmware": "Asenna laiteohjelmisto"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3132,5 +3132,6 @@
     "deviceOnboardingIntroSubtitle": "Un tour rapide et pratique de tout ce que votre Omi peut faire.",
     "deviceOnboardingIntroDuration": "Environ 1 minute",
     "jumpToLatestMessage": "Aller au dernier message",
-    "latest": "Récent"
+    "latest": "Récent",
+    "flashFirmware": "Flasher le firmware"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "סיור מהיר ומעשי בכל מה שה-Omi שלכם יכול לעשות.",
     "deviceOnboardingIntroDuration": "כדקה אחת",
     "jumpToLatestMessage": "קפוץ להודעה האחרונה",
-    "latest": "האחרון"
+    "latest": "האחרון",
+    "flashFirmware": "צריבת קושחה"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3098,5 +3098,6 @@
     "deviceOnboardingIntroSubtitle": "आपका Omi जो कुछ भी कर सकता है, उसका एक त्वरित और व्यावहारिक दौरा।",
     "deviceOnboardingIntroDuration": "लगभग 1 मिनट",
     "jumpToLatestMessage": "नवीनतम संदेश पर जाएं",
-    "latest": "नवीनतम"
+    "latest": "नवीनतम",
+    "flashFirmware": "फ़र्मवेयर फ़्लैश करें"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Brz i praktičan obilazak svega što vaš Omi može.",
     "deviceOnboardingIntroDuration": "Otprilike 1 minuta",
     "jumpToLatestMessage": "Idi na najnoviju poruku",
-    "latest": "Najnovije"
+    "latest": "Najnovije",
+    "flashFirmware": "Instaliraj firmver"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3193,5 +3193,6 @@
     "deviceOnboardingIntroSubtitle": "Gyors, gyakorlatias bemutató mindarról, amire az Omid képes.",
     "deviceOnboardingIntroDuration": "Körülbelül 1 perc",
     "jumpToLatestMessage": "Ugrás a legújabb üzenethez",
-    "latest": "Legújabb"
+    "latest": "Legújabb",
+    "flashFirmware": "Firmware flashelése"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3139,5 +3139,6 @@
     "deviceOnboardingIntroSubtitle": "Tur singkat dan praktis tentang semua yang bisa dilakukan Omi Anda.",
     "deviceOnboardingIntroDuration": "Sekitar 1 menit",
     "jumpToLatestMessage": "Lompat ke pesan terbaru",
-    "latest": "Terbaru"
+    "latest": "Terbaru",
+    "flashFirmware": "Flash Firmware"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Un tour rapido e pratico di tutto ciò che il tuo Omi può fare.",
     "deviceOnboardingIntroDuration": "Circa 1 minuto",
     "jumpToLatestMessage": "Vai all'ultimo messaggio",
-    "latest": "Più recente"
+    "latest": "Più recente",
+    "flashFirmware": "Installa il firmware"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3098,5 +3098,6 @@
     "deviceOnboardingIntroSubtitle": "Omi にできることを、すべて手軽に体験できるクイックツアー。",
     "deviceOnboardingIntroDuration": "約1分",
     "jumpToLatestMessage": "最新のメッセージにジャンプ",
-    "latest": "最新"
+    "latest": "最新",
+    "flashFirmware": "ファームウェアを書き込む"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "ನಿಮ್ಮ Omi ಮಾಡಬಲ್ಲ ಎಲ್ಲದರ ತ್ವರಿತ, ಪ್ರಾಯೋಗಿಕ ಪರಿಚಯ.",
     "deviceOnboardingIntroDuration": "ಸುಮಾರು 1 ನಿಮಿಷ",
     "jumpToLatestMessage": "ಇತ್ತೀಚಿನ ಸಂದೇಶಕ್ಕೆ ಹೋಗಿ",
-    "latest": "ಇತ್ತೀಚಿನ"
+    "latest": "ಇತ್ತೀಚಿನ",
+    "flashFirmware": "ಫರ್ಮ್‌ವೇರ್ ಫ್ಲ್ಯಾಶ್ ಮಾಡಿ"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Omi가 할 수 있는 모든 것을 빠르게 직접 둘러보세요.",
     "deviceOnboardingIntroDuration": "약 1분",
     "jumpToLatestMessage": "최신 메시지로 이동",
-    "latest": "최신"
+    "latest": "최신",
+    "flashFirmware": "펌웨어 플래시"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17660,6 +17660,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Latest'**
   String get latest;
+
+  /// Button on the manual firmware flash page (developer settings)
+  ///
+  /// In en, this message translates to:
+  /// **'Flash Firmware'**
+  String get flashFirmware;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9412,4 +9412,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get latest => 'الأحدث';
+
+  @override
+  String get flashFirmware => 'تحديث البرنامج الثابت';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9498,4 +9498,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get latest => 'Апошні';
+
+  @override
+  String get flashFirmware => 'Усталяваць прашыўку';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9504,4 +9504,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get latest => 'Последно';
+
+  @override
+  String get flashFirmware => 'Инсталирай фърмуера';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9475,4 +9475,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get latest => 'সর্বশেষ';
+
+  @override
+  String get flashFirmware => 'ফার্মওয়্যার ফ্ল্যাশ করুন';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9495,4 +9495,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get latest => 'Najnovije';
+
+  @override
+  String get flashFirmware => 'Instaliraj firmver';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9523,4 +9523,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get latest => 'Últim';
+
+  @override
+  String get flashFirmware => 'Grava el microprogramari';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9469,4 +9469,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get latest => 'Nejnovější';
+
+  @override
+  String get flashFirmware => 'Nahrát firmware';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9454,4 +9454,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get latest => 'Nyeste';
+
+  @override
+  String get flashFirmware => 'Flash firmware';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9547,4 +9547,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get latest => 'Neueste';
+
+  @override
+  String get flashFirmware => 'Firmware flashen';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9536,4 +9536,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get latest => 'Πρόσφατο';
+
+  @override
+  String get flashFirmware => 'Εγκατάσταση firmware';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9464,4 +9464,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get latest => 'Latest';
+
+  @override
+  String get flashFirmware => 'Flash Firmware';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9490,4 +9490,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get latest => 'Más reciente';
+
+  @override
+  String get flashFirmware => 'Flashear firmware';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9466,4 +9466,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get latest => 'Uusim';
+
+  @override
+  String get flashFirmware => 'Installi püsivara';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9471,4 +9471,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get latest => 'آخرین';
+
+  @override
+  String get flashFirmware => 'فلش کردن میان‌افزار';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9469,4 +9469,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get latest => 'Uusin';
+
+  @override
+  String get flashFirmware => 'Asenna laiteohjelmisto';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9554,4 +9554,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get latest => 'Récent';
+
+  @override
+  String get flashFirmware => 'Flasher le firmware';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9397,4 +9397,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get latest => 'האחרון';
+
+  @override
+  String get flashFirmware => 'צריבת קושחה';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9445,4 +9445,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get latest => 'नवीनतम';
+
+  @override
+  String get flashFirmware => 'फ़र्मवेयर फ़्लैश करें';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9502,4 +9502,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get latest => 'Najnovije';
+
+  @override
+  String get flashFirmware => 'Instaliraj firmver';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9509,4 +9509,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get latest => 'Legújabb';
+
+  @override
+  String get flashFirmware => 'Firmware flashelése';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9478,4 +9478,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get latest => 'Terbaru';
+
+  @override
+  String get flashFirmware => 'Flash Firmware';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9524,4 +9524,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get latest => 'Più recente';
+
+  @override
+  String get flashFirmware => 'Installa il firmware';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9314,4 +9314,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get latest => '最新';
+
+  @override
+  String get flashFirmware => 'ファームウェアを書き込む';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9499,4 +9499,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get latest => 'ಇತ್ತೀಚಿನ';
+
+  @override
+  String get flashFirmware => 'ಫರ್ಮ್‌ವೇರ್ ಫ್ಲ್ಯಾಶ್ ಮಾಡಿ';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9315,4 +9315,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get latest => '최신';
+
+  @override
+  String get flashFirmware => '펌웨어 플래시';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9485,4 +9485,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get latest => 'Naujausias';
+
+  @override
+  String get flashFirmware => 'Įrašyti programinę aparatinę įrangą';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9491,4 +9491,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get latest => 'Jaunākais';
+
+  @override
+  String get flashFirmware => 'Instalēt aparātprogrammatūru';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9519,4 +9519,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get latest => 'Најново';
+
+  @override
+  String get flashFirmware => 'Инсталирај фирмвер';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9478,4 +9478,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get latest => 'नवीनतम';
+
+  @override
+  String get flashFirmware => 'फर्मवेअर फ्लॅश करा';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9494,4 +9494,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get latest => 'Terkini';
+
+  @override
+  String get flashFirmware => 'Flash Perisian Tegar';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9495,4 +9495,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get latest => 'Nieuwste';
+
+  @override
+  String get flashFirmware => 'Firmware flashen';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9466,4 +9466,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get latest => 'Nyeste';
+
+  @override
+  String get flashFirmware => 'Flash fastvare';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9494,4 +9494,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get latest => 'Najnowsza';
+
+  @override
+  String get flashFirmware => 'Wgraj oprogramowanie układowe';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9474,4 +9474,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get latest => 'Mais recente';
+
+  @override
+  String get flashFirmware => 'Gravar firmware';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9514,4 +9514,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get latest => 'Recent';
+
+  @override
+  String get flashFirmware => 'Instalați firmware-ul';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9503,4 +9503,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get latest => 'Последнее';
+
+  @override
+  String get flashFirmware => 'Установить прошивку';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9460,4 +9460,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get latest => 'Najnovšia';
+
+  @override
+  String get flashFirmware => 'Nahrať firmvér';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9496,4 +9496,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get latest => 'Najnovejše';
+
+  @override
+  String get flashFirmware => 'Namesti vdelano programsko opremo';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9482,4 +9482,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get latest => 'Најновије';
+
+  @override
+  String get flashFirmware => 'Инсталирај фирмвер';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9474,4 +9474,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get latest => 'Senaste';
+
+  @override
+  String get flashFirmware => 'Installera firmware';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9537,4 +9537,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get latest => 'சமீபத்தியது';
+
+  @override
+  String get flashFirmware => 'ஃபார்ம்வேரை ஃபிளாஷ் செய்யவும்';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9517,4 +9517,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get latest => 'తాజా';
+
+  @override
+  String get flashFirmware => 'ఫర్మ్‌వేర్ ఫ్లాష్ చేయండి';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9417,4 +9417,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get latest => 'ล่าสุด';
+
+  @override
+  String get flashFirmware => 'แฟลชเฟิร์มแวร์';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9557,4 +9557,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get latest => 'Pinakabago';
+
+  @override
+  String get flashFirmware => 'I-flash ang Firmware';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9479,4 +9479,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get latest => 'En son';
+
+  @override
+  String get flashFirmware => 'Donanım Yazılımını Yükle';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9488,4 +9488,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get latest => 'Останнє';
+
+  @override
+  String get flashFirmware => 'Встановити прошивку';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9483,4 +9483,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get latest => 'تازہ ترین';
+
+  @override
+  String get flashFirmware => 'فرم ویئر فلیش کریں';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9466,4 +9466,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get latest => 'Mới nhất';
+
+  @override
+  String get flashFirmware => 'Nạp firmware';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9298,4 +9298,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get latest => '最新';
+
+  @override
+  String get flashFirmware => '刷写固件';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Greita praktinė apžvalga visko, ką gali jūsų Omi.",
     "deviceOnboardingIntroDuration": "Maždaug 1 minutė",
     "jumpToLatestMessage": "Peršokti į naujausią pranešimą",
-    "latest": "Naujausias"
+    "latest": "Naujausias",
+    "flashFirmware": "Įrašyti programinę aparatinę įrangą"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Ātrs, praktisks ieskats visā, ko spēj tavs Omi.",
     "deviceOnboardingIntroDuration": "Apmēram 1 minūte",
     "jumpToLatestMessage": "Pārlēkt uz jaunāko ziņojumu",
-    "latest": "Jaunākais"
+    "latest": "Jaunākais",
+    "flashFirmware": "Instalēt aparātprogrammatūru"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Брза, практична прошетка низ сè што може да направи вашиот Omi.",
     "deviceOnboardingIntroDuration": "Околу 1 минута",
     "jumpToLatestMessage": "Оди до последната порака",
-    "latest": "Најново"
+    "latest": "Најново",
+    "flashFirmware": "Инсталирај фирмвер"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "तुमचा Omi जे काही करू शकतो त्याची झटपट, प्रत्यक्ष ओळख.",
     "deviceOnboardingIntroDuration": "सुमारे 1 मिनिट",
     "jumpToLatestMessage": "नवीनतम संदेशावर जा",
-    "latest": "नवीनतम"
+    "latest": "नवीनतम",
+    "flashFirmware": "फर्मवेअर फ्लॅश करा"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Lawatan ringkas dan praktikal tentang semua yang Omi anda boleh lakukan.",
     "deviceOnboardingIntroDuration": "Kira-kira 1 minit",
     "jumpToLatestMessage": "Lompat ke mesej terkini",
-    "latest": "Terkini"
+    "latest": "Terkini",
+    "flashFirmware": "Flash Perisian Tegar"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Een snelle, praktische rondleiding langs alles wat je Omi kan.",
     "deviceOnboardingIntroDuration": "Ongeveer 1 minuut",
     "jumpToLatestMessage": "Naar nieuwste bericht springen",
-    "latest": "Nieuwste"
+    "latest": "Nieuwste",
+    "flashFirmware": "Firmware flashen"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "En rask, praktisk omvisning i alt din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minutt",
     "jumpToLatestMessage": "Gå til nyeste melding",
-    "latest": "Nyeste"
+    "latest": "Nyeste",
+    "flashFirmware": "Flash fastvare"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3132,5 +3132,6 @@
     "deviceOnboardingIntroSubtitle": "Szybki, praktyczny przegląd wszystkiego, co potrafi Twoje Omi.",
     "deviceOnboardingIntroDuration": "Około 1 minuty",
     "jumpToLatestMessage": "Przejdź do najnowszej wiadomości",
-    "latest": "Najnowsza"
+    "latest": "Najnowsza",
+    "flashFirmware": "Wgraj oprogramowanie układowe"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3133,5 +3133,6 @@
     "deviceOnboardingIntroSubtitle": "Um tour rápido e prático por tudo o que o seu Omi pode fazer.",
     "deviceOnboardingIntroDuration": "Cerca de 1 minuto",
     "jumpToLatestMessage": "Ir para a mensagem mais recente",
-    "latest": "Mais recente"
+    "latest": "Mais recente",
+    "flashFirmware": "Gravar firmware"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Un tur rapid și practic prin tot ce poate face Omi-ul tău.",
     "deviceOnboardingIntroDuration": "Aproximativ 1 minut",
     "jumpToLatestMessage": "Sari la cel mai recent mesaj",
-    "latest": "Recent"
+    "latest": "Recent",
+    "flashFirmware": "Instalați firmware-ul"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3132,5 +3132,6 @@
     "deviceOnboardingIntroSubtitle": "Быстрый практический обзор всего, что умеет ваш Omi.",
     "deviceOnboardingIntroDuration": "Около 1 минуты",
     "jumpToLatestMessage": "Перейти к последнему сообщению",
-    "latest": "Последнее"
+    "latest": "Последнее",
+    "flashFirmware": "Установить прошивку"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3102,5 +3102,6 @@
     "deviceOnboardingIntroSubtitle": "Rýchla praktická prehliadka všetkého, čo váš Omi dokáže.",
     "deviceOnboardingIntroDuration": "Približne 1 minúta",
     "jumpToLatestMessage": "Prejsť na najnovšiu správu",
-    "latest": "Najnovšia"
+    "latest": "Najnovšia",
+    "flashFirmware": "Nahrať firmvér"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Hiter, praktičen ogled vsega, kar zmore vaš Omi.",
     "deviceOnboardingIntroDuration": "Približno 1 minuta",
     "jumpToLatestMessage": "Skoči na najnovejše sporočilo",
-    "latest": "Najnovejše"
+    "latest": "Najnovejše",
+    "flashFirmware": "Namesti vdelano programsko opremo"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Брз, практичан обилазак свега што ваш Omi може.",
     "deviceOnboardingIntroDuration": "Око 1 минута",
     "jumpToLatestMessage": "Иди на најновију поруку",
-    "latest": "Најновије"
+    "latest": "Најновије",
+    "flashFirmware": "Инсталирај фирмвер"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "En snabb, praktisk rundtur i allt din Omi kan.",
     "deviceOnboardingIntroDuration": "Cirka 1 minut",
     "jumpToLatestMessage": "Hoppa till senaste meddelandet",
-    "latest": "Senaste"
+    "latest": "Senaste",
+    "flashFirmware": "Installera firmware"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "உங்கள் Omi செய்யக்கூடிய அனைத்தையும் விரைவாக நேரடியாகப் பார்க்கும் சுற்றுலா.",
     "deviceOnboardingIntroDuration": "சுமார் 1 நிமிடம்",
     "jumpToLatestMessage": "சமீபத்திய செய்திக்குச் செல்",
-    "latest": "சமீபத்தியது"
+    "latest": "சமீபத்தியது",
+    "flashFirmware": "ஃபார்ம்வேரை ஃபிளாஷ் செய்யவும்"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "మీ Omi చేయగలిగే ప్రతిదాని గురించి త్వరిత, ప్రత్యక్ష పరిచయం.",
     "deviceOnboardingIntroDuration": "సుమారు 1 నిమిషం",
     "jumpToLatestMessage": "తాజా సందేశానికి వెళ్ళు",
-    "latest": "తాజా"
+    "latest": "తాజా",
+    "flashFirmware": "ఫర్మ్‌వేర్ ఫ్లాష్ చేయండి"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "ทัวร์สั้น ๆ แบบลงมือทำจริงเกี่ยวกับทุกสิ่งที่ Omi ของคุณทำได้",
     "deviceOnboardingIntroDuration": "ประมาณ 1 นาที",
     "jumpToLatestMessage": "ไปยังข้อความล่าสุด",
-    "latest": "ล่าสุด"
+    "latest": "ล่าสุด",
+    "flashFirmware": "แฟลชเฟิร์มแวร์"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "Isang mabilis at praktikal na pamamasyal sa lahat ng kayang gawin ng iyong Omi.",
     "deviceOnboardingIntroDuration": "Mga 1 minuto",
     "jumpToLatestMessage": "Tumalon sa pinakabagong mensahe",
-    "latest": "Pinakabago"
+    "latest": "Pinakabago",
+    "flashFirmware": "I-flash ang Firmware"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3132,5 +3132,6 @@
     "deviceOnboardingIntroSubtitle": "Omi'nizin yapabileceği her şeyin hızlı ve uygulamalı bir turu.",
     "deviceOnboardingIntroDuration": "Yaklaşık 1 dakika",
     "jumpToLatestMessage": "En son mesaja git",
-    "latest": "En son"
+    "latest": "En son",
+    "flashFirmware": "Donanım Yazılımını Yükle"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3097,5 +3097,6 @@
     "deviceOnboardingIntroSubtitle": "Швидкий практичний огляд усього, що вміє ваш Omi.",
     "deviceOnboardingIntroDuration": "Близько 1 хвилини",
     "jumpToLatestMessage": "Перейти до останнього повідомлення",
-    "latest": "Останнє"
+    "latest": "Останнє",
+    "flashFirmware": "Встановити прошивку"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10675,5 +10675,6 @@
     "deviceOnboardingIntroSubtitle": "آپ کا Omi جو کچھ کر سکتا ہے اس کا ایک تیز اور عملی جائزہ۔",
     "deviceOnboardingIntroDuration": "تقریباً 1 منٹ",
     "jumpToLatestMessage": "تازہ ترین پیغام پر جائیں",
-    "latest": "تازہ ترین"
+    "latest": "تازہ ترین",
+    "flashFirmware": "فرم ویئر فلیش کریں"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3102,5 +3102,6 @@
     "deviceOnboardingIntroSubtitle": "Một chuyến tham quan nhanh, thực tế về mọi điều Omi của bạn có thể làm.",
     "deviceOnboardingIntroDuration": "Khoảng 1 phút",
     "jumpToLatestMessage": "Đi đến tin nhắn mới nhất",
-    "latest": "Mới nhất"
+    "latest": "Mới nhất",
+    "flashFirmware": "Nạp firmware"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3119,5 +3119,6 @@
     "deviceOnboardingIntroSubtitle": "快速、上手地体验 Omi 的全部功能。",
     "deviceOnboardingIntroDuration": "大约 1 分钟",
     "jumpToLatestMessage": "跳转到最新消息",
-    "latest": "最新"
+    "latest": "最新",
+    "flashFirmware": "刷写固件"
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -473,11 +473,8 @@ class CustomErrorWidget extends StatelessWidget {
             const SizedBox(height: 10.0),
             SizedBox(
               width: 210,
-              child: OmiButton(
+              child: OmiButton.legacy(
                 color: Colors.red,
-                borderRadius: 4,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
                 label: context.l10n.copyErrorMessage,
                 icon: Icons.copy_rounded,
                 trailingIcon: true,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -69,6 +69,7 @@ import 'package:omi/services/notifications/important_conversation_notification_h
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/debugging/crashlytics_manager.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -472,21 +473,20 @@ class CustomErrorWidget extends StatelessWidget {
             const SizedBox(height: 10.0),
             SizedBox(
               width: 210,
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+              child: OmiButton(
+                color: Colors.red,
+                borderRadius: 4,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                label: context.l10n.copyErrorMessage,
+                icon: Icons.copy_rounded,
+                trailingIcon: true,
+                iconSize: 24,
+                iconGap: 10,
                 onPressed: () {
                   Clipboard.setData(ClipboardData(text: errorMessage));
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.errorCopied)));
                 },
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Text(context.l10n.copyErrorMessage),
-                    const SizedBox(width: 10),
-                    const Icon(Icons.copy_rounded),
-                  ],
-                ),
               ),
             ),
           ],

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -12,6 +12,7 @@ import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/goals_provider.dart';
 import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/app_review_service.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/debouncer.dart';
 import 'widgets/action_item_form_sheet.dart';
@@ -1793,7 +1794,8 @@ class _GoalCreateSheetState extends State<_GoalCreateSheet> {
               const SizedBox(height: 24),
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
+                child: OmiButton(
+                  label: context.l10n.addGoal,
                   onPressed: () async {
                     final title = titleController.text.trim();
                     if (title.isEmpty) {
@@ -1809,13 +1811,12 @@ class _GoalCreateSheetState extends State<_GoalCreateSheet> {
 
                     widget.onSave(title, current, target);
                   },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF22C55E),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  child: Text(context.l10n.addGoal),
+                  color: const Color(0xFF22C55E),
+                  textColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  borderRadius: 12,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],
@@ -2008,7 +2009,8 @@ class _GoalEditSheetState extends State<_GoalEditSheet> {
                   // Save button
                   Expanded(
                     flex: 2,
-                    child: ElevatedButton(
+                    child: OmiButton(
+                      label: context.l10n.save,
                       onPressed: () async {
                         final title = titleController.text.trim();
                         if (title.isEmpty) {
@@ -2024,13 +2026,12 @@ class _GoalEditSheetState extends State<_GoalEditSheet> {
 
                         widget.onSave(title, current, target);
                       },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF22C55E),
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 14),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      ),
-                      child: Text(context.l10n.save),
+                      color: const Color(0xFF22C55E),
+                      textColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      borderRadius: 12,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
                     ),
                   ),
                 ],

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -1794,7 +1794,7 @@ class _GoalCreateSheetState extends State<_GoalCreateSheet> {
               const SizedBox(height: 24),
               SizedBox(
                 width: double.infinity,
-                child: OmiButton(
+                child: OmiButton.legacy(
                   label: context.l10n.addGoal,
                   onPressed: () async {
                     final title = titleController.text.trim();
@@ -1815,8 +1815,6 @@ class _GoalCreateSheetState extends State<_GoalCreateSheet> {
                   textColor: Colors.white,
                   padding: const EdgeInsets.symmetric(vertical: 14),
                   borderRadius: 12,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],
@@ -2009,7 +2007,7 @@ class _GoalEditSheetState extends State<_GoalEditSheet> {
                   // Save button
                   Expanded(
                     flex: 2,
-                    child: OmiButton(
+                    child: OmiButton.legacy(
                       label: context.l10n.save,
                       onPressed: () async {
                         final title = titleController.text.trim();
@@ -2030,8 +2028,6 @@ class _GoalEditSheetState extends State<_GoalEditSheet> {
                       textColor: Colors.white,
                       padding: const EdgeInsets.symmetric(vertical: 14),
                       borderRadius: 12,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
                     ),
                   ),
                 ],

--- a/app/lib/pages/announcements/announcement_dialog.dart
+++ b/app/lib/pages/announcements/announcement_dialog.dart
@@ -3,6 +3,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/models/announcement.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 
 class AnnouncementDialog extends StatelessWidget {
   final Announcement announcement;
@@ -171,19 +172,15 @@ class AnnouncementDialog extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       height: 52,
-      child: ElevatedButton(
+      child: OmiButton(
+        label: cta.text,
         onPressed: () {
           onCTAPressed?.call();
           Navigator.pop(context);
           _handleCTAAction(context, cta.action);
         },
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(26)),
-          elevation: 0,
-        ),
-        child: Text(cta.text, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+        borderRadius: 26,
+        fontSize: 16,
       ),
     );
   }

--- a/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
@@ -7,6 +7,7 @@ import 'package:timeago/timeago.dart' as timeago;
 import 'package:omi/backend/http/api/apps.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/providers/app_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/widgets/extensions/string.dart';
 
@@ -95,111 +96,111 @@ class _AppOwnerReviewCardState extends State<AppOwnerReviewCard> {
                         child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
                       )
                     : (!showReplyField
-                          ? null
-                          : SingleChildScrollView(
-                              physics: const NeverScrollableScrollPhysics(),
-                              child: Column(
-                                children: [
-                                  SizedBox(
-                                    width: MediaQuery.sizeOf(context).width * 0.88,
-                                    child: TextFormField(
-                                      controller: replyController,
-                                      enabled: isLoading ? false : true,
-                                      keyboardType: TextInputType.multiline,
-                                      maxLength: 250,
-                                      onChanged: (value) {
-                                        if (value.isEmpty) {
-                                          if (value == widget.review.review) {
-                                            updateShowButton(false);
-                                          } else {
-                                            updateShowButton(true);
-                                          }
+                        ? null
+                        : SingleChildScrollView(
+                            physics: const NeverScrollableScrollPhysics(),
+                            child: Column(
+                              children: [
+                                SizedBox(
+                                  width: MediaQuery.sizeOf(context).width * 0.88,
+                                  child: TextFormField(
+                                    controller: replyController,
+                                    enabled: isLoading ? false : true,
+                                    keyboardType: TextInputType.multiline,
+                                    maxLength: 250,
+                                    onChanged: (value) {
+                                      if (value.isEmpty) {
+                                        if (value == widget.review.review) {
+                                          updateShowButton(false);
                                         } else {
                                           updateShowButton(true);
                                         }
-                                      },
-                                      decoration: InputDecoration(
-                                        hintText: context.l10n.writeSomething,
-                                        hintStyle: const TextStyle(color: Colors.grey),
-                                        border: const OutlineInputBorder(
-                                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey),
-                                        ),
-                                        enabledBorder: OutlineInputBorder(
-                                          borderRadius: const BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey[700]!),
-                                        ),
-                                        focusedBorder: const OutlineInputBorder(
-                                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey),
-                                        ),
+                                      } else {
+                                        updateShowButton(true);
+                                      }
+                                    },
+                                    decoration: InputDecoration(
+                                      hintText: context.l10n.writeSomething,
+                                      hintStyle: const TextStyle(color: Colors.grey),
+                                      border: const OutlineInputBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey),
                                       ),
-                                      style: const TextStyle(color: Colors.white),
-                                      maxLines: 3,
+                                      enabledBorder: OutlineInputBorder(
+                                        borderRadius: const BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey[700]!),
+                                      ),
+                                      focusedBorder: const OutlineInputBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey),
+                                      ),
                                     ),
+                                    style: const TextStyle(color: Colors.white),
+                                    maxLines: 3,
                                   ),
-                                  const SizedBox(height: 20),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      SizedBox(
-                                        width: MediaQuery.sizeOf(context).width * 0.36,
-                                        child: OutlinedButton(
-                                          style: OutlinedButton.styleFrom(
-                                            side: const BorderSide(color: Colors.white),
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                                          ),
-                                          onPressed: () {
-                                            updateShowReplyField(false);
-                                          },
-                                          child: Text(
-                                            context.l10n.cancel,
-                                            style: const TextStyle(color: Colors.white, fontSize: 16),
-                                          ),
+                                ),
+                                const SizedBox(height: 20),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    SizedBox(
+                                      width: MediaQuery.sizeOf(context).width * 0.36,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          side: const BorderSide(color: Colors.white),
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                        ),
+                                        onPressed: () {
+                                          updateShowReplyField(false);
+                                        },
+                                        child: Text(
+                                          context.l10n.cancel,
+                                          style: const TextStyle(color: Colors.white, fontSize: 16),
                                         ),
                                       ),
-                                      const SizedBox(width: 30),
-                                      SizedBox(
-                                        width: MediaQuery.sizeOf(context).width * 0.36,
-                                        child: OutlinedButton(
-                                          style: OutlinedButton.styleFrom(
-                                            side: const BorderSide(color: Colors.white),
-                                            backgroundColor: Colors.white,
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                                          ),
-                                          onPressed: () async {
-                                            if (replyController.text.isNotEmpty) {
-                                              setState(() {
-                                                isLoading = true;
-                                              });
-                                              await replyToAppReview(
-                                                widget.appId,
-                                                replyController.text,
-                                                widget.review.uid,
-                                              );
-                                              context.read<AppProvider>().updateLocalAppReviewResponse(
-                                                widget.appId,
-                                                replyController.text,
-                                                widget.review.uid,
-                                              );
-                                              setState(() {
-                                                widget.review.response = replyController.text;
-                                                isLoading = false;
-                                                showReplyField = false;
-                                              });
-                                            }
-                                          },
-                                          child: Text(
-                                            context.l10n.submitReply,
-                                            style: const TextStyle(color: Colors.black, fontSize: 16),
-                                          ),
+                                    ),
+                                    const SizedBox(width: 30),
+                                    SizedBox(
+                                      width: MediaQuery.sizeOf(context).width * 0.36,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          side: const BorderSide(color: Colors.white),
+                                          backgroundColor: Colors.white,
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                        ),
+                                        onPressed: () async {
+                                          if (replyController.text.isNotEmpty) {
+                                            setState(() {
+                                              isLoading = true;
+                                            });
+                                            await replyToAppReview(
+                                              widget.appId,
+                                              replyController.text,
+                                              widget.review.uid,
+                                            );
+                                            context.read<AppProvider>().updateLocalAppReviewResponse(
+                                                  widget.appId,
+                                                  replyController.text,
+                                                  widget.review.uid,
+                                                );
+                                            setState(() {
+                                              widget.review.response = replyController.text;
+                                              isLoading = false;
+                                              showReplyField = false;
+                                            });
+                                          }
+                                        },
+                                        child: Text(
+                                          context.l10n.submitReply,
+                                          style: const TextStyle(color: Colors.black, fontSize: 16),
                                         ),
                                       ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            )),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          )),
               ),
             ),
             !showReplyField && widget.review.response.isNotEmpty
@@ -230,18 +231,15 @@ class _AppOwnerReviewCardState extends State<AppOwnerReviewCard> {
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                        ),
+                      OmiButton(
+                        label:
+                            widget.review.response.isNotEmpty ? context.l10n.editYourReply : context.l10n.replyToReview,
                         onPressed: () {
                           updateShowReplyField(!showReplyField);
                         },
-                        child: Text(
-                          widget.review.response.isNotEmpty ? context.l10n.editYourReply : context.l10n.replyToReview,
-                          style: const TextStyle(color: Colors.black),
-                        ),
+                        borderRadius: 16,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
                       ),
                     ],
                   )

--- a/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
@@ -231,15 +231,13 @@ class _AppOwnerReviewCardState extends State<AppOwnerReviewCard> {
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      OmiButton(
+                      OmiButton.legacy(
                         label:
                             widget.review.response.isNotEmpty ? context.l10n.editYourReply : context.l10n.replyToReview,
                         onPressed: () {
                           updateShowReplyField(!showReplyField);
                         },
                         borderRadius: 16,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
                       ),
                     ],
                   )

--- a/app/lib/pages/apps/widgets/filter_sheet.dart
+++ b/app/lib/pages/apps/widgets/filter_sheet.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/providers/app_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/app_localizations_helper.dart';
 
 class FilterBottomSheet extends StatelessWidget {
@@ -125,20 +126,16 @@ class FilterBottomSheet extends StatelessWidget {
                     ),
                     const SizedBox(width: 16),
                     Expanded(
-                      child: ElevatedButton(
+                      child: OmiButton(
+                        label: AppLocalizations.of(context)!.applyFilters,
                         onPressed: () {
                           Navigator.of(context).pop();
                           Future.microtask(() => provider.applyFilters());
                         },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                        ),
-                        child: Text(
-                          AppLocalizations.of(context)!.applyFilters,
-                          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Colors.black),
-                        ),
+                        borderRadius: 12,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
                       ),
                     ),
                   ],

--- a/app/lib/pages/capture/widgets/limitless_sync_widget.dart
+++ b/app/lib/pages/capture/widgets/limitless_sync_widget.dart
@@ -6,6 +6,7 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/sync_confirmation.dart';
 
@@ -54,17 +55,17 @@ class LimitlessSyncCardWidget extends StatelessWidget {
                     ),
                   ),
                   if (!isSyncing)
-                    ElevatedButton(
+                    OmiButton(
+                      label: context.l10n.syncNow,
                       onPressed: () async {
                         if (await confirmSyncForCustomStt(context) && context.mounted) syncProvider.syncWals();
                       },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.deepPurple,
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                      ),
-                      child: Text(context.l10n.syncNow),
+                      color: Colors.deepPurple,
+                      textColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      borderRadius: 8,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
                     )
                   else
                     Text(

--- a/app/lib/pages/capture/widgets/limitless_sync_widget.dart
+++ b/app/lib/pages/capture/widgets/limitless_sync_widget.dart
@@ -55,7 +55,7 @@ class LimitlessSyncCardWidget extends StatelessWidget {
                     ),
                   ),
                   if (!isSyncing)
-                    OmiButton(
+                    OmiButton.legacy(
                       label: context.l10n.syncNow,
                       onPressed: () async {
                         if (await confirmSyncForCustomStt(context) && context.mounted) syncProvider.syncWals();
@@ -64,8 +64,6 @@ class LimitlessSyncCardWidget extends StatelessWidget {
                       textColor: Colors.white,
                       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                       borderRadius: 8,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
                     )
                   else
                     Text(

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -29,6 +29,7 @@ import 'package:omi/pages/conversation_detail/widgets/summarized_apps_sheet.dart
 import 'package:omi/pages/conversations/widgets/move_to_folder_sheet.dart';
 import 'package:omi/pages/settings/developer.dart';
 import 'package:omi/providers/folder_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/folders/folder_icon_mapper.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/other/time_utils.dart';
@@ -1044,15 +1045,13 @@ class _AppResultDetailWidgetState extends State<AppResultDetailWidget> {
               ),
             ),
             const SizedBox(width: 8),
-            ElevatedButton(
+            OmiButton(
+              label: context.l10n.save,
               onPressed: () => _save(original),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white,
-                foregroundColor: Colors.black,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-              ),
-              child: Text(context.l10n.save, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              borderRadius: 10,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
             ),
           ],
         ),

--- a/app/lib/pages/conversation_detail/widgets/audio_download_progress_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/audio_download_progress_sheet.dart
@@ -220,7 +220,7 @@ class _AudioDownloadProgressSheetState extends State<AudioDownloadProgressSheet>
             if (widget.onRetry != null) ...[
               const SizedBox(width: 12),
               Expanded(
-                child: OmiButton(
+                child: OmiButton.legacy(
                   label: context.l10n.retry,
                   onPressed: () {
                     Navigator.of(context).pop();
@@ -229,8 +229,6 @@ class _AudioDownloadProgressSheetState extends State<AudioDownloadProgressSheet>
                   textColor: const Color(0xFF1C1C1E),
                   padding: const EdgeInsets.symmetric(vertical: 14),
                   borderRadius: 12,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],

--- a/app/lib/pages/conversation_detail/widgets/audio_download_progress_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/audio_download_progress_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 enum AudioDownloadState { preparing, downloading, processing, success, error }
@@ -219,19 +220,17 @@ class _AudioDownloadProgressSheetState extends State<AudioDownloadProgressSheet>
             if (widget.onRetry != null) ...[
               const SizedBox(width: 12),
               Expanded(
-                child: ElevatedButton(
+                child: OmiButton(
+                  label: context.l10n.retry,
                   onPressed: () {
                     Navigator.of(context).pop();
                     widget.onRetry?.call();
                   },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: const Color(0xFF1C1C1E),
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    elevation: 0,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  child: Text(context.l10n.retry),
+                  textColor: const Color(0xFF1C1C1E),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  borderRadius: 12,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],

--- a/app/lib/pages/conversation_detail/widgets/edit_segment_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/edit_segment_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 void showEditSegmentBottomSheet(
@@ -104,15 +105,12 @@ class _EditSegmentSheetState extends State<_EditSegmentSheet> {
               const SizedBox(height: 16),
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
+                child: OmiButton(
+                  label: context.l10n.save,
                   onPressed: _save,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  child: Text(context.l10n.save, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  borderRadius: 12,
+                  fontSize: 15,
                 ),
               ),
             ],

--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -437,11 +437,9 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
   Widget _buildSaveButton() {
     return SizedBox(
       width: double.infinity,
-      child: OmiButton(
+      child: OmiButton.legacy(
         label: context.l10n.save,
         borderRadius: 8,
-        fontSize: 14,
-        fontWeight: FontWeight.w500,
         disabledColor: Colors.white.withValues(alpha: 0.12),
         disabledTextColor: Colors.white.withValues(alpha: 0.38),
         onPressed: !allowSave || loading

--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -8,6 +8,7 @@ import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/pages/settings/people.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/providers/people_provider.dart';
 import 'package:omi/widgets/person_chip.dart';
@@ -436,12 +437,13 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
   Widget _buildSaveButton() {
     return SizedBox(
       width: double.infinity,
-      child: ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        ),
+      child: OmiButton(
+        label: context.l10n.save,
+        borderRadius: 8,
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+        disabledColor: Colors.white.withValues(alpha: 0.12),
+        disabledTextColor: Colors.white.withValues(alpha: 0.38),
         onPressed: !allowSave || loading
             ? null
             : () async {
@@ -467,7 +469,6 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
                   Navigator.pop(context);
                 }
               },
-        child: Center(child: Text(context.l10n.save)),
       ),
     );
   }

--- a/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/widgets/extensions/string.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -410,7 +411,8 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
+            OmiButton(
+              label: context.l10n.openSettings,
               onPressed: () async {
                 // Open app settings
                 if (Platform.isIOS) {
@@ -419,8 +421,10 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
                   await launchUrl(Uri.parse('package:com.friend.ios'));
                 }
               },
-              style: ElevatedButton.styleFrom(backgroundColor: Colors.deepPurple),
-              child: Text(context.l10n.openSettings),
+              color: Colors.deepPurple,
+              borderRadius: 4,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
             ),
           ],
         ),

--- a/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
@@ -411,7 +411,7 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
-            OmiButton(
+            OmiButton.legacy(
               label: context.l10n.openSettings,
               onPressed: () async {
                 // Open app settings
@@ -422,9 +422,6 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
                 }
               },
               color: Colors.deepPurple,
-              borderRadius: 4,
-              fontSize: 14,
-              fontWeight: FontWeight.w500,
             ),
           ],
         ),

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/models/playback_state.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/ui/molecules/omi_confirm_dialog.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/other/temp.dart';
@@ -301,23 +302,17 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
               child: SizedBox(
                 width: double.infinity,
                 height: 56,
-                child: ElevatedButton(
+                child: OmiButton(
+                  label: isTransferring ? context.l10n.cancelTransfer : context.l10n.transferToPhone,
                   onPressed: isTransferring ? _handleCancelTransfer : _handleTransferToPhone,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: isTransferring ? Colors.orange : Colors.deepPurpleAccent,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(isTransferring ? Icons.close : Icons.download, color: Colors.white, size: 22),
-                      const SizedBox(width: 12),
-                      Text(
-                        isTransferring ? context.l10n.cancelTransfer : context.l10n.transferToPhone,
-                        style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
-                      ),
-                    ],
-                  ),
+                  icon: isTransferring ? Icons.close : Icons.download,
+                  color: isTransferring ? Colors.orange : Colors.deepPurpleAccent,
+                  textColor: Colors.white,
+                  borderRadius: 16,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  iconSize: 22,
+                  iconGap: 12,
                 ),
               ),
             ),

--- a/app/lib/pages/conversations/widgets/goals_widget.dart
+++ b/app/lib/pages/conversations/widgets/goals_widget.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/http/api/goals.dart';
 import 'package:omi/providers/goals_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 /// Multi-goal widget supporting up to 3 goals with minimalistic UI
@@ -414,18 +415,18 @@ class GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
                     ],
                     Expanded(
                       flex: isNew ? 1 : 2,
-                      child: ElevatedButton(
+                      child: OmiButton(
+                        label: isNew ? context.l10n.addGoal : context.l10n.save,
                         onPressed: () async {
                           Navigator.pop(context);
                           await _saveGoal(existingGoal);
                         },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF22C55E),
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                        ),
-                        child: Text(isNew ? context.l10n.addGoal : context.l10n.save),
+                        color: const Color(0xFF22C55E),
+                        textColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        borderRadius: 12,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
                       ),
                     ),
                   ],

--- a/app/lib/pages/conversations/widgets/goals_widget.dart
+++ b/app/lib/pages/conversations/widgets/goals_widget.dart
@@ -415,7 +415,7 @@ class GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
                     ],
                     Expanded(
                       flex: isNew ? 1 : 2,
-                      child: OmiButton(
+                      child: OmiButton.legacy(
                         label: isNew ? context.l10n.addGoal : context.l10n.save,
                         onPressed: () async {
                           Navigator.pop(context);
@@ -425,8 +425,6 @@ class GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
                         textColor: Colors.white,
                         padding: const EdgeInsets.symmetric(vertical: 14),
                         borderRadius: 12,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
                       ),
                     ),
                   ],

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -16,6 +16,7 @@ import 'package:vector_math/vector_math_64.dart' as v;
 
 import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -629,7 +630,15 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
-              ElevatedButton(onPressed: _loadGraph, child: Text(context.l10n.retry)),
+              OmiButton(
+                label: context.l10n.retry,
+                onPressed: _loadGraph,
+                color: Colors.black,
+                textColor: Colors.black,
+                borderRadius: 4,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
             ],
           ),
         ),
@@ -679,14 +688,17 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
                     ),
                   )
                 else if (!widget.hideRebuildButtonWhenEmpty)
-                  ElevatedButton.icon(
+                  OmiButton(
+                    label: context.l10n.buildGraphButton,
                     onPressed: _rebuildGraph,
-                    icon: const Icon(Icons.auto_fix_high),
-                    label: Text(context.l10n.buildGraphButton),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.purpleAccent.withValues(alpha: 0.2),
-                      foregroundColor: Colors.purpleAccent,
-                    ),
+                    icon: Icons.auto_fix_high,
+                    iconSize: 24,
+                    color: Colors.purpleAccent.withValues(alpha: 0.2),
+                    textColor: Colors.purpleAccent,
+                    borderRadius: 4,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    padding: const EdgeInsetsDirectional.fromSTEB(12, 0, 16, 0),
                   ),
               ],
             ),

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -630,11 +630,12 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
+              // NOTE: the legacy bare ElevatedButton here resolved to the theme
+              // primary/onPrimary (black-on-black, an effectively invisible label)
+              // on this dark theme. Render the visible canonical button instead.
               OmiButton(
                 label: context.l10n.retry,
                 onPressed: _loadGraph,
-                color: Colors.black,
-                textColor: Colors.black,
                 borderRadius: 4,
                 fontSize: 14,
                 fontWeight: FontWeight.w500,

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -633,12 +633,9 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
               // NOTE: the legacy bare ElevatedButton here resolved to the theme
               // primary/onPrimary (black-on-black, an effectively invisible label)
               // on this dark theme. Render the visible canonical button instead.
-              OmiButton(
+              OmiButton.legacy(
                 label: context.l10n.retry,
                 onPressed: _loadGraph,
-                borderRadius: 4,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
               ),
             ],
           ),
@@ -689,16 +686,13 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
                     ),
                   )
                 else if (!widget.hideRebuildButtonWhenEmpty)
-                  OmiButton(
+                  OmiButton.legacy(
                     label: context.l10n.buildGraphButton,
                     onPressed: _rebuildGraph,
                     icon: Icons.auto_fix_high,
                     iconSize: 24,
                     color: Colors.purpleAccent.withValues(alpha: 0.2),
                     textColor: Colors.purpleAccent,
-                    borderRadius: 4,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
                     padding: const EdgeInsetsDirectional.fromSTEB(12, 0, 16, 0),
                   ),
               ],

--- a/app/lib/pages/onboarding/ai_consent_widget.dart
+++ b/app/lib/pages/onboarding/ai_consent_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/providers/auth_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class AiConsentWidget extends StatefulWidget {
@@ -41,9 +42,7 @@ class _AiConsentWidgetState extends State<AiConsentWidget> {
       children: [
         Expanded(child: Container()),
         ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: mediaQuery.size.height - mediaQuery.padding.top - 16,
-          ),
+          constraints: BoxConstraints(maxHeight: mediaQuery.size.height - mediaQuery.padding.top - 16),
           child: Container(
             width: double.infinity,
             padding: EdgeInsets.fromLTRB(32, 26, 32, mediaQuery.padding.bottom + 8),
@@ -75,8 +74,12 @@ class _AiConsentWidgetState extends State<AiConsentWidget> {
                           const SizedBox(height: 16),
                           Text(
                             context.l10n.consentDataMessage,
-                            style:
-                                const TextStyle(color: Colors.white, fontSize: 15, height: 1.5, fontFamily: 'Manrope'),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 15,
+                              height: 1.5,
+                              fontFamily: 'Manrope',
+                            ),
                           ),
                           const SizedBox(height: 16),
                           RichText(
@@ -112,19 +115,7 @@ class _AiConsentWidgetState extends State<AiConsentWidget> {
                   SizedBox(
                     width: double.infinity,
                     height: 56,
-                    child: ElevatedButton(
-                      onPressed: widget.onAgree,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.white,
-                        foregroundColor: Colors.black,
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                        elevation: 0,
-                      ),
-                      child: Text(
-                        context.l10n.agreeAndContinue,
-                        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                      ),
-                    ),
+                    child: OmiButton(label: context.l10n.agreeAndContinue, onPressed: widget.onAgree),
                   ),
                 ],
               ),

--- a/app/lib/pages/onboarding/apple_watch_permission_page.dart
+++ b/app/lib/pages/onboarding/apple_watch_permission_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/services/devices/apple_watch_connection.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
@@ -101,22 +102,14 @@ class _AppleWatchPermissionPageState extends State<AppleWatchPermissionPage> {
                 ),
               ] else ...[
                 // Continue Button (after permission was requested)
-                SizedBox(
+                OmiButton(
+                  label: context.l10n.continueButton,
+                  onPressed: _continueAndStartRecording,
+                  color: ResponsiveHelper.purplePrimary,
+                  textColor: Colors.white,
+                  borderRadius: 16,
                   width: double.infinity,
                   height: 56,
-                  child: ElevatedButton(
-                    onPressed: _continueAndStartRecording,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: ResponsiveHelper.purplePrimary,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-                    ),
-                  ),
                 ),
                 const SizedBox(height: 24),
 

--- a/app/lib/pages/onboarding/auth.dart
+++ b/app/lib/pages/onboarding/auth.dart
@@ -8,6 +8,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/providers/auth_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class AuthComponent extends StatefulWidget {
@@ -74,31 +75,14 @@ class _AuthComponentState extends State<AuthComponent> {
                       SizedBox(
                         width: double.infinity,
                         height: 56,
-                        child: ElevatedButton(
+                        child: OmiButton(
+                          label: context.l10n.signInWithApple,
+                          icon: FontAwesomeIcons.apple,
+                          iconSize: 24,
                           onPressed: () {
                             HapticFeedback.mediumImpact();
                             provider.onAppleSignIn(widget.onSignIn);
                           },
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.white,
-                            foregroundColor: Colors.black,
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                          ),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              const Icon(FontAwesomeIcons.apple, size: 24),
-                              const SizedBox(width: 8),
-                              Text(
-                                context.l10n.signInWithApple,
-                                style: const TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                  fontFamily: 'Manrope',
-                                ),
-                              ),
-                            ],
-                          ),
                         ),
                       ),
                       const SizedBox(height: 16),
@@ -108,27 +92,14 @@ class _AuthComponentState extends State<AuthComponent> {
                     SizedBox(
                       width: double.infinity,
                       height: 56,
-                      child: ElevatedButton(
+                      child: OmiButton(
+                        label: context.l10n.signInWithGoogle,
+                        icon: FontAwesomeIcons.google,
+                        iconSize: 20,
                         onPressed: () {
                           HapticFeedback.mediumImpact();
                           provider.onGoogleSignIn(widget.onSignIn);
                         },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.white,
-                          foregroundColor: Colors.black,
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Icon(FontAwesomeIcons.google, size: 20),
-                            const SizedBox(width: 8),
-                            Text(
-                              context.l10n.signInWithGoogle,
-                              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                            ),
-                          ],
-                        ),
                       ),
                     ),
 

--- a/app/lib/pages/onboarding/complete_screen.dart
+++ b/app/lib/pages/onboarding/complete_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
+
 class OnboardingCompleteScreen extends StatefulWidget {
   final VoidCallback onComplete;
 
@@ -114,25 +116,11 @@ class _OnboardingCompleteScreenState extends State<OnboardingCompleteScreen> wit
                       SizedBox(
                         width: double.infinity,
                         height: 56,
-                        child: ElevatedButton(
+                        child: OmiButton(
+                          label: 'Start Using Omi',
                           onPressed: widget.onComplete,
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.white,
-                            foregroundColor: Colors.black,
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                            elevation: 0,
-                          ),
-                          child: const Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                'Start Using Omi',
-                                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                              ),
-                              SizedBox(width: 8),
-                              Icon(Icons.arrow_forward_rounded, size: 20),
-                            ],
-                          ),
+                          icon: Icons.arrow_forward_rounded,
+                          trailingIcon: true,
                         ),
                       ),
                       const SizedBox(height: 32),

--- a/app/lib/pages/onboarding/complete_screen.dart
+++ b/app/lib/pages/onboarding/complete_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/ui/atoms/omi_button.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
 class OnboardingCompleteScreen extends StatefulWidget {
   final VoidCallback onComplete;
@@ -117,7 +118,7 @@ class _OnboardingCompleteScreenState extends State<OnboardingCompleteScreen> wit
                         width: double.infinity,
                         height: 56,
                         child: OmiButton(
-                          label: 'Start Using Omi',
+                          label: context.l10n.startUsingOmi,
                           onPressed: widget.onComplete,
                           icon: Icons.arrow_forward_rounded,
                           trailingIcon: true,

--- a/app/lib/pages/onboarding/custom_auth/backend_url.dart
+++ b/app/lib/pages/onboarding/custom_auth/backend_url.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class CustomBackendURLForm extends StatefulWidget {
@@ -97,14 +98,14 @@ class _CustomBackendURLFormState extends State<CustomBackendURLForm> {
                       const SizedBox(height: 24),
                       SizedBox(
                         width: double.infinity,
-                        child: ElevatedButton(
+                        child: OmiButton(
+                          label: context.l10n.saveUrlButton,
                           onPressed: _submitForm,
-                          style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-                            backgroundColor: Colors.blueAccent[700],
-                          ),
-                          child: Text(context.l10n.saveUrlButton, style: const TextStyle(fontSize: 18.0)),
+                          color: Colors.blueAccent[700],
+                          borderRadius: 12.0,
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w500,
+                          padding: const EdgeInsets.symmetric(vertical: 16.0),
                         ),
                       ),
                     ],

--- a/app/lib/pages/onboarding/custom_auth/signin.dart
+++ b/app/lib/pages/onboarding/custom_auth/signin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class CustomAuthSignUp extends StatefulWidget {
@@ -111,14 +112,14 @@ class CustomAuthSignUpState extends State<CustomAuthSignUp> {
                       const SizedBox(height: 24),
                       SizedBox(
                         width: double.infinity,
-                        child: ElevatedButton(
+                        child: OmiButton(
+                          label: context.l10n.signInButton,
                           onPressed: _submitForm,
-                          style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-                            backgroundColor: Colors.blueAccent[700],
-                          ),
-                          child: Text(context.l10n.signInButton, style: const TextStyle(fontSize: 18.0)),
+                          color: Colors.blueAccent[700],
+                          borderRadius: 12.0,
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w500,
+                          padding: const EdgeInsets.symmetric(vertical: 16.0),
                         ),
                       ),
                       const SizedBox(height: 16),

--- a/app/lib/pages/onboarding/custom_auth/signup.dart
+++ b/app/lib/pages/onboarding/custom_auth/signup.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class CustomAuthSignUp extends StatefulWidget {
@@ -152,14 +153,14 @@ class CustomAuthSignUpState extends State<CustomAuthSignUp> {
                       const SizedBox(height: 24),
                       SizedBox(
                         width: double.infinity,
-                        child: ElevatedButton(
+                        child: OmiButton(
+                          label: context.l10n.signUpButton,
                           onPressed: _submitForm,
-                          style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-                            backgroundColor: Colors.blueAccent[700],
-                          ),
-                          child: Text(context.l10n.signUpButton, style: const TextStyle(fontSize: 18.0)),
+                          color: Colors.blueAccent[700],
+                          borderRadius: 12.0,
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w500,
+                          padding: const EdgeInsets.symmetric(vertical: 16.0),
                         ),
                       ),
                       const SizedBox(height: 16),

--- a/app/lib/pages/onboarding/found_omi/found_omi_widget.dart
+++ b/app/lib/pages/onboarding/found_omi/found_omi_widget.dart
@@ -5,6 +5,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class _SourceOption {
@@ -165,7 +166,8 @@ class _FoundOmiWidgetState extends State<FoundOmiWidget> {
                 SizedBox(
                   width: double.infinity,
                   height: 56,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.continueButton,
                     onPressed: _canContinue
                         ? () {
                             FocusManager.instance.primaryFocus?.unfocus();
@@ -178,18 +180,9 @@ class _FoundOmiWidgetState extends State<FoundOmiWidget> {
                             widget.goNext();
                           }
                         : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: _canContinue ? Colors.white : Colors.grey[800],
-                      foregroundColor: _canContinue ? Colors.black : Colors.grey[600],
-                      disabledBackgroundColor: Colors.grey[800],
-                      disabledForegroundColor: Colors.grey[600],
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                    ),
+                    disabledColor: Colors.grey[800],
+                    disabledTextColor: Colors.grey[600],
+                    borderRadius: 28,
                   ),
                 ),
               ],

--- a/app/lib/pages/onboarding/interactive_device_onboarding/widgets/onboarding_step_scaffold.dart
+++ b/app/lib/pages/onboarding/interactive_device_onboarding/widgets/onboarding_step_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/providers/device_onboarding_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 // Persistent, self-animating progress indicator. Rendered once in the wrapper
@@ -100,16 +101,9 @@ class OnboardingContinueButton extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       height: 56,
-      child: ElevatedButton(
+      child: OmiButton(
+        label: label ?? context.l10n.deviceOnboardingContinue,
         onPressed: onPressed,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-          elevation: 0,
-        ),
-        child: Text(label ?? context.l10n.deviceOnboardingContinue,
-            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
       ),
     );
   }

--- a/app/lib/pages/onboarding/knowledge_graph_step.dart
+++ b/app/lib/pages/onboarding/knowledge_graph_step.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/pages/memories/widgets/memory_graph_page.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class OnboardingKnowledgeGraphStep extends StatelessWidget {
@@ -61,19 +62,7 @@ class OnboardingKnowledgeGraphStep extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 height: 56,
-                child: ElevatedButton(
-                  onPressed: onContinue,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                    elevation: 0,
-                  ),
-                  child: Text(
-                    context.l10n.continueAction,
-                    style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                  ),
-                ),
+                child: OmiButton(label: context.l10n.continueAction, onPressed: onContinue),
               ),
             ],
           ),

--- a/app/lib/pages/onboarding/name/name_widget.dart
+++ b/app/lib/pages/onboarding/name/name_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/services/auth_service.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class NameWidget extends StatefulWidget {
@@ -124,7 +125,8 @@ class _NameWidgetState extends State<NameWidget> {
                 SizedBox(
                   width: double.infinity,
                   height: 56,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.continueButton,
                     onPressed: nameController.text.trim().isEmpty
                         ? null
                         : () async {
@@ -132,18 +134,8 @@ class _NameWidgetState extends State<NameWidget> {
                             AuthService.instance.updateGivenName(nameController.text.trim());
                             widget.goNext();
                           },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: nameController.text.trim().isEmpty ? Colors.grey[800] : Colors.white,
-                      foregroundColor: nameController.text.trim().isEmpty ? Colors.grey[600] : Colors.black,
-                      disabledBackgroundColor: Colors.grey[800],
-                      disabledForegroundColor: Colors.grey[600],
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                    ),
+                    disabledColor: Colors.grey[800],
+                    disabledTextColor: Colors.grey[600],
                   ),
                 ),
 

--- a/app/lib/pages/onboarding/permissions/permissions_checker.dart
+++ b/app/lib/pages/onboarding/permissions/permissions_checker.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/providers/onboarding_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/widgets/dialog.dart';
 
@@ -167,7 +168,8 @@ class PermissionsInterstitialPage extends StatelessWidget {
                           : SizedBox(
                               width: double.infinity,
                               height: 56,
-                              child: ElevatedButton(
+                              child: OmiButton(
+                                label: context.l10n.continueButton,
                                 onPressed: () async {
                                   provider.setLoading(true);
                                   if (Platform.isAndroid && !provider.hasBackgroundPermission) {
@@ -191,20 +193,6 @@ class PermissionsInterstitialPage extends StatelessWidget {
                                     _goHome(context);
                                   }
                                 },
-                                style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.white,
-                                  foregroundColor: Colors.black,
-                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                                  elevation: 0,
-                                ),
-                                child: Text(
-                                  context.l10n.continueButton,
-                                  style: const TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.w600,
-                                    fontFamily: 'Manrope',
-                                  ),
-                                ),
                               ),
                             ),
                     ],

--- a/app/lib/pages/onboarding/permissions/permissions_widget.dart
+++ b/app/lib/pages/onboarding/permissions/permissions_widget.dart
@@ -6,6 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/providers/onboarding_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/widgets/dialog.dart';
 
@@ -150,7 +151,8 @@ class _PermissionsWidgetState extends State<PermissionsWidget> {
                         : SizedBox(
                             width: double.infinity,
                             height: 56,
-                            child: ElevatedButton(
+                            child: OmiButton(
+                              label: context.l10n.continueButton,
                               onPressed: () async {
                                 provider.setLoading(true);
                                 if (Platform.isAndroid) {
@@ -173,20 +175,6 @@ class _PermissionsWidgetState extends State<PermissionsWidget> {
                                   provider.setLoading(false);
                                 });
                               },
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.white,
-                                foregroundColor: Colors.black,
-                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                                elevation: 0,
-                              ),
-                              child: Text(
-                                context.l10n.continueButton,
-                                style: const TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                  fontFamily: 'Manrope',
-                                ),
-                              ),
                             ),
                           ),
                   ],

--- a/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
+++ b/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -344,7 +345,8 @@ class _PrimaryLanguageWidgetState extends State<PrimaryLanguageWidget> {
                 SizedBox(
                   width: double.infinity,
                   height: 56,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.continueButton,
                     onPressed: selectedLanguage == null
                         ? null
                         : () async {
@@ -357,18 +359,8 @@ class _PrimaryLanguageWidgetState extends State<PrimaryLanguageWidget> {
 
                             widget.goNext();
                           },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: selectedLanguage == null ? Colors.grey[800] : Colors.white,
-                      foregroundColor: selectedLanguage == null ? Colors.grey[600] : Colors.black,
-                      disabledBackgroundColor: Colors.grey[800],
-                      disabledForegroundColor: Colors.grey[600],
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
-                    ),
+                    disabledColor: Colors.grey[800],
+                    disabledTextColor: Colors.grey[600],
                   ),
                 ),
 

--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -10,6 +10,7 @@ import 'package:omi/pages/speech_profile/percentage_bar_progress.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/speech_profile_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/widgets/dialog.dart';
@@ -310,7 +311,8 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
                               : SizedBox(
                                   width: double.infinity,
                                   height: 56,
-                                  child: ElevatedButton(
+                                  child: OmiButton(
+                                    label: context.l10n.getStarted,
                                     onPressed: () async {
                                       // Check if user has set primary language, if not, show dialog
                                       if (!context.read<HomeProvider>().hasSetPrimaryLanguage) {
@@ -344,20 +346,6 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
                                       if (!mounted) return;
                                       _questionAnimationController.forward();
                                     },
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor: Colors.white,
-                                      foregroundColor: Colors.black,
-                                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                                      elevation: 0,
-                                    ),
-                                    child: Text(
-                                      context.l10n.getStarted,
-                                      style: const TextStyle(
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.w600,
-                                        fontFamily: 'Manrope',
-                                      ),
-                                    ),
                                   ),
                                 ),
                         ] else if (provider.profileCompleted) ...[
@@ -366,22 +354,9 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
                           SizedBox(
                             width: double.infinity,
                             height: 56,
-                            child: ElevatedButton(
+                            child: OmiButton(
+                              label: context.l10n.allDone,
                               onPressed: () => widget.goNext(),
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.white,
-                                foregroundColor: Colors.black,
-                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                                elevation: 0,
-                              ),
-                              child: Text(
-                                context.l10n.allDone,
-                                style: const TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                  fontFamily: 'Manrope',
-                                ),
-                              ),
                             ),
                           ),
                         ] else if (provider.uploadingProfile) ...[

--- a/app/lib/pages/payments/widgets/payment_method_card.dart
+++ b/app/lib/pages/payments/widgets/payment_method_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:skeletonizer/skeletonizer.dart';
 
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/pages/payments/models/payment_method_config.dart';
 
@@ -117,15 +118,13 @@ class PaymentMethodCard extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 if (isConnected && isActive) ...[
-                  ElevatedButton(
+                  OmiButton(
+                    label: context.l10n.update,
                     onPressed: onManageTap,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Colors.black,
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                    ),
-                    child: Text(context.l10n.update, style: const TextStyle(fontWeight: FontWeight.w500)),
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                    borderRadius: 8,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
                   ),
                   const SizedBox(width: 16),
                 ],
@@ -147,15 +146,13 @@ class PaymentMethodCard extends StatelessWidget {
                   ),
                 ],
                 if (!isConnected) ...[
-                  ElevatedButton(
+                  OmiButton(
+                    label: context.l10n.connect,
                     onPressed: onManageTap,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Colors.black,
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                    ),
-                    child: Text(context.l10n.connect, style: const TextStyle(fontWeight: FontWeight.w500)),
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                    borderRadius: 8,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
                   ),
                 ],
               ],

--- a/app/lib/pages/payments/widgets/payment_method_card.dart
+++ b/app/lib/pages/payments/widgets/payment_method_card.dart
@@ -118,13 +118,11 @@ class PaymentMethodCard extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 if (isConnected && isActive) ...[
-                  OmiButton(
+                  OmiButton.legacy(
                     label: context.l10n.update,
                     onPressed: onManageTap,
                     padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
                     borderRadius: 8,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
                   ),
                   const SizedBox(width: 16),
                 ],
@@ -146,13 +144,11 @@ class PaymentMethodCard extends StatelessWidget {
                   ),
                 ],
                 if (!isConnected) ...[
-                  OmiButton(
+                  OmiButton.legacy(
                     label: context.l10n.connect,
                     onPressed: onManageTap,
                     padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
                     borderRadius: 8,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
                   ),
                 ],
               ],

--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -8,6 +8,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
@@ -207,25 +208,18 @@ class _DeleteAccountState extends State<DeleteAccount> {
             child: SizedBox(
               width: double.infinity,
               height: 52,
-              child: ElevatedButton(
+              child: OmiButton(
+                label: context.l10n.continueButton,
                 onPressed: canContinue
                     ? () {
                         PlatformManager.instance.analytics.deleteAccountReasonSelected(reason: _selectedReason!);
                         _next();
                       }
                     : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.grey.shade900,
-                  foregroundColor: Colors.black,
-                  disabledForegroundColor: Colors.grey.shade700,
-                  elevation: 0,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-                ),
-                child: Text(
-                  context.l10n.continueButton,
-                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                ),
+                borderRadius: 14,
+                fontSize: 16,
+                disabledColor: Colors.grey.shade900,
+                disabledTextColor: Colors.grey.shade700,
               ),
             ),
           ),
@@ -339,18 +333,11 @@ class _DeleteAccountState extends State<DeleteAccount> {
                 SizedBox(
                   width: double.infinity,
                   height: 52,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.continueButton,
                     onPressed: _next,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Colors.black,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                    ),
+                    borderRadius: 14,
+                    fontSize: 16,
                   ),
                 ),
                 const SizedBox(height: 8),

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -27,6 +27,7 @@ import 'package:omi/pages/settings/widgets/mcp_api_key_list_item.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/developer_mode_provider.dart';
 import 'package:omi/providers/mcp_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -1985,16 +1986,14 @@ class _ManualFirmwareFlashPageState extends State<_ManualFirmwareFlashPage> with
               SizedBox(
                 width: double.infinity,
                 height: 52,
-                child: ElevatedButton(
+                child: OmiButton(
+                  label: 'Flash Firmware',
                   onPressed: _startFlash,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.deepPurple,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  child: const Text(
-                    'Flash Firmware',
-                    style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
-                  ),
+                  color: Colors.deepPurple,
+                  textColor: Colors.white,
+                  borderRadius: 12,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
                 ),
               ),
             ],

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1987,7 +1987,7 @@ class _ManualFirmwareFlashPageState extends State<_ManualFirmwareFlashPage> with
                 width: double.infinity,
                 height: 52,
                 child: OmiButton(
-                  label: 'Flash Firmware',
+                  label: context.l10n.flashFirmware,
                   onPressed: _startFlash,
                   color: Colors.deepPurple,
                   textColor: Colors.white,

--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -201,7 +202,8 @@ class LanguageSelectionDialog {
                     style: TextButton.styleFrom(foregroundColor: Colors.grey),
                     child: Text(context.l10n.skip),
                   ),
-                ElevatedButton(
+                OmiButton(
+                  label: context.l10n.confirm,
                   onPressed: selectedLanguage == null
                       ? null
                       : () async {
@@ -221,12 +223,13 @@ class LanguageSelectionDialog {
                             AppSnackbar.showSnackbarError(failMsg);
                           }
                         },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.deepPurple,
-                    disabledBackgroundColor: Colors.deepPurple.withValues(alpha: 0.3),
-                    foregroundColor: Colors.white,
-                  ),
-                  child: Text(context.l10n.confirm),
+                  color: Colors.deepPurple,
+                  textColor: Colors.white,
+                  disabledColor: Colors.deepPurple.withValues(alpha: 0.3),
+                  disabledTextColor: Colors.white.withValues(alpha: 0.38),
+                  borderRadius: 4,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
                 ),
               ],
             );

--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -202,7 +202,7 @@ class LanguageSelectionDialog {
                     style: TextButton.styleFrom(foregroundColor: Colors.grey),
                     child: Text(context.l10n.skip),
                   ),
-                OmiButton(
+                OmiButton.legacy(
                   label: context.l10n.confirm,
                   onPressed: selectedLanguage == null
                       ? null
@@ -227,9 +227,6 @@ class LanguageSelectionDialog {
                   textColor: Colors.white,
                   disabledColor: Colors.deepPurple.withValues(alpha: 0.3),
                   disabledTextColor: Colors.white.withValues(alpha: 0.38),
-                  borderRadius: 4,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
                 ),
               ],
             );

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -24,6 +24,7 @@ import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/services/custom_stt_log_service.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/sockets/transcription_service.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -921,10 +922,14 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
                   onPressed: () => Navigator.pop(context, true),
                   child: Text(context.l10n.proceedAnyway, style: const TextStyle(color: Colors.white12, fontSize: 10)),
                 ),
-                ElevatedButton(
+                OmiButton(
+                  label: context.l10n.close,
                   onPressed: () => Navigator.pop(context, false),
-                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-                  child: Text(context.l10n.close, style: const TextStyle(color: Colors.white)),
+                  color: Colors.red,
+                  textColor: Colors.white,
+                  borderRadius: 4,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
                 ),
               ],
               actionsAlignment: MainAxisAlignment.spaceBetween,
@@ -1691,18 +1696,16 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
           Row(
             children: [
               Expanded(
-                child: ElevatedButton.icon(
+                child: OmiButton(
+                  label:
+                      context.l10n.downloadModelWithName('ggml-${_currentModel.isEmpty ? 'tiny' : _currentModel}.bin'),
                   onPressed: _downloadModel,
-                  icon: const Icon(Icons.download, size: 16),
-                  label: Text(
-                    context.l10n.downloadModelWithName('ggml-${_currentModel.isEmpty ? 'tiny' : _currentModel}.bin'),
-                  ),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                  ),
+                  icon: Icons.download,
+                  iconSize: 16,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  borderRadius: 8,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],
@@ -2559,18 +2562,12 @@ class _JsonEditorPageState extends State<_JsonEditorPage> {
         child: SizedBox(
           width: double.infinity,
           height: 50,
-          child: ElevatedButton(
+          child: OmiButton(
+            label: context.l10n.save,
             onPressed: _parseError != null ? null : () => Navigator.of(context).pop(_controller.text),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.white,
-              disabledBackgroundColor: Colors.grey.shade800,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-              elevation: 0,
-            ),
-            child: Text(
-              context.l10n.save,
-              style: const TextStyle(color: Colors.black, fontSize: 16, fontWeight: FontWeight.w600),
-            ),
+            disabledColor: Colors.grey.shade800,
+            borderRadius: 10,
+            fontSize: 16,
           ),
         ),
       ),

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -922,14 +922,11 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
                   onPressed: () => Navigator.pop(context, true),
                   child: Text(context.l10n.proceedAnyway, style: const TextStyle(color: Colors.white12, fontSize: 10)),
                 ),
-                OmiButton(
+                OmiButton.legacy(
                   label: context.l10n.close,
                   onPressed: () => Navigator.pop(context, false),
                   color: Colors.red,
                   textColor: Colors.white,
-                  borderRadius: 4,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
                 ),
               ],
               actionsAlignment: MainAxisAlignment.spaceBetween,
@@ -1696,7 +1693,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
           Row(
             children: [
               Expanded(
-                child: OmiButton(
+                child: OmiButton.legacy(
                   label:
                       context.l10n.downloadModelWithName('ggml-${_currentModel.isEmpty ? 'tiny' : _currentModel}.bin'),
                   onPressed: _downloadModel,
@@ -1704,8 +1701,6 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
                   iconSize: 16,
                   padding: const EdgeInsets.symmetric(vertical: 12),
                   borderRadius: 8,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
                 ),
               ),
             ],
@@ -2566,6 +2561,8 @@ class _JsonEditorPageState extends State<_JsonEditorPage> {
             label: context.l10n.save,
             onPressed: _parseError != null ? null : () => Navigator.of(context).pop(_controller.text),
             disabledColor: Colors.grey.shade800,
+            // The legacy button baked a black label that stayed black when disabled.
+            disabledTextColor: Colors.black,
             borderRadius: 10,
             fontSize: 16,
           ),

--- a/app/lib/pages/settings/widgets/cancel_subscription_sheet.dart
+++ b/app/lib/pages/settings/widgets/cancel_subscription_sheet.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/providers/usage_provider.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -190,25 +191,18 @@ class _CancelSubscriptionFlowState extends State<CancelSubscriptionFlow> {
             child: SizedBox(
               width: double.infinity,
               height: 52,
-              child: ElevatedButton(
+              child: OmiButton(
+                label: context.l10n.continueButton,
                 onPressed: canContinue
                     ? () {
                         PlatformManager.instance.analytics.subscriptionCancelReasonSelected(reason: _selectedReason!);
                         _next();
                       }
                     : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.grey.shade900,
-                  foregroundColor: Colors.black,
-                  disabledForegroundColor: Colors.grey.shade700,
-                  elevation: 0,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-                ),
-                child: Text(
-                  context.l10n.continueButton,
-                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                ),
+                borderRadius: 14,
+                fontSize: 16,
+                disabledColor: Colors.grey.shade900,
+                disabledTextColor: Colors.grey.shade700,
               ),
             ),
           ),
@@ -337,18 +331,11 @@ class _CancelSubscriptionFlowState extends State<CancelSubscriptionFlow> {
                 SizedBox(
                   width: double.infinity,
                   height: 52,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.continueButton,
                     onPressed: _next,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Colors.black,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-                    ),
-                    child: Text(
-                      context.l10n.continueButton,
-                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                    ),
+                    borderRadius: 14,
+                    fontSize: 16,
                   ),
                 ),
                 const SizedBox(height: 8),

--- a/app/lib/pages/settings/widgets/dev_api_key_created_dialog.dart
+++ b/app/lib/pages/settings/widgets/dev_api_key_created_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:omi/backend/schema/dev_api_key.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -201,16 +202,15 @@ class _DevApiKeyCreatedSheetState extends State<DevApiKeyCreatedSheet> {
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.done,
                     onPressed: () => Navigator.of(context).pop(),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFF252525),
-                      foregroundColor: Colors.white,
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      elevation: 0,
-                    ),
-                    child: Text(context.l10n.done, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+                    color: const Color(0xFF252525),
+                    textColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    borderRadius: 12,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ],

--- a/app/lib/pages/settings/widgets/mcp_api_key_created_dialog.dart
+++ b/app/lib/pages/settings/widgets/mcp_api_key_created_dialog.dart
@@ -38,13 +38,10 @@ class McpApiKeyCreatedDialog extends StatelessWidget {
             Navigator.of(context).pop();
           },
         ),
-        OmiButton(
+        OmiButton.legacy(
           label: context.l10n.copy,
           color: Theme.of(context).colorScheme.secondary,
           textColor: Colors.white,
-          borderRadius: 4,
-          fontSize: 14,
-          fontWeight: FontWeight.w500,
           onPressed: () {
             Clipboard.setData(ClipboardData(text: apiKey.key));
             AppSnackbar.showSnackbar(context.l10n.copiedToClipboard(context.l10n.keyWord));

--- a/app/lib/pages/settings/widgets/mcp_api_key_created_dialog.dart
+++ b/app/lib/pages/settings/widgets/mcp_api_key_created_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:omi/backend/schema/mcp_api_key.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -37,12 +38,13 @@ class McpApiKeyCreatedDialog extends StatelessWidget {
             Navigator.of(context).pop();
           },
         ),
-        ElevatedButton(
-          child: Text(context.l10n.copy),
-          style: ElevatedButton.styleFrom(
-            foregroundColor: Colors.white,
-            backgroundColor: Theme.of(context).colorScheme.secondary,
-          ),
+        OmiButton(
+          label: context.l10n.copy,
+          color: Theme.of(context).colorScheme.secondary,
+          textColor: Colors.white,
+          borderRadius: 4,
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
           onPressed: () {
             Clipboard.setData(ClipboardData(text: apiKey.key));
             AppSnackbar.showSnackbar(context.l10n.copiedToClipboard(context.l10n.keyWord));

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -463,14 +463,12 @@ class _PlansSheetState extends State<PlansSheet> {
               onPressed: () => Navigator.of(ctx).pop(false),
               child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
             ),
-            OmiButton(
+            OmiButton.legacy(
               label: context.l10n.confirmUpgrade,
               onPressed: () => Navigator.of(ctx).pop(true),
               color: Colors.deepPurple,
               textColor: Colors.white,
               borderRadius: 8,
-              fontSize: 14,
-              fontWeight: FontWeight.w500,
             ),
           ],
         ),

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -18,6 +18,7 @@ import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/providers/user_provider.dart';
 import 'package:omi/services/freemium_transcription_service.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
@@ -462,14 +463,14 @@ class _PlansSheetState extends State<PlansSheet> {
               onPressed: () => Navigator.of(ctx).pop(false),
               child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
             ),
-            ElevatedButton(
+            OmiButton(
+              label: context.l10n.confirmUpgrade,
               onPressed: () => Navigator.of(ctx).pop(true),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.deepPurple,
-                foregroundColor: Colors.white,
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-              ),
-              child: Text(context.l10n.confirmUpgrade),
+              color: Colors.deepPurple,
+              textColor: Colors.white,
+              borderRadius: 8,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
             ),
           ],
         ),

--- a/app/lib/ui/adaptive_widget.dart
+++ b/app/lib/ui/adaptive_widget.dart
@@ -12,7 +12,9 @@ abstract class AdaptiveWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
+    // sizeOf (not MediaQuery.of) so widgets don't rebuild on every viewInsets
+    // change — e.g. each frame of the keyboard animation.
+    final width = MediaQuery.sizeOf(context).width;
     if (width >= 1100) {
       return buildDesktop(context);
     }

--- a/app/lib/ui/atoms/omi_button.dart
+++ b/app/lib/ui/atoms/omi_button.dart
@@ -39,6 +39,17 @@ class OmiButton extends AdaptiveWidget {
   final double? borderRadius;
   final double? fontSize;
 
+  /// Label weight override (primary defaults to w600).
+  final FontWeight? fontWeight;
+
+  /// Icon size override (defaults to fontSize + 2) and label↔icon gap (defaults to 8).
+  final double? iconSize;
+  final double? iconGap;
+
+  /// Internal padding override (primary). When null, the button's height is
+  /// driven by its content / an outer SizedBox, matching the default CTA.
+  final EdgeInsetsGeometry? padding;
+
   const OmiButton({
     super.key,
     required this.label,
@@ -56,6 +67,10 @@ class OmiButton extends AdaptiveWidget {
     this.height,
     this.borderRadius,
     this.fontSize,
+    this.fontWeight,
+    this.iconSize,
+    this.iconGap,
+    this.padding,
   });
 
   bool get _active => enabled && !isLoading && onPressed != null;
@@ -91,6 +106,7 @@ class OmiButton extends AdaptiveWidget {
         disabledBackgroundColor: disabledColor ?? ResponsiveHelper.backgroundTertiary,
         disabledForegroundColor: disabledTextColor ?? ResponsiveHelper.textQuaternary,
         elevation: 0,
+        padding: padding,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radius)),
       ),
       child: isLoading
@@ -99,7 +115,13 @@ class OmiButton extends AdaptiveWidget {
               height: size + 4,
               child: CircularProgressIndicator(strokeWidth: 2.5, valueColor: AlwaysStoppedAnimation<Color>(fg)),
             )
-          : _labelRow(size: size, weight: FontWeight.w600, color: fg, iconSize: size + 2),
+          : _labelRow(
+              size: size,
+              weight: fontWeight ?? FontWeight.w600,
+              color: fg,
+              iconSize: iconSize ?? (size + 2),
+              iconGap: iconGap ?? 8,
+            ),
     );
 
     if (width != null || height != null) {

--- a/app/lib/ui/atoms/omi_button.dart
+++ b/app/lib/ui/atoms/omi_button.dart
@@ -3,59 +3,63 @@ import 'package:flutter/material.dart';
 import 'package:omi/ui/adaptive_widget.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
-enum OmiButtonType { primary, text, neutral }
-
-/// Shared label/icon button.
+/// Shared filled button.
 ///
-/// The [primary] variant matches the app's canonical white call-to-action
-/// (white background, black label, 28px pill, 18/w600 Manrope, no elevation) —
-/// the same style used across onboarding. On brand: white/neutral, never purple.
-/// Sizing ([width]/[height]) and geometry ([borderRadius]/[fontSize]) are
-/// overridable so existing call sites can be matched exactly.
+/// Defaults match the app's canonical white call-to-action (white background,
+/// black label, 28px pill, 18/w600, no elevation) — the style used across
+/// onboarding. On brand: white/neutral, never purple.
+///
+/// Migrated call sites that still render the raw Material-2 button look use
+/// [OmiButton.legacy]; that constructor is the grep-able work list for the
+/// style-convergence pass.
+///
+/// Known, accepted deviations from the raw ElevatedButtons this replaces
+/// (both effectively invisible on the near-black theme):
+/// - elevation is always 0 (M2 default was 2 resting / 8 pressed);
+/// - the pressed/hover ripple derives from the resolved foreground, so sites
+///   whose label was white only via its Text style now ripple white-based.
 class OmiButton extends AdaptiveWidget {
   final String label;
   final VoidCallback? onPressed;
-  final OmiButtonType type;
-  final bool enabled;
+
+  /// While true the label is replaced by a spinner and taps are blocked; the
+  /// button keeps its enabled background so the color doesn't flash grey.
   final bool isLoading;
+
   final IconData? icon;
 
   /// When true the [icon] is rendered after the label (e.g. a trailing arrow).
   final bool trailingIcon;
 
-  /// Background color override (primary/neutral). Defaults to white for primary.
+  /// Background color override. Defaults to white.
   final Color? color;
 
-  /// Foreground (label/icon) color override. Defaults to black for primary.
+  /// Foreground (label/icon/spinner) color override. Defaults to black.
   final Color? textColor;
 
-  /// Disabled-state background / foreground overrides (primary). Default to the
+  /// Disabled-state background / foreground overrides. Default to the
   /// neutral tokens used by the canonical CTA.
   final Color? disabledColor;
   final Color? disabledTextColor;
 
   final double? width;
   final double? height;
-  final double? borderRadius;
-  final double? fontSize;
+  final double borderRadius;
+  final double fontSize;
+  final FontWeight fontWeight;
 
-  /// Label weight override (primary defaults to w600).
-  final FontWeight? fontWeight;
-
-  /// Icon size override (defaults to fontSize + 2) and label↔icon gap (defaults to 8).
+  /// Icon size (defaults to fontSize + 2) and label↔icon gap.
   final double? iconSize;
-  final double? iconGap;
+  final double iconGap;
 
-  /// Internal padding override (primary). When null, the button's height is
-  /// driven by its content / an outer SizedBox, matching the default CTA.
+  /// Internal padding override. When null, the button's height is driven by
+  /// its content / an outer SizedBox, matching the default CTA.
   final EdgeInsetsGeometry? padding;
 
   const OmiButton({
     super.key,
     required this.label,
     required this.onPressed,
-    this.type = OmiButtonType.primary,
-    this.enabled = true,
     this.isLoading = false,
     this.icon,
     this.trailingIcon = false,
@@ -65,66 +69,70 @@ class OmiButton extends AdaptiveWidget {
     this.disabledTextColor,
     this.width,
     this.height,
-    this.borderRadius,
-    this.fontSize,
-    this.fontWeight,
+    this.borderRadius = 28,
+    this.fontSize = 18,
+    this.fontWeight = FontWeight.w600,
     this.iconSize,
-    this.iconGap,
+    this.iconGap = 8,
     this.padding,
   });
 
-  bool get _active => enabled && !isLoading && onPressed != null;
+  /// A button that intentionally keeps the raw Material-2 ElevatedButton look
+  /// it replaced (radius 4 unless overridden, 14/w500 label). These sites are
+  /// 1:1 carryovers from the pre-design-system migration, not designed styles
+  /// — grep `OmiButton.legacy` to find every button awaiting convergence.
+  const OmiButton.legacy({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.isLoading = false,
+    this.icon,
+    this.trailingIcon = false,
+    this.color,
+    this.textColor,
+    this.disabledColor,
+    this.disabledTextColor,
+    this.width,
+    this.height,
+    this.borderRadius = 4,
+    this.iconSize,
+    this.iconGap = 8,
+    this.padding,
+  })  : fontSize = 14,
+        fontWeight = FontWeight.w500;
+
+  bool get _active => !isLoading && onPressed != null;
 
   @override
-  Widget buildDesktop(BuildContext context) => _base();
+  Widget buildDesktop(BuildContext context) => _button();
 
   @override
-  Widget buildMobile(BuildContext context) => _base();
+  Widget buildMobile(BuildContext context) => _button();
 
-  Widget _base() {
-    switch (type) {
-      case OmiButtonType.primary:
-        return _primary();
-      case OmiButtonType.text:
-        return _text();
-      case OmiButtonType.neutral:
-        return _neutral();
-    }
-  }
-
-  Widget _primary() {
-    final radius = borderRadius ?? 28;
+  Widget _button() {
     final bg = color ?? Colors.white;
     final fg = textColor ?? Colors.black;
-    final size = fontSize ?? 18;
 
     final button = ElevatedButton(
       onPressed: _active ? onPressed : null,
       style: ElevatedButton.styleFrom(
         backgroundColor: bg,
         foregroundColor: fg,
-        disabledBackgroundColor: disabledColor ?? ResponsiveHelper.backgroundTertiary,
+        // While loading the button is technically disabled (taps blocked), but
+        // it keeps its enabled background so the color doesn't flash grey.
+        disabledBackgroundColor: isLoading ? bg : (disabledColor ?? ResponsiveHelper.backgroundTertiary),
         disabledForegroundColor: disabledTextColor ?? ResponsiveHelper.textQuaternary,
         elevation: 0,
         padding: padding,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radius)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(borderRadius)),
       ),
       child: isLoading
           ? SizedBox(
-              width: size + 4,
-              height: size + 4,
+              width: fontSize + 4,
+              height: fontSize + 4,
               child: CircularProgressIndicator(strokeWidth: 2.5, valueColor: AlwaysStoppedAnimation<Color>(fg)),
             )
-          // color: null → the label/icon inherit the ElevatedButton's resolved
-          // foreground (fg when enabled, disabledForegroundColor when disabled),
-          // instead of baking the enabled color on and defeating the disabled state.
-          : _labelRow(
-              size: size,
-              weight: fontWeight ?? FontWeight.w600,
-              color: null,
-              iconSize: iconSize ?? (size + 2),
-              iconGap: iconGap ?? 8,
-            ),
+          : _labelRow(),
     );
 
     if (width != null || height != null) {
@@ -133,58 +141,22 @@ class OmiButton extends AdaptiveWidget {
     return button;
   }
 
-  Widget _text() {
-    final fg = enabled ? (textColor ?? ResponsiveHelper.textSecondary) : ResponsiveHelper.textTertiary;
-    final size = fontSize ?? 14;
-    return TextButton(
-      onPressed: _active ? onPressed : null,
-      child: _labelRow(size: size, weight: FontWeight.normal, color: fg, iconSize: 18, iconGap: 4),
-    );
-  }
-
-  Widget _neutral() {
-    final radius = borderRadius ?? 8;
-    final fg = enabled ? (textColor ?? ResponsiveHelper.textSecondary) : ResponsiveHelper.textQuaternary;
-    final size = fontSize ?? 12;
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: _active ? onPressed : null,
-        borderRadius: BorderRadius.circular(radius),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-          decoration: BoxDecoration(
-            color: (color ?? ResponsiveHelper.backgroundTertiary).withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(radius),
-          ),
-          child: _labelRow(size: size, weight: FontWeight.w500, color: fg, iconSize: 12, iconGap: 6),
-        ),
-      ),
-    );
-  }
-
-  /// [color] may be null so the label/icon inherit the button's own state-aware
-  /// foreground (enabled vs disabled). The [primary] variant relies on this so
-  /// disabledForegroundColor actually dims the disabled label/icon; the
-  /// [text]/[neutral] variants pass an explicit color since they drive their own.
-  Widget _labelRow({
-    required double size,
-    required FontWeight weight,
-    Color? color,
-    required double iconSize,
-    double iconGap = 8,
-  }) {
-    final text = Text(
-      label,
-      style: TextStyle(fontSize: size, fontWeight: weight, fontFamily: 'Manrope', color: color),
-    );
+  /// No explicit colors here: the label and icon inherit the ElevatedButton's
+  /// resolved foreground (fg when enabled, disabledForegroundColor when
+  /// disabled), so the disabled state dims correctly.
+  Widget _labelRow() {
+    final text = Text(label, style: TextStyle(fontSize: fontSize, fontWeight: fontWeight));
     if (icon == null) return text;
-    final iconWidget = Icon(icon, size: iconSize, color: color);
+    // The label is Flexible (like ElevatedButton.icon's) so long localized
+    // labels wrap instead of overflowing the Row.
+    final flexibleText = Flexible(child: text);
+    final iconWidget = Icon(icon, size: iconSize ?? (fontSize + 2));
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
-      children:
-          trailingIcon ? [text, SizedBox(width: iconGap), iconWidget] : [iconWidget, SizedBox(width: iconGap), text],
+      children: trailingIcon
+          ? [flexibleText, SizedBox(width: iconGap), iconWidget]
+          : [iconWidget, SizedBox(width: iconGap), flexibleText],
     );
   }
 }

--- a/app/lib/ui/atoms/omi_button.dart
+++ b/app/lib/ui/atoms/omi_button.dart
@@ -115,10 +115,13 @@ class OmiButton extends AdaptiveWidget {
               height: size + 4,
               child: CircularProgressIndicator(strokeWidth: 2.5, valueColor: AlwaysStoppedAnimation<Color>(fg)),
             )
+          // color: null → the label/icon inherit the ElevatedButton's resolved
+          // foreground (fg when enabled, disabledForegroundColor when disabled),
+          // instead of baking the enabled color on and defeating the disabled state.
           : _labelRow(
               size: size,
               weight: fontWeight ?? FontWeight.w600,
-              color: fg,
+              color: null,
               iconSize: iconSize ?? (size + 2),
               iconGap: iconGap ?? 8,
             ),
@@ -160,10 +163,14 @@ class OmiButton extends AdaptiveWidget {
     );
   }
 
+  /// [color] may be null so the label/icon inherit the button's own state-aware
+  /// foreground (enabled vs disabled). The [primary] variant relies on this so
+  /// disabledForegroundColor actually dims the disabled label/icon; the
+  /// [text]/[neutral] variants pass an explicit color since they drive their own.
   Widget _labelRow({
     required double size,
     required FontWeight weight,
-    required Color color,
+    Color? color,
     required double iconSize,
     double iconGap = 8,
   }) {

--- a/app/lib/ui/atoms/omi_button.dart
+++ b/app/lib/ui/atoms/omi_button.dart
@@ -5,13 +5,34 @@ import 'package:omi/utils/responsive/responsive_helper.dart';
 
 enum OmiButtonType { primary, text, neutral }
 
+/// Shared label/icon button.
+///
+/// The [primary] variant matches the app's canonical white call-to-action
+/// (white background, black label, 28px pill, 18/w600 Manrope, no elevation) —
+/// the same style used across onboarding. On brand: white/neutral, never purple.
+/// Sizing ([width]/[height]) and geometry ([borderRadius]/[fontSize]) are
+/// overridable so existing call sites can be matched exactly.
 class OmiButton extends AdaptiveWidget {
   final String label;
   final VoidCallback? onPressed;
   final OmiButtonType type;
   final bool enabled;
+  final bool isLoading;
   final IconData? icon;
+
+  /// When true the [icon] is rendered after the label (e.g. a trailing arrow).
+  final bool trailingIcon;
+
+  /// Background color override (primary/neutral). Defaults to white for primary.
   final Color? color;
+
+  /// Foreground (label/icon) color override. Defaults to black for primary.
+  final Color? textColor;
+
+  final double? width;
+  final double? height;
+  final double? borderRadius;
+  final double? fontSize;
 
   const OmiButton({
     super.key,
@@ -19,9 +40,18 @@ class OmiButton extends AdaptiveWidget {
     required this.onPressed,
     this.type = OmiButtonType.primary,
     this.enabled = true,
+    this.isLoading = false,
     this.icon,
+    this.trailingIcon = false,
     this.color,
+    this.textColor,
+    this.width,
+    this.height,
+    this.borderRadius,
+    this.fontSize,
   });
+
+  bool get _active => enabled && !isLoading && onPressed != null;
 
   @override
   Widget buildDesktop(BuildContext context) => _base();
@@ -31,101 +61,94 @@ class OmiButton extends AdaptiveWidget {
 
   Widget _base() {
     switch (type) {
-      case OmiButtonType.text:
-        return TextButton(
-          onPressed: enabled ? onPressed : null,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (icon != null) ...[
-                Icon(icon, size: 18, color: enabled ? ResponsiveHelper.textSecondary : ResponsiveHelper.textTertiary),
-                const SizedBox(width: 4),
-              ],
-              Text(
-                label,
-                style: TextStyle(
-                  color: enabled ? ResponsiveHelper.textSecondary : ResponsiveHelper.textTertiary,
-                  fontSize: 14,
-                ),
-              ),
-            ],
-          ),
-        );
       case OmiButtonType.primary:
-        final primaryColor = color ?? ResponsiveHelper.purplePrimary;
-        final primaryAccent = color ?? ResponsiveHelper.purpleAccent;
-
-        return Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: enabled ? onPressed : null,
-            borderRadius: BorderRadius.circular(12),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-              decoration: BoxDecoration(
-                gradient: enabled
-                    ? LinearGradient(
-                        colors: [primaryColor, primaryAccent],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      )
-                    : LinearGradient(
-                        colors: [ResponsiveHelper.backgroundTertiary, ResponsiveHelper.backgroundTertiary],
-                      ),
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: enabled
-                    ? [BoxShadow(color: primaryColor.withValues(alpha: 0.3), blurRadius: 8, offset: const Offset(0, 4))]
-                    : null,
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (icon != null) ...[Icon(icon, size: 18, color: Colors.white), const SizedBox(width: 6)],
-                  Text(
-                    label,
-                    style: const TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
+        return _primary();
+      case OmiButtonType.text:
+        return _text();
       case OmiButtonType.neutral:
-        return Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: enabled ? onPressed : null,
-            borderRadius: BorderRadius.circular(8),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-              decoration: BoxDecoration(
-                color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.6),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (icon != null) ...[
-                    Icon(
-                      icon,
-                      size: 12,
-                      color: enabled ? ResponsiveHelper.textSecondary : ResponsiveHelper.textQuaternary,
-                    ),
-                    const SizedBox(width: 6),
-                  ],
-                  Text(
-                    label,
-                    style: TextStyle(
-                      color: enabled ? ResponsiveHelper.textSecondary : ResponsiveHelper.textQuaternary,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
+        return _neutral();
     }
+  }
+
+  Widget _primary() {
+    final radius = borderRadius ?? 28;
+    final bg = color ?? Colors.white;
+    final fg = textColor ?? Colors.black;
+    final size = fontSize ?? 18;
+
+    final button = ElevatedButton(
+      onPressed: _active ? onPressed : null,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: bg,
+        foregroundColor: fg,
+        disabledBackgroundColor: ResponsiveHelper.backgroundTertiary,
+        disabledForegroundColor: ResponsiveHelper.textQuaternary,
+        elevation: 0,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radius)),
+      ),
+      child: isLoading
+          ? SizedBox(
+              width: size + 4,
+              height: size + 4,
+              child: CircularProgressIndicator(strokeWidth: 2.5, valueColor: AlwaysStoppedAnimation<Color>(fg)),
+            )
+          : _labelRow(size: size, weight: FontWeight.w600, color: fg, iconSize: size + 2),
+    );
+
+    if (width != null || height != null) {
+      return SizedBox(width: width, height: height, child: button);
+    }
+    return button;
+  }
+
+  Widget _text() {
+    final fg = enabled ? (textColor ?? ResponsiveHelper.textSecondary) : ResponsiveHelper.textTertiary;
+    final size = fontSize ?? 14;
+    return TextButton(
+      onPressed: _active ? onPressed : null,
+      child: _labelRow(size: size, weight: FontWeight.normal, color: fg, iconSize: 18, iconGap: 4),
+    );
+  }
+
+  Widget _neutral() {
+    final radius = borderRadius ?? 8;
+    final fg = enabled ? (textColor ?? ResponsiveHelper.textSecondary) : ResponsiveHelper.textQuaternary;
+    final size = fontSize ?? 12;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: _active ? onPressed : null,
+        borderRadius: BorderRadius.circular(radius),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          decoration: BoxDecoration(
+            color: (color ?? ResponsiveHelper.backgroundTertiary).withValues(alpha: 0.6),
+            borderRadius: BorderRadius.circular(radius),
+          ),
+          child: _labelRow(size: size, weight: FontWeight.w500, color: fg, iconSize: 12, iconGap: 6),
+        ),
+      ),
+    );
+  }
+
+  Widget _labelRow({
+    required double size,
+    required FontWeight weight,
+    required Color color,
+    required double iconSize,
+    double iconGap = 8,
+  }) {
+    final text = Text(
+      label,
+      style: TextStyle(fontSize: size, fontWeight: weight, fontFamily: 'Manrope', color: color),
+    );
+    if (icon == null) return text;
+    final iconWidget = Icon(icon, size: iconSize, color: color);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children:
+          trailingIcon ? [text, SizedBox(width: iconGap), iconWidget] : [iconWidget, SizedBox(width: iconGap), text],
+    );
   }
 }

--- a/app/lib/ui/atoms/omi_button.dart
+++ b/app/lib/ui/atoms/omi_button.dart
@@ -29,6 +29,11 @@ class OmiButton extends AdaptiveWidget {
   /// Foreground (label/icon) color override. Defaults to black for primary.
   final Color? textColor;
 
+  /// Disabled-state background / foreground overrides (primary). Default to the
+  /// neutral tokens used by the canonical CTA.
+  final Color? disabledColor;
+  final Color? disabledTextColor;
+
   final double? width;
   final double? height;
   final double? borderRadius;
@@ -45,6 +50,8 @@ class OmiButton extends AdaptiveWidget {
     this.trailingIcon = false,
     this.color,
     this.textColor,
+    this.disabledColor,
+    this.disabledTextColor,
     this.width,
     this.height,
     this.borderRadius,
@@ -81,8 +88,8 @@ class OmiButton extends AdaptiveWidget {
       style: ElevatedButton.styleFrom(
         backgroundColor: bg,
         foregroundColor: fg,
-        disabledBackgroundColor: ResponsiveHelper.backgroundTertiary,
-        disabledForegroundColor: ResponsiveHelper.textQuaternary,
+        disabledBackgroundColor: disabledColor ?? ResponsiveHelper.backgroundTertiary,
+        disabledForegroundColor: disabledTextColor ?? ResponsiveHelper.textQuaternary,
         elevation: 0,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radius)),
       ),

--- a/app/lib/widgets/device_pairing_sheet.dart
+++ b/app/lib/widgets/device_pairing_sheet.dart
@@ -2,6 +2,7 @@ import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 
 import 'package:omi/backend/schema/device_guide.dart';
+import 'package:omi/ui/atoms/omi_button.dart';
 import 'package:omi/utils/analytics/intercom.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
@@ -73,18 +74,14 @@ class DevicePairingSheet extends StatelessWidget {
                 SizedBox(
                   width: double.infinity,
                   height: 52,
-                  child: ElevatedButton(
+                  child: OmiButton(
+                    label: context.l10n.iveDoneThis,
                     onPressed: onDismissAll,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: ResponsiveHelper.purplePrimary,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.iveDoneThis,
-                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                    ),
+                    color: ResponsiveHelper.purplePrimary,
+                    textColor: Colors.white,
+                    borderRadius: 28,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
                 const SizedBox(height: 20),

--- a/app/test/widgets/omi_button_test.dart
+++ b/app/test/widgets/omi_button_test.dart
@@ -6,17 +6,18 @@ import 'package:omi/ui/atoms/omi_button.dart';
 /// The canonical primary CTA the app hand-rolls across onboarding. OmiButton's
 /// primary variant must render an identical [ButtonStyle] so migrated call
 /// sites are a 1:1 visual match.
-ElevatedButton _legacyPrimary(VoidCallback onPressed, String label) => ElevatedButton(
+ElevatedButton _legacyPrimary(VoidCallback onPressed, String label, {double radius = 28, double fontSize = 18}) =>
+    ElevatedButton(
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
         backgroundColor: Colors.white,
         foregroundColor: Colors.black,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(radius)),
         elevation: 0,
       ),
       child: Text(
         label,
-        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+        style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
       ),
     );
 
@@ -50,6 +51,39 @@ void main() {
       expect(omi.elevation!.resolve(enabled), legacy.elevation!.resolve(enabled));
       expect(omi.shape!.resolve(enabled), legacy.shape!.resolve(enabled));
     });
+
+    // The migrated call sites use three geometries: onboarding (28/18),
+    // settings (14/16), announcement (26/16). Assert each maps 1:1.
+    for (final g in const [
+      (radius: 28.0, fontSize: 18.0),
+      (radius: 14.0, fontSize: 16.0),
+      (radius: 26.0, fontSize: 16.0),
+    ]) {
+      testWidgets('matches legacy ButtonStyle at radius ${g.radius} / fontSize ${g.fontSize}', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  _legacyPrimary(noop, 'Continue', radius: g.radius, fontSize: g.fontSize),
+                  OmiButton(label: 'Continue', onPressed: noop, borderRadius: g.radius, fontSize: g.fontSize),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final buttons = find.byType(ElevatedButton);
+        final legacy = tester.widget<ElevatedButton>(buttons.at(0)).style!;
+        final omi = tester.widget<ElevatedButton>(buttons.at(1)).style!;
+        expect(omi.shape!.resolve(enabled), legacy.shape!.resolve(enabled));
+
+        final legacyText = tester.widget<Text>(find.descendant(of: buttons.at(0), matching: find.byType(Text)));
+        final omiText = tester.widget<Text>(find.descendant(of: buttons.at(1), matching: find.byType(Text)));
+        expect(omiText.style!.fontSize, legacyText.style!.fontSize);
+        expect(omiText.style!.fontWeight, legacyText.style!.fontWeight);
+      });
+    }
 
     testWidgets('label uses 18 / w600 / Manrope', (tester) async {
       await tester.pumpWidget(
@@ -132,6 +166,31 @@ void main() {
       const disabled = <WidgetState>{WidgetState.disabled};
       expect(style.backgroundColor!.resolve(disabled), const Color(0xFF111111));
       expect(style.foregroundColor!.resolve(disabled), const Color(0xFF222222));
+    });
+
+    testWidgets('fontWeight / iconSize / iconGap / padding overrides propagate', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: OmiButton(
+              label: 'Go',
+              onPressed: noop,
+              icon: Icons.add,
+              iconSize: 24,
+              iconGap: 10,
+              fontWeight: FontWeight.w500,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.widget<Text>(find.text('Go')).style!.fontWeight, FontWeight.w500);
+      expect(tester.widget<Icon>(find.byType(Icon)).size, 24);
+      final row = tester.widget<Row>(find.byType(Row));
+      expect((row.children[1] as SizedBox).width, 10);
+      final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
+      expect(style.padding!.resolve(<WidgetState>{}), const EdgeInsets.symmetric(horizontal: 16));
     });
   });
 }

--- a/app/test/widgets/omi_button_test.dart
+++ b/app/test/widgets/omi_button_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/ui/atoms/omi_button.dart';
@@ -191,6 +192,36 @@ void main() {
       expect((row.children[1] as SizedBox).width, 10);
       final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
       expect(style.padding!.resolve(<WidgetState>{}), const EdgeInsets.symmetric(horizontal: 16));
+    });
+
+    // Guards against baking the enabled foreground onto the Text/Icon, which
+    // would prevent disabledForegroundColor from dimming the disabled label.
+    testWidgets('disabled label + icon render the DISABLED foreground, not the enabled one', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: OmiButton(
+              label: 'Go',
+              onPressed: null,
+              icon: Icons.add,
+              color: Colors.deepPurple,
+              textColor: Colors.white, // enabled fg
+              disabledColor: Color(0xFF333333),
+              disabledTextColor: Color(0xFF616161), // disabled fg
+            ),
+          ),
+        ),
+      );
+
+      // Effective rendered label color (after DefaultTextStyle merge), not the widget's explicit style.
+      final labelColor = tester.renderObject<RenderParagraph>(find.text('Go')).text.style!.color;
+      expect(labelColor, const Color(0xFF616161),
+          reason: 'disabled label must use disabledTextColor, not enabled white');
+
+      // Effective icon color = explicit Icon.color, else the ambient IconTheme (set by the button).
+      final iconEl = tester.element(find.byIcon(Icons.add));
+      final effectiveIconColor = tester.widget<Icon>(find.byIcon(Icons.add)).color ?? IconTheme.of(iconEl).color;
+      expect(effectiveIconColor, const Color(0xFF616161), reason: 'disabled icon must use disabledTextColor');
     });
   });
 }

--- a/app/test/widgets/omi_button_test.dart
+++ b/app/test/widgets/omi_button_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ui/atoms/omi_button.dart';
+
+/// The canonical primary CTA the app hand-rolls across onboarding. OmiButton's
+/// primary variant must render an identical [ButtonStyle] so migrated call
+/// sites are a 1:1 visual match.
+ElevatedButton _legacyPrimary(VoidCallback onPressed, String label) => ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        elevation: 0,
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+      ),
+    );
+
+void main() {
+  void noop() {}
+  const enabled = <WidgetState>{};
+
+  group('OmiButton primary — 1:1 with legacy white CTA', () {
+    testWidgets('resolves the same enabled-state ButtonStyle', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                _legacyPrimary(noop, 'Continue'),
+                OmiButton(label: 'Continue', onPressed: noop),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final buttons = find.byType(ElevatedButton);
+      expect(buttons, findsNWidgets(2));
+
+      final legacy = tester.widget<ElevatedButton>(buttons.at(0)).style!;
+      final omi = tester.widget<ElevatedButton>(buttons.at(1)).style!;
+
+      expect(omi.backgroundColor!.resolve(enabled), legacy.backgroundColor!.resolve(enabled));
+      expect(omi.foregroundColor!.resolve(enabled), legacy.foregroundColor!.resolve(enabled));
+      expect(omi.elevation!.resolve(enabled), legacy.elevation!.resolve(enabled));
+      expect(omi.shape!.resolve(enabled), legacy.shape!.resolve(enabled));
+    });
+
+    testWidgets('label uses 18 / w600 / Manrope', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: OmiButton(label: 'Continue', onPressed: noop))),
+      );
+
+      final text = tester.widget<Text>(find.text('Continue'));
+      expect(text.style!.fontSize, 18);
+      expect(text.style!.fontWeight, FontWeight.w600);
+      expect(text.style!.fontFamily, 'Manrope');
+    });
+
+    testWidgets('trailing icon renders after the label', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: OmiButton(
+              label: 'Start Using Omi',
+              onPressed: noop,
+              icon: Icons.arrow_forward_rounded,
+              trailingIcon: true,
+            ),
+          ),
+        ),
+      );
+
+      final row = tester.widget<Row>(find.byType(Row));
+      expect(row.children.length, 3);
+      expect(row.children.first, isA<Text>());
+      // Lock complete_screen's exact geometry: 8px gap, size-20 trailing icon.
+      expect((row.children[1] as SizedBox).width, 8);
+      final icon = row.children.last as Icon;
+      expect(icon.icon, Icons.arrow_forward_rounded);
+      expect(icon.size, 20);
+    });
+  });
+
+  group('OmiButton primary — behavior', () {
+    testWidgets('fires onPressed when enabled', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', onPressed: () => taps++))),
+      );
+      await tester.tap(find.byType(OmiButton));
+      expect(taps, 1);
+    });
+
+    testWidgets('isLoading shows a spinner and blocks taps', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', isLoading: true, onPressed: () => taps++))),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.tap(find.byType(OmiButton), warnIfMissed: false);
+      expect(taps, 0);
+      expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed, isNull);
+    });
+
+    testWidgets('enabled: false disables the button', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', enabled: false, onPressed: noop))),
+      );
+      expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed, isNull);
+    });
+  });
+}

--- a/app/test/widgets/omi_button_test.dart
+++ b/app/test/widgets/omi_button_test.dart
@@ -114,5 +114,24 @@ void main() {
       );
       expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed, isNull);
     });
+
+    testWidgets('disabledColor/disabledTextColor override the disabled state', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: OmiButton(
+              label: 'Go',
+              onPressed: null,
+              disabledColor: Color(0xFF111111),
+              disabledTextColor: Color(0xFF222222),
+            ),
+          ),
+        ),
+      );
+      final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
+      const disabled = <WidgetState>{WidgetState.disabled};
+      expect(style.backgroundColor!.resolve(disabled), const Color(0xFF111111));
+      expect(style.foregroundColor!.resolve(disabled), const Color(0xFF222222));
+    });
   });
 }

--- a/app/test/widgets/omi_button_test.dart
+++ b/app/test/widgets/omi_button_test.dart
@@ -4,9 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/ui/atoms/omi_button.dart';
 
-/// The canonical primary CTA the app hand-rolls across onboarding. OmiButton's
-/// primary variant must render an identical [ButtonStyle] so migrated call
-/// sites are a 1:1 visual match.
+/// The canonical primary CTA the app hand-rolls across onboarding. OmiButton
+/// must render an identical [ButtonStyle] so migrated call sites are a 1:1
+/// visual match.
 ElevatedButton _legacyPrimary(VoidCallback onPressed, String label, {double radius = 28, double fontSize = 18}) =>
     ElevatedButton(
       onPressed: onPressed,
@@ -18,15 +18,16 @@ ElevatedButton _legacyPrimary(VoidCallback onPressed, String label, {double radi
       ),
       child: Text(
         label,
-        style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+        style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w600),
       ),
     );
 
 void main() {
   void noop() {}
   const enabled = <WidgetState>{};
+  const disabled = <WidgetState>{WidgetState.disabled};
 
-  group('OmiButton primary — 1:1 with legacy white CTA', () {
+  group('OmiButton — 1:1 with legacy white CTA', () {
     testWidgets('resolves the same enabled-state ButtonStyle', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -86,7 +87,7 @@ void main() {
       });
     }
 
-    testWidgets('label uses 18 / w600 / Manrope', (tester) async {
+    testWidgets('label uses 18 / w600 by default', (tester) async {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: OmiButton(label: 'Continue', onPressed: noop))),
       );
@@ -94,7 +95,6 @@ void main() {
       final text = tester.widget<Text>(find.text('Continue'));
       expect(text.style!.fontSize, 18);
       expect(text.style!.fontWeight, FontWeight.w600);
-      expect(text.style!.fontFamily, 'Manrope');
     });
 
     testWidgets('trailing icon renders after the label', (tester) async {
@@ -113,16 +113,55 @@ void main() {
 
       final row = tester.widget<Row>(find.byType(Row));
       expect(row.children.length, 3);
-      expect(row.children.first, isA<Text>());
+      // The label is Flexible (like ElevatedButton.icon's) so it can wrap.
+      expect(row.children.first, isA<Flexible>());
+      expect((row.children.first as Flexible).child, isA<Text>());
       // Lock complete_screen's exact geometry: 8px gap, size-20 trailing icon.
       expect((row.children[1] as SizedBox).width, 8);
       final icon = row.children.last as Icon;
       expect(icon.icon, Icons.arrow_forward_rounded);
       expect(icon.size, 20);
     });
+
+    testWidgets('long label with icon wraps instead of overflowing a tight width', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              child: OmiButton.legacy(
+                label: 'Download Model (ggml-large-v2.bin)',
+                onPressed: noop,
+                icon: Icons.download,
+              ),
+            ),
+          ),
+        ),
+      );
+      // Legacy ElevatedButton.icon wrapped the label in Flexible; the atom must
+      // do the same so tight widths / large text scales don't RenderFlex-overflow.
+      expect(tester.takeException(), isNull);
+    });
   });
 
-  group('OmiButton primary — behavior', () {
+  group('OmiButton.legacy — pinned Material-2 look', () {
+    testWidgets('defaults to radius 4 / 14 / w500', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: OmiButton.legacy(label: 'Retry', onPressed: noop))),
+      );
+
+      final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
+      expect(
+        style.shape!.resolve(enabled),
+        RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+      );
+      final text = tester.widget<Text>(find.text('Retry'));
+      expect(text.style!.fontSize, 14);
+      expect(text.style!.fontWeight, FontWeight.w500);
+    });
+  });
+
+  group('OmiButton — behavior', () {
     testWidgets('fires onPressed when enabled', (tester) async {
       var taps = 0;
       await tester.pumpWidget(
@@ -132,20 +171,31 @@ void main() {
       expect(taps, 1);
     });
 
-    testWidgets('isLoading shows a spinner and blocks taps', (tester) async {
+    testWidgets('isLoading shows a visible spinner, keeps the background, blocks taps', (tester) async {
       var taps = 0;
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', isLoading: true, onPressed: () => taps++))),
+        MaterialApp(
+          home: Scaffold(
+            body: OmiButton(label: 'Go', isLoading: true, color: Colors.deepPurple, onPressed: () => taps++),
+          ),
+        ),
       );
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       await tester.tap(find.byType(OmiButton), warnIfMissed: false);
       expect(taps, 0);
+
+      final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
       expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed, isNull);
+      // The loading button must NOT flash to the grey disabled background.
+      expect(style.backgroundColor!.resolve(disabled), Colors.deepPurple);
+      // And the spinner must use the enabled foreground, not an invisible color.
+      final spinner = tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator));
+      expect((spinner.valueColor as AlwaysStoppedAnimation<Color>).value, Colors.black);
     });
 
-    testWidgets('enabled: false disables the button', (tester) async {
+    testWidgets('onPressed: null disables the button', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', enabled: false, onPressed: noop))),
+        const MaterialApp(home: Scaffold(body: OmiButton(label: 'Go', onPressed: null))),
       );
       expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed, isNull);
     });
@@ -164,7 +214,6 @@ void main() {
         ),
       );
       final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
-      const disabled = <WidgetState>{WidgetState.disabled};
       expect(style.backgroundColor!.resolve(disabled), const Color(0xFF111111));
       expect(style.foregroundColor!.resolve(disabled), const Color(0xFF222222));
     });
@@ -191,7 +240,7 @@ void main() {
       final row = tester.widget<Row>(find.byType(Row));
       expect((row.children[1] as SizedBox).width, 10);
       final style = tester.widget<ElevatedButton>(find.byType(ElevatedButton)).style!;
-      expect(style.padding!.resolve(<WidgetState>{}), const EdgeInsets.symmetric(horizontal: 16));
+      expect(style.padding!.resolve(enabled), const EdgeInsets.symmetric(horizontal: 16));
     });
 
     // Guards against baking the enabled foreground onto the Text/Icon, which


### PR DESCRIPTION
Consolidates the app's hand-rolled filled buttons onto the shared **OmiButton** atom, migrating each one **style-preserving** — so future styling (de-purple, radius/size convergence) becomes a central change instead of a 40-file hunt.

## What changed

**`OmiButton` (app/lib/ui/atoms/omi_button.dart)**
- Single, honest API: the canonical white CTA by default (white/black, 28px pill, 18/w600, elevation 0) with overrides for everything real call sites need (`color`, `textColor`, `disabledColor`/`disabledTextColor`, `borderRadius`, `fontSize`, `fontWeight`, `icon`/`trailingIcon`/`iconSize`/`iconGap`, `padding`, `width`/`height`, `isLoading`). The unused `text`/`neutral` variants were deleted rather than shipped dead.
- **`OmiButton.legacy`** — a named preset pinning the raw Material-2 look (radius 4, 14/w500). The 19 migrated-but-not-yet-redesigned buttons use it, so the future convergence pass is a grep for `OmiButton.legacy`, not a hunt for magic numbers.
- Label/icon inherit the button's state-aware foreground (disabled labels dim correctly); the label is `Flexible` like `ElevatedButton.icon`'s (long localized labels wrap instead of overflowing — regression-tested); `isLoading` keeps the enabled background and shows a visible spinner; no unbundled-font literal.
- `AdaptiveWidget` uses `MediaQuery.sizeOf`, so buttons don't rebuild every frame of the keyboard animation.

**~50 filled buttons migrated across ~40 files** (raw `ElevatedButton`/`MaterialButton` → `OmiButton`), retaining each button's exact resting look. Off-brand purple buttons keep their purple **by design** — this PR is plumbing; de-purpling is the follow-up it enables.

**l10n:** the two hardcoded labels this migration touched now use ARB keys (`startUsingOmi`, new `flashFirmware` added to all 49 locales; gen-l10n emits zero untranslated warnings).

## Declared deviations from strict 1:1 (all reviewed, none visible at rest on the dark theme)

1. **Elevation** — 27 originals relied on the M2 default (2 resting / 8 pressed); OmiButton renders flat. The black shadow is imperceptible on the near-black theme; ripple feedback is preserved.
2. **Pressed ripple polarity** — sites whose label was white only via its `Text` style (Flash Firmware, transcription Close, WAL transfer) now derive the ripple from the white foreground (lightens instead of darkens on press). Resting pixels identical.
3. **`memory_graph` retry** — the legacy bare `ElevatedButton` resolved to black-on-black (invisible) on this theme; it now renders the visible canonical button. Deliberate bug fix, commented in code.

## Left as-is (bespoke; can't be OmiButton without restyling)
`GradientButton`, `AnimatedLoadingButton` (width-collapse animation), animated-arrow device buttons, custom-spinner loading buttons, `OutlinedButton`s.

## Verification
- `flutter analyze` — 0 errors · full suite **599 tests pass** · clean release APK (`--release --flavor dev`)
- 14 dedicated OmiButton widget tests: resolved-`ButtonStyle` 1:1 at the real geometries (28/18, 14/16, 26/16), rendered (not declared) disabled label/icon colors, loading background retention + spinner visibility, overflow regression, legacy preset, override propagation
- Two independent multi-agent adversarial reviews (per-file 1:1 verify, then an 8-angle correctness/cleanup review with per-finding verification); all confirmed findings fixed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)