### PR TITLE
Fix desktop reconciliation error handling

### DIFF
--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -273,17 +273,60 @@ actor ConversationFinalizationService {
           return
         }
       }
-      let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
-      if segmentCount > 0 {
-        log(
-          "ConversationFinalization: Cloud reconciliation exhausted for session \(sessionId); uploading \(segmentCount) saved local segments"
-        )
-        try await uploadLocalSegments(sessionId: sessionId)
+      if try await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId) {
         return
       }
     }
 
     throw TranscriptionStorageError.invalidState("No matching backend conversation found")
+  }
+
+  @discardableResult
+  func resolveExhaustedCloudReconciliation(
+    session: TranscriptionSessionRecord,
+    sessionId: Int64
+  ) async throws -> Bool {
+    let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
+    switch Self.cloudReconciliationExhaustionAction(session: session, segmentCount: segmentCount) {
+    case .keepRetrying:
+      return false
+    case .uploadLocalSegments:
+      log(
+        "ConversationFinalization: Cloud reconciliation exhausted for session \(sessionId); uploading \(segmentCount) saved local segments"
+      )
+      try await uploadLocalSegments(sessionId: sessionId)
+      return true
+    case .discardEmptyDesktopSession:
+      log("ConversationFinalization: Deleting empty unreconciled desktop session \(sessionId)")
+      try await TranscriptionStorage.shared.deleteSession(id: sessionId)
+      return true
+    case .reportFailure:
+      return false
+    }
+  }
+
+  enum CloudReconciliationExhaustionAction: Equatable {
+    case keepRetrying
+    case uploadLocalSegments
+    case discardEmptyDesktopSession
+    case reportFailure
+  }
+
+  static func cloudReconciliationExhaustionAction(
+    session: TranscriptionSessionRecord,
+    segmentCount: Int,
+    maxRetries: Int = 5
+  ) -> CloudReconciliationExhaustionAction {
+    guard session.retryCount >= maxRetries - 1 else {
+      return .keepRetrying
+    }
+    guard segmentCount == 0 else {
+      return .uploadLocalSegments
+    }
+    guard session.source == ConversationSource.desktop.rawValue else {
+      return .reportFailure
+    }
+    return .discardEmptyDesktopSession
   }
 
   private func completeCloudConversation(

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -260,6 +260,97 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         XCTAssertNil(session)
     }
 
+    func testCloudReconciliationExhaustionKeepsRetryingBeforeMaxAttempts() {
+        let session = TranscriptionSessionRecord(
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            source: ConversationSource.desktop.rawValue,
+            retryCount: 3,
+            finalizationStrategy: .cloudReconcile
+        )
+
+        XCTAssertEqual(
+            ConversationFinalizationService.cloudReconciliationExhaustionAction(
+                session: session,
+                segmentCount: 0
+            ),
+            .keepRetrying
+        )
+    }
+
+    func testCloudReconciliationExhaustionFallsBackToLocalSegmentsWhenAvailable() {
+        let session = TranscriptionSessionRecord(
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            source: ConversationSource.desktop.rawValue,
+            retryCount: 4,
+            finalizationStrategy: .cloudReconcile
+        )
+
+        XCTAssertEqual(
+            ConversationFinalizationService.cloudReconciliationExhaustionAction(
+                session: session,
+                segmentCount: 2
+            ),
+            .uploadLocalSegments
+        )
+    }
+
+    func testCloudReconciliationExhaustionDiscardsEmptyDesktopSessions() {
+        let session = TranscriptionSessionRecord(
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            source: ConversationSource.desktop.rawValue,
+            retryCount: 4,
+            finalizationStrategy: .cloudReconcile
+        )
+
+        XCTAssertEqual(
+            ConversationFinalizationService.cloudReconciliationExhaustionAction(
+                session: session,
+                segmentCount: 0
+            ),
+            .discardEmptyDesktopSession
+        )
+    }
+
+    func testExhaustedEmptyDesktopCloudSessionIsDeletedInsteadOfFailed() async throws {
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: ConversationSource.desktop.rawValue,
+            finalizationStrategy: .cloudReconcile
+        )
+        try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)
+        for _ in 0..<4 {
+            try await TranscriptionStorage.shared.incrementRetryCount(id: sessionId)
+        }
+
+        let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        let session = try XCTUnwrap(storedSession)
+
+        let handled = try await ConversationFinalizationService.shared.resolveExhaustedCloudReconciliation(
+            session: session,
+            sessionId: sessionId
+        )
+
+        XCTAssertTrue(handled)
+        let deletedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
+        XCTAssertNil(deletedSession)
+    }
+
+    func testCloudReconciliationExhaustionReportsEmptyNonDesktopSessions() {
+        let session = TranscriptionSessionRecord(
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            source: ConversationSource.omi.rawValue,
+            retryCount: 4,
+            finalizationStrategy: .cloudReconcile
+        )
+
+        XCTAssertEqual(
+            ConversationFinalizationService.cloudReconciliationExhaustionAction(
+                session: session,
+                segmentCount: 0
+            ),
+            .reportFailure
+        )
+    }
+
     func testCompactsOversizedLocalUploadWithoutDroppingText() {
         let segments = (0..<750).map { index in
             APIClient.UploadSegment(

--- a/desktop/macos/changelog/unreleased/20260630-desktop-reconciliation-errors.json
+++ b/desktop/macos/changelog/unreleased/20260630-desktop-reconciliation-errors.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced false desktop recording errors from empty cloud reconciliation sessions"
+}


### PR DESCRIPTION
## Summary
- discard exhausted empty desktop cloud-reconciliation sessions instead of reporting them as phone mic recording errors
- preserve local segment fallback for non-empty exhausted sessions and structured failure reporting for non-desktop empty sessions
- add state-machine and storage-backed tests for the exhaustion behavior

Fixes #8632

## Verification
- make setup
- git diff --check
- cd desktop/macos && xcrun swift test -c debug --package-path Desktop --filter TranscriptionFinalizationStateMachineTests (17 tests, 0 failures)
- independent subagent review completed with no blocking findings after the storage-backed test was added

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

