### PR TITLE
fix(backend): isolate vector upsert from Firestore write in memories batch (#8634)

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -118,23 +118,31 @@ async def create_memories_batch(
         if memory.visibility == 'public':
             has_public = True
 
-    # Firestore batch write + Pinecone batch upsert run on a worker thread so a
-    # slow embeddings/Pinecone call can't starve the FastAPI sync threadpool.
-    def _persist():
-        memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
-        upsert_memory_vectors_batch(
-            uid,
-            [
-                {
-                    "memory_id": m.id,
-                    "content": m.content,
-                    "category": m.category.value,
-                }
-                for m in memory_dbs
-            ],
-        )
+    # Persist to Firestore first — that write is the authoritative result.
+    # Mirror create_memory above: isolate the best-effort vector upsert so a
+    # transient/BYOK embedding failure (e.g. an OpenAI key without
+    # text-embedding-3-large access -> 403) can't 500 a request whose memories
+    # were already saved, which would make the client retry and duplicate them.
+    try:
+        await run_blocking(db_executor, memories_db.save_memories, uid, [m.dict() for m in memory_dbs])
+    except Exception:
+        logger.exception("Firestore save_memories failed uid=%s count=%s", uid, len(memory_dbs))
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
 
-    await run_blocking(db_executor, _persist)
+    # Pinecone batch upsert runs on a worker thread (postprocess pool, like the
+    # single-create path) so a slow embeddings/Pinecone call can't starve the
+    # FastAPI sync threadpool.
+    try:
+        await run_blocking(
+            postprocess_executor,
+            upsert_memory_vectors_batch,
+            uid,
+            [{"memory_id": m.id, "content": m.content, "category": m.category.value} for m in memory_dbs],
+        )
+    except Exception:
+        logger.exception(
+            "Vector batch upsert failed uid=%s count=%s (memories saved, vectors missing)", uid, len(memory_dbs)
+        )
 
     return BatchMemoriesResponse(memories=memory_dbs, created_count=len(memory_dbs))
 

--- a/backend/tests/unit/test_memories_batch.py
+++ b/backend/tests/unit/test_memories_batch.py
@@ -122,6 +122,53 @@ class TestUpsertMemoryVectorsBatch:
         fake_embeddings.embed_documents.assert_not_called()
 
 
+class TestBatchMemoriesEndpointErrorIsolation:
+    """
+    Regression for the BYOK embedding-403 cluster: POST /v3/memories/batch must
+    isolate the best-effort vector upsert from the authoritative Firestore
+    write. A 403 from `text-embedding-3-large` (or any embedding/Pinecone error)
+    must NOT 500 the request after the memories were already saved — otherwise
+    the client retries and creates duplicate memories. The single create_memory
+    path already isolates its upsert; this guards the batch path the same way.
+
+    Source-structural like TestBatchMemoriesRequestValidation above: importing
+    routers.memories in a unit test pulls in the whole Firestore stack, so we
+    assert the contract against the function source instead.
+    """
+
+    @staticmethod
+    def _batch_fn_source() -> str:
+        import os
+
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'memories.py')
+        with open(os.path.abspath(path), 'r', encoding='utf-8') as f:
+            content = f.read()
+        start = content.index('async def create_memories_batch')
+        # Function body ends at the next top-level decorator/def.
+        rest = content[start:]
+        end = rest.find('\n@router')
+        return rest if end == -1 else rest[:end]
+
+    def test_save_and_upsert_are_separate_steps(self):
+        """The bug was bundling save+upsert in one _persist whose vector failure
+        500s the whole (already-saved) request. They must be separate steps."""
+        src = self._batch_fn_source()
+        assert 'def _persist' not in src, "save and vector upsert must not be bundled into one fallible step"
+        assert 'save_memories' in src
+        assert 'upsert_memory_vectors_batch' in src
+
+    def test_vector_upsert_failure_is_swallowed(self):
+        """The vector upsert must be wrapped so its failure does not fail the
+        request — proven by the 'memories saved, vectors missing' marker."""
+        src = self._batch_fn_source()
+        assert 'memories saved, vectors missing' in src
+
+    def test_firestore_write_failure_still_raises_503(self):
+        """A genuine Firestore write failure must still surface as a retryable 503."""
+        src = self._batch_fn_source()
+        assert 'status_code=503' in src
+
+
 class TestBatchMemoriesRateLimitPolicy:
     def test_policy_exists_with_expected_limits(self):
         """Guardrail so the policy isn't accidentally dropped from the config."""


### PR DESCRIPTION
## Bug
`POST /v3/memories/batch` returns a **500 even though the memories were already saved** when the embedding step fails. The largest error bucket in #8634 is BYOK embedding access: an OpenAI key/project without `text-embedding-3-large` access raises `PermissionDeniedError: 403 model_not_found`. Because the endpoint surfaces a 500, the client retries → **duplicate memories**.

## Root cause
The batch endpoint bundled the authoritative Firestore write and the best-effort Pinecone vector upsert into a single `_persist()` with no error isolation:

```python
def _persist():
    memories_db.save_memories(uid, [...])        # commits to Firestore
    upsert_memory_vectors_batch(uid, [...])      # embeddings.embed_documents -> 403 raises here
await run_blocking(db_executor, _persist)        # propagates -> 500, but memories are already saved
```

The single-create path (`create_memory`, lines 69–82) was deliberately fixed for exactly this asymmetry — it isolates the vector upsert and logs `(memory saved, vector missing)` on failure. The batch path was missed.

## Fix
Mirror the single-create pattern:
- `await` the Firestore write first; its failure is a genuine retryable **503**.
- Run the vector upsert as a caught best-effort step on the **postprocess pool** (same pool the single-create path uses), so a slow/failed embedding call neither starves the FastAPI threadpool nor 500s a request whose memories are already persisted.

Success-path behavior is unchanged (still one Firestore batch write + one embeddings call + one Pinecone upsert).

## Tests
3 source-structural regression tests added to `test_memories_batch.py` (consistent with the file's existing import-free guards): save/upsert are separate steps, the upsert failure is swallowed (`memories saved, vectors missing` marker), and a Firestore failure still raises 503. Full file: 11 passed locally. `black` clean, `scan_async_blockers` clean, `py_compile` OK.

UNVERIFIED at runtime (no live BYOK-403 batch repro available locally).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

