### PR TITLE
fix(parakeet): keep _flush_pending held during GPU inference (#8664)

### DIFF
--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -270,7 +270,11 @@ class BatchEngine:
                 batch_set = set(id(r) for r in batch)
                 self._pending = [r for r in self._pending if id(r) not in batch_set]
 
-            self._flush_pending = False
+            # _flush_pending is reset only in _guarded_flush's finally (after GPU
+            # inference completes). Clearing it here — before inference — let the
+            # 2ms flush timer fire again immediately and spawn batch=1 flushes,
+            # collapsing GPU batch size ~4x (#8664). Keep the flag held so
+            # requests accumulate during inference into the next batch.
 
             if not batch:
                 return

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -752,6 +752,71 @@ class TestLazyVramInit:
             loop.close()
 
 
+class TestFlushPendingHeldDuringInference:
+    """Regression for #8664.
+
+    PR #8535 added an early ``self._flush_pending = False`` inside ``_flush_batch``
+    right after the batch was popped — *before* GPU inference ran. With the 2ms
+    flush timer that let a new flush fire immediately, so requests submitted while
+    a batch was on the GPU each became their own batch=1 flush instead of
+    accumulating. The flag must stay set for the whole inference and reset only in
+    ``_guarded_flush``'s ``finally``.
+    """
+
+    def test_flush_pending_held_until_inference_completes(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        observed = {"at_dispatch": None, "during_inference": None}
+        release = asyncio.Event()
+        started = asyncio.Event()
+
+        def mock_submit(payload, loop):
+            # Captured synchronously the instant GPU work is dispatched — after the
+            # batch was popped. The buggy early reset would make this False.
+            observed["at_dispatch"] = engine._flush_pending
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            item.inference_seconds = 0.01
+            loop.call_soon(started.set)
+
+            async def resolve():
+                await release.wait()
+                if not fut.done():
+                    fut.set_result([{"text": "ok"} for _ in range(payload["batch_size"])])
+
+            asyncio.ensure_future(resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=100, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    f0 = asyncio.ensure_future(engine.submit("/tmp/a0.wav"))
+                    await asyncio.wait_for(started.wait(), timeout=5)
+                    # Inference is now blocked on `release`; flag must still be set.
+                    observed["during_inference"] = engine._flush_pending
+                    release.set()
+                    await asyncio.wait_for(f0, timeout=10)
+                finally:
+                    release.set()
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+        assert observed["at_dispatch"] is True, "_flush_pending cleared before GPU inference dispatched (#8664)"
+        assert observed["during_inference"] is True, "_flush_pending cleared while GPU inference in flight (#8664)"
+
+
 class TestUnlinkSafe:
 
     def test_unlink_existing(self):


### PR DESCRIPTION
## Bug (#8664)

PR #8535 (VRAM-aware batch sizing) introduced an early `self._flush_pending = False` inside `_flush_batch` — right after the batch is popped from `_pending`, but **before** GPU inference runs. Combined with the 2ms flush timer this lets a new flush fire immediately, so requests submitted while a batch is on the GPU each become their own `batch=1` flush instead of accumulating.

**Prod evidence (from the issue, 30 min post-deploy):** ~72.8% of GPU batches contained 1 file (down from 8-12), avg 1.6 files/batch, ~4x lower throughput, and intermittent 504s under peak load (self-resolving at steady state).

## Root cause

`_flush_pending` is the serialization gate `#8535` added to replace the previous accumulation mechanism (`_flush_loop` used to `await self._flush_batch()` directly, which naturally serialized and let requests pile up during the 2-5s GPU inference). The gate is meant to stay **True for the whole inference** and reset **only** in `_guarded_flush`'s `finally`. The extra reset on the popped-batch line clears it prematurely, defeating accumulation:

1. Timer fires (2ms) → `_flush_pending=True`, flush pops 1 request, immediately sets `_flush_pending=False` (bug)
2. 2ms later the timer fires again, grabs the next lone request → `batch=1`
3. Repeat — the GPU never gets time to accumulate a batch

## Fix

Remove the premature `self._flush_pending = False` inside `_flush_batch`. The flag now resets only in `_guarded_flush`'s `finally` (after inference completes), restoring the pre-#8535 accumulation behavior. The `max_inflight` semaphore still bounds concurrent batches, so this is a **pure revert of the one regressing line** back to known-good behavior — no new behavior introduced.

## Test

Added `TestFlushPendingHeldDuringInference` to `test_parakeet_batch_engine.py` (already in `test.sh`): a gated mock GPU asserts `_flush_pending` is still `True` both at dispatch and while inference is in flight. Verified it **fails** with the early reset present and **passes** with it removed.

## Verification

Logic + regression test verified locally (the new test passes; reintroducing the bug makes it fail). GPU throughput itself is **UNVERIFIED** (no GPU locally) — but the change is a strict revert of the line the issue identifies, restoring the documented prior batching behavior.

🤖 automated by hourly watchdog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

