### PR TITLE
fix(backend): build the realtime audio-bytes webhook URL with the right query separator

### DIFF
--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -310,6 +310,45 @@ class TestAsyncTriggerRealtimeAudioBytes:
         assert mock_client.post.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_audio_url_with_existing_query_string_uses_ampersand(self):
+        """A webhook_url that already carries a query string must not get a second '?'."""
+        app = _make_app("a1", "https://example.com/hook?token=abc", triggers_audio=True)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(app_integrations, "get_available_apps", return_value=[app]), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
+        ):
+            await app_integrations.trigger_realtime_audio_bytes("uid-1", 16000, bytearray(b'\x00' * 10))
+
+        assert mock_client.post.call_count == 1
+        called_url = mock_client.post.call_args[0][0]
+        # Exactly one '?' (the original delimiter); sample_rate is joined with '&'.
+        assert called_url == "https://example.com/hook?token=abc&sample_rate=16000&uid=uid-1"
+        assert called_url.count("?") == 1
+
+    @pytest.mark.asyncio
+    async def test_audio_url_without_query_string_uses_question_mark(self):
+        """A webhook_url with no query string still gets a leading '?'."""
+        app = _make_app("a1", "https://example.com/hook", triggers_audio=True)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(app_integrations, "get_available_apps", return_value=[app]), patch.object(
+            app_integrations, "get_webhook_client", return_value=mock_client
+        ):
+            await app_integrations.trigger_realtime_audio_bytes("uid-1", 16000, bytearray(b'\x00' * 10))
+
+        called_url = mock_client.post.call_args[0][0]
+        assert called_url == "https://example.com/hook?sample_rate=16000&uid=uid-1"
+
+    @pytest.mark.asyncio
     async def test_one_failure_doesnt_cancel_others(self):
         """One app timeout should not prevent other apps from receiving audio."""
         import httpx

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -632,7 +632,10 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
             return
 
         url = app.external_integration.webhook_url
-        url += f'?sample_rate={sample_rate}&uid={uid}'
+        # The configured webhook_url may already carry a query string (auth token,
+        # routing param), so pick the right separator instead of always using '?'.
+        separator = '&' if '?' in url else '?'
+        url += f'{separator}sample_rate={sample_rate}&uid={uid}'
 
         cb = get_webhook_circuit_breaker(url)
         if not cb.allow_request():


### PR DESCRIPTION
## What

`_async_trigger_realtime_audio_bytes` (the live audio-bytes webhook fan-out) appends its query params with a hardcoded `?`:

```python
url = app.external_integration.webhook_url
url += f'?sample_rate={sample_rate}&uid={uid}'
```

If an app's configured `webhook_url` already carries a query string (an auth token or routing param, which is common), the result is a malformed URL with two `?` characters:

```
https://hooks.example.com/omi?token=abc?sample_rate=16000&uid=...
```

Per URL semantics only the first `?` delimits the query, so `sample_rate` is folded into the value of the preceding param and the receiver never sees a clean `sample_rate`.

## Fix

Choose the separator based on whether the URL already has a query string:

```python
separator = '&' if '?' in url else '?'
url += f'{separator}sample_rate={sample_rate}&uid={uid}'
```

This matches the two sibling functions in the same file, `trigger_external_integrations` and `_async_trigger_realtime_integrations`, which already do the `if '?' in url` check. The audio-bytes path was the lone outlier.

## Reachability

`routers/pusher.py` calls `trigger_realtime_audio_bytes(uid, sample_rate, data)` continuously while a user is recording, for every installed app whose external integration has the `audio_bytes` trigger. The corruption fires for any such app whose webhook URL carries a query string.

## Test

`tests/unit/test_async_app_integrations.py` (extends the existing `TestAsyncTriggerRealtimeAudioBytes`):
- a webhook URL with an existing query string gets `&sample_rate=...` appended (single `?`, with `sample_rate` as its own param)
- a webhook URL with no query string still gets a leading `?`

Verified that the previous construction produces a double-`?` URL these assertions reject, and the fixed construction matches them.
