### PR TITLE
fix(backend): don't drop a trends category when a topic is missing memory_ids

### DIFF
--- a/backend/database/trends.py
+++ b/backend/database/trends.py
@@ -30,12 +30,17 @@ def get_trends_data() -> List[Dict]:
             category_topics_ref = trends_ref.document(category_data['id']).collection('topics')
             topics_docs = [topic.to_dict() for topic in category_topics_ref.stream(retry=Retry())]
             cleaned_topics = []
-            topics = sorted(topics_docs, key=lambda e: len(e['memory_ids']), reverse=True)
+            # A topic doc can be missing 'memory_ids'. save_trends writes the doc and its
+            # memory_ids in two separate Firestore calls (set, then update with ArrayUnion),
+            # so an interrupted or failed second write leaves a topic with no memory_ids field.
+            # Treat a missing/empty value as a count of 0 so one such topic cannot raise
+            # KeyError and drop the entire category from the public /v1/trends response.
+            topics = sorted(topics_docs, key=lambda e: len(e.get('memory_ids') or []), reverse=True)
             for topic in topics:
                 if topic['topic'] not in valid_items:
                     continue
-                topic['memories_count'] = len(topic['memory_ids'])
-                del topic['memory_ids']
+                topic['memories_count'] = len(topic.get('memory_ids') or [])
+                topic.pop('memory_ids', None)
                 cleaned_topics.append(topic)
 
             category_data['topics'] = cleaned_topics

--- a/backend/tests/unit/test_trends_missing_memory_ids.py
+++ b/backend/tests/unit/test_trends_missing_memory_ids.py
@@ -1,0 +1,107 @@
+"""Regression tests for database.trends.get_trends_data.
+
+save_trends writes each topic in two Firestore calls (set, then update with
+ArrayUnion for memory_ids), so a topic doc can exist without a memory_ids field
+if the second write is interrupted or fails. get_trends_data must not raise
+KeyError on such a doc, because the per-category try/except would otherwise drop
+the entire category from the public /v1/trends response.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+
+def _install_stubs(mock_db):
+    saved = {
+        'database._client': sys.modules.get('database._client'),
+        'firebase_admin': sys.modules.get('firebase_admin'),
+        'firebase_admin.firestore': sys.modules.get('firebase_admin.firestore'),
+    }
+    sys.modules['database._client'] = MagicMock(db=mock_db, document_id_from_seed=lambda s: f'id-{s}')
+    firebase_admin_stub = MagicMock()
+    firebase_firestore_stub = MagicMock()
+    firebase_firestore_stub.ArrayUnion = lambda values: values
+    firebase_admin_stub.firestore = firebase_firestore_stub
+    sys.modules['firebase_admin'] = firebase_admin_stub
+    sys.modules['firebase_admin.firestore'] = firebase_firestore_stub
+    return saved
+
+
+def _restore_stubs(saved):
+    for name, mod in saved.items():
+        if mod is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = mod
+    sys.modules.pop('database.trends', None)
+
+
+def _snap(data):
+    snapshot = MagicMock()
+    snapshot.to_dict.return_value = data
+    return snapshot
+
+
+def _build_db(category, topic_docs):
+    """Mock Firestore so the trends collection yields one category and its topics."""
+    mock_db = MagicMock()
+    trends_ref = MagicMock()
+    mock_db.collection.return_value = trends_ref
+    trends_ref.stream.return_value = [_snap(category)]
+    category_ref = MagicMock()
+    trends_ref.document.return_value = category_ref
+    topics_ref = MagicMock()
+    category_ref.collection.return_value = topics_ref
+    topics_ref.stream.return_value = [_snap(topic) for topic in topic_docs]
+    return mock_db
+
+
+def test_topic_missing_memory_ids_does_not_drop_category():
+    from models.trend import valid_items
+
+    names = sorted(valid_items)
+    good_topic, missing_topic = names[0], names[1]
+
+    category = {'id': 'cat1', 'category': 'company'}
+    topic_docs = [
+        {'id': 't1', 'topic': good_topic, 'memory_ids': ['m1', 'm2']},
+        {'id': 't2', 'topic': missing_topic},  # partial write: no memory_ids field
+    ]
+    saved = _install_stubs(_build_db(category, topic_docs))
+    try:
+        sys.modules.pop('database.trends', None)
+        import database.trends as trends_db
+
+        result = trends_db.get_trends_data()
+
+        # The category must survive; before the fix the missing key raised
+        # KeyError and the except-continue dropped the whole category.
+        assert len(result) == 1
+        topics = {t['topic']: t for t in result[0]['topics']}
+        assert topics[good_topic]['memories_count'] == 2
+        assert topics[missing_topic]['memories_count'] == 0
+        # memory_ids is stripped from the response payload in both cases.
+        assert 'memory_ids' not in topics[good_topic]
+        assert 'memory_ids' not in topics[missing_topic]
+    finally:
+        _restore_stubs(saved)
+
+
+def test_empty_memory_ids_list_counts_zero():
+    from models.trend import valid_items
+
+    topic_name = sorted(valid_items)[0]
+    category = {'id': 'cat1', 'category': 'ceo'}
+    topic_docs = [{'id': 't1', 'topic': topic_name, 'memory_ids': []}]
+    saved = _install_stubs(_build_db(category, topic_docs))
+    try:
+        sys.modules.pop('database.trends', None)
+        import database.trends as trends_db
+
+        result = trends_db.get_trends_data()
+
+        assert len(result) == 1
+        assert result[0]['topics'][0]['memories_count'] == 0
+        assert 'memory_ids' not in result[0]['topics'][0]
+    finally:
+        _restore_stubs(saved)


### PR DESCRIPTION
## What

`get_trends_data` (served by the public `GET /v1/trends` endpoint) read each topic's memory count with `topic['memory_ids']` in both the sort key and the count. A topic document can legitimately exist without a `memory_ids` field, so that unguarded access raised `KeyError`. The surrounding per-category `try/except` caught it and `continue`d, which dropped the entire category (every other valid topic in it) from the response.

## Why a topic can lack memory_ids

`save_trends` persists each topic in two separate Firestore writes:

```python
topic_doc_ref.set({"id": topic_id, "topic": topic}, merge=True)
topic_doc_ref.update({'memory_ids': firestore.firestore.ArrayUnion([memory_id])})
```

If the second write fails or is interrupted, the topic doc is left with no `memory_ids` field. From then on that single topic makes its whole category disappear from `/v1/trends` for every user until a later memory for the same topic re-runs the update.

## Fix

Treat a missing or empty `memory_ids` as a count of 0 in `get_trends_data`, so one partial topic can no longer hide the rest of its category:

- sort key: `len(e.get('memory_ids') or [])`
- count: `len(topic.get('memory_ids') or [])`
- strip: `topic.pop('memory_ids', None)` instead of `del topic['memory_ids']`

This is read-side defense, so it also recovers any categories already affected by partial docs already in Firestore. The two-step write in `save_trends` is left unchanged to keep the diff scoped to the crash, and the root cause is documented inline.

## Test

`tests/unit/test_trends_missing_memory_ids.py`:
- a category with one normal topic and one topic missing `memory_ids` now returns both (count 0 for the partial one) instead of dropping the category
- a topic with an empty `memory_ids` list counts as 0

Verified red/green: the new test fails with `KeyError: 'memory_ids'` against the previous code and passes with the fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

