### PR TITLE
Gate OpenClaw and Hermes pill handoffs by availability

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -186,6 +186,24 @@ final class AgentPillsManager: ObservableObject {
             case .openclaw: return .openclaw
             }
         }
+
+        var executableName: String {
+            switch self {
+            case .hermes: return "hermes"
+            case .openclaw: return "openclaw"
+            }
+        }
+
+        var commandEnvironmentName: String {
+            switch self {
+            case .hermes: return "OMI_HERMES_ADAPTER_COMMAND"
+            case .openclaw: return "OMI_OPENCLAW_ADAPTER_COMMAND"
+            }
+        }
+
+        var setupNeededStatus: String {
+            "\(displayName) needs setup"
+        }
     }
 
     struct ProviderDirective: Equatable {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2540,6 +2540,28 @@ class FloatingControlBarManager {
                 provider.stopAgent()
             }
             routerTracer?.mark("router_classify", metadata: ["route": "agent", "provider": directive.provider.rawValue])
+            let availability = LocalAgentProviderDetector.availability(for: directive.provider)
+            guard availability.isAvailable else {
+                let assistantText = availability.setupPrompt
+                let recordedTurn = provider.recordCompletedTurn(
+                    userText: message,
+                    assistantText: assistantText,
+                    logLabel: "floating-agent-provider-unavailable"
+                )
+                switch presentation {
+                case .visible:
+                    completeVisibleAgentResponse(
+                        userText: message,
+                        assistantMessage: recordedTurn.assistant ?? ChatMessage(text: assistantText, sender: .ai),
+                        barWindow: barWindow
+                    )
+                case .voiceOnly:
+                    barWindow.state.currentQueryFromVoice = false
+                    barWindow.state.isVoiceResponseActive = false
+                    FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)
+                }
+                return
+            }
             let pill = AgentPillsManager.shared.spawnFromUserQuery(
                 directive.rewrittenQuery,
                 model: selectedFloatingModel,
@@ -2683,11 +2705,23 @@ class FloatingControlBarManager {
         assistantText: String,
         barWindow: FloatingControlBarWindow
     ) {
+        completeVisibleAgentResponse(
+            userText: handoff.originalRequest,
+            assistantMessage: assistantMessage ?? ChatMessage(text: assistantText, sender: .ai),
+            barWindow: barWindow
+        )
+    }
+
+    private func completeVisibleAgentResponse(
+        userText: String,
+        assistantMessage: ChatMessage,
+        barWindow: FloatingControlBarWindow
+    ) {
         chatCancellable?.cancel()
         chatCancellable = nil
         barWindow.state.aiInputText = ""
-        barWindow.state.displayedQuery = handoff.originalRequest
-        barWindow.state.currentAIMessage = assistantMessage ?? ChatMessage(text: assistantText, sender: .ai)
+        barWindow.state.displayedQuery = userText
+        barWindow.state.currentAIMessage = assistantMessage
         barWindow.state.isAILoading = false
         barWindow.state.present(.mainResponse)
         barWindow.state.currentQueryFromVoice = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -958,6 +958,23 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
           output: "Unsupported agent provider '\(providerName)'. Use 'hermes' or 'openclaw'.")
         return
       }
+      if let directedProvider {
+        let availability = LocalAgentProviderDetector.availability(for: directedProvider)
+        guard availability.isAvailable else {
+          let setupPrompt = availability.setupPrompt
+          assistantText = setupPrompt
+          barState?.isVoiceResponseActive = true
+          if !audioReceivedThisTurn {
+            speak(directedProvider.setupNeededStatus)
+          }
+          suppressAssistantOutputForCurrentTurn = true
+          log("RealtimeHub[\(providerTag)]: tool spawn_agent provider=\(directedProvider.rawValue) unavailable")
+          sendToolResultIfCurrent(
+            source: source, callId: callId, name: name,
+            output: setupPrompt)
+          return
+        }
+      }
       let model = ShortcutSettings.shared.selectedModel.isEmpty
         ? ModelQoS.Claude.defaultSelection : ShortcutSettings.shared.selectedModel
       // Non-blocking: spawn renders its own pill ("text bubble") and runs on its

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -69,6 +69,34 @@ enum HubTool: String {
 }
 
 enum RealtimeHubTools {
+  private static func localAgentProviderInstruction() -> String {
+    let providers: [AgentPillsManager.DirectedProvider] = [.openclaw, .hermes]
+    let availability = providers.map { LocalAgentProviderDetector.availability(for: $0) }
+    let available = availability.filter(\.isAvailable).map(\.provider)
+    let unavailable = availability.filter { !$0.isAvailable }
+
+    if unavailable.isEmpty {
+      return "If the user asks to use/ask OpenClaw or Hermes, call spawn_agent with provider set to \"openclaw\" or \"hermes\". Treat those as available local providers, not as sessions to inspect."
+    }
+
+    var parts: [String] = []
+    if !available.isEmpty {
+      let names = available.map { "\"\($0.rawValue)\"" }.joined(separator: " or ")
+      parts.append("If the user asks to use/ask \(available.map(\.displayName).joined(separator: " or ")), call spawn_agent with provider set to \(names).")
+    }
+    let missingText = unavailable
+      .map { "\($0.provider.displayName): \($0.setupPrompt)" }
+      .joined(separator: " ")
+    parts.append("If the user asks to use/ask an unavailable local provider, do NOT spawn a default agent. Say it needs setup and use this guidance: \(missingText)")
+    return parts.joined(separator: " ")
+  }
+
+  private static func availableDirectedProviderRawValues() -> [String] {
+    [AgentPillsManager.DirectedProvider.openclaw, .hermes]
+      .filter { LocalAgentProviderDetector.isAvailable($0) }
+      .map(\.rawValue)
+  }
+
   private static func currentCalendarContext(now: Date = Date(), timeZone: TimeZone = .current) -> String {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime, .withColonSeparatorInTimeZone]
@@ -184,8 +212,7 @@ enum RealtimeHubTools {
     user. So always emit the spawn_agent call. You may add one short natural sentence as you \
     call it, but never instead of it. Do NOT ask clarifying questions before spawning — spawn \
     with what you have. Do NOT wait for it, narrate its steps, refuse, or claim you can't.
-    - If the user asks to use/ask OpenClaw or Hermes, call spawn_agent with provider set to \
-    "openclaw" or "hermes". Treat those as available local providers, not as sessions to inspect.
+    - \(localAgentProviderInstruction())
     - Everything else — general questions, facts, chit-chat, explanations, advice, jokes, \
     and creative or long-form requests (stories, brainstorming, drafts): ANSWER YOURSELF. \
     You are fully capable; do it directly, even when the ask is long or open-ended. Do \
@@ -205,9 +232,37 @@ enum RealtimeHubTools {
     """
   }
 
-  /// OpenAI Realtime GA `session.tools` entries. Static `let` — built once, not rebuilt on
-  /// every session (re)connect that reads it.
-  static let openAITools: [[String: Any]] = [
+  /// OpenAI Realtime GA `session.tools` entries.
+  static var openAITools: [[String: Any]] {
+    openAITools(availableDirectedProviders: availableDirectedProviderRawValues())
+  }
+
+  static func openAITools(availableDirectedProviders: [String]) -> [[String: Any]] {
+    let providerProperty: [String: Any]? = availableDirectedProviders.isEmpty ? nil : [
+      "type": "string",
+      "enum": availableDirectedProviders,
+      "description": "Optional available local provider to run this background agent through.",
+    ]
+    return baseOpenAITools(providerProperty: providerProperty)
+  }
+
+  private static func baseOpenAITools(providerProperty: [String: Any]?) -> [[String: Any]] {
+    var spawnAgentProperties: [String: Any] = [
+      "brief": [
+        "type": "string", "description": "A clear, self-contained brief of the task.",
+      ],
+      "title": [
+        "type": "string",
+        "description":
+          "A short Title Case label for the task pill (≤ ~5 words, no trailing "
+          + "punctuation), e.g. 'Draft Launch Email'.",
+      ],
+    ]
+    if let providerProperty {
+      spawnAgentProperties["provider"] = providerProperty
+    }
+
+    return [
       [
         "type": "function",
         "name": HubTool.askHigherModel.rawValue,
@@ -557,22 +612,7 @@ enum RealtimeHubTools {
           + "schedule/automate something for them, or any multi-step work. Returns immediately; the agent works on its own.",
         "parameters": [
           "type": "object",
-          "properties": [
-            "brief": [
-              "type": "string", "description": "A clear, self-contained brief of the task.",
-            ],
-            "title": [
-              "type": "string",
-              "description":
-                "A short Title Case label for the task pill (≤ ~5 words, no trailing "
-                + "punctuation), e.g. 'Draft Launch Email'.",
-            ],
-            "provider": [
-              "type": "string",
-              "enum": ["openclaw", "hermes"],
-              "description": "Optional local provider to run this background agent through.",
-            ],
-          ],
+          "properties": spawnAgentProperties,
           "required": ["brief"],
         ],
       ],
@@ -595,11 +635,17 @@ enum RealtimeHubTools {
           "required": ["x", "y"],
         ],
       ],
-  ]
+    ]
+  }
 
   /// Gemini Live `setup.tools[0].functionDeclarations` entries (same surface). Derived once
   /// from `openAITools`.
-  static let geminiFunctionDeclarations: [[String: Any]] = openAITools.map { tool in
+  static var geminiFunctionDeclarations: [[String: Any]] {
+    geminiFunctionDeclarations(availableDirectedProviders: availableDirectedProviderRawValues())
+  }
+
+  static func geminiFunctionDeclarations(availableDirectedProviders: [String]) -> [[String: Any]] {
+    openAITools(availableDirectedProviders: availableDirectedProviders).map { tool in
       // Gemini wants {name, description, parameters} without the OpenAI "type" wrapper.
       var decl: [String: Any] = [
         "name": tool["name"] as? String ?? "",
@@ -613,6 +659,7 @@ enum RealtimeHubTools {
       }
       return decl
     }
+  }
 
   /// Recursively uppercase every `type` value in a JSON-schema dict so it matches Gemini's
   /// Schema enum (object → OBJECT, string → STRING, …).

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -63,3 +63,93 @@ enum AgentRuntimeRouting {
         }
     }
 }
+
+struct LocalAgentProviderAvailability: Equatable {
+    enum Status: Equatable {
+        case available(command: String)
+        case missing
+    }
+
+    let provider: AgentPillsManager.DirectedProvider
+    let status: Status
+
+    var isAvailable: Bool {
+        if case .available = status { return true }
+        return false
+    }
+
+    var setupPrompt: String {
+        switch provider {
+        case .hermes:
+            return "I don't see Hermes on your PATH. Install Hermes or set OMI_HERMES_ADAPTER_COMMAND."
+        case .openclaw:
+            return "I don't see OpenClaw on your PATH. Install OpenClaw or set OMI_OPENCLAW_ADAPTER_COMMAND."
+        }
+    }
+}
+
+enum LocalAgentProviderDetector {
+    static func availability(
+        for provider: AgentPillsManager.DirectedProvider,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> LocalAgentProviderAvailability {
+        if let command = configuredCommand(for: provider, environment: environment) {
+            return LocalAgentProviderAvailability(provider: provider, status: .available(command: command))
+        }
+
+        if let path = firstExecutable(
+            named: provider.executableName,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        ) {
+            return LocalAgentProviderAvailability(provider: provider, status: .available(command: path))
+        }
+
+        return LocalAgentProviderAvailability(provider: provider, status: .missing)
+    }
+
+    static func isAvailable(
+        _ provider: AgentPillsManager.DirectedProvider,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> Bool {
+        availability(for: provider, environment: environment, fileManager: fileManager, homeDirectory: homeDirectory).isAvailable
+    }
+
+    private static func configuredCommand(
+        for provider: AgentPillsManager.DirectedProvider,
+        environment: [String: String]
+    ) -> String? {
+        let key = provider.commandEnvironmentName
+        let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+
+    private static func firstExecutable(
+        named name: String,
+        fileManager: FileManager,
+        homeDirectory: String
+    ) -> String? {
+        for dir in adapterActivationSearchDirectories(homeDirectory: homeDirectory) {
+            let path = (dir as NSString).appendingPathComponent(name)
+            if fileManager.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    private static func adapterActivationSearchDirectories(homeDirectory: String) -> [String] {
+        [
+            "\(homeDirectory)/.hermes/hermes-agent/venv/bin",
+            "\(homeDirectory)/.hermes/node/bin",
+            "\(homeDirectory)/.hermes/hermes-agent",
+            "\(homeDirectory)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+        ]
+    }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -477,6 +477,12 @@ class ChatToolExecutor {
     default:
       return "Error: Unsupported provider '\(providerName)'. Supported providers: openclaw, hermes."
     }
+    if let directedProvider {
+      let availability = LocalAgentProviderDetector.availability(for: directedProvider)
+      guard availability.isAvailable else {
+        return availability.setupPrompt
+      }
+    }
     let model = ShortcutSettings.shared.selectedModel.isEmpty
       ? "claude-sonnet-4-6" : ShortcutSettings.shared.selectedModel
     let pill = AgentPillsManager.shared.spawnFromUserQuery(

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -44,6 +44,17 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("barWindow.state.chatHistory.reversed().compactMap"))
   }
 
+  func testTypedProviderDirectivePromptsForSetupWhenProviderUnavailable() throws {
+    let source = try floatingControlBarWindowSource()
+
+    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directive.provider)"))
+    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
+    XCTAssertTrue(source.contains("floating-agent-provider-unavailable"))
+    XCTAssertTrue(source.contains("completeVisibleAgentResponse("))
+    XCTAssertFalse(source.contains("completeVisibleProviderSetupPrompt("))
+    XCTAssertTrue(source.contains("FloatingBarVoicePlaybackService.shared.speakOneShot(directive.provider.setupNeededStatus)"))
+  }
+
   func testSubagentChatSpawnRequestCreatesSiblingAgent() throws {
     let source = try floatingControlBarViewSource()
     let agentPillSource = try agentPillSource()

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -30,6 +30,26 @@ final class HubSystemInstructionTests: XCTestCase {
         XCTAssertEqual(toolNames, Set(DesktopCapabilityRegistry.realtimeToolNames))
     }
 
+    func testRealtimeSpawnAgentProviderEnumOnlyAdvertisesAvailableProviders() {
+        let tools = RealtimeHubTools.openAITools(availableDirectedProviders: ["openclaw"])
+        let spawnAgent = tools.first { ($0["name"] as? String) == HubTool.spawnAgent.rawValue }
+        let parameters = spawnAgent?["parameters"] as? [String: Any]
+        let properties = parameters?["properties"] as? [String: Any]
+        let provider = properties?["provider"] as? [String: Any]
+
+        XCTAssertEqual(provider?["enum"] as? [String], ["openclaw"])
+    }
+
+    func testRealtimeSpawnAgentOmitsProviderWhenNoLocalProvidersAreAvailable() {
+        let tools = RealtimeHubTools.openAITools(availableDirectedProviders: [])
+        let spawnAgent = tools.first { ($0["name"] as? String) == HubTool.spawnAgent.rawValue }
+        let parameters = spawnAgent?["parameters"] as? [String: Any]
+        let properties = parameters?["properties"] as? [String: Any]
+
+        XCTAssertNil(properties?["provider"])
+        XCTAssertNotNil(properties?["brief"])
+    }
+
     func testRealtimeTaskAgentStatusToolIsExposed() {
         let tools = RealtimeHubTools.openAITools
         let statusTool = tools.first { ($0["name"] as? String) == HubTool.getTaskAgentStatus.rawValue }

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -44,6 +44,65 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertNil(AgentRuntimeRouting.harnessMode(from: "unknown"))
   }
 
+  func testLocalAgentProviderDetectorUsesExplicitCommand() {
+    let availability = LocalAgentProviderDetector.availability(
+      for: .hermes,
+      environment: ["OMI_HERMES_ADAPTER_COMMAND": " /usr/local/bin/hermes acp "],
+      homeDirectory: "/tmp/missing-home")
+
+    XCTAssertTrue(availability.isAvailable)
+    XCTAssertEqual(availability.status, .available(command: "/usr/local/bin/hermes acp"))
+  }
+
+  func testLocalAgentProviderDetectorFindsExecutableInActivationPath() throws {
+    let home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-provider-detector-\(UUID().uuidString)", isDirectory: true)
+    let bin = home.appendingPathComponent(".local/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let executable = bin.appendingPathComponent("openclaw")
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+    let availability = LocalAgentProviderDetector.availability(
+      for: .openclaw,
+      environment: [:],
+      homeDirectory: home.path)
+
+    XCTAssertEqual(availability.status, .available(command: executable.path))
+  }
+
+  func testLocalAgentProviderDetectorIgnoresArbitraryPathEntries() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-provider-path-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let executable = root.appendingPathComponent("hermes")
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+    let availability = LocalAgentProviderDetector.availability(
+      for: .hermes,
+      environment: ["PATH": root.path],
+      homeDirectory: "/tmp/missing-home")
+
+    XCTAssertFalse(availability.isAvailable)
+  }
+
+  func testLocalAgentProviderDetectorMissingPromptIsUserFacing() {
+    let availability = LocalAgentProviderDetector.availability(
+      for: .openclaw,
+      environment: ["PATH": "/tmp/definitely-missing-\(UUID().uuidString)"],
+      homeDirectory: "/tmp/missing-home")
+
+    XCTAssertFalse(availability.isAvailable)
+    XCTAssertEqual(
+      availability.setupPrompt,
+      "I don't see OpenClaw on your PATH. Install OpenClaw or set OMI_OPENCLAW_ADAPTER_COMMAND.")
+  }
+
   // MARK: - ApiKeysResponse shape assertion
   // After #6594, the response must NOT contain anthropic_api_key.
 

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -22,6 +22,21 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("speak(ack)"))
   }
 
+  func testSpawnAgentPreflightsDirectedProviderAvailability() throws {
+    let source = try realtimeHubControllerSource()
+
+    XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directedProvider)"))
+    XCTAssertTrue(source.contains("guard availability.isAvailable else"))
+    XCTAssertTrue(source.contains("assistantText = setupPrompt"))
+    XCTAssertTrue(source.contains("output: setupPrompt"))
+    XCTAssertTrue(source.contains("""
+          sendToolResultIfCurrent(
+            source: source, callId: callId, name: name,
+            output: setupPrompt)
+          return
+"""))
+  }
+
   func testCanonicalAgentControlSummariesDoNotSpeakOpaqueIds() throws {
     let source = try agentControlServiceSource()
 

--- a/desktop/macos/changelog/unreleased/20260629-agent-provider-availability.json
+++ b/desktop/macos/changelog/unreleased/20260629-agent-provider-availability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved OpenClaw and Hermes agent handoff so unavailable local providers prompt for setup instead of creating failed pills"
+}


### PR DESCRIPTION
## Summary
- detect local Hermes/OpenClaw availability from configured adapter commands or executable search paths
- preflight typed floating-bar and realtime/notch directed provider invocations so unavailable providers show setup guidance instead of failed pills
- filter realtime spawn_agent provider schema/instructions to advertise only available directed providers

## Tests
- ./scripts/agent-logic-harness.sh

## Notes
- On this Mac, both Hermes and OpenClaw are currently detected, so missing-provider behavior is covered by injected-environment unit tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

