### PR TITLE
fix: format 40 files on main + strengthen pre-commit hook docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,6 @@ These rules apply to every AI agent working in this repository. This file is the
 ## Setup
 
 - **Pre-commit hook (required before first commit):** `ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"` — auto-formats staged files on commit.
-- **Pre-push hook (required before first push):** `ln -s -f ../../scripts/pre-push "$(git rev-parse --git-path hooks)/pre-push"` — blocks push if changed files have formatting violations.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 
 ## Safety Rules
@@ -235,24 +234,24 @@ Rules:
 
 ## Formatting
 
-**Install both hooks before your first commit** (see Setup). Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
+**Install the pre-commit hook before your first commit** (see Setup). Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
 
-The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/JSON, web/Prettier, C/C++, Rust). The **pre-push hook** checks formatting of all files changed vs `main` and blocks the push if any are dirty.
+The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/JSON, web/Prettier, C/C++, Rust). You can also format manually:
 
-| Language | Auto-formatted by hook | Manual command |
-|----------|----------------------|----------------|
-| Dart (`app/`) | pre-commit + pre-push | `dart format --line-length 120 <files>` |
-| Python (`backend/`) | pre-commit + pre-push | `black --line-length 120 --skip-string-normalization <files>` |
-| ARB (`app/lib/l10n/`) | pre-commit + pre-push | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
-| C/C++ (firmware) | pre-commit + pre-push | `clang-format -i <files>` |
-| Rust (`desktop/macos/Backend-Rust/`) | pre-commit (fmt + check) + pre-push | `rustfmt --edition 2021 <files>` |
-| Web (`web/`) | pre-commit | `npx prettier --write <files>` |
+| Language | Manual command |
+|----------|----------------|
+| Dart (`app/`) | `dart format --line-length 120 <files>` |
+| Python (`backend/`) | `black --line-length 120 --skip-string-normalization <files>` |
+| ARB (`app/lib/l10n/`) | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
+| C/C++ (firmware) | `clang-format -i <files>` |
+| Rust (`desktop/macos/Backend-Rust/`) | `rustfmt --edition 2021 <files>` |
+| Web (`web/`) | `npx prettier --write <files>` |
 
 Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format manually.
 
 ## Git
 
-- **Before your first commit**, install both Git hooks (see Setup). Commits without hooks bypass formatting and let violations land on `main`.
+- **Before your first commit**, install the pre-commit hook (see Setup). Commits without the hook bypass formatting and let violations land on `main`.
 - Before starting work, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 - Always commit to the current branch — never switch branches mid-task. Always work in a git worktree for code changes (`git worktree add`).
 - Never push directly to `main`. Land changes through PRs only. Never squash-merge — use a regular merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ These rules apply to every AI agent working in this repository. This file is the
 
 ## Setup
 
-- **Worktree setup (required before first commit/push):** `make setup` — installs the repo Git hooks using linked-worktree-safe paths.
+- **Pre-commit hook (required before first commit):** `ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"` — auto-formats staged files on commit.
+- **Pre-push hook (required before first push):** `ln -s -f ../../scripts/pre-push "$(git rev-parse --git-path hooks)/pre-push"` — blocks push if changed files have formatting violations.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 
 ## Safety Rules
@@ -234,7 +235,7 @@ Rules:
 
 ## Formatting
 
-**Run `make setup` before your first commit** — it installs pre-commit and pre-push hooks that auto-format staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
+**Install both hooks before your first commit** (see Setup). Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
 
 The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/JSON, web/Prettier, C/C++, Rust). The **pre-push hook** checks formatting of all files changed vs `main` and blocks the push if any are dirty.
 
@@ -251,7 +252,7 @@ Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format man
 
 ## Git
 
-- **Before your first commit**, run `make setup` to install Git hooks (see Setup). Commits without hooks bypass formatting and let violations land on `main`.
+- **Before your first commit**, install both Git hooks (see Setup). Commits without hooks bypass formatting and let violations land on `main`.
 - Before starting work, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 - Always commit to the current branch — never switch branches mid-task. Always work in a git worktree for code changes (`git worktree add`).
 - Never push directly to `main`. Land changes through PRs only. Never squash-merge — use a regular merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ These rules apply to every AI agent working in this repository. This file is the
 
 ## Setup
 
+- **Worktree setup (required before first commit/push):** `make setup` — installs the repo Git hooks using linked-worktree-safe paths.
 - **Pre-commit hook (required before first commit):** `ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"` — auto-formats staged files on commit.
 - Mobile app setup: `cd app && bash setup.sh ios` (or `android`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,19 +234,24 @@ Rules:
 
 ## Formatting
 
-Always format code after making changes. The pre-commit hook handles this automatically, but you can also run manually:
+**Run `make setup` before your first commit** — it installs pre-commit and pre-push hooks that auto-format staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`.
 
-| Language | Command |
-|----------|---------|
-| Dart (`app/`) | `dart format --line-length 120 <files>` |
-| Python (`backend/`) | `black --line-length 120 --skip-string-normalization <files>` |
-| C/C++ (firmware) | `clang-format -i <files>` |
+The **pre-commit hook** auto-formats staged files on commit (Dart, Python, ARB/JSON, web/Prettier, C/C++, Rust). The **pre-push hook** checks formatting of all files changed vs `main` and blocks the push if any are dirty.
+
+| Language | Auto-formatted by hook | Manual command |
+|----------|----------------------|----------------|
+| Dart (`app/`) | pre-commit + pre-push | `dart format --line-length 120 <files>` |
+| Python (`backend/`) | pre-commit + pre-push | `black --line-length 120 --skip-string-normalization <files>` |
+| ARB (`app/lib/l10n/`) | pre-commit + pre-push | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
+| C/C++ (firmware) | pre-commit + pre-push | `clang-format -i <files>` |
+| Rust (`desktop/macos/Backend-Rust/`) | pre-commit (fmt + check) + pre-push | `rustfmt --edition 2021 <files>` |
+| Web (`web/`) | pre-commit | `npx prettier --write <files>` |
 
 Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format manually.
 
 ## Git
 
-- **Before your first commit**, verify the pre-commit hook is installed (see Setup).
+- **Before your first commit**, run `make setup` to install Git hooks (see Setup). Commits without hooks bypass formatting and let violations land on `main`.
 - Before starting work, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 - Always commit to the current branch — never switch branches mid-task. Always work in a git worktree for code changes (`git worktree add`).
 - Never push directly to `main`. Land changes through PRs only. Never squash-merge — use a regular merge.

--- a/app/lib/backend/http/api/announcements.dart
+++ b/app/lib/backend/http/api/announcements.dart
@@ -51,8 +51,7 @@ Future<List<Announcement>> getPendingAnnouncements({
   String? deviceModel,
 }) async {
   final encodedAppVersion = Uri.encodeComponent(appVersion);
-  var url =
-      "${Env.apiBaseUrl}v1/announcements/pending"
+  var url = "${Env.apiBaseUrl}v1/announcements/pending"
       "?app_version=$encodedAppVersion"
       "&platform=$platform"
       "&trigger=$trigger";

--- a/app/lib/backend/http/api/wrapped.dart
+++ b/app/lib/backend/http/api/wrapped.dart
@@ -75,10 +75,10 @@ Future<Wrapped2025Response?> generateWrapped2025() async {
       status: json['status'] == 'done'
           ? WrappedStatus.done
           : json['status'] == 'processing'
-          ? WrappedStatus.processing
-          : json['status'] == 'error'
-          ? WrappedStatus.error
-          : WrappedStatus.notGenerated,
+              ? WrappedStatus.processing
+              : json['status'] == 'error'
+                  ? WrappedStatus.error
+                  : WrappedStatus.notGenerated,
     );
   }
   return null;

--- a/app/lib/backend/http/clock_skew_detector.dart
+++ b/app/lib/backend/http/clock_skew_detector.dart
@@ -40,8 +40,7 @@ class ClockSkewDetector {
     final event = parseResponse(response);
     if (event == null) return;
 
-    final msg =
-        'Clock skew detected: skew_seconds=${event.skewSeconds}, '
+    final msg = 'Clock skew detected: skew_seconds=${event.skewSeconds}, '
         'server_time=${event.serverTime}, '
         'client_time=${event.clientTime}';
     Logger.warning(msg);

--- a/app/lib/backend/schema/action_item.dart
+++ b/app/lib/backend/schema/action_item.dart
@@ -118,9 +118,8 @@ class ActionItemsResponse {
 
   factory ActionItemsResponse.fromJson(Map<String, dynamic> json) {
     return ActionItemsResponse(
-      actionItems: (json['action_items'] as List<dynamic>)
-          .map((item) => ActionItemWithMetadata.fromJson(item))
-          .toList(),
+      actionItems:
+          (json['action_items'] as List<dynamic>).map((item) => ActionItemWithMetadata.fromJson(item)).toList(),
       hasMore: json['has_more'],
     );
   }
@@ -134,12 +133,10 @@ class PendingSyncResponse {
 
   factory PendingSyncResponse.fromJson(Map<String, dynamic> json) {
     return PendingSyncResponse(
-      pendingExport: (json['pending_export'] as List<dynamic>)
-          .map((item) => ActionItemWithMetadata.fromJson(item))
-          .toList(),
-      syncedItems: (json['synced_items'] as List<dynamic>)
-          .map((item) => ActionItemWithMetadata.fromJson(item))
-          .toList(),
+      pendingExport:
+          (json['pending_export'] as List<dynamic>).map((item) => ActionItemWithMetadata.fromJson(item)).toList(),
+      syncedItems:
+          (json['synced_items'] as List<dynamic>).map((item) => ActionItemWithMetadata.fromJson(item)).toList(),
     );
   }
 }

--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -368,9 +368,8 @@ class App {
       image: json['image'],
       chatPrompt: json['chat_prompt'],
       conversationPrompt: json['memory_prompt'],
-      externalIntegration: json['external_integration'] != null
-          ? ExternalIntegration.fromJson(json['external_integration'])
-          : null,
+      externalIntegration:
+          json['external_integration'] != null ? ExternalIntegration.fromJson(json['external_integration']) : null,
       reviews: AppReview.fromJsonList(json['reviews'] ?? []),
       userReview: json['user_review'] != null ? AppReview.fromJson(json['user_review']) : null,
       ratingAvg: json['rating_avg'],

--- a/app/lib/backend/schema/message_event.dart
+++ b/app/lib/backend/schema/message_event.dart
@@ -116,7 +116,7 @@ class PhotoDescribedEvent extends MessageEvent {
   final bool discarded;
 
   PhotoDescribedEvent({required this.photoId, required this.description, this.discarded = false})
-    : super(eventType: 'photo_described');
+      : super(eventType: 'photo_described');
 
   factory PhotoDescribedEvent.fromJson(Map<String, dynamic> json) {
     return PhotoDescribedEvent(
@@ -160,7 +160,7 @@ class OnboardingQuestionEvent extends MessageEvent {
   final int totalQuestions;
 
   OnboardingQuestionEvent({required this.question, required this.questionIndex, required this.totalQuestions})
-    : super(eventType: 'onboarding_question');
+      : super(eventType: 'onboarding_question');
 
   factory OnboardingQuestionEvent.fromJson(Map<String, dynamic> json) {
     return OnboardingQuestionEvent(
@@ -176,7 +176,7 @@ class OnboardingQuestionAnsweredEvent extends MessageEvent {
   final bool answered;
 
   OnboardingQuestionAnsweredEvent({required this.questionIndex, required this.answered})
-    : super(eventType: 'question_answered');
+      : super(eventType: 'question_answered');
 
   factory OnboardingQuestionAnsweredEvent.fromJson(Map<String, dynamic> json) {
     return OnboardingQuestionAnsweredEvent(
@@ -192,7 +192,7 @@ class OnboardingCompleteEvent extends MessageEvent {
   final String? error;
 
   OnboardingCompleteEvent({this.conversationId, this.memoriesCreated = 0, this.error})
-    : super(eventType: 'onboarding_complete');
+      : super(eventType: 'onboarding_complete');
 
   factory OnboardingCompleteEvent.fromJson(Map<String, dynamic> json) {
     return OnboardingCompleteEvent(
@@ -228,7 +228,7 @@ class FreemiumThresholdReachedEvent extends MessageEvent {
   final FreemiumAction action;
 
   FreemiumThresholdReachedEvent({required this.remainingSeconds, required this.action})
-    : super(eventType: 'freemium_threshold_reached');
+      : super(eventType: 'freemium_threshold_reached');
 
   /// Whether user action is required
   bool get requiresUserAction => action == FreemiumAction.setupOnDeviceStt;

--- a/app/lib/backend/schema/person.dart
+++ b/app/lib/backend/schema/person.dart
@@ -53,9 +53,8 @@ class Person {
       createdAt: DateTime.parse(json['created_at']).toLocal(),
       updatedAt: DateTime.parse(json['updated_at']).toLocal(),
       speechSamples: json['speech_samples'] != null ? List<String>.from(json['speech_samples']) : [],
-      speechSampleTranscripts: json['speech_sample_transcripts'] != null
-          ? List<String>.from(json['speech_sample_transcripts'])
-          : null,
+      speechSampleTranscripts:
+          json['speech_sample_transcripts'] != null ? List<String>.from(json['speech_sample_transcripts']) : null,
       speechSamplesVersion: json['speech_samples_version'] ?? 1,
       colorIdx: json['color_idx'] ?? json['id'].hashCode % speakerColors.length,
     );

--- a/app/lib/models/custom_stt_config.dart
+++ b/app/lib/models/custom_stt_config.dart
@@ -126,19 +126,19 @@ class CustomSttConfig {
   }
 
   Map<String, dynamic> toJson() => {
-    'provider': provider.name,
-    'api_key': apiKey,
-    'language': language,
-    'model': model,
-    'url': url,
-    'host': host,
-    'port': port,
-    'request_type': requestType,
-    'headers': headers,
-    'params': params,
-    'audio_field_name': audioFieldName,
-    'schema': schemaJson,
-  };
+        'provider': provider.name,
+        'api_key': apiKey,
+        'language': language,
+        'model': model,
+        'url': url,
+        'host': host,
+        'port': port,
+        'request_type': requestType,
+        'headers': headers,
+        'params': params,
+        'audio_field_name': audioFieldName,
+        'schema': schemaJson,
+      };
 
   factory CustomSttConfig.fromJson(Map<String, dynamic> json) {
     // Safely cast maps to Map<String, String> by converting all values to strings

--- a/app/lib/models/stt_response_schema.dart
+++ b/app/lib/models/stt_response_schema.dart
@@ -134,18 +134,18 @@ class SttResponseSchema {
   }
 
   Map<String, dynamic> toJson() => {
-    'segments_path': segmentsPath,
-    'segments_text_field': segmentsTextField,
-    'segments_start_field': segmentsStartField,
-    'segments_end_field': segmentsEndField,
-    'segments_speaker_field': segmentsSpeakerField,
-    'segments_speaker_id_field': segmentsSpeakerIdField,
-    'segments_is_user_field': segmentsIsUserField,
-    'segments_person_id_field': segmentsPersonIdField,
-    'segments_translations_field': segmentsTranslationsField,
-    'text_path': textPath,
-    'default_segment_duration': defaultSegmentDuration,
-  };
+        'segments_path': segmentsPath,
+        'segments_text_field': segmentsTextField,
+        'segments_start_field': segmentsStartField,
+        'segments_end_field': segmentsEndField,
+        'segments_speaker_field': segmentsSpeakerField,
+        'segments_speaker_id_field': segmentsSpeakerIdField,
+        'segments_is_user_field': segmentsIsUserField,
+        'segments_person_id_field': segmentsPersonIdField,
+        'segments_translations_field': segmentsTranslationsField,
+        'text_path': textPath,
+        'default_segment_duration': defaultSegmentDuration,
+      };
 }
 
 class JsonPathNavigator {

--- a/app/lib/models/stt_result.dart
+++ b/app/lib/models/stt_result.dart
@@ -149,9 +149,8 @@ class SttTranscriptionResult {
 
           final speakerValue = _schemaValue(seg, schema.segmentsSpeakerField, 'speaker');
           final speakerIdValue = _schemaValue(seg, schema.segmentsSpeakerIdField, 'speaker_id');
-          final speakerId = speakerIdValue != null
-              ? _extractSpeakerId(speakerIdValue)
-              : _extractSpeakerId(speakerValue);
+          final speakerId =
+              speakerIdValue != null ? _extractSpeakerId(speakerIdValue) : _extractSpeakerId(speakerValue);
           final speaker = _extractSpeakerLabel(speakerValue, speakerId);
           final isUser = _extractBool(_schemaValue(seg, schema.segmentsIsUserField, 'is_user'));
           final personId = _extractNullableString(_schemaValue(seg, schema.segmentsPersonIdField, 'person_id'));

--- a/app/lib/pages/announcements/changelog_sheet.dart
+++ b/app/lib/pages/announcements/changelog_sheet.dart
@@ -10,7 +10,7 @@ class ChangelogSheet extends StatefulWidget {
   final Future<List<Announcement>> Function()? changelogsFuture;
 
   const ChangelogSheet({super.key, this.changelogs, this.changelogsFuture})
-    : assert(changelogs != null || changelogsFuture != null);
+      : assert(changelogs != null || changelogsFuture != null);
 
   /// Show the changelog sheet as a modal bottom sheet with pre-loaded data.
   static Future<void> show(BuildContext context, List<Announcement> changelogs) {
@@ -112,17 +112,17 @@ class _ChangelogSheetState extends State<ChangelogSheet> {
             child: _isLoading
                 ? _buildLoadingState()
                 : _error != null
-                ? _buildErrorState()
-                : PageView.builder(
-                    controller: _pageController,
-                    itemCount: _orderedChangelogs.length,
-                    onPageChanged: (index) {
-                      setState(() => _currentPage = index);
-                    },
-                    itemBuilder: (context, index) {
-                      return _buildChangelogPage(_orderedChangelogs[index]);
-                    },
-                  ),
+                    ? _buildErrorState()
+                    : PageView.builder(
+                        controller: _pageController,
+                        itemCount: _orderedChangelogs.length,
+                        onPageChanged: (index) {
+                          setState(() => _currentPage = index);
+                        },
+                        itemBuilder: (context, index) {
+                          return _buildChangelogPage(_orderedChangelogs[index]);
+                        },
+                      ),
           ),
           if (!_isLoading && _error == null) _buildFooter(),
         ],

--- a/app/lib/pages/announcements/feature_screen.dart
+++ b/app/lib/pages/announcements/feature_screen.dart
@@ -539,8 +539,8 @@ class _FeatureScreenState extends State<FeatureScreen> with SingleTickerProvider
         color: isActive
             ? Colors.white
             : isPast
-            ? Colors.white54
-            : ResponsiveHelper.backgroundTertiary,
+                ? Colors.white54
+                : ResponsiveHelper.backgroundTertiary,
         borderRadius: BorderRadius.circular(4),
       ),
     );

--- a/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
@@ -95,111 +95,111 @@ class _AppOwnerReviewCardState extends State<AppOwnerReviewCard> {
                         child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
                       )
                     : (!showReplyField
-                          ? null
-                          : SingleChildScrollView(
-                              physics: const NeverScrollableScrollPhysics(),
-                              child: Column(
-                                children: [
-                                  SizedBox(
-                                    width: MediaQuery.sizeOf(context).width * 0.88,
-                                    child: TextFormField(
-                                      controller: replyController,
-                                      enabled: isLoading ? false : true,
-                                      keyboardType: TextInputType.multiline,
-                                      maxLength: 250,
-                                      onChanged: (value) {
-                                        if (value.isEmpty) {
-                                          if (value == widget.review.review) {
-                                            updateShowButton(false);
-                                          } else {
-                                            updateShowButton(true);
-                                          }
+                        ? null
+                        : SingleChildScrollView(
+                            physics: const NeverScrollableScrollPhysics(),
+                            child: Column(
+                              children: [
+                                SizedBox(
+                                  width: MediaQuery.sizeOf(context).width * 0.88,
+                                  child: TextFormField(
+                                    controller: replyController,
+                                    enabled: isLoading ? false : true,
+                                    keyboardType: TextInputType.multiline,
+                                    maxLength: 250,
+                                    onChanged: (value) {
+                                      if (value.isEmpty) {
+                                        if (value == widget.review.review) {
+                                          updateShowButton(false);
                                         } else {
                                           updateShowButton(true);
                                         }
-                                      },
-                                      decoration: InputDecoration(
-                                        hintText: context.l10n.writeSomething,
-                                        hintStyle: const TextStyle(color: Colors.grey),
-                                        border: const OutlineInputBorder(
-                                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey),
-                                        ),
-                                        enabledBorder: OutlineInputBorder(
-                                          borderRadius: const BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey[700]!),
-                                        ),
-                                        focusedBorder: const OutlineInputBorder(
-                                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                                          borderSide: BorderSide(color: Colors.grey),
-                                        ),
+                                      } else {
+                                        updateShowButton(true);
+                                      }
+                                    },
+                                    decoration: InputDecoration(
+                                      hintText: context.l10n.writeSomething,
+                                      hintStyle: const TextStyle(color: Colors.grey),
+                                      border: const OutlineInputBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey),
                                       ),
-                                      style: const TextStyle(color: Colors.white),
-                                      maxLines: 3,
+                                      enabledBorder: OutlineInputBorder(
+                                        borderRadius: const BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey[700]!),
+                                      ),
+                                      focusedBorder: const OutlineInputBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                                        borderSide: BorderSide(color: Colors.grey),
+                                      ),
                                     ),
+                                    style: const TextStyle(color: Colors.white),
+                                    maxLines: 3,
                                   ),
-                                  const SizedBox(height: 20),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      SizedBox(
-                                        width: MediaQuery.sizeOf(context).width * 0.36,
-                                        child: OutlinedButton(
-                                          style: OutlinedButton.styleFrom(
-                                            side: const BorderSide(color: Colors.white),
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                                          ),
-                                          onPressed: () {
-                                            updateShowReplyField(false);
-                                          },
-                                          child: Text(
-                                            context.l10n.cancel,
-                                            style: const TextStyle(color: Colors.white, fontSize: 16),
-                                          ),
+                                ),
+                                const SizedBox(height: 20),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    SizedBox(
+                                      width: MediaQuery.sizeOf(context).width * 0.36,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          side: const BorderSide(color: Colors.white),
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                        ),
+                                        onPressed: () {
+                                          updateShowReplyField(false);
+                                        },
+                                        child: Text(
+                                          context.l10n.cancel,
+                                          style: const TextStyle(color: Colors.white, fontSize: 16),
                                         ),
                                       ),
-                                      const SizedBox(width: 30),
-                                      SizedBox(
-                                        width: MediaQuery.sizeOf(context).width * 0.36,
-                                        child: OutlinedButton(
-                                          style: OutlinedButton.styleFrom(
-                                            side: const BorderSide(color: Colors.white),
-                                            backgroundColor: Colors.white,
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                                          ),
-                                          onPressed: () async {
-                                            if (replyController.text.isNotEmpty) {
-                                              setState(() {
-                                                isLoading = true;
-                                              });
-                                              await replyToAppReview(
-                                                widget.appId,
-                                                replyController.text,
-                                                widget.review.uid,
-                                              );
-                                              context.read<AppProvider>().updateLocalAppReviewResponse(
-                                                widget.appId,
-                                                replyController.text,
-                                                widget.review.uid,
-                                              );
-                                              setState(() {
-                                                widget.review.response = replyController.text;
-                                                isLoading = false;
-                                                showReplyField = false;
-                                              });
-                                            }
-                                          },
-                                          child: Text(
-                                            context.l10n.submitReply,
-                                            style: const TextStyle(color: Colors.black, fontSize: 16),
-                                          ),
+                                    ),
+                                    const SizedBox(width: 30),
+                                    SizedBox(
+                                      width: MediaQuery.sizeOf(context).width * 0.36,
+                                      child: OutlinedButton(
+                                        style: OutlinedButton.styleFrom(
+                                          side: const BorderSide(color: Colors.white),
+                                          backgroundColor: Colors.white,
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                        ),
+                                        onPressed: () async {
+                                          if (replyController.text.isNotEmpty) {
+                                            setState(() {
+                                              isLoading = true;
+                                            });
+                                            await replyToAppReview(
+                                              widget.appId,
+                                              replyController.text,
+                                              widget.review.uid,
+                                            );
+                                            context.read<AppProvider>().updateLocalAppReviewResponse(
+                                                  widget.appId,
+                                                  replyController.text,
+                                                  widget.review.uid,
+                                                );
+                                            setState(() {
+                                              widget.review.response = replyController.text;
+                                              isLoading = false;
+                                              showReplyField = false;
+                                            });
+                                          }
+                                        },
+                                        child: Text(
+                                          context.l10n.submitReply,
+                                          style: const TextStyle(color: Colors.black, fontSize: 16),
                                         ),
                                       ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            )),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          )),
               ),
             ),
             !showReplyField && widget.review.response.isNotEmpty

--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -9,8 +9,7 @@ import 'package:omi/backend/http/api/apps.dart';
 import 'package:omi/backend/http/api/audio.dart';
 import 'package:omi/backend/http/api/conversations.dart'
     hide unlinkCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
-import 'package:omi/backend/http/api/conversations.dart'
-    as conv_api
+import 'package:omi/backend/http/api/conversations.dart' as conv_api
     show unlinkCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
@@ -449,9 +448,8 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
       if (_isDisposed) return;
 
       // Preserve locally added apps that aren't in the API response yet
-      final locallyAddedApps = _cachedEnabledConversationApps
-          .where((app) => _locallyAddedAppIds.contains(app.id))
-          .toList();
+      final locallyAddedApps =
+          _cachedEnabledConversationApps.where((app) => _locallyAddedAppIds.contains(app.id)).toList();
 
       _cachedEnabledConversationApps.clear();
       _cachedEnabledConversationApps.addAll(apps);

--- a/app/lib/pages/home/firmware_mixin.dart
+++ b/app/lib/pages/home/firmware_mixin.dart
@@ -150,8 +150,8 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
     updateManager.logger.logMessageStream
         .where((log) => log.level.rawValue > 1) // Filter debug messages
         .listen((log) {
-          Logger.debug('dfu log: ${log.message}');
-        });
+      Logger.debug('dfu log: ${log.message}');
+    });
 
     await updateManager.update(images, configuration: configuration);
   }

--- a/app/lib/pages/settings/ai_app_generator_provider.dart
+++ b/app/lib/pages/settings/ai_app_generator_provider.dart
@@ -297,9 +297,8 @@ class AiAppGeneratorProvider extends ChangeNotifier {
         return _createdAppId;
       } else {
         _state = GenerationState.error;
-        _errorMessage = result.$2.isNotEmpty
-            ? result.$2
-            : globalNavigatorKey.currentContext!.l10n.aiGenFailedToCreateApp;
+        _errorMessage =
+            result.$2.isNotEmpty ? result.$2 : globalNavigatorKey.currentContext!.l10n.aiGenFailedToCreateApp;
         notifyListeners();
         return null;
       }

--- a/app/lib/pages/settings/people.dart
+++ b/app/lib/pages/settings/people.dart
@@ -240,92 +240,93 @@ class _UserPeoplePageState extends State<_UserPeoplePage> {
           body: provider.loading
               ? const Center(child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)))
               : provider.people.isEmpty
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      const Icon(Icons.question_mark, size: 40),
-                      const SizedBox(height: 24),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 32),
-                        child: Text(
-                          context.l10n.createPersonHint,
-                          style: const TextStyle(color: Colors.white, fontSize: 24),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                      const SizedBox(height: 64),
-                    ],
-                  ),
-                )
-              : ListView.separated(
-                  itemCount: provider.people.length,
-                  separatorBuilder: (context, index) => const Divider(height: 1),
-                  itemBuilder: (context, index) {
-                    final person = provider.people[index];
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        ListTile(
-                          title: Text(person.name, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500)),
-                          onTap: () => _showPersonDialog(context, provider, person: person),
-                          trailing: IconButton(
-                            icon: const Icon(Icons.delete, size: 20),
-                            onPressed: () => _confirmDeletePerson(person, provider),
-                          ),
-                        ),
-                        if (person.speechSamples != null && person.speechSamples!.isNotEmpty)
+                  ? Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          const Icon(Icons.question_mark, size: 40),
+                          const SizedBox(height: 24),
                           Padding(
-                            padding: const EdgeInsets.only(left: 8, right: 16, bottom: 8),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                const SizedBox(height: 4),
-                                ...person.speechSamples!.mapIndexed(
-                                  (j, sample) => ListTile(
-                                    contentPadding: EdgeInsets.zero,
-                                    leading: IconButton(
-                                      padding: const EdgeInsets.all(0),
-                                      icon: Icon(
-                                        provider.currentPlayingPersonIndex == index &&
-                                                provider.currentPlayingIndex == j &&
-                                                provider.isPlaying
-                                            ? Icons.pause
-                                            : Icons.play_arrow,
-                                      ),
-                                      onPressed: () => provider.playPause(index, j, sample),
-                                    ),
-                                    title: Text(j == 0 ? context.l10n.speechProfile : context.l10n.sampleNumber(j)),
-                                    onTap: () => _confirmDeleteSample(index, person, j, provider),
-                                    subtitle: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        if (person.speechSampleTranscripts != null &&
-                                            j < person.speechSampleTranscripts!.length &&
-                                            person.speechSampleTranscripts![j].isNotEmpty)
-                                          Padding(
-                                            padding: const EdgeInsets.only(bottom: 4),
-                                            child: Text(
-                                              '"${person.speechSampleTranscripts![j]}"',
-                                              style: const TextStyle(fontSize: 14, fontStyle: FontStyle.italic),
-                                            ),
-                                          ),
-                                        Text(
-                                          context.l10n.tapToDelete,
-                                          style: const TextStyle(fontSize: 12, color: Colors.grey),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ],
+                            padding: const EdgeInsets.symmetric(horizontal: 32),
+                            child: Text(
+                              context.l10n.createPersonHint,
+                              style: const TextStyle(color: Colors.white, fontSize: 24),
+                              textAlign: TextAlign.center,
                             ),
                           ),
-                      ],
-                    );
-                  },
-                ),
+                          const SizedBox(height: 64),
+                        ],
+                      ),
+                    )
+                  : ListView.separated(
+                      itemCount: provider.people.length,
+                      separatorBuilder: (context, index) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final person = provider.people[index];
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            ListTile(
+                              title:
+                                  Text(person.name, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500)),
+                              onTap: () => _showPersonDialog(context, provider, person: person),
+                              trailing: IconButton(
+                                icon: const Icon(Icons.delete, size: 20),
+                                onPressed: () => _confirmDeletePerson(person, provider),
+                              ),
+                            ),
+                            if (person.speechSamples != null && person.speechSamples!.isNotEmpty)
+                              Padding(
+                                padding: const EdgeInsets.only(left: 8, right: 16, bottom: 8),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    const SizedBox(height: 4),
+                                    ...person.speechSamples!.mapIndexed(
+                                      (j, sample) => ListTile(
+                                        contentPadding: EdgeInsets.zero,
+                                        leading: IconButton(
+                                          padding: const EdgeInsets.all(0),
+                                          icon: Icon(
+                                            provider.currentPlayingPersonIndex == index &&
+                                                    provider.currentPlayingIndex == j &&
+                                                    provider.isPlaying
+                                                ? Icons.pause
+                                                : Icons.play_arrow,
+                                          ),
+                                          onPressed: () => provider.playPause(index, j, sample),
+                                        ),
+                                        title: Text(j == 0 ? context.l10n.speechProfile : context.l10n.sampleNumber(j)),
+                                        onTap: () => _confirmDeleteSample(index, person, j, provider),
+                                        subtitle: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            if (person.speechSampleTranscripts != null &&
+                                                j < person.speechSampleTranscripts!.length &&
+                                                person.speechSampleTranscripts![j].isNotEmpty)
+                                              Padding(
+                                                padding: const EdgeInsets.only(bottom: 4),
+                                                child: Text(
+                                                  '"${person.speechSampleTranscripts![j]}"',
+                                                  style: const TextStyle(fontSize: 14, fontStyle: FontStyle.italic),
+                                                ),
+                                              ),
+                                            Text(
+                                              context.l10n.tapToDelete,
+                                              style: const TextStyle(fontSize: 12, color: Colors.grey),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                          ],
+                        );
+                      },
+                    ),
         );
       },
     );

--- a/app/lib/pages/settings/widgets/expansion_tile_card.dart
+++ b/app/lib/pages/settings/widgets/expansion_tile_card.dart
@@ -189,8 +189,7 @@ class ExpansionTileCardState extends State<ExpansionTileCard> with SingleTickerP
                       turns: widget.trailing == null || widget.animateTrailing
                           ? _iconTurns
                           : const AlwaysStoppedAnimation(0),
-                      child:
-                          widget.trailing ??
+                      child: widget.trailing ??
                           Icon(
                             Icons.expand_more,
                             color: _isExpanded ? widget.expandedTextStyle.color : widget.collapsedTextStyle.color,

--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -294,50 +294,50 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                               ],
                             )
                           : provider.text.isEmpty
-                          ? const SizedBox.shrink()
-                          : Padding(
-                              padding: const EdgeInsets.only(top: 80.0),
-                              child: LayoutBuilder(
-                                builder: (context, constraints) {
-                                  return ShaderMask(
-                                    shaderCallback: (bounds) {
-                                      if (provider.text.split(' ').length < 10) {
-                                        return const LinearGradient(
-                                          colors: [Colors.white, Colors.white],
-                                        ).createShader(bounds);
-                                      }
-                                      return const LinearGradient(
-                                        colors: [Colors.transparent, Colors.white],
-                                        stops: [0.0, 0.5],
-                                        begin: Alignment.topCenter,
-                                        end: Alignment.bottomCenter,
-                                      ).createShader(bounds);
-                                    },
-                                    blendMode: BlendMode.dstIn,
-                                    child: SizedBox(
-                                      height: 130,
-                                      child: ListView(
-                                        controller: _scrollController,
-                                        shrinkWrap: true,
-                                        physics: const NeverScrollableScrollPhysics(),
-                                        children: [
-                                          Text(
-                                            provider.text,
-                                            textAlign: TextAlign.center,
-                                            style: const TextStyle(
-                                              color: Colors.white,
-                                              fontSize: 20,
-                                              fontWeight: FontWeight.w400,
-                                              height: 1.5,
-                                            ),
+                              ? const SizedBox.shrink()
+                              : Padding(
+                                  padding: const EdgeInsets.only(top: 80.0),
+                                  child: LayoutBuilder(
+                                    builder: (context, constraints) {
+                                      return ShaderMask(
+                                        shaderCallback: (bounds) {
+                                          if (provider.text.split(' ').length < 10) {
+                                            return const LinearGradient(
+                                              colors: [Colors.white, Colors.white],
+                                            ).createShader(bounds);
+                                          }
+                                          return const LinearGradient(
+                                            colors: [Colors.transparent, Colors.white],
+                                            stops: [0.0, 0.5],
+                                            begin: Alignment.topCenter,
+                                            end: Alignment.bottomCenter,
+                                          ).createShader(bounds);
+                                        },
+                                        blendMode: BlendMode.dstIn,
+                                        child: SizedBox(
+                                          height: 130,
+                                          child: ListView(
+                                            controller: _scrollController,
+                                            shrinkWrap: true,
+                                            physics: const NeverScrollableScrollPhysics(),
+                                            children: [
+                                              Text(
+                                                provider.text,
+                                                textAlign: TextAlign.center,
+                                                style: const TextStyle(
+                                                  color: Colors.white,
+                                                  fontSize: 20,
+                                                  fontWeight: FontWeight.w400,
+                                                  height: 1.5,
+                                                ),
+                                              ),
+                                            ],
                                           ),
-                                        ],
-                                      ),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                ),
                     ),
                   ),
                   Align(
@@ -445,68 +445,69 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                               ],
                             )
                           : provider.profileCompleted
-                          ? Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                              decoration: BoxDecoration(
-                                border: const GradientBoxBorder(
-                                  gradient: LinearGradient(
-                                    colors: [
-                                      Color.fromARGB(127, 208, 208, 208),
-                                      Color.fromARGB(127, 188, 99, 121),
-                                      Color.fromARGB(127, 86, 101, 182),
-                                      Color.fromARGB(127, 126, 190, 236),
-                                    ],
+                              ? Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+                                  decoration: BoxDecoration(
+                                    border: const GradientBoxBorder(
+                                      gradient: LinearGradient(
+                                        colors: [
+                                          Color.fromARGB(127, 208, 208, 208),
+                                          Color.fromARGB(127, 188, 99, 121),
+                                          Color.fromARGB(127, 86, 101, 182),
+                                          Color.fromARGB(127, 126, 190, 236),
+                                        ],
+                                      ),
+                                      width: 2,
+                                    ),
+                                    borderRadius: BorderRadius.circular(12),
                                   ),
-                                  width: 2,
-                                ),
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              child: TextButton(
-                                onPressed: () {
-                                  // Conversation processing already triggered in finalize()
-                                  Navigator.pop(context);
-                                },
-                                child: Text(
-                                  context.l10n.allDone,
-                                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                                ),
-                              ),
-                            )
-                          : provider.uploadingProfile
-                          ? const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
-                          : Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const SizedBox(height: 8),
-                                FadeTransition(
-                                  opacity: _questionFadeAnimation,
-                                  child: Text(
-                                    provider.currentQuestion,
-                                    style: const TextStyle(color: Colors.white, fontSize: 22, height: 1.3),
-                                    textAlign: TextAlign.center,
+                                  child: TextButton(
+                                    onPressed: () {
+                                      // Conversation processing already triggered in finalize()
+                                      Navigator.pop(context);
+                                    },
+                                    child: Text(
+                                      context.l10n.allDone,
+                                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                                    ),
                                   ),
-                                ),
-                                const SizedBox(height: 8),
-                                SizedBox(
-                                  width: MediaQuery.sizeOf(context).width * 0.9,
-                                  child: ProgressBarWithPercentage(progressValue: provider.questionProgress),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  context.l10n.keepGoingGreat,
-                                  style: TextStyle(color: Colors.grey.shade300, fontSize: 14, height: 1.3),
-                                  textAlign: TextAlign.center,
-                                ),
-                                const SizedBox(height: 8),
-                                TextButton(
-                                  onPressed: () => provider.skipCurrentQuestion(),
-                                  child: Text(
-                                    context.l10n.skipThisQuestion,
-                                    style: const TextStyle(color: Colors.white70, fontSize: 14),
-                                  ),
-                                ),
-                              ],
-                            ),
+                                )
+                              : provider.uploadingProfile
+                                  ? const CircularProgressIndicator(
+                                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
+                                  : Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        const SizedBox(height: 8),
+                                        FadeTransition(
+                                          opacity: _questionFadeAnimation,
+                                          child: Text(
+                                            provider.currentQuestion,
+                                            style: const TextStyle(color: Colors.white, fontSize: 22, height: 1.3),
+                                            textAlign: TextAlign.center,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 8),
+                                        SizedBox(
+                                          width: MediaQuery.sizeOf(context).width * 0.9,
+                                          child: ProgressBarWithPercentage(progressValue: provider.questionProgress),
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Text(
+                                          context.l10n.keepGoingGreat,
+                                          style: TextStyle(color: Colors.grey.shade300, fontSize: 14, height: 1.3),
+                                          textAlign: TextAlign.center,
+                                        ),
+                                        const SizedBox(height: 8),
+                                        TextButton(
+                                          onPressed: () => provider.skipCurrentQuestion(),
+                                          child: Text(
+                                            context.l10n.skipThisQuestion,
+                                            style: const TextStyle(color: Colors.white70, fontSize: 14),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
                     ),
                   ),
                 ],

--- a/app/lib/providers/phone_call_provider.dart
+++ b/app/lib/providers/phone_call_provider.dart
@@ -438,9 +438,8 @@ class PhoneCallProvider extends ChangeNotifier {
     _transcriptionStatus = TranscriptionStatus.connecting;
     notifyListeners();
 
-    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : 'multi';
+    var language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : 'multi';
 
     var wsUrl = api.buildPhoneCallWebSocketUrl(
       callId: _currentCallId!,

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -169,17 +169,16 @@ class SpeechProfileProvider extends ChangeNotifier
   }
 
   Future<void> _initiateWebsocket({required BleAudioCodec codec, int? sampleRate, bool force = false}) async {
-    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    String language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     int rate = sampleRate ?? (codec.isOpusSupported() ? 16000 : 8000);
 
     _socket = await ServiceManager.instance().socket.speechProfile(
-      codec: codec,
-      sampleRate: rate,
-      language: language,
-      force: force,
-    );
+          codec: codec,
+          sampleRate: rate,
+          language: language,
+          force: force,
+        );
     if (_socket == null) {
       throw Exception("Can not create new speech profile socket");
     }

--- a/app/lib/services/custom_stt_log_service.dart
+++ b/app/lib/services/custom_stt_log_service.dart
@@ -35,16 +35,14 @@ class CustomSttLogService {
 
   bool get hasLogs => _logs.isNotEmpty;
 
-  String get logsAsText => logs
-      .map((l) {
+  String get logsAsText => logs.map((l) {
         final prefix = l.level == CustomSttLogLevel.error
             ? '[ERROR] '
             : l.level == CustomSttLogLevel.warning
-            ? '[WARN] '
-            : '';
+                ? '[WARN] '
+                : '';
         return '$prefix${l.formatted}';
-      })
-      .join('\n');
+      }).join('\n');
 
   void log(CustomSttLogLevel level, String source, String message) {
     Logger.debug("[$source] $message");

--- a/app/lib/services/devices/custom_connection.dart
+++ b/app/lib/services/devices/custom_connection.dart
@@ -143,7 +143,8 @@ abstract class CustomDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -157,7 +158,8 @@ abstract class CustomDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;

--- a/app/lib/services/devices/friend_pendant_connection.dart
+++ b/app/lib/services/devices/friend_pendant_connection.dart
@@ -31,18 +31,18 @@ class FriendPendantDeviceConnection extends DeviceConnection {
     _audioSub = transport
         .getCharacteristicStream(friendPendantServiceUuid, friendPendantAudioCharacteristicUuid)
         .listen((data) {
-          final payload = _processAudioPacket(data);
-          if (payload != null && payload.isNotEmpty) {
-            // Split 90-byte payload into 30-byte LC3 frames and add each separately
-            for (int i = 0; i < payload.length; i += lc3FrameSize) {
-              final end = (i + lc3FrameSize <= payload.length) ? i + lc3FrameSize : payload.length;
-              final chunk = payload.sublist(i, end);
-              if (chunk.length == lc3FrameSize) {
-                _audioController.add(chunk);
-              }
-            }
+      final payload = _processAudioPacket(data);
+      if (payload != null && payload.isNotEmpty) {
+        // Split 90-byte payload into 30-byte LC3 frames and add each separately
+        for (int i = 0; i < payload.length; i += lc3FrameSize) {
+          final end = (i + lc3FrameSize <= payload.length) ? i + lc3FrameSize : payload.length;
+          final chunk = payload.sublist(i, end);
+          if (chunk.length == lc3FrameSize) {
+            _audioController.add(chunk);
           }
-        });
+        }
+      }
+    });
   }
 
   @override
@@ -107,7 +107,8 @@ class FriendPendantDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -121,7 +122,8 @@ class FriendPendantDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;

--- a/app/lib/services/devices/limitless_connection.dart
+++ b/app/lib/services/devices/limitless_connection.dart
@@ -74,9 +74,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   void _attachRxSubscription() {
     _rxSubscription?.cancel();
-    _rxSubscription = transport
-        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
-        .listen(_handleNotification);
+    _rxSubscription =
+        transport.getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid).listen(_handleNotification);
   }
 
   Future<void> _handleTransportReconnected() async {
@@ -375,10 +374,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
           } else {
             // Audio page that yielded zero frames — genuine parse failure
             final firstBytesLen = flashPageData.length < 64 ? flashPageData.length : 64;
-            final firstBytes = flashPageData
-                .sublist(0, firstBytesLen)
-                .map((b) => b.toRadixString(16).padLeft(2, '0'))
-                .join(' ');
+            final firstBytes =
+                flashPageData.sublist(0, firstBytesLen).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ');
             DebugLogManager.logWarning('Limitless flash page yielded zero Opus frames', {
               'index': index,
               'session': session,
@@ -1779,7 +1776,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -1793,7 +1791,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;

--- a/app/lib/services/devices/plaud_connection.dart
+++ b/app/lib/services/devices/plaud_connection.dart
@@ -288,7 +288,8 @@ class PlaudDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;
@@ -320,15 +321,15 @@ class PlaudDeviceConnection extends DeviceConnection {
   List<int> _toBytes32(int v) => [v & 0xFF, (v >> 8) & 0xFF, (v >> 16) & 0xFF, (v >> 24) & 0xFF];
 
   List<int> _toBytes64(int v) => [
-    v & 0xFF,
-    (v >> 8) & 0xFF,
-    (v >> 16) & 0xFF,
-    (v >> 24) & 0xFF,
-    (v >> 32) & 0xFF,
-    (v >> 40) & 0xFF,
-    (v >> 48) & 0xFF,
-    (v >> 56) & 0xFF,
-  ];
+        v & 0xFF,
+        (v >> 8) & 0xFF,
+        (v >> 16) & 0xFF,
+        (v >> 24) & 0xFF,
+        (v >> 32) & 0xFF,
+        (v >> 40) & 0xFF,
+        (v >> 48) & 0xFF,
+        (v >> 56) & 0xFF,
+      ];
 
   int _toInt32(List<int> b) => b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24);
 }

--- a/app/lib/services/sockets/pure_polling.dart
+++ b/app/lib/services/sockets/pure_polling.dart
@@ -154,10 +154,8 @@ class PurePollingSocket implements IPureSocket {
         if (result.segments.isNotEmpty) {
           _audioOffsetSeconds = result.segments.last.end;
         }
-        final segmentsJson = result.segments
-            .where((s) => s.text.trim().isNotEmpty)
-            .map((s) => s.toTranscriptSegmentJson())
-            .toList();
+        final segmentsJson =
+            result.segments.where((s) => s.text.trim().isNotEmpty).map((s) => s.toTranscriptSegmentJson()).toList();
         if (segmentsJson.isNotEmpty) {
           onMessage(jsonEncode(segmentsJson));
         }

--- a/app/lib/ui/atoms/omi_info_card.dart
+++ b/app/lib/ui/atoms/omi_info_card.dart
@@ -34,8 +34,7 @@ class OmiInfoCard extends AdaptiveWidget {
         color: backgroundColor ?? ResponsiveHelper.backgroundSecondary.withValues(alpha: 0.8),
         borderRadius: BorderRadius.circular(borderRadius ?? 20),
         border: Border.all(color: borderColor ?? ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.5), width: 1),
-        boxShadow:
-            shadows ??
+        boxShadow: shadows ??
             [BoxShadow(color: Colors.black.withValues(alpha: 0.1), blurRadius: 20, offset: const Offset(0, 8))],
       ),
       child: Column(children: children),

--- a/app/lib/ui/atoms/omi_typing_indicator.dart
+++ b/app/lib/ui/atoms/omi_typing_indicator.dart
@@ -47,9 +47,9 @@ class _IndicatorState extends State<_Indicator> with SingleTickerProviderStateMi
   }
 
   Animation<Offset> _tween(double delta) => Tween<Offset>(
-    begin: Offset(0, delta),
-    end: Offset(0, -delta),
-  ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+        begin: Offset(0, delta),
+        end: Offset(0, -delta),
+      ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
 
   @override
   void dispose() {
@@ -68,19 +68,19 @@ class _IndicatorState extends State<_Indicator> with SingleTickerProviderStateMi
   // Optimized animation: keeps scale effect with RepaintBoundary isolation
   // Scale range reduced (0.85-1.0) for subtle bounce that's easy on battery
   Widget _bubble(Animation<Offset> anim) => RepaintBoundary(
-    child: SlideTransition(
-      position: anim,
-      child: ScaleTransition(
-        scale: _scale,
-        child: AnimatedBuilder(
-          animation: _color,
-          builder: (context, _) => Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(color: _color.value, shape: BoxShape.circle),
+        child: SlideTransition(
+          position: anim,
+          child: ScaleTransition(
+            scale: _scale,
+            child: AnimatedBuilder(
+              animation: _color,
+              builder: (context, _) => Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(color: _color.value, shape: BoxShape.circle),
+              ),
+            ),
           ),
         ),
-      ),
-    ),
-  );
+      );
 }

--- a/app/lib/utils/audio/audio_transcoder.dart
+++ b/app/lib/utils/audio/audio_transcoder.dart
@@ -86,7 +86,7 @@ class OpusToWavTranscoder implements IAudioTranscoder {
   final SimpleOpusDecoder _decoder;
 
   OpusToWavTranscoder({this.sampleRate = 16000, this.channels = 1})
-    : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
+      : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
 
   @override
   Uint8List transcode(Uint8List opusData) {
@@ -159,7 +159,7 @@ class OpusToRawPcmTranscoder implements IAudioTranscoder {
   final SimpleOpusDecoder _decoder;
 
   OpusToRawPcmTranscoder({this.sampleRate = 16000, this.channels = 1})
-    : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
+      : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
 
   @override
   Uint8List transcode(Uint8List opusData) {
@@ -210,7 +210,7 @@ class OpusFramesToWavTranscoder implements IAudioTranscoder {
   final SimpleOpusDecoder _decoder;
 
   OpusFramesToWavTranscoder({this.sampleRate = 16000, this.channels = 1, this.frameSizeBytes = 80})
-    : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
+      : _decoder = SimpleOpusDecoder(sampleRate: sampleRate, channels: channels);
 
   @override
   Uint8List transcode(Uint8List opusFramesData) {

--- a/app/lib/utils/conversation_sync_utils.dart
+++ b/app/lib/utils/conversation_sync_utils.dart
@@ -39,9 +39,8 @@ class ConversationSyncUtils {
     SyncedConversationType type,
   ) {
     final validConversations = conversations.where((conversation) => conversation != null).toList();
-    final completedConversations = validConversations
-        .where((conversation) => conversation!.status == ConversationStatus.completed)
-        .toList();
+    final completedConversations =
+        validConversations.where((conversation) => conversation!.status == ConversationStatus.completed).toList();
     return completedConversations.map((conversation) => _createPointer(conversation!, type)).toList();
   }
 

--- a/app/lib/utils/other/validators.dart
+++ b/app/lib/utils/other/validators.dart
@@ -1,6 +1,5 @@
 bool isValidUrl(String url) {
-  const urlPattern =
-      r'^(https?:\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)?'
+  const urlPattern = r'^(https?:\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)?'
       r'((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
       r'(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|'
       r'([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}(:[0-9]+)?(\/.*)?$';
@@ -13,8 +12,7 @@ bool isValidPayPalMeUrl(String url) {
 }
 
 bool isValidWebSocketUrl(String url) {
-  const webSocketPattern =
-      r'^(wss?:\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)?'
+  const webSocketPattern = r'^(wss?:\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)?'
       r'((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
       r'(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|'
       r'([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}(:[0-9]+)?(\/.*)?$';

--- a/app/lib/widgets/calendar_date_picker_sheet.dart
+++ b/app/lib/widgets/calendar_date_picker_sheet.dart
@@ -4,15 +4,14 @@ import 'package:calendar_date_picker2/calendar_date_picker2.dart';
 
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
-typedef CalendarYearBuilder =
-    Widget Function({
-      required int year,
-      TextStyle? textStyle,
-      BoxDecoration? decoration,
-      bool? isSelected,
-      bool? isDisabled,
-      bool? isCurrentYear,
-    });
+typedef CalendarYearBuilder = Widget Function({
+  required int year,
+  TextStyle? textStyle,
+  BoxDecoration? decoration,
+  bool? isSelected,
+  bool? isDisabled,
+  bool? isCurrentYear,
+});
 
 CalendarDatePicker2Config getDefaultCalendarConfig({
   DateTime? firstDate,

--- a/app/lib/widgets/expandable_text.dart
+++ b/app/lib/widgets/expandable_text.dart
@@ -64,8 +64,8 @@ class _ExpandableTextWidgetState extends State<ExpandableTextWidget> {
             data: widget.isExpanded
                 ? widget.text
                 : widget.text.length > maxChars
-                ? widget.text.substring(0, maxChars)
-                : widget.text,
+                    ? widget.text.substring(0, maxChars)
+                    : widget.text,
           ),
           // Text(
           //   widget.text,

--- a/app/lib/widgets/extensions/functions.dart
+++ b/app/lib/widgets/extensions/functions.dart
@@ -2,6 +2,6 @@ import 'package:flutter/material.dart';
 
 extension FunctionExt on Function {
   void withPostFrameCallback() => WidgetsBinding.instance.addPostFrameCallback((_) {
-    this();
-  });
+        this();
+      });
 }

--- a/app/lib/widgets/language_picker.dart
+++ b/app/lib/widgets/language_picker.dart
@@ -13,9 +13,8 @@ class LanguagePickerTile extends StatelessWidget {
     return Consumer<LocaleProvider>(
       builder: (context, localeProvider, child) {
         final currentLocale = localeProvider.locale;
-        final displayName = currentLocale != null
-            ? LocaleProvider.getDisplayName(currentLocale)
-            : context.l10n.systemDefault;
+        final displayName =
+            currentLocale != null ? LocaleProvider.getDisplayName(currentLocale) : context.l10n.systemDefault;
 
         return ListTile(
           title: Text(context.l10n.language, style: const TextStyle(color: Colors.white)),

--- a/app/test/providers/device_provider_test.dart
+++ b/app/test/providers/device_provider_test.dart
@@ -200,12 +200,15 @@ void main() {
     test('alert fires again after recovery — the core bug scenario', () {
       // 50% → 15% (alert) → 25% (recover) → 10% (should alert AGAIN)
       final alerts = runSequence([50, 15, 25, 10]);
-      expect(alerts, [
-        false,
-        true,
-        false,
-        true,
-      ], reason: 'Before fix: [false, true, false, false] — second alert never fires');
+      expect(
+          alerts,
+          [
+            false,
+            true,
+            false,
+            true,
+          ],
+          reason: 'Before fix: [false, true, false, false] — second alert never fires');
     });
 
     test('full lifecycle: multiple charge cycles', () {

--- a/backend/tests/unit/test_listen_fallback_removal.py
+++ b/backend/tests/unit/test_listen_fallback_removal.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Constants (mirrored from transcribe.py)
 # ---------------------------------------------------------------------------

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -405,9 +405,7 @@ async def sync_x_for_user(uid: str) -> Dict:
     # Vector-index the raw posts so agents can semantically search the actual
     # tweets (not just the extracted memories) via the MCP search_x_posts tool.
     # Chunk to stay within Pinecone's per-upsert vector limit (~100).
-    items_to_index = [
-        {'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh
-    ]
+    items_to_index = [{'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh]
     for i in range(0, len(items_to_index), 100):
         try:
             upsert_x_post_vectors_batch(uid, items_to_index[i : i + 100])


### PR DESCRIPTION
## Summary
- **Format 40 files** (38 Dart + 2 Python) that had formatting violations on `main`
- **Strengthen AGENTS.md** — expand Formatting section with all 6 language formatters and verification command; add explicit `ln -s` install command for the pre-commit hook in Setup

## Root cause
Two sources of drift:
1. **Dart formatter version change** — 22 files formatted in March 2026 mass-format are now dirty under current `dart format 3.1.4` (SDK 3.11.0)
2. **Commits merged without hooks** — 18 files committed by contributors who didn't install the pre-commit hook

CI (`lint.yml`) only checks *changed files per PR*, so pre-existing violations in untouched files persist indefinitely.

## What changed
- `fix: format 40 files` — ran `dart format --line-length 120` and `black --line-length 120 --skip-string-normalization` on all files; zero functional changes
- `docs(AGENTS.md)` — expanded Formatting section; Setup section now has explicit `ln -s` command for the pre-commit hook

## Action required for all contributors
Run this in every clone/worktree before your first commit:
```bash
ln -s -f ../../scripts/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"
```

Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`

## Test plan
- [x] `dart format --line-length 120 --set-exit-if-changed` on all 631 Dart files — 0 violations
- [x] `black --check --line-length 120` on all 728 Python files — 0 violations
- [x] Pre-commit hook runs clean on commit
- [x] No functional code changes — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)