### PR TITLE
[codex] Add hermetic E2E coverage for listen sync lifecycle

### DIFF
--- a/backend/testing/e2e/conftest.py
+++ b/backend/testing/e2e/conftest.py
@@ -91,6 +91,8 @@ def _set_e2e_env():
     os.environ["BUCKET_CHAT_FILES"] = "chat-files"
     os.environ["BUCKET_DESKTOP_UPDATES"] = "desktop-updates"
     os.environ["DEV_WEBHOOK_RETRY_DELAYS"] = "0,0,0"
+    os.environ["SYNC_DISPATCH_MODE"] = "inline"
+    os.environ["AUDIO_MERGE_DISPATCH_MODE"] = "inline"
     # Disable Stripe validation so startup doesn't fail.
     os.environ["STRIPE_SECRET_KEY"] = ""
     os.environ["ADMIN_KEY"] = ""

--- a/backend/testing/e2e/fakes/stt.py
+++ b/backend/testing/e2e/fakes/stt.py
@@ -12,10 +12,71 @@ If Deepgram HTTP pre-recorded transcription is used instead, we can fake that
 endpoint.
 """
 
-# TODO: Implement Deepgram WebSocket fake for full /v4/listen and pusher scenarios.
-# The Deepgram WS protocol sends JSON metadata followed by binary audio, then
-# streams back transcript results. That remains broader v2 coverage; custom-STT
-# tests below are explicitly scoped to the backend's suggested-transcript seam.
+
+class FakeStreamingSTTSocket:
+    """Minimal STT socket surface used by routers.transcribe._stream_handler."""
+
+    def __init__(self, callback):
+        self.callback = callback
+        self.sent_chunks = []
+        self.finish_calls = 0
+        self.drain_calls = 0
+        self._dead = False
+        self._death_reason = None
+        self._emitted = False
+
+    @property
+    def is_connection_dead(self) -> bool:
+        return self._dead
+
+    @property
+    def death_reason(self):
+        return self._death_reason
+
+    def send(self, data: bytes) -> None:
+        self.sent_chunks.append(data)
+        if self._emitted:
+            return
+        self._emitted = True
+        self.callback(
+            [
+                {
+                    "id": "seg-streaming-stt-1",
+                    "text": "Hermetic streaming STT transcript from the fake socket.",
+                    "speaker": "SPEAKER_00",
+                    "is_user": True,
+                    "person_id": None,
+                    "start": 0.0,
+                    "end": 1.25,
+                    "stt_provider": "e2e-streaming-stt",
+                }
+            ]
+        )
+
+    async def drain_and_close(self):
+        self.drain_calls += 1
+
+    def finish(self) -> None:
+        self.finish_calls += 1
+
+
+def install_streaming_stt_fake(monkeypatch):
+    """Patch routers.transcribe.process_audio_dg and return created fake sockets."""
+    import routers.transcribe as transcribe_router
+
+    sockets = []
+
+    async def fake_process_audio_dg(
+        callback, language, sample_rate, channels, model="nova-3", keywords=None, is_active=None
+    ):
+        socket = FakeStreamingSTTSocket(callback)
+        sockets.append(socket)
+        return socket
+
+    monkeypatch.setattr(transcribe_router, "process_audio_dg", fake_process_audio_dg)
+    monkeypatch.setattr(transcribe_router, "has_transcription_credits", lambda *args, **kwargs: True)
+    monkeypatch.setattr(transcribe_router, "record_usage", lambda *args, **kwargs: None)
+    return sockets
 
 
 def fake_suggested_transcript_event():

--- a/backend/testing/e2e/listen_test_helpers.py
+++ b/backend/testing/e2e/listen_test_helpers.py
@@ -1,24 +1,46 @@
 """Shared helpers for hermetic listen websocket e2e tests."""
 
 import json
+import time
+
+from anyio import ClosedResourceError, EndOfStream, WouldBlock
 
 from fakes.firestore import get_mock_firestore
 
 
-def seed_listen_user(uid: str):
+def seed_listen_user(uid: str, *, uses_custom_stt: bool = True):
     get_mock_firestore().collection("users").document(uid).set(
         {
             "id": uid,
             "language": "en",
             "private_cloud_sync_enabled": False,
-            "transcription_preferences": {"uses_custom_stt": True},
+            "transcription_preferences": {"uses_custom_stt": uses_custom_stt},
         }
     )
 
 
-def receive_until(websocket, predicate, *, limit=20):
+def receive_message(websocket, *, timeout: float = 1.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            return websocket._send_rx.receive_nowait()
+        except WouldBlock:
+            time.sleep(0.01)
+        except (ClosedResourceError, EndOfStream) as e:
+            raise AssertionError("websocket receive stream closed before expected message") from e
+    raise TimeoutError("timed out waiting for websocket message")
+
+
+def receive_until(websocket, predicate, *, limit=20, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
     for _ in range(limit):
-        message = websocket.receive()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            message = receive_message(websocket, timeout=min(0.5, remaining))
+        except TimeoutError:
+            continue
         if message.get("type") == "websocket.close":
             raise AssertionError(f"websocket closed before expected message: {message}")
         text = message.get("text")
@@ -40,3 +62,7 @@ def is_conversation_session_event(payload):
 
 def is_segment_batch(payload):
     return isinstance(payload, list) and payload and payload[0].get("id") == "seg-custom-stt-1"
+
+
+def is_streaming_segment_batch(payload):
+    return isinstance(payload, list) and payload and payload[0].get("id") == "seg-streaming-stt-1"

--- a/backend/testing/e2e/test_conversation_processing.py
+++ b/backend/testing/e2e/test_conversation_processing.py
@@ -1,77 +1,186 @@
-"""
-Scenario 2: Conversation Processing
+"""Hermetic conversation create/process/finalize lifecycle coverage."""
 
-Tests that seeding a transcript into fake Firestore and triggering
-the processing pipeline produces correct structured output (title,
-summary, action items, memories) via deterministic LLM responses.
-"""
+from datetime import datetime, timezone
 
-import json
-
-import pytest
-
-from fakes.firestore import seed_conversation
+from fakes.firestore import read_action_items, read_conversation, seed_conversation
+from models.memories import Memory
+from models.structured import ActionItem, Structured
+from models.transcript_segment import TranscriptSegment
 
 
-class TestConversationProcessing:
-    """Exercise the full processing pipeline with fake LLM."""
+class UnexpectedLLMCall(BaseException):
+    pass
 
-    @pytest.mark.skip(reason="LLM client fakes are scaffolded but not wired into processing clients yet")
-    def test_process_conversation_creates_structured_data(self, client, auth_headers, conversation_fixture):
-        """
-        Seed a conversation with transcript segments, then reprocess it.
 
-        The fake LLM returns a deterministic structured response. We verify
-        that the conversation is updated with title, overview, category, etc.
-        """
-        # Seed a conversation with segments into Firestore directly
-        conv_data = dict(conversation_fixture["with_segments"])
-        conv_id = conv_data["id"]
+def _patch_process_conversation_boundaries(monkeypatch):
+    import utils.conversations.process_conversation as process_module
+    import utils.llm.knowledge_graph as kg_module
 
-        seed_conversation("123", conv_data)
+    kg_calls = []
 
-        # Trigger reprocessing via API
-        resp = client.post(
-            f"/v1/conversations/{conv_id}/reprocess",
-            headers=auth_headers,
-        )
-        # May fail if LLM endpoint doesn't match — that's ok for now
-        # The key test is whether the round-trip works end-to-end
-        if resp.status_code == 200:
-            body = resp.json()
-            assert "id" in body
-            assert "structured" in body
-            s = body["structured"]
-            # Fake LLM should have returned our deterministic response
-            assert s.get("title") != "" or s.get("overview") != ""
-        else:
-            # If reprocessing fails due to LLM endpoint mismatch, that's
-            # informative but not a hard failure for v1 of the harness
-            pass
+    def run_selected_postprocess(_executor, fn, *args, **kwargs):
+        if fn.__name__ in {"_extract_memories", "_save_action_items"}:
+            fn(*args, **kwargs)
 
-    def test_seed_and_read_conversation(self, client, auth_headers, conversation_fixture):
-        """Verify seeded conversations are readable through the API."""
-        conv_data = dict(conversation_fixture["current_format_conversation"])
-        seed_conversation("123", conv_data)
+        class DoneFuture:
+            def result(self, timeout=None):
+                return None
 
-        resp = client.get(f"/v1/conversations/{conv_data['id']}", headers=auth_headers)
-        assert resp.status_code == 200, f"Failed to read seeded conversation: {resp.text}"
+        return DoneFuture()
 
-        body = resp.json()
-        assert body["id"] == conv_data["id"]
-        assert body["source"] == conv_data["source"]
+    def record_kg_extract(*args, **kwargs):
+        kg_calls.append((args, kwargs))
+        return {"nodes": [], "edges": []}
 
-    @pytest.mark.skip(reason="LLM client fakes are scaffolded but not wired into processing clients yet")
-    def test_processing_extracts_action_items(self, client, auth_headers):
-        """
-        After processing, action items should be queryable.
+    monkeypatch.setattr(process_module, "is_trial_paywalled", lambda *args, **kwargs: False)
+    monkeypatch.setattr(process_module, "should_defer_desktop_processing", lambda uid: False)
+    monkeypatch.setattr(process_module, "get_user_name", lambda uid, use_default=True: "David")
+    monkeypatch.setattr(process_module.notification_db, "get_user_time_zone", lambda uid: "UTC")
+    monkeypatch.setattr(process_module.users_db, "get_user_language_preference", lambda uid: "en")
+    monkeypatch.setattr(process_module.users_db, "get_people_by_ids", lambda uid, person_ids: [])
+    monkeypatch.setattr(process_module.folders_db, "get_folders", lambda uid: [])
+    monkeypatch.setattr(process_module.folders_db, "initialize_system_folders", lambda uid: [])
+    monkeypatch.setattr(process_module, "record_usage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "track_usage", lambda *args, **kwargs: _NoopContext())
+    monkeypatch.setattr(process_module, "should_discard_conversation", lambda *args, **kwargs: False)
+    monkeypatch.setattr(process_module, "find_similar_action_items", lambda *args, **kwargs: [])
+    monkeypatch.setattr(process_module, "find_similar_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(process_module, "upsert_vector2", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "update_vector_metadata", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "upsert_transcript_chunk_vectors", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "upsert_memory_vector", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "delete_memory_vector", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "upsert_action_item_vectors_batch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "delete_action_item_vectors_batch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "send_action_item_data_message", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "auto_sync_action_items_batch", _async_noop)
+    monkeypatch.setattr(process_module, "conversation_created_webhook", _async_noop)
+    monkeypatch.setattr(process_module, "get_overlapping_calendar_event", _async_none)
+    monkeypatch.setattr(process_module, "write_conversation_link_to_calendar_event", _async_noop)
+    monkeypatch.setattr(process_module, "precache_conversation_audio", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "_trigger_apps", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "_update_goal_progress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_module, "submit_with_context", run_selected_postprocess)
+    monkeypatch.setattr(kg_module, "extract_knowledge_from_memory", record_kg_extract)
+    monkeypatch.setattr(
+        kg_module,
+        "get_llm",
+        lambda *args, **kwargs: (_ for _ in ()).throw(UnexpectedLLMCall("unexpected KG LLM call")),
+    )
+    monkeypatch.setattr(
+        process_module,
+        "get_transcript_structure",
+        lambda *args, **kwargs: Structured(
+            title="Hermetic Conversation Lifecycle",
+            overview="A deterministic processing result created by the E2E harness.",
+            emoji="🧪",
+            category="work",
+        ),
+    )
+    monkeypatch.setattr(
+        process_module,
+        "get_reprocess_transcript_structure",
+        lambda *args, **kwargs: Structured(
+            title="Hermetic Conversation Lifecycle Reprocessed",
+            overview="A deterministic reprocess result created by the E2E harness.",
+            emoji="🧪",
+            category="work",
+        ),
+    )
+    monkeypatch.setattr(
+        process_module,
+        "extract_action_items",
+        lambda *args, **kwargs: [
+            ActionItem(description="Ship deterministic conversation lifecycle coverage", completed=False)
+        ],
+    )
+    monkeypatch.setattr(
+        process_module,
+        "new_memories_extractor",
+        lambda *args, **kwargs: [
+            Memory(
+                content="David wants conversation lifecycle tests to fail hard.",
+                category="system",
+                visibility="public",
+                tags=["e2e", "conversation"],
+            )
+        ],
+    )
+    return kg_calls
 
-        This tests the full chain: conversation → LLM extraction →
-        action_items collection persistence → GET retrieval.
-        """
-        # Create a conversation with meaningful text
-        conv_id = "proc-ai-test-001"
-        conv_data = {
+
+class _NoopContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+async def _async_noop(*args, **kwargs):
+    return None
+
+
+async def _async_none(*args, **kwargs):
+    return None
+
+
+def test_conversation_create_process_finalize_lifecycle(client, auth_headers, monkeypatch):
+    kg_calls = _patch_process_conversation_boundaries(monkeypatch)
+
+    import utils.conversations.process_conversation as process_module
+    from models.conversation import CreateConversation
+
+    started_at = datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+    create_conversation = CreateConversation(
+        started_at=started_at,
+        finished_at=started_at.replace(minute=5),
+        source="omi",
+        language="en",
+        transcript_segments=[
+            TranscriptSegment(
+                id="seg-life-1",
+                text="We should ship deterministic conversation lifecycle coverage.",
+                speaker="SPEAKER_00",
+                is_user=True,
+                start=0.0,
+                end=2.0,
+            )
+        ],
+    )
+
+    processed = process_module.process_conversation("123", "en", create_conversation)
+    assert processed.status == "completed"
+    assert processed.discarded is False
+    assert processed.structured.title == "Hermetic Conversation Lifecycle"
+    assert processed.structured.action_items[0].description == "Ship deterministic conversation lifecycle coverage"
+
+    persisted = client.get(f"/v1/conversations/{processed.id}", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    body = persisted.json()
+    assert body["id"] == processed.id
+    assert body["status"] == "completed"
+    assert body["structured"]["title"] == "Hermetic Conversation Lifecycle"
+    assert body["transcript_segments"][0]["text"] == "We should ship deterministic conversation lifecycle coverage."
+
+    action_items = read_action_items("123")
+    assert [item["description"] for item in action_items] == ["Ship deterministic conversation lifecycle coverage"]
+    memories_response = client.get("/v3/memories", headers=auth_headers)
+    assert memories_response.status_code == 200, memories_response.text
+    memories = memories_response.json()
+    assert [memory["content"] for memory in memories] == ["David wants conversation lifecycle tests to fail hard."]
+    assert read_conversation("123", processed.id)["status"] == "completed"
+    assert kg_calls == [
+        (("123", "David wants conversation lifecycle tests to fail hard.", memories[0]["id"], "David"), {})
+    ]
+
+
+def test_reprocess_route_persists_deterministic_processing_result(client, auth_headers, monkeypatch):
+    kg_calls = _patch_process_conversation_boundaries(monkeypatch)
+    conv_id = "deterministic-processing-001"
+    seed_conversation(
+        "123",
+        {
             "id": conv_id,
             "created_at": "2025-01-15T12:00:00Z",
             "started_at": "2025-01-15T12:00:00Z",
@@ -79,7 +188,7 @@ class TestConversationProcessing:
             "source": "omi",
             "language": "en",
             "structured": {
-                "title": "",
+                "title": "Before Reprocess",
                 "overview": "",
                 "emoji": "🧠",
                 "category": "other",
@@ -88,140 +197,93 @@ class TestConversationProcessing:
             },
             "transcript_segments": [
                 {
-                    "id": "seg-p1",
-                    "text": "We need to finish the API redesign by next Friday.",
+                    "id": "seg-1",
+                    "text": "Remember to ship the hermetic harness follow-up.",
                     "speaker": "SPEAKER_00",
                     "is_user": True,
                     "start": 0.0,
-                    "end": 3.0,
-                },
-                {
-                    "id": "seg-p2",
-                    "text": "I'll also set up the deployment pipeline.",
-                    "speaker": "SPEAKER_00",
-                    "is_user": True,
-                    "start": 3.1,
-                    "end": 5.5,
-                },
-            ],
-            "discarded": False,
-            "status": "completed",
-            "is_locked": False,
-            "data_protection_level": "standard",
-        }
-
-        seed_conversation("123", conv_data)
-
-        # Try to reprocess
-        resp = client.post(
-            f"/v1/conversations/{conv_id}/reprocess",
-            headers=auth_headers,
-        )
-
-        if resp.status_code == 200:
-            # Check if action items were created
-            ai_resp = client.get("/v1/action-items", headers=auth_headers)
-            if ai_resp.status_code == 200:
-                ai_body = ai_resp.json()
-                items = ai_body.get("action_items", [])
-                # At minimum, the conversation should be readable
-                assert isinstance(items, list)
-
-    @pytest.mark.skip(reason="LLM client fakes are scaffolded but not wired into processing clients yet")
-    def test_memory_extraction_from_processed_conversation(self, client, auth_headers):
-        """After processing, memories should be persisted."""
-        conv_id = "proc-mem-test-001"
-        conv_data = {
-            "id": conv_id,
-            "created_at": "2025-01-15T13:00:00Z",
-            "started_at": "2025-01-15T13:00:00Z",
-            "finished_at": "2025-01-15T13:03:00Z",
-            "source": "omi",
-            "language": "en",
-            "structured": {
-                "title": "",
-                "overview": "",
-                "emoji": "🧠",
-                "category": "other",
-                "action_items": [],
-                "events": [],
-            },
-            "transcript_segments": [
-                {
-                    "id": "seg-m1",
-                    "text": "I learned that Sarah prefers morning meetings.",
-                    "speaker": "SPEAKER_00",
-                    "is_user": True,
-                    "start": 0.0,
-                    "end": 3.0,
+                    "end": 2.0,
                 }
             ],
             "discarded": False,
             "status": "completed",
             "is_locked": False,
             "data_protection_level": "standard",
-        }
+        },
+    )
 
-        seed_conversation("123", conv_data)
+    response = client.post(f"/v1/conversations/{conv_id}/reprocess", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == conv_id
+    assert body["structured"]["title"] == "Hermetic Conversation Lifecycle Reprocessed"
+    assert body["structured"]["action_items"][0]["description"] == (
+        "Ship deterministic conversation lifecycle coverage"
+    )
 
-        # Reprocess to trigger memory extraction
-        resp = client.post(
-            f"/v1/conversations/{conv_id}/reprocess",
-            headers=auth_headers,
-        )
-        if resp.status_code == 200:
-            mem_resp = client.get("/v3/memories", headers=auth_headers)
-            if mem_resp.status_code == 200:
-                memories = mem_resp.json()
-                assert isinstance(memories, list)
+    persisted = client.get(f"/v1/conversations/{conv_id}", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    persisted_body = persisted.json()
+    assert persisted_body["structured"]["title"] == "Hermetic Conversation Lifecycle Reprocessed"
+    assert persisted_body["structured"]["action_items"][0]["description"] == (
+        "Ship deterministic conversation lifecycle coverage"
+    )
+    memories_response = client.get("/v3/memories", headers=auth_headers)
+    assert memories_response.status_code == 200, memories_response.text
+    memories = memories_response.json()
+    assert kg_calls == [
+        (("123", "David wants conversation lifecycle tests to fail hard.", memories[0]["id"], "David"), {})
+    ]
 
 
-class TestConversationStateTransitions:
-    """Test conversation status transitions through the lifecycle."""
+def test_seed_and_read_conversation(client, auth_headers, conversation_fixture):
+    conv_data = dict(conversation_fixture["current_format_conversation"])
+    seed_conversation("123", conv_data)
 
-    def test_in_progress_to_completed(self, client, auth_headers, conversation_fixture):
-        """A conversation can transition from in_progress to completed."""
-        conv_data = dict(conversation_fixture["with_segments"])
-        conv_id = conv_data["id"]
+    response = client.get(f"/v1/conversations/{conv_data['id']}", headers=auth_headers)
+    assert response.status_code == 200, response.text
 
-        seed_conversation("123", conv_data)
+    body = response.json()
+    assert body["id"] == conv_data["id"]
+    assert body["source"] == conv_data["source"]
 
-        # Read in_progress conversation
-        resp = client.get(f"/v1/conversations/{conv_id}", headers=auth_headers)
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        assert body["status"] in ("in_progress", "completed", "processing")
 
-    def test_discarded_conversation_filtered(self, client, auth_headers):
-        """Discarded conversations don't appear in default list."""
-        active_conv = {
-            "id": "discard-test-active",
-            "created_at": "2025-01-15T14:00:00Z",
-            "started_at": "2025-01-15T14:00:00Z",
-            "finished_at": "2025-01-15T14:02:00Z",
-            "source": "omi",
-            "structured": {
-                "title": "Active",
-                "overview": "",
-                "emoji": "🧠",
-                "category": "other",
-                "action_items": [],
-                "events": [],
-            },
-            "transcript_segments": [],
-            "discarded": False,
-            "status": "completed",
-            "is_locked": False,
-        }
-        discarded_conv = dict(active_conv, id="discard-test-discarded", discarded=True)
+def test_in_progress_to_completed_fixture_is_readable(client, auth_headers, conversation_fixture):
+    conv_data = dict(conversation_fixture["with_segments"])
+    seed_conversation("123", conv_data)
 
-        seed_conversation("123", active_conv)
-        seed_conversation("123", discarded_conv)
+    response = client.get(f"/v1/conversations/{conv_data['id']}", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] in ("in_progress", "completed", "processing")
 
-        # Default list excludes discarded
-        resp = client.get("/v1/conversations?include_discarded=false", headers=auth_headers)
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        ids = [c["id"] for c in body]
-        assert "discard-test-active" in ids
-        assert "discard-test-discarded" not in ids
+
+def test_discarded_conversation_filtered(client, auth_headers):
+    active_conv = {
+        "id": "discard-test-active",
+        "created_at": "2025-01-15T14:00:00Z",
+        "started_at": "2025-01-15T14:00:00Z",
+        "finished_at": "2025-01-15T14:02:00Z",
+        "source": "omi",
+        "structured": {
+            "title": "Active",
+            "overview": "",
+            "emoji": "🧠",
+            "category": "other",
+            "action_items": [],
+            "events": [],
+        },
+        "transcript_segments": [],
+        "discarded": False,
+        "status": "completed",
+        "is_locked": False,
+    }
+    discarded_conv = dict(active_conv, id="discard-test-discarded", discarded=True)
+
+    seed_conversation("123", active_conv)
+    seed_conversation("123", discarded_conv)
+
+    response = client.get("/v1/conversations?include_discarded=false", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    ids = [conversation["id"] for conversation in response.json()]
+    assert "discard-test-active" in ids
+    assert "discard-test-discarded" not in ids

--- a/backend/testing/e2e/test_listen_stt.py
+++ b/backend/testing/e2e/test_listen_stt.py
@@ -4,11 +4,12 @@ import json
 import uuid
 
 from fakes.firestore import get_mock_firestore, read_conversation
-from fakes.stt import fake_suggested_transcript_event
+from fakes.stt import fake_suggested_transcript_event, install_streaming_stt_fake
 from listen_test_helpers import (
     is_conversation_session_event,
     is_ready_event,
     is_segment_batch,
+    is_streaming_segment_batch,
     receive_until,
     seed_listen_user,
 )
@@ -168,3 +169,91 @@ def test_web_listen_reconnect_emits_existing_conversation_session_id(client, tes
         get_mock_firestore().collection("users").document(test_uid).collection("conversations").stream()
     )
     assert [conversation.id for conversation in conversations] == [first_event["conversation_id"]]
+
+
+def test_web_listen_streaming_stt_happy_path_persists_segments(client, auth_headers, test_uid, monkeypatch):
+    seed_listen_user(test_uid, uses_custom_stt=False)
+    sockets = install_streaming_stt_fake(monkeypatch)
+
+    with client.websocket_connect("/v4/web/listen?sample_rate=8000&codec=pcm8&source=desktop") as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        session_event = receive_until(websocket, is_conversation_session_event)
+        uuid.UUID(session_event["conversation_id"])
+        receive_until(websocket, is_ready_event)
+
+        websocket.send_bytes(b"\x80" * 320)
+        emitted_segments = receive_until(websocket, is_streaming_segment_batch)
+
+    assert len(sockets) == 1
+    assert sockets[0].sent_chunks
+    assert sockets[0].drain_calls == 1
+    assert sockets[0].finish_calls == 1
+
+    expected_segment = {
+        "id": "seg-streaming-stt-1",
+        "text": "Hermetic streaming STT transcript from the fake socket.",
+        "speaker": "SPEAKER_00",
+        "speaker_id": 0,
+        "is_user": True,
+        "person_id": None,
+        "translations": [],
+        "speech_profile_processed": True,
+        "stt_provider": "e2e-streaming-stt",
+    }
+    assert len(emitted_segments) == 1
+    assert {k: emitted_segments[0][k] for k in expected_segment} == expected_segment
+
+    persisted = client.get(f"/v1/conversations/{session_event['conversation_id']}", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    body = persisted.json()
+    assert body["source"] == "desktop"
+    assert body["status"] == "in_progress"
+    assert body["transcript_segments"] == emitted_segments
+
+
+def test_web_listen_reconnect_reuses_active_conversation_id(client, test_uid, monkeypatch):
+    seed_listen_user(test_uid, uses_custom_stt=False)
+    sockets = install_streaming_stt_fake(monkeypatch)
+
+    with client.websocket_connect(
+        "/v4/web/listen?sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        first_event = receive_until(websocket, is_conversation_session_event)
+        uuid.UUID(first_event["conversation_id"])
+        receive_until(websocket, is_ready_event)
+
+    with client.websocket_connect(
+        "/v4/web/listen?sample_rate=8000&codec=pcm8&conversation_timeout=120&source=desktop"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        second_event = receive_until(websocket, is_conversation_session_event)
+        receive_until(websocket, is_ready_event)
+
+    assert second_event["conversation_id"] == first_event["conversation_id"]
+    assert len(sockets) == 2
+    conversations = list(
+        get_mock_firestore().collection("users").document(test_uid).collection("conversations").stream()
+    )
+    assert [conversation.id for conversation in conversations] == [first_event["conversation_id"]]
+
+
+def test_web_listen_teardown_drains_and_finishes_stt_socket(client, test_uid, monkeypatch):
+    seed_listen_user(test_uid, uses_custom_stt=False)
+    sockets = install_streaming_stt_fake(monkeypatch)
+
+    with client.websocket_connect("/v4/web/listen?sample_rate=8000&codec=pcm8&source=desktop") as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        receive_until(websocket, is_conversation_session_event)
+        receive_until(websocket, is_ready_event)
+        websocket.send_bytes(b"\x80" * 320)
+        receive_until(websocket, is_streaming_segment_batch)
+
+    assert len(sockets) == 1
+    assert sockets[0].sent_chunks
+    assert sockets[0].drain_calls == 1
+    assert sockets[0].finish_calls == 1

--- a/backend/testing/e2e/test_sync_lifecycle.py
+++ b/backend/testing/e2e/test_sync_lifecycle.py
@@ -1,0 +1,260 @@
+"""Hermetic sync v2 lifecycle coverage."""
+
+import time
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fakes.firestore import read_conversation, seed_conversation
+from models.conversation import Conversation
+from models.conversation_enums import ConversationStatus
+from models.transcript_segment import TranscriptSegment
+
+TERMINAL_SYNC_STATUSES = {"completed", "partial_failure", "failed"}
+
+
+def _sync_filename(offset_seconds: int = 60) -> str:
+    timestamp = int(time.time()) - offset_seconds
+    return f"audio_{timestamp}.bin"
+
+
+def _poll_sync_job(client, auth_headers, job_id: str, *, deadline_seconds: float = 5.0):
+    deadline = time.monotonic() + deadline_seconds
+    last_body = None
+    while time.monotonic() < deadline:
+        response = client.get(f"/v2/sync-local-files/{job_id}", headers=auth_headers)
+        assert response.status_code == 200, response.text
+        last_body = response.json()
+        if last_body["status"] in TERMINAL_SYNC_STATUSES:
+            return last_body
+        time.sleep(0.05)
+    raise AssertionError(f"sync job {job_id} did not reach a terminal state: {last_body}")
+
+
+def _drain_background_coroutines(pending_coroutines):
+    while pending_coroutines:
+        asyncio.run(pending_coroutines.pop(0))
+
+
+def _patch_sync_pipeline(
+    monkeypatch,
+    *,
+    transcript_text: str,
+    reprocessed: list[str],
+):
+    import routers.sync as sync_router
+
+    pending_coroutines = []
+
+    def capture_background_task(coro, *, name):
+        pending_coroutines.append(coro)
+
+    def fake_decode_files_to_wav(raw_paths):
+        wav_paths = []
+        for raw_path in raw_paths:
+            wav_path = str(Path(raw_path).with_suffix(".wav"))
+            Path(wav_path).write_bytes(b"fake wav bytes")
+            wav_paths.append(wav_path)
+        return wav_paths
+
+    def fake_retrieve_vad_segments(path, segmented_paths, vad_errors):
+        segmented_paths.add(path)
+
+    def fake_prerecorded(*args, **kwargs):
+        return (
+            [
+                {
+                    "word": transcript_text,
+                    "start": 0.0,
+                    "end": 1.25,
+                    "speaker": 0,
+                    "speaker_confidence": 0.99,
+                    "confidence": 0.99,
+                }
+            ],
+            "en",
+        )
+
+    def fake_postprocess_words(words, offset):
+        return [
+            TranscriptSegment(
+                id="seg-sync-e2e",
+                text=transcript_text,
+                speaker="SPEAKER_00",
+                speaker_id=0,
+                is_user=True,
+                start=0.0,
+                end=1.25,
+            )
+        ]
+
+    def fake_process_conversation(uid, language, conversation):
+        import database.conversations as conversations_db
+        from models.structured import Structured
+
+        conversation_obj = Conversation(
+            id="sync-created-conversation",
+            uid=uid,
+            created_at=conversation.started_at,
+            started_at=conversation.started_at,
+            finished_at=conversation.finished_at,
+            source=conversation.source,
+            language=language,
+            structured=Structured(
+                title="Hermetic Sync Conversation",
+                overview="Sync v2 produced a deterministic conversation.",
+                emoji="🧪",
+                category="work",
+            ),
+            transcript_segments=conversation.transcript_segments,
+            discarded=False,
+            status=ConversationStatus.completed,
+            is_locked=conversation.is_locked,
+        )
+        conversations_db.upsert_conversation(uid, conversation_obj.dict())
+        return conversation_obj
+
+    def fake_reprocess_after_update(uid, conversation_id, language):
+        reprocessed.append(conversation_id)
+
+        conversation = read_conversation(uid, conversation_id)
+        assert conversation is not None
+        conversation["id"] = conversation_id
+        structured = dict(conversation.get("structured") or {})
+        structured.update(
+            {
+                "title": "Hermetic Sync Conversation Reprocessed",
+                "overview": "The target conversation was reprocessed once after sync merge.",
+                "emoji": "🧪",
+                "category": "work",
+                "action_items": [],
+                "events": [],
+            }
+        )
+        updated = dict(conversation)
+        updated["id"] = conversation_id
+        updated["structured"] = structured
+        seed_conversation(uid, updated)
+
+    monkeypatch.setattr(sync_router, "decode_files_to_wav", fake_decode_files_to_wav)
+    monkeypatch.setattr(sync_router, "retrieve_vad_segments", fake_retrieve_vad_segments)
+    monkeypatch.setattr(sync_router, "get_wav_duration", lambda path: 1.25)
+    monkeypatch.setattr(sync_router, "has_transcription_credits", lambda uid: True)
+    monkeypatch.setattr(sync_router, "build_person_embeddings_cache", lambda uid: {})
+    monkeypatch.setattr(sync_router, "get_syncing_file_temporal_signed_url", lambda path: path)
+    monkeypatch.setattr(sync_router, "schedule_syncing_temporal_file_deletion", lambda path: None)
+    monkeypatch.setattr(sync_router, "prerecorded", fake_prerecorded)
+    monkeypatch.setattr(sync_router, "postprocess_words", fake_postprocess_words)
+    monkeypatch.setattr(sync_router, "process_conversation", fake_process_conversation)
+    monkeypatch.setattr(sync_router, "_reprocess_conversation_after_update", fake_reprocess_after_update)
+    monkeypatch.setattr(sync_router, "start_background_task", capture_background_task)
+    return pending_coroutines
+
+
+def test_sync_v2_completes_job_and_creates_conversation(client, auth_headers, monkeypatch):
+    reprocessed = []
+    pending_coroutines = _patch_sync_pipeline(
+        monkeypatch,
+        transcript_text="Hermetic sync transcript from a fake prerecorded STT boundary.",
+        reprocessed=reprocessed,
+    )
+
+    response = client.post(
+        "/v2/sync-local-files",
+        files=[("files", (_sync_filename(), b"fake-pcm-frame", "application/octet-stream"))],
+        headers=auth_headers,
+    )
+    assert response.status_code == 202, response.text
+    queued = response.json()
+    assert queued["status"] == "queued"
+
+    _drain_background_coroutines(pending_coroutines)
+    job = _poll_sync_job(client, auth_headers, queued["job_id"])
+    assert job["status"] == "completed", job
+    assert job["total_segments"] == 1
+    assert job["successful_segments"] == 1
+    assert job["result"]["new_memories"] == ["sync-created-conversation"]
+    assert job["result"]["updated_memories"] == []
+
+    persisted = client.get("/v1/conversations/sync-created-conversation", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    body = persisted.json()
+    assert body["structured"]["title"] == "Hermetic Sync Conversation"
+    assert body["status"] == "completed"
+    assert [segment["text"] for segment in body["transcript_segments"]] == [
+        "Hermetic sync transcript from a fake prerecorded STT boundary."
+    ]
+    assert read_conversation("123", "sync-created-conversation") is not None
+    assert reprocessed == []
+
+
+def test_sync_v2_merges_into_target_conversation_and_reprocesses_once(client, auth_headers, monkeypatch):
+    import database.conversations as conversations_db
+
+    target_id = "sync-target-conversation"
+    timestamp = int(time.time()) - 120
+    target_timestamp = timestamp - 3600
+    seed_conversation(
+        "123",
+        {
+            "id": target_id,
+            "created_at": datetime.fromtimestamp(target_timestamp, tz=timezone.utc).isoformat(),
+            "started_at": datetime.fromtimestamp(target_timestamp, tz=timezone.utc).isoformat(),
+            "finished_at": datetime.fromtimestamp(target_timestamp + 1, tz=timezone.utc).isoformat(),
+            "source": "desktop",
+            "language": "en",
+            "structured": {
+                "title": "Before Sync Merge",
+                "overview": "",
+                "emoji": "🧠",
+                "category": "other",
+                "action_items": [],
+                "events": [],
+            },
+            "transcript_segments": [
+                {
+                    "id": "seg-existing",
+                    "text": "Existing live transcript.",
+                    "speaker": "SPEAKER_00",
+                    "is_user": True,
+                    "start": 0.0,
+                    "end": 1.0,
+                }
+            ],
+            "discarded": False,
+            "status": "completed",
+            "is_locked": False,
+            "data_protection_level": "standard",
+        },
+    )
+    assert read_conversation("123", target_id) is not None
+    assert conversations_db.get_conversation("123", target_id)["id"] == target_id
+    reprocessed = []
+    pending_coroutines = _patch_sync_pipeline(
+        monkeypatch,
+        transcript_text="Merged sync transcript appended to the target conversation.",
+        reprocessed=reprocessed,
+    )
+
+    response = client.post(
+        f"/v2/sync-local-files?conversation_id={target_id}",
+        files=[("files", (f"audio_{timestamp}.bin", b"fake-pcm-frame", "application/octet-stream"))],
+        headers=auth_headers,
+    )
+    assert response.status_code == 202, response.text
+
+    _drain_background_coroutines(pending_coroutines)
+    job = _poll_sync_job(client, auth_headers, response.json()["job_id"])
+    assert job["status"] == "completed", job
+    assert job["result"]["new_memories"] == []
+    assert job["result"]["updated_memories"] == [target_id]
+    assert reprocessed == [target_id]
+
+    persisted = client.get(f"/v1/conversations/{target_id}", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    body = persisted.json()
+    assert body["structured"]["title"] == "Hermetic Sync Conversation Reprocessed"
+    assert [segment["text"] for segment in body["transcript_segments"]] == [
+        "Existing live transcript.",
+        "Merged sync transcript appended to the target conversation.",
+    ]

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -9,6 +9,7 @@ import importlib.util
 import os
 import shutil as _shutil
 import sys
+import time
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1400,6 +1401,9 @@ class TestWsBudgetAndSessionCap:
                             with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                 # Send 32000 bytes = 1s at 16kHz mono
                                 ws.send_bytes(b'\x00' * 32000)
+                                deadline = time.time() + 1.0
+                                while not mock_dg_socket.send.called and time.time() < deadline:
+                                    time.sleep(0.01)
                             # After WS close, finally block should have called record_actual_duration
                             mock_record.assert_called_once()
                             call_args = mock_record.call_args[0]


### PR DESCRIPTION
## Summary
- Adds hermetic E2E coverage for listen WebSocket streaming STT, reconnect reuse, and teardown drain/finish.
- Adds sync v2 lifecycle tests that poll jobs to terminal state and assert durable conversation state.
- Hardens deterministic conversation processing lifecycle coverage with explicit external-boundary fakes.

## Validation
- `.venv/bin/python -m pytest testing/e2e/test_listen_stt.py testing/e2e/test_sync_lifecycle.py testing/e2e/test_conversation_processing.py -q` -> 13 passed
- Full hermetic E2E suite passed during prep: 85 passed, 3 skipped
- Pre-push hook passed
- Oracle pre-implementation and pre-PR reviews passed after repair rounds.

Fixes #8543


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

