### PR TITLE
[codex] Make hosted MCP transport stateless

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -11,10 +11,9 @@ import asyncio
 import json
 import logging
 import os
-import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Union, List, Any
+from typing import Optional, Any
 from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
 
 import firebase_admin.auth
@@ -54,9 +53,6 @@ from utils.mcp_memories import (
 router = APIRouter()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
-
-# Store active sessions
-active_sessions: dict = {}
 
 MCP_RESOURCE_URL = mcp_oauth_db.MCP_RESOURCE_URL
 MCP_AUTHORIZATION_SERVER_URL = os.getenv("MCP_AUTHORIZATION_SERVER_URL", "https://api.omi.me")
@@ -116,16 +112,6 @@ GOALS_READ_SECURITY = [{"type": "oauth2", "scopes": ["goals.read"]}]
 CHAT_READ_SECURITY = [{"type": "oauth2", "scopes": ["chat.read"]}]
 SCREEN_ACTIVITY_READ_SECURITY = [{"type": "oauth2", "scopes": ["screen_activity.read"]}]
 PEOPLE_READ_SECURITY = [{"type": "oauth2", "scopes": ["people.read"]}]
-
-
-class MCPSession:
-    """Represents an active MCP session."""
-
-    def __init__(self, session_id: str, user_id: str):
-        self.session_id = session_id
-        self.user_id = user_id
-        self.created_at = datetime.utcnow()
-        self.initialized = False
 
 
 @dataclass
@@ -1160,9 +1146,7 @@ def create_mcp_error(id: Any, code: int, message: str) -> dict:
     return {"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}}
 
 
-def handle_mcp_message(
-    auth_context: MCPAuthContext, message: dict, session: Optional[MCPSession] = None
-) -> tuple[Optional[dict], Optional[str]]:
+def handle_mcp_message(auth_context: MCPAuthContext, message: dict) -> tuple[Optional[dict], Optional[str]]:
     """
     Process an incoming MCP JSON-RPC message and return a response.
     Returns (response, new_session_id) tuple.
@@ -1170,16 +1154,8 @@ def handle_mcp_message(
     msg_id = message.get("id")
     method = message.get("method")
     params = message.get("params", {})
-    new_session_id = None
 
     if method == "initialize":
-        # Create a new session
-        session_id = str(uuid.uuid4())
-        new_session = MCPSession(session_id, auth_context.uid)
-        new_session.initialized = True
-        active_sessions[session_id] = new_session
-        new_session_id = session_id
-
         return (
             create_mcp_response(
                 msg_id,
@@ -1195,7 +1171,7 @@ def handle_mcp_message(
                     ),
                 },
             ),
-            new_session_id,
+            None,
         )
 
     elif method == "notifications/initialized":
@@ -1441,7 +1417,7 @@ async def mcp_streamable_http(
 
     - POST JSON-RPC messages to this endpoint
     - Responses are returned as SSE stream or JSON depending on Accept header
-    - Session ID is returned in Mcp-Session-Id header after initialization
+    - This hosted transport is stateless; bearer-token auth scopes every request
     """
     # Authenticate
     auth_context = await run_blocking(db_executor, authenticate_mcp_request, authorization)
@@ -1457,16 +1433,6 @@ async def mcp_streamable_http(
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON body")
 
-    # Get session if provided
-    session = None
-    if mcp_session_id:
-        if mcp_session_id not in active_sessions:
-            raise HTTPException(status_code=404, detail="Session not found")
-        session = active_sessions[mcp_session_id]
-        # Verify session belongs to this user
-        if session.user_id != auth_context.uid:
-            raise HTTPException(status_code=403, detail="Session does not belong to this user")
-
     # Handle batch requests (array of messages)
     messages = body if isinstance(body, list) else [body]
 
@@ -1476,7 +1442,7 @@ async def mcp_streamable_http(
     if all_notifications:
         # Process notifications without response
         for msg in messages:
-            await run_blocking(db_executor, handle_mcp_message, auth_context, msg, session)
+            await run_blocking(db_executor, handle_mcp_message, auth_context, msg)
         return Response(status_code=202)
 
     # Process messages and collect responses
@@ -1484,7 +1450,7 @@ async def mcp_streamable_http(
     new_session_id = None
 
     for msg in messages:
-        response, session_id = await run_blocking(db_executor, handle_mcp_message, auth_context, msg, session)
+        response, session_id = await run_blocking(db_executor, handle_mcp_message, auth_context, msg)
         if session_id:
             new_session_id = session_id
         if response:
@@ -1534,6 +1500,8 @@ async def mcp_sse_get(
     if not auth_context:
         raise invalid_mcp_auth_exception()
 
+    await run_blocking(critical_executor, check_rate_limit_inline, auth_context.uid, "mcp:sse")
+
     # For backwards compatibility, also support the old SSE flow
     # Return an empty SSE stream that just sends keepalives
     async def event_generator():
@@ -1575,18 +1543,8 @@ def mcp_delete_session(
     if not auth_context:
         raise invalid_mcp_auth_exception("Invalid or missing API key")
 
-    if not mcp_session_id:
-        raise HTTPException(status_code=400, detail="Mcp-Session-Id header required")
-
-    if mcp_session_id not in active_sessions:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    session = active_sessions[mcp_session_id]
-    if session.user_id != auth_context.uid:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this session")
-
-    # Delete the session
-    del active_sessions[mcp_session_id]
+    # Hosted MCP is stateless; terminate requests are best-effort so stale
+    # or load-balanced session ids do not create client-visible errors.
     return Response(status_code=204)
 
 

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -7,6 +7,7 @@ stubbing pattern in test_mcp_search_memories.py.
 """
 
 from datetime import datetime, timezone
+import json
 from unittest.mock import patch, MagicMock
 import os
 import sys
@@ -147,6 +148,21 @@ NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
 UID = "user-1"
 
 
+async def _run_blocking_inline(_executor, func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+class _JsonRequest:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+    async def is_disconnected(self):
+        return False
+
+
 def test_sse_tools_list_filters_by_oauth_scopes():
     auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
     response, session_id = sse.handle_mcp_message(auth_context, {'id': 1, 'method': 'tools/list'})
@@ -157,6 +173,57 @@ def test_sse_tools_list_filters_by_oauth_scopes():
     assert 'search_memories' in names
     assert 'create_memory' not in names
     assert 'get_conversations' not in names
+
+
+@pytest.mark.asyncio
+async def test_sse_post_tools_list_accepts_missing_session_id():
+    auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
+    request = _JsonRequest({'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'})
+
+    with patch.object(sse, 'run_blocking', side_effect=_run_blocking_inline), patch.object(
+        sse, 'authenticate_mcp_request', return_value=auth_context
+    ):
+        response = await sse.mcp_streamable_http(request, authorization='Bearer token', accept=None)
+
+    payload = json.loads(response.body)
+    names = {tool['name'] for tool in payload['result']['tools']}
+    assert response.status_code == 200
+    assert 'get_memories' in names
+
+
+@pytest.mark.asyncio
+async def test_sse_post_tools_list_ignores_stale_session_id():
+    auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
+    request = _JsonRequest({'jsonrpc': '2.0', 'id': 1, 'method': 'tools/list'})
+
+    with patch.object(sse, 'run_blocking', side_effect=_run_blocking_inline), patch.object(
+        sse, 'authenticate_mcp_request', return_value=auth_context
+    ):
+        response = await sse.mcp_streamable_http(
+            request,
+            authorization='Bearer token',
+            mcp_session_id='session-from-another-instance',
+            accept=None,
+        )
+
+    payload = json.loads(response.body)
+    names = {tool['name'] for tool in payload['result']['tools']}
+    assert response.status_code == 200
+    assert 'get_memories' in names
+
+
+@pytest.mark.asyncio
+async def test_sse_get_keepalive_uses_transport_rate_limit():
+    auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
+    request = _JsonRequest({})
+
+    with patch.object(sse, 'run_blocking', side_effect=_run_blocking_inline), patch.object(
+        sse, 'authenticate_mcp_request', return_value=auth_context
+    ), patch.object(sse, 'check_rate_limit_inline') as check_rate_limit:
+        response = await sse.mcp_sse_get(request, authorization='Bearer token')
+
+    assert response.status_code == 200
+    check_rate_limit.assert_called_once_with(UID, 'mcp:sse')
 
 
 def test_sse_tool_security_schemes_match_runtime_scope_map():


### PR DESCRIPTION
## Summary

- Make hosted `/v1/mcp/sse` POST handling stateless: bearer-token auth/scopes remain required, but `Mcp-Session-Id` no longer depends on process-local storage.
- Stop returning new session ids from `initialize` and make DELETE best-effort/idempotent for stale or load-balanced session ids.
- Apply the existing `mcp:sse` transport rate limit to the optional GET keepalive stream.
- Add regression coverage for missing/stale session IDs and GET keepalive rate limiting.

Fixes Git-on-my-level/omi#38.

## Root cause

`/v1/mcp/sse` stored initialized MCP sessions in a module-level dict. In prod, follow-up requests can land on a different backend instance and fail with `{"detail":"Session not found"}` even though the bearer token is valid.

## Validation

- `backend/test-preflight.sh`
- `python -m pytest backend/tests/unit/test_mcp_data_endpoints.py -q`
- `python backend/scripts/scan_async_blockers.py`
- `backend/test.sh`

## Notes

- Parallel review found one broader follow-up: `validate_access_token()` writes `last_used_at` on every request, which can make active MCP grants a hot Firestore document. I left that out of this PR because it needs a small usage-write design rather than a transport-only patch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

