### PR TITLE
[codex] Add desktop backend parity contract tests

### DIFF
--- a/.github/workflows/desktop-backend-contracts.yml
+++ b/.github/workflows/desktop-backend-contracts.yml
@@ -33,12 +33,18 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version-file: backend/.python-version
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Python contract dependencies
-        run: python -m pip install -r backend/requirements.txt
+        working-directory: backend
+        run: uv pip sync pylock.toml --system
 
       - name: Run Python desktop backend contracts
         run: python -m pytest backend/testing/contracts -v

--- a/.github/workflows/desktop-backend-contracts.yml
+++ b/.github/workflows/desktop-backend-contracts.yml
@@ -1,0 +1,47 @@
+name: Desktop Backend Contracts
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/desktop-backend-contracts.yml"
+      - "backend/testing/contracts/**"
+      - "backend/database/conversations.py"
+      - "backend/database/helpers.py"
+      - "backend/database/memories.py"
+      - "backend/models/**"
+      - "backend/test.sh"
+      - "backend/utils/encryption.py"
+      - "contract_tests/**"
+      - "desktop/macos/Backend-Rust/Cargo.lock"
+      - "desktop/macos/Backend-Rust/Cargo.toml"
+      - "desktop/macos/Backend-Rust/src/models/**"
+      - "desktop/macos/Backend-Rust/src/services/firestore.rs"
+      - "desktop/macos/Backend-Rust/src/services/firestore/**"
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    env:
+      ENCRYPTION_SECRET: omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv
+      FIRESTORE_EMULATOR_HOST: localhost:8787
+      GOOGLE_CLOUD_PROJECT: omi-contract-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Python contract dependencies
+        run: python -m pip install -r backend/requirements.txt
+
+      - name: Run Python desktop backend contracts
+        run: python -m pytest backend/testing/contracts -v
+
+      - name: Run Rust desktop backend contracts
+        run: cargo test --manifest-path desktop/macos/Backend-Rust/Cargo.toml contract

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -103,6 +103,10 @@ if [[ ${#unit_tests[@]} -gt 0 ]]; then
   done
 fi
 
+if [[ -d testing/contracts ]]; then
+  run_pytest_group "backend contract tests" testing/contracts
+fi
+
 # Optional fair-use integration tests require Redis and are intentionally outside
 # the deterministic unit signal.
 if [[ "${RUN_BACKEND_INTEGRATION_TESTS:-0}" == "1" ]]; then

--- a/backend/testing/contracts/test_desktop_backend_parity.py
+++ b/backend/testing/contracts/test_desktop_backend_parity.py
@@ -1,0 +1,249 @@
+import base64
+import json
+import os
+import sys
+import types
+import zlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "omi-contract-tests")
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:8787")
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+REPO_DIR = BACKEND_DIR.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+storage_stub = types.ModuleType("utils.other.storage")
+storage_stub.list_audio_chunks = lambda *_args, **_kwargs: []
+sys.modules.setdefault("utils.other.storage", storage_stub)
+
+from database import conversations as conversations_db
+from database import memories as memories_db
+from models.memories import MemoryCategory, MemoryDB
+
+
+def fixture(name: str) -> dict:
+    return json.loads((REPO_DIR / "contract_tests" / "fixtures" / name).read_text())
+
+
+class FakeDoc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class FakeQuery:
+    def __init__(self, docs=None):
+        self.docs = docs or []
+        self.filters = []
+        self.orders = []
+        self.limit_value = None
+        self.offset_value = None
+        self.collections = []
+
+    def collection(self, name):
+        self.collections.append(name)
+        return self
+
+    def document(self, _name):
+        return self
+
+    def where(self, *, filter):
+        self.filters.append(filter)
+        return self
+
+    def order_by(self, field_path, direction=None):
+        self.orders.append((field_path, direction))
+        return self
+
+    def limit(self, value):
+        self.limit_value = value
+        return self
+
+    def offset(self, value):
+        self.offset_value = value
+        return self
+
+    def stream(self):
+        return [FakeDoc(doc) for doc in self.docs]
+
+
+def filter_parts(field_filter):
+    return (
+        getattr(field_filter, "field_path", getattr(field_filter, "_field_path", None)),
+        getattr(field_filter, "op_string", getattr(field_filter, "_op_string", None)),
+        getattr(field_filter, "value", getattr(field_filter, "_value", None)),
+    )
+
+
+def test_python_conversation_codec_reads_shared_standard_and_enhanced_fixtures():
+    data = fixture("conversations.json")
+    standard = conversations_db._prepare_conversation_for_read(
+        {
+            "data_protection_level": "standard",
+            "transcript_segments": base64.b64decode(data["standard_compressed_transcript_b64"]),
+            "transcript_segments_compressed": True,
+        },
+        data["uid"],
+    )
+    enhanced = conversations_db._prepare_conversation_for_read(
+        {
+            "data_protection_level": "enhanced",
+            "transcript_segments": data["enhanced_encrypted_transcript"],
+            "transcript_segments_compressed": True,
+        },
+        data["uid"],
+    )
+
+    assert standard["transcript_segments"] == data["segments"]
+    assert enhanced["transcript_segments"] == data["segments"]
+
+
+def test_python_conversation_codec_writes_normalized_segments():
+    data = fixture("conversations.json")
+    written = conversations_db._prepare_conversation_for_write(
+        {"transcript_segments": data["segments"]},
+        data["uid"],
+        "standard",
+    )
+
+    assert written["transcript_segments_compressed"] is True
+    assert zlib.decompress(written["transcript_segments"]).decode("utf-8")
+    assert json.loads(zlib.decompress(written["transcript_segments"]).decode("utf-8")) == data["segments"]
+
+
+def test_python_conversation_query_semantics(monkeypatch):
+    data = fixture("conversations.json")["query"]
+    fake_db = FakeQuery()
+    monkeypatch.setattr(conversations_db, "db", fake_db)
+
+    conversations_db.get_conversations(
+        "contract-user-8547",
+        limit=data["limit"],
+        offset=data["offset"],
+        statuses=["completed", "in_progress"],
+        starred=True,
+        folder_id="folder-1",
+        start_date=datetime.fromisoformat(data["start_date"]),
+        end_date=datetime.fromisoformat(data["end_date"]),
+        date_field=data["date_field"],
+    )
+
+    filters = [filter_parts(f) for f in fake_db.filters]
+    assert ("discarded", "==", False) in filters
+    assert ("status", "in", ["completed", "in_progress"]) in filters
+    assert ("starred", "==", True) in filters
+    assert ("folder_id", "==", "folder-1") in filters
+    assert (data["date_field"], ">=", datetime.fromisoformat(data["start_date"])) in filters
+    assert (data["date_field"], "<=", datetime.fromisoformat(data["end_date"])) in filters
+    assert fake_db.orders == [(data["date_field"], "DESCENDING")]
+    assert fake_db.limit_value == data["limit"]
+    assert fake_db.offset_value == data["offset"]
+
+
+def test_python_conversation_query_defaults_to_created_at(monkeypatch):
+    fake_db = FakeQuery()
+    monkeypatch.setattr(conversations_db, "db", fake_db)
+
+    conversations_db.get_conversations("contract-user-8547", limit=2, offset=1)
+
+    assert fake_db.orders == [("created_at", "DESCENDING")]
+    assert fake_db.limit_value == 2
+    assert fake_db.offset_value == 1
+
+
+def test_python_memory_codec_reads_shared_enhanced_fixture():
+    data = fixture("memories.json")
+    memory = memories_db._prepare_memory_for_read(
+        {
+            "data_protection_level": "enhanced",
+            "content": data["enhanced_encrypted_content"],
+        },
+        data["uid"],
+    )
+
+    assert memory["content"] == data["enhanced_plain_content"]
+
+
+def test_python_memory_scoring_matches_shared_fixture():
+    data = fixture("memories.json")
+    created_at = datetime.fromisoformat(data["created_at"])
+
+    for category, expected in data["scoring"].items():
+        if category == "manual_added_interesting":
+            continue
+        memory = MemoryDB(
+            id=f"memory-{category}",
+            uid=data["uid"],
+            content="contract",
+            category=MemoryCategory(category),
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        assert MemoryDB.calculate_score(memory) == expected
+
+    manual_memory = MemoryDB(
+        id="manual-added",
+        uid=data["uid"],
+        content="contract",
+        category=MemoryCategory.interesting,
+        created_at=created_at,
+        updated_at=created_at,
+        manually_added=True,
+    )
+    assert MemoryDB.calculate_score(manual_memory) == data["scoring"]["manual_added_interesting"]
+
+
+def test_python_memory_query_and_filter_semantics(monkeypatch):
+    data = fixture("memories.json")["query"]
+    active = {"id": "active", "content": "active", "user_review": None, "invalid_at": None}
+    rejected = {"id": "rejected", "content": "rejected", "user_review": False, "invalid_at": None}
+    invalidated = {"id": "invalidated", "content": "invalidated", "user_review": None, "invalid_at": "2026-01-03"}
+    fake_db = FakeQuery([active, rejected, invalidated])
+    monkeypatch.setattr(memories_db, "db", fake_db)
+
+    result = memories_db.get_memories(
+        "contract-user-8547",
+        limit=data["limit"],
+        offset=data["offset"],
+        categories=data["categories"],
+        start_date=datetime.fromisoformat(data["start_date"]),
+        end_date=datetime.fromisoformat(data["end_date"]),
+    )
+
+    filters = [filter_parts(f) for f in fake_db.filters]
+    assert ("category", "in", data["categories"]) in filters
+    assert ("created_at", ">=", datetime.fromisoformat(data["start_date"])) in filters
+    assert ("created_at", "<=", datetime.fromisoformat(data["end_date"])) in filters
+    assert fake_db.orders == [("scoring", "DESCENDING"), ("created_at", "DESCENDING")]
+    assert fake_db.limit_value == data["limit"]
+    assert fake_db.offset_value == data["offset"]
+    assert [memory["id"] for memory in result] == ["active"]
+
+    fake_db = FakeQuery([active, rejected, invalidated])
+    monkeypatch.setattr(memories_db, "db", fake_db)
+    result = memories_db.get_memories("contract-user-8547", include_invalidated=True)
+    assert [memory["id"] for memory in result] == ["active", "invalidated"]
+
+
+def test_python_public_memories_treat_missing_visibility_as_public(monkeypatch):
+    fake_db = FakeQuery(
+        [
+            {"id": "missing-visibility", "content": "legacy public"},
+            {"id": "public", "content": "public", "visibility": "public"},
+            {"id": "private", "content": "private", "visibility": "private"},
+        ]
+    )
+    monkeypatch.setattr(memories_db, "db", fake_db)
+
+    result = memories_db.get_user_public_memories("contract-user-8547", limit=5, offset=2)
+
+    assert [memory["id"] for memory in result] == ["missing-visibility", "public"]
+    assert fake_db.orders == [("scoring", "DESCENDING"), ("created_at", "DESCENDING")]
+    assert fake_db.limit_value == 5
+    assert fake_db.offset_value == 2

--- a/contract_tests/fixtures/conversations.json
+++ b/contract_tests/fixtures/conversations.json
@@ -1,0 +1,39 @@
+{
+  "uid": "contract-user-8547",
+  "encryption_secret": "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+  "segments": [
+    {
+      "id": "seg-1",
+      "text": "Hello from desktop",
+      "speaker": "SPEAKER_00",
+      "speaker_id": 0,
+      "is_user": true,
+      "person_id": "person-user",
+      "start": 0,
+      "end": 1.25
+    },
+    {
+      "id": "seg-2",
+      "text": "Rust and Python should agree",
+      "speaker": "SPEAKER_01",
+      "speaker_id": 1,
+      "is_user": false,
+      "start": 1.25,
+      "end": 3.5
+    }
+  ],
+  "standard_compressed_transcript_b64": "eJx1jssKgzAQRX9lyFpFLW6660IodCN2WYoEMj4wTSSTQEvx32uslJTS5dx77nAuTzYItgdG2MUZi4BZvFsfHFFKDa3RNxBIo9WTb2lCPqLxwLkqD6eybtI0KJr1W7oEAzWOVtIah0swoSGt3sB2xCvh15Ybuw1ReSJL8mKOINTLQ73akQWuBFQP22sF1GsnBfDOIP4TzX5Esy/RlkvCwMY7fIR2STFfX2ihWsE=",
+  "enhanced_encrypted_transcript": "AAECAwQFBgcICQoLJBF/bml9IYvujqZv4oTwjU2+neJ5kICizDxOyOkrqw9hfcTtX7vSERBe9oqyb9sdLuDeHrrsxhLEedJ5NIBquK1yQUSSg3hEFJCMDhPfr2xhbOL+CKsHh1gOFancnjkunmkXBkIKSJB4MFhKPot08PyY6P0S2MuCjbWYHeawG8+f+C7MuB8y8OcX8MtI0dzsNyhKatdkfhdCVxpPPzbyveA9Yg7q0NLdPPNpQvUyQ7O3KrYlpozxWEIj49TeWYxamKMiNgHSgsGaw7w8rs3YtT7Jge1XMksd87Kc/vEHLDN3yukqfiSn7wZ+JBrzy5XMUTiqX8XJroIKO2Tcgl/ELRrxeChSGqbl/F6wnLwO3m6RcuZt1915TgIcv/L/kiOAMYHjnBjUvYuu16ALtwu9OerNAmTsq7EM087bru4sxTxpujVj5BIRlpQDzhMUElB1d/FVYAfcqy93vgS5Z8ANN1U1tY5Q94asuFg=",
+  "query": {
+    "limit": 7,
+    "offset": 3,
+    "start_date": "2026-01-02T03:04:05+00:00",
+    "end_date": "2026-02-03T04:05:06+00:00",
+    "date_field": "finished_at"
+  },
+  "wire_values": {
+    "source_external_integration": "external_integration",
+    "status_in_progress": "in_progress",
+    "category_romance": "romantic"
+  }
+}

--- a/contract_tests/fixtures/memories.json
+++ b/contract_tests/fixtures/memories.json
@@ -1,0 +1,31 @@
+{
+  "uid": "contract-user-8547",
+  "encryption_secret": "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+  "created_at": "2026-01-02T03:04:05+00:00",
+  "enhanced_encrypted_content": "DA0ODxAREhMUFRYXxDRpYlQa/R7Anh2SaeAQNma74MyaecBkYZy7hIW3Ij0qnJM4MtmPU4iyNfojkPJfiQ==",
+  "enhanced_plain_content": "Encrypted contract memory content",
+  "query": {
+    "limit": 11,
+    "offset": 4,
+    "categories": ["system", "workflow"],
+    "start_date": "2026-01-01T00:00:00+00:00",
+    "end_date": "2026-01-31T23:59:59+00:00"
+  },
+  "scoring": {
+    "interesting": "00_998_1767323045",
+    "system": "00_999_1767323045",
+    "manual": "00_998_1767323045",
+    "workflow": "00_998_1767323045",
+    "core": "00_998_1767323045",
+    "hobbies": "00_998_1767323045",
+    "lifestyle": "00_998_1767323045",
+    "interests": "00_998_1767323045",
+    "habits": "00_999_1767323045",
+    "work": "00_998_1767323045",
+    "skills": "00_998_1767323045",
+    "learnings": "00_998_1767323045",
+    "other": "00_999_1767323045",
+    "auto": "00_999_1767323045",
+    "manual_added_interesting": "01_998_1767323045"
+  }
+}

--- a/desktop/macos/Backend-Rust/src/models/category.rs
+++ b/desktop/macos/Backend-Rust/src/models/category.rs
@@ -102,11 +102,19 @@ pub enum MemoryCategory {
     Interesting,
     /// Manually added by user
     Manual,
+    /// Workflow-generated memory
+    Workflow,
     // Legacy categories for backward compatibility with old data
     Core,
     Hobbies,
     Lifestyle,
     Interests,
+    Habits,
+    Work,
+    Skills,
+    Learnings,
+    Other,
+    Auto,
 }
 
 impl Default for MemoryCategory {

--- a/desktop/macos/Backend-Rust/src/models/memory.rs
+++ b/desktop/macos/Backend-Rust/src/models/memory.rs
@@ -39,6 +39,8 @@ pub struct MemoryDB {
     pub category: MemoryCategory,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub memory_id: Option<String>,
     pub conversation_id: Option<String>,
     #[serde(default)]
     pub reviewed: bool,
@@ -77,10 +79,28 @@ pub struct MemoryDB {
     pub current_activity: Option<String>,
     /// Window title when memory was extracted
     pub window_title: Option<String>,
+    /// Protection level for encrypted memory content.
+    #[serde(default)]
+    pub data_protection_level: Option<String>,
+    /// Temporal lifecycle fields owned by Python's memory brain.
+    #[serde(default)]
+    pub valid_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub invalid_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub superseded_by: Option<String>,
+    #[serde(default)]
+    pub edited: bool,
+    #[serde(default)]
+    pub is_locked: bool,
+    #[serde(default)]
+    pub kg_extracted: bool,
+    #[serde(default)]
+    pub app_id: Option<String>,
 }
 
 fn default_visibility_field() -> String {
-    "private".to_string()
+    "public".to_string()
 }
 
 impl MemoryDB {
@@ -99,16 +119,20 @@ impl MemoryDB {
             MemoryCategory::Interesting => 1,
             MemoryCategory::System => 0,
             MemoryCategory::Manual => 1,
-            // Legacy categories - treat as system
+            MemoryCategory::Workflow => 1,
             MemoryCategory::Core
             | MemoryCategory::Hobbies
             | MemoryCategory::Lifestyle
-            | MemoryCategory::Interests => 0,
+            | MemoryCategory::Interests
+            | MemoryCategory::Work
+            | MemoryCategory::Skills
+            | MemoryCategory::Learnings => 1,
+            MemoryCategory::Habits | MemoryCategory::Other | MemoryCategory::Auto => 0,
         };
         let cat_boost = 999 - category_boost;
 
         let timestamp = created_at.timestamp();
 
-        format!("{:02}_{:03}_{:010}", manual_boost, cat_boost, timestamp)
+        format!("{:02}_{:02}_{:010}", manual_boost, cat_boost, timestamp)
     }
 }

--- a/desktop/macos/Backend-Rust/src/services/firestore.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore.rs
@@ -109,6 +109,17 @@ pub struct FirestoreService {
 }
 
 impl FirestoreService {
+    #[cfg(test)]
+    pub(super) fn new_for_contract(encryption_secret: Option<Vec<u8>>) -> Self {
+        Self {
+            client: Client::new(),
+            project_id: "contract-tests".to_string(),
+            credentials: None,
+            cached_token: Arc::new(RwLock::new(None)),
+            encryption_secret,
+        }
+    }
+
     /// Create a new Firestore service
     pub async fn new(
         project_id: String,

--- a/desktop/macos/Backend-Rust/src/services/firestore/conversations_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/conversations_repository.rs
@@ -1,5 +1,188 @@
 use super::*;
 
+pub(super) fn build_conversations_query(
+    limit: usize,
+    offset: usize,
+    include_discarded: bool,
+    statuses: &[String],
+    categories: Option<&[String]>,
+    starred: Option<bool>,
+    folder_id: Option<&str>,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+    date_field: &str,
+) -> Value {
+    let mut filters: Vec<Value> = Vec::new();
+
+    if !include_discarded {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "discarded"},
+                "op": "EQUAL",
+                "value": {"booleanValue": false}
+            }
+        }));
+    }
+
+    if let Some(category_values) = categories {
+        if !category_values.is_empty() {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "structured.category"},
+                    "op": "IN",
+                    "value": {
+                        "arrayValue": {
+                            "values": category_values.iter().map(|s| json!({"stringValue": s})).collect::<Vec<_>>()
+                        }
+                    }
+                }
+            }));
+        }
+    }
+
+    if !statuses.is_empty() {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "status"},
+                "op": "IN",
+                "value": {
+                    "arrayValue": {
+                        "values": statuses.iter().map(|s| json!({"stringValue": s})).collect::<Vec<_>>()
+                    }
+                }
+            }
+        }));
+    }
+
+    if let Some(starred_val) = starred {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "starred"},
+                "op": "EQUAL",
+                "value": {"booleanValue": starred_val}
+            }
+        }));
+    }
+
+    if let Some(fid) = folder_id {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "folder_id"},
+                "op": "EQUAL",
+                "value": {"stringValue": fid}
+            }
+        }));
+    }
+
+    if let Some(start) = start_date {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": date_field},
+                "op": "GREATER_THAN_OR_EQUAL",
+                "value": {"timestampValue": start}
+            }
+        }));
+    }
+
+    if let Some(end) = end_date {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": date_field},
+                "op": "LESS_THAN_OR_EQUAL",
+                "value": {"timestampValue": end}
+            }
+        }));
+    }
+
+    let where_clause = if filters.is_empty() {
+        None
+    } else if filters.len() == 1 {
+        filters.into_iter().next()
+    } else {
+        Some(json!({
+            "compositeFilter": {
+                "op": "AND",
+                "filters": filters
+            }
+        }))
+    };
+
+    let sort_field = if start_date.is_some() || end_date.is_some() {
+        date_field
+    } else {
+        "created_at"
+    };
+
+    let mut structured_query = json!({
+        "from": [{"collectionId": CONVERSATIONS_SUBCOLLECTION}],
+        "orderBy": [{"field": {"fieldPath": sort_field}, "direction": "DESCENDING"}],
+        "limit": limit,
+        "offset": offset
+    });
+
+    if let Some(where_filter) = where_clause {
+        structured_query["where"] = where_filter;
+    }
+
+    json!({ "structuredQuery": structured_query })
+}
+
+pub(super) fn update_mask_query(field_paths: impl IntoIterator<Item = String>) -> String {
+    field_paths
+        .into_iter()
+        .map(|field| format!("updateMask.fieldPaths={}", urlencoding::encode(&field)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+pub(super) fn conversation_update_mask_query(doc: &Value) -> String {
+    let mut field_paths = doc
+        .get("fields")
+        .and_then(Value::as_object)
+        .map(|fields| {
+            fields
+                .keys()
+                .filter(|field| field.as_str() != "structured")
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    field_paths.extend(conversation_structured_leaf_paths(doc));
+    update_mask_query(field_paths)
+}
+
+pub(super) fn conversation_structured_leaf_paths(doc: &Value) -> Vec<String> {
+    doc.get("fields")
+        .and_then(|fields| fields.get("structured"))
+        .and_then(|structured| structured.get("mapValue"))
+        .and_then(|map| map.get("fields"))
+        .and_then(Value::as_object)
+        .map(|fields| {
+            fields
+                .keys()
+                .map(|field| format!("structured.{}", field))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+pub(super) fn conversation_patch_url(
+    base_url: &str,
+    uid: &str,
+    conversation_id: &str,
+    doc: &Value,
+) -> String {
+    format!(
+        "{}/{}/{}/{}/{}?{}",
+        base_url,
+        USERS_COLLECTION,
+        uid,
+        CONVERSATIONS_SUBCOLLECTION,
+        conversation_id,
+        conversation_update_mask_query(doc)
+    )
+}
+
 impl FirestoreService {
     pub async fn get_conversations(
         &self,
@@ -8,114 +191,25 @@ impl FirestoreService {
         offset: usize,
         include_discarded: bool,
         statuses: &[String],
+        categories: Option<&[String]>,
         starred: Option<bool>,
         folder_id: Option<&str>,
         start_date: Option<&str>,
         end_date: Option<&str>,
+        date_field: &str,
     ) -> Result<Vec<Conversation>, Box<dyn std::error::Error + Send + Sync>> {
-        // Build filters array (match Python behavior)
-        let mut filters: Vec<Value> = Vec::new();
-
-        // Python: if not include_discarded: where(discarded == False)
-        // Only filter when include_discarded is false
-        if !include_discarded {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "discarded"},
-                    "op": "EQUAL",
-                    "value": {"booleanValue": false}
-                }
-            }));
-        }
-
-        // Python: if len(statuses) > 0: where(status in statuses)
-        if !statuses.is_empty() {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "status"},
-                    "op": "IN",
-                    "value": {
-                        "arrayValue": {
-                            "values": statuses.iter().map(|s| json!({"stringValue": s})).collect::<Vec<_>>()
-                        }
-                    }
-                }
-            }));
-        }
-
-        // Filter by starred status
-        if let Some(starred_val) = starred {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "starred"},
-                    "op": "EQUAL",
-                    "value": {"booleanValue": starred_val}
-                }
-            }));
-        }
-
-        // Filter by folder_id
-        if let Some(fid) = folder_id {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "folder_id"},
-                    "op": "EQUAL",
-                    "value": {"stringValue": fid}
-                }
-            }));
-        }
-
-        // Filter by date range
-        if let Some(start) = start_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "created_at"},
-                    "op": "GREATER_THAN_OR_EQUAL",
-                    "value": {"timestampValue": start}
-                }
-            }));
-        }
-
-        if let Some(end) = end_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "created_at"},
-                    "op": "LESS_THAN",
-                    "value": {"timestampValue": end}
-                }
-            }));
-        }
-
-        // Build the where clause based on number of filters
-        let where_clause = if filters.is_empty() {
-            None
-        } else if filters.len() == 1 {
-            filters.into_iter().next()
-        } else {
-            // Multiple filters need compositeFilter with AND
-            Some(json!({
-                "compositeFilter": {
-                    "op": "AND",
-                    "filters": filters
-                }
-            }))
-        };
-
-        // Build structured query
-        let mut structured_query = json!({
-            "from": [{"collectionId": CONVERSATIONS_SUBCOLLECTION}],
-            "orderBy": [{"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}],
-            "limit": limit,
-            "offset": offset
-        });
-
-        if let Some(where_filter) = where_clause {
-            structured_query["where"] = where_filter;
-        }
-
-        let query = json!({
-            "structuredQuery": structured_query
-        });
+        let query = build_conversations_query(
+            limit,
+            offset,
+            include_discarded,
+            statuses,
+            categories,
+            starred,
+            folder_id,
+            start_date,
+            end_date,
+            date_field,
+        );
 
         let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
 
@@ -302,16 +396,8 @@ impl FirestoreService {
         uid: &str,
         conversation: &Conversation,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!(
-            "{}/{}/{}/{}/{}",
-            self.base_url(),
-            USERS_COLLECTION,
-            uid,
-            CONVERSATIONS_SUBCOLLECTION,
-            conversation.id
-        );
-
         let doc = self.conversation_to_firestore(conversation, uid);
+        let url = conversation_patch_url(&self.base_url(), uid, &conversation.id, &doc);
 
         let response = self
             .build_request(reqwest::Method::PATCH, &url)
@@ -566,5 +652,228 @@ impl FirestoreService {
             uid
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixture() -> Value {
+        let path = format!(
+            "{}/../../../contract_tests/fixtures/conversations.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn field_filter<'a>(filters: &'a [Value], field: &str) -> &'a Value {
+        filters
+            .iter()
+            .find(|filter| filter["fieldFilter"]["field"]["fieldPath"].as_str() == Some(field))
+            .unwrap()
+    }
+
+    #[test]
+    fn contract_conversation_query_matches_python_semantics() {
+        let data = fixture();
+        let query_fixture = &data["query"];
+        let categories = vec!["work".to_string(), "technology".to_string()];
+        let query = build_conversations_query(
+            query_fixture["limit"].as_u64().unwrap() as usize,
+            query_fixture["offset"].as_u64().unwrap() as usize,
+            false,
+            &["completed".to_string(), "in_progress".to_string()],
+            Some(&categories),
+            Some(true),
+            Some("folder-1"),
+            query_fixture["start_date"].as_str(),
+            query_fixture["end_date"].as_str(),
+            query_fixture["date_field"].as_str().unwrap(),
+        );
+        let structured = &query["structuredQuery"];
+        let filters = structured["where"]["compositeFilter"]["filters"]
+            .as_array()
+            .unwrap();
+
+        assert_eq!(
+            field_filter(filters, "discarded")["fieldFilter"]["op"],
+            "EQUAL"
+        );
+        assert_eq!(
+            field_filter(filters, "structured.category")["fieldFilter"]["op"],
+            "IN"
+        );
+        assert_eq!(field_filter(filters, "status")["fieldFilter"]["op"], "IN");
+        assert_eq!(
+            field_filter(filters, "starred")["fieldFilter"]["op"],
+            "EQUAL"
+        );
+        assert_eq!(
+            field_filter(filters, "folder_id")["fieldFilter"]["op"],
+            "EQUAL"
+        );
+        assert_eq!(
+            field_filter(filters, "finished_at")["fieldFilter"]["op"],
+            "GREATER_THAN_OR_EQUAL"
+        );
+        assert!(filters.iter().any(|filter| {
+            filter["fieldFilter"]["field"]["fieldPath"].as_str() == Some("finished_at")
+                && filter["fieldFilter"]["op"] == "LESS_THAN_OR_EQUAL"
+        }));
+        assert_eq!(
+            structured["orderBy"][0]["field"]["fieldPath"],
+            query_fixture["date_field"]
+        );
+        assert_eq!(structured["limit"], query_fixture["limit"]);
+        assert_eq!(structured["offset"], query_fixture["offset"]);
+
+        let default_query =
+            build_conversations_query(2, 1, false, &[], None, None, None, None, None, "created_at");
+        assert_eq!(
+            default_query["structuredQuery"]["orderBy"][0]["field"]["fieldPath"],
+            "created_at"
+        );
+
+        let custom_date_without_range = build_conversations_query(
+            2,
+            1,
+            false,
+            &[],
+            None,
+            None,
+            None,
+            None,
+            None,
+            "finished_at",
+        );
+        assert_eq!(
+            custom_date_without_range["structuredQuery"]["orderBy"][0]["field"]["fieldPath"],
+            "created_at"
+        );
+    }
+
+    #[test]
+    fn contract_conversation_save_path_uses_update_mask_to_preserve_python_fields() {
+        let service = FirestoreService::new_for_contract(None);
+        let now = Utc.timestamp_opt(1_767_323_045, 0).unwrap();
+        let conversation = Conversation {
+            id: "conversation-1".to_string(),
+            created_at: now,
+            started_at: now,
+            finished_at: now,
+            source: crate::models::conversation::ConversationSource::Desktop,
+            language: "en".to_string(),
+            status: crate::models::conversation::ConversationStatus::Completed,
+            discarded: false,
+            deleted: false,
+            starred: false,
+            is_locked: false,
+            folder_id: None,
+            structured: Structured {
+                title: "Rust title".to_string(),
+                overview: "Rust overview".to_string(),
+                emoji: "R".to_string(),
+                category: Category::Technology,
+                action_items: vec![],
+                events: vec![],
+            },
+            transcript_segments: vec![],
+            apps_results: vec![],
+            geolocation: None,
+            photos: vec![],
+            input_device_name: None,
+        };
+        let doc = service.conversation_to_firestore(&conversation, "contract-user-8547");
+
+        let url = conversation_patch_url(
+            "https://firestore.googleapis.com/v1/projects/contract/databases/(default)/documents",
+            "contract-user-8547",
+            "conversation-1",
+            &doc,
+        );
+
+        assert!(url.contains("updateMask.fieldPaths=id"));
+        assert!(url.contains("updateMask.fieldPaths=created_at"));
+        assert!(!url.contains("updateMask.fieldPaths=structured&"));
+        assert!(url.contains("updateMask.fieldPaths=structured.title"));
+        assert!(url.contains("updateMask.fieldPaths=structured.overview"));
+        assert!(url.contains("updateMask.fieldPaths=structured.emoji"));
+        assert!(url.contains("updateMask.fieldPaths=structured.category"));
+        assert!(url.contains("updateMask.fieldPaths=transcript_segments"));
+        assert!(!url.contains("plugins_results"));
+        assert!(!url.contains("python_owned_field"));
+
+        let existing = json!({
+            "fields": {
+                "python_owned_field": {"stringValue": "keep"},
+                "structured": {
+                    "mapValue": {
+                        "fields": {
+                            "title": {"stringValue": "old"},
+                            "python_nested_field": {"stringValue": "keep nested"}
+                        }
+                    }
+                }
+            }
+        });
+        let patched =
+            apply_update_mask_for_contract(existing, &doc, &conversation_update_mask_query(&doc));
+        assert_eq!(
+            patched["fields"]["python_owned_field"]["stringValue"],
+            "keep"
+        );
+        assert_eq!(
+            patched["fields"]["structured"]["mapValue"]["fields"]["python_nested_field"]
+                ["stringValue"],
+            "keep nested"
+        );
+        assert_eq!(
+            patched["fields"]["structured"]["mapValue"]["fields"]["title"]["stringValue"],
+            "Rust title"
+        );
+    }
+
+    fn apply_update_mask_for_contract(
+        mut existing: Value,
+        patch: &Value,
+        mask_query: &str,
+    ) -> Value {
+        for field in mask_query
+            .split('&')
+            .filter_map(|part| part.strip_prefix("updateMask.fieldPaths="))
+            .map(|part| urlencoding::decode(part).unwrap().into_owned())
+        {
+            let patch_value = value_at_field_path(&patch["fields"], &field).cloned();
+            if let Some(value) = patch_value {
+                set_value_at_field_path(&mut existing["fields"], &field, value);
+            }
+        }
+        existing
+    }
+
+    fn value_at_field_path<'a>(fields: &'a Value, field_path: &str) -> Option<&'a Value> {
+        let mut current = fields;
+        for (index, segment) in field_path.split('.').enumerate() {
+            if index == 0 {
+                current = current.get(segment)?;
+            } else {
+                current = current.get("mapValue")?.get("fields")?.get(segment)?;
+            }
+        }
+        Some(current)
+    }
+
+    fn set_value_at_field_path(fields: &mut Value, field_path: &str, value: Value) {
+        let mut current = fields;
+        let parts = field_path.split('.').collect::<Vec<_>>();
+        for (index, segment) in parts.iter().enumerate() {
+            if index == parts.len() - 1 {
+                current[*segment] = value;
+                return;
+            }
+            current = &mut current[*segment]["mapValue"]["fields"];
+        }
     }
 }

--- a/desktop/macos/Backend-Rust/src/services/firestore/folders_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/folders_repository.rs
@@ -188,7 +188,19 @@ impl FirestoreService {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         loop {
             let conversations = self
-                .get_conversations(uid, 500, 0, true, &[], None, Some(folder_id), None, None)
+                .get_conversations(
+                    uid,
+                    500,
+                    0,
+                    true,
+                    &[],
+                    None,
+                    None,
+                    Some(folder_id),
+                    None,
+                    None,
+                    "created_at",
+                )
                 .await?;
             if conversations.is_empty() {
                 break;

--- a/desktop/macos/Backend-Rust/src/services/firestore/memories_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/memories_repository.rs
@@ -1,4 +1,436 @@
+use super::values::{conversation_source_wire, memory_category_wire, memory_is_active};
 use super::*;
+
+pub(super) fn build_memories_query(
+    limit: usize,
+    offset: usize,
+    categories: Option<&[String]>,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+    tags: Option<&[String]>,
+) -> Value {
+    let mut filters: Vec<Value> = Vec::new();
+
+    if let Some(category_values) = categories {
+        if !category_values.is_empty() {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "category"},
+                    "op": "IN",
+                    "value": {
+                        "arrayValue": {
+                            "values": category_values.iter().map(|s| json!({"stringValue": s})).collect::<Vec<_>>()
+                        }
+                    }
+                }
+            }));
+        }
+    }
+
+    if let Some(start) = start_date {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "created_at"},
+                "op": "GREATER_THAN_OR_EQUAL",
+                "value": {"timestampValue": start}
+            }
+        }));
+    }
+
+    if let Some(end) = end_date {
+        filters.push(json!({
+            "fieldFilter": {
+                "field": {"fieldPath": "created_at"},
+                "op": "LESS_THAN_OR_EQUAL",
+                "value": {"timestampValue": end}
+            }
+        }));
+    }
+
+    if let Some(filter_tags) = tags {
+        if let Some(first_tag) = filter_tags.first() {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "tags"},
+                    "op": "ARRAY_CONTAINS",
+                    "value": {"stringValue": first_tag}
+                }
+            }));
+        }
+    }
+
+    let where_clause = if filters.is_empty() {
+        None
+    } else if filters.len() == 1 {
+        filters.into_iter().next()
+    } else {
+        Some(json!({
+            "compositeFilter": {
+                "op": "AND",
+                "filters": filters
+            }
+        }))
+    };
+
+    let mut structured_query = json!({
+        "from": [{"collectionId": MEMORIES_SUBCOLLECTION}],
+        "orderBy": [
+            {"field": {"fieldPath": "scoring"}, "direction": "DESCENDING"},
+            {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
+        ],
+        "limit": limit,
+        "offset": offset
+    });
+
+    if let Some(where_filter) = where_clause {
+        structured_query["where"] = where_filter;
+    }
+
+    json!({ "structuredQuery": structured_query })
+}
+
+pub(super) fn memory_passes_default_filters(
+    memory: &MemoryDB,
+    include_dismissed: bool,
+    include_invalidated: bool,
+    tags: Option<&[String]>,
+) -> bool {
+    if !memory_is_active(memory, include_invalidated) {
+        return false;
+    }
+    if !include_dismissed && memory.is_dismissed {
+        return false;
+    }
+    match tags {
+        Some(filter_tags) if filter_tags.len() > 1 => {
+            filter_tags[1..].iter().all(|tag| memory.tags.contains(tag))
+        }
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixture() -> Value {
+        let path = format!(
+            "{}/../../../contract_tests/fixtures/memories.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn memory(
+        id: &str,
+        user_review: Option<bool>,
+        invalidated: bool,
+        tags: Vec<String>,
+    ) -> MemoryDB {
+        let created_at = Utc.timestamp_opt(1_767_323_045, 0).unwrap();
+        MemoryDB {
+            id: id.to_string(),
+            uid: "contract-user-8547".to_string(),
+            content: id.to_string(),
+            category: MemoryCategory::System,
+            created_at,
+            updated_at: created_at,
+            memory_id: None,
+            conversation_id: None,
+            reviewed: false,
+            user_review,
+            visibility: "public".to_string(),
+            manually_added: false,
+            scoring: None,
+            source: None,
+            input_device_name: None,
+            confidence: None,
+            source_app: None,
+            context_summary: None,
+            is_read: false,
+            is_dismissed: false,
+            tags,
+            reasoning: None,
+            current_activity: None,
+            window_title: None,
+            data_protection_level: None,
+            valid_at: Some(created_at),
+            invalid_at: invalidated.then_some(created_at),
+            superseded_by: None,
+            edited: false,
+            is_locked: false,
+            kg_extracted: false,
+            app_id: None,
+        }
+    }
+
+    fn field_filter<'a>(filters: &'a [Value], field: &str) -> &'a Value {
+        filters
+            .iter()
+            .find(|filter| filter["fieldFilter"]["field"]["fieldPath"].as_str() == Some(field))
+            .unwrap()
+    }
+
+    fn memory_doc(id: &str, user_review: Option<bool>, invalidated: bool) -> Value {
+        let created_at = "2026-01-02T03:04:05+00:00";
+        let mut fields = json!({
+            "content": {"stringValue": id},
+            "category": {"stringValue": "system"},
+            "created_at": {"timestampValue": created_at},
+            "updated_at": {"timestampValue": created_at}
+        });
+        if let Some(review) = user_review {
+            fields["user_review"] = json!({"booleanValue": review});
+        } else {
+            fields["user_review"] = json!({"nullValue": null});
+        }
+        if invalidated {
+            fields["invalid_at"] = json!({"timestampValue": "2026-01-03T00:00:00+00:00"});
+        }
+        json!({
+            "document": {
+                "name": format!("projects/contract/databases/(default)/documents/users/contract-user-8547/memories/{}", id),
+                "fields": fields
+            }
+        })
+    }
+
+    #[test]
+    fn contract_memories_query_and_filter_semantics_match_python() {
+        let data = fixture();
+        let query_fixture = &data["query"];
+        let tags = vec!["first".to_string(), "second".to_string()];
+        let categories = query_fixture["categories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        let query = build_memories_query(
+            query_fixture["limit"].as_u64().unwrap() as usize,
+            query_fixture["offset"].as_u64().unwrap() as usize,
+            Some(&categories),
+            query_fixture["start_date"].as_str(),
+            query_fixture["end_date"].as_str(),
+            Some(&tags),
+        );
+        let structured = &query["structuredQuery"];
+        let filters = structured["where"]["compositeFilter"]["filters"]
+            .as_array()
+            .unwrap();
+
+        assert_eq!(field_filter(filters, "category")["fieldFilter"]["op"], "IN");
+        assert_eq!(
+            field_filter(filters, "created_at")["fieldFilter"]["op"],
+            "GREATER_THAN_OR_EQUAL"
+        );
+        assert!(filters.iter().any(|filter| {
+            filter["fieldFilter"]["field"]["fieldPath"].as_str() == Some("created_at")
+                && filter["fieldFilter"]["op"] == "LESS_THAN_OR_EQUAL"
+        }));
+        assert_eq!(
+            field_filter(filters, "category")["fieldFilter"]["value"]["arrayValue"]["values"][1]
+                ["stringValue"],
+            "workflow"
+        );
+        assert_eq!(
+            field_filter(filters, "tags")["fieldFilter"]["op"],
+            "ARRAY_CONTAINS"
+        );
+        assert_eq!(structured["orderBy"][0]["field"]["fieldPath"], "scoring");
+        assert_eq!(structured["orderBy"][1]["field"]["fieldPath"], "created_at");
+        assert_eq!(structured["limit"], query_fixture["limit"]);
+        assert_eq!(structured["offset"], query_fixture["offset"]);
+
+        let paged_query = build_memories_query(2, 1, None, None, None, None);
+        assert_eq!(paged_query["structuredQuery"]["limit"], 2);
+        assert_eq!(paged_query["structuredQuery"]["offset"], 1);
+
+        assert!(memory_passes_default_filters(
+            &memory(
+                "active",
+                None,
+                false,
+                vec!["first".to_string(), "second".to_string()]
+            ),
+            false,
+            false,
+            Some(&tags)
+        ));
+        assert!(memory_passes_default_filters(
+            &memory("invalidated", None, true, tags.clone()),
+            false,
+            true,
+            Some(&tags)
+        ));
+        assert!(!memory_passes_default_filters(
+            &memory("rejected", Some(false), false, tags.clone()),
+            false,
+            false,
+            Some(&tags)
+        ));
+        assert!(!memory_passes_default_filters(
+            &memory("invalidated", None, true, tags.clone()),
+            false,
+            false,
+            Some(&tags)
+        ));
+        assert!(!memory_passes_default_filters(
+            &memory("missing-tag", None, false, vec!["first".to_string()]),
+            false,
+            false,
+            Some(&tags)
+        ));
+
+        let service = FirestoreService::new_for_contract(None);
+        let page_results = vec![
+            memory_doc("rejected-in-page", Some(false), false),
+            memory_doc("active-in-page", None, false),
+        ];
+        let filtered = service.parse_memory_query_results(
+            "contract-user-8547",
+            page_results,
+            false,
+            false,
+            None,
+        );
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|memory| memory.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["active-in-page"]
+        );
+    }
+
+    #[test]
+    fn contract_create_memory_path_writes_manual_true_and_extracted_null_user_review() {
+        let now = Utc.timestamp_opt(1_767_323_045, 0).unwrap();
+        let fields = build_create_memory_fields(
+            "memory-1",
+            "contract-user-8547",
+            "content",
+            "public",
+            &MemoryCategory::Workflow,
+            false,
+            "00_998_1767323045",
+            now,
+            &["contract".to_string()],
+        );
+
+        assert_eq!(fields["category"]["stringValue"], "workflow");
+        assert_eq!(fields["valid_at"]["timestampValue"], now.to_rfc3339());
+        assert_eq!(fields["edited"]["booleanValue"], false);
+        assert_eq!(fields["is_locked"]["booleanValue"], false);
+        assert_eq!(fields["kg_extracted"]["booleanValue"], false);
+        assert_eq!(fields["reviewed"]["booleanValue"], false);
+        assert_eq!(fields["user_review"]["nullValue"], Value::Null);
+
+        let fields = build_create_memory_fields(
+            "memory-manual",
+            "contract-user-8547",
+            "content",
+            "public",
+            &MemoryCategory::Manual,
+            true,
+            "01_998_1767323045",
+            now,
+            &[],
+        );
+
+        assert_eq!(fields["reviewed"]["booleanValue"], true);
+        assert_eq!(fields["user_review"]["booleanValue"], true);
+
+        let memory = Memory {
+            content: "saved".to_string(),
+            category: MemoryCategory::Workflow,
+            tags: vec![],
+        };
+        let fields = build_save_memory_fields(
+            "memory-2",
+            "contract-user-8547",
+            "conversation-1",
+            &memory,
+            "00_998_1767323045",
+            now,
+        );
+
+        assert_eq!(fields["category"]["stringValue"], "workflow");
+        assert_eq!(fields["valid_at"]["timestampValue"], now.to_rfc3339());
+        assert_eq!(fields["user_review"]["nullValue"], Value::Null);
+        assert_eq!(fields["memory_id"]["stringValue"], "conversation-1");
+    }
+}
+
+pub(super) fn build_create_memory_fields(
+    memory_id: &str,
+    uid: &str,
+    content: &str,
+    visibility: &str,
+    category: &MemoryCategory,
+    manually_added: bool,
+    scoring: &str,
+    now: DateTime<Utc>,
+    tags: &[String],
+) -> Value {
+    let tags_values: Vec<Value> = tags.iter().map(|t| json!({"stringValue": t})).collect();
+    let mut fields = json!({
+        "id": {"stringValue": memory_id},
+        "uid": {"stringValue": uid},
+        "content": {"stringValue": content},
+        "category": {"stringValue": memory_category_wire(category)},
+        "created_at": {"timestampValue": now.to_rfc3339()},
+        "updated_at": {"timestampValue": now.to_rfc3339()},
+        "valid_at": {"timestampValue": now.to_rfc3339()},
+        "reviewed": {"booleanValue": manually_added},
+        "visibility": {"stringValue": visibility},
+        "manually_added": {"booleanValue": manually_added},
+        "scoring": {"stringValue": scoring},
+        "is_read": {"booleanValue": false},
+        "is_dismissed": {"booleanValue": false},
+        "edited": {"booleanValue": false},
+        "is_locked": {"booleanValue": false},
+        "kg_extracted": {"booleanValue": false},
+        "tags": {"arrayValue": {"values": tags_values}}
+    });
+    if manually_added {
+        fields["user_review"] = json!({"booleanValue": true});
+    } else {
+        fields["user_review"] = json!({"nullValue": null});
+    }
+    fields
+}
+
+pub(super) fn build_save_memory_fields(
+    memory_id: &str,
+    uid: &str,
+    conversation_id: &str,
+    memory: &Memory,
+    scoring: &str,
+    now: DateTime<Utc>,
+) -> Value {
+    json!({
+        "id": {"stringValue": memory_id},
+        "uid": {"stringValue": uid},
+        "content": {"stringValue": memory.content},
+        "category": {"stringValue": memory_category_wire(&memory.category)},
+        "created_at": {"timestampValue": now.to_rfc3339()},
+        "updated_at": {"timestampValue": now.to_rfc3339()},
+        "valid_at": {"timestampValue": now.to_rfc3339()},
+        "conversation_id": {"stringValue": conversation_id},
+        "memory_id": {"stringValue": conversation_id},
+        "reviewed": {"booleanValue": false},
+        "user_review": {"nullValue": null},
+        "visibility": {"stringValue": "private"},
+        "manually_added": {"booleanValue": false},
+        "edited": {"booleanValue": false},
+        "is_locked": {"booleanValue": false},
+        "kg_extracted": {"booleanValue": false},
+        "scoring": {"stringValue": scoring},
+        "tags": {"arrayValue": {"values": []}}
+    })
+}
 
 impl FirestoreService {
     pub async fn get_memories_filtered(
@@ -6,141 +438,64 @@ impl FirestoreService {
         uid: &str,
         limit: usize,
         offset: usize,
-        category: Option<&str>,
+        categories: Option<&[String]>,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
         tags: Option<&[String]>,
         include_dismissed: bool,
+        include_invalidated: bool,
     ) -> Result<Vec<MemoryDB>, Box<dyn std::error::Error + Send + Sync>> {
         let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
 
-        // Build filters
-        let mut filters: Vec<Value> = Vec::new();
+        let query = build_memories_query(limit, offset, categories, start_date, end_date, tags);
 
-        // Filter by category if specified
-        if let Some(cat) = category {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "category"},
-                    "op": "EQUAL",
-                    "value": {"stringValue": cat}
-                }
-            }));
+        let response = self
+            .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
+            .await?
+            .json(&query)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            tracing::error!("Firestore query error for memories: {}", error_text);
+            return Err(format!("Firestore query error: {}", error_text).into());
         }
 
-        // Filter by first tag in Firestore (ARRAY_CONTAINS supports one tag per query).
-        // Additional tags (if any) are still filtered in-memory below.
-        if let Some(filter_tags) = tags {
-            if let Some(first_tag) = filter_tags.first() {
-                filters.push(json!({
-                    "fieldFilter": {
-                        "field": {"fieldPath": "tags"},
-                        "op": "ARRAY_CONTAINS",
-                        "value": {"stringValue": first_tag}
-                    }
-                }));
-            }
-        }
-
-        // NOTE: We do NOT filter is_dismissed in Firestore query because existing memories
-        // don't have this field. Firestore only returns documents where the field EXISTS and
-        // matches the value. Instead, we filter in-memory below (matching Python behavior).
-
-        // Build the where clause
-        let where_clause = if filters.is_empty() {
-            None
-        } else if filters.len() == 1 {
-            filters.into_iter().next()
-        } else {
-            Some(json!({
-                "compositeFilter": {
-                    "op": "AND",
-                    "filters": filters
-                }
-            }))
-        };
-
-        // Fetch from Firestore in a loop to handle post-query filtering (rejected, dismissed, tags).
-        // These can't be reliably filtered in Firestore (fields may not exist on all docs),
-        // so we filter in Rust. Keep fetching until we have enough or Firestore is exhausted.
-        let order_by = json!([
-            {"field": {"fieldPath": "scoring"}, "direction": "DESCENDING"},
-            {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
-        ]);
-        let mut memories: Vec<MemoryDB> = Vec::new();
-        let mut current_offset = offset;
-        let fetch_batch = limit.max(500);
-
-        loop {
-            let mut structured_query = json!({
-                "from": [{"collectionId": MEMORIES_SUBCOLLECTION}],
-                "orderBy": order_by.clone(),
-                "limit": fetch_batch,
-                "offset": current_offset
-            });
-
-            if let Some(ref where_filter) = where_clause {
-                structured_query["where"] = where_filter.clone();
-            }
-
-            let query = json!({
-                "structuredQuery": structured_query
-            });
-
-            let response = self
-                .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
-                .await?
-                .json(&query)
-                .send()
-                .await?;
-
-            if !response.status().is_success() {
-                let error_text = response.text().await?;
-                tracing::error!("Firestore query error for memories: {}", error_text);
-                return Err(format!("Firestore query error: {}", error_text).into());
-            }
-
-            let results: Vec<Value> = response.json().await?;
-            let fetched_count = results
-                .iter()
-                .filter(|doc| doc.get("document").is_some())
-                .count();
-
-            let batch: Vec<MemoryDB> = results
-                .into_iter()
-                .filter_map(|doc| {
-                    doc.get("document")
-                        .and_then(|d| self.parse_memory(d, uid).ok())
-                })
-                // Filter out rejected memories (matches Python behavior)
-                .filter(|m| m.user_review != Some(false))
-                // Filter out dismissed memories in-memory (not in Firestore query, since existing
-                // memories don't have is_dismissed field - Firestore requires field to exist for filters)
-                .filter(|m| include_dismissed || !m.is_dismissed)
-                // Filter by remaining tags in-memory (first tag is already filtered by Firestore ARRAY_CONTAINS)
-                .filter(|m| match tags {
-                    Some(filter_tags) if filter_tags.len() > 1 => {
-                        filter_tags[1..].iter().all(|tag| m.tags.contains(tag))
-                    }
-                    _ => true,
-                })
-                .collect();
-
-            memories.extend(batch);
-            if memories.len() >= limit {
-                memories.truncate(limit);
-                break;
-            }
-            current_offset += fetched_count;
-
-            // Stop if Firestore returned fewer than requested (no more data)
-            if fetched_count < fetch_batch {
-                break;
-            }
-        }
+        let results: Vec<Value> = response.json().await?;
+        let mut memories = self.parse_memory_query_results(
+            uid,
+            results,
+            include_dismissed,
+            include_invalidated,
+            tags,
+        );
 
         // Enrich memories with source from linked conversations
         self.enrich_memories_with_source(uid, &mut memories).await;
 
         Ok(memories)
+    }
+
+    pub(super) fn parse_memory_query_results(
+        &self,
+        uid: &str,
+        results: Vec<Value>,
+        include_dismissed: bool,
+        include_invalidated: bool,
+        tags: Option<&[String]>,
+    ) -> Vec<MemoryDB> {
+        results
+            .into_iter()
+            .filter_map(|doc| {
+                doc.get("document")
+                    .and_then(|d| self.parse_memory(d, uid).ok())
+            })
+            // Match Python: Firestore limit/offset already applied, then rejected/invalidated docs are filtered.
+            .filter(|m| {
+                memory_passes_default_filters(m, include_dismissed, include_invalidated, tags)
+            })
+            .collect()
     }
 
     /// Get memories for a user (simple version for backward compatibility)
@@ -151,7 +506,7 @@ impl FirestoreService {
         uid: &str,
         limit: usize,
     ) -> Result<Vec<MemoryDB>, Box<dyn std::error::Error + Send + Sync>> {
-        self.get_memories_filtered(uid, limit, 0, None, None, false)
+        self.get_memories_filtered(uid, limit, 0, None, None, None, None, false, false)
             .await
     }
 
@@ -185,7 +540,7 @@ impl FirestoreService {
 
             for (id, result) in chunk.iter().zip(results) {
                 if let Ok(Some(conv)) = result {
-                    let source_str = format!("{:?}", conv.source).to_lowercase();
+                    let source_str = conversation_source_wire(&conv.source);
                     source_map.insert(id.to_string(), (source_str, conv.input_device_name.clone()));
                 }
             }
@@ -417,16 +772,7 @@ impl FirestoreService {
         let actual_category = category.unwrap_or(MemoryCategory::Manual);
         let scoring = MemoryDB::calculate_scoring(&actual_category, &now, is_manual);
 
-        let category_str = match actual_category {
-            MemoryCategory::System => "system",
-            MemoryCategory::Interesting => "interesting",
-            MemoryCategory::Manual => "manual",
-            // Legacy categories - preserve original value
-            MemoryCategory::Core => "core",
-            MemoryCategory::Hobbies => "hobbies",
-            MemoryCategory::Lifestyle => "lifestyle",
-            MemoryCategory::Interests => "interests",
-        };
+        let category_str = memory_category_wire(&actual_category);
 
         let url = format!(
             "{}/{}/{}/{}/{}",
@@ -437,33 +783,17 @@ impl FirestoreService {
             memory_id
         );
 
-        // Build tags array for Firestore
-        let tags_values: Vec<Value> = tags.iter().map(|t| json!({"stringValue": t})).collect();
-
-        // Build fields - always include base fields
-        // CRITICAL: Include all fields that Python expects (matching save_memories)
-        let mut fields = json!({
-            // CRITICAL: id field required - Python model requires this
-            "id": {"stringValue": &memory_id},
-            // CRITICAL: uid field required - Python model requires this
-            "uid": {"stringValue": uid},
-            "content": {"stringValue": content},
-            "category": {"stringValue": category_str},
-            "created_at": {"timestampValue": now.to_rfc3339()},
-            "updated_at": {"timestampValue": now.to_rfc3339()},
-            "reviewed": {"booleanValue": is_manual},
-            "user_review": {"booleanValue": is_manual},
-            "visibility": {"stringValue": visibility},
-            "manually_added": {"booleanValue": is_manual},
-            "scoring": {"stringValue": scoring},
-            "is_read": {"booleanValue": false},
-            "is_dismissed": {"booleanValue": false},
-            // Additional fields for Python compatibility
-            "edited": {"booleanValue": false},
-            "is_locked": {"booleanValue": false},
-            "kg_extracted": {"booleanValue": false},
-            "tags": {"arrayValue": {"values": tags_values}}
-        });
+        let mut fields = build_create_memory_fields(
+            &memory_id,
+            uid,
+            content,
+            visibility,
+            &actual_category,
+            is_manual,
+            &scoring,
+            now,
+            tags,
+        );
 
         // Add optional fields if present
         if let Some(conf) = confidence {
@@ -840,31 +1170,14 @@ impl FirestoreService {
             );
 
             let doc = json!({
-                "fields": {
-                    // CRITICAL: Include id field - Python model requires this
-                    "id": {"stringValue": memory_id},
-                    // Include uid - Python model requires this
-                    "uid": {"stringValue": uid},
-                    "content": {"stringValue": memory.content},
-                    "category": {"stringValue": format!("{:?}", memory.category).to_lowercase()},
-                    "created_at": {"timestampValue": now.to_rfc3339()},
-                    "updated_at": {"timestampValue": now.to_rfc3339()},
-                    "conversation_id": {"stringValue": conversation_id},
-                    // Legacy field - same as conversation_id, used by get_memory_ids_for_conversation
-                    "memory_id": {"stringValue": conversation_id},
-                    "reviewed": {"booleanValue": false},
-                    // CRITICAL: user_review must exist - Python filters on memory['user_review'] is not False
-                    // None/null means not yet reviewed by user (different from False which means rejected)
-                    "user_review": {"nullValue": null},
-                    "visibility": {"stringValue": "private"},
-                    "manually_added": {"booleanValue": false},
-                    "edited": {"booleanValue": false},
-                    "is_locked": {"booleanValue": false},
-                    "kg_extracted": {"booleanValue": false},
-                    "scoring": {"stringValue": scoring},
-                    // Empty tags array
-                    "tags": {"arrayValue": {"values": []}}
-                }
+                "fields": build_save_memory_fields(
+                    &memory_id,
+                    uid,
+                    conversation_id,
+                    memory,
+                    &scoring,
+                    now,
+                )
             });
 
             let response = self

--- a/desktop/macos/Backend-Rust/src/services/firestore/persona_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/persona_repository.rs
@@ -1,4 +1,23 @@
+use super::values::memory_is_public;
 use super::*;
+
+pub(super) fn build_public_memories_query(limit: usize, offset: usize) -> Value {
+    json!({
+        "structuredQuery": {
+            "from": [{"collectionId": MEMORIES_SUBCOLLECTION}],
+            "orderBy": [
+                {"field": {"fieldPath": "scoring"}, "direction": "DESCENDING"},
+                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
+            ],
+            "limit": limit,
+            "offset": offset
+        }
+    })
+}
+
+pub(super) fn memory_counts_as_public(memory: &MemoryDB) -> bool {
+    memory_is_public(memory)
+}
 
 impl FirestoreService {
     pub async fn get_user_persona(
@@ -272,23 +291,11 @@ impl FirestoreService {
         &self,
         uid: &str,
         limit: usize,
+        offset: usize,
     ) -> Result<Vec<MemoryDB>, Box<dyn std::error::Error + Send + Sync>> {
         let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
 
-        let query = json!({
-            "structuredQuery": {
-                "from": [{"collectionId": MEMORIES_SUBCOLLECTION}],
-                "where": {
-                    "fieldFilter": {
-                        "field": {"fieldPath": "visibility"},
-                        "op": "EQUAL",
-                        "value": {"stringValue": "public"}
-                    }
-                },
-                "orderBy": [{"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}],
-                "limit": limit
-            }
-        });
+        let query = build_public_memories_query(limit, offset);
 
         let response = self
             .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
@@ -304,13 +311,7 @@ impl FirestoreService {
         }
 
         let results: Vec<Value> = response.json().await?;
-        let memories: Vec<MemoryDB> = results
-            .into_iter()
-            .filter_map(|doc| {
-                doc.get("document")
-                    .and_then(|d| self.parse_memory(d, uid).ok())
-            })
-            .collect();
+        let memories = self.parse_public_memory_query_results(uid, results);
 
         tracing::info!("Found {} public memories for user {}", memories.len(), uid);
         Ok(memories)
@@ -327,20 +328,7 @@ impl FirestoreService {
         let limit = 500usize;
 
         loop {
-            let query = json!({
-                "structuredQuery": {
-                    "from": [{"collectionId": MEMORIES_SUBCOLLECTION}],
-                    "where": {
-                        "fieldFilter": {
-                            "field": {"fieldPath": "visibility"},
-                            "op": "EQUAL",
-                            "value": {"stringValue": "public"}
-                        }
-                    },
-                    "limit": limit,
-                    "offset": offset
-                }
-            });
+            let query = build_public_memories_query(limit, offset);
 
             let response = self
                 .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
@@ -359,7 +347,14 @@ impl FirestoreService {
                 .iter()
                 .filter(|doc| doc.get("document").is_some())
                 .count();
-            count += fetched_count as i32;
+            count += results
+                .iter()
+                .filter_map(|doc| {
+                    doc.get("document")
+                        .and_then(|d| self.parse_memory(d, uid).ok())
+                })
+                .filter(memory_counts_as_public)
+                .count() as i32;
             if fetched_count < limit {
                 break;
             }
@@ -367,6 +362,22 @@ impl FirestoreService {
         }
 
         Ok(count)
+    }
+
+    pub(super) fn parse_public_memory_query_results(
+        &self,
+        uid: &str,
+        results: Vec<Value>,
+    ) -> Vec<MemoryDB> {
+        results
+            .into_iter()
+            .filter_map(|doc| {
+                doc.get("document")
+                    .and_then(|d| self.parse_memory(d, uid).ok())
+            })
+            // Match Python get_user_public_memories: Firestore limit/offset first, then only visibility filter.
+            .filter(memory_counts_as_public)
+            .collect()
     }
 
     /// Parse a persona from Firestore document
@@ -413,5 +424,141 @@ impl FirestoreService {
                 .parse_timestamp_optional(fields, "updated_at")
                 .unwrap_or_else(Utc::now),
         })
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn memory(
+        id: &str,
+        visibility: &str,
+        invalidated: bool,
+        user_review: Option<bool>,
+    ) -> MemoryDB {
+        let created_at = Utc.timestamp_opt(1_767_323_045, 0).unwrap();
+        MemoryDB {
+            id: id.to_string(),
+            uid: "contract-user-8547".to_string(),
+            content: id.to_string(),
+            category: MemoryCategory::System,
+            created_at,
+            updated_at: created_at,
+            memory_id: None,
+            conversation_id: None,
+            reviewed: false,
+            user_review,
+            visibility: visibility.to_string(),
+            manually_added: false,
+            scoring: None,
+            source: None,
+            input_device_name: None,
+            confidence: None,
+            source_app: None,
+            context_summary: None,
+            is_read: false,
+            is_dismissed: false,
+            tags: vec![],
+            reasoning: None,
+            current_activity: None,
+            window_title: None,
+            data_protection_level: None,
+            valid_at: Some(created_at),
+            invalid_at: invalidated.then_some(created_at),
+            superseded_by: None,
+            edited: false,
+            is_locked: false,
+            kg_extracted: false,
+            app_id: None,
+        }
+    }
+
+    fn memory_doc(
+        id: &str,
+        visibility: Option<&str>,
+        invalidated: bool,
+        user_review: Option<bool>,
+    ) -> Value {
+        let created_at = "2026-01-02T03:04:05+00:00";
+        let mut fields = json!({
+            "content": {"stringValue": id},
+            "category": {"stringValue": "system"},
+            "created_at": {"timestampValue": created_at},
+            "updated_at": {"timestampValue": created_at}
+        });
+        if let Some(visibility) = visibility {
+            fields["visibility"] = json!({"stringValue": visibility});
+        }
+        if let Some(review) = user_review {
+            fields["user_review"] = json!({"booleanValue": review});
+        }
+        if invalidated {
+            fields["invalid_at"] = json!({"timestampValue": "2026-01-03T00:00:00+00:00"});
+        }
+        json!({
+            "document": {
+                "name": format!("projects/contract/databases/(default)/documents/users/contract-user-8547/memories/{}", id),
+                "fields": fields
+            }
+        })
+    }
+
+    #[test]
+    fn contract_public_memory_query_does_not_filter_missing_visibility_in_firestore() {
+        let query = build_public_memories_query(100, 20);
+        let structured = &query["structuredQuery"];
+
+        assert!(structured.get("where").is_none());
+        assert_eq!(structured["orderBy"][0]["field"]["fieldPath"], "scoring");
+        assert_eq!(structured["orderBy"][1]["field"]["fieldPath"], "created_at");
+        assert_eq!(structured["limit"], 100);
+        assert_eq!(structured["offset"], 20);
+    }
+
+    #[test]
+    fn contract_public_memory_filter_matches_python_visibility_only() {
+        assert!(memory_counts_as_public(&memory(
+            "public", "public", false, None
+        )));
+        assert!(!memory_counts_as_public(&memory(
+            "private", "private", false, None
+        )));
+        assert!(memory_counts_as_public(&memory(
+            "rejected",
+            "public",
+            false,
+            Some(false)
+        )));
+        assert!(memory_counts_as_public(&memory(
+            "invalidated",
+            "public",
+            true,
+            None
+        )));
+
+        let service = FirestoreService::new_for_contract(None);
+        let query = build_public_memories_query(3, 2);
+        assert_eq!(query["structuredQuery"]["limit"], 3);
+        assert_eq!(query["structuredQuery"]["offset"], 2);
+
+        let parsed = service.parse_public_memory_query_results(
+            "contract-user-8547",
+            vec![
+                memory_doc("missing-visibility", None, false, None),
+                memory_doc("private", Some("private"), false, None),
+                memory_doc("rejected", Some("public"), false, Some(false)),
+                memory_doc("invalidated", Some("public"), true, None),
+            ],
+        );
+
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|memory| memory.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["missing-visibility", "rejected", "invalidated"]
+        );
     }
 }

--- a/desktop/macos/Backend-Rust/src/services/firestore/values.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/values.rs
@@ -1,4 +1,37 @@
 use super::*;
+use crate::models::conversation::{ConversationSource, ConversationStatus};
+use serde::Serialize;
+
+pub(super) fn serde_wire_value<T: Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_default()
+}
+
+pub(super) fn conversation_source_wire(source: &ConversationSource) -> String {
+    serde_wire_value(source)
+}
+
+pub(super) fn conversation_status_wire(status: &ConversationStatus) -> String {
+    serde_wire_value(status)
+}
+
+pub(super) fn category_wire(category: &Category) -> String {
+    serde_wire_value(category)
+}
+
+pub(super) fn memory_category_wire(category: &MemoryCategory) -> String {
+    serde_wire_value(category)
+}
+
+pub(super) fn memory_is_active(memory: &MemoryDB, include_invalidated: bool) -> bool {
+    memory.user_review != Some(false) && (include_invalidated || memory.invalid_at.is_none())
+}
+
+pub(super) fn memory_is_public(memory: &MemoryDB) -> bool {
+    memory.visibility == "public"
+}
 
 impl FirestoreService {
     pub(super) fn parse_string_array(&self, fields: &Value, key: &str) -> Vec<String> {
@@ -179,12 +212,13 @@ impl FirestoreService {
                 .unwrap_or_default(),
             created_at: self.parse_timestamp(fields, "created_at")?,
             updated_at: self.parse_timestamp(fields, "updated_at")?,
+            memory_id: self.parse_string(fields, "memory_id"),
             conversation_id: self.parse_string(fields, "conversation_id"),
             reviewed: self.parse_bool(fields, "reviewed").unwrap_or(false),
             user_review: self.parse_bool(fields, "user_review").ok(),
             visibility: self
                 .parse_string(fields, "visibility")
-                .unwrap_or_else(|| "private".to_string()),
+                .unwrap_or_else(|| "public".to_string()),
             manually_added: self.parse_bool(fields, "manually_added").unwrap_or(false),
             scoring: self.parse_string(fields, "scoring"),
             source: self.parse_string(fields, "source"), // Can be stored directly for tips, or enriched from conversation
@@ -198,6 +232,14 @@ impl FirestoreService {
             reasoning: self.parse_string(fields, "reasoning"),
             current_activity: self.parse_string(fields, "current_activity"),
             window_title: self.parse_string(fields, "window_title"),
+            data_protection_level,
+            valid_at: self.parse_timestamp_optional(fields, "valid_at"),
+            invalid_at: self.parse_timestamp_optional(fields, "invalid_at"),
+            superseded_by: self.parse_string(fields, "superseded_by"),
+            edited: self.parse_bool(fields, "edited").unwrap_or(false),
+            is_locked: self.parse_bool(fields, "is_locked").unwrap_or(false),
+            kg_extracted: self.parse_bool(fields, "kg_extracted").unwrap_or(false),
+            app_id: self.parse_string(fields, "app_id"),
         })
     }
 
@@ -737,7 +779,7 @@ impl FirestoreService {
         );
         fields.insert(
             "source".to_string(),
-            json!({"stringValue": format!("{:?}", conv.source).to_lowercase()}),
+            json!({"stringValue": conversation_source_wire(&conv.source)}),
         );
         fields.insert(
             "language".to_string(),
@@ -745,7 +787,7 @@ impl FirestoreService {
         );
         fields.insert(
             "status".to_string(),
-            json!({"stringValue": format!("{:?}", conv.status).to_lowercase()}),
+            json!({"stringValue": conversation_status_wire(&conv.status)}),
         );
         fields.insert(
             "discarded".to_string(),
@@ -841,7 +883,7 @@ impl FirestoreService {
         );
         structured_fields.insert(
             "category".to_string(),
-            json!({"stringValue": format!("{:?}", conv.structured.category).to_lowercase()}),
+            json!({"stringValue": category_wire(&conv.structured.category)}),
         );
         structured_fields.insert(
             "action_items".to_string(),
@@ -1016,5 +1058,123 @@ impl FirestoreService {
             .and_then(|v| v.as_str())
             .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
             .map(|dt| dt.with_timezone(&Utc))
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+
+    fn fixture(name: &str) -> Value {
+        let path = format!(
+            "{}/../../../contract_tests/fixtures/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        );
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn secret_bytes(value: &Value) -> Vec<u8> {
+        value["encryption_secret"]
+            .as_str()
+            .unwrap()
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn contract_wire_values_match_python_enums() {
+        let data = fixture("conversations.json");
+        let expected = &data["wire_values"];
+
+        assert_eq!(
+            conversation_source_wire(&ConversationSource::ExternalIntegration),
+            expected["source_external_integration"].as_str().unwrap()
+        );
+        assert_eq!(
+            conversation_status_wire(&ConversationStatus::InProgress),
+            expected["status_in_progress"].as_str().unwrap()
+        );
+        assert_eq!(
+            category_wire(&Category::Romance),
+            expected["category_romance"].as_str().unwrap()
+        );
+        assert_eq!(memory_category_wire(&MemoryCategory::Workflow), "workflow");
+    }
+
+    #[test]
+    fn contract_parse_transcript_segments_reads_shared_standard_and_enhanced_fixtures() {
+        let data = fixture("conversations.json");
+        let service = FirestoreService::new_for_contract(Some(secret_bytes(&data)));
+        let uid = data["uid"].as_str().unwrap();
+
+        let standard_fields = json!({
+            "data_protection_level": {"stringValue": "standard"},
+            "transcript_segments": {"bytesValue": data["standard_compressed_transcript_b64"]},
+            "transcript_segments_compressed": {"booleanValue": true}
+        });
+        let enhanced_fields = json!({
+            "data_protection_level": {"stringValue": "enhanced"},
+            "transcript_segments": {"stringValue": data["enhanced_encrypted_transcript"]},
+            "transcript_segments_compressed": {"booleanValue": true}
+        });
+
+        let standard = service
+            .parse_transcript_segments(&standard_fields, uid)
+            .unwrap();
+        let enhanced = service
+            .parse_transcript_segments(&enhanced_fields, uid)
+            .unwrap();
+
+        assert_eq!(standard.len(), data["segments"].as_array().unwrap().len());
+        assert_eq!(enhanced.len(), data["segments"].as_array().unwrap().len());
+        assert_eq!(standard[0].text, "Hello from desktop");
+        assert_eq!(enhanced[1].text, "Rust and Python should agree");
+        assert_eq!(standard[0].person_id.as_deref(), Some("person-user"));
+    }
+
+    #[test]
+    fn contract_parse_memory_reads_python_owned_fields_and_missing_visibility_as_public() {
+        let data = fixture("memories.json");
+        let service = FirestoreService::new_for_contract(Some(secret_bytes(&data)));
+        let uid = data["uid"].as_str().unwrap();
+        let doc = json!({
+            "name": "projects/contract/databases/(default)/documents/users/contract-user-8547/memories/memory-1",
+            "fields": {
+                "content": {"stringValue": data["enhanced_encrypted_content"]},
+                "category": {"stringValue": "workflow"},
+                "created_at": {"timestampValue": data["created_at"]},
+                "updated_at": {"timestampValue": data["created_at"]},
+                "data_protection_level": {"stringValue": "enhanced"},
+                "memory_id": {"stringValue": "conversation-1"},
+                "conversation_id": {"stringValue": "conversation-1"},
+                "valid_at": {"timestampValue": data["created_at"]},
+                "invalid_at": {"timestampValue": "2026-02-03T04:05:06+00:00"},
+                "superseded_by": {"stringValue": "memory-2"},
+                "edited": {"booleanValue": true},
+                "is_locked": {"booleanValue": true},
+                "kg_extracted": {"booleanValue": true},
+                "app_id": {"stringValue": "app-1"},
+                "tags": {"arrayValue": {"values": [{"stringValue": "contract"}]}}
+            }
+        });
+
+        let memory = service.parse_memory(&doc, uid).unwrap();
+
+        assert_eq!(memory.id, "memory-1");
+        assert_eq!(
+            memory.content,
+            data["enhanced_plain_content"].as_str().unwrap()
+        );
+        assert_eq!(memory.category, MemoryCategory::Workflow);
+        assert_eq!(memory.visibility, "public");
+        assert_eq!(memory.memory_id.as_deref(), Some("conversation-1"));
+        assert!(memory.invalid_at.is_some());
+        assert_eq!(memory.superseded_by.as_deref(), Some("memory-2"));
+        assert!(memory.edited);
+        assert!(memory.is_locked);
+        assert!(memory.kg_extracted);
+        assert_eq!(memory.app_id.as_deref(), Some("app-1"));
+        assert_eq!(memory.tags, vec!["contract".to_string()]);
     }
 }

--- a/desktop/macos/changelog/unreleased/20260630-desktop-backend-parity-contracts.json
+++ b/desktop/macos/changelog/unreleased/20260630-desktop-backend-parity-contracts.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Improved desktop backend consistency for conversations and memories"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds shared Python/Rust desktop backend contract fixtures for conversations and memories.
- Adds backend Python contract tests and Rust contract tests for wire values, compression, memory lifecycle/defaults, query semantics, public-memory behavior, and field preservation.
- Fixes Rust desktop backend parity gaps in split Firestore repositories and adds CI coverage.

## Validation
- `/Users/dazheng/repos/omi-worktrees/wave2-8543-hermetic-e2e/backend/.venv/bin/python -m pytest backend/testing/contracts -q` -> 8 passed
- `cargo test --manifest-path desktop/macos/Backend-Rust/Cargo.toml contract` -> 9 passed
- Pre-push hook passed
- Oracle pre-implementation and pre-PR reviews passed after repair rounds.

Fixes #8547


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

