### PR TITLE
fix(backend): offload blocking Firestore off the event loop in the calendar-linking helpers

### DIFF
--- a/backend/tests/unit/test_calendar_linking_helpers_async.py
+++ b/backend/tests/unit/test_calendar_linking_helpers_async.py
@@ -1,0 +1,79 @@
+"""The calendar-linking helpers must not block the event loop on Firestore.
+
+``get_overlapping_calendar_event`` and ``write_conversation_link_to_calendar_event`` in
+``utils/conversations/calendar_linking.py`` are ``async`` and ``await`` the httpx Google
+Calendar calls, but each first reads the user's integration with a synchronous
+``users_db.get_integration`` directly on the event loop. The Firestore sync SDK blocks the
+loop (``database.*`` is exactly the class the async-blocker lint does not catch). These are
+awaited from the conversation calendar-link handlers, so blocking here blocks those requests.
+
+They must be offloaded with ``await run_blocking(db_executor, users_db.get_integration, ...)``.
+These AST checks assert the offload stays in place, including that the ``run_blocking`` call is
+actually awaited (a bare call would be a dangling coroutine that never runs).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+CALENDAR_LINKING = BACKEND_DIR / "utils" / "conversations" / "calendar_linking.py"
+
+_HELPERS = {"get_overlapping_calendar_event", "write_conversation_link_to_calendar_event"}
+_BLOCKING = "users_db.get_integration"
+
+
+def _dotted(func):
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return f"{func.value.id}.{func.attr}"
+    return None
+
+
+def _helper_nodes():
+    tree = ast.parse(CALENDAR_LINKING.read_text(encoding="utf-8"))
+    nodes = [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name in _HELPERS]
+    found = {n.name for n in nodes}
+    assert found == _HELPERS, f"expected async helpers {_HELPERS}, found {found}"
+    return nodes
+
+
+def _direct_calls(node):
+    return {name for sub in ast.walk(node) if isinstance(sub, ast.Call) and (name := _dotted(sub.func))}
+
+
+def _offloaded_via_awaited_run_blocking(node):
+    """Names passed as the function arg to an AWAITED ``run_blocking(executor, fn, ...)`` call.
+
+    The run_blocking call must be the operand of an ``await``: a bare ``run_blocking(...)``
+    without ``await`` returns a coroutine that never runs, so the offload would silently break
+    while still passing a looser wrapped-in-run_blocking check.
+    """
+    offloaded = set()
+    for sub in ast.walk(node):
+        if not (isinstance(sub, ast.Await) and isinstance(sub.value, ast.Call)):
+            continue
+        call = sub.value
+        if _dotted(call.func) == "run_blocking" and len(call.args) >= 2:
+            name = _dotted(call.args[1])
+            if name:
+                offloaded.add(name)
+    return offloaded
+
+
+class TestCalendarLinkingHelpersOffloadFirestore:
+    def test_get_integration_is_not_called_directly_in_the_helpers(self):
+        for node in _helper_nodes():
+            assert _BLOCKING not in _direct_calls(node), (
+                f"{node.name} runs {_BLOCKING} directly on the event loop. "
+                f"Offload it with await run_blocking(db_executor, ...)."
+            )
+
+    def test_get_integration_is_offloaded_via_awaited_run_blocking_in_both(self):
+        for node in _helper_nodes():
+            offloaded = _offloaded_via_awaited_run_blocking(node)
+            assert _BLOCKING in offloaded, f"{node.name} does not offload {_BLOCKING} via an awaited run_blocking call"
+
+    def test_helpers_are_async(self):
+        for node in _helper_nodes():
+            assert isinstance(node, ast.AsyncFunctionDef)

--- a/backend/utils/conversations/calendar_linking.py
+++ b/backend/utils/conversations/calendar_linking.py
@@ -17,6 +17,7 @@ from utils.retrieval.tools.calendar_tools import (
     update_google_calendar_event,
 )
 from utils.retrieval.tools.google_utils import refresh_google_token
+from utils.executors import run_blocking, db_executor
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ async def get_overlapping_calendar_event(
     Returns:
         CalendarEventLink if a matching event is found, None otherwise
     """
-    integration = users_db.get_integration(uid, 'google_calendar')
+    integration = await run_blocking(db_executor, users_db.get_integration, uid, 'google_calendar')
     if not integration or not integration.get('connected'):
         return None
 
@@ -150,7 +151,7 @@ async def write_conversation_link_to_calendar_event(
     Silently no-ops on any error — linking the conversation to the event is the primary
     action; failing to write the description link should not block the caller.
     """
-    integration = users_db.get_integration(uid, 'google_calendar')
+    integration = await run_blocking(db_executor, users_db.get_integration, uid, 'google_calendar')
     if not integration or not integration.get('connected'):
         return
 


### PR DESCRIPTION
## What

Follow-up to #8684. `get_overlapping_calendar_event` and `write_conversation_link_to_calendar_event` in `utils/conversations/calendar_linking.py` are `async` and `await` the httpx Google Calendar calls, but each first reads the user's integration with a synchronous `users_db.get_integration` directly on the event loop. The Firestore sync SDK blocks the event loop.

These helpers are awaited from the conversation calendar-link handlers (`link_calendar_event` awaits `write_conversation_link_to_calendar_event`; `auto_link_calendar_event` awaits `get_overlapping_calendar_event`). #8684 offloaded the blocking calls in the handlers themselves and flagged these helper reads as the remaining synchronous ones; this finishes the flow.

## Fix

Offload both reads via `await run_blocking(db_executor, users_db.get_integration, ...)`, the Firestore/Redis CRUD pool per `AGENTS.md`. The surrounding logic (integration None/connected checks, the awaited Google Calendar httpx calls, token refresh) is unchanged.

## Reachability

`POST /v1/conversations/{id}/calendar-event/auto-link` -> `auto_link_calendar_event` -> `await get_overlapping_calendar_event` -> `users_db.get_integration` (now offloaded). `POST /v1/conversations/{id}/calendar-event` -> `link_calendar_event` -> `await write_conversation_link_to_calendar_event` -> `users_db.get_integration` (now offloaded).

## Test

`tests/unit/test_calendar_linking_helpers_async.py` parses `utils/conversations/calendar_linking.py` and asserts at the AST level that neither helper calls `users_db.get_integration` directly and that both route it through an awaited `run_blocking` (the await check guards against a dangling-coroutine regression). Verified red before the change and green after. The async-blocker audit (`scan_async_blockers.py --diff-base origin/main`) reports 0 selected findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

