### PR TITLE
Improve desktop updater recovery

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/updates.rs
+++ b/desktop/macos/Backend-Rust/src/routes/updates.rs
@@ -32,6 +32,8 @@ pub struct ReleaseInfo {
     pub version: String,
     pub build_number: u32,
     pub download_url: String,
+    #[serde(default)]
+    pub manual_download_url: Option<String>,
     pub ed_signature: String,
     pub published_at: String,
     pub changelog: Vec<String>,
@@ -134,18 +136,34 @@ fn generate_appcast_xml(releases: &[ReleaseInfo], platform: &str) -> String {
     xml
 }
 
+fn manual_download_url_for_release(release: &ReleaseInfo) -> String {
+    if let Some(url) = release.manual_download_url.as_deref() {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    if let Some(github_asset_base) = release.download_url.strip_suffix("/Omi.zip") {
+        return format!("{}/Omi.dmg", github_asset_base);
+    }
+
+    release.download_url.clone()
+}
+
 /// GET /appcast.xml - Sparkle appcast feed
 async fn get_appcast(State(state): State<AppState>, Query(query): Query<AppcastQuery>) -> Response {
     // Fetch all releases — generate_appcast_xml handles filtering and per-channel dedup
     let releases = match state.firestore.get_desktop_releases().await {
         Ok(releases) => releases,
         Err(e) => {
-            tracing::warn!(
-                "Failed to fetch releases from Firestore: {}, using fallback",
-                e
-            );
-            // Return empty appcast if no releases found
-            vec![]
+            tracing::error!("Failed to fetch releases from Firestore: {}", e);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                "Desktop update feed is temporarily unavailable",
+            )
+                .into_response();
         }
     };
 
@@ -213,13 +231,9 @@ async fn download_redirect(State(state): State<AppState>) -> impl IntoResponse {
                 .filter(|r| r.is_live && r.channel.as_deref() == Some("stable"))
                 .next()
             {
-                // Serve from GCS bucket for direct download (avoids multi-hop GitHub redirects)
-                let gcs_url = format!(
-                    "https://storage.googleapis.com/omi_macos_updates/releases/v{}/Omi.Beta.dmg",
-                    latest.version
-                );
-                tracing::info!("Redirecting download to GCS: {}", gcs_url);
-                axum::response::Redirect::temporary(&gcs_url).into_response()
+                let download_url = manual_download_url_for_release(&latest);
+                tracing::info!("Redirecting download to release artifact: {}", download_url);
+                axum::response::Redirect::temporary(&download_url).into_response()
             } else {
                 (StatusCode::NOT_FOUND, "No live releases found").into_response()
             }
@@ -241,6 +255,8 @@ pub struct CreateReleaseRequest {
     pub version: String,
     pub build_number: u32,
     pub download_url: String,
+    #[serde(default)]
+    pub manual_download_url: Option<String>,
     pub ed_signature: String,
     #[serde(default)]
     pub changelog: Vec<String>,
@@ -290,6 +306,7 @@ async fn create_release(
         version: request.version.clone(),
         build_number: request.build_number,
         download_url: request.download_url,
+        manual_download_url: request.manual_download_url,
         ed_signature: request.ed_signature,
         published_at: chrono::Utc::now().to_rfc3339(),
         changelog: request.changelog,
@@ -425,6 +442,7 @@ mod tests {
             version: version.to_string(),
             build_number: build,
             download_url: format!("https://example.com/{}.zip", version),
+            manual_download_url: None,
             ed_signature: "sig123".to_string(),
             published_at: "2025-01-01T00:00:00Z".to_string(),
             changelog: vec![],
@@ -513,6 +531,40 @@ mod tests {
         let releases = vec![make_release("0.1.0", 100, Some("stable"), false)];
         let xml = generate_appcast_xml(&releases, "macos");
         assert!(!xml.contains("0.1.0"), "non-live release should not appear");
+    }
+
+    #[test]
+    fn test_manual_download_url_prefers_explicit_url() {
+        let mut release = make_release("0.1.0", 100, Some("stable"), true);
+        release.manual_download_url = Some("https://cdn.example.com/omi.dmg".to_string());
+
+        assert_eq!(
+            manual_download_url_for_release(&release),
+            "https://cdn.example.com/omi.dmg"
+        );
+    }
+
+    #[test]
+    fn test_manual_download_url_derives_github_dmg_from_sparkle_zip() {
+        let mut release = make_release("0.1.0", 100, Some("stable"), true);
+        release.download_url =
+            "https://github.com/BasedHardware/omi/releases/download/v0.1.0%2B100-macos/Omi.zip"
+                .to_string();
+
+        assert_eq!(
+            manual_download_url_for_release(&release),
+            "https://github.com/BasedHardware/omi/releases/download/v0.1.0%2B100-macos/Omi.dmg"
+        );
+    }
+
+    #[test]
+    fn test_manual_download_url_falls_back_to_appcast_url() {
+        let release = make_release("0.1.0", 100, Some("stable"), true);
+
+        assert_eq!(
+            manual_download_url_for_release(&release),
+            release.download_url
+        );
     }
 }
 

--- a/desktop/macos/Backend-Rust/src/services/firestore/desktop_releases_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/desktop_releases_repository.rs
@@ -91,6 +91,7 @@ impl FirestoreService {
             download_url: self
                 .parse_string(fields, "download_url")
                 .unwrap_or_default(),
+            manual_download_url: self.parse_string(fields, "manual_download_url"),
             ed_signature: self
                 .parse_string(fields, "ed_signature")
                 .unwrap_or_default(),
@@ -126,11 +127,17 @@ impl FirestoreService {
             _ => json!({"stringValue": "staging"}),
         };
 
+        let manual_download_url_value = match &release.manual_download_url {
+            Some(url) if !url.trim().is_empty() => json!({"stringValue": url}),
+            _ => json!({"nullValue": null}),
+        };
+
         let doc = json!({
             "fields": {
                 "version": {"stringValue": release.version},
                 "build_number": {"integerValue": release.build_number.to_string()},
                 "download_url": {"stringValue": release.download_url},
+                "manual_download_url": manual_download_url_value,
                 "ed_signature": {"stringValue": release.ed_signature},
                 "published_at": {"stringValue": release.published_at},
                 "changelog": {"arrayValue": {"values": changelog_values}},

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -667,6 +667,10 @@ class AnalyticsManager {
     PostHogManager.shared.updateInstalled(version: version)
   }
 
+  func updateCheckFailed(diagnostics: UpdateFailureDiagnostics) {
+    PostHogManager.shared.updateCheckFailed(diagnostics: diagnostics)
+  }
+
   // MARK: - Notification Events
 
   func notificationSent(notificationId: String, title: String, assistantId: String, surface: String) {

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -76,6 +76,10 @@ enum AppBuild {
     return raw == "staging" ? "beta" : raw
   }
 
+  static var manualDownloadURL: URL {
+    URL(string: "https://api.omi.me/v2/desktop/download/latest?channel=\(currentUpdateChannel)")!
+  }
+
   static var inferredUpdateChannel: String {
     let bundlePath = Bundle.main.bundleURL.path.lowercased()
     let display = displayName.lowercased()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -466,6 +466,49 @@ extension SettingsContentView {
               .foregroundColor(OmiColors.textTertiary)
           }
 
+          if let failure = updaterViewModel.lastUpdateFailure {
+            VStack(alignment: .leading, spacing: 10) {
+              HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.warning)
+
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("Update Needs Attention")
+                    .scaledFont(size: 13, weight: .semibold)
+                    .foregroundColor(OmiColors.textPrimary)
+                  Text(failure.userMessage)
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+              }
+
+              HStack(spacing: 8) {
+                if failure.isRecoverableLaunchLocation {
+                  Button("Open Applications") {
+                    NSWorkspace.shared.open(
+                      URL(fileURLWithPath: "/Applications", isDirectory: true))
+                  }
+                  .buttonStyle(.bordered)
+                }
+
+                Button("Download Latest") {
+                  openURLInDefaultBrowser(AppBuild.manualDownloadURL)
+                }
+                .buttonStyle(.bordered)
+
+                Button("Dismiss") {
+                  updaterViewModel.lastUpdateFailure = nil
+                }
+                .buttonStyle(.borderless)
+              }
+            }
+            .padding(12)
+            .background(OmiColors.backgroundTertiary)
+            .cornerRadius(8)
+          }
+
           Divider()
             .background(OmiColors.backgroundQuaternary)
 

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -622,6 +622,10 @@ extension PostHogManager {
         ])
     }
 
+    func updateCheckFailed(diagnostics: UpdateFailureDiagnostics) {
+        track("Update Check Failed", properties: diagnostics.analyticsProperties)
+    }
+
     // MARK: - Notification Events
 
     func notificationSent(notificationId: String, title: String, assistantId: String, surface: String) {

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -36,6 +36,179 @@ enum UpdateChannel: String, CaseIterable {
 
 private let kUpdateChannelKey = "update_channel"
 
+enum UpdateFailureReason: String {
+  case appcastRetrieval = "appcast_retrieval"
+  case download = "download"
+  case signature = "signature"
+  case readOnlyLocation = "read_only_location"
+  case downloadsLocation = "downloads_location"
+  case temporaryLocation = "temporary_location"
+  case installerLaunch = "installer_launch"
+  case network = "network"
+  case noUpdate = "no_update"
+  case unknown = "unknown"
+}
+
+struct UpdateFailureDiagnostics: Equatable {
+  let reason: UpdateFailureReason
+  let message: String
+  let domain: String
+  let code: Int
+  let underlyingDomain: String?
+  let underlyingCode: Int?
+  let updateChannel: String
+  let launchLocationBucket: String
+
+  var isRecoverableLaunchLocation: Bool {
+    switch reason {
+    case .readOnlyLocation, .downloadsLocation, .temporaryLocation:
+      return true
+    default:
+      return false
+    }
+  }
+
+  var userMessage: String {
+    if isRecoverableLaunchLocation {
+      return
+        "Omi cannot update from its current location. Move it to Applications, reopen it, then check again."
+    }
+
+    switch reason {
+    case .appcastRetrieval:
+      return
+        "Omi could not retrieve update information. You can try again or download the latest version manually."
+    case .download:
+      return
+        "Omi found an update but could not download it. You can try again or download the latest version manually."
+    case .signature:
+      return "Omi could not verify the downloaded update. Download the latest version manually."
+    case .network:
+      return
+        "Omi could not reach the update server. Check your connection or download the latest version manually."
+    case .installerLaunch:
+      return
+        "Omi downloaded an update but could not start the installer. Try again or download the latest version manually."
+    case .noUpdate:
+      return "Omi is up to date."
+    case .unknown:
+      return
+        "Omi could not complete the update check. You can try again or download the latest version manually."
+    case .readOnlyLocation, .downloadsLocation, .temporaryLocation:
+      return
+        "Omi cannot update from its current location. Move it to Applications, reopen it, then check again."
+    }
+  }
+
+  var analyticsProperties: [String: Any] {
+    var properties: [String: Any] = [
+      "update_failure_reason": reason.rawValue,
+      "update_failure_domain": domain,
+      "update_failure_code": code,
+      "update_channel": updateChannel,
+      "launch_location_bucket": launchLocationBucket,
+    ]
+
+    if let underlyingDomain {
+      properties["underlying_domain"] = underlyingDomain
+    }
+    if let underlyingCode {
+      properties["underlying_code"] = underlyingCode
+    }
+
+    return properties
+  }
+
+  static func classify(
+    error: NSError,
+    updateChannel: String,
+    bundlePath: String = Bundle.main.bundlePath
+  ) -> UpdateFailureDiagnostics {
+    let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
+    let message = error.localizedDescription
+    let bucket = launchLocationBucket(for: bundlePath)
+
+    return UpdateFailureDiagnostics(
+      reason: reason(
+        for: error,
+        underlying: underlying,
+        message: message.lowercased(),
+        bucket: bucket
+      ),
+      message: message,
+      domain: error.domain,
+      code: error.code,
+      underlyingDomain: underlying?.domain,
+      underlyingCode: underlying?.code,
+      updateChannel: updateChannel,
+      launchLocationBucket: bucket
+    )
+  }
+
+  static func launchLocationBucket(for bundlePath: String) -> String {
+    let path = bundlePath.lowercased()
+
+    if path.hasPrefix("/volumes/") {
+      return "dmg_mounted"
+    }
+    if path.contains("/downloads/") {
+      return "downloads_folder"
+    }
+    if path.hasPrefix("/private/var/folders/") || path.hasPrefix("/tmp/")
+      || path.hasPrefix("/private/tmp/")
+    {
+      return "temporary_location"
+    }
+    if path.hasPrefix("/applications/") {
+      return "applications_system"
+    }
+    if path.contains("/applications/") {
+      return "applications_user"
+    }
+
+    return "other"
+  }
+
+  private static func reason(
+    for error: NSError,
+    underlying: NSError?,
+    message: String,
+    bucket: String
+  ) -> UpdateFailureReason {
+    if error.domain == SUSparkleErrorDomain && error.code == 1001 {
+      return .noUpdate
+    }
+    if message.contains("read-only") {
+      return .readOnlyLocation
+    }
+    if message.contains("location it was downloaded to") || bucket == "downloads_folder" {
+      return .downloadsLocation
+    }
+    if message.contains("temporary location") || bucket == "temporary_location"
+      || bucket == "dmg_mounted"
+    {
+      return .temporaryLocation
+    }
+    if error.domain == SUSparkleErrorDomain && error.code == 4005 {
+      return .installerLaunch
+    }
+    if message.contains("retrieving update information") || message.contains("appcast") {
+      return .appcastRetrieval
+    }
+    if message.contains("downloading the update") || message.contains("download") {
+      return .download
+    }
+    if message.contains("signature") || message.contains("verify") || message.contains("ed25519") {
+      return .signature
+    }
+    if error.domain == NSURLErrorDomain || underlying?.domain == NSURLErrorDomain {
+      return .network
+    }
+
+    return .unknown
+  }
+}
+
 /// Delegate to track Sparkle update events for analytics
 final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
 
@@ -71,6 +244,7 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
     Task { @MainActor in
       self.viewModel?.latestStableBuildNumber = bestStableBuild
       self.viewModel?.latestStableVersionString = bestStableVersion
+      self.viewModel?.lastUpdateFailure = nil
     }
   }
 
@@ -82,6 +256,7 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
       AnalyticsManager.shared.updateAvailable(version: version)
       self.viewModel?.updateAvailable = true
       self.viewModel?.availableVersion = version
+      self.viewModel?.lastUpdateFailure = nil
     }
   }
 
@@ -90,6 +265,7 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
     logSync("Sparkle: No update available")
     Task { @MainActor in
       self.viewModel?.updateAvailable = false
+      self.viewModel?.lastUpdateFailure = nil
     }
   }
 
@@ -99,11 +275,15 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
   func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
     let message = error.localizedDescription
     let nsError = error as NSError
-    let isUpToDate =
-      nsError.domain == SUSparkleErrorDomain
-      && nsError.code == 1001 /* SUNoUpdateError */
-    if isUpToDate {
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: nsError,
+      updateChannel: UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    )
+    if diagnostics.reason == .noUpdate {
       logSync("Sparkle: Already up to date")
+      Task { @MainActor in
+        self.viewModel?.lastUpdateFailure = nil
+      }
     } else {
       logSync(
         "Sparkle: Update check failed - \(message) [domain=\(nsError.domain) code=\(nsError.code)]")
@@ -121,6 +301,11 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
       let isInstallationError = nsError.domain == SUSparkleErrorDomain && nsError.code == 4005
       if isInstallationError {
         logSync("Sparkle: Installation failed (error 4005), will retry on next check")
+      }
+
+      Task { @MainActor in
+        AnalyticsManager.shared.updateCheckFailed(diagnostics: diagnostics)
+        self.viewModel?.lastUpdateFailure = diagnostics
       }
     }
   }
@@ -377,6 +562,9 @@ final class UpdaterViewModel: ObservableObject {
 
   /// Version string of the available update
   @Published var availableVersion: String = ""
+
+  /// Last non-successful Sparkle update failure, if one needs user recovery.
+  @Published var lastUpdateFailure: UpdateFailureDiagnostics?
 
   /// Latest stable build number from the appcast (for downgrade detection)
   @Published var latestStableBuildNumber: Int?

--- a/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class UpdateFailureDiagnosticsTests: XCTestCase {
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: "update_channel")
+    super.tearDown()
+  }
+
+  func testManualDownloadURLUsesConcreteStableEndpointByDefault() {
+    UserDefaults.standard.removeObject(forKey: "update_channel")
+
+    XCTAssertEqual(
+      AppBuild.manualDownloadURL.absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=stable"
+    )
+  }
+
+  func testManualDownloadURLPreservesBetaChannel() {
+    UserDefaults.standard.set("beta", forKey: "update_channel")
+
+    XCTAssertEqual(
+      AppBuild.manualDownloadURL.absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=beta"
+    )
+  }
+
+  func testLaunchLocationBucketsDownloadsFolder() {
+    XCTAssertEqual(
+      UpdateFailureDiagnostics.launchLocationBucket(
+        for: "/Users/alex/Downloads/Omi.app"
+      ),
+      "downloads_folder"
+    )
+  }
+
+  func testLaunchLocationBucketsMountedVolume() {
+    XCTAssertEqual(
+      UpdateFailureDiagnostics.launchLocationBucket(
+        for: "/Volumes/Omi/Omi.app"
+      ),
+      "dmg_mounted"
+    )
+  }
+
+  func testClassifiesReadOnlyLocation() {
+    let error = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 4005,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "omi can't be updated because it was opened from a read-only or a temporary location."
+      ]
+    )
+
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: error,
+      updateChannel: "stable",
+      bundlePath: "/Volumes/Omi/Omi.app"
+    )
+
+    XCTAssertEqual(diagnostics.reason, .readOnlyLocation)
+    XCTAssertEqual(diagnostics.launchLocationBucket, "dmg_mounted")
+    XCTAssertTrue(diagnostics.isRecoverableLaunchLocation)
+  }
+
+  func testClassifiesDownloadFailure() {
+    let error = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 3002,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "An error occurred while downloading the update. Please try again later."
+      ]
+    )
+
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: error,
+      updateChannel: "beta",
+      bundlePath: "/Applications/Omi.app"
+    )
+
+    XCTAssertEqual(diagnostics.reason, .download)
+    XCTAssertEqual(diagnostics.updateChannel, "beta")
+    XCTAssertEqual(diagnostics.launchLocationBucket, "applications_system")
+  }
+
+  func testClassifiesUnderlyingNetworkFailure() {
+    let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+    let error = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 2001,
+      userInfo: [
+        NSLocalizedDescriptionKey: "The update check failed.",
+        NSUnderlyingErrorKey: underlying,
+      ]
+    )
+
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: error,
+      updateChannel: "stable",
+      bundlePath: "/Applications/Omi.app"
+    )
+
+    XCTAssertEqual(diagnostics.reason, .network)
+    XCTAssertEqual(diagnostics.underlyingDomain, NSURLErrorDomain)
+    XCTAssertEqual(diagnostics.underlyingCode, NSURLErrorTimedOut)
+  }
+
+  func testAnalyticsPropertiesOmitRawPath() {
+    let error = NSError(
+      domain: "SUSparkleErrorDomain",
+      code: 3002,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "An error occurred while downloading the update. Please try again later."
+      ]
+    )
+
+    let diagnostics = UpdateFailureDiagnostics.classify(
+      error: error,
+      updateChannel: "stable",
+      bundlePath: "/Users/alex/Downloads/Omi.app"
+    )
+
+    let properties = diagnostics.analyticsProperties
+    XCTAssertEqual(properties["update_failure_reason"] as? String, "downloads_location")
+    XCTAssertEqual(properties["launch_location_bucket"] as? String, "downloads_folder")
+    XCTAssertNil(properties["bundle_path"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260630-desktop-updater-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260630-desktop-updater-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop update recovery with clearer failure guidance and safer manual downloads"
+}


### PR DESCRIPTION
## Summary

Closes #8635.

- Add structured Sparkle update-failure bucketing for appcast retrieval, download, signature, network, installer launch, and launch-location failures.
- Show a recovery card in Settings > About > Software Updates with launch-location guidance and a manual latest-download fallback.
- Fix desktop manual download routing to use release metadata instead of the hardcoded broken `Omi.Beta.dmg` GCS path, and let release creation store an explicit `manual_download_url`.
- Return a clear 503 when the appcast cannot load releases instead of serving an empty successful feed.

## Root Cause

Update failures were being collapsed into human-readable Sparkle strings, while the backend had a manual download path that could point at a nonexistent stable artifact. Users running from Downloads, mounted DMGs, or temporary/read-only locations also had no clear in-app recovery path.

## Validation

- `cargo test routes::updates`
- `cargo test`
- `xcrun swift test --package-path Desktop --filter UpdateFailureDiagnosticsTests`
- `xcrun swift build -c debug --package-path Desktop`
- `git diff --check`

Note: live UI inspection through `agent-swift` was blocked locally because Accessibility permission is not granted to this terminal, so the UI recovery card was compile-checked but not visually inspected through the accessibility tree.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

