### PR TITLE
Fix MCP OAuth email login

### DIFF
--- a/backend/templates/_oauth_shared_styles.html
+++ b/backend/templates/_oauth_shared_styles.html
@@ -1,0 +1,848 @@
+<style>
+    :root {
+        color-scheme: light dark;
+
+        /* Surfaces */
+        --bg-base: #f1f1ee;
+        --bg-glow: rgba(255, 255, 255, 0.9);
+        --surface: #ffffff;
+        --surface-muted: #fafaf8;
+        --surface-sunken: #f3f3f0;
+        --tile: #f0f0ec;
+
+        /* Text */
+        --text: #131312;
+        --muted: #67675f;
+        --faint: #8c8c84;
+
+        /* Lines */
+        --border: #e7e7e1;
+        --border-strong: #d6d6ce;
+        --line: #d7d7cf;
+
+        /* Accents */
+        --btn-bg: #131312;
+        --btn-bg-hover: #2c2c2a;
+        --btn-fg: #ffffff;
+        --brand-tile-bg: #131312;
+        --brand-tile-fg: #ffffff;
+        --provider-bg: #ffffff;
+        --provider-fg: #131312;
+        --provider-bg-hover: #f5f5f1;
+
+        /* Feedback */
+        --ring: rgba(19, 19, 18, 0.14);
+        --danger: #b3261e;
+        --danger-bg: #fdf3f1;
+        --danger-border: rgba(179, 38, 30, 0.26);
+        --success: #15803d;
+        --success-bg: rgba(21, 128, 61, 0.1);
+        --scroll-shadow: rgba(19, 19, 18, 0.1);
+
+        --radius-card: 18px;
+        --radius: 12px;
+        --radius-sm: 10px;
+        --shadow: 0 1px 2px rgba(17, 17, 17, 0.04), 0 24px 60px -20px rgba(17, 17, 17, 0.22);
+        --shadow-tile: 0 1px 2px rgba(17, 17, 17, 0.05);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --bg-base: #0b0b0c;
+            --bg-glow: rgba(255, 255, 255, 0.045);
+            --surface: #161618;
+            --surface-muted: #1b1b1e;
+            --surface-sunken: #202024;
+            --tile: #232327;
+
+            --text: #f4f4f1;
+            --muted: #a4a49e;
+            --faint: #7c7c76;
+
+            --border: #2a2a2e;
+            --border-strong: #3b3b41;
+            --line: #34343a;
+
+            --btn-bg: #f4f4f1;
+            --btn-bg-hover: #e3e3dd;
+            --btn-fg: #131312;
+            --brand-tile-bg: #f4f4f1;
+            --brand-tile-fg: #131312;
+            --provider-bg: #232327;
+            --provider-fg: #f4f4f1;
+            --provider-bg-hover: #2b2b30;
+
+            --ring: rgba(255, 255, 255, 0.22);
+            --danger: #ff7a6e;
+            --danger-bg: rgba(255, 122, 110, 0.1);
+            --danger-border: rgba(255, 122, 110, 0.3);
+            --success: #4ade80;
+            --success-bg: rgba(74, 222, 128, 0.12);
+            --scroll-shadow: rgba(0, 0, 0, 0.55);
+
+            --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 30px 70px -24px rgba(0, 0, 0, 0.7);
+            --shadow-tile: 0 1px 2px rgba(0, 0, 0, 0.4);
+        }
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    /* The hidden attribute must win over component display rules
+       (e.g. .consent-retry { display: grid }) so the consent button
+       stays hidden until the user has signed in. */
+    [hidden] {
+        display: none !important;
+    }
+
+    html {
+        -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+        margin: 0;
+        min-height: 100vh;
+        min-height: 100dvh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 20px;
+        background:
+            radial-gradient(120% 80% at 50% -10%, var(--bg-glow), transparent 60%),
+            var(--bg-base);
+        color: var(--text);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+    }
+
+    .oauth-shell {
+        width: min(100%, 440px);
+    }
+
+    .oauth-card {
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-card);
+        background: var(--surface);
+        box-shadow: var(--shadow);
+    }
+
+    /* ---- Header ---- */
+    .oauth-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 16px 22px;
+        border-bottom: 1px solid var(--border);
+        background: var(--surface-muted);
+    }
+
+    .omi-logo {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--text);
+        font-size: 15px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .omi-logo .omi-mark {
+        width: 22px;
+        height: 22px;
+    }
+
+    .oauth-eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+    }
+
+    .oauth-eyebrow svg {
+        width: 13px;
+        height: 13px;
+        opacity: 0.85;
+    }
+
+    /* ---- Content ---- */
+    .oauth-content {
+        padding: 30px 26px 26px;
+    }
+
+    /* ---- Connection lockup hero ---- */
+    .oauth-hero {
+        text-align: center;
+        margin-bottom: 26px;
+    }
+
+    .connect-lockup {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 2px auto 22px;
+    }
+
+    .lockup-tile {
+        width: 60px;
+        height: 60px;
+        flex: 0 0 60px;
+        display: grid;
+        place-items: center;
+        border-radius: 16px;
+        font-size: 24px;
+        font-weight: 700;
+        overflow: hidden;
+        box-shadow: var(--shadow-tile);
+    }
+
+    .lockup-app {
+        border: 1px solid var(--border-strong);
+        background: var(--tile);
+        color: var(--text);
+    }
+
+    .lockup-app img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+    }
+
+    .lockup-omi {
+        background: var(--brand-tile-bg);
+        color: var(--brand-tile-fg);
+        border: 1px solid transparent;
+    }
+
+    .lockup-omi .omi-mark {
+        width: 30px;
+        height: 30px;
+    }
+
+    .lockup-bridge {
+        position: relative;
+        flex: 0 0 64px;
+        height: 60px;
+        display: grid;
+        place-items: center;
+    }
+
+    .lockup-bridge::before {
+        content: "";
+        position: absolute;
+        left: 4px;
+        right: 4px;
+        top: 50%;
+        transform: translateY(-50%);
+        border-top: 2px dashed var(--line);
+    }
+
+    .lockup-bridge-badge {
+        position: relative;
+        width: 30px;
+        height: 30px;
+        display: grid;
+        place-items: center;
+        border-radius: 999px;
+        background: var(--surface);
+        border: 1px solid var(--border-strong);
+        color: var(--muted);
+        box-shadow: var(--shadow-tile);
+    }
+
+    .lockup-bridge-badge svg {
+        width: 15px;
+        height: 15px;
+    }
+
+    h1 {
+        margin: 0;
+        color: var(--text);
+        font-size: clamp(22px, 5vw, 27px);
+        font-weight: 700;
+        line-height: 1.15;
+        letter-spacing: -0.02em;
+    }
+
+    .oauth-subtitle {
+        margin: 9px auto 0;
+        max-width: 34ch;
+        color: var(--muted);
+        font-size: 15px;
+        line-height: 1.5;
+    }
+
+    .oauth-subtitle strong {
+        color: var(--text);
+        font-weight: 650;
+    }
+
+    /* ---- Permissions ---- */
+    .permissions-card {
+        margin: 0 0 22px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--surface-muted);
+        overflow: hidden;
+    }
+
+    .permissions-title {
+        margin: 0;
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+
+    .permissions-list {
+        max-height: min(340px, 38vh);
+        overflow: auto;
+        overscroll-behavior: contain;
+        list-style: none;
+        padding: 6px;
+        margin: 0;
+        /* Scroll shadows: top/bottom cues appear only when the list overflows
+           (broad ChatGPT scopes), so users know to scroll for more. */
+        background:
+            linear-gradient(var(--surface-muted) 30%, rgba(0, 0, 0, 0)) center top,
+            linear-gradient(rgba(0, 0, 0, 0), var(--surface-muted) 70%) center bottom,
+            radial-gradient(farthest-side at 50% 0, var(--scroll-shadow), rgba(0, 0, 0, 0)) center top,
+            radial-gradient(farthest-side at 50% 100%, var(--scroll-shadow), rgba(0, 0, 0, 0)) center bottom;
+        background-repeat: no-repeat;
+        background-size: 100% 28px, 100% 28px, 100% 12px, 100% 12px;
+        background-attachment: local, local, scroll, scroll;
+    }
+
+    .permissions-list li {
+        display: flex;
+        align-items: flex-start;
+        gap: 11px;
+        padding: 10px;
+        color: var(--text);
+        font-size: 14px;
+        line-height: 1.45;
+    }
+
+    .permissions-list li + li {
+        border-top: 1px solid var(--border);
+    }
+
+    .perm-check {
+        width: 20px;
+        height: 20px;
+        flex: 0 0 20px;
+        margin-top: 1px;
+        display: inline-grid;
+        place-items: center;
+        border-radius: 999px;
+        background: var(--success-bg);
+        color: var(--success);
+    }
+
+    .perm-check svg {
+        width: 12px;
+        height: 12px;
+    }
+
+    /* Legacy fallback dot (kept for safety; not used in current markup) */
+    .permission-dot {
+        width: 20px;
+        height: 20px;
+        flex: 0 0 20px;
+        display: inline-grid;
+        place-items: center;
+        border-radius: 999px;
+        background: var(--success-bg);
+        color: var(--success);
+    }
+
+    .permission-dot::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 999px;
+        background: currentColor;
+    }
+
+    /* ---- Actions ---- */
+    .oauth-actions {
+        display: grid;
+        gap: 14px;
+    }
+
+    .email-sign-in-form {
+        display: grid;
+        gap: 14px;
+    }
+
+    .oauth-field {
+        display: grid;
+        gap: 6px;
+    }
+
+    .oauth-field label {
+        color: var(--text);
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .oauth-field input {
+        width: 100%;
+        min-height: 48px;
+        padding: 12px 14px;
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--text);
+        font: inherit;
+        font-size: 16px;
+        line-height: 1.3;
+        transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+
+    .oauth-field input::placeholder {
+        color: var(--faint);
+    }
+
+    .oauth-field input:focus {
+        border-color: var(--text);
+        box-shadow: 0 0 0 3px var(--ring);
+        outline: none;
+    }
+
+    .oauth-field input:disabled,
+    .email-sign-in-button:disabled,
+    .connect-button:disabled {
+        cursor: not-allowed;
+        opacity: 0.55;
+    }
+
+    .btn-primary,
+    .email-sign-in-button,
+    .connect-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        width: 100%;
+        min-height: 50px;
+        border: 0;
+        border-radius: var(--radius-sm);
+        background: var(--btn-bg);
+        color: var(--btn-fg);
+        font-size: 15px;
+        font-weight: 650;
+        letter-spacing: -0.01em;
+        cursor: pointer;
+        transition: transform 120ms ease, background 120ms ease, opacity 120ms ease;
+    }
+
+    .email-sign-in-button:hover:not(:disabled),
+    .connect-button:hover:not(:disabled) {
+        background: var(--btn-bg-hover);
+    }
+
+    .email-sign-in-button:active:not(:disabled),
+    .connect-button:active:not(:disabled) {
+        transform: translateY(1px);
+    }
+
+    .oauth-divider {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        color: var(--faint);
+        font-size: 11px;
+        font-weight: 650;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .oauth-divider::before,
+    .oauth-divider::after {
+        content: "";
+        height: 1px;
+        flex: 1;
+        background: var(--border);
+    }
+
+    /* ---- Signed-in identity (consent retry state) ---- */
+    .consent-retry {
+        display: grid;
+        gap: 12px;
+    }
+
+    .signed-in-chip {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-muted);
+        font-size: 13px;
+        color: var(--muted);
+    }
+
+    .signed-in-chip .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 999px;
+        background: var(--success);
+        flex: 0 0 auto;
+    }
+
+    /* ---- Loader / error ---- */
+    .loader,
+    .error {
+        display: none;
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-size: 14px;
+        line-height: 1.45;
+    }
+
+    .loader {
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        background: var(--surface-sunken);
+        color: var(--muted);
+        text-align: center;
+    }
+
+    .loader.is-visible {
+        display: flex;
+    }
+
+    .spinner {
+        width: 16px;
+        height: 16px;
+        border-radius: 999px;
+        border: 2px solid var(--border-strong);
+        border-top-color: var(--text);
+        animation: oauth-spin 720ms linear infinite;
+        flex: 0 0 auto;
+    }
+
+    @keyframes oauth-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+
+    .error {
+        align-items: flex-start;
+        gap: 9px;
+        border: 1px solid var(--danger-border);
+        background: var(--danger-bg);
+        color: var(--danger);
+        font-weight: 500;
+        text-align: left;
+    }
+
+    .error.is-visible {
+        display: flex;
+    }
+
+    .error svg {
+        width: 16px;
+        height: 16px;
+        flex: 0 0 16px;
+        margin-top: 1px;
+    }
+
+    /* ---- Footer ---- */
+    .oauth-footer {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 16px 22px;
+        border-top: 1px solid var(--border);
+        background: var(--surface-muted);
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.5;
+    }
+
+    .oauth-footer svg {
+        width: 15px;
+        height: 15px;
+        flex: 0 0 15px;
+        margin-top: 1px;
+        opacity: 0.85;
+    }
+
+    .oauth-footer a {
+        color: var(--text);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        text-decoration-color: var(--border-strong);
+    }
+
+    .oauth-footer a:hover {
+        text-decoration-color: var(--text);
+    }
+
+    .oauth-footer strong {
+        color: var(--text);
+        font-weight: 650;
+    }
+
+    /* ---- Focus visibility ---- */
+    :focus-visible {
+        outline: 2px solid var(--text);
+        outline-offset: 2px;
+        border-radius: 4px;
+    }
+
+    button:focus-visible {
+        outline-offset: 3px;
+    }
+
+    /* =========================================================
+       FirebaseUI overrides — map FirebaseUI's MDL DOM onto the
+       Omi design system. Kept aligned with the native components
+       above so provider buttons / email forms look identical.
+       ========================================================= */
+    #firebaseui-auth-container {
+        min-height: 0;
+    }
+
+    #firebaseui-auth-container .mdl-card,
+    #firebaseui-auth-container .firebaseui-container {
+        width: 100% !important;
+        max-width: none !important;
+        min-width: 0 !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        border-radius: 0 !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        color: var(--text) !important;
+        font-family: inherit !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-card-header,
+    #firebaseui-auth-container .firebaseui-title,
+    #firebaseui-auth-container .firebaseui-subtitle,
+    #firebaseui-auth-container .firebaseui-tos {
+        display: none !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-card-content,
+    #firebaseui-auth-container .firebaseui-card-actions {
+        width: 100% !important;
+        max-width: none !important;
+        padding: 0 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-list-item {
+        margin: 0 0 10px !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-idp-list {
+        list-style: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-idp-button {
+        width: 100% !important;
+        max-width: none !important;
+        min-height: 50px !important;
+        margin: 0 !important;
+        padding: 0 16px !important;
+        border: 1px solid var(--border-strong) !important;
+        border-radius: var(--radius-sm) !important;
+        background: var(--provider-bg) !important;
+        color: var(--provider-fg) !important;
+        box-shadow: none !important;
+        text-align: center !important;
+        transition: background 120ms ease !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-idp-button:hover {
+        background: var(--provider-bg-hover) !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-idp-text,
+    #firebaseui-auth-container .firebaseui-idp-text-long {
+        color: var(--provider-fg) !important;
+        font-size: 15px !important;
+        font-weight: 600 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-idp-icon-wrapper {
+        left: 16px !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-textfield {
+        width: 100% !important;
+        margin: 0 0 18px !important;
+        padding: 0 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-textfield.mdl-textfield {
+        display: block !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-textfield input {
+        width: 100% !important;
+        height: 48px !important;
+        padding: 12px 14px !important;
+        border: 1px solid var(--border-strong) !important;
+        border-radius: var(--radius-sm) !important;
+        background: var(--surface) !important;
+        color: var(--text) !important;
+        font-family: inherit !important;
+        font-size: 16px !important;
+        line-height: 1.3 !important;
+        box-sizing: border-box !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-textfield input:focus {
+        border-color: var(--text) !important;
+        box-shadow: 0 0 0 3px var(--ring) !important;
+        outline: none !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-label {
+        top: -18px !important;
+        color: var(--text) !important;
+        font-family: inherit !important;
+        font-size: 13px !important;
+        font-weight: 600 !important;
+    }
+
+    #firebaseui-auth-container .mdl-textfield__label::after {
+        display: none !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-input,
+    #firebaseui-auth-container .mdl-textfield__input {
+        border-bottom: 0 !important;
+        color: var(--text) !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-form-actions {
+        display: flex !important;
+        align-items: center !important;
+        justify-content: flex-end !important;
+        gap: 12px !important;
+        width: 100% !important;
+        margin: 18px 0 0 !important;
+        padding: 0 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-button {
+        min-width: 0 !important;
+        height: 46px !important;
+        margin: 0 !important;
+        padding: 0 18px !important;
+        border-radius: var(--radius-sm) !important;
+        box-shadow: none !important;
+        font-family: inherit !important;
+        font-size: 14px !important;
+        font-weight: 650 !important;
+        letter-spacing: 0 !important;
+        text-transform: none !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-id-submit {
+        background: var(--btn-bg) !important;
+        color: var(--btn-fg) !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-id-secondary-link,
+    #firebaseui-auth-container .firebaseui-link {
+        color: var(--text) !important;
+        font-weight: 600 !important;
+        text-decoration: underline !important;
+        text-underline-offset: 2px !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-error {
+        color: var(--danger) !important;
+        font-size: 13px !important;
+        line-height: 1.4 !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-info-bar {
+        margin: 0 0 14px !important;
+        padding: 10px 14px !important;
+        border: 1px solid var(--border) !important;
+        border-radius: var(--radius-sm) !important;
+        background: var(--surface-sunken) !important;
+        color: var(--muted) !important;
+        box-shadow: none !important;
+    }
+
+    #firebaseui-auth-container .firebaseui-info-bar-message {
+        color: var(--muted) !important;
+        font-family: inherit !important;
+        font-size: 13px !important;
+    }
+
+    #firebaseui-auth-container .mdl-progress > .progressbar {
+        background-color: var(--text) !important;
+    }
+
+    /* ---- Responsive ---- */
+    @media (max-width: 480px) {
+        body {
+            align-items: flex-start;
+            padding: 0;
+            background: var(--surface);
+        }
+
+        .oauth-shell {
+            width: 100%;
+            min-height: 100dvh;
+        }
+
+        .oauth-card {
+            min-height: 100dvh;
+            border: 0;
+            border-radius: 0;
+            box-shadow: none;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .oauth-header {
+            background: var(--surface);
+        }
+
+        .oauth-content {
+            flex: 1;
+            padding: 28px 20px 24px;
+        }
+
+        .oauth-footer {
+            background: var(--surface);
+        }
+
+        .permissions-list {
+            max-height: none;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        * {
+            animation-duration: 0.001ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.001ms !important;
+        }
+    }
+</style>

--- a/backend/templates/mcp_oauth_authorize.html
+++ b/backend/templates/mcp_oauth_authorize.html
@@ -9,104 +9,141 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/ui/6.0.1/firebase-ui-auth.js"></script>
     <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/6.0.1/firebase-ui-auth.css" />
-    <style>
-        body {
-            margin: 0;
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: #f7f7f7;
-            color: #222;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        }
-
-        .card {
-            width: min(480px, calc(100vw - 32px));
-            background: #fff;
-            border: 1px solid #e8e8e8;
-            border-radius: 8px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-            overflow: hidden;
-        }
-
-        .header {
-            padding: 18px 24px;
-            border-bottom: 1px solid #eee;
-            font-weight: 650;
-        }
-
-        .content {
-            padding: 28px 24px;
-        }
-
-        h1 {
-            margin: 0 0 8px 0;
-            font-size: 24px;
-            line-height: 1.25;
-        }
-
-        p {
-            margin: 0 0 20px 0;
-            color: #555;
-            line-height: 1.45;
-        }
-
-        ul {
-            padding: 0;
-            margin: 0 0 24px 0;
-            list-style: none;
-            border-top: 1px solid #eee;
-        }
-
-        li {
-            padding: 12px 0;
-            border-bottom: 1px solid #eee;
-            color: #333;
-            font-size: 14px;
-        }
-
-        button {
-            width: 100%;
-            border: 0;
-            border-radius: 8px;
-            background: #111;
-            color: #fff;
-            font-weight: 650;
-            font-size: 15px;
-            padding: 12px 14px;
-            cursor: pointer;
-        }
-
-        #firebaseui-auth-container {
-            margin-top: 20px;
-        }
-
-        .error {
-            margin-top: 12px;
-            color: #b00020;
-            font-size: 14px;
-        }
-    </style>
+    {% include "_oauth_shared_styles.html" %}
 </head>
 
 <body>
-    <div class="card">
-        <div class="header">Omi</div>
-        <div class="content">
-            <h1>Connect ChatGPT</h1>
-            <p>ChatGPT wants to connect to your Omi account.</p>
-            <ul>
-                {% for permission in permissions %}
-                <li>{{ permission }}</li>
-                {% endfor %}
-            </ul>
-            <div id="firebaseui-auth-container"></div>
-            <button id="connect-button" style="display:none;">Connect</button>
-            <div id="loader" style="display:none;">Loading...</div>
-            <div id="error-message" class="error"></div>
+    <main class="oauth-shell">
+        <div class="oauth-card">
+            <div class="oauth-header">
+                <span class="omi-logo">
+                    <svg class="omi-mark" viewBox="237.36 237.338 549.318 549.322" fill="currentColor"
+                        aria-hidden="true">
+                        <circle cx="282.523" cy="511.982" r="45.163" />
+                        <circle cx="339.909" cy="339.89" r="45.107" />
+                        <circle cx="512.014" cy="282.495" r="45.156" />
+                        <circle cx="684.096" cy="339.88" r="45.103" />
+                        <circle cx="741.511" cy="512.003" r="45.167" />
+                        <circle cx="684.096" cy="684.094" r="45.103" />
+                        <circle cx="511.981" cy="741.5" r="45.16" />
+                        <circle cx="339.902" cy="684.107" r="45.103" />
+                    </svg>
+                    Omi
+                </span>
+                <span class="oauth-eyebrow">
+                    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <rect x="5" y="10.5" width="14" height="9" rx="2" stroke="currentColor" stroke-width="1.8" />
+                        <path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" stroke="currentColor" stroke-width="1.8"
+                            stroke-linecap="round" />
+                    </svg>
+                    Secure connection
+                </span>
+            </div>
+            <div class="oauth-content">
+                <div class="oauth-hero">
+                    <div class="connect-lockup" aria-hidden="true">
+                        <span class="lockup-tile lockup-app">C</span>
+                        <span class="lockup-bridge">
+                            <span class="lockup-bridge-badge">
+                                <svg viewBox="0 0 24 24" fill="none">
+                                    <path d="M10.5 13.5a3.4 3.4 0 0 0 4.8 0l2-2a3.4 3.4 0 0 0-4.8-4.8l-1 1"
+                                        stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+                                        stroke-linejoin="round" />
+                                    <path d="M13.5 10.5a3.4 3.4 0 0 0-4.8 0l-2 2a3.4 3.4 0 0 0 4.8 4.8l1-1"
+                                        stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+                                        stroke-linejoin="round" />
+                                </svg>
+                            </span>
+                        </span>
+                        <span class="lockup-tile lockup-omi">
+                            <svg class="omi-mark" viewBox="237.36 237.338 549.318 549.322" fill="currentColor">
+                                <circle cx="282.523" cy="511.982" r="45.163" />
+                                <circle cx="339.909" cy="339.89" r="45.107" />
+                                <circle cx="512.014" cy="282.495" r="45.156" />
+                                <circle cx="684.096" cy="339.88" r="45.103" />
+                                <circle cx="741.511" cy="512.003" r="45.167" />
+                                <circle cx="684.096" cy="684.094" r="45.103" />
+                                <circle cx="511.981" cy="741.5" r="45.16" />
+                                <circle cx="339.902" cy="684.107" r="45.103" />
+                            </svg>
+                        </span>
+                    </div>
+                    <h1>Connect ChatGPT</h1>
+                    <p class="oauth-subtitle">Sign in to review what <strong>ChatGPT</strong> can access and allow the
+                        connection to your Omi account.</p>
+                </div>
+
+                <section class="permissions-card" aria-labelledby="permissions-title">
+                    <p class="permissions-title" id="permissions-title">ChatGPT will be able to</p>
+                    <ul class="permissions-list" tabindex="0" role="list" aria-labelledby="permissions-title">
+                        {% for permission in permissions %}
+                        <li>
+                            <span class="perm-check" aria-hidden="true">
+                                <svg viewBox="0 0 16 16" fill="none">
+                                    <path d="M3.5 8.5 6.5 11.5 12.5 4.5" stroke="currentColor" stroke-width="2"
+                                        stroke-linecap="round" stroke-linejoin="round" />
+                                </svg>
+                            </span>
+                            <span>{{ permission }}</span>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </section>
+
+                <div class="oauth-actions">
+                    <form class="email-sign-in-form" id="email-sign-in-form" novalidate>
+                        <div class="oauth-field">
+                            <label for="email-input">Email</label>
+                            <input id="email-input" name="email" type="email" autocomplete="email"
+                                autocapitalize="none" autocorrect="off" spellcheck="false" inputmode="email"
+                                placeholder="you@example.com" required>
+                        </div>
+                        <div class="oauth-field">
+                            <label for="password-input">Password</label>
+                            <input id="password-input" name="password" type="password" autocomplete="current-password"
+                                placeholder="••••••••" required>
+                        </div>
+                        <button class="email-sign-in-button" id="email-sign-in-button" type="submit">
+                            Sign in &amp; allow access
+                        </button>
+                    </form>
+                    <div class="oauth-divider" id="social-sign-in-divider">or continue with</div>
+                    <div id="firebaseui-auth-container"></div>
+
+                    <div class="consent-retry" id="consent-retry" hidden>
+                        <div class="signed-in-chip" id="signed-in-chip">
+                            <span class="dot" aria-hidden="true"></span>
+                            <span id="signed-in-label">You're signed in</span>
+                        </div>
+                        <button class="connect-button" id="connect-button">Allow access</button>
+                    </div>
+
+                    <div class="loader" id="loader" role="status" aria-live="polite">
+                        <span class="spinner" aria-hidden="true"></span>
+                        <span>Connecting…</span>
+                    </div>
+                    <div id="error-message" class="error" role="alert">
+                        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                            <circle cx="8" cy="8" r="6.6" stroke="currentColor" stroke-width="1.5" />
+                            <path d="M8 4.6v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                            <circle cx="8" cy="11" r="0.9" fill="currentColor" />
+                        </svg>
+                        <span id="error-text"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="oauth-footer">
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 3 5 6v5c0 4.2 2.9 7.6 7 9 4.1-1.4 7-4.8 7-9V6l-7-3Z" stroke="currentColor"
+                        stroke-width="1.7" stroke-linejoin="round" />
+                    <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"
+                        stroke-linejoin="round" />
+                </svg>
+                <span>Only continue if you trust <strong>ChatGPT</strong> with the Omi data shown above. You can revoke
+                    access anytime from your Omi settings.</span>
+            </div>
         </div>
-    </div>
+    </main>
 
     <script>
         const oauthParams = {{ oauth_params | tojson }};
@@ -114,20 +151,69 @@
         firebase.initializeApp(firebaseConfig);
 
         let idToken = null;
-        const signInOptions = [firebase.auth.EmailAuthProvider.PROVIDER_ID, firebase.auth.GoogleAuthProvider.PROVIDER_ID];
+        let signedInEmail = null;
+        const emailSignInForm = document.getElementById('email-sign-in-form');
+        const emailInput = document.getElementById('email-input');
+        const passwordInput = document.getElementById('password-input');
+        const emailSignInButton = document.getElementById('email-sign-in-button');
+        const socialSignInDivider = document.getElementById('social-sign-in-divider');
+        const firebaseUiContainer = document.getElementById('firebaseui-auth-container');
+        const consentRetry = document.getElementById('consent-retry');
+        const connectButton = document.getElementById('connect-button');
+        const signedInLabel = document.getElementById('signed-in-label');
+        const loader = document.getElementById('loader');
+        const errorMessage = document.getElementById('error-message');
+        const errorText = document.getElementById('error-text');
+        const signInOptions = [firebase.auth.GoogleAuthProvider.PROVIDER_ID];
         if (/Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
             signInOptions.push('apple.com');
         }
 
+        function setLoading(isLoading) {
+            loader.classList.toggle('is-visible', isLoading);
+            emailInput.disabled = isLoading;
+            passwordInput.disabled = isLoading;
+            emailSignInButton.disabled = isLoading;
+            connectButton.disabled = isLoading;
+        }
+
+        function clearError() {
+            errorText.textContent = '';
+            errorMessage.classList.remove('is-visible');
+        }
+
+        function showConsentRetry() {
+            if (signedInEmail) {
+                signedInLabel.textContent = 'Signed in as ' + signedInEmail;
+            }
+            consentRetry.hidden = false;
+        }
+
         function showError(error) {
-            document.getElementById('error-message').textContent = error.message || String(error);
-            document.getElementById('loader').style.display = 'none';
-            document.getElementById('connect-button').style.display = idToken ? 'block' : 'none';
+            errorText.textContent = error.message || String(error);
+            errorMessage.classList.add('is-visible');
+            setLoading(false);
+            if (idToken) {
+                showConsentRetry();
+            } else {
+                consentRetry.hidden = true;
+            }
+        }
+
+        function showSignInError() {
+            showError(new Error('We could not sign in with that email and password. Check the credentials and try again.'));
+        }
+
+        function hideSignInOptions() {
+            emailSignInForm.style.display = 'none';
+            socialSignInDivider.style.display = 'none';
+            firebaseUiContainer.style.display = 'none';
         }
 
         function submitConsent() {
-            document.getElementById('loader').style.display = 'block';
-            document.getElementById('connect-button').style.display = 'none';
+            clearError();
+            setLoading(true);
+            consentRetry.hidden = true;
             const formData = new FormData();
             Object.entries(oauthParams).forEach(([key, value]) => formData.append(key, value));
             formData.append('firebase_id_token', idToken);
@@ -157,27 +243,53 @@
                 .catch(showError);
         }
 
-        document.getElementById('connect-button').addEventListener('click', submitConsent);
+        function finishSignIn(user) {
+            setLoading(true);
+            clearError();
+            signedInEmail = user.email || null;
+            user.getIdToken().then(function (token) {
+                idToken = token;
+                hideSignInOptions();
+                submitConsent();
+            }).catch(showError);
+        }
+
+        emailSignInForm.addEventListener('submit', function (event) {
+            event.preventDefault();
+            clearError();
+
+            if (!emailInput.value.trim() || !passwordInput.value) {
+                showError(new Error('Enter the review email and password to continue.'));
+                return;
+            }
+
+            setLoading(true);
+            firebase.auth()
+                .signInWithEmailAndPassword(emailInput.value.trim(), passwordInput.value)
+                .then(function (result) {
+                    finishSignIn(result.user);
+                })
+                .catch(function () {
+                    passwordInput.value = '';
+                    showSignInError();
+                });
+        });
+
+        connectButton.addEventListener('click', submitConsent);
         const ui = new firebaseui.auth.AuthUI(firebase.auth());
         ui.start('#firebaseui-auth-container', {
             signInFlow: 'popup',
             signInOptions: signInOptions,
             callbacks: {
                 signInSuccessWithAuthResult: function (authResult) {
-                    document.getElementById('loader').style.display = 'block';
-                    authResult.user.getIdToken().then(function (token) {
-                        idToken = token;
-                        document.getElementById('firebaseui-auth-container').style.display = 'none';
-                        document.getElementById('connect-button').style.display = 'block';
-                        document.getElementById('loader').style.display = 'none';
-                    }).catch(showError);
+                    finishSignIn(authResult.user);
                     return false;
                 },
                 signInFailure: function (error) {
                     showError(error);
                 },
                 uiShown: function () {
-                    document.getElementById('loader').style.display = 'none';
+                    setLoading(false);
                 }
             }
         });

--- a/backend/templates/mcp_oauth_authorize.html
+++ b/backend/templates/mcp_oauth_authorize.html
@@ -243,14 +243,19 @@
                 .catch(showError);
         }
 
-        function finishSignIn(user) {
+        function finishSignIn(user, autoSubmitConsent) {
             setLoading(true);
             clearError();
             signedInEmail = user.email || null;
             user.getIdToken().then(function (token) {
                 idToken = token;
                 hideSignInOptions();
-                submitConsent();
+                if (autoSubmitConsent) {
+                    submitConsent();
+                    return;
+                }
+                setLoading(false);
+                showConsentRetry();
             }).catch(showError);
         }
 
@@ -267,7 +272,7 @@
             firebase.auth()
                 .signInWithEmailAndPassword(emailInput.value.trim(), passwordInput.value)
                 .then(function (result) {
-                    finishSignIn(result.user);
+                    finishSignIn(result.user, true);
                 })
                 .catch(function () {
                     passwordInput.value = '';
@@ -282,7 +287,7 @@
             signInOptions: signInOptions,
             callbacks: {
                 signInSuccessWithAuthResult: function (authResult) {
-                    finishSignIn(authResult.user);
+                    finishSignIn(authResult.user, false);
                     return false;
                 },
                 signInFailure: function (error) {

--- a/backend/templates/oauth_authenticate.html
+++ b/backend/templates/oauth_authenticate.html
@@ -4,197 +4,131 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Omi</title>
+    <title>Connect {{ app_name }} to Omi</title>
     <!-- Include Firebase SDKs -->
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
     <!-- Include FirebaseUI for easy login UI, or use custom Firebase auth calls -->
     <script src="https://www.gstatic.com/firebasejs/ui/6.0.1/firebase-ui-auth.js"></script>
     <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/6.0.1/firebase-ui-auth.css" />
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
-            margin: 0;
-            background-color: #f7f7f7;
-            color: #333;
-        }
-
-        .oauth-card {
-            background-color: white;
-            border-radius: 8px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-            width: 100%;
-            max-width: 480px;
-            margin: 20px;
-            overflow: hidden;
-        }
-
-        .card-header {
-            padding: 16px 24px;
-            border-bottom: 1px solid #eee;
-            font-size: 16px;
-            font-weight: 500;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .card-header .omi-logo {
-            font-weight: bold;
-        }
-
-        .card-content {
-            padding: 32px 24px;
-            text-align: center;
-        }
-
-        .app-info img {
-            width: 64px;
-            height: 64px;
-            border-radius: 12px;
-            margin-bottom: 16px;
-            object-fit: cover;
-            border: 1px solid #eee;
-        }
-
-        .app-info h1 {
-            font-size: 24px;
-            font-weight: 600;
-            margin-top: 0;
-            margin-bottom: 8px;
-        }
-
-        .app-info p {
-            font-size: 16px;
-            color: #555;
-            margin-bottom: 24px;
-        }
-
-        .permissions-title {
-            font-size: 14px;
-            font-weight: 500;
-            color: #333;
-            text-align: left;
-            margin-bottom: 8px;
-            padding-left: 10px;
-            /* Align with items */
-        }
-
-        .permissions-list {
-            list-style: none;
-            padding: 0;
-            margin: 0 0 24px 0;
-            text-align: left;
-        }
-
-        .permissions-list li {
-            font-size: 14px;
-            color: #555;
-            padding: 8px 10px;
-            border-top: 1px solid #f0f0f0;
-            display: flex;
-            align-items: center;
-        }
-
-        .permissions-list li:first-child {
-            border-top: none;
-        }
-
-        .permissions-list li .perm-icon {
-            margin-right: 8px;
-            font-size: 16px;
-        }
-
-        #firebaseui-auth-container {
-            margin-top: 20px;
-        }
-
-        .error {
-            color: red;
-            margin-top: 15px;
-            font-size: 14px;
-        }
-
-        .card-footer {
-            padding: 16px 24px;
-            background-color: #f9f9f9;
-            border-top: 1px solid #eee;
-            font-size: 12px;
-            color: #777;
-            text-align: left;
-        }
-
-        .card-footer a {
-            color: #555;
-            text-decoration: underline;
-        }
-
-        /* FirebaseUI overrides for a cleaner look if needed */
-        .firebaseui-card-header {
-            display: none !important;
-        }
-
-        /* Hide FirebaseUI's own header */
-        .firebaseui-card-content {
-            padding: 0 !important;
-            box-shadow: none !important;
-        }
-
-        .firebaseui-list-item {
-            margin: 10px 0 !important;
-        }
-
-        .firebaseui-idp-button {
-            max-width: 100% !important;
-        }
-    </style>
+    {% include "_oauth_shared_styles.html" %}
 </head>
 
 <body>
-    <div class="oauth-card">
-        <div class="card-header">
-            <span class="omi-logo">Omi</span>
-            <!-- Optionally, display user info if available: <span class="user-info">username@example.com</span> -->
-        </div>
-        <div class="card-content">
-            <div class="app-info">
-                {% if app_image %}
-                <img src="{{ app_image }}" alt="{{ app_name }} logo">
-                {% else %}
-                <img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧩</text></svg>"
-                    alt="{{ app_name }} logo"> <!-- Placeholder icon -->
+    <main class="oauth-shell">
+        <div class="oauth-card">
+            <div class="oauth-header">
+                <span class="omi-logo">
+                    <svg class="omi-mark" viewBox="237.36 237.338 549.318 549.322" fill="currentColor"
+                        aria-hidden="true">
+                        <circle cx="282.523" cy="511.982" r="45.163" />
+                        <circle cx="339.909" cy="339.89" r="45.107" />
+                        <circle cx="512.014" cy="282.495" r="45.156" />
+                        <circle cx="684.096" cy="339.88" r="45.103" />
+                        <circle cx="741.511" cy="512.003" r="45.167" />
+                        <circle cx="684.096" cy="684.094" r="45.103" />
+                        <circle cx="511.981" cy="741.5" r="45.16" />
+                        <circle cx="339.902" cy="684.107" r="45.103" />
+                    </svg>
+                    Omi
+                </span>
+                <span class="oauth-eyebrow">
+                    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <rect x="5" y="10.5" width="14" height="9" rx="2" stroke="currentColor" stroke-width="1.8" />
+                        <path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" stroke="currentColor" stroke-width="1.8"
+                            stroke-linecap="round" />
+                    </svg>
+                    Secure connection
+                </span>
+            </div>
+            <div class="oauth-content">
+                <div class="oauth-hero">
+                    <div class="connect-lockup" aria-hidden="true">
+                        <span class="lockup-tile lockup-app">
+                            {% if app_image %}
+                            <img src="{{ app_image }}" alt="">
+                            {% else %}
+                            {{ app_name[:1] }}
+                            {% endif %}
+                        </span>
+                        <span class="lockup-bridge">
+                            <span class="lockup-bridge-badge">
+                                <svg viewBox="0 0 24 24" fill="none">
+                                    <path d="M10.5 13.5a3.4 3.4 0 0 0 4.8 0l2-2a3.4 3.4 0 0 0-4.8-4.8l-1 1"
+                                        stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+                                        stroke-linejoin="round" />
+                                    <path d="M13.5 10.5a3.4 3.4 0 0 0-4.8 0l-2 2a3.4 3.4 0 0 0 4.8 4.8l1-1"
+                                        stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+                                        stroke-linejoin="round" />
+                                </svg>
+                            </span>
+                        </span>
+                        <span class="lockup-tile lockup-omi">
+                            <svg class="omi-mark" viewBox="237.36 237.338 549.318 549.322" fill="currentColor">
+                                <circle cx="282.523" cy="511.982" r="45.163" />
+                                <circle cx="339.909" cy="339.89" r="45.107" />
+                                <circle cx="512.014" cy="282.495" r="45.156" />
+                                <circle cx="684.096" cy="339.88" r="45.103" />
+                                <circle cx="741.511" cy="512.003" r="45.167" />
+                                <circle cx="684.096" cy="684.094" r="45.103" />
+                                <circle cx="511.981" cy="741.5" r="45.16" />
+                                <circle cx="339.902" cy="684.107" r="45.103" />
+                            </svg>
+                        </span>
+                    </div>
+                    <h1>Connect {{ app_name }}</h1>
+                    <p class="oauth-subtitle">Sign in to allow <strong>{{ app_name }}</strong> to access your Omi
+                        account.</p>
+                </div>
+
+                {% if permissions %}
+                <section class="permissions-card" aria-labelledby="permissions-title">
+                    <p class="permissions-title" id="permissions-title">{{ app_name }} will be able to</p>
+                    <ul class="permissions-list" tabindex="0" role="list" aria-labelledby="permissions-title">
+                        {% for perm in permissions %}
+                        <li>
+                            <span class="perm-check" aria-hidden="true">
+                                <svg viewBox="0 0 16 16" fill="none">
+                                    <path d="M3.5 8.5 6.5 11.5 12.5 4.5" stroke="currentColor" stroke-width="2"
+                                        stroke-linecap="round" stroke-linejoin="round" />
+                                </svg>
+                            </span>
+                            <span>{{ perm.text }}</span>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </section>
                 {% endif %}
-                <h1>{{ app_name }}</h1>
-                <p>wants to access your Omi account.</p>
-            </div>
 
-            {% if permissions %}
-            <div class="permissions-section">
-                <p class="permissions-title"><strong>{{ app_name }}</strong> wants to:</p>
-                <ul class="permissions-list">
-                    {% for perm in permissions %}
-                    <li><span class="perm-icon">{{ perm.icon }}</span> {{ perm.text }}</li>
-                    {% endfor %}
-                </ul>
+                <div class="oauth-actions">
+                    <div id="firebaseui-auth-container"></div>
+                    <div class="loader" id="loader" role="status" aria-live="polite">
+                        <span class="spinner" aria-hidden="true"></span>
+                        <span>Connecting…</span>
+                    </div>
+                    <div id="error-message" class="error" role="alert">
+                        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                            <circle cx="8" cy="8" r="6.6" stroke="currentColor" stroke-width="1.5" />
+                            <path d="M8 4.6v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+                            <circle cx="8" cy="11" r="0.9" fill="currentColor" />
+                        </svg>
+                        <span id="error-text"></span>
+                    </div>
+                </div>
             </div>
-            {% endif %}
-
-            <div id="firebaseui-auth-container"></div>
-            <div id="loader" style="display:none;">Loading...</div>
-            <div id="error-message" class="error"></div>
+            <div class="oauth-footer">
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 3 5 6v5c0 4.2 2.9 7.6 7 9 4.1-1.4 7-4.8 7-9V6l-7-3Z" stroke="currentColor"
+                        stroke-width="1.7" stroke-linejoin="round" />
+                    <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"
+                        stroke-linejoin="round" />
+                </svg>
+                <span>Only continue if you trust <strong>{{ app_name }}</strong>. By authorizing, you allow it to use
+                    your data under Omi's <a href="https://www.omi.me/pages/privacy">Terms of Service</a> and <a
+                        href="https://www.omi.me/pages/privacy">Privacy Policy</a>.</span>
+            </div>
         </div>
-        <div class="card-footer">
-            Make sure you trust <strong>{{ app_name }}</strong>.
-            By authorizing, you allow this app to use your data in accordance with Omi's <a
-                href="https://www.omi.me/pages/privacy">Terms of
-                Service</a> and <a href="https://www.omi.me/pages/privacy">Privacy Policy</a>.
-        </div>
-    </div>
+    </main>
 
     <script>
         // These values are passed from the backend template rendering
@@ -210,6 +144,27 @@
 
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
+
+        const loader = document.getElementById('loader');
+        const errorMessage = document.getElementById('error-message');
+        const errorText = document.getElementById('error-text');
+        const firebaseUiContainer = document.getElementById('firebaseui-auth-container');
+
+        function setLoading(isLoading) {
+            loader.classList.toggle('is-visible', isLoading);
+        }
+
+        function clearError() {
+            errorText.textContent = '';
+            errorMessage.classList.remove('is-visible');
+        }
+
+        function showError(message) {
+            errorText.textContent = message;
+            errorMessage.classList.add('is-visible');
+            setLoading(false);
+            firebaseUiContainer.style.display = 'block'; // Show login again
+        }
 
         function isAppleDevice() {
             return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
@@ -229,9 +184,9 @@
             signInOptions: signInOptions,
             callbacks: {
                 signInSuccessWithAuthResult: function (authResult, redirectUrlParam) {
-                    document.getElementById('loader').style.display = 'block';
-                    document.getElementById('firebaseui-auth-container').style.display = 'none';
-                    document.getElementById('error-message').textContent = '';
+                    setLoading(true);
+                    firebaseUiContainer.style.display = 'none';
+                    clearError();
 
                     authResult.user.getIdToken().then(function (idToken) {
                         // Send ID token to backend /oauth/token
@@ -261,28 +216,21 @@
                             })
                             .catch(error => {
                                 console.error('Error during token exchange:', error);
-                                document.getElementById('error-message').textContent = 'Error: ' + error.message;
-                                document.getElementById('loader').style.display = 'none';
-                                document.getElementById('firebaseui-auth-container').style.display = 'block'; // Show login again
+                                showError(error.message);
                             });
                     }).catch(function (error) {
                         console.error('Error getting ID token:', error);
-                        document.getElementById('error-message').textContent = 'Error: Could not get user token.';
-                        document.getElementById('loader').style.display = 'none';
-                        document.getElementById('firebaseui-auth-container').style.display = 'block';
+                        showError('We could not complete sign-in. Please try again.');
                     });
 
                     return false;
                 },
                 signInFailure: function (error) {
                     console.error('FirebaseUI signInFailure error:', error);
-                    document.getElementById('error-message').textContent = 'Sign-in failed. Code: ' + error.code + (error.message ? ' Message: ' + error.message : '');
-                    document.getElementById('loader').style.display = 'none';
-                    document.getElementById('firebaseui-auth-container').style.display = 'block'; // Show login again
+                    showError('Sign-in failed. Please try again.');
                 },
                 uiShown: function () {
-                    console.log("FirebaseUI uiShown: UI has been rendered.");
-                    document.getElementById('loader').style.display = 'none';
+                    setLoading(false);
                 }
             }
         };

--- a/backend/templates/oauth_authenticate.html
+++ b/backend/templates/oauth_authenticate.html
@@ -101,6 +101,23 @@
                 {% endif %}
 
                 <div class="oauth-actions">
+                    <form class="email-sign-in-form" id="email-sign-in-form" novalidate>
+                        <div class="oauth-field">
+                            <label for="email-input">Email</label>
+                            <input id="email-input" name="email" type="email" autocomplete="email"
+                                autocapitalize="none" autocorrect="off" spellcheck="false" inputmode="email"
+                                placeholder="you@example.com" required>
+                        </div>
+                        <div class="oauth-field">
+                            <label for="password-input">Password</label>
+                            <input id="password-input" name="password" type="password" autocomplete="current-password"
+                                placeholder="••••••••" required>
+                        </div>
+                        <button class="email-sign-in-button" id="email-sign-in-button" type="submit">
+                            Sign in
+                        </button>
+                    </form>
+                    <div class="oauth-divider" id="social-sign-in-divider">or continue with</div>
                     <div id="firebaseui-auth-container"></div>
                     <div class="loader" id="loader" role="status" aria-live="polite">
                         <span class="spinner" aria-hidden="true"></span>
@@ -124,7 +141,7 @@
                         stroke-linejoin="round" />
                 </svg>
                 <span>Only continue if you trust <strong>{{ app_name }}</strong>. By authorizing, you allow it to use
-                    your data under Omi's <a href="https://www.omi.me/pages/privacy">Terms of Service</a> and <a
+                    your data under Omi's <a href="https://www.omi.me/pages/terms-of-service">Terms of Service</a> and <a
                         href="https://www.omi.me/pages/privacy">Privacy Policy</a>.</span>
             </div>
         </div>
@@ -148,10 +165,18 @@
         const loader = document.getElementById('loader');
         const errorMessage = document.getElementById('error-message');
         const errorText = document.getElementById('error-text');
+        const emailSignInForm = document.getElementById('email-sign-in-form');
+        const emailInput = document.getElementById('email-input');
+        const passwordInput = document.getElementById('password-input');
+        const emailSignInButton = document.getElementById('email-sign-in-button');
+        const socialSignInDivider = document.getElementById('social-sign-in-divider');
         const firebaseUiContainer = document.getElementById('firebaseui-auth-container');
 
         function setLoading(isLoading) {
             loader.classList.toggle('is-visible', isLoading);
+            emailInput.disabled = isLoading;
+            passwordInput.disabled = isLoading;
+            emailSignInButton.disabled = isLoading;
         }
 
         function clearError() {
@@ -163,7 +188,60 @@
             errorText.textContent = message;
             errorMessage.classList.add('is-visible');
             setLoading(false);
-            firebaseUiContainer.style.display = 'block'; // Show login again
+            emailSignInForm.style.display = 'grid';
+            socialSignInDivider.style.display = 'flex';
+            firebaseUiContainer.style.display = 'block';
+        }
+
+        function showSignInError() {
+            showError('We could not sign in with that email and password. Check the credentials and try again.');
+        }
+
+        function hideSignInOptions() {
+            emailSignInForm.style.display = 'none';
+            socialSignInDivider.style.display = 'none';
+            firebaseUiContainer.style.display = 'none';
+        }
+
+        function exchangeFirebaseToken(idToken) {
+            const formData = new FormData();
+            formData.append('firebase_id_token', idToken);
+            formData.append('app_id', appId);
+            if (state) {
+                formData.append('state', state);
+            }
+
+            fetch('/v1/oauth/token', {
+                method: 'POST',
+                body: formData
+            })
+                .then(response => {
+                    if (!response.ok) {
+                        return response.json().then(err => { throw new Error(err.detail || 'Authentication failed'); });
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    let finalRedirectUrl = data.redirect_url + "?uid=" + data.uid;
+                    if (data.state) {
+                        finalRedirectUrl += "&state=" + data.state;
+                    }
+                    window.location.href = finalRedirectUrl;
+                })
+                .catch(error => {
+                    showError(error.message);
+                });
+        }
+
+        function finishSignIn(user) {
+            setLoading(true);
+            hideSignInOptions();
+            clearError();
+            user.getIdToken()
+                .then(exchangeFirebaseToken)
+                .catch(function () {
+                    showError('We could not complete sign-in. Please try again.');
+                });
         }
 
         function isAppleDevice() {
@@ -178,55 +256,37 @@
             signInOptions.push('apple.com');
         }
 
+        emailSignInForm.addEventListener('submit', function (event) {
+            event.preventDefault();
+            clearError();
+
+            if (!emailInput.value.trim() || !passwordInput.value) {
+                showError('Enter your email and password to continue.');
+                return;
+            }
+
+            setLoading(true);
+            firebase.auth()
+                .signInWithEmailAndPassword(emailInput.value.trim(), passwordInput.value)
+                .then(function (result) {
+                    finishSignIn(result.user);
+                })
+                .catch(function () {
+                    passwordInput.value = '';
+                    showSignInError();
+                });
+        });
+
         const uiConfig = {
             signInFlow: 'popup', // Use popup flow instead of redirect
             signInSuccessUrl: null, // We will handle redirect manually
             signInOptions: signInOptions,
             callbacks: {
                 signInSuccessWithAuthResult: function (authResult, redirectUrlParam) {
-                    setLoading(true);
-                    firebaseUiContainer.style.display = 'none';
-                    clearError();
-
-                    authResult.user.getIdToken().then(function (idToken) {
-                        // Send ID token to backend /oauth/token
-                        const formData = new FormData();
-                        formData.append('firebase_id_token', idToken);
-                        formData.append('app_id', appId);
-                        if (state) {
-                            formData.append('state', state);
-                        }
-
-                        fetch('/v1/oauth/token', {
-                            method: 'POST',
-                            body: formData
-                        })
-                            .then(response => {
-                                if (!response.ok) {
-                                    return response.json().then(err => {throw new Error(err.detail || 'Authentication failed');});
-                                }
-                                return response.json();
-                            })
-                            .then(data => {
-                                let finalRedirectUrl = data.redirect_url + "?uid=" + data.uid;
-                                if (data.state) {
-                                    finalRedirectUrl += "&state=" + data.state;
-                                }
-                                window.location.href = finalRedirectUrl;
-                            })
-                            .catch(error => {
-                                console.error('Error during token exchange:', error);
-                                showError(error.message);
-                            });
-                    }).catch(function (error) {
-                        console.error('Error getting ID token:', error);
-                        showError('We could not complete sign-in. Please try again.');
-                    });
-
+                    finishSignIn(authResult.user);
                     return false;
                 },
                 signInFailure: function (error) {
-                    console.error('FirebaseUI signInFailure error:', error);
                     showError('Sign-in failed. Please try again.');
                 },
                 uiShown: function () {

--- a/backend/tests/unit/test_mcp_oauth_template.py
+++ b/backend/tests/unit/test_mcp_oauth_template.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates"
+
+
+def _render_mcp_template() -> str:
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
+    return env.get_template("mcp_oauth_authorize.html").render(
+        permissions=[
+            "Read your Omi memories",
+            "Create, update, and delete your Omi action items",
+        ],
+        oauth_params={
+            "response_type": "code",
+            "client_id": "test-client",
+            "redirect_uri": "https://chatgpt.com/connector/oauth/test",
+            "resource": "https://api.omi.me/v1/mcp/sse",
+            "scope": "memories.read action_items.write",
+            "state": "state",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        },
+        firebase_config={
+            "apiKey": "test-api-key",
+            "authDomain": "test.firebaseapp.com",
+            "projectId": "test-project",
+        },
+    )
+
+
+def test_mcp_oauth_template_uses_deterministic_email_password_sign_in():
+    html = _render_mcp_template()
+
+    assert 'id="email-sign-in-form"' in html
+    assert 'id="email-input"' in html
+    assert 'id="password-input"' in html
+    assert "signInWithEmailAndPassword" in html
+
+
+def test_mcp_oauth_template_does_not_offer_firebaseui_email_signup_flow():
+    html = _render_mcp_template()
+
+    assert "firebase.auth.EmailAuthProvider.PROVIDER_ID" not in html
+    assert "Create account" not in html
+
+
+def test_mcp_oauth_template_still_renders_permissions_and_social_sign_in():
+    html = _render_mcp_template()
+
+    assert "Read your Omi memories" in html
+    assert "Create, update, and delete your Omi action items" in html
+    assert "firebase.auth.GoogleAuthProvider.PROVIDER_ID" in html
+    assert "firebaseui-auth-container" in html

--- a/backend/tests/unit/test_mcp_oauth_template.py
+++ b/backend/tests/unit/test_mcp_oauth_template.py
@@ -30,6 +30,22 @@ def _render_mcp_template() -> str:
     )
 
 
+def _render_oauth_authenticate_template() -> str:
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
+    return env.get_template("oauth_authenticate.html").render(
+        app_name="Test App",
+        app_image=None,
+        app_id="test-app",
+        state="state",
+        firebase_api_key="test-api-key",
+        firebase_auth_domain="test.firebaseapp.com",
+        firebase_project_id="test-project",
+        permissions=[
+            {"text": "Read your memories"},
+        ],
+    )
+
+
 def test_mcp_oauth_template_uses_deterministic_email_password_sign_in():
     html = _render_mcp_template()
 
@@ -37,6 +53,7 @@ def test_mcp_oauth_template_uses_deterministic_email_password_sign_in():
     assert 'id="email-input"' in html
     assert 'id="password-input"' in html
     assert "signInWithEmailAndPassword" in html
+    assert "finishSignIn(result.user, true)" in html
 
 
 def test_mcp_oauth_template_does_not_offer_firebaseui_email_signup_flow():
@@ -46,6 +63,14 @@ def test_mcp_oauth_template_does_not_offer_firebaseui_email_signup_flow():
     assert "Create account" not in html
 
 
+def test_mcp_oauth_social_sign_in_requires_explicit_consent_after_login():
+    html = _render_mcp_template()
+
+    assert 'id="consent-retry"' in html
+    assert "finishSignIn(authResult.user, false)" in html
+    assert "showConsentRetry()" in html
+
+
 def test_mcp_oauth_template_still_renders_permissions_and_social_sign_in():
     html = _render_mcp_template()
 
@@ -53,3 +78,21 @@ def test_mcp_oauth_template_still_renders_permissions_and_social_sign_in():
     assert "Create, update, and delete your Omi action items" in html
     assert "firebase.auth.GoogleAuthProvider.PROVIDER_ID" in html
     assert "firebaseui-auth-container" in html
+
+
+def test_app_oauth_template_uses_deterministic_email_password_sign_in():
+    html = _render_oauth_authenticate_template()
+
+    assert 'id="email-sign-in-form"' in html
+    assert 'id="email-input"' in html
+    assert 'id="password-input"' in html
+    assert "signInWithEmailAndPassword" in html
+    assert "firebase.auth.EmailAuthProvider.PROVIDER_ID" not in html
+    assert "Create account" not in html
+
+
+def test_app_oauth_template_terms_and_privacy_links_are_distinct():
+    html = _render_oauth_authenticate_template()
+
+    assert 'href="https://www.omi.me/pages/terms-of-service">Terms of Service</a>' in html
+    assert 'href="https://www.omi.me/pages/privacy">Privacy Policy</a>' in html


### PR DESCRIPTION
## Summary
- replace FirebaseUI email login on the MCP OAuth consent page with deterministic email/password sign-in
- keep Google/Apple social sign-in as secondary options
- share cleaned OAuth page styling and add template regression tests

## Verification
- Independent subagent review found no blocking issues
- `backend/test-preflight.sh`
- `backend/test.sh`
- `python3 -m pytest backend/tests/unit/test_mcp_oauth_template.py -v`
- Local browser harness with mocked Firebase/AuthUI verified email sign-in posts a Firebase token to `/authorize` and no Create account text is shown

No review credentials were committed or printed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

