### PR TITLE
Surface actionable agent failure details

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -295,6 +295,7 @@ enum BridgeError: LocalizedError {
   case restarting
   case requestAlreadyActive
   case agentError(String)
+  case agentRuntimeFailure(AgentRuntimeFailure)
   case quotaExceeded(plan: String, unit: String, used: Double, limit: Double?, resetAtUnix: Int?)
   case authMissing
 
@@ -326,6 +327,8 @@ enum BridgeError: LocalizedError {
       return "A response is already running for this chat."
     case .authMissing:
       return "Please sign in to use AI chat."
+    case .agentRuntimeFailure(let failure):
+      return failure.displayMessage
     case .agentError(let msg):
       let lower = msg.lowercased()
       if lower.contains("leaked") || lower.contains("api key") || lower.contains("api_key")

--- a/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum AgentFailureTranscriptFormatter {
+  static func errorText(for projection: AgentRunProjection) -> String? {
+    switch projection.status {
+    case .failed, .timedOut, .orphaned:
+      return projection.failure?.displayMessage
+        ?? projection.errorMessage
+        ?? projection.statusText
+        ?? "Agent failed"
+    case .idle, .queued, .starting, .running, .waitingInput, .waitingApproval, .cancelling, .succeeded, .cancelled:
+      return nil
+    }
+  }
+
+  static func transcriptText(for errorText: String) -> String? {
+    let trimmed = errorText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if trimmed.lowercased().hasPrefix("failed:") {
+      return trimmed
+    }
+    return "Failed: \(trimmed)"
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -891,8 +891,17 @@ actor AgentRuntimeProcess {
       log("AgentRuntimeProcess: dropping unroutable result")
       return
     }
-    if (message.payload["terminalStatus"] as? String) == "cancelled" {
+    let terminalStatus = message.payload["terminalStatus"] as? String
+    if terminalStatus == "cancelled" {
       request.continuation.resume(throwing: BridgeError.stopped)
+      return
+    }
+    if let terminalStatus,
+       ["failed", "timed_out", "orphaned"].contains(terminalStatus) {
+      let failure = AgentRuntimeFailure.parse(from: message.payload["failure"])
+      let raw = failure?.displayMessage ?? message.payload["text"] as? String ?? "Agent failed"
+      log("AgentRuntimeProcess: agent result failed (raw): \(raw)")
+      request.continuation.resume(throwing: failure.map(BridgeError.agentRuntimeFailure) ?? BridgeError.agentError(raw))
       return
     }
     request.continuation.resume(returning: queryResult(from: message))
@@ -915,7 +924,7 @@ actor AgentRuntimeProcess {
       let controlRequest = activeControlRequests.removeValue(forKey: requestKey)
     {
       log("AgentRuntimeProcess: control tool error (raw): \(raw)")
-      controlRequest.continuation.resume(throwing: BridgeError.agentError(raw))
+      controlRequest.continuation.resume(throwing: failure.map(BridgeError.agentRuntimeFailure) ?? BridgeError.agentError(raw))
       return
     }
     guard let requestKey = message.requestKey, let request = activeRequests.removeValue(forKey: requestKey) else {
@@ -923,7 +932,7 @@ actor AgentRuntimeProcess {
       return
     }
     log("AgentRuntimeProcess: agent error (raw): \(raw)")
-    request.continuation.resume(throwing: BridgeError.agentError(raw))
+    request.continuation.resume(throwing: failure.map(BridgeError.agentRuntimeFailure) ?? BridgeError.agentError(raw))
   }
 
   private func queryResult(from message: RuntimeMessage) -> AgentBridge.QueryResult {

--- a/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
@@ -124,6 +124,7 @@ extension ChatErrorState {
   ///   - `.encodingError`        (internal error, retry won't help)
   ///   - `.quotaExceeded`        (paywall — kept as separate sheet)
   ///   - `.agentError`           (varied; existing banner already classifies)
+  ///   - `.agentRuntimeFailure`  (already carries runtime-specific copy)
   ///   - `.requestAlreadyActive` (the existing banner explains the active turn)
   static func from(_ bridgeError: BridgeError) -> ChatErrorState? {
     switch bridgeError {
@@ -141,7 +142,7 @@ extension ChatErrorState {
       return .bridgeUnavailable(reason: .unknown)
     case .authMissing:
       return .authRequired
-    case .encodingError, .quotaExceeded, .agentError, .requestAlreadyActive:
+    case .encodingError, .quotaExceeded, .agentError, .agentRuntimeFailure, .requestAlreadyActive:
       return nil
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -1183,9 +1183,8 @@ final class AgentPillsManager: ObservableObject {
     }
 
     private static func ensureFailureMessage(_ errorText: String, for pill: AgentPill) {
-        let text = errorText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        let failureMessage = ChatMessage(text: "Failed: \(text)", sender: .ai)
+        guard let failureText = AgentFailureTranscriptFormatter.transcriptText(for: errorText) else { return }
+        let failureMessage = ChatMessage(text: failureText, sender: .ai)
         if pill.conversationMessages.isEmpty {
             pill.conversationMessages = [
                 ChatMessage(text: pill.query, sender: .user),

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -45,6 +45,10 @@ class TaskChatState: ObservableObject {
     /// Follow-up chaining
     private var pendingFollowUpText: String?
 
+    private var runtimeProjectionCancellable: AnyCancellable?
+    private var surfacedFailureKeys: Set<String> = []
+    private var activeAssistantMessageId: String?
+
     // MARK: - Streaming Buffers (mirrored from ChatProvider)
 
     private var streamingTextBuffer: String = ""
@@ -70,7 +74,11 @@ class TaskChatState: ObservableObject {
 
         do {
             let records = try await TaskChatMessageStorage.shared.getMessages(forTaskId: taskId)
-            guard !records.isEmpty else { return }
+            observeRuntimeProjectionFailures()
+            guard !records.isEmpty else {
+                surfaceCurrentRuntimeFailureIfNeeded()
+                return
+            }
 
             messages = records.map { $0.toChatMessage() }
 
@@ -78,6 +86,7 @@ class TaskChatState: ObservableObject {
                 self.legacyAcpSessionId = legacyAcpSessionId
             }
 
+            surfaceCurrentRuntimeFailureIfNeeded()
             log("TaskChatState[\(taskId)]: Loaded \(records.count) persisted messages")
         } catch {
             logError("TaskChatState[\(taskId)]: Failed to load persisted messages", error: error)
@@ -213,6 +222,7 @@ class TaskChatState: ObservableObject {
             isStreaming: true
         )
         messages.append(aiMessage)
+        activeAssistantMessageId = aiMessageId
 
         do {
             let systemPrompt = systemPromptBuilder?() ?? ""
@@ -309,15 +319,43 @@ class TaskChatState: ObservableObject {
 
             // Finalize AI message
             if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
-                let messageText = messages[index].text.isEmpty ? queryResult.text : messages[index].text
-                messages[index].text = messageText
-                messages[index].isStreaming = false
-                completeRemainingToolCalls(messageId: aiMessageId)
-                persistMessage(messages[index])
+                let terminalStatus = AgentRunProjectionStatus.fromWire(queryResult.terminalStatus) ?? .succeeded
+                if terminalStatus == .failed || terminalStatus == .timedOut || terminalStatus == .orphaned {
+                    surfaceCurrentRuntimeFailureIfNeeded(fallbackMessage: "Agent failed")
+                    if let currentIndex = messages.firstIndex(where: { $0.id == aiMessageId }) {
+                        let shouldPersistPartial =
+                            messages[currentIndex].isStreaming
+                            && (
+                                !messages[currentIndex].text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                || !messages[currentIndex].contentBlocks.isEmpty
+                            )
+                        messages[currentIndex].isStreaming = false
+                        completeRemainingToolCalls(messageId: aiMessageId)
+                        if shouldPersistPartial {
+                            persistMessage(messages[currentIndex])
+                        }
+                    }
+                } else {
+                    let messageText = messages[index].text.isEmpty ? queryResult.text : messages[index].text
+                    messages[index].text = messageText
+                    messages[index].isStreaming = false
+                    completeRemainingToolCalls(messageId: aiMessageId)
+                    persistMessage(messages[index])
+                }
             }
 
             log("TaskChatState[\(taskId)]: response complete (cost=$\(queryResult.costUsd))")
-            TaskAgentStatusRegistry.shared.markCompleted(taskId: taskId)
+            let terminalStatus = AgentRunProjectionStatus.fromWire(queryResult.terminalStatus) ?? .succeeded
+            if terminalStatus == .failed || terminalStatus == .timedOut || terminalStatus == .orphaned {
+                let failureText =
+                    AgentRuntimeStatusStore.shared.projection(for: .taskChat(taskId: taskId))
+                    .flatMap(AgentFailureTranscriptFormatter.errorText(for:))
+                    ?? "Agent failed"
+                errorMessage = failureText
+                TaskAgentStatusRegistry.shared.markFailed(taskId: taskId, error: failureText)
+            } else {
+                TaskAgentStatusRegistry.shared.markCompleted(taskId: taskId)
+            }
         } catch {
             streamingFlushWorkItem?.cancel()
             streamingFlushWorkItem = nil
@@ -350,6 +388,7 @@ class TaskChatState: ObservableObject {
             logError("TaskChatState[\(taskId)]: query failed", error: error)
         }
 
+        activeAssistantMessageId = nil
         isSending = false
         isStopping = false
 
@@ -364,7 +403,87 @@ class TaskChatState: ObservableObject {
 
     static func applyFailureTextIfNeeded(to message: inout ChatMessage, errorDescription: String) {
         if message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            message.text = "Failed: \(errorDescription)"
+            message.text = AgentFailureTranscriptFormatter.transcriptText(for: errorDescription) ?? "Failed: Agent failed"
+        }
+    }
+
+    func surfaceRuntimeFailure(_ projection: AgentRunProjection, fallbackMessage: String? = nil, persist: Bool = true) {
+        guard projection.surface == .taskChat(taskId: taskId) else { return }
+        guard let errorText = AgentFailureTranscriptFormatter.errorText(for: projection) ?? fallbackMessage else { return }
+        let failureKey = [
+            projection.runId,
+            projection.attemptId,
+            projection.sessionId,
+            projection.completedAt.map { String($0.timeIntervalSinceReferenceDate) },
+            errorText,
+        ]
+        .compactMap { $0 }
+        .joined(separator: "|")
+        guard surfacedFailureKeys.insert(failureKey).inserted else { return }
+
+        appendFailureTranscriptMessage(errorText, persist: persist)
+        errorMessage = errorText
+    }
+
+    private func observeRuntimeProjectionFailures() {
+        guard runtimeProjectionCancellable == nil else { return }
+        let surface = AgentSurfaceReference.taskChat(taskId: taskId)
+        runtimeProjectionCancellable = AgentRuntimeStatusStore.shared.$projectionsBySurface
+            .dropFirst()
+            .sink { [weak self] projections in
+                guard let self, let projection = projections[surface.key] else { return }
+                self.surfaceRuntimeFailure(projection)
+            }
+    }
+
+    private func surfaceCurrentRuntimeFailureIfNeeded(fallbackMessage: String? = nil) {
+        if let projection = AgentRuntimeStatusStore.shared.projection(for: .taskChat(taskId: taskId)) {
+            surfaceRuntimeFailure(projection, fallbackMessage: fallbackMessage)
+        } else if let fallbackMessage {
+            appendFailureTranscriptMessage(fallbackMessage)
+            errorMessage = fallbackMessage
+        }
+    }
+
+    private func appendFailureTranscriptMessage(_ errorText: String, persist: Bool = true) {
+        guard let failureText = AgentFailureTranscriptFormatter.transcriptText(for: errorText) else { return }
+        if messages.contains(where: { message in
+            message.sender == .ai
+                && message.text.trimmingCharacters(in: .whitespacesAndNewlines) == failureText
+        }) {
+            return
+        }
+
+        if let activeAssistantMessageId,
+           let index = messages.firstIndex(where: { $0.id == activeAssistantMessageId }),
+           messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: errorText)
+            messages[index].isStreaming = false
+            completeRemainingToolCalls(messageId: activeAssistantMessageId)
+            if persist {
+                persistMessage(messages[index])
+            }
+            return
+        }
+
+        if let index = messages.lastIndex(where: { message in
+            message.sender == .ai
+                && message.isStreaming
+                && message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: errorText)
+            messages[index].isStreaming = false
+            completeRemainingToolCalls(messageId: messages[index].id)
+            if persist {
+                persistMessage(messages[index])
+            }
+            return
+        }
+
+        let failureMessage = ChatMessage(text: failureText, sender: .ai)
+        messages.append(failureMessage)
+        if persist {
+            persistMessage(failureMessage)
         }
     }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -715,7 +715,8 @@ final class AgentPillLifecycleTests: XCTestCase {
     XCTAssertTrue(source.contains("Self.ensureFailureMessage(\"Agent ended before reporting a final result\", for: pill)"))
     XCTAssertTrue(source.contains("ensureFailureMessage(message, for: pill)"))
     XCTAssertTrue(source.contains("projection.failure?.displayMessage ?? projection.errorMessage ?? \"Agent failed\""))
-    XCTAssertTrue(source.contains("ChatMessage(text: \"Failed: \\(text)\", sender: .ai)"))
+    XCTAssertTrue(source.contains("AgentFailureTranscriptFormatter.transcriptText(for: errorText)"))
+    XCTAssertTrue(source.contains("ChatMessage(text: failureText, sender: .ai)"))
   }
 
   func testLateMessageActivityCannotOverwriteTerminalPillStatus() throws {

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -252,7 +252,8 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains("activeControlRequests[requestKey]"))
     XCTAssertTrue(source.contains("completeControlRequest(message)"))
     XCTAssertTrue(source.contains("if !sent, let request = activeControlRequests.removeValue(forKey: requestKey)"))
-    XCTAssertTrue(source.contains("controlRequest.continuation.resume(throwing: BridgeError.agentError(raw))"))
+    XCTAssertTrue(source.contains("failure.map(BridgeError.agentRuntimeFailure) ?? BridgeError.agentError(raw)"))
+    XCTAssertTrue(source.contains(#"["failed", "timed_out", "orphaned"].contains(terminalStatus)"#))
   }
 
   func testDirectControlToolRequestsUseDedicatedSignedInOwnerEnvelope() throws {

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -128,6 +128,40 @@ final class ChatErrorStateTests: XCTestCase {
       )
     )
     XCTAssertNil(ChatErrorState.from(.agentError("something opaque went wrong")))
+    XCTAssertNil(
+      ChatErrorState.from(
+        .agentRuntimeFailure(
+          AgentRuntimeFailure(
+            code: "adapter_config_invalid",
+            userMessage: "OpenClaw needs a config migration.",
+            technicalMessage: nil,
+            source: "adapter_process",
+            adapterId: "openclaw",
+            provider: nil,
+            retryable: false
+          )
+        )
+      )
+    )
+  }
+
+  func testStructuredAgentRuntimeFailureKeepsUserMessage() {
+    let error = BridgeError.agentRuntimeFailure(
+      AgentRuntimeFailure(
+        code: "adapter_config_invalid",
+        userMessage: "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry.",
+        technicalMessage: "OpenClaw config is invalid",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        provider: nil,
+        retryable: false
+      )
+    )
+
+    XCTAssertEqual(
+      error.localizedDescription,
+      "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry."
+    )
   }
 
   // MARK: - Bridge-unavailable reason coverage

--- a/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
@@ -45,6 +45,8 @@ final class TaskChatLegacyAcpMigrationTests: XCTestCase {
 
     XCTAssertTrue(source.contains("Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: error.localizedDescription)"))
     XCTAssertTrue(source.contains("persistMessage(messages[index])"))
+    XCTAssertTrue(source.contains("observeRuntimeProjectionFailures()"))
+    XCTAssertTrue(source.contains("surfaceRuntimeFailure(projection)"))
   }
 
   @MainActor
@@ -63,6 +65,83 @@ final class TaskChatLegacyAcpMigrationTests: XCTestCase {
 
     XCTAssertEqual(message.text, "Failed: OpenClaw failed")
     XCTAssertFalse(message.contentBlocks.isEmpty)
+  }
+
+  func testFailureTranscriptFormatterUsesStructuredProjectionFailure() {
+    let projection = AgentRunProjection(
+      surface: .taskChat(taskId: "task-runtime-failure"),
+      sessionId: "session-1",
+      runId: "run-1",
+      attemptId: "attempt-1",
+      adapterSessionId: nil,
+      status: .failed,
+      statusText: nil,
+      errorMessage: nil,
+      failure: AgentRuntimeFailure(
+        code: "adapter_process_exited",
+        userMessage: "OpenClaw failed: OpenAI API error: upstream unavailable",
+        technicalMessage: "OpenAI API error: upstream unavailable",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        provider: "openai",
+        retryable: true
+      ),
+      updatedAt: Date(),
+      completedAt: Date(),
+      costUsd: nil,
+      inputTokens: nil,
+      outputTokens: nil
+    )
+
+    XCTAssertEqual(
+      AgentFailureTranscriptFormatter.errorText(for: projection),
+      "OpenClaw failed: OpenAI API error: upstream unavailable"
+    )
+    XCTAssertEqual(
+      AgentFailureTranscriptFormatter.transcriptText(for: AgentFailureTranscriptFormatter.errorText(for: projection) ?? ""),
+      "Failed: OpenClaw failed: OpenAI API error: upstream unavailable"
+    )
+  }
+
+  func testFailureTranscriptFormatterDoesNotDoublePrefix() {
+    XCTAssertEqual(
+      AgentFailureTranscriptFormatter.transcriptText(for: "OpenClaw failed"),
+      "Failed: OpenClaw failed"
+    )
+    XCTAssertEqual(
+      AgentFailureTranscriptFormatter.transcriptText(for: "Failed: OpenClaw failed"),
+      "Failed: OpenClaw failed"
+    )
+  }
+
+  func testRuntimeFailureProjectionSurfacingDoesNotReRecordStatus() throws {
+    let source = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift")
+    guard let functionRange = source.range(of: "func surfaceRuntimeFailure(") else {
+      return XCTFail("surfaceRuntimeFailure function missing")
+    }
+    let rest = source[functionRange.lowerBound...]
+    let nextFunction = rest.range(of: "\n    private func observeRuntimeProjectionFailures()")
+    let body = nextFunction.map { String(rest[..<$0.lowerBound]) } ?? String(rest)
+
+    XCTAssertFalse(body.contains("TaskAgentStatusRegistry.shared.markFailed"))
+    XCTAssertTrue(body.contains("appendFailureTranscriptMessage(errorText"))
+  }
+
+  func testTerminalFailureFinalizeDoesNotPersistFailureTranscriptTwice() throws {
+    let source = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift")
+    guard let branchRange = source.range(of: "if terminalStatus == .failed || terminalStatus == .timedOut || terminalStatus == .orphaned {") else {
+      return XCTFail("terminal failure branch missing")
+    }
+    let rest = source[branchRange.lowerBound...]
+    guard let elseRange = rest.range(of: "\n                } else {") else {
+      return XCTFail("terminal failure branch end missing")
+    }
+    let branch = String(rest[..<elseRange.lowerBound])
+
+    XCTAssertTrue(branch.contains("surfaceCurrentRuntimeFailureIfNeeded(fallbackMessage: \"Agent failed\")"))
+    XCTAssertTrue(branch.contains("let shouldPersistPartial"))
+    XCTAssertTrue(branch.contains("if shouldPersistPartial"))
+    XCTAssertFalse(branch.contains("persistMessage(messages[index])"))
   }
 
   func testActionItemChatSessionIdLegacyMarkerStillUsesTaskId() throws {

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -70,6 +70,15 @@ export function failureFromProcessExit(input: {
 }): RuntimeFailure {
   const diagnostic = sanitizeProcessDiagnostic(input.recentStderr);
   const technicalMessage = diagnostic || `${input.adapterId} ACP process exited with code ${input.exitCode}`;
+  const classified = classifyAdapterProcessFailure(input.adapterId, diagnostic);
+  if (classified) {
+    return normalizeRuntimeFailure({
+      source: "adapter_process",
+      adapterId: input.adapterId,
+      technicalMessage,
+      ...classified,
+    });
+  }
   const provider = providerFromDiagnostic(diagnostic);
   const label = adapterFailureLabel(input.adapterId, provider);
   return normalizeRuntimeFailure({
@@ -81,6 +90,33 @@ export function failureFromProcessExit(input: {
     userMessage: `${label} failed: ${technicalMessage}`,
     technicalMessage,
   });
+}
+
+function classifyAdapterProcessFailure(
+  adapterId: ProductionAdapterId,
+  diagnostic: string
+): Partial<RuntimeFailure> | undefined {
+  if (adapterId === "openclaw" && isOpenClawInvalidConfig(diagnostic)) {
+    return {
+      code: "adapter_config_invalid",
+      retryable: false,
+      userMessage:
+        "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry. Inspect with `openclaw config validate`.",
+    };
+  }
+  return undefined;
+}
+
+function isOpenClawInvalidConfig(diagnostic: string): boolean {
+  const lower = diagnostic.toLowerCase();
+  return (
+    lower.includes("openclaw config is invalid") ||
+    lower.includes("invalid config at") ||
+    lower.includes("legacy config keys detected") ||
+    lower.includes("openclaw doctor --fix") ||
+    lower.includes("openclaw config validate") ||
+    lower.includes("channels.telegram.streaming: invalid config")
+  );
 }
 
 export function failureFromProcessError(input: {

--- a/desktop/macos/agent/src/runtime/kernel.ts
+++ b/desktop/macos/agent/src/runtime/kernel.ts
@@ -505,11 +505,20 @@ export class AgentRuntimeKernel {
       lastAttempt = attempt;
 
       if (!this.registry.has(adapterId)) {
+        const failure: RuntimeFailure = {
+          code: "adapter_not_registered",
+          source: "runtime",
+          adapterId,
+          retryable: false,
+          userMessage: `Adapter not registered: ${adapterId}`,
+          technicalMessage: `Adapter not registered: ${adapterId}`,
+        };
         this.failAttemptBeforeExecution(
           attempt,
           "adapter_not_registered",
-          `Adapter not registered: ${adapterId}`,
-          false
+          failure.userMessage,
+          false,
+          failure
         );
         break;
       }
@@ -560,7 +569,13 @@ export class AgentRuntimeKernel {
       } catch (error) {
         pool.unprotectPinnedBinding(bindingResolutionProtectedBindingId);
         if (isStaleBindingError(error)) {
-          this.failAttemptBeforeExecution(attempt, "stale_binding", messageFrom(error), attemptNo < maxAttempts);
+          const failure = failureFromError(error, {
+            code: "stale_binding",
+            source: "adapter_process",
+            adapterId: attempt.adapterId,
+            retryable: attemptNo < maxAttempts,
+          });
+          this.failAttemptBeforeExecution(attempt, "stale_binding", failure.userMessage, attemptNo < maxAttempts, failure);
           retryReason = "stale_binding";
           resumeFromAttemptId = attempt.attemptId;
           continue;
@@ -570,7 +585,13 @@ export class AgentRuntimeKernel {
           resumeFromAttemptId = attempt.attemptId;
           continue;
         }
-        this.failAttemptBeforeExecution(attempt, "binding_failed", messageFrom(error), false);
+        const failure = failureFromError(error, {
+          code: "binding_failed",
+          source: "adapter_process",
+          adapterId: attempt.adapterId,
+          retryable: false,
+        });
+        this.failAttemptBeforeExecution(attempt, "binding_failed", failure.userMessage, false, failure);
         break;
       }
 
@@ -627,7 +648,13 @@ export class AgentRuntimeKernel {
         this.activeExecutions.delete(accepted.run.runId);
         if (isStaleBindingError(error)) {
           this.markBindingStale(binding, attempt, messageFrom(error));
-          this.failAttemptBeforeExecution(attempt, "stale_binding", messageFrom(error), attemptNo < maxAttempts);
+          const failure = failureFromError(error, {
+            code: "stale_binding",
+            source: "adapter_execution",
+            adapterId: attempt.adapterId,
+            retryable: attemptNo < maxAttempts,
+          });
+          this.failAttemptBeforeExecution(attempt, "stale_binding", failure.userMessage, attemptNo < maxAttempts, failure);
           retryReason = "stale_binding";
           resumeFromAttemptId = attempt.attemptId;
           continue;
@@ -1638,7 +1665,13 @@ export class AgentRuntimeKernel {
     });
   }
 
-  private failAttemptBeforeExecution(attempt: RunAttempt, errorCode: string, errorMessage: string, retryable: boolean): void {
+  private failAttemptBeforeExecution(
+    attempt: RunAttempt,
+    errorCode: string,
+    errorMessage: string,
+    retryable: boolean,
+    failure?: RuntimeFailure
+  ): void {
     const run = this.readRun(attempt.runId);
     this.withTransaction(() => {
       this.updateAttempt(attempt.attemptId, {
@@ -1654,6 +1687,7 @@ export class AgentRuntimeKernel {
           status: "failed",
           errorCode,
           errorMessage,
+          resultJson: failure ? JSON.stringify({ failure }) : null,
           completedAtMs: Date.now(),
           updatedAtMs: Date.now(),
         });
@@ -1662,7 +1696,7 @@ export class AgentRuntimeKernel {
           runId: attempt.runId,
           attemptId: attempt.attemptId,
           type: "run.failed",
-          payload: { runId: attempt.runId, errorCode, errorMessage },
+          payload: { runId: attempt.runId, errorCode, errorMessage, failure },
         });
       }
       this.appendEvent({
@@ -1670,7 +1704,7 @@ export class AgentRuntimeKernel {
         runId: attempt.runId,
         attemptId: attempt.attemptId,
         type: "attempt.failed",
-        payload: { attemptId: attempt.attemptId, errorCode, errorMessage, retryable },
+        payload: { attemptId: attempt.attemptId, errorCode, errorMessage, retryable, failure },
       });
     });
   }
@@ -1694,7 +1728,13 @@ export class AgentRuntimeKernel {
     if (!recovered) {
       return false;
     }
-    this.failAttemptBeforeExecution(attempt, errorCode, messageFrom(error), true);
+    const failure = failureFromError(error, {
+      code: errorCode,
+      source: "adapter_process",
+      adapterId: attempt.adapterId,
+      retryable: true,
+    });
+    this.failAttemptBeforeExecution(attempt, errorCode, failure.userMessage, true, failure);
     return true;
   }
 

--- a/desktop/macos/agent/tests/compatibility-facade.test.ts
+++ b/desktop/macos/agent/tests/compatibility-facade.test.ts
@@ -82,6 +82,52 @@ describe("JsonlCompatibilityFacade", () => {
     store.close();
   });
 
+  it("emits structured runtime failures when binding fails before execution", async () => {
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath());
+    const sent: OutboundMessage[] = [];
+    adapter.failNextOpenError = new AdapterRuntimeError({
+      code: "adapter_config_invalid",
+      source: "adapter_process",
+      adapterId: "openclaw",
+      retryable: false,
+      userMessage:
+        "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry. Inspect with `openclaw config validate`.",
+      technicalMessage: "OpenClaw config is invalid",
+    });
+    const facade = new JsonlCompatibilityFacade({
+      kernel,
+      send: (message) => sent.push(message),
+      defaultAdapterId: "fake",
+      defaultCwd: () => "/tmp/default",
+    });
+
+    await facade.handleQuery({
+      ...v1Query({ id: "request-binding-failed", prompt: "fail before execution" }),
+      protocolVersion: 2,
+      requestId: "request-binding-failed",
+      clientId: "client-binding-failed",
+      adapterId: "fake",
+    });
+
+    expect(adapter.executed).toHaveLength(0);
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: "error",
+      message:
+        "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry. Inspect with `openclaw config validate`.",
+      failure: expect.objectContaining({
+        code: "adapter_config_invalid",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        retryable: false,
+      }),
+    }));
+    expect(JSON.parse(store.getRow("SELECT result_json FROM runs").result_json).failure).toMatchObject({
+      code: "adapter_config_invalid",
+      adapterId: "openclaw",
+    });
+    store.close();
+  });
+
   it("selects the sole running request for unscoped tool-call correlation", () => {
     expect(
       selectUnscopedToolCallCorrelation([

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -262,6 +262,43 @@ describe("AcpRuntimeAdapter process spawning", () => {
     });
   });
 
+  it("classifies OpenClaw invalid config exits with repair instructions", async () => {
+    const proc = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(proc as any);
+    const adapter = new AcpRuntimeAdapter({
+      adapterId: "openclaw",
+      command: "openclaw acp",
+      envCommandName: "OMI_OPENCLAW_ADAPTER_COMMAND",
+    });
+    proc.stdin.on("data", () => {});
+    await adapter.start();
+
+    const request = adapter.request("initialize");
+    proc.stderr.write("OpenClaw config is invalid\n");
+    proc.stderr.write("File: ~/.openclaw/openclaw.json\n");
+    proc.stderr.write("- channels.telegram.streaming: invalid config: must be object\n");
+    proc.stderr.write("Fix: openclaw doctor --fix\n");
+    proc.stderr.write("Inspect: openclaw config validate\n");
+    await Promise.resolve();
+    proc.emit("exit", 1);
+
+    await expect(request).rejects.toThrow(
+      "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry. Inspect with `openclaw config validate`."
+    );
+    await request.catch((error) => {
+      expect(error).toBeInstanceOf(AdapterRuntimeError);
+      expect((error as AdapterRuntimeError).failure).toMatchObject({
+        code: "adapter_config_invalid",
+        source: "adapter_process",
+        adapterId: "openclaw",
+        retryable: false,
+        userMessage:
+          "OpenClaw needs a config migration. Run `openclaw doctor --fix`, then retry. Inspect with `openclaw config validate`.",
+        technicalMessage: expect.stringContaining("OpenClaw config is invalid"),
+      });
+    });
+  });
+
   it("structures OpenClaw subprocess spawn errors", async () => {
     const proc = createMockProcess();
     vi.mocked(spawn).mockReturnValue(proc as any);

--- a/desktop/macos/changelog/unreleased/20260630-agent-failure-transcripts.json
+++ b/desktop/macos/changelog/unreleased/20260630-agent-failure-transcripts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed failed agents so their error details appear in the agent chat transcript"
+}


### PR DESCRIPTION
## Summary
- classify OpenClaw invalid config exits as structured `adapter_config_invalid` failures with repair instructions
- preserve structured agent runtime failures through the Swift bridge instead of collapsing them to generic copy
- show failed task/floating agent details inside the agent transcript, with shared failure transcript formatting

## Verification
- `cd desktop/macos && ./scripts/agent-logic-harness.sh`
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'TaskChatLegacyAcpMigrationTests|ChatErrorStateTests|AgentRuntimeProcessTests|AgentPillLifecycleTests/testFallbackFailurePathsRecordCompletionTime'`
- `cd desktop/macos/agent && npm test -- runtime-adapter.test.ts`
- `git diff --check`
- pre-push checks passed

## Review
- final subagent review found a task-chat projection feedback-loop risk and load/observer race
- addressed both findings and re-ran validation
- reviewer re-check reported no blocking findings

Fixes #8663
