### PR TITLE
[codex] Improve Rewind scrub and capture efficiency

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1292,6 +1292,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Stop recurring task scheduler
     RecurringTaskScheduler.shared.stop()
 
+    // Finalize the active Rewind MP4 chunk while the app is still alive.
+    // AVAssetWriter files are not readable until finishWriting writes the trailer.
+    let rewindFlushSemaphore = DispatchSemaphore(value: 0)
+    Task.detached(priority: .userInitiated) {
+      await RewindIndexer.shared.stop()
+      rewindFlushSemaphore.signal()
+    }
+    if rewindFlushSemaphore.wait(timeout: .now() + 5) == .timedOut {
+      logError("AppDelegate: Timed out flushing Rewind chunk during termination")
+    }
+
     // Mark clean shutdown so next launch skips expensive DB integrity check
     RewindDatabase.markCleanShutdown()
 

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1294,17 +1294,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Finalize the active Rewind MP4 chunk while the app is still alive.
     // AVAssetWriter files are not readable until finishWriting writes the trailer.
-    let rewindFlushSemaphore = DispatchSemaphore(value: 0)
-    Task.detached(priority: .userInitiated) {
-      await RewindIndexer.shared.stop()
-      rewindFlushSemaphore.signal()
-    }
-    if rewindFlushSemaphore.wait(timeout: .now() + 5) == .timedOut {
-      logError("AppDelegate: Timed out flushing Rewind chunk during termination")
-    }
+    let didFlushRewind = RewindShutdownFlush.flush(timeout: 5, context: "AppDelegate")
 
-    // Mark clean shutdown so next launch skips expensive DB integrity check
-    RewindDatabase.markCleanShutdown()
+    // Mark clean shutdown only after Rewind finalized its active MP4 chunk.
+    if didFlushRewind {
+      RewindDatabase.markCleanShutdown()
+    }
 
     // Report final resources before termination
     ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -534,6 +534,9 @@ public class ProactiveAssistantsPlugin: NSObject {
                 await memory.stop()
             }
         }
+        Task {
+            await RewindIndexer.shared.stop()
+        }
 
         focusAssistant = nil
         taskAssistant = nil

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -534,9 +534,7 @@ public class ProactiveAssistantsPlugin: NSObject {
                 await memory.stop()
             }
         }
-        Task {
-            await RewindIndexer.shared.stop()
-        }
+        _ = RewindShutdownFlush.flush(timeout: 5, context: "ProactiveAssistantsPlugin")
 
         focusAssistant = nil
         taskAssistant = nil

--- a/desktop/macos/Desktop/Sources/ResourceMonitor.swift
+++ b/desktop/macos/Desktop/Sources/ResourceMonitor.swift
@@ -155,11 +155,11 @@ class ResourceMonitor {
     let bufferStatus = await VideoChunkEncoder.shared.getBufferStatus()
     components["videoEncoder_frameCount"] = bufferStatus.frameCount
     components["videoEncoder_maxBufferFrames"] = bufferStatus.maxBufferFrames
-    components["videoEncoder_isFFmpegRunning"] = bufferStatus.isFFmpegRunning
+    components["videoEncoder_isEncoderRunning"] = bufferStatus.isEncoderRunning
     components["videoEncoder_consecutiveWriteFailures"] = bufferStatus.consecutiveWriteFailures
     components["videoEncoder_restartCount"] = bufferStatus.encoderRestartCount
     components["videoEncoder_emergencyResetCount"] = bufferStatus.emergencyResetCount
-    components["videoEncoder_ffmpegNotReadyCount"] = bufferStatus.ffmpegNotReadyCount
+    components["videoEncoder_writerNotReadyCount"] = bufferStatus.writerNotReadyCount
     if let age = bufferStatus.oldestFrameAge {
       components["videoEncoder_oldestFrameAgeSec"] = Int(age)
     }
@@ -367,9 +367,9 @@ class ResourceMonitor {
     onMemoryPressureTrimTranscript?()
 
     Task {
-      // Flush VideoChunkEncoder and await completion. If ffmpeg is wedged, the
-      // encoder's watchdog will kill it; ResourceMonitor records the reset counters
-      // in component diagnostics so hang/memory Sentry events can be correlated.
+      // Flush VideoChunkEncoder and await completion; ResourceMonitor records
+      // reset counters in component diagnostics so hang/memory Sentry events can
+      // be correlated.
       _ = try? await VideoChunkEncoder.shared.flushCurrentChunk()
 
       // Clear focus assistant pending tasks specifically

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -1,16 +1,12 @@
 import AppKit
+import AVFoundation
 import CoreGraphics
-import Darwin
 import Foundation
 import Sentry
 
-/// Encodes screenshot frames into H.265 video chunks using ffmpeg for efficient storage.
-/// Uses fragmented MP4 format so frames can be read while the file is still being written.
+/// Encodes screenshot frames into H.265 video chunks using VideoToolbox for efficient storage.
 actor VideoChunkEncoder {
     static let shared = VideoChunkEncoder()
-
-    // Track if we've reported ffmpeg source this session (once per app launch)
-    private static var hasReportedFFmpegSource = false
 
     // MARK: - Configuration
 
@@ -30,8 +26,8 @@ actor VideoChunkEncoder {
     private let aspectRatioChangeThreshold: CGFloat = 0.2
 
     /// Seconds the new aspect ratio must remain stable before switching chunks.
-    /// Prevents rapid app switching from spawning bursts of short-lived ffmpeg processes
-    /// that hang the hevc_videotoolbox hardware encoder during finalization (10s stall each).
+    /// Prevents rapid app switching from spawning bursts of short-lived chunks
+    /// that churn the hardware encoder during finalization.
     private let aspectRatioStabilityDelay: TimeInterval = 2.0
 
     /// Maximum frames to buffer before forcing a flush (memory safety)
@@ -41,24 +37,24 @@ actor VideoChunkEncoder {
         Int(chunkDuration * frameRate) + 20
     }
 
-    /// Maximum consecutive ffmpeg failures before emergency reset
+    /// Maximum consecutive encoder failures before emergency reset
     private let maxConsecutiveFailures = 5
 
-    /// Consecutive nil-process/stdin states that force an encoder reset. This keeps
-    /// "FFmpeg not ready" loops bounded instead of emitting one Sentry event per frame.
+    /// Consecutive not-ready states that force an encoder reset. This keeps
+    /// writer readiness loops bounded instead of emitting one Sentry event per frame.
     private let maxConsecutiveNotReadyFailures = 3
 
     // MARK: - State
 
     /// Buffer stores only timestamps, not CGImages (memory optimization)
-    /// CGImages are written to ffmpeg immediately and not retained
+    /// CGImages are written to the encoder immediately and not retained.
     private var frameTimestamps: [Date] = []
 
-    /// Track consecutive ffmpeg write failures for recovery
+    /// Track consecutive encoder write failures for recovery.
     private var consecutiveWriteFailures = 0
     private var encoderRestartCount = 0
     private var emergencyResetCount = 0
-    private var ffmpegNotReadyCount = 0
+    private var writerNotReadyCount = 0
 
     /// Pending aspect ratio debounce state
     private var pendingAspectRatioSize: CGSize?
@@ -67,9 +63,10 @@ actor VideoChunkEncoder {
     private(set) var currentChunkPath: String?
     private var frameOffsetInChunk: Int = 0
 
-    // FFmpeg process state
-    private var ffmpegProcess: Process?
-    private var ffmpegStdin: FileHandle?
+    // Native HEVC writer state
+    private var assetWriter: AVAssetWriter?
+    private var writerInput: AVAssetWriterInput?
+    private var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
     private var currentOutputSize: CGSize?
     private var currentChunkInputSize: CGSize?  // Track input size for aspect ratio comparison
 
@@ -108,6 +105,10 @@ actor VideoChunkEncoder {
         self.videosDirectory = videosDirectory
         isInitialized = true
         log("VideoChunkEncoder: Initialized at \(videosDirectory.path)")
+    }
+
+    func hasFinalizedChunkForDedupe() -> Bool {
+        hasFinalizedAnyChunk
     }
 
     // MARK: - Frame Processing
@@ -168,24 +169,24 @@ actor VideoChunkEncoder {
             frameOffsetInChunk = 0
             currentChunkInputSize = newFrameSize
 
-            // Start ffmpeg process for this chunk
+            // Start native HEVC writer for this chunk
             do {
-                try await startFFmpegProcess(
+                try startVideoWriter(
                     for: currentChunkPath!,
                     videosDir: videosDir,
                     imageSize: newFrameSize
                 )
                 consecutiveWriteFailures = 0 // Reset on successful start
-                ffmpegNotReadyCount = 0
+                writerNotReadyCount = 0
                 encoderRestartCount += 1
             } catch {
                 consecutiveWriteFailures += 1
-                logError("VideoChunkEncoder: Failed to start ffmpeg (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
+                logError("VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
 
                 // Reset the half-initialized chunk state so the NEXT frame cleanly retries
-                // starting ffmpeg. Without this, currentChunkStartTime stays set while
-                // ffmpegStdin is nil, so every subsequent frame skips the start path and
-                // fails inside writeFrame() with "FFmpeg not ready" — needlessly dropping
+                // starting the writer. Without this, currentChunkStartTime stays set while
+                // writer state is nil, so every subsequent frame skips the start path and
+                // fails inside writeFrame() with "Video writer not ready" — needlessly dropping
                 // ~5 frames (2.5s of Rewind footage) and emitting misleading write-failure
                 // errors until the emergency-reset threshold finally clears the state.
                 currentChunkStartTime = nil
@@ -195,8 +196,8 @@ actor VideoChunkEncoder {
                 frameOffsetInChunk = 0
 
                 if consecutiveWriteFailures >= maxConsecutiveFailures {
-                    logError("VideoChunkEncoder: Too many ffmpeg failures, performing emergency reset")
-                    try await emergencyReset(reason: "ffmpeg_start_failure")
+                    logError("VideoChunkEncoder: Too many video writer failures, performing emergency reset")
+                    try await emergencyReset(reason: "writer_start_failure")
                 }
                 throw error
             }
@@ -213,7 +214,7 @@ actor VideoChunkEncoder {
 
         frameOffsetInChunk += 1
 
-        // Write frame to ffmpeg immediately (CGImage not stored after this)
+        // Write frame to the encoder immediately (CGImage not stored after this)
         do {
             try await writeFrame(image: image)
             consecutiveWriteFailures = 0 // Reset on successful write
@@ -265,9 +266,9 @@ actor VideoChunkEncoder {
         return ChunkFlushResult(videoChunkPath: chunkPath, frames: frames)
     }
 
-    // MARK: - FFmpeg Process Management
+    // MARK: - Video Writer Management
 
-    private func startFFmpegProcess(for relativePath: String, videosDir: URL, imageSize: CGSize) async throws {
+    private func startVideoWriter(for relativePath: String, videosDir: URL, imageSize: CGSize) throws {
         // Create day subdirectory if needed
         let components = relativePath.components(separatedBy: "/")
         if components.count > 1 {
@@ -281,44 +282,57 @@ actor VideoChunkEncoder {
         let outputSize = calculateOutputSize(for: imageSize)
         currentOutputSize = outputSize
 
-        // Find ffmpeg path
-        let ffmpegPath = findFFmpegPath()
+        if FileManager.default.fileExists(atPath: fullPath.path) {
+            try FileManager.default.removeItem(at: fullPath)
+        }
 
-        // Build ffmpeg command
-        // Uses fragmented MP4 so the file can be read while still being written
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: ffmpegPath)
-        process.arguments = [
-            "-f", "image2pipe",
-            "-vcodec", "png",
-            "-r", String(frameRate),
-            "-i", "-",
-            "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2", // Ensure even dimensions
-            "-vcodec", "hevc_videotoolbox",
-            "-tag:v", "hvc1",
-            "-q:v", "65",  // Quality scale 1-100 (65 ≈ CRF 15 equivalent)
-            "-allow_sw", "true",  // Fall back to software if HW encoder busy
-            "-realtime", "true",  // Hint: real-time capture, don't block
-            "-prio_speed", "true",  // Prioritize speed over compression
-            // Fragmented MP4 - allows reading while writing
-            "-movflags", "frag_keyframe+empty_moov+default_base_moof",
-            "-pix_fmt", "yuv420p",
-            "-y", // Overwrite output
-            fullPath.path
+        let width = Int(outputSize.width)
+        let height = Int(outputSize.height)
+        let bitrate = estimatedHEVCBitrate(width: width, height: height)
+
+        let writer = try AVAssetWriter(outputURL: fullPath, fileType: .mp4)
+        writer.shouldOptimizeForNetworkUse = true
+
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+            AVVideoCompressionPropertiesKey: [
+                AVVideoAverageBitRateKey: bitrate,
+                AVVideoExpectedSourceFrameRateKey: max(1, Int(ceil(frameRate))),
+                AVVideoMaxKeyFrameIntervalDurationKey: 10,
+                AVVideoAllowFrameReorderingKey: false
+            ]
         ]
 
-        // Set up pipes
-        let stdinPipe = Pipe()
-        process.standardInput = stdinPipe
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        input.expectsMediaDataInRealTime = true
 
-        try process.run()
+        guard writer.canAdd(input) else {
+            throw RewindError.storageError("Cannot add HEVC writer input")
+        }
+        writer.add(input)
 
-        ffmpegProcess = process
-        ffmpegStdin = stdinPipe.fileHandleForWriting
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+                kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+            ]
+        )
 
-        log("VideoChunkEncoder: Started ffmpeg for chunk at \(relativePath)")
+        guard writer.startWriting() else {
+            throw RewindError.storageError("Failed to start HEVC writer: \(writer.error?.localizedDescription ?? "unknown error")")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        assetWriter = writer
+        writerInput = input
+        pixelBufferAdaptor = adaptor
+
+        log("VideoChunkEncoder: Started native HEVC writer for chunk at \(relativePath)")
 
         // Log frame dimensions to Sentry for debugging user quality issues
         let breadcrumb = Breadcrumb(level: .info, category: "video_encoder")
@@ -330,87 +344,65 @@ actor VideoChunkEncoder {
             "output_width": Int(outputSize.width),
             "output_height": Int(outputSize.height),
             "quality": 65,
-            "encoder": "hevc_videotoolbox",
+            "estimated_bitrate": bitrate,
+            "encoder": "AVAssetWriter.hevc",
+            "input_format": "cvpixelbuffer_bgra",
             "max_resolution": Int(maxResolution)
         ]
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 
     private func writeFrame(image: CGImage) async throws {
-        guard let stdin = ffmpegStdin,
+        guard let input = writerInput,
+              let adaptor = pixelBufferAdaptor,
               let outputSize = currentOutputSize
         else {
-            ffmpegNotReadyCount += 1
+            writerNotReadyCount += 1
 
-            if ffmpegNotReadyCount >= maxConsecutiveNotReadyFailures {
-                logError("VideoChunkEncoder: FFmpeg not ready \(ffmpegNotReadyCount)x, resetting encoder state")
-                try await emergencyReset(reason: "ffmpeg_not_ready_loop")
+            if writerNotReadyCount >= maxConsecutiveNotReadyFailures {
+                logError("VideoChunkEncoder: Video writer not ready \(writerNotReadyCount)x, resetting encoder state")
+                try await emergencyReset(reason: "writer_not_ready_loop")
             } else {
-                log("VideoChunkEncoder: FFmpeg not ready (\(ffmpegNotReadyCount)/\(maxConsecutiveNotReadyFailures))")
+                log("VideoChunkEncoder: Video writer not ready (\(writerNotReadyCount)/\(maxConsecutiveNotReadyFailures))")
             }
 
-            throw RewindError.storageError("FFmpeg not ready")
+            throw RewindError.storageError("Video writer not ready")
         }
 
-        // Wrap image scaling + PNG encoding in autoreleasepool to prevent
-        // CGContext/NSBitmapImageRep accumulation in async actor contexts.
-        // Without this, temporary Obj-C objects from each frame pile up
-        // because Swift concurrency doesn't drain autorelease pools between tasks.
-        let pngData: Data = try autoreleasepool {
-            let scaledImage = scaleImage(image, to: outputSize)
-            guard let data = createPNGData(from: scaledImage) else {
-                throw RewindError.storageError("Failed to create PNG data")
-            }
-            return data
+        try await waitForWriterInputReady(input)
+
+        let pixelBuffer: CVPixelBuffer = try autoreleasepool {
+            try createPixelBuffer(from: image, size: outputSize, adaptor: adaptor)
         }
 
-        // Write to ffmpeg stdin
-        do {
-            try stdin.write(contentsOf: pngData)
-            ffmpegNotReadyCount = 0
-        } catch {
-            throw RewindError.storageError("Failed to write frame to ffmpeg: \(error.localizedDescription)")
+        let presentationTime = CMTime(seconds: Double(max(0, frameOffsetInChunk - 1)) / frameRate, preferredTimescale: 600)
+        guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
+            throw RewindError.storageError("Failed to append frame to HEVC writer: \(assetWriter?.error?.localizedDescription ?? "unknown error")")
         }
+        writerNotReadyCount = 0
     }
 
     private func finalizeCurrentChunk() async throws {
         stalenessCheckTask?.cancel()
         stalenessCheckTask = nil
-
-        // Close stdin to signal end of input to ffmpeg
-        if let stdin = ffmpegStdin {
-            try? stdin.close()
-            ffmpegStdin = nil
+        defer {
+            resetCurrentChunkState()
         }
 
-        // Wait for ffmpeg to finish, but don't block forever.
-        // Under memory pressure, ffmpeg can hang in a disk I/O syscall and never respond
-        // to stdin close. A 10-second watchdog force-kills it so the cooperative thread
-        // isn't blocked indefinitely, which would deadlock the entire actor.
-        if let process = ffmpegProcess {
-            let pid = process.processIdentifier
+        if let input = writerInput, let writer = assetWriter {
             let frameCount = frameTimestamps.count
-
-            let watchdog = Task.detached(priority: .background) {
-                try? await Task.sleep(nanoseconds: 10_000_000_000)
-                if process.isRunning {
-                    logError("VideoChunkEncoder: ffmpeg hung for 10s — force killing PID \(pid)")
-                    kill(pid, SIGKILL)
-                }
+            input.markAsFinished()
+            do {
+                try await finishWriting(writer)
+            } catch {
+                writer.cancelWriting()
+                throw error
             }
-
-            process.waitUntilExit()
-            watchdog.cancel()
-
-            if process.terminationStatus != 0 {
-                logError("VideoChunkEncoder: FFmpeg exited with status \(process.terminationStatus)")
-            } else {
-                log("VideoChunkEncoder: Finalized chunk with \(frameCount) frames (restartCount=\(encoderRestartCount), emergencyResets=\(emergencyResetCount))")
-            }
-
-            ffmpegProcess = nil
+            log("VideoChunkEncoder: Finalized chunk with \(frameCount) frames (restartCount=\(encoderRestartCount), emergencyResets=\(emergencyResetCount))")
         }
+    }
 
+    private func resetCurrentChunkState() {
         // Reset state (timestamps only - no CGImages retained)
         frameTimestamps.removeAll()
         currentChunkStartTime = nil
@@ -418,6 +410,9 @@ actor VideoChunkEncoder {
         frameOffsetInChunk = 0
         currentOutputSize = nil
         currentChunkInputSize = nil
+        assetWriter = nil
+        writerInput = nil
+        pixelBufferAdaptor = nil
         consecutiveWriteFailures = 0
         pendingAspectRatioSize = nil
         pendingAspectRatioSince = nil
@@ -427,7 +422,7 @@ actor VideoChunkEncoder {
 
     /// Reset the staleness timer after each successful frame write.
     /// If no new frame arrives within chunkDuration + 10s, finalize the chunk
-    /// to release the ffmpeg process and H.265 hardware encoder context.
+    /// to release the H.265 hardware encoder context.
     private func resetStalenessTimer() {
         stalenessCheckTask?.cancel()
         let timeout = chunkDuration + 10.0
@@ -504,68 +499,108 @@ actor VideoChunkEncoder {
         return CGSize(width: CGFloat(newWidth), height: CGFloat(newHeight))
     }
 
-    private func scaleImage(_ image: CGImage, to targetSize: CGSize) -> CGImage {
-        let currentSize = CGSize(width: image.width, height: image.height)
+    private func estimatedHEVCBitrate(width: Int, height: Int) -> Int {
+        let bitsPerPixelFrame = 0.35
+        let bitrate = Double(width * height) * max(frameRate, 1.0) * bitsPerPixelFrame
+        return max(350_000, min(8_000_000, Int(bitrate)))
+    }
 
-        // If already the right size, return as-is
-        if currentSize.width == targetSize.width && currentSize.height == targetSize.height {
-            return image
+    private func createPixelBuffer(
+        from image: CGImage,
+        size: CGSize,
+        adaptor: AVAssetWriterInputPixelBufferAdaptor
+    ) throws -> CVPixelBuffer {
+        let width = Int(size.width)
+        let height = Int(size.height)
+        guard width > 0, height > 0 else {
+            throw RewindError.storageError("Invalid pixel buffer size \(size)")
         }
 
-        // Create a context at the target size
+        let pixelBuffer: CVPixelBuffer
+        if let pool = adaptor.pixelBufferPool {
+            var pooledBuffer: CVPixelBuffer?
+            let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pooledBuffer)
+            guard status == kCVReturnSuccess, let pooledBuffer else {
+                throw RewindError.storageError("Failed to create pooled pixel buffer: \(status)")
+            }
+            pixelBuffer = pooledBuffer
+        } else {
+            var createdBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                nil,
+                width,
+                height,
+                kCVPixelFormatType_32BGRA,
+                [
+                    kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+                ] as CFDictionary,
+                &createdBuffer
+            )
+            guard status == kCVReturnSuccess, let createdBuffer else {
+                throw RewindError.storageError("Failed to create pixel buffer: \(status)")
+            }
+            pixelBuffer = createdBuffer
+        }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+
+        guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+            throw RewindError.storageError("Pixel buffer has no base address")
+        }
+
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
         guard let context = CGContext(
-            data: nil,
-            width: Int(targetSize.width),
-            height: Int(targetSize.height),
+            data: baseAddress,
+            width: width,
+            height: height,
             bitsPerComponent: 8,
-            bytesPerRow: 0,
+            bytesPerRow: bytesPerRow,
             space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
         ) else {
-            return image
+            throw RewindError.storageError("Failed to create pixel buffer context")
         }
 
         context.interpolationQuality = .high
-        context.draw(image, in: CGRect(origin: .zero, size: targetSize))
-
-        return context.makeImage() ?? image
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return pixelBuffer
     }
 
-    private func createPNGData(from image: CGImage) -> Data? {
-        let bitmapRep = NSBitmapImageRep(cgImage: image)
-        return bitmapRep.representation(using: .png, properties: [:])
-    }
-
-    private func findFFmpegPath() -> String {
-        // Common locations for ffmpeg (bundled first for users without Homebrew)
-        // Use Bundle.resourceBundle for SPM resources (they're in a nested bundle, not main bundle)
-        let bundledPath = Bundle.resourceBundle.path(forResource: "ffmpeg", ofType: nil)
-        let possiblePaths: [(path: String, source: String)] = [
-            (bundledPath ?? "", "bundled"),
-            ("/opt/homebrew/bin/ffmpeg", "homebrew"),
-            ("/usr/local/bin/ffmpeg", "usr_local"),
-            ("/usr/bin/ffmpeg", "system"),
-        ].filter { !$0.path.isEmpty }
-
-        for (path, source) in possiblePaths {
-            if FileManager.default.fileExists(atPath: path) {
-                reportFFmpegSource(source: source, path: path)
-                return path
+    private func finishWriting(_ writer: AVAssetWriter) async throws {
+        let writerBox = AssetWriterBox(writer)
+        try await withCheckedThrowingContinuation { continuation in
+            writerBox.writer.finishWriting {
+                switch writerBox.writer.status {
+                case .completed:
+                    continuation.resume()
+                case .failed, .cancelled:
+                    continuation.resume(throwing: RewindError.storageError("HEVC writer failed: \(writerBox.writer.error?.localizedDescription ?? Self.writerStatusDescription(writerBox.writer.status))"))
+                default:
+                    continuation.resume(throwing: RewindError.storageError("HEVC writer ended in unexpected state: \(Self.writerStatusDescription(writerBox.writer.status))"))
+                }
             }
         }
-
-        // Fall back to PATH lookup
-        reportFFmpegSource(source: "path_fallback", path: "ffmpeg")
-        return "ffmpeg"
     }
 
-    private func reportFFmpegSource(source: String, path: String) {
-        // Only report once per app launch
-        guard !Self.hasReportedFFmpegSource else { return }
-        Self.hasReportedFFmpegSource = true
+    private func waitForWriterInputReady(_ input: AVAssetWriterInput) async throws {
+        let deadline = Date().addingTimeInterval(2.0)
+        while !input.isReadyForMoreMediaData {
+            if Date() >= deadline {
+                throw RewindError.storageError("Video writer input backpressured")
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
 
-        Task { @MainActor in
-            PostHogManager.shared.ffmpegResolved(source: source, path: path)
+    private nonisolated static func writerStatusDescription(_ status: AVAssetWriter.Status) -> String {
+        switch status {
+        case .unknown: return "unknown"
+        case .writing: return "writing"
+        case .completed: return "completed"
+        case .failed: return "failed"
+        case .cancelled: return "cancelled"
+        @unknown default: return "unrecognized"
         }
     }
 
@@ -576,26 +611,11 @@ actor VideoChunkEncoder {
         stalenessCheckTask?.cancel()
         stalenessCheckTask = nil
 
-        // Close stdin first
-        if let stdin = ffmpegStdin {
-            try? stdin.close()
-            ffmpegStdin = nil
-        }
-
-        // Terminate ffmpeg process
-        if let process = ffmpegProcess {
-            let pid = process.processIdentifier
-            process.terminate() // SIGTERM
-            ffmpegProcess = nil
-            // Force kill after 2s if ffmpeg didn't respond to SIGTERM
-            // (e.g., stuck in disk I/O under memory pressure)
-            Task.detached(priority: .background) {
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                if process.isRunning {
-                    kill(pid, SIGKILL)
-                }
-            }
-        }
+        writerInput?.markAsFinished()
+        assetWriter?.cancelWriting()
+        assetWriter = nil
+        writerInput = nil
+        pixelBufferAdaptor = nil
 
         frameTimestamps.removeAll()
         currentChunkStartTime = nil
@@ -604,10 +624,10 @@ actor VideoChunkEncoder {
         currentOutputSize = nil
         currentChunkInputSize = nil
         consecutiveWriteFailures = 0
-        ffmpegNotReadyCount = 0
+        writerNotReadyCount = 0
     }
 
-    /// Emergency reset when ffmpeg fails repeatedly or buffer overflows
+    /// Emergency reset when encoding fails repeatedly or buffer overflows
     /// Clears all state and allows fresh start on next frame
     private func emergencyReset(reason: String = "failure_threshold") async throws {
         stalenessCheckTask?.cancel()
@@ -623,7 +643,7 @@ actor VideoChunkEncoder {
             "reason": reason,
             "dropped_frames": droppedFrames,
             "consecutive_failures": consecutiveWriteFailures,
-            "ffmpeg_not_ready_count": ffmpegNotReadyCount,
+            "writer_not_ready_count": writerNotReadyCount,
             "encoder_restart_count": encoderRestartCount,
             "emergency_reset_count": emergencyResetCount,
             "buffer_limit": maxBufferFrames,
@@ -633,40 +653,11 @@ actor VideoChunkEncoder {
 
         logError("VideoChunkEncoder: Emergency reset (reason=\(reason)) - dropping \(droppedFrames) frames to prevent memory leak")
 
-        // Close stdin first (don't wait for ffmpeg to finish - it may be hung)
-        if let stdin = ffmpegStdin {
-            try? stdin.close()
-            ffmpegStdin = nil
-        }
+        writerInput?.markAsFinished()
+        assetWriter?.cancelWriting()
 
-        // Terminate ffmpeg process forcefully.
-        // Use SIGTERM first, then SIGKILL after 2s if it doesn't respond.
-        // ffmpeg can get stuck in disk I/O when the system is under memory pressure,
-        // causing SIGTERM to be ignored (process is in uninterruptible sleep in the kernel).
-        // Without the SIGKILL fallback, zombie ffmpeg processes accumulate and eventually
-        // push the app's memory to 7GB+, making the entire system unresponsive.
-        if let process = ffmpegProcess {
-            let pid = process.processIdentifier
-            process.terminate() // SIGTERM
-            ffmpegProcess = nil
-            Task.detached(priority: .background) {
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                if process.isRunning {
-                    logError("VideoChunkEncoder: ffmpeg still running 2s after SIGTERM — force killing PID \(pid)")
-                    kill(pid, SIGKILL)
-                }
-            }
-        }
-
-        // Clear all state
-        frameTimestamps.removeAll()
-        currentChunkStartTime = nil
-        currentChunkPath = nil
-        frameOffsetInChunk = 0
-        currentOutputSize = nil
-        currentChunkInputSize = nil
-        consecutiveWriteFailures = 0
-        ffmpegNotReadyCount = 0
+        resetCurrentChunkState()
+        writerNotReadyCount = 0
 
         log("VideoChunkEncoder: Emergency reset complete, ready for new frames")
     }
@@ -676,11 +667,11 @@ actor VideoChunkEncoder {
         let maxBufferFrames: Int
         let oldestFrameAge: TimeInterval?
         let currentChunkAge: TimeInterval?
-        let isFFmpegRunning: Bool
+        let isEncoderRunning: Bool
         let consecutiveWriteFailures: Int
         let encoderRestartCount: Int
         let emergencyResetCount: Int
-        let ffmpegNotReadyCount: Int
+        let writerNotReadyCount: Int
     }
 
     /// Get current buffer and lifecycle status for memory diagnostics.
@@ -691,11 +682,19 @@ actor VideoChunkEncoder {
             maxBufferFrames: maxBufferFrames,
             oldestFrameAge: frameTimestamps.first.map { now.timeIntervalSince($0) },
             currentChunkAge: currentChunkStartTime.map { now.timeIntervalSince($0) },
-            isFFmpegRunning: ffmpegProcess?.isRunning ?? false,
+            isEncoderRunning: assetWriter != nil,
             consecutiveWriteFailures: consecutiveWriteFailures,
             encoderRestartCount: encoderRestartCount,
             emergencyResetCount: emergencyResetCount,
-            ffmpegNotReadyCount: ffmpegNotReadyCount
+            writerNotReadyCount: writerNotReadyCount
         )
+    }
+}
+
+private final class AssetWriterBox: @unchecked Sendable {
+    let writer: AVAssetWriter
+
+    init(_ writer: AVAssetWriter) {
+        self.writer = writer
     }
 }

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -525,16 +525,19 @@ actor RewindIndexer {
         }
     }
 
-    /// Stop the indexer
-    func stop() async {
+    /// Stop the indexer and return whether pending video frames flushed successfully.
+    @discardableResult
+    func stop() async -> Bool {
         // Flush any pending video frames before stopping
         do {
             _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
         } catch {
             logError("RewindIndexer: Failed to flush video chunk: \(error)")
+            return false
         }
 
         log("RewindIndexer: Stopped")
+        return true
     }
 
     // MARK: - OCR Backfill (battery → AC)
@@ -762,6 +765,44 @@ actor RewindIndexer {
 
         // Fallback: assume 1 fps
         return Int(CMTimeGetSeconds(duration))
+    }
+}
+
+enum RewindShutdownFlush {
+    static func flush(timeout: TimeInterval, context: String) -> Bool {
+        let state = RewindFlushState()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached(priority: .userInitiated) {
+            state.setFlushed(await RewindIndexer.shared.stop())
+            semaphore.signal()
+        }
+
+        if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            logError("\(context): Timed out flushing Rewind chunk")
+            return false
+        }
+
+        if !state.didFlush {
+            logError("\(context): Failed to flush Rewind chunk")
+        }
+        return state.didFlush
+    }
+}
+
+private final class RewindFlushState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flushed = false
+
+    var didFlush: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return flushed
+    }
+
+    func setFlushed(_ value: Bool) {
+        lock.lock()
+        flushed = value
+        lock.unlock()
     }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -21,6 +21,12 @@ actor RewindIndexer {
     private var statsLastLogTime = Date()
     private let statsLogInterval: TimeInterval = 60
 
+    /// Drop repeated static captures, but keep periodic anchors so long-running
+    /// unchanged screens still appear in the timeline.
+    private let frameDedupeMaxInterval: TimeInterval = 30.0
+    private var lastEncodedFrameSignature: FrameDedupeSignature?
+    private var lastEncodedFrameTimestamp: Date?
+
     /// Backoff state for initialization retries
     private var initFailureCount = 0
     private var nextRetryTime: Date = .distantPast
@@ -44,6 +50,8 @@ actor RewindIndexer {
         isInitializing = false
         initFailureCount = 0
         nextRetryTime = .distantPast
+        lastEncodedFrameSignature = nil
+        lastEncodedFrameTimestamp = nil
         log("RewindIndexer: Reset (will re-initialize on next frame)")
     }
 
@@ -132,6 +140,43 @@ actor RewindIndexer {
         }
     }
 
+    private func makeFrameDedupeSignature(cgImage: CGImage, appName: String, windowTitle: String?) -> FrameDedupeSignature {
+        FrameDedupeSignature(
+            fingerprint: RewindOCRService.dHash(of: cgImage),
+            width: cgImage.width,
+            height: cgImage.height,
+            appName: appName,
+            windowTitle: windowTitle
+        )
+    }
+
+    private func shouldSkipFrameForDedupe(_ signature: FrameDedupeSignature, timestamp: Date) async -> Bool {
+        guard await VideoChunkEncoder.shared.hasFinalizedChunkForDedupe() else {
+            return false
+        }
+
+        guard let lastSignature = lastEncodedFrameSignature,
+              let lastTimestamp = lastEncodedFrameTimestamp,
+              signature == lastSignature
+        else {
+            return false
+        }
+
+        return timestamp.timeIntervalSince(lastTimestamp) <= frameDedupeMaxInterval
+    }
+
+    private func markFrameEncodedForDedupe(_ signature: FrameDedupeSignature, timestamp: Date) {
+        lastEncodedFrameSignature = signature
+        lastEncodedFrameTimestamp = timestamp
+    }
+
+    private func hasMetadata(focusStatus: String?, extractedTasks: [String]?, insight: String?) -> Bool {
+        if focusStatus != nil { return true }
+        if extractedTasks?.isEmpty == false { return true }
+        if insight?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false { return true }
+        return false
+    }
+
     // MARK: - Frame Processing
 
     /// Process a captured frame from ProactiveAssistantsPlugin
@@ -151,6 +196,11 @@ actor RewindIndexer {
 
             guard let cgImage = cgImage else {
                 logError("RewindIndexer: Failed to create CGImage from frame data")
+                return
+            }
+
+            let dedupeSignature = makeFrameDedupeSignature(cgImage: cgImage, appName: frame.appName, windowTitle: frame.windowTitle)
+            if await shouldSkipFrameForDedupe(dedupeSignature, timestamp: frame.captureTime) {
                 return
             }
 
@@ -181,7 +231,7 @@ actor RewindIndexer {
                 recordOCROutcome(.ran)
                 do {
                     let ocrResult = try await Task(priority: .utility) {
-                        try await RewindOCRService.shared.extractTextWithBounds(from: frame.jpegData)
+                        try await RewindOCRService.shared.extractTextWithBounds(from: cgImage)
                     }.value
                     ocrText = ocrResult.fullText
                     if let data = try? JSONEncoder().encode(ocrResult) {
@@ -207,6 +257,7 @@ actor RewindIndexer {
             )
 
             let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
+            markFrameEncodedForDedupe(dedupeSignature, timestamp: frame.captureTime)
 
             // Embed OCR text for semantic search (non-blocking)
             if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
@@ -232,6 +283,11 @@ actor RewindIndexer {
         scheduleRetentionCleanupIfDue()
 
         do {
+            let dedupeSignature = makeFrameDedupeSignature(cgImage: cgImage, appName: appName, windowTitle: windowTitle)
+            if await shouldSkipFrameForDedupe(dedupeSignature, timestamp: captureTime) {
+                return
+            }
+
             // Add frame to video encoder (CGImage directly, no decode needed)
             let encodedFrame = try await VideoChunkEncoder.shared.addFrame(
                 image: cgImage,
@@ -283,6 +339,7 @@ actor RewindIndexer {
             )
 
             let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
+            markFrameEncodedForDedupe(dedupeSignature, timestamp: captureTime)
 
             // Embed OCR text for semantic search (non-blocking)
             if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
@@ -320,6 +377,12 @@ actor RewindIndexer {
                 return
             }
 
+            let dedupeSignature = makeFrameDedupeSignature(cgImage: cgImage, appName: frame.appName, windowTitle: frame.windowTitle)
+            let carriesMetadata = hasMetadata(focusStatus: focusStatus, extractedTasks: extractedTasks, insight: insight)
+            if !carriesMetadata, await shouldSkipFrameForDedupe(dedupeSignature, timestamp: frame.captureTime) {
+                return
+            }
+
             // Add frame to video encoder
             let encodedFrame = try await VideoChunkEncoder.shared.addFrame(
                 image: cgImage,
@@ -346,7 +409,7 @@ actor RewindIndexer {
                 recordOCROutcome(.ran)
                 do {
                     let ocrResult = try await Task(priority: .utility) {
-                        try await RewindOCRService.shared.extractTextWithBounds(from: frame.jpegData)
+                        try await RewindOCRService.shared.extractTextWithBounds(from: cgImage)
                     }.value
                     ocrText = ocrResult.fullText
                     if let data = try? JSONEncoder().encode(ocrResult) {
@@ -383,6 +446,9 @@ actor RewindIndexer {
             )
 
             let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
+            if !carriesMetadata {
+                markFrameEncodedForDedupe(dedupeSignature, timestamp: frame.captureTime)
+            }
 
             // Embed OCR text for semantic search (non-blocking)
             if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
@@ -704,5 +770,13 @@ private struct FrameMetadata {
     let timestamp: Date
     let frameOffset: Int
     let appName: String?
+    let windowTitle: String?
+}
+
+private struct FrameDedupeSignature: Equatable {
+    let fingerprint: UInt64
+    let width: Int
+    let height: Int
+    let appName: String
     let windowTitle: String?
 }

--- a/desktop/macos/Desktop/Sources/Rewind/UI/InteractiveTimelineBar.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/InteractiveTimelineBar.swift
@@ -144,6 +144,8 @@ class TimeBasedTimelineNSView: NSView {
 
     private var trackingArea: NSTrackingArea?
     private var tooltipWindow: NSWindow?
+    private var isScrubbing = false
+    private var lastScrubbedIndex: Int?
 
     override var isFlipped: Bool { true }
 
@@ -259,13 +261,38 @@ class TimeBasedTimelineNSView: NSView {
 
         if let index = indexAtPoint(location) {
             log("TimelineBar: Click at \(location) resolved to index \(index) of \(screenshots.count)")
-            onSelect?(index)
+            beginScrubbing(at: index)
         } else {
             log("TimelineBar: Click at \(location) not in timeline rect \(rect), bounds=\(bounds), screenshots=\(screenshots.count)")
         }
     }
 
+    override func mouseDragged(with event: NSEvent) {
+        guard isScrubbing else { return }
+        let location = convert(event.locationInWindow, from: nil)
+        guard let index = scrubIndex(at: location) else { return }
+        selectScrubIndex(index)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard isScrubbing else { return }
+        let location = convert(event.locationInWindow, from: nil)
+        if let index = scrubIndex(at: location) {
+            selectScrubIndex(index)
+        }
+        isScrubbing = false
+        lastScrubbedIndex = nil
+        if !timelineRect().contains(location) {
+            hoveredIndex = nil
+            hoveredGapIndex = nil
+            onHover?(nil)
+            onGapHover?(nil)
+            needsDisplay = true
+        }
+    }
+
     override func mouseMoved(with event: NSEvent) {
+        guard !isScrubbing else { return }
         let location = convert(event.locationInWindow, from: nil)
 
         // Check if hovering over a gap
@@ -292,6 +319,7 @@ class TimeBasedTimelineNSView: NSView {
     }
 
     override func mouseExited(with event: NSEvent) {
+        guard !isScrubbing else { return }
         hoveredIndex = nil
         hoveredGapIndex = nil
         onHover?(nil)
@@ -300,10 +328,46 @@ class TimeBasedTimelineNSView: NSView {
         needsDisplay = true
     }
 
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(timelineRect(), cursor: .pointingHand)
+    }
+
+    private func beginScrubbing(at index: Int) {
+        isScrubbing = true
+        hideTooltip()
+        selectScrubIndex(index)
+    }
+
+    private func selectScrubIndex(_ index: Int) {
+        guard index >= 0, index < screenshots.count, index != lastScrubbedIndex else { return }
+        lastScrubbedIndex = index
+        hoveredIndex = index
+        hoveredGapIndex = nil
+        onHover?(index)
+        onGapHover?(nil)
+        onSelect?(index)
+        needsDisplay = true
+    }
+
     private func indexAtPoint(_ point: CGPoint) -> Int? {
         let rect = timelineRect()
-        guard rect.contains(point), !screenshots.isEmpty else { return nil }
+        guard rect.width > 0, rect.contains(point), !screenshots.isEmpty else { return nil }
+        return nearestIndex(forX: point.x, in: rect)
+    }
 
+    private func scrubIndex(at point: CGPoint) -> Int? {
+        let rect = timelineRect()
+        guard rect.width > 0, !screenshots.isEmpty else { return nil }
+
+        let verticallyNearTimeline = point.y >= rect.minY - 28 && point.y <= rect.maxY + 28
+        guard verticallyNearTimeline else { return nil }
+
+        let clampedX = max(rect.minX, min(rect.maxX, point.x))
+        return nearestIndex(forX: clampedX, in: rect)
+    }
+
+    private func nearestIndex(forX x: CGFloat, in rect: NSRect) -> Int? {
         // Recalculate layout if bounds changed (lightweight, no segment rebuild)
         if !segments.isEmpty && needsLayoutRecalculation() {
             calculateLayout()
@@ -312,9 +376,9 @@ class TimeBasedTimelineNSView: NSView {
         // If layout hasn't been computed yet, use linear fallback
         if frameXPositions.isEmpty || (frameXPositions.count > 1 && frameXPositions.allSatisfy { $0 == 0 }) {
             // Linear fallback (like the old implementation)
-            let relativeX = point.x - rect.minX
+            let relativeX = x - rect.minX
             let ratio = relativeX / rect.width
-            let index = Int(ratio * CGFloat(screenshots.count))
+            let index = Int(round(ratio * CGFloat(max(0, screenshots.count - 1))))
             return max(0, min(screenshots.count - 1, index))
         }
 
@@ -322,8 +386,8 @@ class TimeBasedTimelineNSView: NSView {
         var closestIndex = 0
         var closestDistance = CGFloat.infinity
 
-        for (index, x) in frameXPositions.enumerated() {
-            let distance = abs(point.x - x)
+        for (index, frameX) in frameXPositions.enumerated() {
+            let distance = abs(x - frameX)
             if distance < closestDistance {
                 closestDistance = distance
                 closestIndex = index

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -11,6 +11,8 @@ struct RewindPage: View {
     @State private var currentIndex: Int = 0
     @State private var currentImage: NSImage?
     @State private var isLoadingFrame = false
+    @State private var frameLoadTask: Task<Void, Never>?
+    @State private var frameLoadRequestID = UUID()
     @State private var showDatePicker = false
 
     @State private var searchViewMode: SearchViewMode? = nil
@@ -173,7 +175,7 @@ struct RewindPage: View {
                 // First load or current screenshot deleted — start at newest (last index, ASC order)
                 currentIndex = newScreenshots.count - 1
                 selectedGroupIndex = 0
-                Task { await loadCurrentFrame() }
+                scheduleLoadCurrentFrame()
             }
         }
         .onChange(of: viewModel.activeSearchQuery) { oldQuery, newQuery in
@@ -436,7 +438,7 @@ struct RewindPage: View {
                         searchViewMode = .results
                         if !viewModel.screenshots.isEmpty {
                             currentIndex = 0
-                            Task { await loadCurrentFrame() }
+                            scheduleLoadCurrentFrame()
                         }
                     } label: {
                         Image(systemName: "list.bullet")
@@ -452,7 +454,7 @@ struct RewindPage: View {
                     Button {
                         if searchViewMode != .timeline && !viewModel.screenshots.isEmpty {
                             currentIndex = 0
-                            Task { await loadCurrentFrame() }
+                            scheduleLoadCurrentFrame()
                         }
                         searchViewMode = .timeline
                     } label: {
@@ -530,7 +532,7 @@ struct RewindPage: View {
                                 selectedGroupIndex = groupIndex
                                 currentIndex = 0
                                 searchViewMode = .timeline
-                                Task { await loadCurrentFrame() }
+                                scheduleLoadCurrentFrame()
                             }
                         )
                         .id(groupIndex)
@@ -817,22 +819,39 @@ struct RewindPage: View {
 
     // MARK: - Playback
 
-    private func loadCurrentFrame() async {
+    private func scheduleLoadCurrentFrame() {
+        frameLoadTask?.cancel()
+        frameLoadRequestID = UUID()
+        let requestID = frameLoadRequestID
+        let requestedIndex = currentIndex
+        frameLoadTask = Task {
+            await loadCurrentFrame(at: requestedIndex, requestID: requestID)
+        }
+    }
+
+    private func isCurrentFrameLoad(index: Int, requestID: UUID) -> Bool {
+        !Task.isCancelled && frameLoadRequestID == requestID && currentIndex == index
+    }
+
+    private func loadCurrentFrame(at requestedIndex: Int, requestID: UUID) async {
         let screenshots = activeScreenshots
-        guard currentIndex < screenshots.count else { return }
+        guard requestedIndex < screenshots.count else { return }
 
         isLoadingFrame = true
 
-        // Try to load the current frame
-        if let image = await tryLoadFrame(at: currentIndex) {
+        // Try to load the requested frame. Scrubbing can launch several loads;
+        // only the newest request is allowed to update visible state.
+        if let image = await tryLoadFrame(at: requestedIndex) {
+            guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID) else { return }
             currentImage = image
-            viewModel.selectScreenshot(screenshots[currentIndex])
+            viewModel.selectScreenshot(screenshots[requestedIndex])
             isLoadingFrame = false
             return
         }
 
         // Frame failed to load (likely in an unfinalized video chunk).
         // Do NOT move currentIndex — keep the user's position and show the last valid image.
+        guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID) else { return }
         isLoadingFrame = false
     }
 
@@ -886,7 +905,7 @@ struct RewindPage: View {
         guard newIndex != currentIndex else { return }
 
         currentIndex = newIndex
-        Task { await loadCurrentFrame() }
+        scheduleLoadCurrentFrame()
     }
 
     private func nextFrame() {

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -189,6 +189,11 @@ struct RewindPage: View {
                 searchViewMode = nil
                 selectedGroupIndex = 0
             }
+            invalidatePendingFrameLoad()
+            if searchViewMode != .results && !activeScreenshots.isEmpty {
+                currentIndex = min(currentIndex, activeScreenshots.count - 1)
+                scheduleLoadCurrentFrame()
+            }
         }
         // Global keyboard handlers
         .onKeyPress(.escape) {
@@ -454,9 +459,9 @@ struct RewindPage: View {
                     Button {
                         if searchViewMode != .timeline && !viewModel.screenshots.isEmpty {
                             currentIndex = 0
-                            scheduleLoadCurrentFrame()
                         }
                         searchViewMode = .timeline
+                        scheduleLoadCurrentFrame()
                     } label: {
                         Image(systemName: "timeline.selection")
                             .scaledFont(size: 11)
@@ -541,6 +546,11 @@ struct RewindPage: View {
                 .padding(.vertical, 8)
             }
             .onChange(of: selectedGroupIndex) { _, newIndex in
+                invalidatePendingFrameLoad()
+                if searchViewMode == .timeline && !activeScreenshots.isEmpty {
+                    currentIndex = min(currentIndex, activeScreenshots.count - 1)
+                    scheduleLoadCurrentFrame()
+                }
                 withAnimation {
                     proxy.scrollTo(newIndex, anchor: .center)
                 }
@@ -561,6 +571,25 @@ struct RewindPage: View {
             return currentGroupScreenshots
         }
         return viewModel.screenshots
+    }
+
+    private var activeFrameSourceToken: String {
+        let screenshots = activeScreenshots
+        let currentScreenshotID: String
+        if currentIndex < screenshots.count {
+            let screenshot = screenshots[currentIndex]
+            currentScreenshotID = screenshot.id.map(String.init)
+                ?? "\(screenshot.timestamp.timeIntervalSince1970):\(screenshot.videoChunkPath ?? screenshot.imagePath ?? "")"
+        } else {
+            currentScreenshotID = "none"
+        }
+        return [
+            searchViewMode.map(String.init(describing:)) ?? "timeline",
+            viewModel.activeSearchQuery ?? "",
+            String(selectedGroupIndex),
+            String(screenshots.count),
+            currentScreenshotID,
+        ].joined(separator: "|")
     }
 
     // MARK: - Timeline with Search
@@ -824,16 +853,27 @@ struct RewindPage: View {
         frameLoadRequestID = UUID()
         let requestID = frameLoadRequestID
         let requestedIndex = currentIndex
+        let sourceToken = activeFrameSourceToken
         frameLoadTask = Task {
-            await loadCurrentFrame(at: requestedIndex, requestID: requestID)
+            await loadCurrentFrame(at: requestedIndex, requestID: requestID, sourceToken: sourceToken)
         }
     }
 
-    private func isCurrentFrameLoad(index: Int, requestID: UUID) -> Bool {
-        !Task.isCancelled && frameLoadRequestID == requestID && currentIndex == index
+    private func invalidatePendingFrameLoad() {
+        frameLoadTask?.cancel()
+        frameLoadTask = nil
+        frameLoadRequestID = UUID()
+        isLoadingFrame = false
     }
 
-    private func loadCurrentFrame(at requestedIndex: Int, requestID: UUID) async {
+    private func isCurrentFrameLoad(index: Int, requestID: UUID, sourceToken: String) -> Bool {
+        !Task.isCancelled
+            && frameLoadRequestID == requestID
+            && currentIndex == index
+            && activeFrameSourceToken == sourceToken
+    }
+
+    private func loadCurrentFrame(at requestedIndex: Int, requestID: UUID, sourceToken: String) async {
         let screenshots = activeScreenshots
         guard requestedIndex < screenshots.count else { return }
 
@@ -842,7 +882,7 @@ struct RewindPage: View {
         // Try to load the requested frame. Scrubbing can launch several loads;
         // only the newest request is allowed to update visible state.
         if let image = await tryLoadFrame(at: requestedIndex) {
-            guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID) else { return }
+            guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID, sourceToken: sourceToken) else { return }
             currentImage = image
             viewModel.selectScreenshot(screenshots[requestedIndex])
             isLoadingFrame = false
@@ -851,7 +891,7 @@ struct RewindPage: View {
 
         // Frame failed to load (likely in an unfinalized video chunk).
         // Do NOT move currentIndex — keep the user's position and show the last valid image.
-        guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID) else { return }
+        guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID, sourceToken: sourceToken) else { return }
         isLoadingFrame = false
     }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -789,8 +789,8 @@ struct RewindPage: View {
                     }
                 }
 
-                // Scroll hint
-                Text("scroll to navigate")
+                // Navigation hint
+                Text("scroll or drag to navigate")
                     .scaledFont(size: 9)
                     .foregroundColor(.white.opacity(0.3))
             }

--- a/desktop/macos/changelog/unreleased/20260630-rewind-scrub-and-storage.json
+++ b/desktop/macos/changelog/unreleased/20260630-rewind-scrub-and-storage.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Rewind scrubbing and made screenshot history capture more efficient"
+}


### PR DESCRIPTION
## Summary
- Add click-and-drag scrubbing to the Rewind timeline while preserving scroll-wheel navigation
- Move Rewind video capture from ffmpeg subprocess encoding to native AVAssetWriter HEVC chunks backed by BGRA pixel buffers
- Avoid extra JPEG round-trips in the Rewind indexing/OCR path and skip repeated static frames with periodic timeline anchors

## Validation
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`
- `git diff --check`
- Native HEVC smoke test produced a valid HEVC MP4 and verified frame-index extraction with ffmpeg
- Pre-push checks passed, including desktop changelog validation

## Notes
- Attempted a named-bundle app run with `OMI_APP_NAME="omi-rewind-scrub" ./run.sh --yolo`; build reached signing, then stopped because no Apple signing identity is installed. The script refused ad-hoc signing to avoid resetting Screen Recording permissions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

