### PR TITLE
Improve onboarding graph share branding

### DIFF
--- a/desktop/macos/Desktop/Sources/OnboardingStepScaffold.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingStepScaffold.swift
@@ -190,7 +190,7 @@ struct OnboardingLogoMark: View {
 
   var body: some View {
     Group {
-      if let logoImage = onboardingLogoImage() {
+      if let logoImage = onboardingTextLogoImage() {
         Image(nsImage: logoImage)
           .resizable()
           .renderingMode(.template)
@@ -208,18 +208,6 @@ struct OnboardingLogoMark: View {
       onForceComplete?()
     }
     .accessibilityLabel("omi")
-  }
-
-  private func onboardingLogoImage() -> NSImage? {
-    guard
-      let logoURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-      let loadedLogoImage = NSImage(contentsOf: logoURL)
-    else {
-      return nil
-    }
-    let logoImage = loadedLogoImage.copy() as? NSImage ?? loadedLogoImage
-    logoImage.isTemplate = true
-    return logoImage
   }
 }
 
@@ -262,13 +250,7 @@ private struct OnboardingSecondBrainPane: View {
     }
     .overlay(alignment: .top) {
       if case .graph = mode, !graphViewModel.isEmpty {
-        Text("This is your second brain.")
-          .font(.system(size: 14, weight: .semibold))
-          .foregroundColor(.white)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 6)
-          .background(Color.black.opacity(0.35))
-          .cornerRadius(8)
+        OnboardingGraphBrandMark()
           .padding(.top, 18)
       }
     }
@@ -313,13 +295,24 @@ private struct OnboardingSecondBrainPane: View {
           MemoryGraphSceneView(viewModel: graphViewModel)
             .ignoresSafeArea()
 
-          HStack(spacing: 20) {
-            graphHintItem(icon: "arrow.triangle.2.circlepath", label: "Drag to rotate")
-            graphHintItem(icon: "magnifyingglass", label: "Scroll to zoom")
-            graphHintItem(icon: "hand.draw", label: "Two-finger to pan")
+          VStack(spacing: 10) {
+            Text("This is your 2nd brain")
+              .font(.system(size: 15, weight: .semibold))
+              .foregroundColor(.white)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 7)
+              .background(Color.black.opacity(0.38))
+              .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            HStack(spacing: 20) {
+              graphHintItem(icon: "arrow.triangle.2.circlepath", label: "Drag to rotate")
+              graphHintItem(icon: "magnifyingglass", label: "Scroll to zoom")
+              graphHintItem(icon: "hand.draw", label: "Two-finger to pan")
+            }
           }
           .padding(.horizontal, 16)
-          .padding(.vertical, 10)
+          .padding(.top, 42)
+          .padding(.bottom, 10)
           .background(
             LinearGradient(
               colors: [Color.black.opacity(0), Color.black.opacity(0.5)],
@@ -341,6 +334,47 @@ private struct OnboardingSecondBrainPane: View {
     }
     .foregroundColor(.white.opacity(0.5))
   }
+}
+
+private struct OnboardingGraphBrandMark: View {
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 0) {
+      if let logoImage = onboardingTextLogoImage() {
+        Image(nsImage: logoImage)
+          .resizable()
+          .renderingMode(.template)
+          .foregroundColor(.white)
+          .scaledToFit()
+          .frame(width: 45, height: 20)
+      } else {
+        Text("omi")
+          .font(.system(size: 20, weight: .semibold))
+          .foregroundColor(.white)
+      }
+
+      Text(".me")
+        .font(.system(size: 20, weight: .semibold))
+        .foregroundColor(.white)
+        .offset(y: -1)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 7)
+    .background(Color.black.opacity(0.28))
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .accessibilityLabel("omi.me")
+  }
+}
+
+private func onboardingTextLogoImage() -> NSImage? {
+  guard
+    let logoURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
+    let loadedLogoImage = NSImage(contentsOf: logoURL)
+  else {
+    return nil
+  }
+  let logoImage = loadedLogoImage.copy() as? NSImage ?? loadedLogoImage
+  logoImage.isTemplate = true
+  return logoImage
 }
 
 struct OnboardingCardButtonStyle: ButtonStyle {

--- a/desktop/macos/changelog/unreleased/20260629-onboarding-graph-share-brand.json
+++ b/desktop/macos/changelog/unreleased/20260629-onboarding-graph-share-brand.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the onboarding second-brain graph branding for sharing"
+}


### PR DESCRIPTION
## Summary
- add an omi.me brand mark to the top of the onboarding graph pane
- move the second-brain caption to the bottom above graph controls
- tighten the logo/.me spacing so the mark reads as one unit

## Verification
- xcrun swift build -c debug --package-path Desktop
- relaunched /Applications/omi-onboarding-share.app and verified the live onboarding graph step via agent-swift
- git diff --check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

