### PR TITLE
Add privacy-safe desktop diagnostics

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -572,6 +572,13 @@ class AnalyticsManager {
     PostHogManager.shared.feedbackSubmitted(feedbackLength: feedbackLength)
   }
 
+  func desktopHealthEvent(name: String, properties: [String: Any]) {
+    guard !Self.isDevBuild else { return }
+    var props = properties
+    props["health_event"] = name
+    PostHogManager.shared.track("desktop_health_event", properties: props)
+  }
+
   // MARK: - Rewind Events (Desktop-specific)
 
   func rewindSearchPerformed(queryLength: Int) {

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -1,0 +1,288 @@
+import Foundation
+import Sentry
+import Darwin
+
+enum DesktopHealthEventName: String {
+  case pttStarted = "ptt_started"
+  case pttAudioCaptureSilentTurn = "ptt_audio_capture_silent_turn"
+  case pttAudioCaptureWatchdogTriggered = "ptt_audio_capture_watchdog_triggered"
+  case pttAudioCaptureDeviceRouteChanged = "ptt_audio_capture_device_route_changed"
+  case pttCommitted = "ptt_committed"
+  case realtimeTokenMintFailed = "realtime_token_mint_failed"
+  case realtimeProviderPolicyClose = "realtime_provider_policy_close"
+  case realtimeProviderSessionError = "realtime_provider_session_error"
+}
+
+struct DesktopHealthSnapshot {
+  let timestamp: Date
+  let event: DesktopHealthEventName
+  let properties: [String: Any]
+
+  func dictionary() -> [String: Any] {
+    var dict = properties
+    dict["timestamp"] = ISO8601DateFormatter.desktopDiagnostics.string(from: timestamp)
+    dict["event"] = event.rawValue
+    return dict
+  }
+}
+
+private extension ISO8601DateFormatter {
+  static let desktopDiagnostics: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+}
+
+final class DesktopDiagnosticsManager {
+  static let shared = DesktopDiagnosticsManager()
+
+  private let lock = NSLock()
+  private var snapshots: [DesktopHealthSnapshot] = []
+  private let snapshotLimit = 150
+  private var consecutiveNearZeroPTTTurns = 0
+  private var lastPTTWatchdogIncidentAt: Date?
+  private let pttWatchdogThreshold = 3
+  private let pttWatchdogDedupWindow: TimeInterval = 15 * 60
+
+  private init() {}
+
+  func recordPTTStarted(mode: String, hubActive: Bool, micPermissionGranted: Bool) {
+    record(
+      .pttStarted,
+      properties: [
+        "mode": mode,
+        "hub_active": hubActive,
+        "tcc_microphone_granted": micPermissionGranted,
+      ],
+      trackRemotely: false)
+  }
+
+  func recordPTTSilentTurn(
+    source: String,
+    mode: String,
+    audioSeconds: Double,
+    voicedSeconds: Double?,
+    peak: Int,
+    rms: Int,
+    deviceDescription: String?,
+    micPermissionGranted: Bool,
+    hubActive: Bool
+  ) {
+    let nearZero = peak <= 5 && rms <= 5
+    if nearZero && micPermissionGranted {
+      consecutiveNearZeroPTTTurns += 1
+    } else if peak > 50 || rms > 20 {
+      consecutiveNearZeroPTTTurns = 0
+    }
+
+    var properties: [String: Any] = [
+      "source": source,
+      "mode": mode,
+      "hub_active": hubActive,
+      "turn_audio_seconds": rounded(audioSeconds),
+      "peak": peak,
+      "rms": rms,
+      "is_near_zero": nearZero,
+      "consecutive_silent_turns": consecutiveNearZeroPTTTurns,
+      "tcc_microphone_granted": micPermissionGranted,
+      "input_device_class": classifyInputDevice(deviceDescription),
+      "recovery_action": "none",
+      "recovery_result": "not_attempted",
+    ]
+    if let voicedSeconds {
+      properties["voiced_audio_seconds"] = rounded(voicedSeconds)
+    }
+
+    record(.pttAudioCaptureSilentTurn, properties: properties)
+
+    guard nearZero && micPermissionGranted && consecutiveNearZeroPTTTurns >= pttWatchdogThreshold
+    else { return }
+    recordPTTWatchdogTriggered(latestProperties: properties)
+  }
+
+  func recordPTTCommitted(mode: String, hubActive: Bool) {
+    consecutiveNearZeroPTTTurns = 0
+    record(
+      .pttCommitted,
+      properties: [
+        "mode": mode,
+        "hub_active": hubActive,
+      ],
+      trackRemotely: false)
+  }
+
+  func recordPTTDeviceRouteChanged(recoveryAction: String, recoveryResult: String) {
+    record(
+      .pttAudioCaptureDeviceRouteChanged,
+      properties: [
+        "recovery_action": recoveryAction,
+        "recovery_result": recoveryResult,
+      ])
+  }
+
+  func recordRealtimeTokenMintFailed(provider: String, reason: String, phase: String) {
+    record(
+      .realtimeTokenMintFailed,
+      properties: [
+        "provider": safeProvider(provider),
+        "reason": reason,
+        "phase": phase,
+      ])
+  }
+
+  func recordRealtimeProviderClose(provider: String, category: String?, aliveFor: TimeInterval, activeTurn: Bool) {
+    let event: DesktopHealthEventName = category == RealtimeHubCloseCategory.providerPolicyCloseFast.rawValue
+      ? .realtimeProviderPolicyClose
+      : .realtimeProviderSessionError
+    record(
+      event,
+      properties: [
+        "provider": safeProvider(provider),
+        "category": category ?? "unclassified",
+        "alive_for_seconds": Int(aliveFor),
+        "active_turn": activeTurn,
+      ])
+  }
+
+  func currentSnapshotsForSentry() -> [[String: Any]] {
+    lock.lock()
+    let current = snapshots.map { $0.dictionary() }
+    lock.unlock()
+    return current
+  }
+
+  func writeDiagnosticsAttachment() -> URL? {
+    let payload: [String: Any] = [
+      "generated_at": ISO8601DateFormatter.desktopDiagnostics.string(from: Date()),
+      "privacy": "safe_operational_fields_only",
+      "snapshots": currentSnapshotsForSentry(),
+    ]
+    guard JSONSerialization.isValidJSONObject(payload),
+      let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+    else { return nil }
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-desktop-diagnostics-\(UUID().uuidString).json")
+    do {
+      try data.write(to: url, options: .atomic)
+      return url
+    } catch {
+      log("DesktopDiagnostics: failed to write diagnostics attachment")
+      return nil
+    }
+  }
+
+  private func record(
+    _ event: DesktopHealthEventName,
+    properties: [String: Any],
+    trackRemotely: Bool = true
+  ) {
+    let snapshot = DesktopHealthSnapshot(
+      timestamp: Date(),
+      event: event,
+      properties: commonProperties().merging(sanitized(properties)) { _, new in new })
+
+    lock.lock()
+    snapshots.append(snapshot)
+    if snapshots.count > snapshotLimit {
+      snapshots.removeFirst(snapshots.count - snapshotLimit)
+    }
+    lock.unlock()
+
+    guard trackRemotely else { return }
+    Task { @MainActor in
+      AnalyticsManager.shared.desktopHealthEvent(
+        name: event.rawValue,
+        properties: snapshot.dictionary())
+    }
+  }
+
+  private func recordPTTWatchdogTriggered(latestProperties: [String: Any]) {
+    let now = Date()
+    if let last = lastPTTWatchdogIncidentAt, now.timeIntervalSince(last) < pttWatchdogDedupWindow {
+      return
+    }
+    lastPTTWatchdogIncidentAt = now
+
+    let properties = latestProperties.merging([
+      "threshold": pttWatchdogThreshold,
+      "recovery_action": "prompt_restart",
+      "recovery_result": "not_attempted",
+    ]) { _, new in new }
+    record(.pttAudioCaptureWatchdogTriggered, properties: properties)
+
+    SentrySDK.capture(message: "PTT Silent Capture Watchdog Triggered") { scope in
+      scope.setLevel(.warning)
+      scope.setTag(value: "ptt_silent_capture_watchdog", key: "diagnostic")
+      scope.setContext(value: properties, key: "audio_capture")
+      scope.setContext(
+        value: ["snapshots": self.currentSnapshotsForSentry()],
+        key: "desktop_health_snapshots")
+    }
+  }
+
+  private func commonProperties() -> [String: Any] {
+    var properties: [String: Any] = [
+      "build": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+      "build_number": Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+      "os_version": osVersionString(),
+      "device_model": deviceModel(),
+    ]
+    properties["system_audio_mode"] =
+      UserDefaults.standard.string(forKey: "systemAudioCaptureMode") ?? "onlyDuringMeetings"
+    return properties
+  }
+
+  private func sanitized(_ properties: [String: Any]) -> [String: Any] {
+    var safe: [String: Any] = [:]
+    for (key, value) in properties {
+      switch value {
+      case let string as String:
+        safe[key] = String(string.prefix(96))
+      case let int as Int:
+        safe[key] = int
+      case let double as Double:
+        safe[key] = rounded(double)
+      case let bool as Bool:
+        safe[key] = bool
+      default:
+        continue
+      }
+    }
+    return safe
+  }
+
+  private func rounded(_ value: Double) -> Double {
+    (value * 100).rounded() / 100
+  }
+
+  private func classifyInputDevice(_ description: String?) -> String {
+    let lower = (description ?? "").lowercased()
+    if lower.contains("built-in") { return "built_in_mic" }
+    if lower.contains("bluetooth") { return "bluetooth_headset" }
+    if lower.contains("virtual") || lower.contains("aggregate") { return "virtual_audio_device" }
+    if lower.isEmpty || lower == "?" { return "unknown" }
+    return "external_or_default_mic"
+  }
+
+  private func safeProvider(_ provider: String) -> String {
+    switch provider.lowercased() {
+    case "openai", "gemini": return provider.lowercased()
+    default: return "unknown"
+    }
+  }
+
+  private func osVersionString() -> String {
+    let version = ProcessInfo.processInfo.operatingSystemVersion
+    return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+  }
+
+  private func deviceModel() -> String {
+    var size = 0
+    sysctlbyname("hw.model", nil, &size, nil, 0)
+    guard size > 0 else { return "unknown" }
+    var model = [CChar](repeating: 0, count: size)
+    sysctlbyname("hw.model", &model, &size, nil, 0)
+    return String(cString: model)
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -175,13 +175,15 @@ final class DesktopDiagnosticsManager {
     }
   }
 
+  #if DEBUG
   func resetForTests() {
     lock.lock()
     snapshots.removeAll()
-    lock.unlock()
     consecutiveNearZeroPTTTurns = 0
     lastPTTWatchdogIncidentAt = nil
+    lock.unlock()
   }
+  #endif
 
   private func record(
     _ event: DesktopHealthEventName,

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -44,6 +44,7 @@ final class DesktopDiagnosticsManager {
   private var lastPTTWatchdogIncidentAt: Date?
   private let pttWatchdogThreshold = 3
   private let pttWatchdogDedupWindow: TimeInterval = 15 * 60
+  private let pttWatchdogMinimumAudioSeconds: Double = 0.35
 
   private init() {}
 
@@ -70,7 +71,8 @@ final class DesktopDiagnosticsManager {
     hubActive: Bool
   ) {
     let nearZero = peak <= 5 && rms <= 5
-    if nearZero && micPermissionGranted {
+    let watchdogEligible = audioSeconds >= pttWatchdogMinimumAudioSeconds
+    if nearZero && micPermissionGranted && watchdogEligible {
       consecutiveNearZeroPTTTurns += 1
     } else if peak > 50 || rms > 20 {
       consecutiveNearZeroPTTTurns = 0
@@ -84,6 +86,7 @@ final class DesktopDiagnosticsManager {
       "peak": peak,
       "rms": rms,
       "is_near_zero": nearZero,
+      "watchdog_eligible": watchdogEligible,
       "consecutive_silent_turns": consecutiveNearZeroPTTTurns,
       "tcc_microphone_granted": micPermissionGranted,
       "input_device_class": classifyInputDevice(deviceDescription),
@@ -96,7 +99,7 @@ final class DesktopDiagnosticsManager {
 
     record(.pttAudioCaptureSilentTurn, properties: properties)
 
-    guard nearZero && micPermissionGranted && consecutiveNearZeroPTTTurns >= pttWatchdogThreshold
+    guard nearZero && micPermissionGranted && watchdogEligible && consecutiveNearZeroPTTTurns >= pttWatchdogThreshold
     else { return }
     recordPTTWatchdogTriggered(latestProperties: properties)
   }
@@ -170,6 +173,14 @@ final class DesktopDiagnosticsManager {
       log("DesktopDiagnostics: failed to write diagnostics attachment")
       return nil
     }
+  }
+
+  func resetForTests() {
+    lock.lock()
+    snapshots.removeAll()
+    lock.unlock()
+    consecutiveNearZeroPTTTurns = 0
+    lastPTTWatchdogIncidentAt = nil
   }
 
   private func record(

--- a/desktop/macos/Desktop/Sources/FeedbackView.swift
+++ b/desktop/macos/Desktop/Sources/FeedbackView.swift
@@ -147,6 +147,13 @@ struct FeedbackView: View {
         let attachment = Attachment(path: logPath, filename: logFilename, contentType: "text/plain")
         scope.addAttachment(attachment)
       }
+      if let diagnosticsURL = DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment() {
+        let attachment = Attachment(
+          path: diagnosticsURL.path,
+          filename: "desktop_diagnostics.json",
+          contentType: "application/json")
+        scope.addAttachment(attachment)
+      }
     }
 
     // Also send as Sentry feedback if there's a message

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -311,6 +311,10 @@ class PushToTalkManager: ObservableObject {
 
     let isFollowUp = isCurrentSessionFollowUp
     AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_hold" : "hold")
+    DesktopDiagnosticsManager.shared.recordPTTStarted(
+      mode: isFollowUp ? "follow_up_hold" : "hold",
+      hubActive: RealtimeHubController.shared.isActive,
+      micPermissionGranted: hasMicPermission)
     let preOverlayImage = ScreenCaptureManager.captureScreenImage()
     updateBarState()
 
@@ -338,6 +342,10 @@ class PushToTalkManager: ObservableObject {
 
     let isFollowUp = isCurrentSessionFollowUp
     AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_locked" : "locked")
+    DesktopDiagnosticsManager.shared.recordPTTStarted(
+      mode: isFollowUp ? "follow_up_locked" : "locked",
+      hubActive: RealtimeHubController.shared.isActive,
+      micPermissionGranted: hasMicPermission)
 
     // If we were already listening from the first tap, keep going.
     // Otherwise start fresh.
@@ -611,6 +619,16 @@ class PushToTalkManager: ObservableObject {
       if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
         let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
         let dev = audioCaptureService?.currentDeviceDescription ?? "?"
+        DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+          source: "hub",
+          mode: finalizedMode,
+          audioSeconds: totalSec,
+          voicedSeconds: nil,
+          peak: peak,
+          rms: rms,
+          deviceDescription: dev,
+          micPermissionGranted: hasMicPermission,
+          hubActive: true)
         log(
           "PushToTalkManager: discarding hub turn — audio \(String(format: "%.2f", totalSec))s "
             + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] "
@@ -629,6 +647,7 @@ class PushToTalkManager: ObservableObject {
       // itself; no transcript/router/LLM hop here.
       RealtimeHubController.shared.commitTurn()
       silentMicRecoveryPolicy.recordSuccessfulHubTurn()
+      DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
       // Collapse the bar on release — the hub speaks its reply as audio (no inline
       // status UI), the same as the legacy voice path.
       updateBarState()
@@ -650,6 +669,17 @@ class PushToTalkManager: ObservableObject {
       batchAudioLock.unlock()
       let (totalSec, voicedSec) = Self.voicedAudioSeconds(pcm16k: turnAudio)
       if totalSec < Self.minTurnAudioSeconds || voicedSec < Self.minVoicedSeconds {
+        let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
+        DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+          source: isOmniSTT ? "omni_stt" : "batch_stt",
+          mode: finalizedMode,
+          audioSeconds: totalSec,
+          voicedSeconds: voicedSec,
+          peak: peak,
+          rms: rms,
+          deviceDescription: audioCaptureService?.currentDeviceDescription,
+          micPermissionGranted: hasMicPermission,
+          hubActive: false)
         log(
           "PushToTalkManager: discarding silent turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s) — not transcribing"
         )
@@ -795,6 +825,9 @@ class PushToTalkManager: ObservableObject {
       hadTranscript: hasQuery,
       transcriptLength: query.count
     )
+    if hasQuery {
+      DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: false)
+    }
 
     isCurrentSessionFollowUp = false
 
@@ -1012,6 +1045,16 @@ class PushToTalkManager: ObservableObject {
     if !Self.hubTurnHasSpeech(pcm16k: turnAudio) {
       let (peak, rms) = Self.audioEnergy(pcm16k: turnAudio)
       let dev = audioCaptureService?.currentDeviceDescription ?? "?"
+      DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+        source: "buffered_hub",
+        mode: finalizedMode,
+        audioSeconds: totalSec,
+        voicedSeconds: nil,
+        peak: peak,
+        rms: rms,
+        deviceDescription: dev,
+        micPermissionGranted: hasMicPermission,
+        hubActive: true)
       log(
         "PushToTalkManager: discarding buffered hub turn — audio \(String(format: "%.2f", totalSec))s "
           + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] — not committing")
@@ -1023,6 +1066,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
     RealtimeHubController.shared.commitTurn()
+    DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
     state = .idle
     updateBarState()
     AnalyticsManager.shared.floatingBarPTTEnded(
@@ -1036,6 +1080,17 @@ class PushToTalkManager: ObservableObject {
     batchAudioLock.unlock()
     let (totalSec, voicedSec) = Self.voicedAudioSeconds(pcm16k: audio)
     guard totalSec >= Self.minTurnAudioSeconds, voicedSec >= Self.minVoicedSeconds else {
+      let (peak, rms) = Self.audioEnergy(pcm16k: audio)
+      DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+        source: "warm_wait_fallback",
+        mode: finalizedMode,
+        audioSeconds: totalSec,
+        voicedSeconds: voicedSec,
+        peak: peak,
+        rms: rms,
+        deviceDescription: audioCaptureService?.currentDeviceDescription,
+        micPermissionGranted: hasMicPermission,
+        hubActive: false)
       log(
         "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)")
       AnalyticsManager.shared.floatingBarPTTEnded(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -309,17 +309,17 @@ class PushToTalkManager: ObservableObject {
       sound?.play()
     }
 
-    let isFollowUp = isCurrentSessionFollowUp
-    AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_hold" : "hold")
+    let mode = currentPTTMode()
+    AnalyticsManager.shared.floatingBarPTTStarted(mode: mode)
     DesktopDiagnosticsManager.shared.recordPTTStarted(
-      mode: isFollowUp ? "follow_up_hold" : "hold",
+      mode: mode,
       hubActive: RealtimeHubController.shared.isActive,
-      micPermissionGranted: hasMicPermission)
+      micPermissionGranted: refreshedMicPermission())
     let preOverlayImage = ScreenCaptureManager.captureScreenImage()
     updateBarState()
 
     captureContextAndStartAudio(preOverlayImage: preOverlayImage)
-    log("PushToTalkManager: started listening (hold mode, followUp=\(isFollowUp))")
+    log("PushToTalkManager: started listening (mode=\(mode))")
   }
 
   private func enterLockedListening() {
@@ -340,12 +340,12 @@ class PushToTalkManager: ObservableObject {
       sound?.play()
     }
 
-    let isFollowUp = isCurrentSessionFollowUp
-    AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_locked" : "locked")
+    let mode = currentPTTMode()
+    AnalyticsManager.shared.floatingBarPTTStarted(mode: mode)
     DesktopDiagnosticsManager.shared.recordPTTStarted(
-      mode: isFollowUp ? "follow_up_locked" : "locked",
+      mode: mode,
       hubActive: RealtimeHubController.shared.isActive,
-      micPermissionGranted: hasMicPermission)
+      micPermissionGranted: refreshedMicPermission())
 
     // If we were already listening from the first tap, keep going.
     // Otherwise start fresh.
@@ -359,7 +359,7 @@ class PushToTalkManager: ObservableObject {
     }
 
     updateBarState()
-    log("PushToTalkManager: entered locked listening mode (followUp=\(isFollowUp))")
+    log("PushToTalkManager: entered locked listening mode (mode=\(mode))")
   }
 
   private func enterPendingLockDecision() {
@@ -453,6 +453,16 @@ class PushToTalkManager: ObservableObject {
   }
 
   private var finalizedMode: String = "hold"
+
+  private func currentPTTMode() -> String {
+    let baseMode = state == .lockedListening ? "locked" : "hold"
+    return isCurrentSessionFollowUp ? "follow_up_\(baseMode)" : baseMode
+  }
+
+  private func refreshedMicPermission() -> Bool {
+    hasMicPermission = AudioCaptureService.checkPermission()
+    return hasMicPermission
+  }
 
   // MARK: - QueryTracer
 
@@ -586,7 +596,7 @@ class PushToTalkManager: ObservableObject {
     lastOptionUpTime = 0
     // Dictation is over — restore any audio we muted so the track resumes immediately.
     SystemAudioMuteController.shared.restore()
-    finalizedMode = state == .lockedListening ? "locked" : "hold"
+    finalizedMode = currentPTTMode()
     state = .finalizing
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
@@ -1119,9 +1129,18 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  private func startMicCapture(batchMode: Bool = false, overrideDeviceID: AudioDeviceID? = nil) {
+  private func startMicCapture(
+    batchMode: Bool = false,
+    overrideDeviceID: AudioDeviceID? = nil,
+    diagnosticRecoveryAction: String? = nil
+  ) {
     guard !micCaptureStartInFlight && !(audioCaptureService?.capturing ?? false) else {
       log("PushToTalkManager: mic capture start ignored — already active")
+      if let diagnosticRecoveryAction {
+        DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+          recoveryAction: diagnosticRecoveryAction,
+          recoveryResult: "ignored_already_active")
+      }
       return
     }
     micCaptureStartInFlight = true
@@ -1195,10 +1214,20 @@ class PushToTalkManager: ObservableObject {
           if isCurrentGeneration {
             self.micCaptureStartInFlight = false
           }
+          if let diagnosticRecoveryAction {
+            DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+              recoveryAction: diagnosticRecoveryAction,
+              recoveryResult: "ignored_turn_ended")
+          }
           log("PushToTalkManager: mic capture start completed after turn ended — stopped")
           return
         }
         self.micCaptureStartInFlight = false
+        if let diagnosticRecoveryAction {
+          DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+            recoveryAction: diagnosticRecoveryAction,
+            recoveryResult: "succeeded")
+        }
         log("PushToTalkManager: mic capture started (batch=\(batchMode))")
       } catch {
         guard self.micCaptureGeneration == generation else {
@@ -1206,6 +1235,11 @@ class PushToTalkManager: ObservableObject {
           return
         }
         self.micCaptureStartInFlight = false
+        if let diagnosticRecoveryAction {
+          DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+            recoveryAction: diagnosticRecoveryAction,
+            recoveryResult: "failed")
+        }
         logError("PushToTalkManager: mic capture failed", error: error)
         self.stopListening()
       }
@@ -1228,12 +1262,18 @@ class PushToTalkManager: ObservableObject {
       silentMicRecoveryPolicy.recordCaptureRebuild()
       stopMicCapture()
       clearBufferedTurnAudio()
-      startMicCapture(batchMode: batchMode, overrideDeviceID: builtInID)
+      startMicCapture(
+        batchMode: batchMode,
+        overrideDeviceID: builtInID,
+        diagnosticRecoveryAction: "switch_to_built_in_mic")
       return
     }
 
     if detection.suggestedAction == .fallbackToBuiltIn {
       log("PushToTalkManager: silent-mic detected but no built-in mic to fall back to")
+      DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
+        recoveryAction: "switch_to_built_in_mic",
+        recoveryResult: "no_built_in_mic")
     }
 
     requestCoreAudioCaptureRecovery(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -330,6 +330,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       guard let self else { return }
       self.minting = false
       guard let token else {
+        DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+          provider: providerParam,
+          reason: "unknown",
+          phase: "warm")
         // Mint failed for this provider — try the OTHER realtime provider before the
         // legacy Claude cascade.
         if !self.failoverToAlternateProvider() {
@@ -1044,6 +1048,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       hasActiveTurn: hasActiveTurn)
     let categoryText = closeCategory.map { " category=\($0.rawValue)" } ?? ""
     let safeMessage = closeCategory == .providerPolicyCloseFast ? "" : " \(message)"
+    DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+      provider: providerTag,
+      category: closeCategory?.rawValue,
+      aliveFor: aliveFor,
+      activeTurn: hasActiveTurn)
     if RealtimeHubCloseClassifier.shouldReportToSentry(closeCategory) {
       logError("RealtimeHub: session error —\(categoryText) provider=\(providerTag)\(safeMessage)")
     } else {

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopDiagnosticsManagerTests: XCTestCase {
+  func testDiagnosticsAttachmentUsesSafeOperationalFields() throws {
+    DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+      source: "hub",
+      mode: "hold",
+      audioSeconds: 2.14,
+      voicedSeconds: nil,
+      peak: 0,
+      rms: 0,
+      deviceDescription: "built-in id=123 Alice private microphone",
+      micPermissionGranted: true,
+      hubActive: true)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let snapshot = try XCTUnwrap(snapshots.last)
+
+    XCTAssertEqual(snapshot["event"] as? String, "ptt_audio_capture_silent_turn")
+    XCTAssertEqual(snapshot["input_device_class"] as? String, "built_in_mic")
+    XCTAssertEqual(snapshot["peak"] as? Int, 0)
+    XCTAssertEqual(snapshot["rms"] as? Int, 0)
+
+    let json = String(data: data, encoding: .utf8) ?? ""
+    XCTAssertFalse(json.contains("Alice"))
+    XCTAssertFalse(json.contains("private microphone"))
+    XCTAssertFalse(json.contains("id=123"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -3,6 +3,16 @@ import XCTest
 @testable import Omi_Computer
 
 final class DesktopDiagnosticsManagerTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    DesktopDiagnosticsManager.shared.resetForTests()
+  }
+
+  override func tearDown() {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    super.tearDown()
+  }
+
   func testDiagnosticsAttachmentUsesSafeOperationalFields() throws {
     DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
       source: "hub",
@@ -32,5 +42,32 @@ final class DesktopDiagnosticsManagerTests: XCTestCase {
     XCTAssertFalse(json.contains("Alice"))
     XCTAssertFalse(json.contains("private microphone"))
     XCTAssertFalse(json.contains("id=123"))
+  }
+
+  func testShortSilentTurnsDoNotAdvanceWatchdogCounter() throws {
+    for _ in 0..<3 {
+      DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+        source: "hub",
+        mode: "hold",
+        audioSeconds: 0,
+        voicedSeconds: nil,
+        peak: 0,
+        rms: 0,
+        deviceDescription: "built-in microphone",
+        micPermissionGranted: true,
+        hubActive: true)
+    }
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+
+    XCTAssertEqual(snapshots.count, 3)
+    XCTAssertTrue(snapshots.allSatisfy { $0["event"] as? String == "ptt_audio_capture_silent_turn" })
+    XCTAssertTrue(snapshots.allSatisfy { $0["watchdog_eligible"] as? Bool == false })
+    XCTAssertTrue(snapshots.allSatisfy { $0["consecutive_silent_turns"] as? Int == 0 })
   }
 }

--- a/desktop/macos/changelog/unreleased/20260630-privacy-safe-desktop-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/20260630-privacy-safe-desktop-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added privacy-safe desktop diagnostics for push-to-talk audio and realtime voice reliability"
+}


### PR DESCRIPTION
Closes Git-on-my-level/omi#35

## Summary
- Added a privacy-safe desktop diagnostics manager with an in-memory ring buffer and allowlisted operational fields for push-to-talk and realtime voice health.
- Emits aggregate PostHog `desktop_health_event` records and a thresholded Sentry warning for repeated near-zero PTT capture, attaching only safe snapshots.
- Adds a safe `desktop_diagnostics.json` attachment to explicit feedback reports while leaving raw logs user-initiated through the existing feedback path.
- Hooks PTT start/silence/commit/fallback and realtime token/close classifications, plus tests that verify raw device descriptions are not written and short cancelled turns do not advance the watchdog.

## Review fixes
- Gates the silent-capture watchdog on minimum captured audio duration so cancelled taps do not count as failures.
- Uses one canonical PTT mode for start, silence, and commit diagnostics, preserving `follow_up_` modes.
- Re-checks microphone permission before recording the PTT start diagnostic.
- Records built-in-mic fallback diagnostics only with concrete no-op/success/failure outcomes.
- Adds singleton reset coverage for diagnostics tests.

## Validation
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter 'DesktopDiagnosticsManagerTests|RealtimeHubCloseClassifierTests|PushToTalkStateMachineTests'`
- `git push origin codex/desktop-privacy-safe-diagnostics` passed repo fast pre-push checks with Node 22.
- Named bundle packaging for `omi-desktop-diagnostics` previously reached signing, but local launch was blocked because this machine has no valid code-signing identity (`security find-identity` reports 0 valid identities).