### PR TITLE
fix(backend): offload blocking geolocation read in the agent tool-call path

### DIFF
--- a/backend/tests/unit/test_agent_tool_geolocation_async.py
+++ b/backend/tests/unit/test_agent_tool_geolocation_async.py
@@ -1,0 +1,79 @@
+"""Structural test: the agent tool-call path offloads the blocking geolocation Redis read.
+
+`_call_tool_endpoint` in utils/retrieval/tools/app_tools.py runs inside the agentic RAG
+tool-calling flow (an async path). It read the user's cached geolocation through the synchronous
+`get_cached_user_geolocation` (a Redis read in database/redis_db.py), which blocks the event loop
+for the duration of that call. This test parses the source (no import, so no heavy langchain deps)
+and asserts the read is routed through an AWAITED `run_blocking(db_executor, get_cached_user_geolocation, ...)`
+and never called directly. The await check guards against a dangling coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+APP_TOOLS = BACKEND_DIR / 'utils' / 'retrieval' / 'tools' / 'app_tools.py'
+TARGET_FN = '_call_tool_endpoint'
+BLOCKING_CALL = 'get_cached_user_geolocation'
+
+
+def _load_function(name):
+    tree = ast.parse(APP_TOOLS.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {APP_TOOLS}')
+
+
+def _call_name(call):
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _call_name(n) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _call_name(call) != 'run_blocking':
+            continue
+        if len(call.args) >= 2 and isinstance(call.args[0], ast.Name) and isinstance(call.args[1], ast.Name):
+            yield call.args[0].id, call.args[1].id
+
+
+def test_geolocation_read_is_not_called_directly():
+    fn = _load_function(TARGET_FN)
+    assert (
+        _direct_calls(fn, BLOCKING_CALL) == []
+    ), f'{BLOCKING_CALL} is called directly in {TARGET_FN}; it must be offloaded via run_blocking'
+
+
+def test_geolocation_read_is_offloaded_and_awaited():
+    fn = _load_function(TARGET_FN)
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+    assert BLOCKING_CALL in targets, (
+        f'{BLOCKING_CALL} must be offloaded via an AWAITED run_blocking(db_executor, '
+        f'{BLOCKING_CALL}, ...); awaited run_blocking targets found: {targets}'
+    )
+
+
+def test_geolocation_offload_uses_db_executor():
+    fn = _load_function(TARGET_FN)
+    pools = [executor for executor, target in _awaited_run_blocking_offloads(fn) if target == BLOCKING_CALL]
+    assert pools == ['db_executor'], (
+        f'{BLOCKING_CALL} is a Redis read and must be offloaded on db_executor (Firestore/Redis CRUD '
+        f'pool); executors found: {pools}'
+    )

--- a/backend/utils/retrieval/tools/app_tools.py
+++ b/backend/utils/retrieval/tools/app_tools.py
@@ -256,10 +256,10 @@ async def _call_tool_endpoint(kwargs: dict, config: Optional[RunnableConfig], ap
     if not uid:
         return f"Error: User ID not found for {app_tool.name}"
 
-    # Get geolocation from cache
+    # Get geolocation from cache (offloaded: the Redis read is sync and blocks the event loop)
     geolocation = None
     try:
-        geolocation = get_cached_user_geolocation(uid)
+        geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
     except Exception:
         pass
 


### PR DESCRIPTION
## What

`_call_tool_endpoint` in `utils/retrieval/tools/app_tools.py` runs inside the agentic RAG tool-calling flow, which is an async path. It read the user's cached geolocation through the synchronous `get_cached_user_geolocation` (a Redis read in `database/redis_db.py`) and called it directly:

```python
geolocation = get_cached_user_geolocation(uid)
```

A synchronous Redis read on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop. The rest of this same file already offloads its blocking calls through `run_blocking`; this read was the one straggler the async-blocker scanner still flagged.

## Fix

Offload the read to the `db_executor` pool, matching the pattern already used throughout the file:

```python
geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
```

`db_executor` is the correct pool for a Redis read (Firestore/Redis CRUD per the backend async guidance). No new import is added: `db_executor` and `run_blocking` were already imported at the top of the file, so this change carries no import-change risk for the rest of the module.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range.

## Test

Adds `tests/unit/test_agent_tool_geolocation_async.py`, an AST-structural test that parses the source (no import, so no heavy langchain dependency is pulled into the unit suite) and asserts:

- `get_cached_user_geolocation` is never called directly inside `_call_tool_endpoint`.
- it is routed through an awaited `run_blocking(db_executor, get_cached_user_geolocation, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The test fails if the offload, the await, or the pool choice is dropped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

