### PR TITLE
[codex] Add hermetic OpenAPI contract drift check

### DIFF
--- a/.github/workflows/openapi-contract.yml
+++ b/.github/workflows/openapi-contract.yml
@@ -45,6 +45,15 @@ jobs:
         working-directory: backend
         run: uv pip sync pylock.toml --system
 
+      - name: Prewarm tokenizer cache
+        working-directory: backend
+        run: |
+          python - <<'PY'
+          import tiktoken
+
+          tiktoken.encoding_for_model('gpt-4')
+          PY
+
       - name: Check committed OpenAPI contract
         working-directory: backend
         run: python scripts/export_openapi.py --check ../docs/api-reference/openapi.json

--- a/.github/workflows/openapi-contract.yml
+++ b/.github/workflows/openapi-contract.yml
@@ -1,0 +1,50 @@
+name: OpenAPI Contract
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - 'docs/api-reference/openapi.json'
+      - 'docs/docs.json'
+      - '.github/workflows/openapi-contract.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'docs/api-reference/openapi.json'
+      - 'docs/docs.json'
+      - '.github/workflows/openapi-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  openapi-contract:
+    name: Public Developer API contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: uv pip sync pylock.toml --system
+
+      - name: Check committed OpenAPI contract
+        working-directory: backend
+        run: python scripts/export_openapi.py --check ../docs/api-reference/openapi.json

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
-from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 import database.folders as folders_db
 import database.memories as memories_db
@@ -16,7 +16,6 @@ import database.goals as goals_db
 import database.users as users_db
 from database.vector_db import upsert_memory_vectors_batch
 
-from models.folder import Folder
 from models.memories import MemoryCategory, Memory, MemoryDB
 from models.conversation import (
     Conversation as OmiConversation,
@@ -68,12 +67,12 @@ _FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6f
 # ******************************************************
 
 
-@router.get("/v1/dev/keys", response_model=List[DevApiKey], tags=["developer"])
+@router.get("/v1/dev/keys", response_model=List[DevApiKey], tags=["API Keys"], operation_id="listApiKeys")
 def get_keys(uid: str = Depends(get_current_user_id)):
     return dev_api_key_db.get_dev_keys_for_user(uid)
 
 
-@router.post("/v1/dev/keys", response_model=DevApiKeyCreated, tags=["developer"])
+@router.post("/v1/dev/keys", response_model=DevApiKeyCreated, tags=["API Keys"], operation_id="createApiKey")
 def create_key(key_data: DevApiKeyCreate, uid: str = Depends(get_current_user_id)):
     """
     Create a new Developer API key with optional scopes.
@@ -105,7 +104,7 @@ def create_key(key_data: DevApiKeyCreate, uid: str = Depends(get_current_user_id
     return DevApiKeyCreated(**api_key_data.model_dump(), key=raw_key)
 
 
-@router.delete("/v1/dev/keys/{key_id}", status_code=204, tags=["developer"])
+@router.delete("/v1/dev/keys/{key_id}", status_code=204, tags=["API Keys"], operation_id="revokeApiKey")
 def delete_key(key_id: str, uid: str = Depends(get_current_user_id)):
     dev_api_key_db.delete_dev_key(uid, key_id)
     invalidate_developer_cache(uid)
@@ -141,8 +140,9 @@ def _coerce_optional_memory_datetime(value) -> Optional[datetime]:
     return None
 
 
-class CleanerMemory(BaseModel):
-    # Core fields (aligned with MemoryResponse)
+class DeveloperMemory(BaseModel):
+    model_config = ConfigDict(title='DeveloperMemory')
+
     id: str
     content: str = ''
     category: MemoryCategory = MemoryCategory.interesting
@@ -151,10 +151,6 @@ class CleanerMemory(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     manually_added: bool = False
-    scoring: Optional[str] = None
-    reviewed: bool = False
-    user_review: Optional[bool] = None
-    edited: bool = False
 
     @field_validator('id', mode='before')
     def coerce_id(cls, value):
@@ -185,27 +181,11 @@ class CleanerMemory(BaseModel):
             return []
         return [str(tag) for tag in value if tag is not None]
 
-    @field_validator('scoring', mode='before')
-    def coerce_scoring(cls, value):
-        if value is None:
-            return None
-        return str(value)
-
     @field_validator('created_at', 'updated_at', mode='before')
     def coerce_datetime(cls, value):
         return _coerce_optional_memory_datetime(value)
 
-    @field_validator('user_review', mode='before')
-    def coerce_user_review(cls, value):
-        if isinstance(value, bool):
-            return value
-        if value in [None, '']:
-            return None
-        if isinstance(value, str):
-            return value.lower() in ['true', '1', 'yes']
-        return bool(value)
-
-    @field_validator('manually_added', 'reviewed', 'edited', mode='before')
+    @field_validator('manually_added', mode='before')
     def coerce_bool(cls, value):
         if isinstance(value, bool):
             return value
@@ -217,6 +197,8 @@ class CleanerMemory(BaseModel):
 
 
 class CreateMemoryRequest(BaseModel):
+    model_config = ConfigDict(title='CreateMemoryRequest')
+
     content: str = Field(description="The content of the memory", min_length=1, max_length=500)
     category: Optional[MemoryCategory] = Field(
         default=None, description="Memory category: interesting, system, or manual (auto-categorized if not provided)"
@@ -226,34 +208,33 @@ class CreateMemoryRequest(BaseModel):
 
 
 class UpdateMemoryRequest(BaseModel):
+    model_config = ConfigDict(title='UpdateMemoryRequest')
+
     content: Optional[str] = Field(default=None, description="New content for the memory", min_length=1, max_length=500)
     visibility: Optional[str] = Field(default=None, description="New visibility: public or private")
     tags: Optional[List[str]] = Field(default=None, description="New tags for the memory")
     category: Optional[MemoryCategory] = Field(default=None, description="New category for the memory")
 
 
-class MemoryResponse(BaseModel):
-    id: str
-    content: str
-    category: MemoryCategory
-    visibility: str
-    tags: List[str]
-    created_at: datetime
-    updated_at: datetime
-    manually_added: bool
-    scoring: str
-
-
 class BatchMemoriesRequest(BaseModel):
+    model_config = ConfigDict(title='BatchMemoriesRequest')
+
     memories: List[CreateMemoryRequest] = Field(description="List of memories to create", max_length=25)
 
 
 class BatchMemoriesResponse(BaseModel):
-    memories: List[MemoryResponse]
+    model_config = ConfigDict(title='BatchMemoriesResponse')
+
+    memories: List[DeveloperMemory]
     created_count: int
 
 
-@router.get("/v1/dev/user/memories", tags=["developer"], response_model=List[CleanerMemory])
+@router.get(
+    "/v1/dev/user/memories",
+    tags=["Memories"],
+    response_model=List[DeveloperMemory],
+    operation_id="listMemories",
+)
 def get_memories(
     uid: str = Depends(get_uid_with_memories_read),
     limit: int = 25,
@@ -279,7 +260,7 @@ def get_memories(
             content = str(memory.get('content') or '')
             memory['content'] = (content[:70] + '...') if len(content) > 70 else content
         try:
-            valid_memories.append(CleanerMemory.model_validate(memory))
+            valid_memories.append(DeveloperMemory.model_validate(memory))
         except ValidationError as e:
             missing_fields = [err['loc'][0] for err in e.errors() if err.get('loc')]
             logger.warning(
@@ -290,7 +271,7 @@ def get_memories(
     return valid_memories
 
 
-@router.post("/v1/dev/user/memories", response_model=MemoryResponse, tags=["developer"])
+@router.post("/v1/dev/user/memories", response_model=DeveloperMemory, tags=["Memories"], operation_id="createMemory")
 def create_memory(
     request: CreateMemoryRequest,
     uid: str = Depends(with_rate_limit(get_uid_with_memories_write, "dev:memories")),
@@ -323,7 +304,7 @@ def create_memory(
     # Save to database
     memories_db.create_memory(uid, memory_db.dict())
 
-    return MemoryResponse(
+    return DeveloperMemory(
         id=memory_db.id,
         content=memory_db.content,
         category=memory_db.category,
@@ -332,11 +313,15 @@ def create_memory(
         created_at=memory_db.created_at,
         updated_at=memory_db.updated_at,
         manually_added=memory_db.manually_added,
-        scoring=memory_db.scoring,
     )
 
 
-@router.post("/v1/dev/user/memories/batch", response_model=BatchMemoriesResponse, tags=["developer"])
+@router.post(
+    "/v1/dev/user/memories/batch",
+    response_model=BatchMemoriesResponse,
+    tags=["Memories"],
+    operation_id="createMemoriesBatch",
+)
 def create_memories_batch(
     request: BatchMemoriesRequest,
     uid: str = Depends(with_rate_limit(get_uid_with_memories_write, "dev:memories_batch")),
@@ -398,7 +383,7 @@ def create_memories_batch(
 
     # Prepare response
     created_memories = [
-        MemoryResponse(
+        DeveloperMemory(
             id=mem.id,
             content=mem.content,
             category=mem.category,
@@ -407,7 +392,6 @@ def create_memories_batch(
             created_at=mem.created_at,
             updated_at=mem.updated_at,
             manually_added=mem.manually_added,
-            scoring=mem.scoring,
         )
         for mem in memory_dbs
     ]
@@ -415,7 +399,7 @@ def create_memories_batch(
     return BatchMemoriesResponse(memories=created_memories, created_count=len(created_memories))
 
 
-@router.delete("/v1/dev/user/memories/{memory_id}", tags=["developer"])
+@router.delete("/v1/dev/user/memories/{memory_id}", tags=["Memories"], operation_id="deleteMemory")
 def delete_memory(
     memory_id: str,
     uid: str = Depends(get_uid_with_memories_write),
@@ -435,7 +419,12 @@ def delete_memory(
     return {"success": True}
 
 
-@router.patch("/v1/dev/user/memories/{memory_id}", response_model=CleanerMemory, tags=["developer"])
+@router.patch(
+    "/v1/dev/user/memories/{memory_id}",
+    response_model=DeveloperMemory,
+    tags=["Memories"],
+    operation_id="updateMemory",
+)
 def update_memory(
     memory_id: str,
     request: UpdateMemoryRequest,
@@ -489,6 +478,8 @@ def update_memory(
 
 
 class ActionItemResponse(BaseModel):
+    model_config = ConfigDict(title='DeveloperActionItem')
+
     id: str
     description: str
     completed: bool
@@ -500,6 +491,8 @@ class ActionItemResponse(BaseModel):
 
 
 class CreateActionItemRequest(BaseModel):
+    model_config = ConfigDict(title='CreateActionItemRequest')
+
     description: str = Field(description="The action item description", min_length=1, max_length=500)
     completed: bool = Field(default=False, description="Whether the action item is completed")
     due_at: Optional[datetime] = Field(
@@ -508,21 +501,32 @@ class CreateActionItemRequest(BaseModel):
 
 
 class UpdateActionItemRequest(BaseModel):
+    model_config = ConfigDict(title='UpdateActionItemRequest')
+
     description: Optional[str] = Field(default=None, description="New description", min_length=1, max_length=500)
     completed: Optional[bool] = Field(default=None, description="New completion status")
     due_at: Optional[datetime] = Field(default=None, description="New due date (ISO format with timezone)")
 
 
 class BatchActionItemsRequest(BaseModel):
+    model_config = ConfigDict(title='BatchActionItemsRequest')
+
     action_items: List[CreateActionItemRequest] = Field(description="List of action items to create", max_length=50)
 
 
 class BatchActionItemsResponse(BaseModel):
+    model_config = ConfigDict(title='BatchActionItemsResponse')
+
     action_items: List[ActionItemResponse]
     created_count: int
 
 
-@router.get("/v1/dev/user/action-items", tags=["developer"], response_model=List[ActionItemResponse])
+@router.get(
+    "/v1/dev/user/action-items",
+    tags=["Action Items"],
+    response_model=List[ActionItemResponse],
+    operation_id="listActionItems",
+)
 def get_action_items(
     uid: str = Depends(get_uid_with_action_items_read),
     conversation_id: Optional[str] = None,
@@ -574,7 +578,12 @@ def get_action_items(
     return valid_action_items
 
 
-@router.post("/v1/dev/user/action-items", response_model=ActionItemResponse, tags=["developer"])
+@router.post(
+    "/v1/dev/user/action-items",
+    response_model=ActionItemResponse,
+    tags=["Action Items"],
+    operation_id="createActionItem",
+)
 def create_action_item(
     request: CreateActionItemRequest,
     uid: str = Depends(get_uid_with_action_items_write),
@@ -614,7 +623,12 @@ def create_action_item(
     return ActionItemResponse(**action_item)
 
 
-@router.post("/v1/dev/user/action-items/batch", response_model=BatchActionItemsResponse, tags=["developer"])
+@router.post(
+    "/v1/dev/user/action-items/batch",
+    response_model=BatchActionItemsResponse,
+    tags=["Action Items"],
+    operation_id="createActionItemsBatch",
+)
 def create_action_items_batch(
     request: BatchActionItemsRequest,
     uid: str = Depends(get_uid_with_action_items_write),
@@ -666,7 +680,11 @@ def create_action_items_batch(
     return BatchActionItemsResponse(action_items=created_items, created_count=len(created_items))
 
 
-@router.delete("/v1/dev/user/action-items/{action_item_id}", tags=["developer"])
+@router.delete(
+    "/v1/dev/user/action-items/{action_item_id}",
+    tags=["Action Items"],
+    operation_id="deleteActionItem",
+)
 def delete_action_item(
     action_item_id: str,
     uid: str = Depends(get_uid_with_action_items_write),
@@ -686,7 +704,12 @@ def delete_action_item(
     return {"success": True}
 
 
-@router.patch("/v1/dev/user/action-items/{action_item_id}", response_model=ActionItemResponse, tags=["developer"])
+@router.patch(
+    "/v1/dev/user/action-items/{action_item_id}",
+    response_model=ActionItemResponse,
+    tags=["Action Items"],
+    operation_id="updateActionItem",
+)
 def update_action_item(
     action_item_id: str,
     request: UpdateActionItemRequest,
@@ -749,6 +772,8 @@ def update_action_item(
 
 
 class ActionItem(BaseModel):
+    model_config = ConfigDict(title='DeveloperConversationActionItem')
+
     description: str
     completed: bool = False
     created_at: Optional[datetime] = None
@@ -759,6 +784,8 @@ class ActionItem(BaseModel):
 
 
 class Event(BaseModel):
+    model_config = ConfigDict(title='DeveloperConversationEvent')
+
     title: str
     description: str = ''
     start: datetime
@@ -767,6 +794,8 @@ class Event(BaseModel):
 
 
 class SimpleStructured(BaseModel):
+    model_config = ConfigDict(title='DeveloperConversationStructured')
+
     title: str
     overview: str
     emoji: str = '🧠'
@@ -776,6 +805,8 @@ class SimpleStructured(BaseModel):
 
 
 class SimpleTranscriptSegment(BaseModel):
+    model_config = ConfigDict(title='DeveloperTranscriptSegment')
+
     id: Optional[str] = None
     text: str
     speaker_id: Optional[int] = None
@@ -785,6 +816,8 @@ class SimpleTranscriptSegment(BaseModel):
 
 
 class Conversation(BaseModel):
+    model_config = ConfigDict(title='DeveloperConversation')
+
     id: str
     created_at: datetime
     started_at: Optional[datetime]
@@ -799,6 +832,8 @@ class Conversation(BaseModel):
 
 
 class CreateConversationRequest(BaseModel):
+    model_config = ConfigDict(title='CreateConversationRequest')
+
     text: str = Field(description="The conversation text/transcript", min_length=1, max_length=100000)
     text_source: ExternalIntegrationConversationSource = Field(
         default=ExternalIntegrationConversationSource.other,
@@ -816,12 +851,16 @@ class CreateConversationRequest(BaseModel):
 
 
 class ConversationResponse(BaseModel):
+    model_config = ConfigDict(title='ConversationCreateResponse')
+
     id: str
     status: str
     discarded: bool
 
 
 class UpdateConversationRequest(BaseModel):
+    model_config = ConfigDict(title='UpdateConversationRequest')
+
     title: Optional[str] = Field(
         default=None, description="New title for the conversation", min_length=1, max_length=500
     )
@@ -829,6 +868,8 @@ class UpdateConversationRequest(BaseModel):
 
 
 class DevTranscriptSegment(BaseModel):
+    model_config = ConfigDict(title='CreateConversationTranscriptSegment')
+
     text: str = Field(description="The text spoken in this segment")
     speaker: Optional[str] = Field(
         default='SPEAKER_00', description="Speaker identifier (e.g., 'SPEAKER_00', 'SPEAKER_01')"
@@ -841,6 +882,8 @@ class DevTranscriptSegment(BaseModel):
 
 
 class CreateConversationFromTranscriptRequest(BaseModel):
+    model_config = ConfigDict(title='CreateConversationFromTranscriptRequest')
+
     transcript_segments: List[DevTranscriptSegment] = Field(
         description="List of transcript segments with speaker and timing info", min_length=1, max_length=500
     )
@@ -873,7 +916,23 @@ class CreateConversationFromTranscriptRequest(BaseModel):
         return value
 
 
-@router.get("/v1/dev/user/folders", response_model=List[Folder], tags=["developer"])
+class DeveloperFolder(BaseModel):
+    model_config = ConfigDict(title='DeveloperFolder')
+
+    id: str
+    name: str
+    description: Optional[str] = None
+    color: str
+    icon: str
+    created_at: datetime
+    updated_at: datetime
+    order: int = 0
+    is_default: bool = False
+    is_system: bool = False
+    conversation_count: int = 0
+
+
+@router.get("/v1/dev/user/folders", response_model=List[DeveloperFolder], tags=["Folders"], operation_id="listFolders")
 def get_user_folders(uid: str = Depends(get_uid_with_conversations_read)):
     """
     Get all folders for the authenticated user.
@@ -898,7 +957,12 @@ def get_user_folders(uid: str = Depends(get_uid_with_conversations_read)):
     return folders_db.get_folders(uid)
 
 
-@router.get("/v1/dev/user/conversations", response_model=List[Conversation], tags=["developer"])
+@router.get(
+    "/v1/dev/user/conversations",
+    response_model=List[Conversation],
+    tags=["Conversations"],
+    operation_id="listConversations",
+)
 def get_conversations(
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
@@ -966,7 +1030,12 @@ def get_conversations(
     return valid_conversations
 
 
-@router.post("/v1/dev/user/conversations", response_model=ConversationResponse, tags=["developer"])
+@router.post(
+    "/v1/dev/user/conversations",
+    response_model=ConversationResponse,
+    tags=["Conversations"],
+    operation_id="createConversation",
+)
 def create_conversation(
     request: CreateConversationRequest,
     uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
@@ -1044,7 +1113,12 @@ def create_conversation(
     )
 
 
-@router.get("/v1/dev/user/conversations/{conversation_id}", response_model=Conversation, tags=["developer"])
+@router.get(
+    "/v1/dev/user/conversations/{conversation_id}",
+    response_model=Conversation,
+    tags=["Conversations"],
+    operation_id="getConversation",
+)
 def get_conversation_endpoint(
     conversation_id: str,
     include_transcript: bool = False,
@@ -1271,7 +1345,12 @@ def create_conversation_from_segments_user(
     return _create_conversation_from_segments(uid, request)
 
 
-@router.post("/v1/dev/user/conversations/from-segments", response_model=ConversationResponse, tags=["developer"])
+@router.post(
+    "/v1/dev/user/conversations/from-segments",
+    response_model=ConversationResponse,
+    tags=["Conversations"],
+    operation_id="createConversationFromSegments",
+)
 def create_conversation_from_segments(
     request: CreateConversationFromTranscriptRequest,
     uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
@@ -1326,7 +1405,11 @@ def create_conversation_from_segments(
     return _create_conversation_from_segments(uid, request)
 
 
-@router.delete("/v1/dev/user/conversations/{conversation_id}", tags=["developer"])
+@router.delete(
+    "/v1/dev/user/conversations/{conversation_id}",
+    tags=["Conversations"],
+    operation_id="deleteConversation",
+)
 def delete_conversation_endpoint(
     conversation_id: str,
     uid: str = Depends(get_uid_with_conversations_write),
@@ -1348,7 +1431,12 @@ def delete_conversation_endpoint(
     return {"success": True}
 
 
-@router.patch("/v1/dev/user/conversations/{conversation_id}", response_model=Conversation, tags=["developer"])
+@router.patch(
+    "/v1/dev/user/conversations/{conversation_id}",
+    response_model=Conversation,
+    tags=["Conversations"],
+    operation_id="updateConversation",
+)
 def update_conversation_endpoint(
     conversation_id: str,
     request: UpdateConversationRequest,
@@ -1397,6 +1485,8 @@ class GoalType(str, Enum):
 
 
 class GoalResponse(BaseModel):
+    model_config = ConfigDict(title='DeveloperGoal')
+
     id: str
     title: str
     goal_type: str
@@ -1411,6 +1501,8 @@ class GoalResponse(BaseModel):
 
 
 class CreateGoalRequest(BaseModel):
+    model_config = ConfigDict(title='CreateGoalRequest')
+
     title: str = Field(description="The goal title/description", min_length=1, max_length=500)
     goal_type: GoalType = Field(default=GoalType.scale, description="Type of goal metric: boolean, scale, or numeric")
     target_value: float = Field(description="Target value to achieve")
@@ -1421,6 +1513,8 @@ class CreateGoalRequest(BaseModel):
 
 
 class UpdateGoalRequest(BaseModel):
+    model_config = ConfigDict(title='UpdateGoalRequest')
+
     title: Optional[str] = Field(default=None, description="New title", min_length=1, max_length=500)
     target_value: Optional[float] = Field(default=None, description="New target value")
     current_value: Optional[float] = Field(default=None, description="New progress value")
@@ -1438,7 +1532,7 @@ def _serialize_goal_datetimes(goal: dict) -> dict:
     return goal
 
 
-@router.get("/v1/dev/user/goals", tags=["developer"], response_model=List[GoalResponse])
+@router.get("/v1/dev/user/goals", tags=["Goals"], response_model=List[GoalResponse], operation_id="listGoals")
 def get_goals(
     uid: str = Depends(get_uid_with_goals_read),
     limit: int = 10,
@@ -1458,7 +1552,7 @@ def get_goals(
     return [_serialize_goal_datetimes(g) for g in goals]
 
 
-@router.get("/v1/dev/user/goals/{goal_id}", tags=["developer"], response_model=GoalResponse)
+@router.get("/v1/dev/user/goals/{goal_id}", tags=["Goals"], response_model=GoalResponse, operation_id="getGoal")
 def get_goal(
     goal_id: str,
     uid: str = Depends(get_uid_with_goals_read),
@@ -1477,7 +1571,7 @@ def get_goal(
     return _serialize_goal_datetimes(goal)
 
 
-@router.post("/v1/dev/user/goals", tags=["developer"], response_model=GoalResponse)
+@router.post("/v1/dev/user/goals", tags=["Goals"], response_model=GoalResponse, operation_id="createGoal")
 def create_goal(
     request: CreateGoalRequest,
     uid: str = Depends(get_uid_with_goals_write),
@@ -1511,7 +1605,7 @@ def create_goal(
     return _serialize_goal_datetimes(created_goal)
 
 
-@router.patch("/v1/dev/user/goals/{goal_id}", tags=["developer"], response_model=GoalResponse)
+@router.patch("/v1/dev/user/goals/{goal_id}", tags=["Goals"], response_model=GoalResponse, operation_id="updateGoal")
 def update_goal(
     goal_id: str,
     request: UpdateGoalRequest,
@@ -1544,7 +1638,12 @@ def update_goal(
     return _serialize_goal_datetimes(updated_goal)
 
 
-@router.patch("/v1/dev/user/goals/{goal_id}/progress", tags=["developer"], response_model=GoalResponse)
+@router.patch(
+    "/v1/dev/user/goals/{goal_id}/progress",
+    tags=["Goals"],
+    response_model=GoalResponse,
+    operation_id="updateGoalProgress",
+)
 def update_goal_progress(
     goal_id: str,
     current_value: float = Query(..., description="New progress value"),
@@ -1564,7 +1663,7 @@ def update_goal_progress(
     return _serialize_goal_datetimes(updated_goal)
 
 
-@router.get("/v1/dev/user/goals/{goal_id}/history", tags=["developer"])
+@router.get("/v1/dev/user/goals/{goal_id}/history", tags=["Goals"], operation_id="listGoalHistory")
 def get_goal_history(
     goal_id: str,
     days: HistoryDays = 30,
@@ -1585,7 +1684,7 @@ def get_goal_history(
     return history
 
 
-@router.delete("/v1/dev/user/goals/{goal_id}", tags=["developer"])
+@router.delete("/v1/dev/user/goals/{goal_id}", tags=["Goals"], operation_id="deleteGoal")
 def delete_goal(
     goal_id: str,
     uid: str = Depends(get_uid_with_goals_write),

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -151,6 +151,10 @@ class DeveloperMemory(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     manually_added: bool = False
+    reviewed: bool = False
+    user_review: Optional[bool] = None
+    edited: bool = False
+    scoring: Optional[str] = None
 
     @field_validator('id', mode='before')
     def coerce_id(cls, value):
@@ -185,7 +189,7 @@ class DeveloperMemory(BaseModel):
     def coerce_datetime(cls, value):
         return _coerce_optional_memory_datetime(value)
 
-    @field_validator('manually_added', mode='before')
+    @field_validator('manually_added', 'reviewed', 'edited', mode='before')
     def coerce_bool(cls, value):
         if isinstance(value, bool):
             return value
@@ -194,6 +198,26 @@ class DeveloperMemory(BaseModel):
         if isinstance(value, str):
             return value.lower() in ['true', '1', 'yes']
         return bool(value)
+
+    @field_validator('user_review', mode='before')
+    def coerce_optional_bool(cls, value):
+        if value in [None, '']:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ['true', '1', 'yes']
+        return bool(value)
+
+    @field_validator('scoring', mode='before')
+    def coerce_scoring(cls, value):
+        if value is None:
+            return None
+        return str(value)
+
+
+# Backward-compatible name used by unit tests and older docs.
+CleanerMemory = DeveloperMemory
 
 
 class CreateMemoryRequest(BaseModel):

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""Export and check the public Developer API OpenAPI contract.
+
+Contract-surface decision for issue #8546:
+- `docs/api-reference/openapi.json` is the public Mintlify Developer API contract.
+- The public contract is generated from the real FastAPI app, but filtered to
+  `/v1/dev/...` routes so internal, admin, task, and app-client routes are not
+  published through Mintlify by accident.
+- Public-like routes that intentionally stay out of Mintlify must be listed in
+  `UNDOCUMENTED_PUBLIC_ROUTES` with a reason.
+
+The bootstrap is hermetic: it disables dotenv loading, removes real credential
+env vars, installs fake Firestore/Redis/GCS boundaries, patches Firebase app
+initialization, and blocks non-local network while importing the app.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import logging
+import os
+import socket
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from fastapi.routing import APIRoute
+from fastapi.openapi.utils import get_openapi
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+BACKEND_DIR = ROOT_DIR / 'backend'
+E2E_DIR = BACKEND_DIR / 'testing' / 'e2e'
+DEFAULT_SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'openapi.json'
+
+DOCUMENTED_PUBLIC_PREFIXES = ('/v1/dev/',)
+AUDITED_PUBLIC_PREFIXES = (
+    '/v1/dev/',
+    '/v1/conversations',
+)
+UNDOCUMENTED_PUBLIC_ROUTES: dict[tuple[str, str], str] = {
+    (
+        'POST',
+        '/v1/conversations',
+    ): 'Firebase-authenticated first-party app route; public docs expose Developer API key conversation creation.',
+    (
+        'GET',
+        '/v1/conversations',
+    ): 'Firebase-authenticated first-party app route; public docs expose Developer API key conversation listing.',
+    (
+        'GET',
+        '/v1/conversations/count',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}',
+    ): 'Firebase-authenticated first-party app route; public docs expose the Developer API key conversation detail route.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/title',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/visibility',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/starred',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/folder',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'DELETE',
+        '/v1/conversations/{conversation_id}/calendar-event',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/{conversation_id}/calendar-event',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/{conversation_id}/calendar-event/auto-link',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/summary',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/segments/text',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/segments/{segment_idx}/assign',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/segments/assign-bulk',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/assign-speaker/{speaker_id}',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'DELETE',
+        '/v1/conversations/{conversation_id}',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/recording',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/photos',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/transcripts',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/events',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/action-items',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/action-items',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'PATCH',
+        '/v1/conversations/{conversation_id}/action-items/{action_item_idx}',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'DELETE',
+        '/v1/conversations/{conversation_id}/action-items',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/shared',
+    ): 'Unauthenticated shared-conversation route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/search',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/merge',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'GET',
+        '/v1/conversations/{conversation_id}/suggested-apps',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/{conversation_id}/test-prompt',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/{conversation_id}/finalize',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/{conversation_id}/reprocess',
+    ): 'Firebase-authenticated first-party app route; not part of the Developer API key contract.',
+    (
+        'POST',
+        '/v1/conversations/from-segments',
+    ): 'Firebase-authenticated app-client alias; public docs expose the Developer API key route only.',
+}
+
+HTTP_METHODS = {'GET', 'POST', 'PUT', 'PATCH', 'DELETE'}
+
+OPENAPI_TITLE = 'Omi Developer API'
+OPENAPI_VERSION = '1.0.0'
+OPENAPI_DESCRIPTION = (
+    'Programmatic access to your Omi data - memories, conversations, action items, goals, folders, and API keys. '
+    'Build custom integrations, analytics dashboards, and automation workflows.'
+)
+OPENAPI_CONTACT = {'name': 'Omi', 'url': 'https://omi.me'}
+OPENAPI_LICENSE = {'name': 'MIT', 'url': 'https://github.com/BasedHardware/omi/blob/main/LICENSE'}
+OPENAPI_SERVERS = [{'url': 'https://api.omi.me', 'description': 'Production'}]
+OPENAPI_TAGS = [
+    {'name': 'Memories', 'description': 'Read and write user memories - timeless facts, preferences, and insights.'},
+    {
+        'name': 'Conversations',
+        'description': 'Create and retrieve conversation transcripts with AI-generated summaries.',
+    },
+    {'name': 'Folders', 'description': 'Retrieve user-defined folders for organizing conversations.'},
+    {
+        'name': 'Action Items',
+        'description': 'Manage tasks and to-dos extracted from conversations or created manually.',
+    },
+    {'name': 'Goals', 'description': 'Manage user goals and progress history.'},
+    {'name': 'API Keys', 'description': 'Create, list, and revoke developer API keys.'},
+]
+FIREBASE_BEARER_AUTH_SCHEME = {
+    'type': 'http',
+    'scheme': 'bearer',
+    'bearerFormat': 'Firebase ID token',
+    'description': 'Send `Authorization: Bearer <firebase_id_token>`.',
+}
+DEVELOPER_API_KEY_AUTH_SCHEME = {
+    'type': 'http',
+    'scheme': 'bearer',
+    'bearerFormat': 'Omi Developer API key',
+    'description': 'Send `Authorization: Bearer <omi_developer_api_key>`.',
+}
+ERROR_RESPONSE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'detail': {
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'array'},
+                {'type': 'object'},
+            ],
+            'description': 'Error detail returned by the API.',
+        }
+    },
+    'required': ['detail'],
+    'title': 'ErrorResponse',
+}
+COMMON_RESPONSES = {
+    '401': {'description': 'Missing or invalid authentication credentials.'},
+    '403': {'description': 'Authenticated, but the token does not grant the required scope.'},
+    '404': {'description': 'Requested resource was not found.'},
+}
+SIDE_EFFECT_PATHS = (
+    BACKEND_DIR / 'google-credentials.json',
+    BACKEND_DIR / '_temp',
+    BACKEND_DIR / '_samples',
+    BACKEND_DIR / '_segments',
+    BACKEND_DIR / '_speech_profiles',
+)
+RESTORABLE_SIDE_EFFECT_PATHS = {
+    BACKEND_DIR / '_temp': 'created by backend/main.py import-time temp-dir bootstrap',
+    BACKEND_DIR / '_samples': 'created by backend/main.py import-time temp-dir bootstrap',
+    BACKEND_DIR / '_segments': 'created by backend/main.py import-time temp-dir bootstrap',
+    BACKEND_DIR / '_speech_profiles': 'created by backend/main.py import-time temp-dir bootstrap',
+}
+
+
+class OpenAPIContractError(RuntimeError):
+    """Raised when the generated OpenAPI contract fails a deterministic check."""
+
+
+def configure_hermetic_environment() -> None:
+    os.environ['PYTHON_DOTENV_DISABLED'] = '1'
+    os.environ['LOCAL_DEVELOPMENT'] = 'true'
+    os.environ['ENCRYPTION_SECRET'] = 'test-encryption-secret-for-openapi-testing-32chars!'
+    os.environ['FIREBASE_PROJECT_ID'] = 'test-openapi-project'
+    os.environ['GOOGLE_CLOUD_PROJECT'] = 'test-openapi-project'
+    os.environ['REDIS_DB_HOST'] = 'localhost'
+    os.environ['REDIS_DB_PORT'] = '6379'
+    os.environ['REDIS_DB_PASSWORD'] = ''
+    os.environ['DEEPGRAM_API_KEY'] = 'fake-deepgram-key'
+    os.environ['OPENAI_API_KEY'] = 'fake-openai-key'
+    os.environ['ANTHROPIC_API_KEY'] = 'fake-anthropic-key'
+    os.environ['OPENROUTER_API_KEY'] = 'fake-openrouter-key'
+    os.environ['GOOGLE_API_KEY'] = 'fake-google-key'
+    os.environ['TYPESENSE_HOST'] = 'localhost'
+    os.environ['TYPESENSE_HOST_PORT'] = '8108'
+    os.environ['TYPESENSE_API_KEY'] = 'fake-typesense-key'
+    os.environ['STRIPE_SECRET_KEY'] = ''
+    os.environ['STRIPE_API_KEY'] = ''
+    os.environ['ADMIN_KEY'] = ''
+
+    for bucket_var in (
+        'BUCKET_SPEECH_PROFILES',
+        'BUCKET_POSTPROCESSING',
+        'BUCKET_PRIVATE_CLOUD_SYNC',
+        'BUCKET_TEMPORAL_SYNC_LOCAL',
+        'BUCKET_MEMORIES_RECORDINGS',
+        'BUCKET_APP_THUMBNAILS',
+        'BUCKET_CHAT_FILES',
+        'BUCKET_DESKTOP_UPDATES',
+    ):
+        os.environ[bucket_var] = bucket_var.lower().replace('bucket_', '').replace('_', '-')
+
+    for secret_var in (
+        'SERVICE_ACCOUNT_JSON',
+        'GOOGLE_APPLICATION_CREDENTIALS',
+        'PINECONE_API_KEY',
+        'LANGCHAIN_API_KEY',
+        'HUME_API_KEY',
+        'HUME_CALLBACK_URL',
+    ):
+        os.environ.pop(secret_var, None)
+
+    for proxy_var in (
+        'HTTP_PROXY',
+        'HTTPS_PROXY',
+        'ALL_PROXY',
+        'NO_PROXY',
+        'http_proxy',
+        'https_proxy',
+        'all_proxy',
+        'no_proxy',
+    ):
+        os.environ.pop(proxy_var, None)
+
+
+def _install_import_paths() -> None:
+    for path in (str(BACKEND_DIR), str(E2E_DIR)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def is_local_address(host: object) -> bool:
+    if host is None:
+        return True
+    if isinstance(host, bytes):
+        host = host.decode('idna')
+    if not isinstance(host, str):
+        return False
+    normalized = host.strip().strip('[]').lower()
+    if normalized in {'', 'localhost'}:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _host_from_address(address: object) -> object:
+    if isinstance(address, tuple) and address:
+        return address[0]
+    return None
+
+
+@contextmanager
+def record_and_block_outbound_network() -> Iterator[list[str]]:
+    attempts: list[str] = []
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+    original_create_connection = socket.create_connection
+    original_getaddrinfo = socket.getaddrinfo
+    original_gethostbyname = socket.gethostbyname
+    original_gethostbyname_ex = socket.gethostbyname_ex
+
+    def record(kind: str, target: object) -> None:
+        attempts.append(f'{kind}: {target!r}')
+
+    def guarded_connect(sock: socket.socket, address: object):
+        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+            record('connect', address)
+            raise OpenAPIContractError(f'blocked outbound network connection to {address!r}')
+        return original_connect(sock, address)
+
+    def guarded_connect_ex(sock: socket.socket, address: object):
+        if sock.family != socket.AF_UNIX and not is_local_address(_host_from_address(address)):
+            record('connect_ex', address)
+            raise OpenAPIContractError(f'blocked outbound network connection to {address!r}')
+        return original_connect_ex(sock, address)
+
+    def guarded_create_connection(address: object, *args, **kwargs):
+        if not is_local_address(_host_from_address(address)):
+            record('create_connection', address)
+            raise OpenAPIContractError(f'blocked outbound network connection to {address!r}')
+        return original_create_connection(address, *args, **kwargs)
+
+    def guarded_getaddrinfo(host: object, *args, **kwargs):
+        if not is_local_address(host):
+            record('getaddrinfo', host)
+            raise OpenAPIContractError(f'blocked DNS resolution for {host!r}')
+        return original_getaddrinfo(host, *args, **kwargs)
+
+    def guarded_gethostbyname(host: object):
+        if not is_local_address(host):
+            record('gethostbyname', host)
+            raise OpenAPIContractError(f'blocked DNS resolution for {host!r}')
+        return original_gethostbyname(host)
+
+    def guarded_gethostbyname_ex(host: object):
+        if not is_local_address(host):
+            record('gethostbyname_ex', host)
+            raise OpenAPIContractError(f'blocked DNS resolution for {host!r}')
+        return original_gethostbyname_ex(host)
+
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+    socket.create_connection = guarded_create_connection
+    socket.getaddrinfo = guarded_getaddrinfo
+    socket.gethostbyname = guarded_gethostbyname
+    socket.gethostbyname_ex = guarded_gethostbyname_ex
+    try:
+        yield attempts
+    finally:
+        socket.socket.connect = original_connect
+        socket.socket.connect_ex = original_connect_ex
+        socket.create_connection = original_create_connection
+        socket.getaddrinfo = original_getaddrinfo
+        socket.gethostbyname = original_gethostbyname
+        socket.gethostbyname_ex = original_gethostbyname_ex
+
+
+def snapshot_side_effect_paths() -> dict[Path, tuple[bool, int | None, int | None]]:
+    snapshot: dict[Path, tuple[bool, int | None, int | None]] = {}
+    for path in SIDE_EFFECT_PATHS:
+        if path.exists():
+            stat = path.stat()
+            snapshot[path] = (True, stat.st_mtime_ns, stat.st_size if path.is_file() else None)
+        else:
+            snapshot[path] = (False, None, None)
+    return snapshot
+
+
+def assert_no_side_effect_path_mutations(snapshot: dict[Path, tuple[bool, int | None, int | None]]) -> None:
+    mutations = []
+    for path, before in snapshot.items():
+        if path.exists():
+            stat = path.stat()
+            after = (True, stat.st_mtime_ns, stat.st_size if path.is_file() else None)
+        else:
+            after = (False, None, None)
+        if before != after:
+            try:
+                mutations.append(str(path.relative_to(ROOT_DIR)))
+            except ValueError:
+                mutations.append(str(path))
+    if mutations:
+        raise OpenAPIContractError('OpenAPI export mutated side-effect paths: ' + ', '.join(mutations))
+
+
+def restore_restorable_side_effect_paths(snapshot: dict[Path, tuple[bool, int | None, int | None]]) -> None:
+    for path, before in snapshot.items():
+        existed_before = before[0]
+        if existed_before or not path.exists():
+            continue
+        if path not in RESTORABLE_SIDE_EFFECT_PATHS:
+            continue
+        if path.is_dir() and not any(path.iterdir()):
+            path.rmdir()
+
+
+def assert_env_unchanged(expected_env: dict[str, str]) -> None:
+    current_env = dict(os.environ)
+    if current_env == expected_env:
+        return
+
+    added = sorted(set(current_env) - set(expected_env))
+    removed = sorted(set(expected_env) - set(current_env))
+    changed = sorted(key for key in set(current_env) & set(expected_env) if current_env[key] != expected_env[key])
+    details = []
+    if added:
+        details.append('added=' + ','.join(added))
+    if removed:
+        details.append('removed=' + ','.join(removed))
+    if changed:
+        details.append('changed=' + ','.join(changed))
+    raise OpenAPIContractError('OpenAPI export mutated environment: ' + '; '.join(details))
+
+
+def install_hermetic_dependency_patches():
+    import dotenv
+    import google.auth
+    import google.auth.credentials
+    from fakes.firestore import get_mock_firestore, patch_google_firestore, setup_fake_firestore
+    from fakes.redis import get_fake_redis, patch_redis_client, setup_fake_redis
+    from fakes.storage import patch_google_storage, setup_fake_storage
+
+    dotenv.load_dotenv = lambda *args, **kwargs: False
+    google.auth.default = lambda *args, **kwargs: (
+        google.auth.credentials.AnonymousCredentials(),
+        'test-openapi-project',
+    )
+
+    fake_firestore = setup_fake_firestore()
+    fake_redis = setup_fake_redis()
+    setup_fake_storage()
+
+    patch_google_firestore()
+    patch_redis_client()
+    patch_google_storage()
+
+    import firebase_admin
+
+    firebase_admin.initialize_app = lambda *args, **kwargs: None
+    firebase_admin.get_app = lambda *args, **kwargs: object()
+
+    return fake_firestore, fake_redis, get_mock_firestore, get_fake_redis
+
+
+def relink_imported_service_singletons(fake_firestore, fake_redis, get_mock_firestore, get_fake_redis) -> None:
+    import database._client as db_client
+    import database.redis_db as redis_db
+
+    old_db = db_client.db
+    old_r = redis_db.r
+    db_client.db = fake_firestore
+    redis_db.r = fake_redis
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        for attr_name, attr_value in list(vars(module).items()):
+            try:
+                if attr_value is old_db:
+                    setattr(module, attr_name, get_mock_firestore())
+                elif attr_value is old_r:
+                    setattr(module, attr_name, get_fake_redis())
+            except Exception:
+                continue
+
+
+def generate_public_openapi() -> dict[str, Any]:
+    original_env = dict(os.environ)
+    side_effect_snapshot = snapshot_side_effect_paths()
+    configure_hermetic_environment()
+    expected_fake_env = dict(os.environ)
+    _install_import_paths()
+
+    logging.disable(logging.CRITICAL)
+    try:
+        fake_firestore, fake_redis, get_mock_firestore, get_fake_redis = install_hermetic_dependency_patches()
+        with record_and_block_outbound_network() as network_attempts:
+            import main as backend_main
+
+            relink_imported_service_singletons(fake_firestore, fake_redis, get_mock_firestore, get_fake_redis)
+            schema = build_public_openapi(backend_main.app)
+
+            if network_attempts:
+                raise OpenAPIContractError(
+                    'OpenAPI export attempted outbound network during import/generation: ' + '; '.join(network_attempts)
+                )
+
+            assert_env_unchanged(expected_fake_env)
+            return schema
+    finally:
+        logging.disable(logging.NOTSET)
+        restore_restorable_side_effect_paths(side_effect_snapshot)
+        os.environ.clear()
+        os.environ.update(original_env)
+        assert_no_side_effect_path_mutations(side_effect_snapshot)
+
+
+def route_key(method: str, path: str) -> tuple[str, str]:
+    return method.upper(), path
+
+
+def iter_route_keys(routes: Iterable[Any]) -> list[tuple[str, str]]:
+    keys: list[tuple[str, str]] = []
+    for route in routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in sorted((route.methods or set()) & HTTP_METHODS):
+            keys.append(route_key(method, route.path))
+    return sorted(set(keys))
+
+
+def is_public_contract_path(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in DOCUMENTED_PUBLIC_PREFIXES)
+
+
+def is_audited_public_path(path: str) -> bool:
+    for prefix in AUDITED_PUBLIC_PREFIXES:
+        if prefix.endswith('/'):
+            if path.startswith(prefix):
+                return True
+        elif path == prefix or path.startswith(f'{prefix}/'):
+            return True
+    return False
+
+
+def public_contract_routes(app) -> list[APIRoute]:
+    return [
+        route
+        for route in app.routes
+        if isinstance(route, APIRoute) and is_public_contract_path(route.path) and route.include_in_schema
+    ]
+
+
+def documented_route_keys(schema: dict[str, Any]) -> list[tuple[str, str]]:
+    documented: list[tuple[str, str]] = []
+    for path, operations in schema.get('paths', {}).items():
+        for method in operations:
+            method_upper = method.upper()
+            if method_upper in HTTP_METHODS:
+                documented.append(route_key(method_upper, path))
+    return sorted(documented)
+
+
+def _normalize_bearer_security(schema: dict[str, Any]) -> None:
+    components = schema.setdefault('components', {})
+    security_schemes = components.setdefault('securitySchemes', {})
+    security_schemes.clear()
+    security_schemes['firebaseBearer'] = FIREBASE_BEARER_AUTH_SCHEME
+    security_schemes['developerApiKey'] = DEVELOPER_API_KEY_AUTH_SCHEME
+    components.setdefault('schemas', {})['ErrorResponse'] = ERROR_RESPONSE_SCHEMA
+    responses = components.setdefault('responses', {})
+    for status_code, response in COMMON_RESPONSES.items():
+        responses[f'Error{status_code}'] = {
+            **response,
+            'content': {
+                'application/json': {
+                    'schema': {'$ref': '#/components/schemas/ErrorResponse'},
+                }
+            },
+        }
+    schema.pop('security', None)
+
+    for path, operations in schema.get('paths', {}).items():
+        for method, operation in operations.items():
+            if method.upper() in HTTP_METHODS:
+                if path.startswith('/v1/dev/keys'):
+                    operation['security'] = [{'firebaseBearer': []}]
+                else:
+                    operation['security'] = [{'developerApiKey': []}]
+                operation.setdefault('responses', {})['401'] = {'$ref': '#/components/responses/Error401'}
+                if operation['security'] == [{'developerApiKey': []}]:
+                    operation['responses'].setdefault('403', {'$ref': '#/components/responses/Error403'})
+                if '{' in path and method.upper() in {'GET', 'PATCH', 'DELETE'}:
+                    operation['responses'].setdefault('404', {'$ref': '#/components/responses/Error404'})
+
+
+def _rewrite_refs(value: Any, ref_map: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        ref = value.get('$ref')
+        if ref in ref_map:
+            value['$ref'] = ref_map[ref]
+        for child in value.values():
+            _rewrite_refs(child, ref_map)
+    elif isinstance(value, list):
+        for child in value:
+            _rewrite_refs(child, ref_map)
+
+
+def _normalize_component_names(schema: dict[str, Any]) -> None:
+    schemas = schema.get('components', {}).get('schemas', {})
+    renamed: dict[str, Any] = {}
+    ref_map: dict[str, str] = {}
+
+    for name, component_schema in schemas.items():
+        title = component_schema.get('title')
+        new_name = title if isinstance(title, str) and title and title != name else name
+        if new_name in schemas and new_name != name:
+            raise OpenAPIContractError(f'component title {new_name!r} conflicts with an existing schema key')
+        if new_name in renamed:
+            raise OpenAPIContractError(f'component title {new_name!r} is not unique')
+        renamed[new_name] = component_schema
+        if new_name != name:
+            ref_map[f'#/components/schemas/{name}'] = f'#/components/schemas/{new_name}'
+
+    if ref_map:
+        schemas.clear()
+        schemas.update(renamed)
+        _rewrite_refs(schema, ref_map)
+
+
+def build_public_openapi(app) -> dict[str, Any]:
+    routes = public_contract_routes(app)
+    schema = get_openapi(
+        title=OPENAPI_TITLE,
+        version=OPENAPI_VERSION,
+        description=OPENAPI_DESCRIPTION,
+        routes=routes,
+        tags=OPENAPI_TAGS,
+        servers=OPENAPI_SERVERS,
+        contact=OPENAPI_CONTACT,
+        license_info=OPENAPI_LICENSE,
+    )
+    _normalize_bearer_security(schema)
+    _normalize_component_names(schema)
+    validate_contract(app, schema)
+    return schema
+
+
+def assert_unique_operation_ids(schema: dict[str, Any]) -> None:
+    operation_ids: dict[str, tuple[str, str]] = {}
+    duplicates: list[str] = []
+    missing: list[str] = []
+    for path, operations in schema.get('paths', {}).items():
+        for method, operation in operations.items():
+            if method.upper() not in HTTP_METHODS:
+                continue
+            operation_id = operation.get('operationId')
+            if not operation_id:
+                missing.append(f'{method.upper()} {path}')
+                continue
+            if operation_id in operation_ids:
+                previous_method, previous_path = operation_ids[operation_id]
+                duplicates.append(f'{operation_id}: {previous_method} {previous_path} and {method.upper()} {path}')
+            operation_ids[operation_id] = (method.upper(), path)
+    if missing or duplicates:
+        details = []
+        if missing:
+            details.append('missing operationId: ' + ', '.join(missing))
+        if duplicates:
+            details.append('duplicate operationId: ' + '; '.join(duplicates))
+        raise OpenAPIContractError('\n'.join(details))
+
+
+def assert_route_inventory(app, schema: dict[str, Any]) -> None:
+    audited_routes = [
+        route for route in app.routes if isinstance(route, APIRoute) and is_audited_public_path(route.path)
+    ]
+    expected = set(iter_route_keys(audited_routes))
+    documented = set(documented_route_keys(schema))
+    allowlisted = set(UNDOCUMENTED_PUBLIC_ROUTES)
+
+    missing = sorted(expected - documented - allowlisted)
+    extra = sorted(documented - expected)
+    stale_allowlist = sorted(route for route in allowlisted if route not in set(iter_route_keys(app.routes)))
+
+    if missing or extra or stale_allowlist:
+        parts = []
+        if missing:
+            parts.append('public routes missing from OpenAPI: ' + ', '.join(f'{m} {p}' for m, p in missing))
+        if extra:
+            parts.append('OpenAPI routes not present in FastAPI app: ' + ', '.join(f'{m} {p}' for m, p in extra))
+        if stale_allowlist:
+            parts.append(
+                'stale undocumented route allowlist entries: ' + ', '.join(f'{m} {p}' for m, p in stale_allowlist)
+            )
+        raise OpenAPIContractError('\n'.join(parts))
+
+
+def validate_contract(app, schema: dict[str, Any]) -> None:
+    if schema.get('openapi') != '3.1.0':
+        raise OpenAPIContractError(f"expected OpenAPI 3.1.0, got {schema.get('openapi')!r}")
+    assert_unique_operation_ids(schema)
+    assert_route_inventory(app, schema)
+    for path in schema.get('paths', {}):
+        if not is_public_contract_path(path):
+            raise OpenAPIContractError(f'non-public route leaked into public OpenAPI: {path}')
+
+
+def stable_json(schema: dict[str, Any]) -> str:
+    return json.dumps(schema, indent=2, sort_keys=True, ensure_ascii=False) + '\n'
+
+
+def write_spec(path: Path, generated: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(generated)
+
+
+def check_spec(path: Path, generated: str) -> None:
+    if not path.exists():
+        raise OpenAPIContractError(f'{path} does not exist; run export_openapi.py --write {path}')
+    current = path.read_text()
+    if current != generated:
+        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py --write {path}')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Export or verify the public Developer API OpenAPI contract.')
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument('--write', nargs='?', const=str(DEFAULT_SPEC_PATH), metavar='PATH', help='write generated spec')
+    action.add_argument('--check', nargs='?', const=str(DEFAULT_SPEC_PATH), metavar='PATH', help='check generated spec')
+    action.add_argument('--print', action='store_true', help='print generated spec to stdout')
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        generated = stable_json(generate_public_openapi())
+        if args.print:
+            sys.stdout.write(generated)
+        elif args.write:
+            write_spec(Path(args.write), generated)
+            print(f'wrote {args.write}')
+        elif args.check:
+            check_spec(Path(args.check), generated)
+            print(f'{args.check} is up to date')
+        return 0
+    except OpenAPIContractError as e:
+        print(f'OpenAPI contract check failed: {e}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/test-preflight.sh
+++ b/backend/test-preflight.sh
@@ -60,7 +60,7 @@ echo ""
 echo "Python packages:"
 
 missing_pkgs=()
-for pkg in pydantic fastapi firebase_admin google.cloud.firestore redis deepgram_sdk openpipe pytest_asyncio; do
+for pkg in pydantic fastapi firebase_admin google.cloud.firestore redis deepgram_sdk openpipe pytest_asyncio fake_firestore fakeredis; do
   if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" -c "import $pkg" &>/dev/null 2>&1; then
     ok "$pkg"
   else
@@ -138,6 +138,12 @@ if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" scripts/select_backend_unit_tests.py 
   ok "$selected_test_count backend unit test files selected"
 else
   bad "backend unit test selection failed"
+fi
+
+if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" scripts/export_openapi.py --help &>/dev/null 2>&1; then
+  ok "OpenAPI export script is runnable"
+else
+  bad "OpenAPI export script failed to start"
 fi
 
 # ── Summary ──

--- a/backend/tests/unit/test_openapi_contract.py
+++ b/backend/tests/unit/test_openapi_contract.py
@@ -1,0 +1,235 @@
+import json
+import os
+import socket
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel, ConfigDict
+
+from scripts import export_openapi
+
+
+@pytest.fixture(autouse=True)
+def narrow_undocumented_route_allowlist(monkeypatch):
+    monkeypatch.setattr(
+        export_openapi,
+        'UNDOCUMENTED_PUBLIC_ROUTES',
+        {
+            (
+                'POST',
+                '/v1/conversations/from-segments',
+            ): 'Synthetic Firebase-authenticated app-client alias.',
+        },
+    )
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get('/v1/dev/example', operation_id='getExample', tags=['Examples'])
+    def get_example():
+        return {'ok': True}
+
+    @app.post('/v1/internal/example', operation_id='postInternalExample', tags=['Internal'])
+    def post_internal_example():
+        return {'ok': True}
+
+    @app.post('/v1/conversations/from-segments', operation_id='postFromSegmentsAlias', tags=['Conversations'])
+    def post_from_segments_alias():
+        return {'ok': True}
+
+    return app
+
+
+def test_public_openapi_filters_to_developer_contract():
+    schema = export_openapi.build_public_openapi(_make_app())
+
+    assert list(schema['paths']) == ['/v1/dev/example']
+    assert schema['paths']['/v1/dev/example']['get']['operationId'] == 'getExample'
+    assert schema['components']['securitySchemes'] == {
+        'developerApiKey': export_openapi.DEVELOPER_API_KEY_AUTH_SCHEME,
+        'firebaseBearer': export_openapi.FIREBASE_BEARER_AUTH_SCHEME,
+    }
+    assert schema['paths']['/v1/dev/example']['get']['security'] == [{'developerApiKey': []}]
+    assert schema['paths']['/v1/dev/example']['get']['responses']['401'] == {'$ref': '#/components/responses/Error401'}
+
+
+def test_route_inventory_fails_when_public_route_missing_from_spec():
+    app = _make_app()
+    schema = {
+        'openapi': '3.1.0',
+        'paths': {},
+        'components': {'securitySchemes': {'developerApiKey': export_openapi.DEVELOPER_API_KEY_AUTH_SCHEME}},
+    }
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='public routes missing from OpenAPI'):
+        export_openapi.assert_route_inventory(app, schema)
+
+
+def test_public_like_route_must_be_documented_or_allowlisted():
+    app = _make_app()
+
+    @app.get('/v1/conversations/new-public-route', operation_id='newPublicRoute')
+    def new_public_route():
+        return {'ok': True}
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='public routes missing from OpenAPI'):
+        export_openapi.build_public_openapi(app)
+
+
+def test_exact_v1_conversations_route_is_audited_when_not_allowlisted(monkeypatch):
+    monkeypatch.setattr(export_openapi, 'UNDOCUMENTED_PUBLIC_ROUTES', {})
+    app = _make_app()
+
+    @app.post('/v1/conversations', operation_id='createFirstPartyConversation')
+    def create_first_party_conversation():
+        return {'ok': True}
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='POST /v1/conversations'):
+        export_openapi.build_public_openapi(app)
+
+
+def test_similar_prefix_without_path_boundary_is_not_audited():
+    app = _make_app()
+
+    @app.get('/v1/conversations-v2/preview', operation_id='conversationV2Preview')
+    def conversation_v2_preview():
+        return {'ok': True}
+
+    schema = export_openapi.build_public_openapi(app)
+
+    assert '/v1/conversations-v2/preview' not in schema['paths']
+
+
+def test_firebase_key_routes_get_firebase_auth_scheme():
+    app = FastAPI()
+
+    @app.get('/v1/dev/keys', operation_id='listApiKeys')
+    def list_api_keys():
+        return []
+
+    @app.post('/v1/conversations/from-segments', operation_id='postFromSegmentsAlias', tags=['Conversations'])
+    def post_from_segments_alias():
+        return {'ok': True}
+
+    schema = export_openapi.build_public_openapi(app)
+
+    assert schema['paths']['/v1/dev/keys']['get']['security'] == [{'firebaseBearer': []}]
+
+
+def test_component_names_follow_explicit_schema_titles():
+    class InternalRuntimeName(BaseModel):
+        model_config = ConfigDict(title='PublicContractName')
+
+        value: str
+
+    app = FastAPI()
+
+    @app.get('/v1/dev/titled', response_model=InternalRuntimeName, operation_id='getTitled')
+    def get_titled():
+        return {'value': 'ok'}
+
+    @app.post('/v1/conversations/from-segments', operation_id='postFromSegmentsAlias', tags=['Conversations'])
+    def post_from_segments_alias():
+        return {'ok': True}
+
+    schema = export_openapi.build_public_openapi(app)
+
+    assert 'PublicContractName' in schema['components']['schemas']
+    assert 'InternalRuntimeName' not in schema['components']['schemas']
+    assert schema['paths']['/v1/dev/titled']['get']['responses']['200']['content']['application/json']['schema'] == {
+        '$ref': '#/components/schemas/PublicContractName'
+    }
+
+
+def test_operation_id_uniqueness_check_reports_duplicates():
+    schema = {
+        'paths': {
+            '/v1/dev/a': {'get': {'operationId': 'duplicateOperation'}},
+            '/v1/dev/b': {'post': {'operationId': 'duplicateOperation'}},
+        }
+    }
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='duplicate operationId'):
+        export_openapi.assert_unique_operation_ids(schema)
+
+
+def test_check_spec_detects_stale_file(tmp_path):
+    spec_path = tmp_path / 'openapi.json'
+    spec_path.write_text(json.dumps({'stale': True}) + '\n')
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='is stale'):
+        export_openapi.check_spec(spec_path, json.dumps({'fresh': True}) + '\n')
+
+
+def test_network_recorder_fails_even_when_blocked_attempt_is_swallowed():
+    with export_openapi.record_and_block_outbound_network() as attempts:
+        try:
+            socket.getaddrinfo('example.com', 443)
+        except export_openapi.OpenAPIContractError:
+            pass
+
+    assert attempts == ["getaddrinfo: 'example.com'"]
+
+
+def test_hermetic_environment_restore_pattern():
+    before = dict(os.environ)
+    export_openapi.configure_hermetic_environment()
+    os.environ.clear()
+    os.environ.update(before)
+
+    assert dict(os.environ) == before
+
+
+def test_env_mutation_detector_reports_added_changed_and_removed_keys(monkeypatch):
+    monkeypatch.setenv('OPENAPI_TEST_EXISTING', 'before')
+    expected = dict(os.environ)
+    monkeypatch.setenv('OPENAPI_TEST_EXISTING', 'after')
+    monkeypatch.setenv('OPENAPI_TEST_ADDED', 'value')
+    monkeypatch.delenv('PATH', raising=False)
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match='mutated environment'):
+        export_openapi.assert_env_unchanged(expected)
+
+
+def test_restorable_side_effect_paths_remove_only_empty_created_dirs(tmp_path, monkeypatch):
+    restorable_dir = tmp_path / 'created-empty'
+    nonempty_dir = tmp_path / 'created-nonempty'
+    monkeypatch.setattr(
+        export_openapi,
+        'RESTORABLE_SIDE_EFFECT_PATHS',
+        {
+            restorable_dir: 'test-created empty dir',
+            nonempty_dir: 'test-created non-empty dir',
+        },
+    )
+    snapshot = {
+        restorable_dir: (False, None, None),
+        nonempty_dir: (False, None, None),
+    }
+    restorable_dir.mkdir()
+    nonempty_dir.mkdir()
+    (nonempty_dir / 'kept.txt').write_text('keep')
+
+    export_openapi.restore_restorable_side_effect_paths(snapshot)
+
+    assert not restorable_dir.exists()
+    assert nonempty_dir.exists()
+    with pytest.raises(export_openapi.OpenAPIContractError, match='mutated side-effect paths'):
+        export_openapi.assert_no_side_effect_path_mutations(snapshot)
+
+
+def test_snapshot_side_effect_paths_tracks_file_and_directory_state(tmp_path, monkeypatch):
+    tracked_file = tmp_path / 'tracked.json'
+    tracked_dir = tmp_path / 'tracked-dir'
+    tracked_file.write_text('{}')
+    tracked_dir.mkdir()
+    monkeypatch.setattr(export_openapi, 'SIDE_EFFECT_PATHS', (tracked_file, tracked_dir, tmp_path / 'missing'))
+
+    snapshot = export_openapi.snapshot_side_effect_paths()
+
+    assert snapshot[tracked_file][0] is True
+    assert snapshot[tracked_file][2] == 2
+    assert snapshot[tracked_dir][0] is True
+    assert snapshot[tracked_dir][2] is None
+    assert snapshot[tmp_path / 'missing'] == (False, None, None)

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1239,6 +1239,11 @@
             ],
             "title": "Created At"
           },
+          "edited": {
+            "default": false,
+            "title": "Edited",
+            "type": "boolean"
+          },
           "id": {
             "title": "Id",
             "type": "string"
@@ -1247,6 +1252,22 @@
             "default": false,
             "title": "Manually Added",
             "type": "boolean"
+          },
+          "reviewed": {
+            "default": false,
+            "title": "Reviewed",
+            "type": "boolean"
+          },
+          "scoring": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scoring"
           },
           "tags": {
             "items": {
@@ -1266,6 +1287,17 @@
               }
             ],
             "title": "Updated At"
+          },
+          "user_review": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Review"
           },
           "visibility": {
             "anyOf": [

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1,1237 +1,3501 @@
 {
-  "openapi": "3.1.0",
+  "components": {
+    "responses": {
+      "Error401": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Missing or invalid authentication credentials."
+      },
+      "Error403": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Authenticated, but the token does not grant the required scope."
+      },
+      "Error404": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Requested resource was not found."
+      }
+    },
+    "schemas": {
+      "BatchActionItemsRequest": {
+        "properties": {
+          "action_items": {
+            "description": "List of action items to create",
+            "items": {
+              "$ref": "#/components/schemas/CreateActionItemRequest"
+            },
+            "maxItems": 50,
+            "title": "Action Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "action_items"
+        ],
+        "title": "BatchActionItemsRequest",
+        "type": "object"
+      },
+      "BatchActionItemsResponse": {
+        "properties": {
+          "action_items": {
+            "items": {
+              "$ref": "#/components/schemas/DeveloperActionItem"
+            },
+            "title": "Action Items",
+            "type": "array"
+          },
+          "created_count": {
+            "title": "Created Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action_items",
+          "created_count"
+        ],
+        "title": "BatchActionItemsResponse",
+        "type": "object"
+      },
+      "BatchMemoriesRequest": {
+        "properties": {
+          "memories": {
+            "description": "List of memories to create",
+            "items": {
+              "$ref": "#/components/schemas/CreateMemoryRequest"
+            },
+            "maxItems": 25,
+            "title": "Memories",
+            "type": "array"
+          }
+        },
+        "required": [
+          "memories"
+        ],
+        "title": "BatchMemoriesRequest",
+        "type": "object"
+      },
+      "BatchMemoriesResponse": {
+        "properties": {
+          "created_count": {
+            "title": "Created Count",
+            "type": "integer"
+          },
+          "memories": {
+            "items": {
+              "$ref": "#/components/schemas/DeveloperMemory"
+            },
+            "title": "Memories",
+            "type": "array"
+          }
+        },
+        "required": [
+          "memories",
+          "created_count"
+        ],
+        "title": "BatchMemoriesResponse",
+        "type": "object"
+      },
+      "CategoryEnum": {
+        "enum": [
+          "personal",
+          "education",
+          "health",
+          "finance",
+          "legal",
+          "philosophy",
+          "spiritual",
+          "science",
+          "entrepreneurship",
+          "parenting",
+          "romantic",
+          "travel",
+          "inspiration",
+          "technology",
+          "business",
+          "social",
+          "work",
+          "sports",
+          "politics",
+          "literature",
+          "history",
+          "architecture",
+          "music",
+          "weather",
+          "news",
+          "entertainment",
+          "psychology",
+          "real",
+          "design",
+          "family",
+          "economics",
+          "environment",
+          "other"
+        ],
+        "title": "CategoryEnum",
+        "type": "string"
+      },
+      "ConversationCreateResponse": {
+        "properties": {
+          "discarded": {
+            "title": "Discarded",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "discarded"
+        ],
+        "title": "ConversationCreateResponse",
+        "type": "object"
+      },
+      "ConversationSource": {
+        "enum": [
+          "friend",
+          "omi",
+          "fieldy",
+          "bee",
+          "plaud",
+          "frame",
+          "friend_com",
+          "apple_watch",
+          "phone",
+          "phone_call",
+          "desktop",
+          "openglass",
+          "screenpipe",
+          "workflow",
+          "sdcard",
+          "external_integration",
+          "limitless",
+          "onboarding",
+          "unknown"
+        ],
+        "title": "ConversationSource",
+        "type": "string"
+      },
+      "CreateActionItemRequest": {
+        "properties": {
+          "completed": {
+            "default": false,
+            "description": "Whether the action item is completed",
+            "title": "Completed",
+            "type": "boolean"
+          },
+          "description": {
+            "description": "The action item description",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Description",
+            "type": "string"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the action item is due (ISO format with timezone)",
+            "title": "Due At"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "CreateActionItemRequest",
+        "type": "object"
+      },
+      "CreateConversationFromTranscriptRequest": {
+        "properties": {
+          "client_session_id": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stable client-generated session ID. When provided, retries return the same conversation ID.",
+            "title": "Client Session Id"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When conversation finished (calculated from segments duration if not provided)",
+            "title": "Finished At"
+          },
+          "geolocation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Geolocation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Geolocation where conversation occurred"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "en",
+            "description": "Language code (ISO 639-1, e.g., 'en', 'es', 'fr')",
+            "title": "Language"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "external_integration",
+            "description": "Source of the conversation (e.g., omi, friend, openglass, phone, external_integration)"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When conversation started (defaults to now)",
+            "title": "Started At"
+          },
+          "transcript_segments": {
+            "description": "List of transcript segments with speaker and timing info",
+            "items": {
+              "$ref": "#/components/schemas/CreateConversationTranscriptSegment"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Transcript Segments",
+            "type": "array"
+          }
+        },
+        "required": [
+          "transcript_segments"
+        ],
+        "title": "CreateConversationFromTranscriptRequest",
+        "type": "object"
+      },
+      "CreateConversationRequest": {
+        "properties": {
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the conversation finished (defaults to started_at + 5 minutes)",
+            "title": "Finished At"
+          },
+          "geolocation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Geolocation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Geolocation where conversation occurred"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "en",
+            "description": "Language code (ISO 639-1, e.g., 'en', 'es', 'fr')",
+            "title": "Language"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the conversation started (defaults to now)",
+            "title": "Started At"
+          },
+          "text": {
+            "description": "The conversation text/transcript",
+            "maxLength": 100000,
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          },
+          "text_source": {
+            "$ref": "#/components/schemas/ExternalIntegrationConversationSource",
+            "default": "other_text",
+            "description": "Source type: audio_transcript, message, or other_text"
+          },
+          "text_source_spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Additional source specification (e.g., 'email', 'slack', 'whatsapp')",
+            "title": "Text Source Spec"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "CreateConversationRequest",
+        "type": "object"
+      },
+      "CreateConversationTranscriptSegment": {
+        "properties": {
+          "end": {
+            "description": "End time in seconds (e.g., 1.5, 3.0, 65.8)",
+            "title": "End",
+            "type": "number"
+          },
+          "is_user": {
+            "default": false,
+            "description": "Whether this segment is from the user",
+            "title": "Is User",
+            "type": "boolean"
+          },
+          "person_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of person speaking (if known)",
+            "title": "Person Id"
+          },
+          "speaker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "SPEAKER_00",
+            "description": "Speaker identifier (e.g., 'SPEAKER_00', 'SPEAKER_01')",
+            "title": "Speaker"
+          },
+          "speaker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Numeric speaker ID",
+            "title": "Speaker Id"
+          },
+          "start": {
+            "description": "Start time in seconds (e.g., 0.0, 1.5, 60.2)",
+            "title": "Start",
+            "type": "number"
+          },
+          "text": {
+            "description": "The text spoken in this segment",
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "start",
+          "end"
+        ],
+        "title": "CreateConversationTranscriptSegment",
+        "type": "object"
+      },
+      "CreateGoalRequest": {
+        "properties": {
+          "current_value": {
+            "default": 0,
+            "description": "Current progress value",
+            "title": "Current Value",
+            "type": "number"
+          },
+          "goal_type": {
+            "$ref": "#/components/schemas/GoalType",
+            "default": "scale",
+            "description": "Type of goal metric: boolean, scale, or numeric"
+          },
+          "max_value": {
+            "default": 10,
+            "description": "Maximum value of the scale",
+            "title": "Max Value",
+            "type": "number"
+          },
+          "min_value": {
+            "default": 0,
+            "description": "Minimum value of the scale",
+            "title": "Min Value",
+            "type": "number"
+          },
+          "target_value": {
+            "description": "Target value to achieve",
+            "title": "Target Value",
+            "type": "number"
+          },
+          "title": {
+            "description": "The goal title/description",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unit label (e.g., 'users', 'points')",
+            "title": "Unit"
+          }
+        },
+        "required": [
+          "title",
+          "target_value"
+        ],
+        "title": "CreateGoalRequest",
+        "type": "object"
+      },
+      "CreateMemoryRequest": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MemoryCategory"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Memory category: interesting, system, or manual (auto-categorized if not provided)"
+          },
+          "content": {
+            "description": "The content of the memory",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Content",
+            "type": "string"
+          },
+          "tags": {
+            "default": [],
+            "description": "Tags associated with the memory",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "visibility": {
+            "default": "private",
+            "description": "Visibility: public or private",
+            "title": "Visibility",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "CreateMemoryRequest",
+        "type": "object"
+      },
+      "DevApiKey": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "key_prefix": {
+            "title": "Key Prefix",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scopes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scopes"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "key_prefix",
+          "created_at"
+        ],
+        "title": "DevApiKey",
+        "type": "object"
+      },
+      "DevApiKeyCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scopes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scopes"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "DevApiKeyCreate",
+        "type": "object"
+      },
+      "DevApiKeyCreated": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "key_prefix": {
+            "title": "Key Prefix",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scopes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scopes"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "key_prefix",
+          "created_at",
+          "key"
+        ],
+        "title": "DevApiKeyCreated",
+        "type": "object"
+      },
+      "DeveloperActionItem": {
+        "properties": {
+          "completed": {
+            "title": "Completed",
+            "type": "boolean"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "completed"
+        ],
+        "title": "DeveloperActionItem",
+        "type": "object"
+      },
+      "DeveloperConversation": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "folder_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Folder Id"
+          },
+          "folder_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Folder Name"
+          },
+          "geolocation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Geolocation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "structured": {
+            "$ref": "#/components/schemas/DeveloperConversationStructured"
+          },
+          "transcript_segments": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DeveloperTranscriptSegment"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transcript Segments"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "started_at",
+          "finished_at",
+          "structured"
+        ],
+        "title": "DeveloperConversation",
+        "type": "object"
+      },
+      "DeveloperConversationActionItem": {
+        "properties": {
+          "completed": {
+            "default": false,
+            "title": "Completed",
+            "type": "boolean"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "DeveloperConversationActionItem",
+        "type": "object"
+      },
+      "DeveloperConversationEvent": {
+        "properties": {
+          "created": {
+            "default": false,
+            "title": "Created",
+            "type": "boolean"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "duration": {
+            "default": 30,
+            "title": "Duration",
+            "type": "integer"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "start"
+        ],
+        "title": "DeveloperConversationEvent",
+        "type": "object"
+      },
+      "DeveloperConversationStructured": {
+        "properties": {
+          "action_items": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DeveloperConversationActionItem"
+            },
+            "title": "Action Items",
+            "type": "array"
+          },
+          "category": {
+            "$ref": "#/components/schemas/CategoryEnum"
+          },
+          "emoji": {
+            "default": "🧠",
+            "title": "Emoji",
+            "type": "string"
+          },
+          "events": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DeveloperConversationEvent"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "overview": {
+            "title": "Overview",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "overview",
+          "category"
+        ],
+        "title": "DeveloperConversationStructured",
+        "type": "object"
+      },
+      "DeveloperFolder": {
+        "properties": {
+          "color": {
+            "title": "Color",
+            "type": "string"
+          },
+          "conversation_count": {
+            "default": 0,
+            "title": "Conversation Count",
+            "type": "integer"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "icon": {
+            "title": "Icon",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "is_default": {
+            "default": false,
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "order": {
+            "default": 0,
+            "title": "Order",
+            "type": "integer"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "color",
+          "icon",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DeveloperFolder",
+        "type": "object"
+      },
+      "DeveloperGoal": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "current_value": {
+            "title": "Current Value",
+            "type": "number"
+          },
+          "goal_type": {
+            "title": "Goal Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "max_value": {
+            "title": "Max Value",
+            "type": "number"
+          },
+          "min_value": {
+            "title": "Min Value",
+            "type": "number"
+          },
+          "target_value": {
+            "title": "Target Value",
+            "type": "number"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "goal_type",
+          "target_value",
+          "current_value",
+          "min_value",
+          "max_value",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DeveloperGoal",
+        "type": "object"
+      },
+      "DeveloperMemory": {
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/MemoryCategory",
+            "default": "interesting"
+          },
+          "content": {
+            "default": "",
+            "title": "Content",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "manually_added": {
+            "default": false,
+            "title": "Manually Added",
+            "type": "boolean"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "private",
+            "title": "Visibility"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "DeveloperMemory",
+        "type": "object"
+      },
+      "DeveloperTranscriptSegment": {
+        "properties": {
+          "end": {
+            "title": "End",
+            "type": "number"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "speaker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker Id"
+          },
+          "speaker_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker Name"
+          },
+          "start": {
+            "title": "Start",
+            "type": "number"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "start",
+          "end"
+        ],
+        "title": "DeveloperTranscriptSegment",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              }
+            ],
+            "description": "Error detail returned by the API."
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorResponse",
+        "type": "object"
+      },
+      "ExternalIntegrationConversationSource": {
+        "enum": [
+          "audio_transcript",
+          "message",
+          "other_text"
+        ],
+        "title": "ExternalIntegrationConversationSource",
+        "type": "string"
+      },
+      "Geolocation": {
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "google_place_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Place Id"
+          },
+          "latitude": {
+            "title": "Latitude",
+            "type": "number"
+          },
+          "location_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Type"
+          },
+          "longitude": {
+            "title": "Longitude",
+            "type": "number"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "title": "Geolocation",
+        "type": "object"
+      },
+      "GoalType": {
+        "enum": [
+          "boolean",
+          "scale",
+          "numeric"
+        ],
+        "title": "GoalType",
+        "type": "string"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "MemoryCategory": {
+        "enum": [
+          "interesting",
+          "system",
+          "manual",
+          "workflow",
+          "core",
+          "hobbies",
+          "lifestyle",
+          "interests",
+          "habits",
+          "work",
+          "skills",
+          "learnings",
+          "other",
+          "auto"
+        ],
+        "title": "MemoryCategory",
+        "type": "string"
+      },
+      "UpdateActionItemRequest": {
+        "properties": {
+          "completed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New completion status",
+            "title": "Completed"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New description",
+            "title": "Description"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New due date (ISO format with timezone)",
+            "title": "Due At"
+          }
+        },
+        "title": "UpdateActionItemRequest",
+        "type": "object"
+      },
+      "UpdateConversationRequest": {
+        "properties": {
+          "discarded": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the conversation is discarded",
+            "title": "Discarded"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New title for the conversation",
+            "title": "Title"
+          }
+        },
+        "title": "UpdateConversationRequest",
+        "type": "object"
+      },
+      "UpdateGoalRequest": {
+        "properties": {
+          "current_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New progress value",
+            "title": "Current Value"
+          },
+          "max_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New maximum value",
+            "title": "Max Value"
+          },
+          "min_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New minimum value",
+            "title": "Min Value"
+          },
+          "target_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New target value",
+            "title": "Target Value"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New title",
+            "title": "Title"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New unit label",
+            "title": "Unit"
+          }
+        },
+        "title": "UpdateGoalRequest",
+        "type": "object"
+      },
+      "UpdateMemoryRequest": {
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MemoryCategory"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New category for the memory"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New content for the memory",
+            "title": "Content"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New tags for the memory",
+            "title": "Tags"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New visibility: public or private",
+            "title": "Visibility"
+          }
+        },
+        "title": "UpdateMemoryRequest",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "developerApiKey": {
+        "bearerFormat": "Omi Developer API key",
+        "description": "Send `Authorization: Bearer <omi_developer_api_key>`.",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "firebaseBearer": {
+        "bearerFormat": "Firebase ID token",
+        "description": "Send `Authorization: Bearer <firebase_id_token>`.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
   "info": {
-    "title": "Omi Developer API",
-    "description": "Programmatic access to your Omi data — memories, conversations, action items, and API keys. Build custom integrations, analytics dashboards, and automation workflows.",
-    "version": "1.0.0",
     "contact": {
       "name": "Omi",
-      "url": "https://omi.me"
+      "url": "https://omi.me/"
     },
+    "description": "Programmatic access to your Omi data - memories, conversations, action items, goals, folders, and API keys. Build custom integrations, analytics dashboards, and automation workflows.",
     "license": {
       "name": "MIT",
       "url": "https://github.com/BasedHardware/omi/blob/main/LICENSE"
-    }
+    },
+    "title": "Omi Developer API",
+    "version": "1.0.0"
   },
-  "servers": [
-    {
-      "url": "https://api.omi.me",
-      "description": "Production"
-    }
-  ],
-  "security": [
-    {
-      "bearerAuth": []
-    }
-  ],
-  "tags": [
-    { "name": "Memories", "description": "Read and write user memories — timeless facts, preferences, and insights." },
-    { "name": "Conversations", "description": "Create and retrieve conversation transcripts with AI-generated summaries." },
-    { "name": "Folders", "description": "Retrieve user-defined folders for organizing conversations." },
-    { "name": "Action Items", "description": "Manage tasks and to-dos extracted from conversations or created manually." },
-    { "name": "API Keys", "description": "Create, list, and revoke developer API keys." }
-  ],
+  "openapi": "3.1.0",
   "paths": {
-    "/v1/dev/user/memories": {
-      "get": {
-        "operationId": "listMemories",
-        "summary": "List memories",
-        "description": "Retrieve your memories with optional filtering by category. Returns memories sorted by most recent first.",
-        "tags": ["Memories"],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of memories to return.",
-            "schema": { "type": "integer", "default": 25 }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "Number of memories to skip for pagination.",
-            "schema": { "type": "integer", "default": 0 }
-          },
-          {
-            "name": "categories",
-            "in": "query",
-            "description": "Comma-separated list of categories to filter by (e.g. `interesting,system`).",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of memories.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/Memory" }
-                },
-                "example": [
-                  {
-                    "id": "mem_789ghi",
-                    "content": "User is building an AI fitness app with personal trainer",
-                    "category": "interesting",
-                    "visibility": "private",
-                    "tags": [],
-                    "created_at": "2025-01-15T10:30:00Z",
-                    "updated_at": "2025-01-15T10:30:00Z",
-                    "manually_added": false,
-                    "reviewed": false,
-                    "user_review": null,
-                    "edited": false
-                  }
-                ]
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
-        }
-      },
-      "post": {
-        "operationId": "createMemory",
-        "summary": "Create memory",
-        "description": "Create a new memory. Memories are timeless facts about the user — preferences, relationships, personal details, and notable insights.",
-        "tags": ["Memories"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateMemory" },
-              "example": {
-                "content": "User prefers dark mode in all applications",
-                "category": "system",
-                "tags": ["preferences", "ui"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The created memory.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/Memory" },
-                "example": {
-                  "id": "mem_xyz789",
-                  "content": "User prefers dark mode in all applications",
-                  "category": "system",
-                  "visibility": "private",
-                  "tags": ["preferences", "ui"],
-                  "created_at": "2025-12-06T10:35:00Z",
-                  "updated_at": "2025-12-06T10:35:00Z",
-                  "manually_added": true
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/memories/batch": {
-      "post": {
-        "operationId": "createMemoriesBatch",
-        "summary": "Create memories (batch)",
-        "description": "Create multiple memories in a single request. Maximum 25 memories per batch.",
-        "tags": ["Memories"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/BatchCreateMemories" },
-              "example": {
-                "memories": [
-                  { "content": "User prefers async communication over meetings", "category": "system" },
-                  { "content": "User speaks fluent Japanese and French", "category": "interesting" }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Batch creation result.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/BatchMemoriesResponse" },
-                "example": {
-                  "memories": [
-                    { "id": "mem_001", "content": "User prefers async communication over meetings", "category": "system" },
-                    { "id": "mem_002", "content": "User speaks fluent Japanese and French", "category": "interesting" }
-                  ],
-                  "created_count": 2
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/memories/{memory_id}": {
-      "delete": {
-        "operationId": "deleteMemory",
-        "summary": "Delete memory",
-        "description": "Permanently delete a memory. This action cannot be undone.",
-        "tags": ["Memories"],
-        "parameters": [
-          {
-            "name": "memory_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the memory to delete.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Memory deleted.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponse" },
-                "example": { "success": true }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
-        }
-      },
-      "patch": {
-        "operationId": "updateMemory",
-        "summary": "Update memory",
-        "description": "Update a memory's content or visibility. At least one field must be provided.",
-        "tags": ["Memories"],
-        "parameters": [
-          {
-            "name": "memory_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the memory to update.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateMemory" },
-              "example": {
-                "content": "User strongly prefers dark mode in all applications",
-                "visibility": "private"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The updated memory.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/Memory" }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/folders": {
-      "get": {
-        "operationId": "listFolders",
-        "summary": "List folders",
-        "description": "Retrieve all folders for the authenticated user. This endpoint is strictly read-only and returns an empty list if the user has no folders yet. System folders (Work, Personal, Social) are initialized lazily through other paths (the mobile app opening the conversations screen, or the conversation post-processing pipeline), not by this endpoint.",
-        "tags": ["Folders"],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "List of folders.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/Folder" }
-                },
-                "example": [
-                  {
-                    "id": "folder_uuid_work",
-                    "name": "Work",
-                    "description": "Work, business, professional, and career-related conversations",
-                    "color": "#3B82F6",
-                    "icon": "💼",
-                    "created_at": "2025-01-15T10:00:00Z",
-                    "updated_at": "2025-01-20T13:50:00Z",
-                    "order": 0,
-                    "is_default": false,
-                    "is_system": true,
-                    "category_mapping": "work",
-                    "conversation_count": 12
-                  }
-                ]
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": {
-            "description": "Insufficient permissions. Required scope: `conversations:read`.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-                "example": { "detail": "Insufficient permissions. Required scope: conversations:read" }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/dev/user/conversations": {
-      "get": {
-        "operationId": "listConversations",
-        "summary": "List conversations",
-        "description": "Retrieve your conversation transcripts. Only returns completed, non-discarded conversations.",
-        "tags": ["Conversations"],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of conversations to return.",
-            "schema": { "type": "integer", "default": 25 }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "Number of conversations to skip.",
-            "schema": { "type": "integer", "default": 0 }
-          },
-          {
-            "name": "start_date",
-            "in": "query",
-            "description": "Filter by start date (inclusive). ISO 8601 format.",
-            "schema": { "type": "string", "format": "date-time" }
-          },
-          {
-            "name": "end_date",
-            "in": "query",
-            "description": "Filter by end date (inclusive). ISO 8601 format.",
-            "schema": { "type": "string", "format": "date-time" }
-          },
-          {
-            "name": "include_transcript",
-            "in": "query",
-            "description": "Include full transcript segments in the response.",
-            "schema": { "type": "boolean", "default": false }
-          },
-          {
-            "name": "categories",
-            "in": "query",
-            "description": "Comma-separated list of conversation categories to filter by (e.g. `work,personal`). Matches conversations whose category is any of the listed values (OR semantics).",
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "folder_id",
-            "in": "query",
-            "description": "Filter conversations by folder ID. Each conversation belongs to at most one folder, so this is a single-value filter. Must be a non-empty string.",
-            "schema": { "type": "string", "minLength": 1 }
-          },
-          {
-            "name": "starred",
-            "in": "query",
-            "description": "Filter by starred status. Pass `true` for starred conversations only, `false` for non-starred.",
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of conversations.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
-                },
-                "example": [
-                  {
-                    "id": "conv_202",
-                    "created_at": "2025-01-20T13:50:00Z",
-                    "started_at": "2025-01-20T13:50:00Z",
-                    "finished_at": "2025-01-20T14:10:00Z",
-                    "language": "en",
-                    "source": "omi",
-                    "structured": {
-                      "title": "Feature Discussion",
-                      "overview": "Brainstorming session for new features",
-                      "emoji": "💼",
-                      "category": "business",
-                      "action_items": [],
-                      "events": []
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid `categories` value (must be a comma-separated list of valid `CategoryEnum` values).",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-                "example": { "detail": "Invalid category 'foo' is not a valid CategoryEnum" }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": {
-            "description": "Insufficient permissions. Required scope: `conversations:read`.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-                "example": { "detail": "Insufficient permissions. Required scope: conversations:read" }
-              }
-            }
-          },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      },
-      "post": {
-        "operationId": "createConversation",
-        "summary": "Create conversation from text",
-        "description": "Create a new conversation from text content. The text is processed through the full AI pipeline: discard detection, structured generation, action item extraction, memory extraction, app integration, and webhooks.",
-        "tags": ["Conversations"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateConversation" },
-              "example": {
-                "text": "Meeting notes: Discussed Q1 goals. Action item: prepare budget by Friday.",
-                "text_source": "other_text",
-                "text_source_spec": "meeting_notes",
-                "started_at": "2025-12-06T14:00:00+00:00",
-                "language": "en"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Conversation created.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ConversationResponse" },
-                "example": {
-                  "id": "conv_456",
-                  "status": "completed",
-                  "discarded": false
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/conversations/{conversation_id}": {
-      "get": {
-        "operationId": "getConversation",
-        "summary": "Get conversation",
-        "description": "Retrieve a single conversation by ID, optionally including transcript segments.",
-        "tags": ["Conversations"],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the conversation to retrieve.",
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "include_transcript",
-            "in": "query",
-            "description": "Include full transcript segments.",
-            "schema": { "type": "boolean", "default": false }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The conversation.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
-        }
-      },
-      "patch": {
-        "operationId": "updateConversation",
-        "summary": "Update conversation",
-        "description": "Update a conversation's title or discard status. At least one field must be provided.",
-        "tags": ["Conversations"],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the conversation to update.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateConversation" },
-              "example": {
-                "title": "Q1 Planning Meeting - Budget Discussion"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The updated conversation.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      },
-      "delete": {
-        "operationId": "deleteConversation",
-        "summary": "Delete conversation",
-        "description": "Permanently delete a conversation and its associated data. This action cannot be undone. Consider using PATCH with `discarded: true` to hide instead.",
-        "tags": ["Conversations"],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the conversation to delete.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Conversation deleted.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponse" },
-                "example": { "success": true }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
-        }
-      }
-    },
-    "/v1/dev/user/conversations/from-segments": {
-      "post": {
-        "operationId": "createConversationFromSegments",
-        "summary": "Create conversation from transcript segments",
-        "description": "Create a conversation from structured transcript segments with speaker diarization. Unlike text-based conversations, transcript segments are stored and can be retrieved with `include_transcript=true`.",
-        "tags": ["Conversations"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateConversationFromSegments" },
-              "example": {
-                "transcript_segments": [
-                  { "text": "Let's review the quarterly results", "speaker": "SPEAKER_00", "is_user": true, "start": 0.0, "end": 3.5 },
-                  { "text": "Revenue is up 25% from last quarter", "speaker": "SPEAKER_01", "is_user": false, "start": 4.0, "end": 7.2 }
-                ],
-                "source": "phone",
-                "language": "en"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Conversation created.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ConversationResponse" },
-                "example": {
-                  "id": "conv_789",
-                  "status": "completed",
-                  "discarded": false
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/action-items": {
-      "get": {
-        "operationId": "listActionItems",
-        "summary": "List action items",
-        "description": "Retrieve your action items (tasks/to-dos) with optional filtering.",
-        "tags": ["Action Items"],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of items to return.",
-            "schema": { "type": "integer", "default": 100 }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "Number of items to skip.",
-            "schema": { "type": "integer", "default": 0 }
-          },
-          {
-            "name": "completed",
-            "in": "query",
-            "description": "Filter by completion status.",
-            "schema": { "type": "boolean" }
-          },
-          {
-            "name": "conversation_id",
-            "in": "query",
-            "description": "Filter by associated conversation ID.",
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "start_date",
-            "in": "query",
-            "description": "Filter by creation start date (inclusive).",
-            "schema": { "type": "string", "format": "date-time" }
-          },
-          {
-            "name": "end_date",
-            "in": "query",
-            "description": "Filter by creation end date (inclusive).",
-            "schema": { "type": "string", "format": "date-time" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of action items.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/ActionItem" }
-                },
-                "example": [
-                  {
-                    "id": "action_101",
-                    "description": "Review budget proposal",
-                    "completed": false,
-                    "created_at": "2025-01-20T10:15:00Z",
-                    "updated_at": "2025-01-20T10:15:00Z",
-                    "due_at": null,
-                    "completed_at": null,
-                    "conversation_id": "conv_202"
-                  }
-                ]
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
-        }
-      },
-      "post": {
-        "operationId": "createActionItem",
-        "summary": "Create action item",
-        "description": "Create a new action item (task/to-do). Push notifications are sent to the Omi app if a `due_at` date is provided.",
-        "tags": ["Action Items"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateActionItem" },
-              "example": {
-                "description": "Review pull request #123",
-                "completed": false,
-                "due_at": "2025-12-08T15:00:00+00:00"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The created action item.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ActionItem" },
-                "example": {
-                  "id": "action_abc123",
-                  "description": "Review pull request #123",
-                  "completed": false,
-                  "created_at": "2025-12-06T10:30:00Z",
-                  "updated_at": "2025-12-06T10:30:00Z",
-                  "due_at": "2025-12-08T15:00:00+00:00",
-                  "completed_at": null,
-                  "conversation_id": null
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/action-items/batch": {
-      "post": {
-        "operationId": "createActionItemsBatch",
-        "summary": "Create action items (batch)",
-        "description": "Create multiple action items in a single request. Maximum 50 per batch.",
-        "tags": ["Action Items"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/BatchCreateActionItems" },
-              "example": {
-                "action_items": [
-                  { "description": "Review Q1 report", "due_at": "2025-12-10T17:00:00Z" },
-                  { "description": "Schedule team meeting" }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Batch creation result.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/BatchActionItemsResponse" },
-                "example": {
-                  "action_items": [
-                    { "id": "action_001", "description": "Review Q1 report" },
-                    { "id": "action_002", "description": "Schedule team meeting" }
-                  ],
-                  "created_count": 2
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      }
-    },
-    "/v1/dev/user/action-items/{action_item_id}": {
-      "patch": {
-        "operationId": "updateActionItem",
-        "summary": "Update action item",
-        "description": "Update an action item's description, completion status, or due date. Setting `completed: true` automatically sets `completed_at`.",
-        "tags": ["Action Items"],
-        "parameters": [
-          {
-            "name": "action_item_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the action item to update.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateActionItem" },
-              "example": { "completed": true }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The updated action item.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ActionItem" }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
-      },
-      "delete": {
-        "operationId": "deleteActionItem",
-        "summary": "Delete action item",
-        "description": "Permanently delete an action item. This action cannot be undone.",
-        "tags": ["Action Items"],
-        "parameters": [
-          {
-            "name": "action_item_id",
-            "in": "path",
-            "required": true,
-            "description": "The ID of the action item to delete.",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Action item deleted.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponse" },
-                "example": { "success": true }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
-        }
-      }
-    },
     "/v1/dev/keys": {
       "get": {
         "operationId": "listApiKeys",
-        "summary": "List API keys",
-        "description": "Retrieve all your developer API keys. Secret key values are not returned — only the prefix is shown.",
-        "tags": ["API Keys"],
         "responses": {
           "200": {
-            "description": "List of API keys.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/ApiKey" }
-                },
-                "example": [
-                  {
-                    "id": "key_123abc",
-                    "name": "My Analytics Dashboard",
-                    "key_prefix": "omi_dev_abc123",
-                    "created_at": "2025-01-15T10:30:00Z",
-                    "last_used_at": "2025-01-20T14:22:00Z"
-                  }
-                ]
+                  "items": {
+                    "$ref": "#/components/schemas/DevApiKey"
+                  },
+                  "title": "Response Listapikeys",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Keys",
+        "tags": [
+          "API Keys"
+        ]
+      },
+      "post": {
+        "description": "Create a new Developer API key with optional scopes.\n\n- **name**: Descriptive name for the key\n- **scopes**: Optional list of scopes. If not provided, defaults to read-only access.\n  Available scopes:\n  - conversations:read\n  - conversations:write\n  - memories:read\n  - memories:write\n  - action_items:read\n  - action_items:write\n  - goals:read\n  - goals:write",
+        "operationId": "createApiKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DevApiKeyCreate"
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
-        }
-      },
-      "post": {
-        "operationId": "createApiKey",
-        "summary": "Create API key",
-        "description": "Create a new developer API key. The full key is only returned once — store it securely immediately.",
-        "tags": ["API Keys"],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateApiKey" },
-              "example": { "name": "My New Integration" }
-            }
-          }
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "The created API key with full secret.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiKeyCreated" },
-                "example": {
-                  "id": "key_789ghi",
-                  "name": "My New Integration",
-                  "key_prefix": "omi_dev_ghi789",
-                  "key": "omi_dev_ghi789_full_secret_key_here",
-                  "created_at": "2025-01-20T15:00:00Z",
-                  "last_used_at": null
+                "schema": {
+                  "$ref": "#/components/schemas/DevApiKeyCreated"
                 }
               }
-            }
+            },
+            "description": "Successful Response"
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "422": { "$ref": "#/components/responses/ValidationError" }
-        }
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Create Key",
+        "tags": [
+          "API Keys"
+        ]
       }
     },
     "/v1/dev/keys/{key_id}": {
       "delete": {
         "operationId": "revokeApiKey",
-        "summary": "Revoke API key",
-        "description": "Permanently revoke (delete) a specific API key. Any requests using this key will immediately stop working.",
-        "tags": ["API Keys"],
         "parameters": [
           {
-            "name": "key_id",
             "in": "path",
+            "name": "key_id",
             "required": true,
-            "description": "The ID of the key to revoke.",
-            "schema": { "type": "string" }
+            "schema": {
+              "title": "Key Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
-            "description": "Key revoked successfully."
+            "description": "Successful Response"
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
-        }
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Delete Key",
+        "tags": [
+          "API Keys"
+        ]
+      }
+    },
+    "/v1/dev/user/action-items": {
+      "get": {
+        "description": "Get action items with optional filters. Locked action items are excluded.\n\n- **conversation_id**: Filter by conversation ID (None for standalone items)\n- **completed**: Filter by completion status\n- **start_date**: Filter by start date (inclusive)\n- **end_date**: Filter by end date (inclusive)\n- **limit**: Maximum number of items to return\n- **offset**: Number of items to skip",
+        "operationId": "listActionItems",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "conversation_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "completed",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Completed"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DeveloperActionItem"
+                  },
+                  "title": "Response Listactionitems",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Action Items",
+        "tags": [
+          "Action Items"
+        ]
+      },
+      "post": {
+        "description": "Create a new action item for the authenticated user.\n\n- **description**: The action item description (1-500 characters)\n- **completed**: Whether the action item is completed (default: False)\n- **due_at**: Optional due date in ISO 8601 format with timezone",
+        "operationId": "createActionItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActionItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperActionItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Action Item",
+        "tags": [
+          "Action Items"
+        ]
+      }
+    },
+    "/v1/dev/user/action-items/batch": {
+      "post": {
+        "description": "Create multiple action items in a batch.\n\n- **action_items**: List of action items to create (max 50)",
+        "operationId": "createActionItemsBatch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchActionItemsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchActionItemsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Action Items Batch",
+        "tags": [
+          "Action Items"
+        ]
+      }
+    },
+    "/v1/dev/user/action-items/{action_item_id}": {
+      "delete": {
+        "description": "Delete an action item by ID.\n\n- **action_item_id**: The ID of the action item to delete",
+        "operationId": "deleteActionItem",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_item_id",
+            "required": true,
+            "schema": {
+              "title": "Action Item Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Delete Action Item",
+        "tags": [
+          "Action Items"
+        ]
+      },
+      "patch": {
+        "description": "Update an action item.\n\n- **action_item_id**: The ID of the action item to update\n- **description**: New description (optional)\n- **completed**: New completion status (optional)\n- **due_at**: New due date (optional, set to null to remove)",
+        "operationId": "updateActionItem",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_item_id",
+            "required": true,
+            "schema": {
+              "title": "Action Item Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateActionItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperActionItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Update Action Item",
+        "tags": [
+          "Action Items"
+        ]
+      }
+    },
+    "/v1/dev/user/conversations": {
+      "get": {
+        "description": "Get conversations with optional transcript inclusion.\n\n- **include_transcript**: If True, includes full transcript_segments in the response\n- **folder_id**: Filter by folder ID (must be a non-empty string if provided)\n- **starred**: Filter by starred status (true/false)",
+        "operationId": "listConversations",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "categories",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Categories"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_transcript",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Transcript",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "folder_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Folder Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "starred",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Starred"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DeveloperConversation"
+                  },
+                  "title": "Response Listconversations",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Conversations",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "post": {
+        "description": "Create a new conversation from text for the authenticated user.\n\nThis endpoint processes the provided text through the full conversation pipeline:\n- Generates structured data (title, overview, category, emoji)\n- Extracts action items (with deduplication)\n- Extracts memories (with quality filtering)\n- Determines if conversation should be discarded\n- Triggers app integrations\n- Triggers webhooks\n\n**Request Parameters:**\n- **text**: The conversation text/transcript (1-100,000 characters)\n- **text_source**: Source type - audio_transcript, message, or other_text (default: other_text)\n- **text_source_spec**: Additional source info (e.g., 'email', 'slack')\n- **started_at**: When conversation started (defaults to now)\n- **finished_at**: When conversation finished (defaults to started_at + 5 minutes)\n- **language**: Language code (default: 'en')\n- **geolocation**: Optional geolocation data\n\n**Response:**\n- Returns the created conversation ID and status\n- Use GET /v1/dev/user/conversations/{id} to retrieve full details",
+        "operationId": "createConversation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConversationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationCreateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Conversation",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/v1/dev/user/conversations/from-segments": {
+      "post": {
+        "description": "Create a new conversation from structured transcript segments.\n\nThis endpoint is for advanced integrations that have speaker diarization and timing information.\nIt processes the transcript segments through the full conversation pipeline.\n\n**Transcript Segments:**\n- **text**: The text spoken (required)\n- **speaker**: Speaker identifier like 'SPEAKER_00', 'SPEAKER_01' (default: 'SPEAKER_00')\n- **speaker_id**: Numeric speaker ID (auto-calculated from speaker if not provided)\n- **is_user**: Whether this segment is from the user (default: False)\n- **person_id**: ID of known person speaking (optional)\n- **start**: Start time in seconds, e.g., 0.0, 1.5, 60.2 (required)\n- **end**: End time in seconds, e.g., 1.5, 3.0, 65.8 (required)\n\n**Other Parameters:**\n- **source**: Source of conversation (default: external_integration). Options:\n  - omi, friend, openglass, phone, desktop, apple_watch, bee, plaud, frame, etc.\n- **started_at**: When conversation started (defaults to now)\n- **finished_at**: When conversation finished (calculated from last segment if not provided)\n- **language**: Language code (default: 'en')\n- **geolocation**: Optional geolocation data\n\n**Example:**\n```json\n{\n  \"transcript_segments\": [\n    {\n      \"text\": \"Hey, how are you doing?\",\n      \"speaker\": \"SPEAKER_00\",\n      \"is_user\": true,\n      \"start\": 0.0,\n      \"end\": 2.5\n    },\n    {\n      \"text\": \"I'm doing great, thanks!\",\n      \"speaker\": \"SPEAKER_01\",\n      \"is_user\": false,\n      \"start\": 2.8,\n      \"end\": 5.2\n    }\n  ],\n  \"source\": \"phone\",\n  \"language\": \"en\"\n}\n```",
+        "operationId": "createConversationFromSegments",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConversationFromTranscriptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationCreateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Conversation From Segments",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/v1/dev/user/conversations/{conversation_id}": {
+      "delete": {
+        "description": "Delete a conversation by ID.\n\nThis also deletes any associated photos in the conversation's subcollection.\n\n- **conversation_id**: The ID of the conversation to delete",
+        "operationId": "deleteConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Delete Conversation Endpoint",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "get": {
+        "description": "Get a single conversation by ID.\n\n- **conversation_id**: The ID of the conversation to retrieve\n- **include_transcript**: If True, includes full transcript_segments in the response",
+        "operationId": "getConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_transcript",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Transcript",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperConversation"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Conversation Endpoint",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "patch": {
+        "description": "Update a conversation's title or discard status.\n\n- **conversation_id**: The ID of the conversation to update\n- **title**: New title for the conversation (optional)\n- **discarded**: Whether the conversation is discarded (optional)",
+        "operationId": "updateConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateConversationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperConversation"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Update Conversation Endpoint",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/v1/dev/user/folders": {
+      "get": {
+        "description": "Get all folders for the authenticated user.\n\nThis endpoint is strictly read-only and returns an empty list if the user has no folders.\nUnlike the internal `/v1/folders` endpoint, it does NOT call `initialize_system_folders`,\nbecause doing so under a `conversations:read` scope would silently write to Firestore\n(violating the read-only contract) and opens a TOCTOU window where concurrent first\nrequests can race past the outer empty-check and create duplicate system folders.\n\nSystem folders (Work, Personal, Social) are still initialized lazily through other paths:\n- The mobile app calls the internal `GET /v1/folders` whenever the conversations screen\n  is rendered (`app/lib/pages/conversations/conversations_page.dart`), which triggers\n  `initialize_system_folders` on first access.\n- The conversation post-processing pipeline calls `initialize_system_folders` whenever\n  a new conversation is created (`backend/utils/conversations/process_conversation.py`).\n\nIn practice, any user who can issue a Developer API key has already gone through one of\nthose paths, so the empty-list case here only affects users who have never opened the\nconversations tab nor created a single conversation.",
+        "operationId": "listFolders",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DeveloperFolder"
+                  },
+                  "title": "Response Listfolders",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get User Folders",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
+    "/v1/dev/user/goals": {
+      "get": {
+        "description": "Get user goals.\n\n- **limit**: Maximum number of goals to return\n- **include_inactive**: If True, includes inactive/completed goals",
+        "operationId": "listGoals",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_inactive",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Inactive",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DeveloperGoal"
+                  },
+                  "title": "Response Listgoals",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Goals",
+        "tags": [
+          "Goals"
+        ]
+      },
+      "post": {
+        "description": "Create a new goal. Supports up to 3 active goals; the oldest is deactivated if at max.\n\n- **title**: The goal title/description (1-500 characters)\n- **goal_type**: Type of goal metric: boolean, scale, or numeric (default: scale)\n- **target_value**: Target value to achieve\n- **current_value**: Current progress (default: 0)\n- **min_value**: Minimum scale value (default: 0)\n- **max_value**: Maximum scale value (default: 10)\n- **unit**: Optional unit label (e.g., 'users', 'points')",
+        "operationId": "createGoal",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGoalRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperGoal"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Goal",
+        "tags": [
+          "Goals"
+        ]
+      }
+    },
+    "/v1/dev/user/goals/{goal_id}": {
+      "delete": {
+        "description": "Delete a goal by ID.\n\n- **goal_id**: The ID of the goal to delete",
+        "operationId": "deleteGoal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Delete Goal",
+        "tags": [
+          "Goals"
+        ]
+      },
+      "get": {
+        "description": "Get a single goal by ID.\n\n- **goal_id**: The ID of the goal to retrieve",
+        "operationId": "getGoal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperGoal"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Goal",
+        "tags": [
+          "Goals"
+        ]
+      },
+      "patch": {
+        "description": "Update a goal.\n\n- **goal_id**: The ID of the goal to update\n- **title**: New title (optional)\n- **target_value**: New target value (optional)\n- **current_value**: New progress value (optional)\n- **min_value**: New minimum value (optional)\n- **max_value**: New maximum value (optional)\n- **unit**: New unit label (optional)",
+        "operationId": "updateGoal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGoalRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperGoal"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Update Goal",
+        "tags": [
+          "Goals"
+        ]
+      }
+    },
+    "/v1/dev/user/goals/{goal_id}/history": {
+      "get": {
+        "description": "Get progress history for a goal.\n\n- **goal_id**: The ID of the goal\n- **days**: Number of days of history to return (max 365, default 30)",
+        "operationId": "listGoalHistory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 365,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Listgoalhistory",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Goal History",
+        "tags": [
+          "Goals"
+        ]
+      }
+    },
+    "/v1/dev/user/goals/{goal_id}/progress": {
+      "patch": {
+        "description": "Update the progress value of a goal.\n\n- **goal_id**: The ID of the goal to update\n- **current_value**: New progress value (query parameter)",
+        "operationId": "updateGoalProgress",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "New progress value",
+            "in": "query",
+            "name": "current_value",
+            "required": true,
+            "schema": {
+              "description": "New progress value",
+              "title": "Current Value",
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperGoal"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Update Goal Progress",
+        "tags": [
+          "Goals"
+        ]
+      }
+    },
+    "/v1/dev/user/memories": {
+      "get": {
+        "operationId": "listMemories",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "categories",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Categories"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DeveloperMemory"
+                  },
+                  "title": "Response Listmemories",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Memories",
+        "tags": [
+          "Memories"
+        ]
+      },
+      "post": {
+        "description": "Create a new memory for the authenticated user.\n\n- **content**: The content of the memory (1-500 characters)\n- **category**: Memory category (auto-categorized if not provided)\n- **visibility**: Visibility: public or private (default: private)\n- **tags**: List of tags associated with the memory",
+        "operationId": "createMemory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMemoryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperMemory"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Memory",
+        "tags": [
+          "Memories"
+        ]
+      }
+    },
+    "/v1/dev/user/memories/batch": {
+      "post": {
+        "description": "Create multiple memories in a batch.\n\n- **memories**: List of memories to create (max 25)",
+        "operationId": "createMemoriesBatch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchMemoriesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchMemoriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Create Memories Batch",
+        "tags": [
+          "Memories"
+        ]
+      }
+    },
+    "/v1/dev/user/memories/{memory_id}": {
+      "delete": {
+        "description": "Delete a memory by ID.\n\n- **memory_id**: The ID of the memory to delete",
+        "operationId": "deleteMemory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "title": "Memory Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Delete Memory",
+        "tags": [
+          "Memories"
+        ]
+      },
+      "patch": {
+        "description": "Update a memory's content, visibility, tags, or category.\n\n- **memory_id**: The ID of the memory to update\n- **content**: New content for the memory (optional)\n- **visibility**: New visibility: public or private (optional)\n- **tags**: New tags for the memory (optional)\n- **category**: New category for the memory (optional)",
+        "operationId": "updateMemory",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "title": "Memory Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemoryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperMemory"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Update Memory",
+        "tags": [
+          "Memories"
+        ]
       }
     }
   },
-  "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "Developer API key. Get one from **Settings → Developer → Create Key** in the Omi app. Keys are prefixed with `omi_dev_`."
-      }
-    },
-    "schemas": {
-      "Memory": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Unique identifier." },
-          "content": { "type": "string", "description": "The memory content." },
-          "category": { "type": "string", "enum": ["interesting", "system", "manual"], "description": "Memory category." },
-          "visibility": { "type": "string", "enum": ["public", "private"], "description": "Visibility level." },
-          "tags": { "type": "array", "items": { "type": "string" }, "description": "List of tags." },
-          "created_at": { "type": "string", "format": "date-time", "description": "When the memory was created." },
-          "updated_at": { "type": "string", "format": "date-time", "description": "When the memory was last updated." },
-          "manually_added": { "type": "boolean", "description": "Whether the memory was added manually (via API or app)." },
-          "reviewed": { "type": "boolean", "description": "Whether the memory has been reviewed." },
-          "user_review": { "type": ["boolean", "null"], "description": "User's review decision." },
-          "edited": { "type": "boolean", "description": "Whether the memory has been edited." }
-        }
-      },
-      "CreateMemory": {
-        "type": "object",
-        "required": ["content"],
-        "properties": {
-          "content": { "type": "string", "minLength": 1, "maxLength": 500, "description": "The memory content." },
-          "category": { "type": "string", "enum": ["interesting", "system", "manual"], "description": "Memory category. Auto-categorized if not provided." },
-          "visibility": { "type": "string", "enum": ["public", "private"], "default": "private", "description": "Visibility level." },
-          "tags": { "type": "array", "items": { "type": "string" }, "description": "List of tags." }
-        }
-      },
-      "UpdateMemory": {
-        "type": "object",
-        "properties": {
-          "content": { "type": "string", "minLength": 1, "maxLength": 500, "description": "New memory content." },
-          "visibility": { "type": "string", "enum": ["public", "private"], "description": "New visibility level." }
-        }
-      },
-      "BatchCreateMemories": {
-        "type": "object",
-        "required": ["memories"],
-        "properties": {
-          "memories": { "type": "array", "items": { "$ref": "#/components/schemas/CreateMemory" }, "maxItems": 25, "description": "List of memories to create (max 25)." }
-        }
-      },
-      "BatchMemoriesResponse": {
-        "type": "object",
-        "properties": {
-          "memories": { "type": "array", "items": { "$ref": "#/components/schemas/Memory" } },
-          "created_count": { "type": "integer", "description": "Number of memories created." }
-        }
-      },
-      "Conversation": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Unique identifier." },
-          "created_at": { "type": "string", "format": "date-time", "description": "When the conversation record was created." },
-          "started_at": { "type": "string", "format": "date-time", "description": "When the conversation started." },
-          "finished_at": { "type": "string", "format": "date-time", "description": "When the conversation ended." },
-          "language": { "type": "string", "description": "Language code (e.g. `en`)." },
-          "source": { "type": "string", "description": "Source device or app." },
-          "structured": { "$ref": "#/components/schemas/StructuredData" },
-          "transcript_segments": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/TranscriptSegment" },
-            "description": "Transcript segments (only present when `include_transcript=true`)."
-          },
-          "geolocation": { "$ref": "#/components/schemas/Geolocation" },
-          "folder_id": { "type": ["string", "null"], "description": "ID of the folder this conversation belongs to, or null if not in any folder." },
-          "folder_name": { "type": ["string", "null"], "description": "Display name of the folder, or null if not in any folder." }
-        }
-      },
-      "StructuredData": {
-        "type": "object",
-        "properties": {
-          "title": { "type": "string", "description": "AI-generated title." },
-          "overview": { "type": "string", "description": "Summary of the conversation." },
-          "emoji": { "type": "string", "description": "Representative emoji." },
-          "category": { "type": "string", "description": "Category (work, personal, etc.)." },
-          "action_items": { "type": "array", "items": { "$ref": "#/components/schemas/ActionItemSummary" } },
-          "events": { "type": "array", "items": { "type": "object" } }
-        }
-      },
-      "ActionItemSummary": {
-        "type": "object",
-        "properties": {
-          "description": { "type": "string" },
-          "completed": { "type": "boolean" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" },
-          "due_at": { "type": ["string", "null"], "format": "date-time" },
-          "completed_at": { "type": ["string", "null"], "format": "date-time" }
-        }
-      },
-      "TranscriptSegment": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Segment identifier." },
-          "text": { "type": "string", "description": "The transcribed text." },
-          "speaker_id": { "type": "integer", "description": "Numeric speaker identifier." },
-          "speaker_name": { "type": "string", "description": "Human-readable speaker name." },
-          "start": { "type": "number", "description": "Start timestamp in seconds." },
-          "end": { "type": "number", "description": "End timestamp in seconds." }
-        }
-      },
-      "Geolocation": {
-        "type": "object",
-        "properties": {
-          "latitude": { "type": "number" },
-          "longitude": { "type": "number" },
-          "address": { "type": "string" },
-          "google_place_id": { "type": "string" },
-          "location_type": { "type": "string" }
-        }
-      },
-      "CreateConversation": {
-        "type": "object",
-        "required": ["text"],
-        "properties": {
-          "text": { "type": "string", "minLength": 1, "maxLength": 100000, "description": "The conversation text/transcript." },
-          "text_source": { "type": "string", "enum": ["audio_transcript", "message", "other_text"], "default": "other_text", "description": "Source type." },
-          "text_source_spec": { "type": "string", "description": "Additional source info (e.g. `email`, `slack`, `whatsapp`)." },
-          "started_at": { "type": "string", "format": "date-time", "description": "When conversation started (defaults to now)." },
-          "finished_at": { "type": "string", "format": "date-time", "description": "When conversation finished." },
-          "language": { "type": "string", "default": "en", "description": "Language code." },
-          "geolocation": { "$ref": "#/components/schemas/GeolocationInput" }
-        }
-      },
-      "CreateConversationFromSegments": {
-        "type": "object",
-        "required": ["transcript_segments"],
-        "properties": {
-          "transcript_segments": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 500,
-            "items": { "$ref": "#/components/schemas/TranscriptSegmentInput" },
-            "description": "List of transcript segments (1–500)."
-          },
-          "source": { "type": "string", "default": "external_integration", "description": "Source of conversation." },
-          "started_at": { "type": "string", "format": "date-time", "description": "When conversation started." },
-          "finished_at": { "type": "string", "format": "date-time", "description": "When conversation finished." },
-          "language": { "type": "string", "default": "en", "description": "Language code." },
-          "geolocation": { "$ref": "#/components/schemas/GeolocationInput" }
-        }
-      },
-      "TranscriptSegmentInput": {
-        "type": "object",
-        "required": ["text", "start", "end"],
-        "properties": {
-          "text": { "type": "string", "description": "The spoken text." },
-          "speaker": { "type": "string", "default": "SPEAKER_00", "description": "Speaker identifier (e.g. `SPEAKER_00`)." },
-          "speaker_id": { "type": "integer", "description": "Numeric speaker ID." },
-          "is_user": { "type": "boolean", "default": false, "description": "Whether this segment is from the user." },
-          "person_id": { "type": "string", "description": "ID of known person speaking." },
-          "start": { "type": "number", "description": "Start time in seconds." },
-          "end": { "type": "number", "description": "End time in seconds." }
-        }
-      },
-      "GeolocationInput": {
-        "type": "object",
-        "properties": {
-          "latitude": { "type": "number" },
-          "longitude": { "type": "number" }
-        }
-      },
-      "UpdateConversation": {
-        "type": "object",
-        "properties": {
-          "title": { "type": "string", "minLength": 1, "maxLength": 500, "description": "New title." },
-          "discarded": { "type": "boolean", "description": "Whether the conversation is discarded." }
-        }
-      },
-      "ConversationResponse": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Conversation ID." },
-          "status": { "type": "string", "description": "Processing status." },
-          "discarded": { "type": "boolean", "description": "Whether the conversation was discarded." }
-        }
-      },
-      "ActionItem": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Unique identifier." },
-          "description": { "type": "string", "description": "The action item text." },
-          "completed": { "type": "boolean", "description": "Whether completed." },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" },
-          "due_at": { "type": ["string", "null"], "format": "date-time", "description": "Due date (null if not set)." },
-          "completed_at": { "type": ["string", "null"], "format": "date-time", "description": "When completed (null if pending)." },
-          "conversation_id": { "type": ["string", "null"], "description": "Associated conversation ID." }
-        }
-      },
-      "CreateActionItem": {
-        "type": "object",
-        "required": ["description"],
-        "properties": {
-          "description": { "type": "string", "minLength": 1, "maxLength": 500, "description": "The action item description." },
-          "completed": { "type": "boolean", "default": false, "description": "Whether completed." },
-          "due_at": { "type": "string", "format": "date-time", "description": "Due date in ISO 8601 format." }
-        }
-      },
-      "UpdateActionItem": {
-        "type": "object",
-        "properties": {
-          "description": { "type": "string", "minLength": 1, "maxLength": 500, "description": "New description." },
-          "completed": { "type": "boolean", "description": "New completion status." },
-          "due_at": { "type": "string", "format": "date-time", "description": "New due date." }
-        }
-      },
-      "BatchCreateActionItems": {
-        "type": "object",
-        "required": ["action_items"],
-        "properties": {
-          "action_items": { "type": "array", "items": { "$ref": "#/components/schemas/CreateActionItem" }, "maxItems": 50, "description": "List of action items to create (max 50)." }
-        }
-      },
-      "BatchActionItemsResponse": {
-        "type": "object",
-        "properties": {
-          "action_items": { "type": "array", "items": { "$ref": "#/components/schemas/ActionItem" } },
-          "created_count": { "type": "integer", "description": "Number of action items created." }
-        }
-      },
-      "ApiKey": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Unique key identifier." },
-          "name": { "type": "string", "description": "Descriptive name." },
-          "key_prefix": { "type": "string", "description": "First part of the key (for identification)." },
-          "created_at": { "type": "string", "format": "date-time" },
-          "last_used_at": { "type": ["string", "null"], "format": "date-time", "description": "When the key was last used." },
-
-          "scopes": {
-            "type": ["array", "null"],
-            "items": { "type": "string" },
-            "description": "Permission scopes assigned to the API key. Null for legacy keys (treated as read-only)."
-          }
-        }
-      },
-      "ApiKeyCreated": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "key_prefix": { "type": "string" },
-          "key": { "type": "string", "description": "The full API key. **Only returned once during creation.**" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "last_used_at": { "type": ["string", "null"], "format": "date-time" },
-
-          "scopes": {
-            "type": ["array", "null"],
-            "items": { "type": "string" },
-            "description": "Permission scopes assigned to the API key. Null for legacy keys (treated as read-only)."
-          }
-        }
-      },
-      "CreateApiKey": {
-        "type": "object",
-        "required": ["name"],
-        "properties": {
-          "name": { "type": "string", "description": "Descriptive name for the key." },
-
-          "scopes": {
-           "type": "array",
-           "items": {
-             "type": "string",
-             "enum": [
-               "conversations:read", "conversations:write",
-               "memories:read", "memories:write",
-               "action_items:read", "action_items:write",
-               "goals:read", "goals:write"
-              ]
-            },
-            "description": "Optional scopes to assign. Defaults to read-only (conversations:read, memories:read, action_items:read, goals:read) if not provided."
-          }
-        }
-      },
-      "SuccessResponse": {
-        "type": "object",
-        "properties": {
-          "success": { "type": "boolean" }
-        }
-      },
-      "Folder": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "description": "Unique identifier." },
-          "name": { "type": "string", "minLength": 1, "maxLength": 100, "description": "Display name of the folder." },
-          "description": { "type": ["string", "null"], "maxLength": 500, "description": "Natural language description of what belongs in this folder." },
-          "color": { "type": "string", "default": "#6B7280", "description": "Hex color code for the folder." },
-          "icon": { "type": "string", "default": "folder", "description": "Emoji or icon identifier for the folder." },
-          "created_at": { "type": "string", "format": "date-time", "description": "When the folder was created." },
-          "updated_at": { "type": "string", "format": "date-time", "description": "When the folder was last updated." },
-          "order": { "type": "integer", "default": 0, "description": "Display order index (lower = earlier)." },
-          "is_default": { "type": "boolean", "default": false, "description": "Whether this is the default folder for unassigned conversations." },
-          "is_system": { "type": "boolean", "default": false, "description": "True for category-based system folders (Work, Personal, Social)." },
-          "category_mapping": { "type": ["string", "null"], "description": "Maps to a CategoryEnum value for backwards compatibility with category-based filtering." },
-          "conversation_count": { "type": "integer", "default": 0, "description": "Number of non-discarded conversations in this folder." }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "detail": { "type": "string", "description": "Error description." }
-        }
-      }
-    },
-    "responses": {
-      "Unauthorized": {
-        "description": "Invalid or missing API key.",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-            "example": { "detail": "Invalid API key" }
-          }
-        }
-      },
-      "NotFound": {
-        "description": "Resource not found.",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-            "example": { "detail": "Not found" }
-          }
-        }
-      },
-      "ValidationError": {
-        "description": "Validation error.",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-            "example": { "detail": "Validation error: content is required" }
-          }
-        }
-      }
+  "servers": [
+    {
+      "description": "Production",
+      "url": "https://api.omi.me"
     }
-  }
+  ],
+  "tags": [
+    {
+      "description": "Read and write user memories - timeless facts, preferences, and insights.",
+      "name": "Memories"
+    },
+    {
+      "description": "Create and retrieve conversation transcripts with AI-generated summaries.",
+      "name": "Conversations"
+    },
+    {
+      "description": "Retrieve user-defined folders for organizing conversations.",
+      "name": "Folders"
+    },
+    {
+      "description": "Manage tasks and to-dos extracted from conversations or created manually.",
+      "name": "Action Items"
+    },
+    {
+      "description": "Manage user goals and progress history.",
+      "name": "Goals"
+    },
+    {
+      "description": "Create, list, and revoke developer API keys.",
+      "name": "API Keys"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds a hermetic OpenAPI exporter/checker for the public Developer API contract.
- Adds route inventory, audited route drift, operation ID, auth/security, side-effect, and schema checks.
- Regenerates `docs/api-reference/openapi.json` from the audited route surface and adds CI coverage.

## Validation
- `.venv/bin/python scripts/export_openapi.py --check ../docs/api-reference/openapi.json` -> passed
- `.venv/bin/pytest tests/unit/test_openapi_contract.py -q` -> 14 passed
- `bash backend/test-preflight.sh` passed during prep with optional local warnings
- Pre-push hook passed
- Oracle pre-implementation and pre-PR reviews passed after repair rounds.

Fixes #8546


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

