### PR TITLE
fix(backend): bound limit/offset on the Developer API list endpoints

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -265,6 +265,10 @@ def get_memories(
     offset: int = 0,
     categories: Optional[str] = None,
 ):
+    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+    # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
+    offset = max(0, offset)
+    limit = max(1, min(limit, 1000))
     category_list = []
     if categories:
         try:
@@ -570,6 +574,10 @@ def get_action_items(
     - **limit**: Maximum number of items to return
     - **offset**: Number of items to skip
     """
+    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+    # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
+    offset = max(0, offset)
+    limit = max(1, min(limit, 1000))
     action_items = action_items_db.get_action_items(
         uid=uid,
         conversation_id=conversation_id,
@@ -1005,6 +1013,10 @@ def get_conversations(
     - **folder_id**: Filter by folder ID (must be a non-empty string if provided)
     - **starred**: Filter by starred status (true/false)
     """
+    # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
+    # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
+    offset = max(0, offset)
+    limit = max(1, min(limit, 1000))
     try:
         category_list = [CategoryEnum(c.strip()) for c in categories.split(",") if c.strip()] if categories else []
     except ValueError as e:

--- a/backend/tests/unit/test_dev_api_action_items_poison.py
+++ b/backend/tests/unit/test_dev_api_action_items_poison.py
@@ -144,6 +144,7 @@ import database.action_items as action_items_db  # noqa: E402  (the stub)
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from routers.developer import router as developer_router  # noqa: E402
+import routers.developer as developer_module  # noqa: E402
 from dependencies import get_uid_with_action_items_read  # noqa: E402
 
 
@@ -164,3 +165,15 @@ def test_malformed_action_item_skipped_not_500():
         resp = _build().get('/v1/dev/user/action-items')
     assert resp.status_code == 200
     assert [i['id'] for i in resp.json()] == ['a1', 'a2']
+
+
+def test_pagination_is_clamped_before_firestore():
+    # Out-of-range pagination is clamped before the query: a negative limit/offset would raise
+    # (HTTP 500) and limit=0 hit the falsy `if limit:` guard and streamed the whole collection.
+    # Call the handler directly; get_action_items passes limit/offset as keyword args.
+    with patch.object(action_items_db, 'get_action_items', return_value=[]) as m:
+        developer_module.get_action_items(uid='uid1', limit=99999, offset=-1)
+        developer_module.get_action_items(uid='uid1', limit=0, offset=5)
+    high = m.call_args_list[0].kwargs
+    assert high['limit'] == 1000 and high['offset'] == 0  # 99999 -> 1000, -1 -> 0
+    assert m.call_args_list[1].kwargs['limit'] == 1  # 0 -> 1

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -180,3 +180,18 @@ def test_malformed_conversation_skipped_not_500():
         resp = _build().get('/v1/dev/user/conversations')
     assert resp.status_code == 200
     assert [c['id'] for c in resp.json()] == ['c1', 'c2']
+
+
+def test_pagination_is_clamped_before_firestore():
+    # Out-of-range pagination is clamped before the Firestore query: a negative offset/limit
+    # would otherwise raise (HTTP 500) and an oversized/zero limit would stream the whole
+    # collection. Call the handler directly (the TestClient async path is flaky on Windows; the
+    # clamp is what matters). get_conversations(uid, limit, offset, ...) is positional.
+    with patch.object(conversations_db, 'get_conversations', return_value=[]) as m, patch.object(
+        developer_module, 'populate_folder_names', lambda *a, **k: None
+    ), patch.object(developer_module, 'populate_speaker_names', lambda *a, **k: None):
+        developer_module.get_conversations(uid='uid1', limit=99999, offset=-1)
+        developer_module.get_conversations(uid='uid1', limit=0, offset=5)
+    high = m.call_args_list[0].args
+    assert high[1] == 1000 and high[2] == 0  # limit 99999 -> 1000, offset -1 -> 0
+    assert m.call_args_list[1].args[1] == 1  # limit 0 -> 1

--- a/backend/tests/unit/test_dev_api_memories_pagination.py
+++ b/backend/tests/unit/test_dev_api_memories_pagination.py
@@ -172,6 +172,7 @@ from models.memories import MemoryCategory  # noqa: E402  (real model; stubs pre
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from routers.developer import router as developer_router  # noqa: E402
+import routers.developer as developer_module  # noqa: E402
 from dependencies import get_uid_with_memories_read  # noqa: E402
 
 _VALID_CATEGORY = next(iter(MemoryCategory)).value
@@ -259,3 +260,15 @@ def test_all_valid_records_returned():
         resp = client.get('/v1/dev/user/memories')
     assert resp.status_code == 200
     assert len(resp.json()) == 2
+
+
+def test_pagination_is_clamped_before_firestore():
+    # Out-of-range pagination is clamped before the Firestore query: a negative offset/limit
+    # would raise (HTTP 500), an oversized/zero limit would stream the whole collection. Mirrors
+    # the mobile /v3/memories hardening. get_memories(uid, limit, offset, categories) is positional.
+    with patch.object(memories_db, 'get_memories', return_value=[]) as m:
+        developer_module.get_memories(uid='uid1', limit=99999, offset=-1)
+        developer_module.get_memories(uid='uid1', limit=0, offset=5)
+    high = m.call_args_list[0].args
+    assert high[1] == 1000 and high[2] == 0  # limit 99999 -> 1000, offset -1 -> 0
+    assert m.call_args_list[1].args[1] == 1  # limit 0 -> 1


### PR DESCRIPTION
## What

The partner-facing Developer API list endpoints passed `limit`/`offset` straight to Firestore `.limit()`/`.offset()` with no bounds:

- `GET /v1/dev/user/conversations`, `GET /v1/dev/user/memories`, `GET /v1/dev/user/action-items`.

Failure modes:
- A negative `offset` or `limit` makes Firestore raise, so `?offset=-1` (or `?limit=-1`) returns HTTP 500. This is the exact crash already fixed for the mobile `/v3/memories` endpoint; the Developer API copies never got it.
- A huge `limit` (e.g. `?limit=99999999`), or `limit=0` on action-items (which hit a falsy `if limit:` guard and skipped `.limit()` entirely), streams the user's whole collection unbounded (cost/latency/memory).

## Fix

Clamp `offset` to `>= 0` and `limit` to `[1, 1000]` in each handler before the query, mirroring the `GET /v3/memories` hardening: `offset = max(0, offset)` / `limit = max(1, min(limit, 1000))`.

Clamping (rather than rejecting out-of-range input with a 422) keeps the params as plain ints, so the public OpenAPI contract is unchanged. The handlers stay sync `def`; only the clamp lines are added. `GET /v1/dev/user/goals` is left as-is (it applies its limit in Python, not via Firestore, so it has no 500 path).

## Test

Adds a clamp test to each endpoint's existing dev-api test file (`test_dev_api_conversations_poison.py`, `test_dev_api_action_items_poison.py`, `test_dev_api_memories_pagination.py`). Each calls the handler directly with out-of-range pagination and asserts the value reaching Firestore is clamped (`limit 99999` to `1000`, `offset -1` to `0`, `limit 0` to `1`). Verified green locally.

Same-class siblings exist in `routers/mcp.py` and `routers/imports.py` (unbounded `limit`/`offset`); this PR is scoped to the Developer API.
