### PR TITLE
[codex] Guard backend runtime env drift

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -133,6 +133,11 @@ jobs:
           chmod +x /usr/local/bin/yq
           bash backend/scripts/sync_cloudrun_secrets_from_chart.sh ${{ vars.ENV }} backend backend-sync backend-integration
 
+      - name: Validate backend runtime env
+        run: |
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/validate-backend-runtime-env.py --env ${{ vars.ENV }} --check-live-cloud-run
+
       # If required, use the Cloud Run url output in later steps
       - name: Show Output
         run: echo ${{ steps.deploy-backend.outputs.url }}

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -78,18 +78,6 @@ jobs:
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
 
-      # Mirror every secret declared in backend-secrets chart into Cloud Run
-      # (additive). The GKE pods get them via the helm chart's ExternalSecret;
-      # Cloud Run needs the matching --update-secrets bindings. Without this,
-      # a new chart key (e.g. X_OAUTH_CLIENT_ID) ships to GKE but stays
-      # undefined on the Cloud Run revisions that api.omi.me / api.omiapi.com
-      # actually serve, and the new code reads None.
-      - name: Sync Cloud Run secrets from backend-secrets chart
-        run: |
-          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
-          bash backend/scripts/sync_cloudrun_secrets_from_chart.sh dev backend backend-sync backend-integration
-
       - name: Deploy ${{ env.SERVICE }}-sync to Cloud Run
         id: deploy-backend-sync
         uses: google-github-actions/deploy-cloudrun@v2
@@ -144,6 +132,23 @@ jobs:
           secrets: |
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
+
+      # Mirror every secret declared in backend-secrets chart into Cloud Run
+      # (additive). The GKE pods get them via the helm chart's ExternalSecret;
+      # Cloud Run needs the matching --update-secrets bindings. Without this,
+      # a new chart key (e.g. X_OAUTH_CLIENT_ID) ships to GKE but stays
+      # undefined on the Cloud Run revisions that api.omi.me / api.omiapi.com
+      # actually serve, and the new code reads None.
+      - name: Sync Cloud Run secrets from backend-secrets chart
+        run: |
+          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          bash backend/scripts/sync_cloudrun_secrets_from_chart.sh dev backend backend-sync backend-integration
+
+      - name: Validate backend runtime env
+        run: |
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows --check-live-cloud-run
 
       - name: Show Output
         run: echo "Backend deployed to development environment"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,7 @@ jobs:
           echo "has_frontend=$(echo "$FILES" | grep -q '^web/frontend/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_workflows=$(echo "$FILES" | grep -qE '^\.github/workflows/.*\.ya?ml$|^\.github/actionlint\.ya?ml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_backend_runtime_env=$(echo "$FILES" | grep -qE '^backend/deploy/runtime_env\.yaml$|^backend/charts/backend-listen/.*_values\.yaml$|^backend/scripts/validate-backend-runtime-env\.py$|^\.github/workflows/gcp_backend.*\.ya?ml$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_backend_async_gate=$(echo "$FILES" | grep -qE '^backend/.*\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
@@ -76,6 +77,13 @@ jobs:
 
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
+
+      - name: Check backend runtime env manifest
+        if: steps.changed.outputs.has_backend_runtime_env == 'true'
+        run: |
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
+          python3 backend/scripts/validate-backend-runtime-env.py --env prod
 
       - name: Summarize deferred-work markers
         continue-on-error: true

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -16,6 +16,8 @@ environments:
               name: dev-omi-backend-secrets
               key: OMI_LLM_GATEWAY_SERVICE_TOKEN
     cloud_run:
+      workflow_files:
+        - .github/workflows/gcp_backend_auto_dev.yml
       services:
         backend:
           env:

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -38,6 +38,11 @@ def main() -> int:
         help='Fetch Cloud Run service state with gcloud and validate required env/secrets.',
     )
     parser.add_argument(
+        '--check-workflows',
+        action='store_true',
+        help='Validate checked-in Cloud Run workflow env_vars blocks against the manifest.',
+    )
+    parser.add_argument(
         '--strict-provisional',
         action='store_true',
         help='Require provisional manifest values to match exactly. By default they only require presence.',
@@ -49,6 +54,7 @@ def main() -> int:
         manifest_path=args.manifest,
         cloud_run_state_path=args.cloud_run_state,
         check_live_cloud_run=args.check_live_cloud_run,
+        check_workflows=args.check_workflows,
         strict_provisional=args.strict_provisional,
     )
     for error in errors:
@@ -65,6 +71,7 @@ def validate_runtime_env(
     manifest_path: Path = DEFAULT_MANIFEST,
     cloud_run_state_path: Path | None = None,
     check_live_cloud_run: bool = False,
+    check_workflows: bool = False,
     strict_provisional: bool = False,
 ) -> list[ValidationError]:
     manifest = _load_yaml(manifest_path)
@@ -74,6 +81,8 @@ def validate_runtime_env(
         return errors
 
     errors.extend(_validate_gke(env_config, strict_provisional=strict_provisional))
+    if check_workflows:
+        errors.extend(_validate_cloud_run_workflows(env_config, strict_provisional=strict_provisional))
 
     cloud_run_state = None
     if cloud_run_state_path is not None:
@@ -175,6 +184,43 @@ def _validate_cloud_run(
     return errors
 
 
+def _validate_cloud_run_workflows(
+    env_config: dict[str, Any],
+    *,
+    strict_provisional: bool,
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    workflow_files = env_config.get('cloud_run', {}).get('workflow_files', [])
+    if not isinstance(workflow_files, list):
+        return [ValidationError('cloud_run/workflows', 'workflow_files must be a list')]
+
+    expected_services = env_config['cloud_run']['services']
+    workflow_services: dict[str, dict[str, Any]] = {}
+    for workflow_file in workflow_files:
+        if not isinstance(workflow_file, str):
+            errors.append(ValidationError('cloud_run/workflows', 'workflow file paths must be strings'))
+            continue
+        workflow_path = ROOT / workflow_file
+        workflow = _load_yaml(workflow_path)
+        workflow_services.update(_extract_workflow_cloud_run_services(workflow))
+
+    for service, service_config in expected_services.items():
+        service_state = workflow_services.get(service)
+        if service_state is None:
+            errors.append(ValidationError(f'cloud_run_workflow/{service}', 'missing deploy-cloudrun env_vars block'))
+            continue
+        actual_env = _literal_env_entries_by_name(service_state.get('env_vars', {}))
+        errors.extend(
+            _validate_env_entries(
+                scope=f'cloud_run_workflow/{service}',
+                expected=service_config.get('env', {}),
+                actual=actual_env,
+                strict_provisional=strict_provisional,
+            )
+        )
+    return errors
+
+
 def _validate_env_entries(
     *,
     scope: str,
@@ -234,6 +280,72 @@ def _env_entries_by_name(raw_env: Any) -> dict[str, dict[str, Any]]:
     for entry in raw_env:
         if isinstance(entry, dict) and isinstance(entry.get('name'), str):
             result[entry['name']] = entry
+    return result
+
+
+def _literal_env_entries_by_name(raw_env: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw_env, dict):
+        return {}
+    return {name: {'name': name, 'value': str(value)} for name, value in raw_env.items()}
+
+
+def _extract_workflow_cloud_run_services(workflow: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    workflow_env = workflow.get('env', {})
+    if not isinstance(workflow_env, dict):
+        workflow_env = {}
+    result: dict[str, dict[str, Any]] = {}
+    jobs = workflow.get('jobs', {})
+    if not isinstance(jobs, dict):
+        return result
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get('steps', [])
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not _is_cloud_run_deploy_step(step):
+                continue
+            step_with = step.get('with', {})
+            service = _resolve_workflow_string(step_with.get('service'), workflow_env)
+            if service is None:
+                continue
+            env_vars = _parse_workflow_env_vars(step_with.get('env_vars'))
+            if env_vars:
+                result[service] = {'env_vars': env_vars}
+    return result
+
+
+def _is_cloud_run_deploy_step(step: Any) -> bool:
+    if not isinstance(step, dict):
+        return False
+    uses = step.get('uses')
+    return isinstance(uses, str) and uses.startswith('google-github-actions/deploy-cloudrun@')
+
+
+def _resolve_workflow_string(value: Any, workflow_env: dict[str, Any]) -> str | None:
+    if not isinstance(value, str):
+        return None
+    resolved = value
+    for env_name, env_value in workflow_env.items():
+        resolved = resolved.replace('${{ env.' + str(env_name) + ' }}', str(env_value))
+    return resolved
+
+
+def _parse_workflow_env_vars(raw_env_vars: Any) -> dict[str, str]:
+    if raw_env_vars is None:
+        return {}
+    if isinstance(raw_env_vars, dict):
+        return {str(name): str(value) for name, value in raw_env_vars.items()}
+    if not isinstance(raw_env_vars, str):
+        return {}
+    result: dict[str, str] = {}
+    for raw_line in raw_env_vars.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        name, value = line.split('=', 1)
+        result[name.strip()] = value.strip()
     return result
 
 

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -32,6 +32,14 @@ def test_repo_gke_values_match_manifest():
     assert errors == []
 
 
+def test_repo_cloud_run_workflows_match_manifest():
+    validator = load_validator()
+
+    errors = validator.validate_runtime_env(env='dev', check_workflows=True)
+
+    assert errors == []
+
+
 def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
     validator = load_validator()
     state_path = tmp_path / 'cloud_run_state.json'
@@ -75,6 +83,79 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
 
     assert [error.message for error in errors] == ['missing env OMI_LLM_GATEWAY_URL']
     assert errors[0].scope == 'cloud_run/backend'
+
+
+def test_cloud_run_workflow_reports_missing_gateway_url(tmp_path):
+    validator = load_validator()
+    values_file = tmp_path / 'backend_listen.yaml'
+    write_yaml(
+        values_file,
+        {
+            'env': [
+                {'name': 'OMI_LLM_GATEWAY_URL', 'value': 'http://gateway.local'},
+            ]
+        },
+    )
+    workflow_file = tmp_path / 'deploy.yml'
+    write_yaml(
+        workflow_file,
+        {
+            'env': {'SERVICE': 'backend'},
+            'jobs': {
+                'deploy': {
+                    'steps': [
+                        {
+                            'uses': 'google-github-actions/deploy-cloudrun@v2',
+                            'with': {
+                                'service': '${{ env.SERVICE }}',
+                                'env_vars': 'GOOGLE_CLOUD_PROJECT=based-hardware\n',
+                            },
+                        }
+                    ]
+                }
+            },
+        },
+    )
+    manifest_path = tmp_path / 'runtime_env.yaml'
+    write_yaml(
+        manifest_path,
+        {
+            'schema_version': 1,
+            'environments': {
+                'dev': {
+                    'gcp_project': 'based-hardware-dev',
+                    'region': 'us-central1',
+                    'gke': {
+                        'backend-listen': {
+                            'values_file': str(values_file),
+                            'env': {
+                                'OMI_LLM_GATEWAY_URL': {
+                                    'value': 'http://gateway.local',
+                                },
+                            },
+                        }
+                    },
+                    'cloud_run': {
+                        'workflow_files': [str(workflow_file)],
+                        'services': {
+                            'backend': {
+                                'env': {
+                                    'GOOGLE_CLOUD_PROJECT': {'value': 'based-hardware'},
+                                    'OMI_LLM_GATEWAY_URL': {'value': 'http://172.16.63.232'},
+                                },
+                                'secrets': {},
+                            }
+                        },
+                    },
+                }
+            },
+        },
+    )
+
+    errors = validator.validate_runtime_env(env='dev', manifest_path=manifest_path, check_workflows=True)
+
+    assert [error.message for error in errors] == ['missing env OMI_LLM_GATEWAY_URL']
+    assert errors[0].scope == 'cloud_run_workflow/backend'
 
 
 def test_cloud_run_state_accepts_secret_bindings(tmp_path):


### PR DESCRIPTION
## Summary
- extend the backend runtime env validator to compare manifest Cloud Run env expectations against checked-in deploy workflow env_vars blocks
- add lint CI coverage for the runtime env manifest, backend-listen Helm values, and backend deploy workflows
- run live Cloud Run runtime env validation after deploy secret sync, and move dev secret sync after all Cloud Run revisions are deployed

## Issue
Refs #8515

## Validation
- python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
- python3 backend/scripts/validate-backend-runtime-env.py --env prod
- python3 -m pytest backend/tests/unit/test_backend_runtime_env_validator.py -q
- black --check --line-length 120 --skip-string-normalization backend/scripts/validate-backend-runtime-env.py backend/tests/unit/test_backend_runtime_env_validator.py
- actionlint -shellcheck "" .github/workflows/gcp_backend.yml .github/workflows/gcp_backend_auto_dev.yml .github/workflows/lint.yml
- backend/test-preflight.sh passed with optional dependency/service warnings

## Notes
- Full backend/test.sh was stopped because the local runner used system Python 3.9.6 while backend/.python-version requires 3.11.15; unrelated collection failures hit Python 3.10+ type syntax and missing optional packages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

