### PR TITLE
[codex] Fail clearly for missing local agents

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1038,7 +1038,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate, AVSpeec
           log("RealtimeHub[\(providerTag)]: tool spawn_agent provider=\(directedProvider.rawValue) unavailable")
           sendToolResultIfCurrent(
             source: source, callId: callId, name: name,
-            output: setupPrompt)
+            output: availability.toolError)
           return
         }
       }

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -81,10 +81,14 @@ struct LocalAgentProviderAvailability: Equatable {
     var setupPrompt: String {
         switch provider {
         case .hermes:
-            return "I don't see Hermes on your PATH. Install Hermes or set OMI_HERMES_ADAPTER_COMMAND."
+            return "I don't see Hermes installed. Make sure Hermes is installed first, then try again."
         case .openclaw:
-            return "I don't see OpenClaw on your PATH. Install OpenClaw or set OMI_OPENCLAW_ADAPTER_COMMAND."
+            return "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again."
         }
+    }
+
+    var toolError: String {
+        "Error: \(setupPrompt)"
     }
 }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -480,7 +480,7 @@ class ChatToolExecutor {
     if let directedProvider {
       let availability = LocalAgentProviderDetector.availability(for: directedProvider)
       guard availability.isAvailable else {
-        return availability.setupPrompt
+        return availability.toolError
       }
     }
     let model = ShortcutSettings.shared.selectedModel.isEmpty

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -100,7 +100,10 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertFalse(availability.isAvailable)
     XCTAssertEqual(
       availability.setupPrompt,
-      "I don't see OpenClaw on your PATH. Install OpenClaw or set OMI_OPENCLAW_ADAPTER_COMMAND.")
+      "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again.")
+    XCTAssertEqual(
+      availability.toolError,
+      "Error: I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again.")
   }
 
   // MARK: - ApiKeysResponse shape assertion

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -28,11 +28,11 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(source.contains("LocalAgentProviderDetector.availability(for: directedProvider)"))
     XCTAssertTrue(source.contains("guard availability.isAvailable else"))
     XCTAssertTrue(source.contains("assistantText = setupPrompt"))
-    XCTAssertTrue(source.contains("output: setupPrompt"))
+    XCTAssertTrue(source.contains("output: availability.toolError"))
     XCTAssertTrue(source.contains("""
           sendToolResultIfCurrent(
             source: source, callId: callId, name: name,
-            output: setupPrompt)
+            output: availability.toolError)
           return
 """))
   }

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -93,9 +93,9 @@ export function adapterActivationError(adapterId: ProductionAdapterId): string |
   if (!envName) return undefined;
   const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : "Hermes";
   if (adapterId === "hermes" || adapterId === "openclaw") {
-    return `${label} command is not configured. Install ${label} or choose a custom ${label} command in settings. Advanced override: ${envName}.`;
+    return `${label} is not available. Make sure ${label} is installed first, then try again.`;
   }
-  return `${label} adapter is unavailable. Advanced override: ${envName}.`;
+  return `${label} adapter is unavailable.`;
 }
 
 export function ensureRegisteredAdapter(

--- a/desktop/macos/agent/tests/adapter-selection.test.ts
+++ b/desktop/macos/agent/tests/adapter-selection.test.ts
@@ -49,10 +49,14 @@ describe("adapter selection and activation", () => {
       activationEnv: "OMI_OPENCLAW_ADAPTER_COMMAND",
       capabilities: { supportsTools: false, supportsModelSwitching: false },
     });
-    expect(adapterActivationError("hermes")).toContain("Hermes command is not configured");
-    expect(adapterActivationError("hermes")).toContain("Advanced override: OMI_HERMES_ADAPTER_COMMAND");
-    expect(adapterActivationError("openclaw")).toContain("OpenClaw command is not configured");
-    expect(adapterActivationError("openclaw")).toContain("Advanced override: OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationError("hermes")).toBe(
+      "Hermes is not available. Make sure Hermes is installed first, then try again."
+    );
+    expect(adapterActivationError("hermes")).not.toContain("OMI_HERMES_ADAPTER_COMMAND");
+    expect(adapterActivationError("openclaw")).toBe(
+      "OpenClaw is not available. Make sure OpenClaw is installed first, then try again."
+    );
+    expect(adapterActivationError("openclaw")).not.toContain("OMI_OPENCLAW_ADAPTER_COMMAND");
   });
 
   it("source: daemon registers Hermes/OpenClaw explicitly and does not stamp MCP env as ACP", () => {

--- a/desktop/macos/changelog/unreleased/20260630-local-agent-install-errors.json
+++ b/desktop/macos/changelog/unreleased/20260630-local-agent-install-errors.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made unavailable local agents fail clearly with install-first guidance instead of exposing adapter environment variables."
+}


### PR DESCRIPTION
## Summary
- Replace missing Hermes/OpenClaw user-facing setup text with install-first guidance that does not expose adapter environment variables.
- Return explicit `Error:` tool results from chat and PTT/realtime `spawn_agent` when the requested local provider is unavailable, so Omi does not silently fall back to another agent.
- Update runtime adapter activation errors, tests, and desktop changelog coverage.

## Root Cause
Unavailable directed local providers were surfaced as soft setup guidance, and some messages included internal adapter environment variable names. That allowed the model to treat the handoff as non-fatal and continue with a default provider.

## Validation
- `git diff --check`
- `xcrun swift test --package-path Desktop --filter 'PiMonoWiringTests|RealtimeHubSpawnAgentTests|ChatToolExecutorSpawnAgentTests'` (29 tests, 0 failures)
- `npm test -- adapter-selection.test.ts` (4 tests)
- `npm run build` in `desktop/macos/agent`
- `desktop/macos/scripts/agent-logic-harness.sh`
- Pre-push hook fast checks, including desktop changelog validation, agent tool manifest/control tests, node tools tests, and pi-mono-extension tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

