### PR TITLE
test(backend): stop test_action_items_timezone from poisoning sys.modules (#8661)

### DIFF
--- a/backend/tests/unit/test_action_items_timezone.py
+++ b/backend/tests/unit/test_action_items_timezone.py
@@ -69,7 +69,13 @@ def _load_module_from_file(module_name, file_path):
 
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies
+#
+# Snapshot sys.modules first so the stubs installed below do not leak into other
+# test files during bulk ``pytest tests/unit/`` collection (issue #8661). They are
+# restored right after the module under test is imported.
 # ---------------------------------------------------------------------------
+_SYS_MODULES_SNAPSHOT = dict(sys.modules)
+
 for mod_name in [
     "firebase_admin",
     "firebase_admin.firestore",
@@ -164,6 +170,18 @@ action_item_tools = _load_module_from_file(
     BACKEND_DIR / "utils" / "retrieval" / "tools" / "action_item_tools.py",
 )
 get_action_items_tool = action_item_tools.get_action_items_tool
+
+# Restore sys.modules now that the module under test is imported and bound to its
+# (stubbed) dependencies. This stops the empty-package stubs above from leaking into
+# other test files during bulk collection (issue #8661). The tests below patch
+# ``action_item_tools.action_items_db`` directly, so the restore does not affect them.
+for _name in list(sys.modules):
+    if _name in _SYS_MODULES_SNAPSHOT:
+        if sys.modules[_name] is not _SYS_MODULES_SNAPSHOT[_name]:
+            sys.modules[_name] = _SYS_MODULES_SNAPSHOT[_name]
+    else:
+        del sys.modules[_name]
+del _SYS_MODULES_SNAPSHOT
 
 
 def _make_config(uid="test-user-123"):


### PR DESCRIPTION
## What

Fixes the `test_action_items_timezone.py` part of #8661.

This file installed its stubs by writing to `sys.modules` at module scope and never restored them. The `_stub_package()` helper replaced real packages (`utils`, `utils.retrieval`, `utils.retrieval.tools`, `utils.conversations`, `database`, `langchain_core`) with empty `types.ModuleType` stubs. During a bulk `pytest tests/unit/` run, pytest collects every file, so this file's module-level code ran and permanently replaced those packages, and every test file collected alphabetically after it then failed to import from them.

## Fix

Snapshot `sys.modules` before the stubbing begins, and restore it right after the module under test (`action_item_tools`) is imported:

```python
_SYS_MODULES_SNAPSHOT = dict(sys.modules)
# ... install stubs, load the module under test ...
for _name in list(sys.modules):
    if _name in _SYS_MODULES_SNAPSHOT:
        if sys.modules[_name] is not _SYS_MODULES_SNAPSHOT[_name]:
            sys.modules[_name] = _SYS_MODULES_SNAPSHOT[_name]
    else:
        del sys.modules[_name]
```

The loaded module keeps its references to the stubbed dependencies (Python binds them at import time), and the tests patch `action_item_tools.action_items_db` directly rather than by string path, so the restore does not change behaviour.

## Verification

```
pytest tests/unit/test_action_items_timezone.py -q                 # 11 passed (own tests unchanged)
pytest tests/unit/test_action_items_timezone.py \
       tests/unit/test_apps_create_app_json.py -q                  # 26 passed (was a collection ERROR before)
```

This addresses one of the three module-level-stub files in #8661. The other two (`test_action_item_date_validation.py`, `test_tools_router.py`) and the missing `fake-firestore` dependency are out of scope here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

