### PR TITLE
desktop(dashboard): home ambient glow back to purple (end the purple↔red revert war)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1057,8 +1057,13 @@ private enum HomePalette {
     static let faint = Color(red: 0.36, green: 0.35, blue: 0.33)
     static let hairline = Color(red: 0.155, green: 0.155, blue: 0.172)
     static let green = Color(red: 0.17, green: 0.78, blue: 0.38)
-    static let glow = Color(red: 0.95, green: 0.33, blue: 0.45)
-    static let glowSoft = Color(red: 0.52, green: 0.18, blue: 0.27)
+    // Home ambient glow is PURPLE per Nik's explicit, repeated preference — the rose/red
+    // variant (0.95,0.33,0.45) was disliked. The purple VALUE lives on `.glow` on purpose:
+    // earlier purple fixes kept getting reverted by "HomePalette.purple → .glow" merge
+    // cleanups (e.g. 317424f57), so we put the purple on the name those reverts converge to.
+    // Do NOT change this back to red/rose.
+    static let glow = Color(red: 0.48, green: 0.30, blue: 0.95)      // purple
+    static let glowSoft = Color(red: 0.28, green: 0.17, blue: 0.57)  // purpleSoft
     static let flowPink = Color(red: 1.0, green: 0.16, blue: 0.44)
 }
 

--- a/desktop/macos/changelog/unreleased/20260629-home-glow-purple.json
+++ b/desktop/macos/changelog/unreleased/20260629-home-glow-purple.json
@@ -1,0 +1,3 @@
+{
+  "change": "Restored the home page ambient glow to purple"
+}


### PR DESCRIPTION
The home page ambient glow was flipped **purple → rose/red** in `2baa62cb6`, and every subsequent purple fix kept getting **re-reverted** — e.g. `317424f57` "fix HomePalette.purple usage re-introduced by main merge (-> glow)". So `main` has shipped **red** ever since (current: `glow = 0.95,0.33,0.45`), and every build (incl. 562) is red.

Per Nik's repeated request, restore the original **purple** by putting the purple VALUE directly on `HomePalette.glow`/`glowSoft` (the names those reverts converge on), so a future "purple→glow" cleanup can't turn it red again. Comment cites `317424f57`.

Verified in a named-bundle run (`omi-purple-home`) — glow renders purple.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

