### PR TITLE
fix(backend): offload blocking Firestore off the event loop in the OAuth callback

### DIFF
--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -15,6 +15,7 @@ import database.users as users_db
 import database.redis_db as redis_db
 from utils.other import endpoints as auth
 from utils.log_sanitizer import sanitize
+from utils.executors import run_blocking, db_executor
 import logging
 
 logger = logging.getLogger(__name__)
@@ -479,7 +480,7 @@ async def handle_oauth_callback(
 
             # Store in Firebase
             try:
-                users_db.set_integration(uid, app_key, integration_data)
+                await run_blocking(db_executor, users_db.set_integration, uid, app_key, integration_data)
             except Exception as e:
                 logger.error(f'{app_key}: Error storing tokens in Firebase: {e}')
                 return render_oauth_response(request, app_key, success=False, error_type='server_error')

--- a/backend/tests/unit/test_oauth_callback_async.py
+++ b/backend/tests/unit/test_oauth_callback_async.py
@@ -1,0 +1,71 @@
+"""The OAuth callback handler must not block the event loop on Firestore.
+
+``handle_oauth_callback`` (``routers/integrations.py``, the OAuth redirect endpoint that
+finishes connecting an integration) is ``async`` and ``await``s the httpx token exchange and
+``fetch_additional_data``, but it then persisted the tokens with a synchronous
+``users_db.set_integration`` directly on the event loop. The Firestore sync SDK blocks the
+loop (``database.*`` is exactly the class the async-blocker lint does not catch), stalling
+every other connection during the write.
+
+It must be offloaded with ``await run_blocking(db_executor, users_db.set_integration, ...)``.
+These AST checks assert the offload stays in place. The check is scoped to
+``handle_oauth_callback``; the other ``users_db.set_integration`` calls in this file are sync
+``def`` endpoints that FastAPI already runs in a threadpool, so they are fine as-is.
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+INTEGRATIONS_ROUTER = BACKEND_DIR / "routers" / "integrations.py"
+
+_HANDLER = "handle_oauth_callback"
+_BLOCKING = "users_db.set_integration"
+
+
+def _dotted(func):
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return f"{func.value.id}.{func.attr}"
+    return None
+
+
+def _handler_node():
+    tree = ast.parse(INTEGRATIONS_ROUTER.read_text(encoding="utf-8"))
+    node = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == _HANDLER),
+        None,
+    )
+    assert node is not None, f"async def {_HANDLER} not found in routers/integrations.py"
+    return node
+
+
+def _direct_calls(node):
+    return {name for sub in ast.walk(node) if isinstance(sub, ast.Call) and (name := _dotted(sub.func))}
+
+
+def _offloaded_via_run_blocking(node):
+    offloaded = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and _dotted(sub.func) == "run_blocking" and len(sub.args) >= 2:
+            name = _dotted(sub.args[1])
+            if name:
+                offloaded.add(name)
+    return offloaded
+
+
+class TestOAuthCallbackOffloadsFirestore:
+    def test_set_integration_is_not_called_directly_in_the_async_handler(self):
+        leaked = _BLOCKING in _direct_calls(_handler_node())
+        assert not leaked, (
+            f"{_HANDLER} runs {_BLOCKING} directly on the event loop. "
+            f"Offload it with await run_blocking(db_executor, ...)."
+        )
+
+    def test_set_integration_is_offloaded_via_run_blocking(self):
+        offloaded = _offloaded_via_run_blocking(_handler_node())
+        assert _BLOCKING in offloaded, f"{_BLOCKING} is not offloaded via run_blocking in {_HANDLER}"
+
+    def test_handler_is_async(self):
+        assert isinstance(_handler_node(), ast.AsyncFunctionDef)

--- a/backend/tests/unit/test_oauth_callback_async.py
+++ b/backend/tests/unit/test_oauth_callback_async.py
@@ -46,10 +46,20 @@ def _direct_calls(node):
 
 
 def _offloaded_via_run_blocking(node):
+    """Names passed as the function arg to an AWAITED ``run_blocking(executor, fn, ...)`` call.
+
+    The ``run_blocking`` call must be the operand of an ``await``. A bare ``run_blocking(...)``
+    without ``await`` returns a coroutine that never runs, so the offload would silently break
+    while still passing a looser "is it wrapped in run_blocking" check. Requiring the await
+    closes that regression gap.
+    """
     offloaded = set()
     for sub in ast.walk(node):
-        if isinstance(sub, ast.Call) and _dotted(sub.func) == "run_blocking" and len(sub.args) >= 2:
-            name = _dotted(sub.args[1])
+        if not (isinstance(sub, ast.Await) and isinstance(sub.value, ast.Call)):
+            continue
+        call = sub.value
+        if _dotted(call.func) == "run_blocking" and len(call.args) >= 2:
+            name = _dotted(call.args[1])
             if name:
                 offloaded.add(name)
     return offloaded
@@ -66,6 +76,21 @@ class TestOAuthCallbackOffloadsFirestore:
     def test_set_integration_is_offloaded_via_run_blocking(self):
         offloaded = _offloaded_via_run_blocking(_handler_node())
         assert _BLOCKING in offloaded, f"{_BLOCKING} is not offloaded via run_blocking in {_HANDLER}"
+
+    def test_offload_is_awaited_not_a_dangling_coroutine(self):
+        # A bare run_blocking(...) without await returns a coroutine that never runs, which
+        # would silently break the offload (set_integration would never execute) while still
+        # passing a looser wrapped-in-run_blocking check. Assert the call is awaited.
+        node = _handler_node()
+        awaited = any(
+            isinstance(sub, ast.Await)
+            and isinstance(sub.value, ast.Call)
+            and _dotted(sub.value.func) == "run_blocking"
+            and len(sub.value.args) >= 2
+            and _dotted(sub.value.args[1]) == _BLOCKING
+            for sub in ast.walk(node)
+        )
+        assert awaited, f"the run_blocking({_BLOCKING}) call must be awaited, not a dangling coroutine"
 
     def test_handler_is_async(self):
         assert isinstance(_handler_node(), ast.AsyncFunctionDef)


### PR DESCRIPTION
## What

`handle_oauth_callback` in `routers/integrations.py` (the OAuth redirect endpoint that finishes connecting an integration such as Google Calendar, Notion, and others) is `async` and `await`s the httpx token exchange and `fetch_additional_data`, but it then persisted the tokens with a synchronous `users_db.set_integration` call directly on the event loop. The Firestore sync SDK blocks the event loop, stalling every other connection during the write.

## Fix

Offload the write via `await run_blocking(db_executor, users_db.set_integration, ...)`, the Firestore/Redis CRUD pool per `AGENTS.md`. `run_blocking` propagates exceptions, so the existing `try/except` around the write still catches a storage failure and returns the `server_error` page. The other `users_db.set_integration` calls in this file are sync `def` endpoints that FastAPI already runs in a threadpool, so they are left as-is.

## Reachability

`main.py` registers the integrations router. The OAuth provider redirects to this callback; `handle_oauth_callback` -> exchange code for token (awaited httpx) -> `users_db.set_integration` (now offloaded). Reached on every integration OAuth connect.

## Test

`tests/unit/test_oauth_callback_async.py` parses `routers/integrations.py` and asserts at the AST level that `handle_oauth_callback` does not call `users_db.set_integration` directly and routes it through `run_blocking`, scoped to that async handler (the sync-endpoint calls are intentionally untouched). Verified red before the change and green after. The async-blocker audit (`scan_async_blockers.py --diff-base origin/main`) reports 0 selected findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

