### PR TITLE
[codex] Fix PTT silent mic recovery

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -251,6 +251,7 @@ class AppState: ObservableObject {
   }
   var captureGateInFlight = false
   var captureReconcilePending = false
+  var pendingCoreAudioCaptureRecoveryReason: String?
   @Published var isAwaitingMeeting = false
 
   var effectiveSystemAudioMode: AssistantSettings.SystemAudioCaptureMode {
@@ -339,6 +340,10 @@ class AppState: ObservableObject {
   var systemAudioCaptureModeObserver: NSObjectProtocol? {
     get { servicesCoordinator.systemAudioCaptureModeObserver }
     set { servicesCoordinator.systemAudioCaptureModeObserver = newValue }
+  }
+  var coreAudioCaptureRecoveryObserver: NSObjectProtocol? {
+    get { servicesCoordinator.coreAudioCaptureRecoveryObserver }
+    set { servicesCoordinator.coreAudioCaptureRecoveryObserver = newValue }
   }
 
   var wasTranscribingBeforeSleep = false
@@ -603,6 +608,17 @@ class AppState: ObservableObject {
     ) { [weak self] _ in
       Task { @MainActor in
         await self?.reconcileCapture()
+      }
+    }
+
+    coreAudioCaptureRecoveryObserver = NotificationCenter.default.addObserver(
+      forName: .coreAudioCaptureRecoveryRequested,
+      object: nil,
+      queue: .main
+    ) { [weak self] note in
+      let reason = note.userInfo?["reason"] as? String ?? "unspecified"
+      Task { @MainActor in
+        await self?.rebuildCoreAudioCaptureStack(reason: reason)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
@@ -23,6 +23,7 @@ final class AppServicesCoordinator {
   var screenCapturePermissionLostObserver: NSObjectProtocol?
   var screenCaptureKitBrokenObserver: NSObjectProtocol?
   var systemAudioCaptureModeObserver: NSObjectProtocol?
+  var coreAudioCaptureRecoveryObserver: NSObjectProtocol?
 
   var buttonStreamTask: Task<Void, Never>?
   var bluetoothStateCancellable: AnyCancellable?
@@ -69,6 +70,10 @@ final class AppServicesCoordinator {
     if let observer = systemAudioCaptureModeObserver {
       NotificationCenter.default.removeObserver(observer)
       systemAudioCaptureModeObserver = nil
+    }
+    if let observer = coreAudioCaptureRecoveryObserver {
+      NotificationCenter.default.removeObserver(observer)
+      coreAudioCaptureRecoveryObserver = nil
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -297,12 +297,17 @@ extension AppState {
   func startMicrophoneAudioCapture() async {
     guard let audioCaptureService = audioCaptureService else { return }
 
-    // Silent-mic watchdog: on A2DP profile conflict the Bluetooth input device returns
-    // zero samples even though CoreAudio reports healthy capture. Fall back to the
-    // built-in mic when the watchdog fires.
-    audioCaptureService.onSilentMicDetected = { [weak self] in
+    // Silent-mic watchdog: on A2DP profile conflict the Bluetooth input device returns zero
+    // samples even though CoreAudio reports healthy capture. Fall back to built-in mic for
+    // Bluetooth, and rebuild the full CoreAudio capture stack for stale-route wedges.
+    audioCaptureService.onSilentMicDetected = { [weak self] detection in
       Task { @MainActor in
-        self?.handleSilentMicFallback()
+        switch detection.suggestedAction {
+        case .fallbackToBuiltIn:
+          self?.handleSilentMicFallback()
+        case .rebuildCoreAudioStack:
+          await self?.rebuildCoreAudioCaptureStack(reason: detection.reason)
+        }
       }
     }
 
@@ -483,6 +488,11 @@ extension AppState {
     }
 
     captureGateInFlight = false
+    if let recoveryReason = pendingCoreAudioCaptureRecoveryReason {
+      pendingCoreAudioCaptureRecoveryReason = nil
+      await rebuildCoreAudioCaptureStack(reason: recoveryReason)
+      return
+    }
     if captureReconcilePending {
       captureReconcilePending = false
       await reconcileCapture()
@@ -515,6 +525,40 @@ extension AppState {
       await self.startMicrophoneAudioCapture()
       self.silentMicFallbackInProgress = false
     }
+  }
+
+  @MainActor
+  func rebuildCoreAudioCaptureStack(reason: String) async {
+    guard isTranscribing, audioCaptureService != nil else { return }
+
+    if captureGateInFlight {
+      pendingCoreAudioCaptureRecoveryReason = reason
+      return
+    }
+
+    log("Transcription: rebuilding CoreAudio capture stack — \(reason)")
+    captureReconcilePending = false
+    silentMicFallbackInProgress = false
+
+    if #available(macOS 14.4, *) {
+      if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
+        systemService.stopCapture()
+      }
+      systemAudioCaptureService = nil
+      AudioLevelMonitor.shared.updateSystemLevel(0)
+    }
+
+    audioCaptureService?.stopCapture()
+    audioCaptureService = AudioCaptureService()
+    AudioLevelMonitor.shared.updateMicrophoneLevel(0)
+
+    if !useLocalSTT {
+      audioMixer?.stop()
+      audioMixer = AudioMixer()
+    }
+
+    recordingInputDeviceName = AudioCaptureService.getCurrentMicrophoneName() ?? recordingInputDeviceName
+    await startMicrophoneAudioCapture()
   }
 
   /// Start BLE device audio capture
@@ -951,6 +995,7 @@ extension AppState {
     meetingDetector = nil
     captureGateInFlight = false
     captureReconcilePending = false
+    pendingCoreAudioCaptureRecoveryReason = nil
     isAwaitingMeeting = false
 
     // Stop system audio capture first (if available)

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -16,6 +16,26 @@ class AudioCaptureService: @unchecked Sendable {
     /// Callback for receiving audio levels (0.0 - 1.0)
     typealias AudioLevelHandler = (Float) -> Void
 
+    enum SilentMicRecoveryAction {
+        case fallbackToBuiltIn
+        case rebuildCoreAudioStack
+    }
+
+    struct SilentMicDetection {
+        let deviceID: AudioDeviceID
+        let deviceDescription: String
+        let consecutiveSilentWindows: Int
+        let isBluetoothTransport: Bool
+
+        var suggestedAction: SilentMicRecoveryAction {
+            isBluetoothTransport ? .fallbackToBuiltIn : .rebuildCoreAudioStack
+        }
+
+        var reason: String {
+            "silent input on \(deviceDescription) after \(consecutiveSilentWindows) windows"
+        }
+    }
+
     enum AudioCaptureError: LocalizedError {
         case noInputAvailable
         case engineStartFailed(Error)
@@ -64,9 +84,12 @@ class AudioCaptureService: @unchecked Sendable {
     private var onAudioLevel: AudioLevelHandler?
 
     /// Called once when the mic has been alive-but-silent for `silentMicWindowThreshold`
-    /// seconds AND the current device transports over Bluetooth. Caller is expected to
-    /// fall back to the built-in mic. Fires at most once per capture session.
-    var onSilentMicDetected: (() -> Void)?
+    /// seconds. By default this is limited to Bluetooth inputs, where macOS can feed
+    /// zeros during A2DP/HFP profile conflicts. PTT enables all-transport detection so
+    /// it can recover a stale HAL route that reports the built-in mic but still returns
+    /// silence. Fires at most once per capture session.
+    var onSilentMicDetected: ((SilentMicDetection) -> Void)?
+    var detectSilentMicOnAnyTransport = false
 
     /// Human-readable description of the capture device currently in use — for
     /// diagnostics (which mic a turn was recorded from).
@@ -108,6 +131,13 @@ class AudioCaptureService: @unchecked Sendable {
     private let audioQueue = DispatchQueue(label: "com.omi.audiocapture.device")
 
     // MARK: - Public Methods
+
+    func resetSilentMicWatchdog() {
+        consecutiveSilentWindows = 0
+        silentMicDetectedFired = false
+        watchdogWindowPeak = 0
+        watchdogWindowStart = 0
+    }
 
     /// Check if microphone permission is granted
     static func checkPermission() -> Bool {
@@ -152,6 +182,7 @@ class AudioCaptureService: @unchecked Sendable {
 
         self.onAudioChunk = onAudioChunk
         self.onAudioLevel = onAudioLevel
+        resetSilentMicWatchdog()
 
         // All CoreAudio HAL calls (AudioObjectGetPropertyData, AudioDeviceStart, etc.) are
         // synchronous IPC to coreaudiod via mach_msg. After wake from sleep the daemon can
@@ -263,6 +294,7 @@ class AudioCaptureService: @unchecked Sendable {
         isReconfiguring = false
         onAudioChunk = nil
         onAudioLevel = nil
+        resetSilentMicWatchdog()
 
         // Clean up converter
         audioConverter = nil
@@ -500,12 +532,23 @@ class AudioCaptureService: @unchecked Sendable {
                 } else {
                     consecutiveSilentWindows = 0
                 }
+                let isBluetooth = Self.isBluetoothTransport(deviceID: deviceID)
                 if consecutiveSilentWindows >= silentMicWindowThreshold,
-                   Self.isBluetoothTransport(deviceID: deviceID) {
+                   isBluetooth || detectSilentMicOnAnyTransport {
                     silentMicDetectedFired = true
-                    log("AudioCapture: Bluetooth mic returning silence for \(consecutiveSilentWindows)s — falling back to built-in mic")
+                    let detection = SilentMicDetection(
+                        deviceID: deviceID,
+                        deviceDescription: currentDeviceDescription,
+                        consecutiveSilentWindows: consecutiveSilentWindows,
+                        isBluetoothTransport: isBluetooth
+                    )
+                    if isBluetooth {
+                        log("AudioCapture: Bluetooth mic returning silence for \(consecutiveSilentWindows)s — falling back to built-in mic")
+                    } else {
+                        log("AudioCapture: Input device returning silence for \(consecutiveSilentWindows)s — rebuilding CoreAudio capture")
+                    }
                     let handler = onSilentMicDetected
-                    DispatchQueue.main.async { handler?() }
+                    DispatchQueue.main.async { handler?(detection) }
                 }
                 watchdogWindowPeak = 0
                 watchdogWindowStart = nowAbs

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -206,6 +206,8 @@ class AudioCaptureService: @unchecked Sendable {
 
     /// Performs all blocking CoreAudio HAL setup. Must be called on audioQueue, not the main thread.
     private func startCaptureOnQueue() throws {
+        resetSilentMicWatchdog()
+
         // 1. Resolve input device: explicit override wins while available, otherwise
         // fall back to the system default instead of pinning capture to a stale device.
         let inputDeviceID = try resolveInputDeviceID()
@@ -279,6 +281,7 @@ class AudioCaptureService: @unchecked Sendable {
 
     /// Stop capturing audio
     func stopCapture() {
+        resetSilentMicWatchdog()
         guard isCapturing else { return }
 
         removePropertyListeners()
@@ -294,7 +297,6 @@ class AudioCaptureService: @unchecked Sendable {
         isReconfiguring = false
         onAudioChunk = nil
         onAudioLevel = nil
-        resetSilentMicWatchdog()
 
         // Clean up converter
         audioConverter = nil
@@ -511,10 +513,9 @@ class AudioCaptureService: @unchecked Sendable {
             return Data(buffer: buffer)
         }
 
-        // Silent-mic watchdog: on Bluetooth-to-Bluetooth A2DP/HFP profile conflicts macOS
-        // accepts the IOProc but delivers only zero samples. Track the peak amplitude within
-        // a rolling ~1s window; if the window is silent AND the device transports over
-        // Bluetooth, fire onSilentMicDetected so the caller can swap to the built-in mic.
+        // Silent-mic watchdog: macOS can accept the IOProc but deliver only zero samples.
+        // Bluetooth inputs recover by switching to the built-in mic; PTT can opt into
+        // all-transport detection so a stale built-in/default route triggers a full rebuild.
         // Fires at most once per capture session.
         if !silentMicDetectedFired {
             for s in pcmData {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3,6 +3,35 @@ import Cocoa
 import Combine
 import CoreAudio
 
+struct PTTSilentMicRecoveryPolicy {
+  static let deadMicPeakThreshold = 5
+  static let minDeadTurnSeconds: TimeInterval = 0.25
+  static let consecutiveDeadTurnThreshold = 2
+
+  private(set) var consecutiveDeadMicTurns = 0
+
+  mutating func recordDiscardedHubTurn(totalSec: TimeInterval, peak: Int) -> Bool {
+    if totalSec >= Self.minDeadTurnSeconds && peak <= Self.deadMicPeakThreshold {
+      consecutiveDeadMicTurns += 1
+    } else {
+      consecutiveDeadMicTurns = 0
+    }
+    return consecutiveDeadMicTurns >= Self.consecutiveDeadTurnThreshold
+  }
+
+  mutating func recordSuccessfulHubTurn() {
+    consecutiveDeadMicTurns = 0
+  }
+
+  mutating func recordCaptureRebuild() {
+    consecutiveDeadMicTurns = 0
+  }
+}
+
+extension Notification.Name {
+  static let coreAudioCaptureRecoveryRequested = Notification.Name("coreAudioCaptureRecoveryRequested")
+}
+
 /// Push-to-talk manager for voice input via the Option (⌥) key.
 ///
 /// State machine:
@@ -61,6 +90,7 @@ class PushToTalkManager: ObservableObject {
   private var omniTurnSent = false  // dedup: send/fallback the omni turn at most once
   private var audioCaptureService: AudioCaptureService?
   private var micCaptureStartInFlight = false
+  private var silentMicRecoveryPolicy = PTTSilentMicRecoveryPolicy()
   private var transcriptSegments: [String] = []
   private var lastInterimText: String = ""
   private var finalizeWorkItem: DispatchWorkItem?
@@ -586,6 +616,9 @@ class PushToTalkManager: ObservableObject {
             + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] "
             + "(peak≈0 ⇒ dead mic; high peak ⇒ classifier misfire; low ⇒ quiet/far mic) — not committing"
         )
+        if silentMicRecoveryPolicy.recordDiscardedHubTurn(totalSec: totalSec, peak: peak) {
+          requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
+        }
         RealtimeHubController.shared.cancelTurn()
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: finalizedMode, hadTranscript: false, transcriptLength: 0)
@@ -595,6 +628,7 @@ class PushToTalkManager: ObservableObject {
       // Real speech — commit. The hub speaks the reply and dispatches tools
       // itself; no transcript/router/LLM hop here.
       RealtimeHubController.shared.commitTurn()
+      silentMicRecoveryPolicy.recordSuccessfulHubTurn()
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
       updateBarState()
@@ -911,9 +945,7 @@ class PushToTalkManager: ObservableObject {
     // which drops the OUTPUT rate too and chops the spoken reply (the A2DP↔HFP
     // flap). So when output is Bluetooth, capture from the built-in mic instead.
     if !bufferWhileWarming {
-      if AudioCaptureService.isDefaultOutputBluetooth(),
-        let builtIn = AudioCaptureService.findBuiltInMicDeviceID()
-      {
+      if let builtIn = preferredPTTInputOverrideDeviceID() {
         log("PushToTalkManager: hub on Bluetooth output — capturing from built-in mic to keep A2DP")
         startMicCapture(overrideDeviceID: builtIn)
       } else {
@@ -928,9 +960,7 @@ class PushToTalkManager: ObservableObject {
     isHubMode = false
     batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
     RealtimeHubController.shared.ensureWarm()
-    if AudioCaptureService.isDefaultOutputBluetooth(),
-      let builtIn = AudioCaptureService.findBuiltInMicDeviceID()
-    {
+    if let builtIn = preferredPTTInputOverrideDeviceID() {
       log("PushToTalkManager: waiting for realtime hub — buffering built-in mic audio")
       startMicCapture(batchMode: true, overrideDeviceID: builtIn)
     } else {
@@ -1049,11 +1079,13 @@ class PushToTalkManager: ObservableObject {
     }
     guard let capture = audioCaptureService else { return }
 
-    // Silent-mic watchdog: Bluetooth input often returns zero samples while another app
-    // holds A2DP output. Fall back to the built-in mic so PTT still captures the user.
-    capture.onSilentMicDetected = { [weak self] in
+    // Silent-mic watchdog: Bluetooth inputs can return zeros during A2DP/HFP conflicts,
+    // and stale CoreAudio routes can do the same even when the selected device is built-in.
+    capture.resetSilentMicWatchdog()
+    capture.detectSilentMicOnAnyTransport = true
+    capture.onSilentMicDetected = { [weak self] detection in
       Task { @MainActor in
-        self?.handleSilentMicFallback(batchMode: batchMode)
+        self?.handleSilentMicDetection(detection, batchMode: batchMode)
       }
     }
 
@@ -1110,21 +1142,63 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  /// Swap the current capture for one pinned to the built-in mic when the silent-mic
-  /// watchdog detects a dead Bluetooth input (A2DP profile conflict).
+  /// Recover when the silent-mic watchdog detects a capture that is running but
+  /// returning zeros. Bluetooth profile conflicts can usually be fixed by pinning
+  /// to the built-in mic. Non-Bluetooth silence points to a stale CoreAudio route,
+  /// so rebuild the whole capture stack instead.
   @MainActor
-  private func handleSilentMicFallback(batchMode: Bool) {
+  private func handleSilentMicDetection(_ detection: AudioCaptureService.SilentMicDetection, batchMode: Bool) {
     guard state == .listening || state == .lockedListening || state == .pendingLockDecision else {
       return
     }
-    guard let builtInID = AudioCaptureService.findBuiltInMicDeviceID() else {
-      log("PushToTalkManager: silent-mic detected but no built-in mic to fall back to")
+    if detection.suggestedAction == .fallbackToBuiltIn,
+       let builtInID = AudioCaptureService.findBuiltInMicDeviceID(),
+       builtInID != detection.deviceID {
+      log("PushToTalkManager: silent-mic fallback — switching to built-in mic (deviceID=\(builtInID))")
+      silentMicRecoveryPolicy.recordCaptureRebuild()
+      audioCaptureService?.stopCapture()
+      audioCaptureService = nil
+      clearBufferedTurnAudio()
+      startMicCapture(batchMode: batchMode, overrideDeviceID: builtInID)
       return
     }
-    log("PushToTalkManager: silent-mic fallback — switching to built-in mic (deviceID=\(builtInID))")
+
+    if detection.suggestedAction == .fallbackToBuiltIn {
+      log("PushToTalkManager: silent-mic detected but no built-in mic to fall back to")
+    }
+
+    requestCoreAudioCaptureRecovery(
+      reason: "silent PTT mic on \(detection.deviceDescription)",
+      restartPTT: true,
+      batchMode: batchMode
+    )
+  }
+
+  private func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {
+    guard AudioCaptureService.isDefaultOutputBluetooth() else { return nil }
+    return AudioCaptureService.findBuiltInMicDeviceID()
+  }
+
+  private func requestCoreAudioCaptureRecovery(reason: String, restartPTT: Bool, batchMode: Bool) {
+    log("PushToTalkManager: requesting CoreAudio capture rebuild — \(reason)")
+    silentMicRecoveryPolicy.recordCaptureRebuild()
     audioCaptureService?.stopCapture()
     audioCaptureService = nil
-    startMicCapture(batchMode: batchMode, overrideDeviceID: builtInID)
+    clearBufferedTurnAudio()
+    NotificationCenter.default.post(
+      name: .coreAudioCaptureRecoveryRequested,
+      object: nil,
+      userInfo: ["reason": "PushToTalkManager: \(reason)"]
+    )
+    if restartPTT {
+      startMicCapture(batchMode: batchMode, overrideDeviceID: preferredPTTInputOverrideDeviceID())
+    }
+  }
+
+  private func clearBufferedTurnAudio() {
+    batchAudioLock.lock()
+    batchAudioBuffer = Data()
+    batchAudioLock.unlock()
   }
 
   private func stopAudioTranscription() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1174,11 +1174,6 @@ class PushToTalkManager: ObservableObject {
     )
   }
 
-  private func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {
-    guard AudioCaptureService.isDefaultOutputBluetooth() else { return nil }
-    return AudioCaptureService.findBuiltInMicDeviceID()
-  }
-
   private func requestCoreAudioCaptureRecovery(reason: String, restartPTT: Bool, batchMode: Bool) {
     log("PushToTalkManager: requesting CoreAudio capture rebuild — \(reason)")
     silentMicRecoveryPolicy.recordCaptureRebuild()
@@ -1193,6 +1188,15 @@ class PushToTalkManager: ObservableObject {
     if restartPTT {
       startMicCapture(batchMode: batchMode, overrideDeviceID: preferredPTTInputOverrideDeviceID())
     }
+  }
+
+  private func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {
+    if AudioCaptureService.isDefaultOutputBluetooth(),
+      let builtIn = AudioCaptureService.findBuiltInMicDeviceID()
+    {
+      return builtIn
+    }
+    return nil
   }
 
   private func clearBufferedTurnAudio() {

--- a/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentMicRecoveryPolicyTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PTTSilentMicRecoveryPolicyTests: XCTestCase {
+  func testRepeatedDeadMicTurnsRequestRecovery() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 1)
+
+    XCTAssertTrue(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 2)
+  }
+
+  func testShortSilentTapDoesNotCountAsDeadMic() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 0.05, peak: 0))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+  }
+
+  func testQuietButNonZeroTurnResetsDeadMicCounter() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: PTTSilentMicRecoveryPolicy.deadMicPeakThreshold + 1))
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+  }
+
+  func testSuccessfulTurnResetsDeadMicCounter() {
+    var policy = PTTSilentMicRecoveryPolicy()
+
+    XCTAssertFalse(policy.recordDiscardedHubTurn(totalSec: 1.0, peak: 0))
+    policy.recordSuccessfulHubTurn()
+
+    XCTAssertEqual(policy.consecutiveDeadMicTurns, 0)
+  }
+}

--- a/desktop/macos/Desktop/Tests/PushToTalkStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkStateMachineTests.swift
@@ -19,6 +19,20 @@ final class PushToTalkStateMachineTests: XCTestCase {
     XCTAssertFalse(source.contains("private var micCaptureActive"))
   }
 
+  func testSilentMicRecoveryPreservesBluetoothOutputRouting() throws {
+    let source = try pushToTalkManagerSource()
+
+    XCTAssertTrue(source.contains("private func preferredPTTInputOverrideDeviceID() -> AudioDeviceID?"))
+    XCTAssertTrue(source.contains("startMicCapture(batchMode: batchMode, overrideDeviceID: preferredPTTInputOverrideDeviceID())"))
+  }
+
+  func testSilentMicRecoveryResetsCaptureWatchdogForNewPTTTurn() throws {
+    let source = try pushToTalkManagerSource()
+
+    XCTAssertTrue(source.contains("capture.resetSilentMicWatchdog()"))
+    XCTAssertTrue(source.contains("capture.detectSilentMicOnAnyTransport = true"))
+  }
+
   private func pushToTalkManagerSource() throws -> String {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/desktop/macos/changelog/unreleased/20260629-ptt-silent-mic-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260629-ptt-silent-mic-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk getting stuck with silent microphone capture until Omi was relaunched"
+}


### PR DESCRIPTION
## Summary
- detect PTT mic capture that is running but returning silence on non-Bluetooth routes
- rebuild PTT capture and notify AppState to recreate the long-lived mic/system CoreAudio stack
- keep always-on transcription's broader silence handling limited to the existing Bluetooth fallback to avoid resets during normal quiet rooms
- add a desktop changelog fragment and focused recovery policy tests

## Root cause
PTT already recreated its short-lived mic IOProc per turn, but the app can still hold stale long-lived CoreAudio state through transcription/system-audio capture. The existing silent-mic watchdog only recovered Bluetooth/A2DP conflicts by switching to built-in mic, so a built-in or stale-route running-silent capture never triggered a reset.

## Validation
- `git diff --check`
- `xcrun swift test --package-path Desktop --filter PTTSilentMicRecoveryPolicyTests`
- `xcrun swift build -c debug --package-path Desktop`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --swift-only`
- pre-push hook fast checks passed, including desktop changelog validation

## Notes
The HAL wedge itself is not directly reproducible in unit tests; this PR verifies the policy and rebuild wiring around the recovery path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

