### PR TITLE
Adopt NeMo PR #13 lifecycle improvements for parakeet server

### DIFF
--- a/backend/parakeet/batch_engine.py
+++ b/backend/parakeet/batch_engine.py
@@ -53,6 +53,7 @@ class BatchEngine:
         self._lock = asyncio.Lock()
         self._flush_task: Optional[asyncio.Task] = None
         self._flush_pending = False
+        self._batches_inflight = 0
         self._inflight_tasks: set[asyncio.Task] = set()
         self._inflight_sem: Optional[asyncio.Semaphore] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -207,7 +208,7 @@ class BatchEngine:
     async def _flush_loop(self) -> None:
         while not self._shutting_down:
             await asyncio.sleep(self._max_wait_seconds)
-            if self._pending and not self._flush_pending:
+            if self._pending and not self._flush_pending and self._batches_inflight == 0:
                 self._flush_pending = True
                 t = asyncio.create_task(self._guarded_flush())
                 self._inflight_tasks.add(t)
@@ -261,6 +262,7 @@ class BatchEngine:
 
     async def _flush_batch(self) -> None:
         await self._inflight_sem.acquire()
+        self._batches_inflight += 1
         try:
             self._try_init_vram()
             async with self._lock:
@@ -269,6 +271,7 @@ class BatchEngine:
                 batch = self._form_vram_safe_batch(self._pending)
                 batch_set = set(id(r) for r in batch)
                 self._pending = [r for r in self._pending if id(r) not in batch_set]
+            self._flush_pending = False
 
             if not batch:
                 return
@@ -346,6 +349,7 @@ class BatchEngine:
                     if req.owns_file:
                         _unlink_safe(req.audio_path)
         finally:
+            self._batches_inflight -= 1
             self._inflight_sem.release()
 
     @property

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -69,6 +69,7 @@ class GPUWorker:
         self._ready = threading.Event()
         self._load_error: Optional[Exception] = None
         self._running = False
+        self._submit_lock = threading.Lock()
         self._attn_mode = os.getenv("PARAKEET_ATTENTION_MODE", "full").lower()
         if self._attn_mode not in _VALID_ATTN_MODES:
             raise ValueError(f"PARAKEET_ATTENTION_MODE must be one of {_VALID_ATTN_MODES}, got '{self._attn_mode}'")
@@ -106,14 +107,15 @@ class GPUWorker:
             raise self._load_error
 
     def stop(self) -> None:
-        if not self._running:
-            return
+        with self._submit_lock:
+            if not self._running:
+                return
+            self._running = False
         evt = threading.Event()
         try:
             self._queue.put(WorkItem(WorkType.SHUTDOWN, None, sync_event=evt), timeout=5)
         except queue.Full:
             pass
-        self._running = False
         if self._thread:
             self._thread.join(timeout=30)
 
@@ -122,23 +124,31 @@ class GPUWorker:
             fut = loop.create_future()
             fut.set_exception(RuntimeError("GPU worker not ready"))
             return fut, None
-        fut = loop.create_future()
-        item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
-        try:
-            self._queue.put_nowait(item)
-        except queue.Full:
-            fut.set_exception(RuntimeError("GPU queue full"))
-        return fut, item
+        with self._submit_lock:
+            if not self._running:
+                fut = loop.create_future()
+                fut.set_exception(RuntimeError("GPU worker shutting down"))
+                return fut, None
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            try:
+                self._queue.put_nowait(item)
+            except queue.Full:
+                fut.set_exception(RuntimeError("GPU queue full"))
+            return fut, item
 
     def submit_sync(self, payload: dict, timeout: float = 120.0) -> list:
         if not self.is_ready:
             raise RuntimeError("GPU worker not ready")
-        evt = threading.Event()
-        item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, sync_event=evt)
-        try:
-            self._queue.put(item, timeout=5)
-        except queue.Full:
-            raise RuntimeError("GPU queue full")
+        with self._submit_lock:
+            if not self._running:
+                raise RuntimeError("GPU worker shutting down")
+            evt = threading.Event()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, sync_event=evt)
+            try:
+                self._queue.put(item, timeout=5)
+            except queue.Full:
+                raise RuntimeError("GPU queue full")
         if not evt.wait(timeout=timeout):
             raise TimeoutError("GPU transcription timed out")
         if item.sync_error is not None:
@@ -148,12 +158,15 @@ class GPUWorker:
     def submit_embedding_sync(self, payload: dict, timeout: float = 30.0):
         if not self.is_ready:
             raise RuntimeError("GPU worker not ready")
-        evt = threading.Event()
-        item = WorkItem(WorkType.EMBEDDING, payload, sync_event=evt)
-        try:
-            self._queue.put(item, timeout=5)
-        except queue.Full:
-            raise RuntimeError("GPU queue full")
+        with self._submit_lock:
+            if not self._running:
+                raise RuntimeError("GPU worker shutting down")
+            evt = threading.Event()
+            item = WorkItem(WorkType.EMBEDDING, payload, sync_event=evt)
+            try:
+                self._queue.put(item, timeout=5)
+            except queue.Full:
+                raise RuntimeError("GPU queue full")
         if not evt.wait(timeout=timeout):
             raise TimeoutError("GPU embedding timed out")
         if item.sync_error is not None:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -50,6 +50,7 @@ pytest tests/unit/test_parakeet_stream_session.py -v
 pytest tests/unit/test_parakeet_gpu_worker.py -v
 pytest tests/unit/test_parakeet_batch_engine.py -v
 pytest tests/unit/test_flush_pending_batch1.py -v
+pytest tests/unit/test_gpu_worker_submit_lock.py -v
 pytest tests/unit/test_vram_batch.py -v
 pytest tests/unit/test_oom_reproduction.py -v
 pytest tests/unit/test_parakeet_batch_routing.py -v

--- a/backend/tests/unit/test_gpu_worker_submit_lock.py
+++ b/backend/tests/unit/test_gpu_worker_submit_lock.py
@@ -104,6 +104,52 @@ class TestSubmitLockRace(unittest.TestCase):
         loop.close()
         self.assertEqual(len(enqueued_after_stop), 0, "No work should be enqueued after _running is set to False")
 
+    def test_concurrent_stop_and_submit_sync_no_enqueue(self):
+        """Concurrent stop() + submit_sync() must not enqueue to dead queue."""
+        worker = self._make_started_worker()
+        errors = []
+
+        def submitter():
+            for _ in range(50):
+                try:
+                    worker.submit_sync({"audio_paths": ["/tmp/x.wav"]}, timeout=0.01)
+                except (RuntimeError, TimeoutError):
+                    pass
+                except Exception as e:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=submitter) for _ in range(4)]
+        threads.append(threading.Thread(target=worker.stop))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(len(errors), 0, f"Unexpected errors: {errors}")
+
+    def test_concurrent_stop_and_submit_embedding_sync_no_enqueue(self):
+        """Concurrent stop() + submit_embedding_sync() must not enqueue to dead queue."""
+        worker = self._make_started_worker()
+        errors = []
+
+        def submitter():
+            for _ in range(50):
+                try:
+                    worker.submit_embedding_sync({"waveform": None, "sample_rate": 16000}, timeout=0.01)
+                except (RuntimeError, TimeoutError):
+                    pass
+                except Exception as e:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=submitter) for _ in range(4)]
+        threads.append(threading.Thread(target=worker.stop))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(len(errors), 0, f"Unexpected errors: {errors}")
+
     def test_stop_sets_running_false_atomically(self):
         """stop() must set _running=False under the lock before releasing it."""
         worker = self._make_started_worker()

--- a/backend/tests/unit/test_gpu_worker_submit_lock.py
+++ b/backend/tests/unit/test_gpu_worker_submit_lock.py
@@ -1,0 +1,116 @@
+"""Tests for GPUWorker._submit_lock: stop()/submit() race prevention."""
+
+import asyncio
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+os.environ.setdefault("PARAKEET_MODEL", "nvidia/parakeet-tdt-0.6b-v3")
+os.environ.setdefault("PARAKEET_DEVICE", "cpu")
+os.environ.setdefault("PARAKEET_TORCH_COMPILE", "false")
+os.environ.setdefault("PARAKEET_CUDA_GRAPHS", "false")
+
+_torch = MagicMock()
+_torch.cuda.is_available.return_value = False
+_torch.cuda.memory_allocated.return_value = 0
+_torch_props = MagicMock()
+_torch_props.total_memory = 16 * 1024**3
+_torch.cuda.get_device_properties.return_value = _torch_props
+_torch.cuda.empty_cache = MagicMock()
+_torch.cuda.mem_get_info.return_value = (10 * 1024**3, 16 * 1024**3)
+_torch.inference_mode = lambda: (lambda fn: fn)
+_torch.compile = lambda m: m
+_torch.backends.cudnn = MagicMock()
+sys.modules.setdefault("torch", _torch)
+
+for _mod in ["nemo", "nemo.collections", "nemo.collections.asr"]:
+    sys.modules.setdefault(_mod, MagicMock())
+for _mod in ["pyannote", "pyannote.audio", "pyannote.audio.core", "pyannote.audio.core.model"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../parakeet"))
+
+from gpu_worker import GPUWorker
+
+
+class TestSubmitLockRace(unittest.TestCase):
+
+    def _make_started_worker(self):
+        worker = GPUWorker()
+        worker._running = True
+        worker._ready.set()
+        return worker
+
+    def test_submit_after_stop_raises_shutting_down(self):
+        worker = self._make_started_worker()
+        worker.stop()
+
+        loop = asyncio.new_event_loop()
+        try:
+            fut, item = worker.submit({"audio_paths": ["/tmp/a.wav"]}, loop)
+            self.assertIsNone(item)
+            self.assertTrue(fut.done())
+            with self.assertRaises(RuntimeError) as ctx:
+                fut.result()
+            self.assertIn("shutting down", str(ctx.exception))
+        finally:
+            loop.close()
+
+    def test_submit_sync_after_stop_raises_shutting_down(self):
+        worker = self._make_started_worker()
+        worker.stop()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            worker.submit_sync({"audio_paths": ["/tmp/a.wav"]})
+        self.assertIn("shutting down", str(ctx.exception))
+
+    def test_submit_embedding_sync_after_stop_raises_shutting_down(self):
+        worker = self._make_started_worker()
+        worker.stop()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            worker.submit_embedding_sync({"waveform": None, "sample_rate": 16000})
+        self.assertIn("shutting down", str(ctx.exception))
+
+    def test_concurrent_stop_and_submit_no_enqueue_to_dead_queue(self):
+        """Multiple threads calling stop() and submit() concurrently must not
+        enqueue work after _running is set to False."""
+        worker = self._make_started_worker()
+        loop = asyncio.new_event_loop()
+        errors = []
+        enqueued_after_stop = []
+
+        def submitter():
+            for _ in range(50):
+                try:
+                    fut, item = worker.submit({"audio_paths": ["/tmp/x.wav"]}, loop)
+                    if not worker._running and item is not None:
+                        enqueued_after_stop.append(True)
+                except Exception as e:
+                    errors.append(e)
+
+        def stopper():
+            worker.stop()
+
+        threads = [threading.Thread(target=submitter) for _ in range(4)]
+        threads.append(threading.Thread(target=stopper))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        loop.close()
+        self.assertEqual(len(enqueued_after_stop), 0, "No work should be enqueued after _running is set to False")
+
+    def test_stop_sets_running_false_atomically(self):
+        """stop() must set _running=False under the lock before releasing it."""
+        worker = self._make_started_worker()
+        self.assertTrue(worker._running)
+        worker.stop()
+        self.assertFalse(worker._running)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_gpu_worker_submit_lock.py
+++ b/backend/tests/unit/test_gpu_worker_submit_lock.py
@@ -108,11 +108,14 @@ class TestSubmitLockRace(unittest.TestCase):
         """Concurrent stop() + submit_sync() must not enqueue to dead queue."""
         worker = self._make_started_worker()
         errors = []
+        enqueued_after_stop = []
 
         def submitter():
             for _ in range(50):
                 try:
                     worker.submit_sync({"audio_paths": ["/tmp/x.wav"]}, timeout=0.01)
+                    if not worker._running:
+                        enqueued_after_stop.append(True)
                 except (RuntimeError, TimeoutError):
                     pass
                 except Exception as e:
@@ -126,16 +129,20 @@ class TestSubmitLockRace(unittest.TestCase):
             t.join(timeout=10)
 
         self.assertEqual(len(errors), 0, f"Unexpected errors: {errors}")
+        self.assertEqual(len(enqueued_after_stop), 0, "No work should be enqueued after _running is set to False")
 
     def test_concurrent_stop_and_submit_embedding_sync_no_enqueue(self):
         """Concurrent stop() + submit_embedding_sync() must not enqueue to dead queue."""
         worker = self._make_started_worker()
         errors = []
+        enqueued_after_stop = []
 
         def submitter():
             for _ in range(50):
                 try:
                     worker.submit_embedding_sync({"waveform": None, "sample_rate": 16000}, timeout=0.01)
+                    if not worker._running:
+                        enqueued_after_stop.append(True)
                 except (RuntimeError, TimeoutError):
                     pass
                 except Exception as e:
@@ -149,6 +156,7 @@ class TestSubmitLockRace(unittest.TestCase):
             t.join(timeout=10)
 
         self.assertEqual(len(errors), 0, f"Unexpected errors: {errors}")
+        self.assertEqual(len(enqueued_after_stop), 0, "No work should be enqueued after _running is set to False")
 
     def test_stop_sets_running_false_atomically(self):
         """stop() must set _running=False under the lock before releasing it."""

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -907,6 +907,67 @@ class TestBatchesInflight:
         finally:
             loop.close()
 
+    def test_batches_inflight_resets_after_oom(self):
+        """After a CUDA OOM, _batches_inflight must return to 0."""
+        oom_fired = {"count": 0}
+
+        def on_oom():
+            oom_fired["count"] += 1
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            loop.call_soon(fut.set_exception, RuntimeError("CUDA out of memory"))
+            item.inference_seconds = 0.01
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(
+            gpu, max_batch_size=1, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0, on_gpu_oom=on_oom
+        )
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    with pytest.raises(RuntimeError, match="CUDA out of memory"):
+                        await asyncio.wait_for(engine.submit("/tmp/oom.wav"), timeout=5)
+                    assert engine._batches_inflight == 0
+                    assert oom_fired["count"] == 1
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_batches_inflight_resets_on_empty_pending(self):
+        """When _flush_batch finds no pending requests, _batches_inflight
+        must still decrement properly."""
+        gpu = _make_mock_gpu_worker()
+        engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    result = await asyncio.wait_for(engine.submit("/tmp/ok.wav"), timeout=5)
+                    assert result["text"] == "ok:/tmp/ok.wav"
+                    await asyncio.sleep(0.01)
+                    assert engine._batches_inflight == 0
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
 
 class TestUnlinkSafe:
 

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -754,6 +754,160 @@ class TestLazyVramInit:
             loop.close()
 
 
+class TestBatchesInflight:
+
+    def test_full_batch_uses_second_inflight_slot(self):
+        """When a full batch is processing (inflight=1), a second full batch
+        should dispatch immediately using the second inflight slot."""
+        batch_sizes = []
+        gate = asyncio.Event()
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            batch_sizes.append(payload["batch_size"])
+
+            async def resolve():
+                if len(batch_sizes) == 1:
+                    await gate.wait()
+                results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = 0.01
+
+            asyncio.ensure_future(resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = [asyncio.ensure_future(engine.submit(f"/tmp/a{i}.wav")) for i in range(4)]
+                    await asyncio.sleep(0.02)
+                    assert len(batch_sizes) >= 1, "First batch should have dispatched"
+                    more_futs = [asyncio.ensure_future(engine.submit(f"/tmp/b{i}.wav")) for i in range(4)]
+                    await asyncio.sleep(0.02)
+                    assert len(batch_sizes) >= 2, (
+                        f"Second full batch should dispatch while first is inflight "
+                        f"(got {len(batch_sizes)} dispatches, batches={batch_sizes})"
+                    )
+                    gate.set()
+                    all_futs = futs + more_futs
+                    results = await asyncio.wait_for(asyncio.gather(*all_futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 8
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_batches_inflight_resets_after_gpu_error(self):
+        """After a GPU error, _batches_inflight must return to 0 so the
+        flush timer can dispatch future batches."""
+        call_count = {"n": 0}
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                loop.call_soon(fut.set_exception, RuntimeError("GPU exploded"))
+            else:
+                results = [{"text": "ok"} for _ in range(payload["batch_size"])]
+                loop.call_soon(fut.set_result, results)
+            item.inference_seconds = 0.01
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    with pytest.raises(RuntimeError, match="GPU exploded"):
+                        await asyncio.wait_for(engine.submit("/tmp/fail.wav"), timeout=5)
+                    assert (
+                        engine._batches_inflight == 0
+                    ), f"_batches_inflight must be 0 after error, got {engine._batches_inflight}"
+                    result = await asyncio.wait_for(engine.submit("/tmp/ok.wav"), timeout=5)
+                    assert result["text"] == "ok"
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_timer_flush_blocked_during_inflight(self):
+        """When _batches_inflight > 0, the 2ms flush timer must NOT create
+        new flush tasks — requests accumulate instead."""
+        batch_sizes = []
+
+        def mock_submit(payload, loop):
+            fut = loop.create_future()
+            item = WorkItem(WorkType.BATCH_TRANSCRIBE, payload, future=fut, loop=loop)
+            batch_sizes.append(payload["batch_size"])
+
+            async def delayed_resolve():
+                await asyncio.sleep(0.1)
+                results = [{"text": f"ok_{i}"} for i in range(payload["batch_size"])]
+                if not fut.done():
+                    fut.set_result(results)
+                item.inference_seconds = 0.1
+
+            asyncio.ensure_future(delayed_resolve())
+            return fut, item
+
+        gpu = MagicMock(spec=GPUWorker)
+        gpu.is_ready = True
+        gpu.vram_info = {"total_mb": 0, "baseline_mb": 0, "attention_mode": "full", "auto_threshold_sec": 300}
+        gpu.submit.side_effect = mock_submit
+
+        engine = BatchEngine(gpu, max_batch_size=32, max_wait_seconds=0.002, max_inflight=1, vram_safety_factor=0)
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                await engine.start()
+                try:
+                    futs = []
+                    futs.append(asyncio.ensure_future(engine.submit("/tmp/first.wav")))
+                    await asyncio.sleep(0.01)
+                    for i in range(5):
+                        futs.append(asyncio.ensure_future(engine.submit(f"/tmp/later_{i}.wav")))
+                        await asyncio.sleep(0.005)
+                    results = await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=10)
+                    successes = [r for r in results if not isinstance(r, Exception)]
+                    assert len(successes) == 6
+                    batch1_count = sum(1 for b in batch_sizes if b == 1)
+                    assert batch1_count <= 1, (
+                        f"At most 1 batch=1 expected (got {batch1_count}, batches={batch_sizes}). "
+                        f"Timer should not flush while batches_inflight > 0."
+                    )
+                finally:
+                    await engine.stop()
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+
 class TestUnlinkSafe:
 
     def test_unlink_existing(self):

--- a/backend/tests/unit/test_parakeet_batch_engine.py
+++ b/backend/tests/unit/test_parakeet_batch_engine.py
@@ -947,20 +947,21 @@ class TestBatchesInflight:
             loop.close()
 
     def test_batches_inflight_resets_on_empty_pending(self):
-        """When _flush_batch finds no pending requests, _batches_inflight
-        must still decrement properly."""
+        """Directly calling _flush_batch with empty _pending must still
+        decrement _batches_inflight (exercises the early return branch)."""
         gpu = _make_mock_gpu_worker()
-        engine = BatchEngine(gpu, max_batch_size=1, max_wait_seconds=0.002, max_inflight=2, vram_safety_factor=0)
+        engine = BatchEngine(gpu, max_batch_size=4, max_wait_seconds=1.0, max_inflight=2, vram_safety_factor=0)
         loop = asyncio.new_event_loop()
         try:
 
             async def run():
                 await engine.start()
                 try:
-                    result = await asyncio.wait_for(engine.submit("/tmp/ok.wav"), timeout=5)
-                    assert result["text"] == "ok:/tmp/ok.wav"
-                    await asyncio.sleep(0.01)
                     assert engine._batches_inflight == 0
+                    await engine._flush_batch()
+                    assert (
+                        engine._batches_inflight == 0
+                    ), f"_batches_inflight must be 0 after empty-pending flush, got {engine._batches_inflight}"
                 finally:
                     await engine.stop()
 

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -203,6 +203,7 @@ class TestGPUWorkerQueueFull:
 
     def test_sync_queue_full(self):
         worker = GPUWorker()
+        worker._running = True
         worker._ready.set()
         for _ in range(512):
             try:
@@ -215,6 +216,7 @@ class TestGPUWorkerQueueFull:
 
     def test_async_queue_full(self):
         worker = GPUWorker()
+        worker._running = True
         worker._ready.set()
         for _ in range(512):
             try:


### PR DESCRIPTION
## Summary

Adopts two key improvements from [beastoin/NeMo#13](https://github.com/beastoin/NeMo/pull/13) into the omi parakeet server:

1. **`_batches_inflight` counter** (`batch_engine.py`) — Replaces the `_flush_pending` flag-only approach with a counter that tracks active GPU batches. The 2ms flush timer only fires when `_batches_inflight == 0`, preventing batch=1 spam while still allowing full batches to use the second inflight slot (`max_inflight=2`). The early `_flush_pending` reset after dequeue is restored (safe with the counter guard).

2. **`_submit_lock`** (`gpu_worker.py`) — Adds a `threading.Lock` to prevent the stop/submit race condition where `stop()` sets `_running=False` while `submit()` is between the ready check and `queue.put()`, which could enqueue work to dead queues. All three submit methods (`submit`, `submit_sync`, `submit_embedding_sync`) are protected.

## Changes

- `backend/parakeet/batch_engine.py`: Added `_batches_inflight` counter in `__init__`, flush loop guard, `_flush_batch()` increment/decrement, restored early `_flush_pending` reset
- `backend/parakeet/gpu_worker.py`: Added `_submit_lock`, wrapped `stop()` and all `submit*()` methods
- `backend/tests/unit/test_parakeet_batch_engine.py`: 5 new tests (second inflight slot, error recovery, timer blocking, OOM reset, empty-pending early-return)
- `backend/tests/unit/test_gpu_worker_submit_lock.py`: 7 new tests (post-stop rejection for all submit methods, concurrent race for all 3 paths with enqueue-after-stop assertion, atomicity)
- `backend/tests/unit/test_parakeet_gpu_worker.py`: Updated queue-full tests to set `_running=True`
- `backend/test.sh`: Wired new test file

## Test plan

- [x] All 37 parakeet-related tests pass (`python3 -m pytest tests/unit/test_parakeet_batch_engine.py tests/unit/test_gpu_worker_submit_lock.py tests/unit/test_flush_pending_batch1.py -v` → 37 passed)
- [x] Full `backend/test.sh` passes (only pre-existing unrelated failure in `test_file_upload_endpoint_security.py`)
- [x] Existing regression test `test_flush_pending_batch1.py` still passes with the counter approach
- [x] CODEx reviewer: PR_APPROVED_LGTM
- [x] CODEx tester: TESTS_APPROVED
- [ ] Live GPU test (requires L4/T4 GPU — not available on VPS)

## Test detail table

| Path ID | Changed path | Assertion intent | Test command | Result |
|---|---|---|---|---|
| P1 | `batch_engine.py:__init__` — `_batches_inflight=0` | Counter initialized to 0 | `pytest tests/unit/test_parakeet_batch_engine.py::TestBatchesInflight -v` | PASS |
| P2 | `batch_engine.py:_flush_loop` — `_batches_inflight==0` guard | Timer blocked during GPU work | `TestBatchesInflight::test_timer_flush_blocked_during_inflight` | PASS |
| P3 | `batch_engine.py:_flush_batch` — increment after sem acquire | Counter tracks active GPU batches | `TestBatchesInflight::test_full_batch_uses_second_inflight_slot` | PASS |
| P4 | `batch_engine.py:_flush_batch` — `_flush_pending=False` restore | Early reset safe with counter | `TestFlushPendingBatch1Regression` | PASS |
| P5 | `batch_engine.py:_flush_batch` — decrement in finally | Counter resets after GPU error/OOM | `TestBatchesInflight::test_batches_inflight_resets_after_gpu_error` + `test_batches_inflight_resets_after_oom` | PASS |
| P6 | `gpu_worker.py:__init__` — `_submit_lock` | Lock created | All submit_lock tests | PASS |
| P7 | `gpu_worker.py:stop()` — set `_running=False` under lock | Atomic stop | `TestSubmitLockRace::test_stop_sets_running_false_atomically` | PASS |
| P8 | `gpu_worker.py:submit()` — lock + `_running` check | No enqueue after stop | `TestSubmitLockRace::test_submit_after_stop_raises_shutting_down` + `test_concurrent_stop_and_submit_no_enqueue_to_dead_queue` | PASS |
| P9 | `gpu_worker.py:submit_sync()` — lock + `_running` check | No enqueue after stop | `TestSubmitLockRace::test_submit_sync_after_stop_raises_shutting_down` + `test_concurrent_stop_and_submit_sync_no_enqueue` | PASS |
| P10 | `gpu_worker.py:submit_embedding_sync()` — lock + `_running` check | No enqueue after stop | `TestSubmitLockRace::test_submit_embedding_sync_after_stop_raises_shutting_down` + `test_concurrent_stop_and_submit_embedding_sync_no_enqueue` | PASS |

Closes #8686

_by AI for @beastoin_