### PR TITLE
fix(backend): offload blocking Firestore writes off the event loop in agent-VM ensure

### DIFF
--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -133,11 +133,11 @@ async def _restart_vm_background(uid: str, vm_name: str, zone: str):
     """Background task: start stopped VM, update Firestore with new IP when ready."""
     try:
         ip = await _start_vm_and_wait(vm_name, zone)
-        _update_firestore_vm(uid, ip, "ready")
+        await run_blocking(db_executor, _update_firestore_vm, uid, ip, "ready")
         logger.info(f"[vm-ensure] VM {vm_name} restarted, ip={ip}")
     except Exception as e:
         logger.error(f"[vm-ensure] Failed to restart VM {vm_name}: {e}")
-        _update_firestore_vm(uid, None, "error")
+        await run_blocking(db_executor, _update_firestore_vm, uid, None, "error")
 
 
 # --------------- endpoints ---------------
@@ -181,12 +181,12 @@ async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_cu
 
         if gce_status in ("TERMINATED", "STOPPED"):
             logger.info(f"[vm-ensure] VM {vm_name} is {gce_status}, restarting...")
-            _update_firestore_vm(uid, None, "provisioning")
+            await run_blocking(db_executor, _update_firestore_vm, uid, None, "provisioning")
             background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
             return {"has_vm": True, "status": "provisioning"}
 
         if gce_status == "RUNNING" and fs_status != "ready":
-            _update_firestore_vm(uid, vm.get("ip"), "ready")
+            await run_blocking(db_executor, _update_firestore_vm, uid, vm.get("ip"), "ready")
             return {"has_vm": True, "status": "ready"}
 
     return {"has_vm": True, "status": fs_status}

--- a/backend/tests/unit/test_agent_vm_async.py
+++ b/backend/tests/unit/test_agent_vm_async.py
@@ -1,0 +1,67 @@
+"""The agent-VM endpoints must not block the event loop on Firestore writes.
+
+``ensure_vm`` (``POST /v1/agent/vm-ensure``) and its background task
+``_restart_vm_background`` are ``async`` and ``await`` the GCE lifecycle calls, but they
+wrote the user's ``agentVm`` status to Firestore by calling the synchronous
+``_update_firestore_vm`` directly on the event loop. The Firestore sync SDK blocks the loop
+(``database.*`` is exactly the class the async-blocker lint does not catch), and ``ensure_vm``
+already offloads its read via ``run_blocking`` one line up, so the writes were the
+inconsistent part.
+
+They must be offloaded with ``await run_blocking(db_executor, _update_firestore_vm, ...)``.
+These AST checks assert the offload stays in place.
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+AGENT_ROUTER = BACKEND_DIR / "routers" / "agent_tools.py"
+
+_HANDLERS = {"ensure_vm", "_restart_vm_background"}
+_BLOCKING = {"_update_firestore_vm"}
+
+
+def _func_nodes():
+    tree = ast.parse(AGENT_ROUTER.read_text(encoding="utf-8"))
+    nodes = [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name in _HANDLERS]
+    found = {n.name for n in nodes}
+    assert found == _HANDLERS, f"expected async functions {_HANDLERS}, found {found}"
+    return nodes
+
+
+def _direct_calls(node):
+    return {sub.func.id for sub in ast.walk(node) if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)}
+
+
+def _offloaded_via_run_blocking(node):
+    """Names passed as the function argument to ``run_blocking(executor, fn, ...)``."""
+    offloaded = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id == "run_blocking":
+            if len(sub.args) >= 2 and isinstance(sub.args[1], ast.Name):
+                offloaded.add(sub.args[1].id)
+    return offloaded
+
+
+class TestAgentVmOffloadsFirestoreWrites:
+    def test_firestore_write_is_not_called_directly_in_the_async_functions(self):
+        for node in _func_nodes():
+            leaked = _BLOCKING & _direct_calls(node)
+            assert not leaked, (
+                f"{node.name} writes Firestore directly on the event loop via {sorted(leaked)}. "
+                f"Offload with await run_blocking(db_executor, _update_firestore_vm, ...)."
+            )
+
+    def test_firestore_write_is_offloaded_via_run_blocking(self):
+        offloaded = set()
+        for node in _func_nodes():
+            offloaded |= _offloaded_via_run_blocking(node)
+        missing = _BLOCKING - offloaded
+        assert not missing, f"_update_firestore_vm is not offloaded via run_blocking: {sorted(missing)}"
+
+    def test_functions_are_async(self):
+        # Plain def would run in FastAPI's threadpool (background tasks excepted); this fix
+        # matters because these are async and await the GCE lifecycle calls.
+        for node in _func_nodes():
+            assert isinstance(node, ast.AsyncFunctionDef)

--- a/backend/tests/unit/test_agent_vm_async.py
+++ b/backend/tests/unit/test_agent_vm_async.py
@@ -35,12 +35,21 @@ def _direct_calls(node):
 
 
 def _offloaded_via_run_blocking(node):
-    """Names passed as the function argument to ``run_blocking(executor, fn, ...)``."""
+    """Names passed as the function argument to an AWAITED ``run_blocking(executor, fn, ...)``.
+
+    The run_blocking call must be the operand of an ``await``. A bare ``run_blocking(...)``
+    without ``await`` returns a coroutine that never runs, so the offload would silently break
+    while still passing a looser wrapped-in-run_blocking check. Requiring the await closes that
+    regression gap.
+    """
     offloaded = set()
     for sub in ast.walk(node):
-        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id == "run_blocking":
-            if len(sub.args) >= 2 and isinstance(sub.args[1], ast.Name):
-                offloaded.add(sub.args[1].id)
+        if not (isinstance(sub, ast.Await) and isinstance(sub.value, ast.Call)):
+            continue
+        call = sub.value
+        if isinstance(call.func, ast.Name) and call.func.id == "run_blocking" and len(call.args) >= 2:
+            if isinstance(call.args[1], ast.Name):
+                offloaded.add(call.args[1].id)
     return offloaded
 
 


### PR DESCRIPTION
## What

`ensure_vm` (`POST /v1/agent/vm-ensure`) and its background task `_restart_vm_background` in `routers/agent_tools.py` are `async` and `await` the GCE VM lifecycle calls, but they wrote the user's `agentVm` status to Firestore by calling the synchronous `_update_firestore_vm` directly on the event loop (four sites: provisioning/ready in `ensure_vm`, ready/error in `_restart_vm_background`). `_update_firestore_vm` does a sync Firestore `document().update()`, which blocks the event loop.

`ensure_vm` already offloads its read one line up (`await run_blocking(db_executor, get_agent_vm, uid)`), so the writes were the inconsistent part.

## Fix

Offload all four `_update_firestore_vm` calls via `await run_blocking(db_executor, _update_firestore_vm, ...)`, the Firestore CRUD pool that is already imported and used throughout this file. No new import.

## Reachability

`main.py` registers `agent_tools.router`. `POST /v1/agent/vm-ensure` -> `ensure_vm` reaches the writes when a user's agent VM is `TERMINATED`/`STOPPED` (provisioning + the background restart) or `RUNNING`-but-not-ready (ready). The background task runs the restart and writes ready/error.

## Test

`tests/unit/test_agent_vm_async.py` parses `routers/agent_tools.py` and asserts at the AST level that neither `ensure_vm` nor `_restart_vm_background` calls `_update_firestore_vm` directly and that both route it through `run_blocking`. Verified red before the change and green after.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

