### PR TITLE
Add local device rename support

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -54,6 +54,43 @@ class SharedPreferencesUtil {
 
   String get deviceName => getString('deviceName');
 
+  Map<String, String> get customDeviceNames {
+    final raw = getString('customDeviceNames');
+    if (raw.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return {};
+      return decoded.map((key, value) => MapEntry(key.toString(), value.toString()));
+    } catch (e) {
+      Logger.debug('Error parsing customDeviceNames: $e');
+      return {};
+    }
+  }
+
+  String getCustomDeviceName(String deviceId) {
+    if (deviceId.isEmpty) return '';
+    return customDeviceNames[deviceId] ?? '';
+  }
+
+  Future<bool> saveCustomDeviceName(String deviceId, String deviceName) async {
+    if (deviceId.isEmpty) return false;
+    final names = customDeviceNames;
+    final trimmedName = deviceName.trim();
+    if (trimmedName.isEmpty) {
+      names.remove(deviceId);
+    } else {
+      names[deviceId] = trimmedName;
+    }
+    return saveString('customDeviceNames', jsonEncode(names));
+  }
+
+  Future<bool> removeCustomDeviceName(String deviceId) async {
+    if (deviceId.isEmpty) return false;
+    final names = customDeviceNames;
+    names.remove(deviceId);
+    return saveString('customDeviceNames', jsonEncode(names));
+  }
+
   bool get deviceIsV2 => getBool('deviceIsV2');
 
   set deviceIsV2(bool value) => saveBool('deviceIsV2', value);

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -105,7 +105,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     final device = provider.pairedDevice ?? provider.connectedDevice;
     if (device == null || device.id.isEmpty) return;
 
-    final controller = TextEditingController(text: device.name);
+    final currentDisplayName = provider.getDeviceDisplayName(device);
+    final controller = TextEditingController(text: currentDisplayName);
     final newName = await showDialog<String>(
       context: context,
       builder: (dialogContext) {
@@ -144,9 +145,9 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     if (newName == null) return;
 
     final trimmedName = newName.trim();
-    if (trimmedName.isEmpty || trimmedName == device.name) return;
+    if (trimmedName.isEmpty || trimmedName == currentDisplayName) return;
 
-    await provider.updateCustomDeviceName(trimmedName);
+    await provider.updateCustomDeviceName(device.id, trimmedName);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.saved)));
   }
@@ -415,11 +416,6 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               // Save device ID before clearing prefs
               final deviceId = provider.connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
 
-              // Clear stored device
-              await provider.clearCustomDeviceName(deviceId);
-              await SharedPreferencesUtil().btDeviceSet(BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0));
-              SharedPreferencesUtil().deviceName = '';
-
               // Fully tear down connection, transport, and native service
               if (deviceId.isNotEmpty) {
                 await ServiceManager.instance().device.forgetDevice(deviceId);
@@ -427,6 +423,10 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                   BleHostApi().unmanageDevice(deviceId);
                 } catch (_) {}
               }
+
+              await provider.clearCustomDeviceName(deviceId);
+              await SharedPreferencesUtil().btDeviceSet(BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0));
+              SharedPreferencesUtil().deviceName = '';
 
               if (mounted) {
                 context.read<DeviceProvider>().setIsConnected(false);
@@ -472,15 +472,16 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                     () => Navigator.of(context).pop(),
                     () async {
                       Navigator.of(context).pop();
-                      final deviceId = provider.connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
+                      final device = provider.connectedDevice;
+                      final deviceId = device?.id ?? SharedPreferencesUtil().btDevice.id;
+                      if (device != null) {
+                        await _bleUnpairDevice(device);
+                      }
                       await provider.clearCustomDeviceName(deviceId);
                       await SharedPreferencesUtil().btDeviceSet(
                         BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0),
                       );
                       SharedPreferencesUtil().deviceName = '';
-                      if (provider.connectedDevice != null) {
-                        await _bleUnpairDevice(provider.connectedDevice!);
-                      }
                       if (context.mounted) {
                         context.read<DeviceProvider>().setIsConnected(false);
                         context.read<DeviceProvider>().setConnectedDevice(null);
@@ -528,7 +529,9 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   }
 
   Widget _buildDeviceInfoSection(DeviceProvider provider) {
-    final deviceName = provider.pairedDevice?.name ?? context.l10n.unknownDevice;
+    final deviceName = provider.pairedDevice == null
+        ? context.l10n.unknownDevice
+        : provider.getDeviceDisplayName(provider.pairedDevice);
     final modelNumber = provider.pairedDevice?.modelNumber ?? context.l10n.unknown;
     final manufacturer = provider.pairedDevice?.manufacturerName ?? context.l10n.unknown;
     final firmware = provider.pairedDevice?.firmwareRevision ?? context.l10n.unknown;

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -101,6 +101,56 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.copiedToClipboard(title))));
   }
 
+  Future<void> _showRenameDeviceDialog(DeviceProvider provider) async {
+    final device = provider.pairedDevice ?? provider.connectedDevice;
+    if (device == null || device.id.isEmpty) return;
+
+    final controller = TextEditingController(text: device.name);
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor: const Color(0xFF1C1C1E),
+          title: Text(context.l10n.deviceName, style: const TextStyle(color: Colors.white)),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            maxLength: 32,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              labelText: context.l10n.deviceName,
+              labelStyle: const TextStyle(color: Color(0xFF8E8E93)),
+              enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Color(0xFF3C3C43))),
+              focusedBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.white)),
+            ),
+            textInputAction: TextInputAction.done,
+            onSubmitted: (value) => Navigator.of(dialogContext).pop(value),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(context.l10n.cancel, style: const TextStyle(color: Color(0xFF8E8E93))),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(controller.text),
+              child: Text(context.l10n.save, style: const TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+
+    controller.dispose();
+    if (newName == null) return;
+
+    final trimmedName = newName.trim();
+    if (trimmedName.isEmpty || trimmedName == device.name) return;
+
+    await provider.updateCustomDeviceName(trimmedName);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.saved)));
+  }
+
   Widget _buildProfileStyleItem({
     required IconData icon,
     required String title,
@@ -366,6 +416,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               final deviceId = provider.connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
 
               // Clear stored device
+              await provider.clearCustomDeviceName(deviceId);
               await SharedPreferencesUtil().btDeviceSet(BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0));
               SharedPreferencesUtil().deviceName = '';
 
@@ -421,6 +472,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                     () => Navigator.of(context).pop(),
                     () async {
                       Navigator.of(context).pop();
+                      final deviceId = provider.connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
+                      await provider.clearCustomDeviceName(deviceId);
                       await SharedPreferencesUtil().btDeviceSet(
                         BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0),
                       );
@@ -500,10 +553,10 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
         children: [
           _buildProfileStyleItem(
             icon: FontAwesomeIcons.microchip,
-            title: context.l10n.productName,
+            title: context.l10n.deviceName,
             chipValue: deviceName,
-            copyValue: deviceName,
-            showChevron: false,
+            onTap: () => _showRenameDeviceDialog(provider),
+            showChevron: true,
           ),
           const Divider(height: 1, color: Color(0xFF3C3C43)),
           _buildProfileStyleItem(

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -69,6 +69,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Timer? _discoveryTimer;
   final Debouncer _disconnectDebouncer = Debouncer(delay: const Duration(milliseconds: 500));
   final Debouncer _connectDebouncer = Debouncer(delay: const Duration(milliseconds: 100));
+  int _connectionEventToken = 0;
 
   void Function(BtDevice device)? onDeviceConnected;
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
@@ -77,34 +78,31 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     ServiceManager.instance().device.subscribe(this, this);
   }
 
-  BtDevice _withCustomDisplayName(BtDevice device) {
+  String getDeviceDisplayName(BtDevice? device) {
+    if (device == null) return '';
     final customName = SharedPreferencesUtil().getCustomDeviceName(device.id);
-    if (customName.isEmpty) return device;
-    return device.copyWith(name: customName);
+    return customName.isEmpty ? device.name : customName;
   }
 
-  Future<void> updateCustomDeviceName(String name) async {
-    final deviceId = pairedDevice?.id ?? connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
+  Future<void> updateCustomDeviceName(String deviceId, String name) async {
     if (deviceId.isEmpty) return;
 
     await SharedPreferencesUtil().saveCustomDeviceName(deviceId, name);
 
-    final rawDevice = pairedDevice ?? connectedDevice ?? SharedPreferencesUtil().btDevice;
-    final displayDevice = _withCustomDisplayName(rawDevice);
-
-    connectedDevice = connectedDevice?.id == deviceId ? displayDevice : connectedDevice;
-    pairedDevice = pairedDevice?.id == deviceId ? displayDevice : pairedDevice;
-    if (pairedDevice == null || pairedDevice!.id.isEmpty) {
-      pairedDevice = displayDevice;
-    }
-
-    SharedPreferencesUtil().btDevice = displayDevice;
-    SharedPreferencesUtil().deviceName = displayDevice.name;
+    final storedDevice = SharedPreferencesUtil().btDevice;
+    final rawDevice = pairedDevice?.id == deviceId
+        ? pairedDevice
+        : connectedDevice?.id == deviceId
+            ? connectedDevice
+            : storedDevice.id == deviceId
+                ? storedDevice
+                : null;
+    final displayName = rawDevice == null ? name.trim() : getDeviceDisplayName(rawDevice);
 
     BatteryWidgetService().updateBatteryInfo(
-      deviceName: displayDevice.name,
+      deviceName: displayName,
       batteryLevel: batteryLevel,
-      deviceType: displayDevice.type.name,
+      deviceType: rawDevice?.type.name ?? 'omi',
       isConnected: isConnected,
     );
     notifyListeners();
@@ -121,9 +119,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   Future<void> setConnectedDevice(BtDevice? device) async {
-    final displayDevice = device == null ? null : _withCustomDisplayName(device);
-    connectedDevice = displayDevice;
-    pairedDevice = displayDevice;
+    connectedDevice = device;
+    pairedDevice = device;
     await getDeviceInfo();
     Logger.debug('setConnectedDevice: $device');
     notifyListeners();
@@ -136,14 +133,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         return;
       }
       var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
-      final deviceInfo = await connectedDevice?.getDeviceInfo(connection);
-      pairedDevice = _withCustomDisplayName(deviceInfo ?? connectedDevice!);
+      pairedDevice = await connectedDevice?.getDeviceInfo(connection) ?? connectedDevice;
       SharedPreferencesUtil().btDevice = pairedDevice!;
     } else {
       if (SharedPreferencesUtil().btDevice.id.isEmpty) {
         pairedDevice = BtDevice.empty();
       } else {
-        pairedDevice = _withCustomDisplayName(SharedPreferencesUtil().btDevice);
+        pairedDevice = SharedPreferencesUtil().btDevice;
       }
     }
     notifyListeners();
@@ -201,7 +197,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       onBatteryLevelChange: (int value) {
         batteryLevel = value;
         BatteryWidgetService().updateBatteryInfo(
-          deviceName: connectedDevice?.name ?? '',
+          deviceName: getDeviceDisplayName(connectedDevice),
           batteryLevel: value,
           deviceType: connectedDevice?.type.name ?? 'omi',
           isConnected: true,
@@ -378,7 +374,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       if (connection != null) {
         await setConnectedDevice(connection.device);
         setisDeviceStorageSupport();
-        SharedPreferencesUtil().deviceName = connectedDevice?.name ?? connection.device.name;
+        SharedPreferencesUtil().deviceName = connection.device.name;
         PlatformManager.instance.analytics.deviceConnected();
         setIsConnected(true);
       }
@@ -416,6 +412,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void onDeviceDisconnected() async {
     Logger.debug('onDisconnected inside: $connectedDevice');
+    _connectionEventToken++;
     _havingNewFirmware = false;
     _isFirmwareDialogShowing = false;
     _bleChargingStatusListener?.cancel();
@@ -480,7 +477,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void _onDeviceConnected(BtDevice device) async {
     Logger.debug('_onConnected inside: $connectedDevice');
+    final connectionEventToken = ++_connectionEventToken;
     await setConnectedDevice(device);
+    if (_connectionEventToken != connectionEventToken || connectedDevice?.id != device.id) return;
 
     if (captureProvider != null) {
       captureProvider?.updateRecordingDevice(connectedDevice ?? device);
@@ -491,10 +490,11 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
     // Read initial battery level
     int currentLevel = await _retrieveBatteryLevel(device.id);
+    if (_connectionEventToken != connectionEventToken || connectedDevice?.id != device.id) return;
     if (currentLevel != -1) {
       batteryLevel = currentLevel;
       BatteryWidgetService().updateBatteryInfo(
-        deviceName: connectedDevice?.name ?? device.name,
+        deviceName: getDeviceDisplayName(connectedDevice ?? device),
         batteryLevel: currentLevel,
         deviceType: (connectedDevice ?? device).type.name,
         isConnected: true,
@@ -504,26 +504,29 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Then set up listeners for battery changes and charging status
     await initiateBleBatteryListener();
     await initiateChargingStatusListener();
+    if (_connectionEventToken != connectionEventToken || connectedDevice?.id != device.id) return;
     if (batteryLevel != -1 && batteryLevel < 20) {
       _hasLowBatteryAlerted = false;
     }
     updateConnectingStatus(false);
     await captureProvider?.streamDeviceRecording(device: device);
+    if (_connectionEventToken != connectionEventToken || connectedDevice?.id != device.id) return;
 
     await getDeviceInfo();
+    if (_connectionEventToken != connectionEventToken || connectedDevice?.id != device.id) return;
     SharedPreferencesUtil().deviceName = pairedDevice?.name ?? connectedDevice?.name ?? device.name;
 
     // Wals
     final syncs = ServiceManager.instance().wal.getSyncs();
-    final displayDevice = connectedDevice ?? device;
-    syncs.setDevice(displayDevice);
-    syncs.sdcard.setDevice(displayDevice);
-    syncs.flashPage.setDevice(displayDevice);
-    syncs.storage.setDevice(displayDevice);
-    syncs.ring.setDevice(displayDevice);
+    final syncDevice = connectedDevice ?? device;
+    syncs.setDevice(syncDevice);
+    syncs.sdcard.setDevice(syncDevice);
+    syncs.flashPage.setDevice(syncDevice);
+    syncs.storage.setDevice(syncDevice);
+    syncs.ring.setDevice(syncDevice);
 
     // Auto-sync: check if device has offline files
-    _checkAndStartAutoSync(displayDevice);
+    _checkAndStartAutoSync(syncDevice);
 
     notifyListeners();
 

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -77,6 +77,43 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     ServiceManager.instance().device.subscribe(this, this);
   }
 
+  BtDevice _withCustomDisplayName(BtDevice device) {
+    final customName = SharedPreferencesUtil().getCustomDeviceName(device.id);
+    if (customName.isEmpty) return device;
+    return device.copyWith(name: customName);
+  }
+
+  Future<void> updateCustomDeviceName(String name) async {
+    final deviceId = pairedDevice?.id ?? connectedDevice?.id ?? SharedPreferencesUtil().btDevice.id;
+    if (deviceId.isEmpty) return;
+
+    await SharedPreferencesUtil().saveCustomDeviceName(deviceId, name);
+
+    final rawDevice = pairedDevice ?? connectedDevice ?? SharedPreferencesUtil().btDevice;
+    final displayDevice = _withCustomDisplayName(rawDevice);
+
+    connectedDevice = connectedDevice?.id == deviceId ? displayDevice : connectedDevice;
+    pairedDevice = pairedDevice?.id == deviceId ? displayDevice : pairedDevice;
+    if (pairedDevice == null || pairedDevice!.id.isEmpty) {
+      pairedDevice = displayDevice;
+    }
+
+    SharedPreferencesUtil().btDevice = displayDevice;
+    SharedPreferencesUtil().deviceName = displayDevice.name;
+
+    BatteryWidgetService().updateBatteryInfo(
+      deviceName: displayDevice.name,
+      batteryLevel: batteryLevel,
+      deviceType: displayDevice.type.name,
+      isConnected: isConnected,
+    );
+    notifyListeners();
+  }
+
+  Future<void> clearCustomDeviceName(String deviceId) async {
+    await SharedPreferencesUtil().removeCustomDeviceName(deviceId);
+  }
+
   void setProviders(CaptureProvider provider, LocalRecordingsProvider recordingsProvider) {
     captureProvider = provider;
     localRecordingsProvider = recordingsProvider;
@@ -84,8 +121,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   Future<void> setConnectedDevice(BtDevice? device) async {
-    connectedDevice = device;
-    pairedDevice = device;
+    final displayDevice = device == null ? null : _withCustomDisplayName(device);
+    connectedDevice = displayDevice;
+    pairedDevice = displayDevice;
     await getDeviceInfo();
     Logger.debug('setConnectedDevice: $device');
     notifyListeners();
@@ -98,13 +136,14 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         return;
       }
       var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
-      pairedDevice = await connectedDevice?.getDeviceInfo(connection);
+      final deviceInfo = await connectedDevice?.getDeviceInfo(connection);
+      pairedDevice = _withCustomDisplayName(deviceInfo ?? connectedDevice!);
       SharedPreferencesUtil().btDevice = pairedDevice!;
     } else {
       if (SharedPreferencesUtil().btDevice.id.isEmpty) {
         pairedDevice = BtDevice.empty();
       } else {
-        pairedDevice = SharedPreferencesUtil().btDevice;
+        pairedDevice = _withCustomDisplayName(SharedPreferencesUtil().btDevice);
       }
     }
     notifyListeners();
@@ -339,7 +378,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       if (connection != null) {
         await setConnectedDevice(connection.device);
         setisDeviceStorageSupport();
-        SharedPreferencesUtil().deviceName = connection.device.name;
+        SharedPreferencesUtil().deviceName = connectedDevice?.name ?? connection.device.name;
         PlatformManager.instance.analytics.deviceConnected();
         setIsConnected(true);
       }
@@ -441,10 +480,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void _onDeviceConnected(BtDevice device) async {
     Logger.debug('_onConnected inside: $connectedDevice');
-    setConnectedDevice(device);
+    await setConnectedDevice(device);
 
     if (captureProvider != null) {
-      captureProvider?.updateRecordingDevice(device);
+      captureProvider?.updateRecordingDevice(connectedDevice ?? device);
     }
 
     setisDeviceStorageSupport();
@@ -455,9 +494,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (currentLevel != -1) {
       batteryLevel = currentLevel;
       BatteryWidgetService().updateBatteryInfo(
-        deviceName: device.name,
+        deviceName: connectedDevice?.name ?? device.name,
         batteryLevel: currentLevel,
-        deviceType: device.type.name,
+        deviceType: (connectedDevice ?? device).type.name,
         isConnected: true,
       );
     }
@@ -472,18 +511,19 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     await captureProvider?.streamDeviceRecording(device: device);
 
     await getDeviceInfo();
-    SharedPreferencesUtil().deviceName = device.name;
+    SharedPreferencesUtil().deviceName = pairedDevice?.name ?? connectedDevice?.name ?? device.name;
 
     // Wals
     final syncs = ServiceManager.instance().wal.getSyncs();
-    syncs.setDevice(device);
-    syncs.sdcard.setDevice(device);
-    syncs.flashPage.setDevice(device);
-    syncs.storage.setDevice(device);
-    syncs.ring.setDevice(device);
+    final displayDevice = connectedDevice ?? device;
+    syncs.setDevice(displayDevice);
+    syncs.sdcard.setDevice(displayDevice);
+    syncs.flashPage.setDevice(displayDevice);
+    syncs.storage.setDevice(displayDevice);
+    syncs.ring.setDevice(displayDevice);
 
     // Auto-sync: check if device has offline files
-    _checkAndStartAutoSync(device);
+    _checkAndStartAutoSync(displayDevice);
 
     notifyListeners();
 


### PR DESCRIPTION
## Summary
- add local custom device-name storage keyed by device id
- apply the custom display name when the paired/connected device is loaded or reconnects
- add an editable Device Name row in Device Settings and clear custom names when a device is forgotten/unpaired

## Validation
- git diff --check
- Flutter/Dart analysis not run: flutter, dart, and fvm are not installed in this environment.

/claim #2824


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

