### PR TITLE
Fix ChatGPT prod MCP OAuth token exchange

### DIFF
--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -35,6 +35,7 @@ AUTH_CODE_TTL_SECONDS = int(os.getenv("MCP_OAUTH_AUTH_CODE_TTL_SECONDS", "600"))
 REFRESH_TOKEN_TTL_DAYS = int(os.getenv("MCP_OAUTH_REFRESH_TOKEN_TTL_DAYS", "365"))
 PKCE_ALLOWED_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
 SUPPORTED_TOKEN_AUTH_METHODS = ["client_secret_post", "none"]
+PUBLIC_CHATGPT_CLIENT_IDS = {"omi-chatgpt-prod"}
 
 
 def hash_secret(secret: str) -> str:
@@ -126,6 +127,12 @@ def _env_clients() -> dict[str, dict]:
 def _legacy_chatgpt_client() -> dict:
     secret = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_SECRET", "")
     secret_hash = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_SECRET_SHA256", "")
+    auth_method = os.getenv("MCP_OAUTH_CHATGPT_TOKEN_AUTH_METHOD", "").strip()
+    if not auth_method and DEFAULT_CLIENT_ID in PUBLIC_CHATGPT_CLIENT_IDS:
+        auth_method = "none"
+    auth_method = auth_method or "client_secret_post"
+    if auth_method not in SUPPORTED_TOKEN_AUTH_METHODS:
+        auth_method = "client_secret_post"
     return {
         "id": DEFAULT_CLIENT_ID,
         "name": DEFAULT_CLIENT_NAME,
@@ -133,8 +140,9 @@ def _legacy_chatgpt_client() -> dict:
         "allowed_redirect_uris": _csv_env("MCP_OAUTH_CHATGPT_REDIRECT_URIS"),
         "allowed_resources": [MCP_RESOURCE_URL],
         "allowed_scopes": SUPPORTED_SCOPES,
-        "token_endpoint_auth_method": "client_secret_post",
-        "client_secret_hash": secret_hash or (hash_secret(secret) if secret else ""),
+        "token_endpoint_auth_method": auth_method,
+        "client_secret_hash": secret_hash
+        or (hash_secret(secret) if secret and auth_method == "client_secret_post" else ""),
         "disabled_at": None,
     }
 

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -1256,6 +1256,18 @@ def _redirect_with_code(redirect_uri: str, code: str, state: Optional[str]) -> s
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(params), parts.fragment))
 
 
+async def _get_token_request_data(request: Request) -> dict:
+    content_type = (request.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+    if content_type == "application/json":
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise ValueError("Invalid request body")
+        return body
+
+    form_data = await request.form()
+    return dict(form_data)
+
+
 @router.get("/authorize", response_class=HTMLResponse, tags=["mcp"])
 def mcp_authorize(
     request: Request,
@@ -1270,17 +1282,19 @@ def mcp_authorize(
 ):
     """OAuth authorize endpoint."""
     try:
-        _, scopes = _validate_authorize_request(
+        client, scopes = _validate_authorize_request(
             response_type, client_id, redirect_uri, resource, scope, code_challenge, code_challenge_method
         )
     except ValueError as e:
         return _oauth_error("invalid_request", str(e))
 
+    client_name = str(client.get("name") or client_id)
     permissions = [SCOPE_PERMISSION_TEXT[item] for item in scopes]
     return templates.TemplateResponse(
         "mcp_oauth_authorize.html",
         {
             "request": request,
+            "client_name": client_name,
             "oauth_params": {
                 "response_type": response_type,
                 "client_id": client_id,
@@ -1337,30 +1351,19 @@ def mcp_authorize_consent(
 async def mcp_token(request: Request):
     """OAuth token endpoint."""
     try:
-        form_data = await request.form()
-        client_secret = form_data.get("client_secret")
-        client_id = form_data.get("client_id")
-        grant_type = form_data.get("grant_type")
-        code = form_data.get("code")
-        redirect_uri = form_data.get("redirect_uri")
-        resource = form_data.get("resource")
-        code_verifier = form_data.get("code_verifier")
-        refresh_token = form_data.get("refresh_token")
-        scope = form_data.get("scope")
+        request_data = await _get_token_request_data(request)
     except Exception:
-        try:
-            body = await request.json()
-            client_secret = body.get("client_secret")
-            client_id = body.get("client_id")
-            grant_type = body.get("grant_type")
-            code = body.get("code")
-            redirect_uri = body.get("redirect_uri")
-            resource = body.get("resource")
-            code_verifier = body.get("code_verifier")
-            refresh_token = body.get("refresh_token")
-            scope = body.get("scope")
-        except Exception:
-            return _oauth_error("invalid_request", "Invalid request body")
+        return _oauth_error("invalid_request", "Invalid request body")
+
+    client_secret = request_data.get("client_secret")
+    client_id = request_data.get("client_id")
+    grant_type = request_data.get("grant_type")
+    code = request_data.get("code")
+    redirect_uri = request_data.get("redirect_uri")
+    resource = request_data.get("resource")
+    code_verifier = request_data.get("code_verifier")
+    refresh_token = request_data.get("refresh_token")
+    scope = request_data.get("scope")
 
     client = await run_blocking(db_executor, mcp_oauth_db.get_client, client_id or "")
     if (

--- a/backend/templates/mcp_oauth_authorize.html
+++ b/backend/templates/mcp_oauth_authorize.html
@@ -4,7 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Connect ChatGPT to Omi</title>
+    {% set display_client_name = client_name | default("ChatGPT") %}
+    <title>Connect {{ display_client_name }} to Omi</title>
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/ui/6.0.1/firebase-ui-auth.js"></script>
@@ -68,13 +69,13 @@
                             </svg>
                         </span>
                     </div>
-                    <h1>Connect ChatGPT</h1>
-                    <p class="oauth-subtitle">Sign in to review what <strong>ChatGPT</strong> can access and allow the
+                    <h1>Connect {{ display_client_name }}</h1>
+                    <p class="oauth-subtitle">Sign in to review what <strong>{{ display_client_name }}</strong> can access and allow the
                         connection to your Omi account.</p>
                 </div>
 
                 <section class="permissions-card" aria-labelledby="permissions-title">
-                    <p class="permissions-title" id="permissions-title">ChatGPT will be able to</p>
+                    <p class="permissions-title" id="permissions-title">{{ display_client_name }} will be able to</p>
                     <ul class="permissions-list" tabindex="0" role="list" aria-labelledby="permissions-title">
                         {% for permission in permissions %}
                         <li>
@@ -139,7 +140,7 @@
                     <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"
                         stroke-linejoin="round" />
                 </svg>
-                <span>Only continue if you trust <strong>ChatGPT</strong> with the Omi data shown above. You can revoke
+                <span>Only continue if you trust <strong>{{ display_client_name }}</strong> with the Omi data shown above. You can revoke
                     access anytime from your Omi settings.</span>
             </div>
         </div>

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -154,6 +154,7 @@ async def _run_blocking_inline(_executor, func, *args, **kwargs):
 
 class _JsonRequest:
     def __init__(self, body):
+        self.headers = {"content-type": "application/json"}
         self.body = body
 
     async def json(self):
@@ -161,6 +162,37 @@ class _JsonRequest:
 
     async def is_disconnected(self):
         return False
+
+
+class _FormRequest:
+    def __init__(self, body):
+        self.headers = {"content-type": "application/x-www-form-urlencoded"}
+        self.body = body
+
+    async def form(self):
+        return self.body
+
+
+@pytest.mark.asyncio
+async def test_token_request_parser_reads_json_body():
+    body = {
+        'grant_type': 'authorization_code',
+        'client_id': 'omi-chatgpt-prod',
+        'code': 'omi_code_test',
+    }
+
+    assert await sse._get_token_request_data(_JsonRequest(body)) == body
+
+
+@pytest.mark.asyncio
+async def test_token_request_parser_reads_form_body():
+    body = {
+        'grant_type': 'authorization_code',
+        'client_id': 'omi-chatgpt-prod',
+        'code': 'omi_code_test',
+    }
+
+    assert await sse._get_token_request_data(_FormRequest(body)) == body
 
 
 def test_sse_tools_list_filters_by_oauth_scopes():

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -175,6 +175,58 @@ def test_public_client_uses_pkce_without_shared_secret():
     )
 
 
+def test_chatgpt_prod_client_uses_public_pkce_exchange(monkeypatch):
+    redirect_uri = 'https://chatgpt.com/connector/oauth/OUbdUMlL15Ct'
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_CLIENT_ID', 'omi-chatgpt-prod')
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_CLIENT_SECRET', 'configured-but-not-sent-by-chatgpt')
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_REDIRECT_URIS', redirect_uri)
+    monkeypatch.delenv('MCP_OAUTH_CHATGPT_TOKEN_AUTH_METHOD', raising=False)
+    monkeypatch.setattr(mcp_oauth, 'DEFAULT_CLIENT_ID', 'omi-chatgpt-prod')
+
+    client = mcp_oauth.get_client('omi-chatgpt-prod')
+    assert client['token_endpoint_auth_method'] == 'none'
+    assert mcp_oauth.verify_client_auth(client, None)
+    assert not mcp_oauth.verify_client_auth(client, 'unexpected-secret')
+    assert mcp_oauth.validate_redirect_uri(client, redirect_uri)
+
+    scopes = mcp_oauth.normalize_scopes(
+        (
+            'memories.read memories.write conversations.read action_items.read action_items.write '
+            'goals.read chat.read screen_activity.read people.read'
+        ),
+        client,
+    )
+    verifier = 'c' * 64
+    grant = mcp_oauth.create_or_update_grant('chatgpt-reviewer', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    code = mcp_oauth.issue_authorization_code(
+        'chatgpt-reviewer',
+        grant['id'],
+        'omi-chatgpt-prod',
+        redirect_uri,
+        mcp_oauth.MCP_RESOURCE_URL,
+        scopes,
+        mcp_oauth.pkce_s256(verifier),
+    )
+
+    token_pair = mcp_oauth.exchange_authorization_code_for_tokens(
+        code, 'omi-chatgpt-prod', redirect_uri, mcp_oauth.MCP_RESOURCE_URL, verifier
+    )
+    assert token_pair['access_token'].startswith('omi_oat_')
+    assert token_pair['scope'] == ' '.join(scopes)
+
+
+def test_chatgpt_token_auth_method_env_can_force_confidential_client(monkeypatch):
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_CLIENT_ID', 'omi-chatgpt-prod')
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_CLIENT_SECRET', 'client-secret')
+    monkeypatch.setenv('MCP_OAUTH_CHATGPT_TOKEN_AUTH_METHOD', 'client_secret_post')
+    monkeypatch.setattr(mcp_oauth, 'DEFAULT_CLIENT_ID', 'omi-chatgpt-prod')
+
+    client = mcp_oauth.get_client('omi-chatgpt-prod')
+    assert client['token_endpoint_auth_method'] == 'client_secret_post'
+    assert mcp_oauth.verify_client_auth(client, 'client-secret')
+    assert not mcp_oauth.verify_client_auth(client, None)
+
+
 def test_public_client_rejects_unregistered_redirect_uri():
     client = mcp_oauth.get_client('omi-mcp-public')
     assert not mcp_oauth.validate_redirect_uri(client, 'https://example.com/oauth/callback')

--- a/backend/tests/unit/test_mcp_oauth_template.py
+++ b/backend/tests/unit/test_mcp_oauth_template.py
@@ -6,8 +6,13 @@ TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates"
 
 
 def _render_mcp_template() -> str:
+    return _render_mcp_template_for_client("ChatGPT")
+
+
+def _render_mcp_template_for_client(client_name: str) -> str:
     env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
     return env.get_template("mcp_oauth_authorize.html").render(
+        client_name=client_name,
         permissions=[
             "Read your Omi memories",
             "Create, update, and delete your Omi action items",
@@ -78,6 +83,22 @@ def test_mcp_oauth_template_still_renders_permissions_and_social_sign_in():
     assert "Create, update, and delete your Omi action items" in html
     assert "firebase.auth.GoogleAuthProvider.PROVIDER_ID" in html
     assert "firebaseui-auth-container" in html
+
+
+def test_mcp_oauth_template_uses_client_display_name():
+    html = _render_mcp_template_for_client("Claude")
+
+    assert "Connect Claude" in html
+    assert "Claude will be able to" in html
+    assert "<strong>Claude</strong>" in html
+    assert "ChatGPT will be able to" not in html
+
+
+def test_mcp_oauth_template_escapes_client_display_name():
+    html = _render_mcp_template_for_client("<script>alert(1)</script>")
+
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<script>alert(1)</script>" not in html
 
 
 def test_app_oauth_template_uses_deterministic_email_password_sign_in():


### PR DESCRIPTION
## Summary

Fixes #8650.

ChatGPT's prod MCP connector exchanges authorization codes as a public PKCE client and does not send `client_secret`. The backend treated the prod ChatGPT client id (`omi-chatgpt-prod`) as confidential, so `/token` returned `invalid_client` after the reviewer completed Omi sign-in.

This PR:
- treats `omi-chatgpt-prod` as a public PKCE OAuth client by default, while preserving `MCP_OAUTH_CHATGPT_TOKEN_AUTH_METHOD=client_secret_post` as an explicit override
- keeps redirect URI allowlisting and PKCE verification as the proof for public clients
- parses `/token` JSON requests by `Content-Type` instead of relying on form parsing to throw first
- renders the actual OAuth client display name on the MCP consent screen instead of hardcoding ChatGPT for every client

## Validation

- `python -m pytest backend/tests/unit/test_mcp_oauth.py backend/tests/unit/test_mcp_oauth_template.py backend/tests/unit/test_mcp_data_endpoints.py -q` passed: 49 tests, 1 existing Pydantic deprecation warning
- `python backend/scripts/scan_async_blockers.py` passed selected fail policy: 0 high network I/O findings
- `python backend/scripts/validate-backend-runtime-env.py --env prod` passed
- `git diff --check` passed

## Notes

Installed missing local `cryptography` package to run `backend/tests/unit/test_mcp_data_endpoints.py`; no vendored dependency files were changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

