### PR TITLE
[codex] Fix deterministic desktop recording finalization

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -89,6 +89,14 @@ enum DesktopConversationMatchPolicy {
     conversationId == boundBackendId && source == .desktop && status != .inProgress
   }
 
+  static func canForceProcessBoundCloudSession(
+    capturedBackendId: String?,
+    persistedBackendId: String?
+  ) -> Bool {
+    guard let capturedBackendId, !capturedBackendId.isEmpty else { return false }
+    return persistedBackendId == capturedBackendId
+  }
+
   static func parseMemoryEventDate(_ value: Any?) -> Date? {
     if let date = value as? Date {
       return date

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -682,9 +682,11 @@ extension AppState {
 
     Task {
       if let sessionId = capturedSessionId {
+        var persistedBackendId: String?
         if let backendId = capturedBackendId, !backendId.isEmpty {
           do {
             try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+            persistedBackendId = try await TranscriptionStorage.shared.getSession(id: sessionId)?.backendId
           } catch {
             logError(
               "Transcription: Failed to persist backend conversation \(backendId) for stopped session \(sessionId)",
@@ -702,7 +704,10 @@ extension AppState {
         await ConversationFinalizationService.shared.finalizeSession(
           id: sessionId,
           reason: .userStop,
-          allowCloudForceProcess: capturedBackendId?.isEmpty == false
+          allowCloudForceProcess: DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+            capturedBackendId: capturedBackendId,
+            persistedBackendId: persistedBackendId
+          )
         )
       }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -643,10 +643,10 @@ extension AppState {
     buttonStreamTask = nil
   }
 
-  /// Stop real-time transcription
-  /// The Python backend handles conversation lifecycle automatically — disconnecting the WebSocket
-  /// triggers conversation processing on the backend side. We also call force-process to ensure
-  /// the conversation is finalized, preventing the retry service from creating duplicates.
+  /// Stop real-time transcription.
+  /// The Python backend handles conversation lifecycle automatically when the WebSocket closes.
+  /// When `/v4/listen` has announced the backend conversation id, finalize that exact conversation
+  /// instead of relying on the user's current in-progress pointer.
   func stopTranscription() {
     // On-device path: there is no backend WebSocket/conversation, so skip the cloud
     // force-process/reconciliation entirely. Stop capture, then AWAIT both Parakeet instances'
@@ -667,37 +667,42 @@ extension AppState {
       return
     }
 
-    // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil)
+    // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil).
     let capturedSessionId = currentSessionId
-    let generationAtStop = recordingGeneration
+    let capturedBackendId = currentBackendConversationId ?? pendingBackendConversationId
 
     stopAudioCapture()
     clearTranscriptionState(
       finalizationReason: .userStop,
       runFinalizer: false,
-      allowCloudForceProcess: false
+      allowCloudForceProcess: false,
+      finishSession: false
     )
     silentMicFallbackInProgress = false
 
-    // After WS close, the Python backend processes the conversation automatically.
-    // Call force-process to ensure finalization and get the backend conversation ID.
-    // This prevents the retry service from picking up the pendingUpload session.
     Task {
-      try? await Task.sleep(nanoseconds: 3_000_000_000)  // 3s for backend to process after WS close
-
-      // If a new recording started during the delay, skip force-process — it would
-      // finalize the NEW conversation instead of the one we just stopped.
-      // The retry service will reconcile the old session by timestamp matching.
-      guard self.recordingGeneration == generationAtStop else {
-        log("Transcription: New recording started during delay, skipping force-process for session \(capturedSessionId.map(String.init) ?? "nil")")
-        return
-      }
-
       if let sessionId = capturedSessionId {
+        if let backendId = capturedBackendId, !backendId.isEmpty {
+          do {
+            try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+          } catch {
+            logError(
+              "Transcription: Failed to persist backend conversation \(backendId) for stopped session \(sessionId)",
+              error: error
+            )
+          }
+        }
+        do {
+          try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)
+        } catch {
+          logError("Transcription: Failed to finish DB session \(sessionId)", error: error)
+          return
+        }
+
         await ConversationFinalizationService.shared.finalizeSession(
           id: sessionId,
           reason: .userStop,
-          allowCloudForceProcess: true
+          allowCloudForceProcess: capturedBackendId?.isEmpty == false
         )
       }
 

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -61,7 +61,10 @@ actor ConversationFinalizationService {
       case .localSegments:
         try await uploadLocalSegments(sessionId: sessionId)
       case .cloudReconcile:
-        try await finalizeCloudSession(session: session, allowForceProcess: allowCloudForceProcess)
+        guard let latestSession = try await TranscriptionStorage.shared.getSession(id: sessionId) else {
+          throw TranscriptionStorageError.sessionNotFound
+        }
+        try await finalizeCloudSession(session: latestSession, allowForceProcess: allowCloudForceProcess)
       }
     } catch {
       await markRetryableFailure(sessionId: sessionId, error: error)

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -223,8 +223,39 @@ final class StopReconciliationTests: XCTestCase {
         let capturedBackendId: String? = nil
 
         XCTAssertFalse(
-            capturedBackendId?.isEmpty == false,
+            DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+                capturedBackendId: capturedBackendId,
+                persistedBackendId: nil
+            ),
             "Unbound sessions should not force-process the user's current in-progress pointer"
+        )
+    }
+
+    func testCapturedButUnpersistedBackendIdDoesNotUseGlobalForceProcessFallback() {
+        XCTAssertFalse(
+            DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+                capturedBackendId: "backend-conversation-123",
+                persistedBackendId: nil
+            ),
+            "A captured listen id must be durably stored before force-processing is allowed"
+        )
+    }
+
+    func testCapturedBackendIdMustMatchPersistedBackendIdBeforeForceProcess() {
+        XCTAssertFalse(
+            DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+                capturedBackendId: "backend-conversation-123",
+                persistedBackendId: "backend-conversation-456"
+            )
+        )
+    }
+
+    func testPersistedCapturedBackendIdAllowsSpecificFinalize() {
+        XCTAssertTrue(
+            DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+                capturedBackendId: "backend-conversation-123",
+                persistedBackendId: "backend-conversation-123"
+            )
         )
     }
 

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -1,41 +1,9 @@
 import XCTest
 @testable import Omi_Computer
 
-/// Tests for the stop/reconciliation logic in the from-segments removal migration.
-/// Covers: generation guard, source filtering, and force-process response validation.
+/// Tests for the stop/reconciliation logic in the deterministic desktop finalization flow.
+/// Covers: source filtering, bound backend ids, and legacy timestamp fallback validation.
 final class StopReconciliationTests: XCTestCase {
-
-    // MARK: - Recording Generation Guard
-
-    /// Verify that recordingGeneration increments correctly and can detect
-    /// when a new recording started during a delay window.
-    func testRecordingGenerationDetectsNewRecording() {
-        // Simulate the pattern used in stopTranscription():
-        // 1. Capture generation before stop
-        // 2. New recording starts (increments generation)
-        // 3. Check if generation changed
-        var generation: UInt64 = 0
-        let capturedGeneration = generation
-
-        // Simulate new recording starting
-        generation &+= 1
-
-        XCTAssertNotEqual(generation, capturedGeneration,
-            "Generation should change when a new recording starts")
-    }
-
-    func testRecordingGenerationStableWhenNoNewRecording() {
-        var generation: UInt64 = 42
-        let capturedGeneration = generation
-
-        // No new recording
-        XCTAssertEqual(generation, capturedGeneration,
-            "Generation should be stable when no new recording starts")
-
-        // Incrementing only when recording starts
-        generation &+= 1
-        XCTAssertNotEqual(generation, capturedGeneration)
-    }
 
     // MARK: - Conversation Source Filtering
 
@@ -53,11 +21,11 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertNotEqual(omiSource, .desktop, "Omi source should not match desktop filter")
     }
 
-    // MARK: - Force-Process Response Validation
+    // MARK: - Legacy Timestamp Fallback Validation
 
-    /// Simulate the validation logic used in stopTranscription() when
-    /// force-process returns a conversation.
-    func testForceProcessValidationAcceptsMatchingConversation() {
+    /// Simulate the validation logic used only for older unbound sessions that have no durable
+    /// backend conversation id.
+    func testTimestampFallbackAcceptsMatchingConversation() {
         let sessionStartTime = Date()
         let convStartedAt = sessionStartTime.addingTimeInterval(2) // 2s offset
         let convSource: ConversationSource = .desktop
@@ -71,7 +39,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertTrue(matches, "Conversation within 10s and source=desktop should match")
     }
 
-    func testForceProcessValidationRejectsTimeMismatch() {
+    func testTimestampFallbackRejectsTimeMismatch() {
         let sessionStartTime = Date()
         let convStartedAt = sessionStartTime.addingTimeInterval(15) // 15s offset
         let convSource: ConversationSource = .desktop
@@ -85,7 +53,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertFalse(matches, "Conversation >10s away should not match")
     }
 
-    func testForceProcessValidationRejectsSourceMismatch() {
+    func testTimestampFallbackRejectsSourceMismatch() {
         let sessionStartTime = Date()
         let convStartedAt = sessionStartTime.addingTimeInterval(1) // 1s offset
         let convSource: ConversationSource = .phone
@@ -99,7 +67,7 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertFalse(matches, "Non-desktop conversation should not match")
     }
 
-    func testForceProcessValidationRejectsBothMismatch() {
+    func testTimestampFallbackRejectsBothMismatch() {
         let sessionStartTime = Date()
         let convStartedAt = sessionStartTime.addingTimeInterval(20)
         let convSource: ConversationSource = .omi
@@ -239,6 +207,25 @@ final class StopReconciliationTests: XCTestCase {
 
         XCTAssertNotEqual(returnedBackendId, boundBackendId,
             "Force-process must not bind a different conversation when the listen session id is known")
+    }
+
+    func testBoundBackendConversationShouldUseSpecificFinalizePath() {
+        let capturedBackendId = "backend-conversation-123"
+
+        XCTAssertFalse(capturedBackendId.isEmpty)
+        XCTAssertEqual(
+            "v1/conversations/\(capturedBackendId)/finalize",
+            "v1/conversations/backend-conversation-123/finalize"
+        )
+    }
+
+    func testUnboundStopDoesNotUseGlobalForceProcessFallback() {
+        let capturedBackendId: String? = nil
+
+        XCTAssertFalse(
+            capturedBackendId?.isEmpty == false,
+            "Unbound sessions should not force-process the user's current in-progress pointer"
+        )
     }
 
     func testBoundBackendConversationCompletionRejectsNonDesktopExactMatch() {

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -173,6 +173,33 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         XCTAssertFalse(secondClaim)
     }
 
+    func testRestartRecoveryDoesNotForceProcessWhenCapturedBackendIdWasNotPersisted() async throws {
+        let capturedBackendId = "backend-conversation-123"
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: "desktop",
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.finishSession(
+            id: sessionId,
+            reason: .userStop
+        )
+
+        await RewindDatabase.shared.close()
+        await TranscriptionStorage.shared.invalidateCache()
+        try await RewindDatabase.shared.initialize()
+
+        let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let recoveredSession = try XCTUnwrap(storedSession)
+        XCTAssertNil(recoveredSession.backendId)
+        XCTAssertFalse(
+            DesktopConversationMatchPolicy.canForceProcessBoundCloudSession(
+                capturedBackendId: capturedBackendId,
+                persistedBackendId: recoveredSession.backendId
+            ),
+            "After restart, a captured-but-unpersisted id must not enable current-pointer force-process"
+        )
+    }
+
     func testProcessingServerConversationDoesNotStampFinalizationCompletedAt() async throws {
         let conversation = makeServerConversation(status: .processing)
 

--- a/desktop/macos/changelog/unreleased/20260630-deterministic-desktop-finalization.json
+++ b/desktop/macos/changelog/unreleased/20260630-deterministic-desktop-finalization.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop recordings so stop and retry finalize the exact backend conversation when available"
+}


### PR DESCRIPTION
## Summary
- finalize stopped desktop cloud recordings by the `/v4/listen` backend conversation id instead of the user's current Redis in-progress pointer
- reload the just-finished local session before cloud finalization so newly persisted backend ids are honored
- update stop/reconciliation tests and add a desktop changelog fragment

Fixes #8193.

## Validation
- `python -m pytest backend/tests/unit/test_conversation_search_date_validation.py -q`
- `xcrun swift test -c debug --package-path Desktop --filter StopReconciliationTests`
- `xcrun swift test -c debug --package-path Desktop --filter TranscriptionFinalizationStateMachineTests`
- `xcrun swift build -c debug --package-path Desktop`
- pre-push hook passed against `origin/main` during push

Note: pushing to the fork remote first hit a stale `fork/main` pre-push comparison and local Node 20 lacked `node:sqlite`; rerunning with Node 22 and pushing to upstream `origin` passed the hook against the correct base.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

