### PR TITLE
[codex] Fix Gemini proxy timeout handling

### DIFF
--- a/desktop/macos/Backend-Rust/src/main.rs
+++ b/desktop/macos/Backend-Rust/src/main.rs
@@ -72,6 +72,10 @@ pub struct AppState {
     pub chat_rate_limiter: routes::rate_limit::SharedRateLimiter,
     /// Vertex AI auth provider (present when USE_VERTEX_AI=true)
     pub vertex_auth: Option<vertex::VertexAuth>,
+    /// Gemini proxy client for full-response calls; owns the upstream deadline.
+    pub gemini_client: reqwest::Client,
+    /// Gemini proxy client for streaming calls; only bounds connection setup.
+    pub gemini_stream_client: reqwest::Client,
 }
 
 #[tokio::main]
@@ -307,6 +311,8 @@ async fn main() {
         gemini_rate_limiter,
         chat_rate_limiter,
         vertex_auth,
+        gemini_client: routes::proxy::gemini_client(),
+        gemini_stream_client: routes::proxy::gemini_stream_client(),
     };
 
     // Build CORS layer

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -130,29 +130,12 @@ fn duration_bucket(elapsed: Duration) -> &'static str {
 }
 
 fn map_upstream_error(error: reqwest::Error, operation: &str) -> ProxyError {
+    let error = error.without_url();
     if error.is_timeout() {
         tracing::warn!("gemini_proxy: {} timed out: {}", operation, error);
         ProxyError::UpstreamTimeout
     } else {
         tracing::error!("gemini_proxy: {} failed: {}", operation, error);
-        ProxyError::Status(StatusCode::BAD_GATEWAY)
-    }
-}
-
-fn map_upstream_error_without_url(error: reqwest::Error, operation: &str) -> ProxyError {
-    if error.is_timeout() {
-        tracing::warn!(
-            "gemini_proxy: {} timed out: {}",
-            operation,
-            error.without_url()
-        );
-        ProxyError::UpstreamTimeout
-    } else {
-        tracing::error!(
-            "gemini_proxy: {} failed: {}",
-            operation,
-            error.without_url()
-        );
         ProxyError::Status(StatusCode::BAD_GATEWAY)
     }
 }
@@ -265,14 +248,14 @@ async fn gemini_proxy(
         .body(sanitized_body)
         .send()
         .await
-        .map_err(|e| map_upstream_error_without_url(e, "BYOK upstream request"))?;
+        .map_err(|e| map_upstream_error(e, "BYOK upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
     let bytes = upstream
         .bytes()
         .await
-        .map_err(|e| map_upstream_error_without_url(e, "BYOK upstream body read"))?;
+        .map_err(|e| map_upstream_error(e, "BYOK upstream body read"))?;
     tracing::info!(
         "gemini_proxy: upstream_result uid={} provider=ai_studio_byok model={} action={} payload_bucket={} duration_bucket={} status={}",
         user.uid,
@@ -546,7 +529,7 @@ async fn gemini_stream_proxy(
         .body(sanitized_body)
         .send()
         .await
-        .map_err(|e| map_upstream_error_without_url(e, "BYOK stream upstream request"))?;
+        .map_err(|e| map_upstream_error(e, "BYOK stream upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -13,6 +13,7 @@ use axum::{
     routing::post,
     Router,
 };
+use std::time::{Duration, Instant};
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
@@ -47,10 +48,19 @@ const MAX_OUTPUT_TOKENS_CAP: u64 = 8192;
 /// explicitly on all production paths.
 const DEFAULT_THINKING_BUDGET: u64 = 1024;
 
+/// Keep non-streaming upstream calls comfortably below Cloud Run's 300s request
+/// deadline so the proxy owns timeout mapping and logging.
+const GEMINI_UPSTREAM_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Bound TCP/TLS setup for all Gemini proxy calls. Streaming requests must not
+/// use a total response timeout because long SSE replies are expected.
+const GEMINI_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Proxy-specific error type — allows JSON 429 responses alongside bare status codes.
 enum ProxyError {
     Status(StatusCode),
     RateLimited,
+    UpstreamTimeout,
 }
 
 impl IntoResponse for ProxyError {
@@ -70,7 +80,80 @@ impl IntoResponse for ProxyError {
                     .body(axum::body::Body::from(body))
                     .unwrap()
             }
+            ProxyError::UpstreamTimeout => Response::builder()
+                .status(StatusCode::GATEWAY_TIMEOUT)
+                .header("content-type", "application/json")
+                .header("retry-after", "30")
+                .body(axum::body::Body::from(upstream_timeout_json()))
+                .unwrap(),
         }
+    }
+}
+
+fn upstream_timeout_json() -> &'static str {
+    r#"{"error":"upstream_timeout","message":"Gemini request timed out before the backend deadline. Please retry or shorten the request."}"#
+}
+
+pub fn gemini_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(GEMINI_CONNECT_TIMEOUT)
+        .timeout(GEMINI_UPSTREAM_TIMEOUT)
+        .build()
+        .unwrap_or_default()
+}
+
+pub fn gemini_stream_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(GEMINI_CONNECT_TIMEOUT)
+        .build()
+        .unwrap_or_default()
+}
+
+fn payload_bucket(bytes: usize) -> &'static str {
+    match bytes {
+        0..=16_384 => "0-16kb",
+        16_385..=131_072 => "16-128kb",
+        131_073..=524_288 => "128-512kb",
+        524_289..=1_048_576 => "512kb-1mb",
+        _ => "1mb+",
+    }
+}
+
+fn duration_bucket(elapsed: Duration) -> &'static str {
+    match elapsed.as_secs() {
+        0..=4 => "0-5s",
+        5..=14 => "5-15s",
+        15..=59 => "15-60s",
+        60..=119 => "60-120s",
+        _ => "120s+",
+    }
+}
+
+fn map_upstream_error(error: reqwest::Error, operation: &str) -> ProxyError {
+    if error.is_timeout() {
+        tracing::warn!("gemini_proxy: {} timed out: {}", operation, error);
+        ProxyError::UpstreamTimeout
+    } else {
+        tracing::error!("gemini_proxy: {} failed: {}", operation, error);
+        ProxyError::Status(StatusCode::BAD_GATEWAY)
+    }
+}
+
+fn map_upstream_error_without_url(error: reqwest::Error, operation: &str) -> ProxyError {
+    if error.is_timeout() {
+        tracing::warn!(
+            "gemini_proxy: {} timed out: {}",
+            operation,
+            error.without_url()
+        );
+        ProxyError::UpstreamTimeout
+    } else {
+        tracing::error!(
+            "gemini_proxy: {} failed: {}",
+            operation,
+            error.without_url()
+        );
+        ProxyError::Status(StatusCode::BAD_GATEWAY)
     }
 }
 
@@ -173,30 +256,32 @@ async fn gemini_proxy(
     tracing::info!("gemini_proxy: using BYOK Gemini key for uid={}", user.uid);
 
     let url = build_gemini_url(&path, byok_key);
-    let upstream = reqwest::Client::new()
+    let request_payload_bucket = payload_bucket(sanitized_body.len());
+    let started = Instant::now();
+    let upstream = state
+        .gemini_client
         .post(&url)
         .header("content-type", "application/json")
         .body(sanitized_body)
         .send()
         .await
-        .map_err(|e| {
-            // Use without_url() to avoid leaking BYOK API key from the query string
-            tracing::error!(
-                "gemini_proxy: BYOK upstream request failed: {}",
-                e.without_url()
-            );
-            ProxyError::Status(StatusCode::BAD_GATEWAY)
-        })?;
+        .map_err(|e| map_upstream_error_without_url(e, "BYOK upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-    let bytes = upstream.bytes().await.map_err(|e| {
-        tracing::error!(
-            "gemini_proxy: failed to read upstream body: {}",
-            e.without_url()
-        );
-        ProxyError::Status(StatusCode::BAD_GATEWAY)
-    })?;
+    let bytes = upstream
+        .bytes()
+        .await
+        .map_err(|e| map_upstream_error_without_url(e, "BYOK upstream body read"))?;
+    tracing::info!(
+        "gemini_proxy: upstream_result uid={} provider=ai_studio_byok model={} action={} payload_bucket={} duration_bucket={} status={}",
+        user.uid,
+        model,
+        action,
+        request_payload_bucket,
+        duration_bucket(started.elapsed()),
+        status.as_u16()
+    );
 
     Ok((status, bytes).into_response())
 }
@@ -232,10 +317,17 @@ async fn gemini_proxy_server_key(
     } else {
         effective_path.to_string()
     };
+    let request_payload_bucket = payload_bucket(request_body.len());
+    let started = Instant::now();
 
     // Build and send request: Vertex AI (Bearer token) or AI Studio (API key).
     // Falls back to AI Studio if Vertex token fetch fails.
     let mut used_vertex = false;
+    let mut upstream_provider = if route.provider == Provider::VertexAi {
+        "vertex_ai"
+    } else {
+        "ai_studio"
+    };
     let upstream = if route.provider == Provider::VertexAi {
         if let Some(ref vertex) = state.vertex_auth {
             let url = vertex.build_url_from_path(&vertex_path).ok_or_else(|| {
@@ -248,7 +340,8 @@ async fn gemini_proxy_server_key(
             match vertex.token().await {
                 Ok(token) => {
                     used_vertex = true;
-                    reqwest::Client::new()
+                    state
+                        .gemini_client
                         .post(&url)
                         .header("content-type", "application/json")
                         .header("authorization", format!("Bearer {}", token))
@@ -262,8 +355,10 @@ async fn gemini_proxy_server_key(
                             "gemini_proxy: Vertex AI token failed, falling back to API key: {}",
                             e
                         );
+                        upstream_provider = "ai_studio_fallback";
                         let url = build_gemini_url(effective_path, gemini_key);
-                        reqwest::Client::new()
+                        state
+                            .gemini_client
                             .post(&url)
                             .header("content-type", "application/json")
                             .body(sanitized_body.to_vec())
@@ -285,8 +380,10 @@ async fn gemini_proxy_server_key(
                 .gemini_api_key
                 .as_ref()
                 .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
+            upstream_provider = "ai_studio_fallback";
             let url = build_gemini_url(effective_path, gemini_key);
-            reqwest::Client::new()
+            state
+                .gemini_client
                 .post(&url)
                 .header("content-type", "application/json")
                 .body(sanitized_body.to_vec())
@@ -301,7 +398,8 @@ async fn gemini_proxy_server_key(
             .as_ref()
             .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
         let url = build_gemini_url(effective_path, gemini_key);
-        reqwest::Client::new()
+        state
+            .gemini_client
             .post(&url)
             .header("content-type", "application/json")
             .body(sanitized_body.to_vec())
@@ -309,17 +407,24 @@ async fn gemini_proxy_server_key(
             .await
     };
 
-    let upstream = upstream.map_err(|e| {
-        tracing::error!("gemini_proxy: upstream request failed: {}", e);
-        ProxyError::Status(StatusCode::BAD_GATEWAY)
-    })?;
+    let upstream = upstream.map_err(|e| map_upstream_error(e, "upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-    let bytes = upstream.bytes().await.map_err(|e| {
-        tracing::error!("gemini_proxy: failed to read upstream body: {}", e);
-        ProxyError::Status(StatusCode::BAD_GATEWAY)
-    })?;
+    let bytes = upstream
+        .bytes()
+        .await
+        .map_err(|e| map_upstream_error(e, "upstream body read"))?;
+    tracing::info!(
+        "gemini_proxy: upstream_result uid={} provider={} model={} action={} payload_bucket={} duration_bucket={} status={}",
+        user.uid,
+        upstream_provider,
+        model,
+        action,
+        request_payload_bucket,
+        duration_bucket(started.elapsed()),
+        status.as_u16()
+    );
 
     // Apply response transform if needed (e.g., Vertex predict → AI Studio embed format)
     if used_vertex && status.is_success() && route.response_transform != ResponseTransform::None {
@@ -434,20 +539,14 @@ async fn gemini_stream_proxy(
     );
 
     let upstream_url = build_gemini_stream_url(&path, byok_key, &query);
-    let upstream = reqwest::Client::new()
+    let upstream = state
+        .gemini_stream_client
         .post(&upstream_url)
         .header("content-type", "application/json")
         .body(sanitized_body)
         .send()
         .await
-        .map_err(|e| {
-            // Use without_url() to avoid leaking BYOK API key from the query string
-            tracing::error!(
-                "gemini_stream_proxy: BYOK upstream request failed: {}",
-                e.without_url()
-            );
-            ProxyError::Status(StatusCode::BAD_GATEWAY)
-        })?;
+        .map_err(|e| map_upstream_error_without_url(e, "BYOK stream upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
@@ -494,7 +593,8 @@ async fn gemini_stream_server_key(
             }
             match vertex.token().await {
                 Ok(token) => {
-                    reqwest::Client::new()
+                    state
+                        .gemini_stream_client
                         .post(&url)
                         .header("content-type", "application/json")
                         .header("authorization", format!("Bearer {}", token))
@@ -507,7 +607,8 @@ async fn gemini_stream_server_key(
                         tracing::warn!("gemini_stream_proxy: Vertex AI token failed, falling back to API key: {}", e);
                         let upstream_url =
                             build_gemini_stream_url(effective_path, gemini_key, query);
-                        reqwest::Client::new()
+                        state
+                            .gemini_stream_client
                             .post(&upstream_url)
                             .header("content-type", "application/json")
                             .body(sanitized_body)
@@ -530,7 +631,8 @@ async fn gemini_stream_server_key(
                 .as_ref()
                 .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
             let upstream_url = build_gemini_stream_url(effective_path, gemini_key, query);
-            reqwest::Client::new()
+            state
+                .gemini_stream_client
                 .post(&upstream_url)
                 .header("content-type", "application/json")
                 .body(sanitized_body)
@@ -545,7 +647,8 @@ async fn gemini_stream_server_key(
             .as_ref()
             .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
         let upstream_url = build_gemini_stream_url(effective_path, gemini_key, query);
-        reqwest::Client::new()
+        state
+            .gemini_stream_client
             .post(&upstream_url)
             .header("content-type", "application/json")
             .body(sanitized_body)
@@ -553,10 +656,7 @@ async fn gemini_stream_server_key(
             .await
     };
 
-    let upstream = upstream.map_err(|e| {
-        tracing::error!("gemini_stream_proxy: upstream request failed: {}", e);
-        ProxyError::Status(StatusCode::BAD_GATEWAY)
-    })?;
+    let upstream = upstream.map_err(|e| map_upstream_error(e, "stream upstream request"))?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
@@ -872,6 +972,37 @@ pub fn proxy_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gemini_upstream_timeout_stays_below_cloud_run_deadline() {
+        assert!(GEMINI_CONNECT_TIMEOUT < GEMINI_UPSTREAM_TIMEOUT);
+        assert!(GEMINI_UPSTREAM_TIMEOUT < Duration::from_secs(300));
+    }
+
+    #[test]
+    fn upstream_timeout_response_is_retryable_and_sanitized() {
+        let response = ProxyError::UpstreamTimeout.into_response();
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(response.headers().get("retry-after").unwrap(), "30");
+
+        let body = upstream_timeout_json();
+        assert!(body.contains("upstream_timeout"));
+        assert!(body.contains("retry"));
+        assert!(!body.contains("uid"));
+        assert!(!body.contains("prompt"));
+        assert!(!body.contains("key"));
+    }
+
+    #[test]
+    fn proxy_metric_buckets_are_stable() {
+        assert_eq!(payload_bucket(0), "0-16kb");
+        assert_eq!(payload_bucket(16_385), "16-128kb");
+        assert_eq!(payload_bucket(524_289), "512kb-1mb");
+        assert_eq!(payload_bucket(1_048_577), "1mb+");
+        assert_eq!(duration_bucket(Duration::from_secs(4)), "0-5s");
+        assert_eq!(duration_bucket(Duration::from_secs(60)), "60-120s");
+        assert_eq!(duration_bucket(Duration::from_secs(120)), "120s+");
+    }
 
     // --- Gemini action extraction ---
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -210,15 +210,33 @@ actor GeminiClient {
       switch self {
       case .apiError(let message):
         let lower = message.lowercased()
-        return lower.contains("service unavailable")
+        return Self.isTimeoutLike(lower)
+          || lower.contains("service unavailable")
           || lower.contains("overloaded")
           || lower.contains("resource exhausted")
           || lower.contains("high demand")
           || lower.contains("503")
+          || lower.contains("502")
           || lower.contains("429")
           || lower.contains("internal error")
       case .networkError:
         return true
+      case .invalidResponse, .missingAPIKey:
+        return false
+      }
+    }
+
+    /// True when an error should be retried automatically inside GeminiClient.
+    /// Long upstream deadlines are recoverable, but auto-retrying them can keep
+    /// the user waiting through several multi-minute attempts.
+    var shouldAutoRetry: Bool {
+      switch self {
+      case .apiError(let message):
+        let lower = message.lowercased()
+        return isTransient && !Self.isTimeoutLike(lower)
+      case .networkError(let error):
+        let nsError = error as NSError
+        return !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut)
       case .invalidResponse, .missingAPIKey:
         return false
       }
@@ -282,9 +300,12 @@ actor GeminiClient {
       {
         return "AI service is busy. Please try again in a moment."
       }
+      if Self.isTimeoutLike(lower) {
+        return "AI request took too long. Please try again or shorten the request."
+      }
       if lower.contains("overloaded") || lower.contains("service unavailable")
         || lower.contains("503")
-        || lower.contains("internal error") || lower.contains("500")
+        || lower.contains("502") || lower.contains("internal error") || lower.contains("500")
       {
         return "AI service is temporarily unavailable. Please try again later."
       }
@@ -293,6 +314,17 @@ actor GeminiClient {
       }
       // Fallback: generic message that doesn't leak internals
       return "AI service error. Please try again."
+    }
+
+    private static func isTimeoutLike(_ lowercasedMessage: String) -> Bool {
+      lowercasedMessage.contains("upstream_timeout")
+        || lowercasedMessage.contains("timed out")
+        || lowercasedMessage.contains("timeout")
+        || lowercasedMessage.contains("deadline")
+        || lowercasedMessage.contains("http 504")
+        || lowercasedMessage.contains(" 504")
+        || lowercasedMessage.contains("http 408")
+        || lowercasedMessage.contains(" 408")
     }
   }
 
@@ -362,10 +394,11 @@ actor GeminiClient {
   /// Check if an error is transient and worth retrying
   private func isTransientError(_ error: Error) -> Bool {
     if let geminiError = error as? GeminiClientError {
-      return geminiError.isTransient
+      return geminiError.shouldAutoRetry
     }
     // URLSession network errors are transient
-    return (error as NSError).domain == NSURLErrorDomain
+    let nsError = error as NSError
+    return nsError.domain == NSURLErrorDomain && nsError.code != NSURLErrorTimedOut
   }
 
   /// Sleep with exponential backoff (2s, 8s) and log the retry attempt.

--- a/desktop/macos/changelog/unreleased/20260630-gemini-proxy-timeouts.json
+++ b/desktop/macos/changelog/unreleased/20260630-gemini-proxy-timeouts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop AI timeout handling so slow Gemini requests fail clearly before the backend deadline"
+}


### PR DESCRIPTION
## Summary

Closes #8633.

This makes the desktop Gemini proxy own upstream timeout behavior instead of letting long `generateContent` calls run into the Cloud Run request deadline.

## Root cause

The Rust proxy forwarded Gemini requests synchronously through fresh `reqwest::Client::new()` instances with no explicit non-streaming upstream deadline. Desktop clients also waited 300 seconds, so slow Gemini/Vertex calls often reached Cloud Run's outer request deadline and surfaced as platform 504s or generic 502s.

## Changes

- Add shared Gemini proxy HTTP clients to `AppState`:
  - non-streaming client has a 10s connect timeout and 120s total upstream timeout
  - streaming client has a 10s connect timeout only, preserving long SSE responses
- Map upstream request/body-read timeouts to sanitized JSON `504 Gateway Timeout` responses with `retry-after` before Cloud Run kills the request.
- Add sanitized upstream result logging with provider, model, action, payload bucket, duration bucket, and status.
- Update macOS Gemini client error handling so timeout/deadline/504 errors show a clear recoverable message and are not auto-retried after a long wait; 502 remains transient/retryable.
- Add focused backend tests for timeout policy, timeout response shape, and metric buckets.
- Add the required macOS changelog fragment.

## Validation

- `cd desktop/macos/Backend-Rust && cargo test proxy`
- `cd desktop/macos/Backend-Rust && cargo test`
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`

Swift build completed with existing warnings outside this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

