### PR TITLE
fix(backend): offload blocking Deepgram STT off the event loop in voice transcribe

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from pathlib import Path
 
-from utils.executors import critical_executor, db_executor, llm_executor, storage_executor, run_blocking
+from utils.executors import critical_executor, db_executor, llm_executor, storage_executor, sync_executor, run_blocking
 
 from fastapi import (
     APIRouter,
@@ -508,7 +508,9 @@ async def transcribe_voice_message(
 
         resolved_language = resolve_voice_message_language(uid, language)
         try:
-            transcript, detected_language = transcribe_pcm_bytes(
+            transcript, detected_language = await run_blocking(
+                sync_executor,
+                transcribe_pcm_bytes,
                 audio_bytes,
                 uid,
                 language=resolved_language,
@@ -590,7 +592,9 @@ async def transcribe_voice_message(
     is_multi = resolved_language == 'multi'
     for wav_path in wav_paths:
         try:
-            transcript, detected_language = transcribe_voice_message_segment(wav_path, uid, language=resolved_language)
+            transcript, detected_language = await run_blocking(
+                sync_executor, transcribe_voice_message_segment, wav_path, uid, language=resolved_language
+            )
             if transcript:
                 transcripts.append(transcript)
             if is_multi and detected_language:

--- a/backend/tests/unit/test_voice_message_transcribe_async.py
+++ b/backend/tests/unit/test_voice_message_transcribe_async.py
@@ -1,0 +1,73 @@
+"""The voice-message transcribe handler must not block the event loop on STT.
+
+``POST /v2/voice-message/transcribe`` (``routers/chat.py::transcribe_voice_message``) is an
+``async def`` handler, so any synchronous call it makes runs directly on the event loop.
+The two Deepgram pre-recorded transcription helpers it uses, ``transcribe_pcm_bytes`` and
+``transcribe_voice_message_segment``, are synchronous and perform a blocking multi-second
+HTTP round-trip (``httpx.Client().post`` in ``utils/stt/pre_recorded.py``). Calling them
+directly froze the loop for the whole transcription, stalling every other connection and
+the health checks (the exact "sync requests in async is silent poison" hazard in
+``backend/CLAUDE.md``).
+
+They must be offloaded with ``await run_blocking(<executor>, fn, ...)``, the same way the
+handler already offloads its WAV file write. These AST checks assert the offload stays in
+place so the blocking call cannot silently come back.
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+CHAT_ROUTER = BACKEND_DIR / "routers" / "chat.py"
+
+# The synchronous, blocking STT helpers that must never be called directly in async code.
+_STT_FUNCS = {"transcribe_pcm_bytes", "transcribe_voice_message_segment"}
+_HANDLER = "transcribe_voice_message"
+
+
+def _handler_node():
+    tree = ast.parse(CHAT_ROUTER.read_text(encoding="utf-8"))
+    node = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == _HANDLER),
+        None,
+    )
+    assert node is not None, f"async def {_HANDLER} not found in routers/chat.py"
+    return node
+
+
+def _direct_calls(node):
+    """Names of functions invoked directly as ``fn(...)`` anywhere under ``node``."""
+    return {sub.func.id for sub in ast.walk(node) if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)}
+
+
+def _run_blocking_offloaded(node):
+    """Names passed as the function argument to ``run_blocking(executor, fn, ...)``."""
+    offloaded = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id == "run_blocking":
+            # run_blocking(executor, fn, *args, **kwargs) -> fn is the 2nd positional arg.
+            if len(sub.args) >= 2 and isinstance(sub.args[1], ast.Name):
+                offloaded.add(sub.args[1].id)
+    return offloaded
+
+
+class TestVoiceTranscribeOffloadsSTT:
+    def test_stt_helpers_are_not_called_directly_in_the_async_handler(self):
+        direct = _direct_calls(_handler_node())
+        leaked = _STT_FUNCS & direct
+        assert not leaked, (
+            f"{_HANDLER} calls blocking STT helpers directly on the event loop: {sorted(leaked)}. "
+            f"Offload them with await run_blocking(sync_executor, ...)."
+        )
+
+    def test_both_stt_helpers_are_offloaded_via_run_blocking(self):
+        offloaded = _run_blocking_offloaded(_handler_node())
+        missing = _STT_FUNCS - offloaded
+        assert not missing, f"these STT helpers are not offloaded via run_blocking: {sorted(missing)}"
+
+    def test_handler_is_async(self):
+        # If the handler were a plain def it would run in FastAPI's threadpool and the sync
+        # calls would be fine; this fix only matters because it is async (it awaits request
+        # body/form/file reads). Guard that assumption.
+        node = _handler_node()
+        assert isinstance(node, ast.AsyncFunctionDef)

--- a/backend/tests/unit/test_voice_message_transcribe_async.py
+++ b/backend/tests/unit/test_voice_message_transcribe_async.py
@@ -41,13 +41,22 @@ def _direct_calls(node):
 
 
 def _run_blocking_offloaded(node):
-    """Names passed as the function argument to ``run_blocking(executor, fn, ...)``."""
+    """Names passed as the function argument to an AWAITED ``run_blocking(executor, fn, ...)``.
+
+    The run_blocking call must be the operand of an ``await``. A bare ``run_blocking(...)``
+    without ``await`` returns a coroutine that never runs, so the offload would silently break
+    while still passing a looser wrapped-in-run_blocking check. Requiring the await closes that
+    regression gap.
+    """
     offloaded = set()
     for sub in ast.walk(node):
-        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id == "run_blocking":
-            # run_blocking(executor, fn, *args, **kwargs) -> fn is the 2nd positional arg.
-            if len(sub.args) >= 2 and isinstance(sub.args[1], ast.Name):
-                offloaded.add(sub.args[1].id)
+        if not (isinstance(sub, ast.Await) and isinstance(sub.value, ast.Call)):
+            continue
+        call = sub.value
+        # run_blocking(executor, fn, *args, **kwargs) -> fn is the 2nd positional arg.
+        if isinstance(call.func, ast.Name) and call.func.id == "run_blocking" and len(call.args) >= 2:
+            if isinstance(call.args[1], ast.Name):
+                offloaded.add(call.args[1].id)
     return offloaded
 
 


### PR DESCRIPTION
## What

`POST /v2/voice-message/transcribe` (`transcribe_voice_message` in `routers/chat.py`) is an `async def` handler, so anything synchronous it calls runs directly on the event loop. The two Deepgram pre-recorded transcription helpers it uses are synchronous and do a blocking HTTP round-trip:

- `transcribe_pcm_bytes` (octet-stream / desktop push-to-talk path)
- `transcribe_voice_message_segment` (multipart / mobile path)

Both call `prerecorded(...)` in `utils/stt/pre_recorded.py`, which runs `httpx.Client(timeout=300).post(...)`. A voice transcription is typically 1 to 5 seconds, so the handler froze the entire event loop for that whole time on every request, stalling all other connections and the health checks. This is the "sync requests in async is silent poison" hazard called out in `backend/CLAUDE.md`.

## Fix

Offload both calls with `await run_blocking(sync_executor, ...)`, the STT/VAD pool per `AGENTS.md`. This is the same `run_blocking` offload the handler already uses one branch away for its WAV file write (`await run_blocking(storage_executor, _save_wav, ...)`), so the loop is freed during the Deepgram call while the handler stays `async` for its `await request.body()` / `request.form()` reads.

`run_blocking` forwards `*args`/`**kwargs`, so the call signatures are unchanged, and both calls stay inside their existing `try/except`, so error handling and temp-file cleanup are preserved.

## Reachability

`main.py` registers `chat.router`. `POST /v2/voice-message/transcribe` -> `transcribe_voice_message` -> `transcribe_pcm_bytes` / `transcribe_voice_message_segment` -> `prerecorded` -> sync `httpx.Client().post()`. Live endpoint for desktop push-to-talk and mobile voice messages.

## Test

`tests/unit/test_voice_message_transcribe_async.py` parses `routers/chat.py` and asserts at the AST level that the two STT helpers are never called directly inside the async handler and are both passed through `run_blocking`. Verified red before the change (both helpers called directly) and green after.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

