### PR TITLE
Fix parakeet batch=1 throughput collapse from flush_pending early reset

### DIFF
--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -270,8 +270,6 @@ class BatchEngine:
                 batch_set = set(id(r) for r in batch)
                 self._pending = [r for r in self._pending if id(r) not in batch_set]
 
-            self._flush_pending = False
-
             if not batch:
                 return
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -26,6 +26,7 @@ pytest tests/unit/test_parakeet_nim.py -v
 pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_parakeet_gpu_worker.py -v
 pytest tests/unit/test_parakeet_batch_engine.py -v
+pytest tests/unit/test_flush_pending_batch1.py -v
 pytest tests/unit/test_vram_batch.py -v
 pytest tests/unit/test_oom_reproduction.py -v
 pytest tests/unit/test_parakeet_batch_routing.py -v

--- a/backend/tests/unit/test_flush_pending_batch1.py
+++ b/backend/tests/unit/test_flush_pending_batch1.py
@@ -1,0 +1,134 @@
+"""
+Regression test for #8664: flush_pending early reset causes batch=1.
+
+Reproduces the exact production failure: when requests arrive one-at-a-time
+with realistic GPU latency (seconds, not instant), the early
+_flush_pending=False reset inside _flush_batch() lets the 2ms flush timer
+fire between each arrival, producing batch=1 instead of accumulating.
+
+RED on main with the early reset (line 273).
+GREEN after removing line 273.
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
+os.environ.setdefault("PARAKEET_DEVICE", "cpu")
+os.environ.setdefault("PARAKEET_TORCH_COMPILE", "false")
+os.environ.setdefault("PARAKEET_CUDA_GRAPHS", "false")
+
+_torch = MagicMock()
+_torch.cuda.is_available.return_value = False
+_torch.cuda.memory_allocated.return_value = 0
+_torch_props = MagicMock()
+_torch_props.total_memory = 16 * 1024**3
+_torch.cuda.get_device_properties.return_value = _torch_props
+_torch.cuda.empty_cache = MagicMock()
+_torch.cuda.mem_get_info.return_value = (10 * 1024**3, 16 * 1024**3)
+_torch.inference_mode = lambda: (lambda fn: fn)
+_torch.compile = lambda m: m
+_torch.backends.cudnn = MagicMock()
+sys.modules.setdefault("torch", _torch)
+
+for _mod in ["nemo", "nemo.collections", "nemo.collections.asr"]:
+    sys.modules.setdefault(_mod, MagicMock())
+for _mod in ["pyannote", "pyannote.audio", "pyannote.audio.core", "pyannote.audio.core.model"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
+
+from batch_engine import BatchEngine
+from gpu_worker import GPUWorker, WorkItem, WorkType
+
+GPU_DELAY_SEC = 0.3
+REQUEST_INTERVAL_SEC = 0.02
+NUM_REQUESTS = 12
+MAX_BATCH_SIZE = 32
+
+
+class TestFlushPendingBatch1Regression(unittest.TestCase):
+    """
+    Simulates production traffic: requests arrive every 20ms, GPU takes 300ms
+    per batch. With a 2ms flush timer and the early _flush_pending reset,
+    the timer fires between arrivals and flushes batch=1 each time.
+
+    Expected healthy behavior: requests accumulate during the ~300ms GPU
+    processing window, producing batches of 5-15 files.
+    """
+
+    def test_staggered_arrivals_accumulate_not_batch1(self):
+        batch_sizes = []
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            batch_sizes.append(payload["batch_size"])
+
+            async def delayed_resolve():
+                await asyncio.sleep(GPU_DELAY_SEC)
+                results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = GPU_DELAY_SEC
+
+            asyncio.ensure_future(delayed_resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(
+            gpu,
+            max_batch_size=MAX_BATCH_SIZE,
+            max_wait_seconds=0.002,
+            max_inflight=2,
+            vram_safety_factor=0,
+        )
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(engine.start())
+
+            async def run():
+                futs = []
+                for i in range(NUM_REQUESTS):
+                    futs.append(asyncio.create_task(engine.submit(f"/tmp/stagger_{i}.wav")))
+                    await asyncio.sleep(REQUEST_INTERVAL_SEC)
+                return await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=30)
+
+            results = loop.run_until_complete(run())
+        finally:
+            loop.run_until_complete(engine.stop())
+            loop.close()
+
+        successes = [r for r in results if not isinstance(r, Exception)]
+        self.assertEqual(len(successes), NUM_REQUESTS, f"All requests must succeed, got {len(successes)}")
+
+        total_batches = len(batch_sizes)
+        avg_batch = sum(batch_sizes) / total_batches if total_batches else 0
+        batch1_count = sum(1 for b in batch_sizes if b == 1)
+        batch1_pct = batch1_count / total_batches * 100 if total_batches else 0
+
+        self.assertGreater(
+            avg_batch,
+            2.0,
+            f"Average batch size must be >2.0 (got {avg_batch:.1f}, "
+            f"batches={batch_sizes}, batch=1 rate={batch1_pct:.0f}%)",
+        )
+        self.assertLessEqual(
+            batch1_count,
+            1,
+            f"At most 1 initial batch=1 is expected (got {batch1_count}, "
+            f"batches={batch_sizes}). Multiple batch=1 means flush_pending "
+            f"resets too early, preventing accumulation.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -565,23 +565,22 @@ class TestConcurrentFlush:
 
 class TestMaxInflight2:
 
-    def test_two_batches_inflight_concurrently(self):
-        concurrent_count = {"current": 0, "peak": 0}
-        gate = asyncio.Event()
+    def test_sequential_batching_accumulates_requests(self):
+        """With flush_pending gate held during GPU work, requests accumulate
+        into larger batches instead of being flushed one-at-a-time."""
+        batch_sizes = []
 
         def mock_submit(payload, loop):
             fut = loop.create_future()
             item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
-            concurrent_count["current"] += 1
-            concurrent_count["peak"] = max(concurrent_count["peak"], concurrent_count["current"])
+            batch_sizes.append(payload["batch_size"])
 
             async def delayed_resolve():
-                await gate.wait()
-                concurrent_count["current"] -= 1
+                await asyncio.sleep(0.05)
                 results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
                 if not fut.done():
                     fut.set_result(results)
-                item.inference_seconds = 0.01
+                item.inference_seconds = 0.05
 
             asyncio.ensure_future(delayed_resolve())
             return fut, item
@@ -591,29 +590,32 @@ class TestMaxInflight2:
         gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
         gpu.submit.side_effect = mock_submit
 
-        engine = BatchEngine(gpu, max_batch_size=2, max_wait_seconds=0.005, max_inflight=2, vram_safety_factor=0)
+        engine = BatchEngine(gpu, max_batch_size=8, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
         loop = asyncio.new_event_loop()
         try:
 
             async def run():
                 await engine.start()
                 try:
-                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(4)]
-                    for _ in range(50):
-                        await asyncio.sleep(0.01)
-                        if concurrent_count["current"] >= 2:
-                            break
-                    assert concurrent_count["peak"] >= 2, f"peak={concurrent_count['peak']} should be >=2"
-                    gate.set()
+                    futs = []
+                    for i in range(6):
+                        futs.append(asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")))
+                        await asyncio.sleep(0.005)
                     results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
                     successes = [r for r in results if not isinstance(r, Exception)]
-                    assert len(successes) == 4
+                    assert len(successes) == 6
                 finally:
                     await engine.stop()
 
             loop.run_until_complete(run())
         finally:
             loop.close()
+
+        batch1_count = sum(1 for b in batch_sizes if b == 1)
+        assert batch1_count <= 1, (
+            f"At most 1 batch=1 expected (got {batch1_count}, batches={batch_sizes}). "
+            f"flush_pending gate should prevent rapid batch=1 flushes."
+        )
 
 
 class TestFlushGuard:


### PR DESCRIPTION
## Summary

Fixes batch=1 throughput collapse introduced in PR #8535. Production data showed 72.8% of GPU batches containing only 1 file (avg 1.6 files/batch), causing LB 504 timeouts.

**Root cause:** The early `self._flush_pending = False` reset inside `_flush_batch()` (line 273) allowed the 2ms flush timer to fire between individual request arrivals, producing batch=1 flushes instead of accumulating requests during GPU processing.

**Fix:** Remove the early reset so `_flush_pending` only resets in `_guarded_flush()`'s `finally` block. This keeps the gate held during the entire GPU inference cycle, letting requests accumulate while GPU is busy.

### Changes
- `batch_engine.py`: Remove early `_flush_pending = False` on line 273
- `test_flush_pending_batch1.py`: New regression test — simulates staggered arrivals (20ms interval) with GPU latency (300ms), asserts batch accumulation
- `test_parakeet_batch_engine.py`: Replace `test_two_batches_inflight_concurrently` (which depended on early reset) with `test_sequential_batching_accumulates_requests`
- `test.sh`: Wire new regression test into CI

### RED/GREEN evidence
- **RED** (main, with early reset): `batches=[1, 1, 10]`, batch1_count=2 → FAIL
- **GREEN** (fix, without early reset): `batches=[1, 11]`, batch1_count=1 → PASS

### Test evidence
All 25 parakeet batch engine tests pass (24 existing + 1 new regression test). 239 total parakeet tests pass.

### Changed-path coverage

| Path ID | Changed path | Happy-path test | Non-happy-path test | L1 result | L2 result |
|---|---|---|---|---|---|
| P1 | `batch_engine.py:_flush_batch` — removed early `_flush_pending=False` reset | Staggered arrivals accumulate into batches >1 during GPU processing: `batches=[1, 11]`, avg=6.0 | First-tick unavoidable batch=1 still allowed: batch1_count=1 ≤ 1 | PASS (25/25 tests) | PASS (production trace confirms root cause) |

### Risks
- Concurrent batches via timer-triggered flushing no longer possible — batches are now sequential per `_guarded_flush` call. This is the pre-#8535 behavior and is correct: the semaphore still allows `max_inflight=2` concurrent GPU batches when `submit()` triggers immediate flush (queue >= max_batch_size).
- No VRAM or duration logic changes.

Closes #8664

_by AI for @beastoin_