### PR TITLE
Add desktop credential health recovery

### DIFF
--- a/desktop/macos/Backend-Rust/src/auth.rs
+++ b/desktop/macos/Backend-Rust/src/auth.rs
@@ -13,7 +13,12 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::timeout;
+
+const UNKNOWN_KID_REFRESH_COOLDOWN: Duration = Duration::from_secs(5);
+const UNKNOWN_KID_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Firebase public keys cache
 /// Keys are fetched from Google's public key endpoint
@@ -24,6 +29,12 @@ pub struct FirebaseAuth {
     client: Client,
     /// Firebase project ID
     project_id: String,
+    /// Serializes on-demand JWK refreshes so an unknown kid burst only fetches once.
+    refresh_lock: Arc<Mutex<()>>,
+    /// Last on-demand refresh attempt for unknown kids. Throttles invalid-token probes.
+    last_unknown_kid_refresh: Arc<RwLock<Option<Instant>>>,
+    /// Whether the most recent unknown-kid refresh attempt failed.
+    last_unknown_kid_refresh_failed: Arc<RwLock<bool>>,
 }
 
 /// JWT Claims from Firebase ID token
@@ -84,6 +95,8 @@ impl IntoResponse for AuthError {
             StatusCode::PAYMENT_REQUIRED
         } else if self.error == "byok_validation_failed" {
             StatusCode::FORBIDDEN
+        } else if self.error == "jwks_refresh_failed" {
+            StatusCode::SERVICE_UNAVAILABLE
         } else {
             StatusCode::UNAUTHORIZED
         };
@@ -98,6 +111,9 @@ impl FirebaseAuth {
             keys: Arc::new(RwLock::new(HashMap::new())),
             client: Client::new(),
             project_id,
+            refresh_lock: Arc::new(Mutex::new(())),
+            last_unknown_kid_refresh: Arc::new(RwLock::new(None)),
+            last_unknown_kid_refresh_failed: Arc::new(RwLock::new(false)),
         }
     }
 
@@ -140,13 +156,6 @@ impl FirebaseAuth {
             message: "Token missing kid header".to_string(),
         })?;
 
-        // Get the key for this kid
-        let keys = self.keys.read().await;
-        let key = keys.get(&kid).ok_or_else(|| AuthError {
-            error: "invalid_token".to_string(),
-            message: format!("Unknown key id: {}", kid),
-        })?;
-
         // Set up validation
         let mut validation = Validation::new(jsonwebtoken::Algorithm::RS256);
         validation.set_audience(&[&self.project_id]);
@@ -155,18 +164,114 @@ impl FirebaseAuth {
             self.project_id
         )]);
 
-        // Decode and validate token
-        let token_data =
-            decode::<FirebaseClaims>(token, key, &validation).map_err(|e| AuthError {
-                error: "invalid_token".to_string(),
-                message: format!("Token validation failed: {}", e),
-            })?;
+        if let Some(result) = self
+            .try_decode_with_cached_key(token, &kid, &validation)
+            .await
+        {
+            let token_data = result?;
+            return Ok((
+                token_data.claims.sub,
+                token_data.claims.name,
+                token_data.claims.email,
+            ));
+        }
+
+        tracing::warn!("Firebase token kid unknown; refreshing JWKs once");
+        self.refresh_keys_for_unknown_kid().await?;
+
+        let result = self
+            .try_decode_with_cached_key(token, &kid, &validation)
+            .await;
+        let token_data = match result {
+            Some(result) => result?,
+            None => {
+                return Err(AuthError {
+                    error: "unknown_key_id".to_string(),
+                    message: "Firebase token key id is not recognized after JWK refresh"
+                        .to_string(),
+                });
+            }
+        };
 
         Ok((
             token_data.claims.sub,
             token_data.claims.name,
             token_data.claims.email,
         ))
+    }
+
+    async fn try_decode_with_cached_key(
+        &self,
+        token: &str,
+        kid: &str,
+        validation: &Validation,
+    ) -> Option<Result<jsonwebtoken::TokenData<FirebaseClaims>, AuthError>> {
+        let keys = self.keys.read().await;
+        let key = keys.get(kid)?;
+        Some(
+            decode::<FirebaseClaims>(token, key, validation).map_err(|e| AuthError {
+                error: "invalid_token".to_string(),
+                message: format!("Token validation failed: {}", e),
+            }),
+        )
+    }
+
+    async fn refresh_keys_for_unknown_kid(&self) -> Result<(), AuthError> {
+        let _guard = self.refresh_lock.lock().await;
+
+        {
+            let last = self.last_unknown_kid_refresh.read().await;
+            if last
+                .map(|instant| instant.elapsed() < UNKNOWN_KID_REFRESH_COOLDOWN)
+                .unwrap_or(false)
+            {
+                tracing::warn!(
+                    "Skipping Firebase JWK refresh; unknown-kid refresh was attempted recently"
+                );
+                if *self.last_unknown_kid_refresh_failed.read().await {
+                    return Err(AuthError {
+                        error: "jwks_refresh_failed".to_string(),
+                        message: "Firebase signing keys refresh was attempted recently and failed"
+                            .to_string(),
+                    });
+                }
+                return Ok(());
+            }
+        }
+
+        {
+            let mut last = self.last_unknown_kid_refresh.write().await;
+            *last = Some(Instant::now());
+        }
+
+        match timeout(UNKNOWN_KID_REFRESH_TIMEOUT, self.refresh_keys()).await {
+            Ok(Ok(())) => {
+                let mut failed = self.last_unknown_kid_refresh_failed.write().await;
+                *failed = false;
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                let mut failed = self.last_unknown_kid_refresh_failed.write().await;
+                *failed = true;
+                tracing::warn!("Firebase JWK refresh after unknown kid failed: {}", e);
+                Err(AuthError {
+                    error: "jwks_refresh_failed".to_string(),
+                    message: "Firebase signing keys could not be refreshed".to_string(),
+                })
+            }
+            Err(_) => {
+                let mut failed = self.last_unknown_kid_refresh_failed.write().await;
+                *failed = true;
+                tracing::warn!(
+                    "Firebase JWK refresh after unknown kid timed out after {:?}",
+                    UNKNOWN_KID_REFRESH_TIMEOUT
+                );
+                Err(AuthError {
+                    error: "jwks_refresh_failed".to_string(),
+                    message: "Firebase signing keys refresh timed out".to_string(),
+                })
+            }
+        }
     }
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -76,11 +76,16 @@ actor APIClient {
 
   // MARK: - Request Building
 
-  func buildHeaders(requireAuth: Bool = true) async throws -> [String: String] {
+  func buildHeaders(
+    requireAuth: Bool = true,
+    forceRefreshAuth: Bool = false,
+    includeBYOK: Bool = true
+  ) async throws -> [String: String] {
     var headers: [String: String] = [
       "Content-Type": "application/json",
       "X-App-Platform": "macos",
       "X-Request-Start-Time": String(Date().timeIntervalSince1970),
+      "X-Desktop-Request-ID": UUID().uuidString,
     ]
 
     if requireAuth {
@@ -88,15 +93,28 @@ actor APIClient {
         headers["Authorization"] = testHeader
       } else {
         let authService = await MainActor.run { AuthService.shared }
-        let authHeader = try await authService.getAuthHeader()
+        let authHeader = try await authService.getAuthHeader(forceRefresh: forceRefreshAuth)
         headers["Authorization"] = authHeader
       }
     }
 
     // BYOK: attach user-provided keys so the backend uses them for LLM/STT
     // calls this request triggers. Sent per-request; never stored server-side.
-    for (provider, entry) in APIKeyService.byokSnapshot {
-      headers[provider.headerName] = entry.key
+    if includeBYOK, APIKeyService.isByokActive {
+      let health = await MainActor.run { CredentialHealthManager.shared }
+      let snapshot = APIKeyService.byokSnapshot
+      for (provider, entry) in snapshot {
+        let canAttach = await MainActor.run {
+          health.canUseBYOK(provider: provider, fingerprint: entry.fingerprint)
+        }
+        if canAttach {
+          headers[provider.headerName] = entry.key
+        } else {
+          log(
+            "CredentialHealth: context=build_headers failure_class=byok_invalid_suppressed"
+              + " provider=\(provider.rawValue)")
+        }
+      }
     }
 
     return headers
@@ -122,14 +140,15 @@ actor APIClient {
     _ endpoint: String,
     body: B,
     requireAuth: Bool = true,
-    customBaseURL: String? = nil
+    customBaseURL: String? = nil,
+    includeBYOK: Bool = true
   ) async throws -> T {
     let base = customBaseURL ?? baseURL
     let url = URL(string: base + endpoint)!
     log("APIClient: POST \(url.absoluteString)")
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth)
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth, includeBYOK: includeBYOK)
     request.httpBody = try JSONEncoder().encode(body)
 
     return try await performRequest(request)
@@ -138,34 +157,98 @@ actor APIClient {
   func post<T: Decodable>(
     _ endpoint: String,
     requireAuth: Bool = true,
-    customBaseURL: String? = nil
+    customBaseURL: String? = nil,
+    includeBYOK: Bool = true
   ) async throws -> T {
     let base = customBaseURL ?? baseURL
     let url = URL(string: base + endpoint)!
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth)
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth, includeBYOK: includeBYOK)
 
     return try await performRequest(request)
   }
 
   /// Phase 2 realtime hub: ask the backend to mint a short-lived ephemeral token
-  /// for `provider` ("openai"|"gemini"). The backend gates on auth + paywall and
-  /// returns 402/403 if not entitled — any non-200 surfaces here as a thrown error,
-  /// so we return nil and the caller falls back to the legacy cascade.
-  func mintRealtimeToken(provider: String) async -> String? {
+  /// for `provider` ("openai"|"gemini"). The backend gates on auth + paywall.
+  /// Credential failures are typed so the hub can recover deterministically instead
+  /// of treating every failure as a silent fallback.
+  func mintRealtimeToken(provider: String) async throws -> String {
     struct Resp: Decodable { let token: String }
     let base = rustBackendURL
-    guard !base.isEmpty else { return nil }
+    guard !base.isEmpty else {
+      throw CredentialHealthError.backendTransient(
+        statusCode: nil,
+        message: "Desktop backend URL is not configured.")
+    }
     let normalized = base.hasSuffix("/") ? base : base + "/"
+    guard let url = URL(string: normalized + "v2/realtime/session") else {
+      throw CredentialHealthError.backendTransient(statusCode: nil, message: "Invalid desktop backend URL.")
+    }
+
+    let providerType = CredentialHealthManager.realtimeProvider(from: provider)
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true, includeBYOK: false)
+    request.httpBody = try JSONEncoder().encode(["provider": provider])
+
     do {
-      let resp: Resp = try await post(
-        "v2/realtime/session", body: ["provider": provider], customBaseURL: normalized)
-      return resp.token.isEmpty ? nil : resp.token
+      return try await performRealtimeMintRequest(request, provider: providerType, retriedAuth: false)
+    } catch let error as CredentialHealthError {
+      log("APIClient: realtime token mint failed for \(provider): \(error.localizedDescription)")
+      throw error
     } catch {
       log("APIClient: realtime token mint failed for \(provider): \(error.localizedDescription)")
-      return nil
+      throw CredentialHealthError.backendTransient(statusCode: nil, message: error.localizedDescription)
     }
+  }
+
+  private func performRealtimeMintRequest(
+    _ request: URLRequest,
+    provider: RealtimeHubProvider?,
+    retriedAuth: Bool
+  ) async throws -> String {
+    struct Resp: Decodable { let token: String }
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw CredentialHealthError.backendTransient(statusCode: nil, message: APIError.invalidResponse.localizedDescription)
+    }
+
+    if httpResponse.statusCode == 401, !retriedAuth {
+      let authService = await MainActor.run { AuthService.shared }
+      var retry = request
+      do {
+        retry.setValue(try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: "Authorization")
+      } catch AuthError.notSignedIn {
+        throw CredentialHealthError.requiresLogin(message: "Please sign in again to use voice responses.")
+      } catch {
+        throw CredentialHealthError.backendTransient(statusCode: nil, message: error.localizedDescription)
+      }
+
+      do {
+        let token = try await performRealtimeMintRequest(retry, provider: provider, retriedAuth: true)
+        log("CredentialHealth: context=realtime_mint_auth_retry failure_class=retry_succeeded")
+        return token
+      } catch let error as CredentialHealthError {
+        throw error
+      } catch {
+        throw CredentialHealthError.backendTransient(statusCode: nil, message: error.localizedDescription)
+      }
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+      let payload = Self.extractErrorPayload(from: data)
+      throw CredentialHealthManager.classifyHTTPFailure(
+        statusCode: httpResponse.statusCode,
+        payload: payload,
+        provider: provider)
+    }
+
+    let resp = try decoder.decode(Resp.self, from: data)
+    guard !resp.token.isEmpty else {
+      throw CredentialHealthError.backendTransient(statusCode: httpResponse.statusCode, message: "Realtime token was empty.")
+    }
+    return resp.token
   }
 
   /// Report a managed realtime turn's token usage so the backend can price it and record
@@ -211,13 +294,14 @@ actor APIClient {
   func delete(
     _ endpoint: String,
     requireAuth: Bool = true,
-    customBaseURL: String? = nil
+    customBaseURL: String? = nil,
+    includeBYOK: Bool = true
   ) async throws {
     let base = customBaseURL ?? baseURL
     let url = URL(string: base + endpoint)!
     var request = URLRequest(url: url)
     request.httpMethod = "DELETE"
-    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth)
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: requireAuth, includeBYOK: includeBYOK)
 
     let (_, response) = try await session.data(for: request)
 
@@ -247,11 +331,10 @@ actor APIClient {
     if httpResponse.statusCode == 401 {
       // Try to refresh token and retry once
       let authService = await MainActor.run { AuthService.shared }
-      _ = try await authService.getIdToken(forceRefresh: true)
 
       var retryRequest = request
       retryRequest.setValue(
-        try await authService.getAuthHeader(), forHTTPHeaderField: "Authorization")
+        try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: "Authorization")
 
       let (retryData, retryResponse) = try await session.data(for: retryRequest)
 
@@ -304,11 +387,18 @@ actor APIClient {
   }
 
   private static func extractErrorDetail(from data: Data) -> String? {
+    if let payload = extractErrorPayload(from: data) {
+      return payload.preferredMessage
+    }
     guard
       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
       let detail = json["detail"] as? String
     else { return nil }
     return detail
+  }
+
+  private static func extractErrorPayload(from data: Data) -> APIErrorPayload? {
+    try? JSONDecoder().decode(APIErrorPayload.self, from: data)
   }
 }
 
@@ -4829,13 +4919,13 @@ extension APIClient {
     }
     struct Empty: Decodable {}
     let _: Empty = try await post(
-      "v1/users/me/byok-active", body: Request(fingerprints: fingerprints)
+      "v1/users/me/byok-active", body: Request(fingerprints: fingerprints), includeBYOK: false
     )
   }
 
   /// Deactivate BYOK (user cleared keys) so they return to the paid plan gate.
   func deactivateBYOK() async throws {
-    try await delete("v1/users/me/byok-active")
+    try await delete("v1/users/me/byok-active", includeBYOK: false)
   }
 
   /// Fetches all people for the current user

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -946,8 +946,9 @@ class AuthService {
                 // where auth_isSignedIn=true but no valid tokens exist.
                 isSignedIn = false
                 saveAuthState(isSignedIn: false, email: nil, userId: nil)
+                throw AuthError.notSignedIn
             }
-            throw AuthError.notSignedIn
+            throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1001,6 +1002,7 @@ class AuthService {
 
         // Second try: Refresh using stored refresh token
         // Allow refresh when expectedUserId is nil (token was saved by valid sign-in)
+        var refreshFailure: Error?
         if let _ = storedRefreshToken {
             let tokenUserId = storedTokenUserId
             let canRefresh = tokenUserId == nil || expectedUserId == nil || tokenUserId == expectedUserId
@@ -1008,6 +1010,7 @@ class AuthService {
                 do {
                     return try await refreshIdToken()
                 } catch {
+                    refreshFailure = error
                     NSLog("OMI AUTH: Token refresh failed: %@", error.localizedDescription)
                 }
             }
@@ -1030,11 +1033,15 @@ class AuthService {
             }
         }
 
+        if let refreshFailure {
+            throw refreshFailure
+        }
+
         throw AuthError.notSignedIn
     }
 
-    func getAuthHeader() async throws -> String {
-        let token = try await getIdToken(forceRefresh: false)
+    func getAuthHeader(forceRefresh: Bool = false) async throws -> String {
+        let token = try await getIdToken(forceRefresh: forceRefresh)
         return "Bearer \(token)"
     }
 
@@ -1079,6 +1086,7 @@ class AuthService {
 
         try Auth.auth().signOut()
         isSignedIn = false
+        CredentialHealthManager.shared.reset()
         APIKeyService.shared.clear()
         // Clear saved auth state and tokens
         saveAuthState(isSignedIn: false, email: nil, userId: nil)

--- a/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
+++ b/desktop/macos/Desktop/Sources/CredentialHealthManager.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+enum CredentialAuthMode: String, Equatable {
+  case managed
+  case byok
+}
+
+enum CredentialFailureClass: Equatable {
+  case backendUnauthorized
+  case requiresLogin
+  case paywalled
+  case byokEnrollmentMismatch(provider: BYOKProvider?)
+  case providerAuthFailed(provider: RealtimeHubProvider, mode: CredentialAuthMode)
+  case providerQuotaExceeded(provider: RealtimeHubProvider)
+  case backendTransient(statusCode: Int?)
+  case providerTransient(provider: RealtimeHubProvider)
+  case providerPolicyClose(provider: RealtimeHubProvider)
+  case unknown
+
+  var isAccountWide: Bool {
+    switch self {
+    case .backendUnauthorized, .requiresLogin, .paywalled, .byokEnrollmentMismatch:
+      return true
+    default:
+      return false
+    }
+  }
+
+  var logValue: String {
+    switch self {
+    case .backendUnauthorized: return "backend_unauthorized"
+    case .requiresLogin: return "requires_login"
+    case .paywalled: return "paywalled"
+    case .byokEnrollmentMismatch: return "byok_enrollment_mismatch"
+    case .providerAuthFailed: return "provider_auth_failed"
+    case .providerQuotaExceeded: return "provider_quota_exceeded"
+    case .backendTransient: return "backend_transient"
+    case .providerTransient: return "provider_transient"
+    case .providerPolicyClose: return "provider_policy_close"
+    case .unknown: return "unknown"
+    }
+  }
+}
+
+struct CredentialRecoveryIssue: Equatable {
+  let failureClass: CredentialFailureClass
+  let message: String
+  let provider: RealtimeHubProvider?
+  let authMode: CredentialAuthMode?
+}
+
+enum CredentialHealthError: LocalizedError, Equatable {
+  case requiresLogin(message: String)
+  case paywalled(message: String)
+  case byokMismatch(provider: BYOKProvider?, message: String)
+  case providerAuth(provider: RealtimeHubProvider, mode: CredentialAuthMode, message: String)
+  case providerQuota(provider: RealtimeHubProvider, message: String)
+  case backendTransient(statusCode: Int?, message: String)
+  case providerTransient(provider: RealtimeHubProvider, message: String)
+  case unknown(message: String)
+
+  var failureClass: CredentialFailureClass {
+    switch self {
+    case .requiresLogin:
+      return .requiresLogin
+    case .paywalled:
+      return .paywalled
+    case .byokMismatch(let provider, _):
+      return .byokEnrollmentMismatch(provider: provider)
+    case .providerAuth(let provider, let mode, _):
+      return .providerAuthFailed(provider: provider, mode: mode)
+    case .providerQuota(let provider, _):
+      return .providerQuotaExceeded(provider: provider)
+    case .backendTransient(let statusCode, _):
+      return .backendTransient(statusCode: statusCode)
+    case .providerTransient(let provider, _):
+      return .providerTransient(provider: provider)
+    case .unknown:
+      return .unknown
+    }
+  }
+
+  var provider: RealtimeHubProvider? {
+    switch self {
+    case .providerAuth(let provider, _, _), .providerQuota(let provider, _), .providerTransient(let provider, _):
+      return provider
+    default:
+      return nil
+    }
+  }
+
+  var authMode: CredentialAuthMode? {
+    switch self {
+    case .providerAuth(_, let mode, _):
+      return mode
+    default:
+      return nil
+    }
+  }
+
+  var errorDescription: String? {
+    switch self {
+    case .requiresLogin(let message),
+      .paywalled(let message),
+      .byokMismatch(_, let message),
+      .providerAuth(_, _, let message),
+      .providerQuota(_, let message),
+      .backendTransient(_, let message),
+      .providerTransient(_, let message),
+      .unknown(let message):
+      return message
+    }
+  }
+}
+
+@MainActor
+final class CredentialHealthManager: ObservableObject {
+  static let shared = CredentialHealthManager()
+
+  @Published private(set) var visibleRecovery: CredentialRecoveryIssue?
+
+  private var invalidBYOKFingerprints: [BYOKProvider: String] = [:]
+
+  private init() {}
+
+  func reset() {
+    visibleRecovery = nil
+    invalidBYOKFingerprints.removeAll()
+  }
+
+  func canUseBYOK(provider: BYOKProvider, fingerprint: String?) -> Bool {
+    guard let fingerprint, let invalid = invalidBYOKFingerprints[provider] else { return true }
+    return invalid != fingerprint
+  }
+
+  func record(_ error: CredentialHealthError, context: String) {
+    record(
+      failureClass: error.failureClass,
+      provider: error.provider,
+      authMode: error.authMode,
+      message: error.localizedDescription,
+      context: context)
+  }
+
+  func recordProviderFailure(
+    _ failureClass: CredentialFailureClass,
+    provider: RealtimeHubProvider,
+    authMode: CredentialAuthMode,
+    fingerprint: String?,
+    context: String
+  ) {
+    if case .providerAuthFailed(_, .byok) = failureClass, let fingerprint {
+      invalidBYOKFingerprints[provider.byokProvider] = fingerprint
+    }
+    record(
+      failureClass: failureClass,
+      provider: provider,
+      authMode: authMode,
+      message: recoveryMessage(for: failureClass, provider: provider),
+      context: context)
+  }
+
+  private func record(
+    failureClass: CredentialFailureClass,
+    provider: RealtimeHubProvider?,
+    authMode: CredentialAuthMode?,
+    message: String,
+    context: String
+  ) {
+    visibleRecovery = CredentialRecoveryIssue(
+      failureClass: failureClass,
+      message: message,
+      provider: provider,
+      authMode: authMode)
+    log(
+      "CredentialHealth: context=\(context) failure_class=\(failureClass.logValue)"
+        + " provider=\(provider?.rawValue ?? "none") auth_mode=\(authMode?.rawValue ?? "none")")
+  }
+
+  private func recoveryMessage(for failureClass: CredentialFailureClass, provider: RealtimeHubProvider) -> String {
+    switch failureClass {
+    case .providerAuthFailed(_, .byok):
+      return "Your \(provider.displayName) key was rejected. Update it in Settings."
+    case .providerAuthFailed:
+      return "\(provider.displayName) authentication failed. Voice responses are using fallback."
+    case .providerQuotaExceeded:
+      return "Your \(provider.displayName) quota is exhausted. Add quota or switch providers."
+    case .providerPolicyClose:
+      return "\(provider.displayName) rejected the realtime session. Voice responses are using fallback."
+    case .providerTransient:
+      return "\(provider.displayName) is temporarily unavailable. Voice responses are using fallback."
+    default:
+      return "Voice credential recovery is required."
+    }
+  }
+
+  nonisolated static func realtimeProvider(from raw: String) -> RealtimeHubProvider? {
+    switch raw.lowercased() {
+    case "openai": return .openai
+    case "gemini": return .gemini
+    default: return nil
+    }
+  }
+
+  nonisolated static func classifyHTTPFailure(
+    statusCode: Int,
+    payload: APIErrorPayload?,
+    provider: RealtimeHubProvider?
+  ) -> CredentialHealthError {
+    let message = payload?.preferredMessage ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
+    switch statusCode {
+    case 401:
+      return .requiresLogin(message: "Please sign in again to use voice responses.")
+    case 402:
+      return .paywalled(message: message.isEmpty ? "Upgrade or add BYOK keys to use voice responses." : message)
+    case 403:
+      return .byokMismatch(provider: nil, message: message.isEmpty ? "Revalidate your BYOK keys in Settings." : message)
+    case 429:
+      if let provider {
+        return .providerQuota(provider: provider, message: message)
+      }
+      return .backendTransient(statusCode: statusCode, message: message)
+    case 500...599:
+      return .backendTransient(statusCode: statusCode, message: message)
+    default:
+      if let provider, containsProviderAuthSignal(message) {
+        return .providerAuth(provider: provider, mode: .managed, message: message)
+      }
+      return .unknown(message: message)
+    }
+  }
+
+  nonisolated static func classifyProviderClose(
+    message: String,
+    provider: RealtimeHubProvider
+  ) -> CredentialFailureClass {
+    let lower = message.lowercased()
+    if lower.contains("insufficient_quota") || lower.contains("quota") || lower.contains("resource exhausted")
+      || lower.contains("429")
+    {
+      return .providerQuotaExceeded(provider: provider)
+    }
+    if containsProviderAuthSignal(lower) {
+      return .providerAuthFailed(provider: provider, mode: .byok)
+    }
+    if lower.contains("websocket closed (1008)") || lower.contains("policy") {
+      return .providerPolicyClose(provider: provider)
+    }
+    return .providerTransient(provider: provider)
+  }
+
+  nonisolated private static func containsProviderAuthSignal(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("invalid api key")
+      || lower.contains("api key not valid")
+      || lower.contains("invalid authentication credentials")
+      || lower.contains("unauthorized")
+      || lower.contains("authentication failed")
+      || lower.contains("permission denied")
+  }
+}
+
+struct APIErrorPayload: Decodable, Equatable {
+  let error: String?
+  let code: String?
+  let message: String?
+  let detail: String?
+  let provider: String?
+  let retryAfterSeconds: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case error
+    case code
+    case message
+    case detail
+    case provider
+    case retryAfterSeconds = "retry_after_seconds"
+  }
+
+  var preferredMessage: String? {
+    detail ?? message ?? error ?? code
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -28,7 +28,10 @@ import Foundation
 /// reported, but with a stable category instead of raw provider text.
 enum RealtimeHubCloseCategory: String {
   case expectedIdleTeardown = "expected_idle_teardown"
+  case providerAuthFailed = "provider_auth_failed"
+  case providerQuotaExceeded = "provider_quota_exceeded"
   case providerPolicyCloseFast = "provider_policy_close_fast"
+  case providerTransient = "provider_transient"
 }
 
 enum RealtimeHubCloseClassifier {
@@ -41,6 +44,18 @@ enum RealtimeHubCloseClassifier {
   ) -> RealtimeHubCloseCategory? {
     let lower = message.lowercased()
     guard lower.contains("websocket closed (1008)") else { return nil }
+    if CredentialHealthManager.classifyProviderClose(
+      message: message,
+      provider: .openai) == .providerQuotaExceeded(provider: .openai)
+    {
+      return .providerQuotaExceeded
+    }
+    if CredentialHealthManager.classifyProviderClose(
+      message: message,
+      provider: .openai) == .providerAuthFailed(provider: .openai, mode: .byok)
+    {
+      return .providerAuthFailed
+    }
     if !hasActiveTurn && aliveFor >= idleTeardownThreshold { return .expectedIdleTeardown }
     return .providerPolicyCloseFast
   }
@@ -309,6 +324,23 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     if session != nil { teardownSession() }
 
     if let key = APIKeyService.byokKey(provider.byokProvider) {
+      let fingerprint = APIKeyService.byokFingerprint(key)
+      guard CredentialHealthManager.shared.canUseBYOK(provider: provider.byokProvider, fingerprint: fingerprint) else {
+        log("RealtimeHub: skipping known-bad \(provider.displayName) BYOK key fingerprint")
+        if failoverToAlternateProvider() {
+          return
+        } else if AuthService.shared.isSignedIn {
+          mintAndConnect(provider: provider)
+        } else {
+          CredentialHealthManager.shared.recordProviderFailure(
+            .providerAuthFailed(provider: provider, mode: .byok),
+            provider: provider,
+            authMode: .byok,
+            fingerprint: fingerprint,
+            context: "realtime_byok_blocked")
+        }
+        return
+      }
       startSession(provider: provider, auth: .byokKey(key))
     } else if AuthService.shared.isSignedIn {
       mintAndConnect(provider: provider)
@@ -326,21 +358,37 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     let providerParam = provider == .openai ? "openai" : "gemini"
     log("RealtimeHub: minting ephemeral \(provider.displayName) token (managed)")
     Task { [weak self] in
-      let token = await APIClient.shared.mintRealtimeToken(provider: providerParam)
       guard let self else { return }
-      self.minting = false
-      guard let token else {
+      let token: String
+      do {
+        token = try await APIClient.shared.mintRealtimeToken(provider: providerParam)
+      } catch let error as CredentialHealthError {
+        self.minting = false
+        CredentialHealthManager.shared.record(error, context: "realtime_mint")
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
-          reason: "unknown",
+          reason: error.failureClass.logValue,
           phase: "warm")
-        // Mint failed for this provider — try the OTHER realtime provider before the
-        // legacy Claude cascade.
+        if error.failureClass.isAccountWide {
+          log("RealtimeHub: account credential failure during mint — staying on cascade")
+        } else if !self.failoverToAlternateProvider() {
+          log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
+        }
+        return
+      } catch {
+        self.minting = false
+        let typed = CredentialHealthError.backendTransient(statusCode: nil, message: error.localizedDescription)
+        CredentialHealthManager.shared.record(typed, context: "realtime_mint")
+        DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+          provider: providerParam,
+          reason: "backend_transient",
+          phase: "warm")
         if !self.failoverToAlternateProvider() {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
         return
       }
+      self.minting = false
       // Provider may have changed (picker/failover) while minting; only connect if still wanted.
       guard self.effectiveProvider == provider, self.session == nil
       else { return }
@@ -418,22 +466,37 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     let providerParam = provider == .openai ? "openai" : "gemini"
     log("RealtimeHub[\(provider.displayName)]: minting fresh token for barge-in replacement")
     Task { [weak self] in
-      let token = await APIClient.shared.mintRealtimeToken(provider: providerParam)
       guard let self else { return }
-      self.minting = false
-      guard self.bargeInReplacementInFlight else { return }
+      guard self.bargeInReplacementInFlight else {
+        self.minting = false
+        return
+      }
       guard self.effectiveProvider == provider, self.session == nil else {
+        self.minting = false
         self.clearBargeInReplacementState()
         self.ensureWarm()
         return
       }
-      guard let token else {
-        self.failBargeInReplacement(provider: provider, reason: "token mint failed")
+      let token: String
+      do {
+        token = try await APIClient.shared.mintRealtimeToken(provider: providerParam)
+      } catch let error as CredentialHealthError {
+        self.minting = false
+        CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")
+        self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
+        if !error.failureClass.isAccountWide, !self.failoverToAlternateProvider() {
+          log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement token mint failed")
+        }
+        return
+      } catch {
+        self.minting = false
+        self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
         if !self.failoverToAlternateProvider() {
           log("⚠️ RealtimeHub[\(provider.displayName)]: barge-in replacement token mint failed")
         }
         return
       }
+      self.minting = false
       self.startReplacementSessionForBargeIn(provider: provider, auth: .ephemeral(token))
     }
   }
@@ -1046,8 +1109,31 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
       message: message,
       aliveFor: aliveFor,
       hasActiveTurn: hasActiveTurn)
+    let provider = sessionProvider
+    let authMode: CredentialAuthMode = sessionAuth?.isEphemeral == true ? .managed : .byok
+    let fingerprint = provider.flatMap { APIKeyService.byokKey($0.byokProvider) }.map(APIKeyService.byokFingerprint)
+    var credentialFailureClass: CredentialFailureClass?
+    if let provider, closeCategory != .expectedIdleTeardown {
+      var failureClass = CredentialHealthManager.classifyProviderClose(message: message, provider: provider)
+      if authMode == .managed, case .providerAuthFailed = failureClass {
+        failureClass = .providerAuthFailed(provider: provider, mode: .managed)
+      }
+      credentialFailureClass = failureClass
+      CredentialHealthManager.shared.recordProviderFailure(
+        failureClass,
+        provider: provider,
+        authMode: authMode,
+        fingerprint: fingerprint,
+        context: "realtime_socket")
+    }
     let categoryText = closeCategory.map { " category=\($0.rawValue)" } ?? ""
-    let safeMessage = closeCategory == .providerPolicyCloseFast ? "" : " \(message)"
+    let shouldRedactProviderMessage: Bool = {
+      if closeCategory == .providerPolicyCloseFast { return true }
+      if case .providerAuthFailed = credentialFailureClass { return true }
+      if case .providerQuotaExceeded = credentialFailureClass { return true }
+      return false
+    }()
+    let safeMessage = shouldRedactProviderMessage ? "" : " \(message)"
     DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
       provider: providerTag,
       category: closeCategory?.rawValue,
@@ -1071,6 +1157,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
     // A session that died fast (connected, then the provider rejected/aborted it — e.g.
     // Gemini close 1008 / 429) is a real provider failure: try the OTHER realtime provider
     // before the cascade. One that lived long was a normal idle-close → re-warm the same.
+    if case .providerAuthFailed = credentialFailureClass {
+      if aliveFor < 10, failoverToAlternateProvider() { return }
+      return
+    }
+    if case .providerQuotaExceeded = credentialFailureClass {
+      if failoverToAlternateProvider() { return }
+      return
+    }
     if aliveFor < 10, failoverToAlternateProvider() { return }
     // Re-warm so the NEXT PTT uses the hub, not the STT cascade. Gemini idle-closes
     // the socket (~2.5 min, close 1008) even before the first turn; managed users have

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -182,8 +182,14 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
         auth = .byokKey(key)
       } else {
         let p = provider == .openai ? "openai" : "gemini"
-        guard let token = await APIClient.shared.mintRealtimeToken(provider: p) else {
-          return ["error": "ephemeral mint failed for \(p) (check backend route + entitlement)"]
+        let token: String
+        do {
+          token = try await APIClient.shared.mintRealtimeToken(provider: p)
+        } catch {
+          return [
+            "error": "ephemeral mint failed for \(p)",
+            "detail": error.localizedDescription,
+          ]
         }
         auth = .ephemeral(token)
       }

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -478,11 +478,11 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(hubSource.contains("private var bargeInReplacementAudioBuffer: [Data] = []"))
     XCTAssertTrue(hubSource.contains("private func restartSessionForBargeIn() -> Bool"))
     XCTAssertTrue(hubSource.contains("case .ephemeral:\n      remintReplacementSessionForBargeIn(provider: provider)"))
-    XCTAssertTrue(hubSource.contains("let token = await APIClient.shared.mintRealtimeToken(provider: providerParam)"))
+    XCTAssertTrue(hubSource.contains("token = try await APIClient.shared.mintRealtimeToken(provider: providerParam)"))
     XCTAssertTrue(hubSource.contains("startReplacementSessionForBargeIn(provider: provider, auth: .ephemeral(token))"))
     XCTAssertTrue(hubSource.contains("bargeInReplacementAudioBuffer.append(pcm16k)"))
     XCTAssertTrue(hubSource.contains("bargeInReplacementPendingCommit = true"))
-    XCTAssertTrue(hubSource.contains("failBargeInReplacement(provider: provider, reason: \"token mint failed\")"))
+    XCTAssertTrue(hubSource.contains("failBargeInReplacement(provider: provider, reason: error.localizedDescription)"))
     XCTAssertTrue(hubSource.contains("if provider == .gemini, let speculativeScreenshot"))
     XCTAssertTrue(hubSource.contains("session?.sendVideoFrame(speculativeScreenshot, mime: \"image/jpeg\")"))
     XCTAssertTrue(hubSource.contains("responding = false\n    realtimePlaybackActive = false"))
@@ -508,6 +508,33 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(sessionSource.contains("return eventResponseID == expected"))
     XCTAssertFalse(sessionSource.contains("guard let expected = openAIActiveResponseID else { return true }"))
     XCTAssertTrue(sessionSource.contains("ignoring stale response.done"))
+  }
+
+  func testCredentialHealthRetryAndFailoverInvariants() throws {
+    let apiSource = try apiClientSource()
+    let hubSource = try realtimeHubControllerSource()
+
+    XCTAssertTrue(
+      apiSource.contains("try await authService.getAuthHeader(forceRefresh: true), forHTTPHeaderField: \"Authorization\")"),
+      "Backend 401 retry paths must force-refresh Firebase auth")
+    XCTAssertTrue(
+      apiSource.contains("throw CredentialHealthError.backendTransient(statusCode: nil, message: error.localizedDescription)"),
+      "Realtime mint retry transport failures must stay transient, not requires-login")
+    XCTAssertTrue(
+      apiSource.contains("} catch AuthError.notSignedIn {\n        throw CredentialHealthError.requiresLogin"),
+      "Only definitive not-signed-in refresh failures should become requires-login")
+    XCTAssertTrue(
+      hubSource.contains("self.minting = false\n        CredentialHealthManager.shared.record(error, context: \"realtime_mint\")"),
+      "Mint failure must clear minting before failover starts the alternate provider")
+    XCTAssertTrue(
+      hubSource.contains("if case .providerAuthFailed = credentialFailureClass {\n      if aliveFor < 10, failoverToAlternateProvider() { return }"),
+      "Provider auth failures should try alternate provider before stopping reconnect")
+    XCTAssertTrue(
+      hubSource.contains("if case .providerQuotaExceeded = credentialFailureClass {\n      if failoverToAlternateProvider() { return }"),
+      "Provider quota failures should try alternate provider regardless of socket age")
+    XCTAssertTrue(
+      hubSource.contains("let shouldRedactProviderMessage: Bool"),
+      "Credential close logs must redact raw provider auth/quota payloads")
   }
 
   func testSpeechSynthesizerDidCancelClearsGlow() throws {
@@ -971,6 +998,14 @@ final class AgentPillLifecycleTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/RealtimeHubController.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private func apiClientSource() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/APIClient.swift")
     return try String(contentsOf: sourceURL, encoding: .utf8)
   }
 

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -22,6 +22,7 @@ final class BYOKPaywallTests: XCTestCase {
     }
 
     override func tearDown() {
+        CredentialHealthManager.shared.reset()
         clearAllBYOKKeys()
         UserDefaults.standard.removeObject(forKey: paywallKey)
         super.tearDown()
@@ -40,6 +41,49 @@ final class BYOKPaywallTests: XCTestCase {
         // All four → active
         setAllBYOKKeys()
         XCTAssertTrue(APIKeyService.isByokActive)
+    }
+
+    func testBuildHeadersDoesNotAttachPartialByokKeys() async throws {
+        clearAllBYOKKeys()
+        UserDefaults.standard.set("sk-test-openai", forKey: BYOKProvider.openai.storageKey)
+
+        let client = APIClient()
+        await client.setTestAuthHeader("Bearer test-token")
+        let headers = try await client.buildHeaders()
+
+        XCTAssertNil(headers[BYOKProvider.openai.headerName])
+    }
+
+    func testBuildHeadersCanExplicitlyExcludeByokKeys() async throws {
+        setAllBYOKKeys()
+
+        let client = APIClient()
+        await client.setTestAuthHeader("Bearer test-token")
+        let headers = try await client.buildHeaders(includeBYOK: false)
+
+        for provider in BYOKProvider.allCases {
+            XCTAssertNil(headers[provider.headerName])
+        }
+    }
+
+    func testBuildHeadersSuppressesOnlyInvalidByokHeader() async throws {
+        setAllBYOKKeys()
+        let openAIKey = try XCTUnwrap(APIKeyService.byokKey(.openai))
+        CredentialHealthManager.shared.recordProviderFailure(
+            .providerAuthFailed(provider: .openai, mode: .byok),
+            provider: .openai,
+            authMode: .byok,
+            fingerprint: APIKeyService.byokFingerprint(openAIKey),
+            context: "test")
+
+        let client = APIClient()
+        await client.setTestAuthHeader("Bearer test-token")
+        let headers = try await client.buildHeaders()
+
+        XCTAssertNil(headers[BYOKProvider.openai.headerName])
+        for provider in BYOKProvider.allCases where provider != .openai {
+            XCTAssertEqual(headers[provider.headerName], "sk-test-\(provider.rawValue)")
+        }
     }
 
     func testPaywallFlagSuppressedWhenByokActive() {

--- a/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
@@ -39,4 +39,20 @@ final class RealtimeHubCloseClassifierTests: XCTestCase {
     XCTAssertNil(category)
     XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
   }
+
+  func testCredentialClassifierDetectsProviderAuthFailures() {
+    let failure = CredentialHealthManager.classifyProviderClose(
+      message: "Request had invalid authentication credentials",
+      provider: .openai)
+
+    XCTAssertEqual(failure, .providerAuthFailed(provider: .openai, mode: .byok))
+  }
+
+  func testCredentialClassifierDetectsQuotaFailures() {
+    let failure = CredentialHealthManager.classifyProviderClose(
+      message: "insufficient_quota.insufficient_quota",
+      provider: .gemini)
+
+    XCTAssertEqual(failure, .providerQuotaExceeded(provider: .gemini))
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260630-credential-health-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260630-credential-health-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved voice response recovery when sign-in or provider credentials become stale"
+}


### PR DESCRIPTION
## Summary
- add a desktop credential health manager that classifies auth/payment/credential failures and coordinates recovery
- retry realtime hub handshakes after recoverable credential refreshes and fail over cleanly when recovery is exhausted
- refresh Firebase JWKs on unknown key IDs in the desktop Rust backend

## Validation
- cargo test -q in desktop/macos/Backend-Rust
- xcrun swift build -c debug --package-path Desktop

## Diff check
- origin/main...HEAD is 0 behind / 1 ahead
- 10 files changed, 715 insertions, 55 deletions

Fixes Git-on-my-level/omi#34

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

