### PR TITLE
fix(backend): offload blocking file-metadata read in the streaming chat-with-file path

### DIFF
--- a/backend/tests/unit/test_chat_file_stream_async.py
+++ b/backend/tests/unit/test_chat_file_stream_async.py
@@ -1,0 +1,79 @@
+"""Structural test: the streaming chat-with-file path offloads its blocking Firestore read.
+
+FileChatTool.process_chat_with_file_stream in utils/other/chat_file.py is an async method on the
+chat-with-file streaming path. It read the attached files' metadata through the synchronous
+chat_db.get_chat_files_desc (a Firestore read in database/chat.py), which blocks the event loop for
+the duration of that call. This test parses the source (no import, so no heavy openai/PIL deps) and
+asserts the read is routed through an awaited run_blocking(db_executor, chat_db.get_chat_files_desc, ...)
+and never called directly. The await check guards against a dangling coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+CHAT_FILE = BACKEND_DIR / 'utils' / 'other' / 'chat_file.py'
+TARGET_FN = 'process_chat_with_file_stream'
+BLOCKING_CALL = 'get_chat_files_desc'
+
+
+def _load_function(name):
+    tree = ast.parse(CHAT_FILE.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {CHAT_FILE}')
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_files_read_is_not_called_directly():
+    fn = _load_function(TARGET_FN)
+    assert (
+        _direct_calls(fn, BLOCKING_CALL) == []
+    ), f'{BLOCKING_CALL} is called directly in {TARGET_FN}; it must be offloaded via run_blocking'
+
+
+def test_files_read_is_offloaded_and_awaited():
+    fn = _load_function(TARGET_FN)
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+    assert BLOCKING_CALL in targets, (
+        f'{BLOCKING_CALL} must be offloaded via an AWAITED run_blocking(db_executor, '
+        f'chat_db.{BLOCKING_CALL}, ...); awaited run_blocking targets found: {targets}'
+    )
+
+
+def test_files_read_offload_uses_db_executor():
+    fn = _load_function(TARGET_FN)
+    pools = [executor for executor, target in _awaited_run_blocking_offloads(fn) if target == BLOCKING_CALL]
+    assert pools == ['db_executor'], (
+        f'{BLOCKING_CALL} is a Firestore read and must be offloaded on db_executor (Firestore/Redis '
+        f'CRUD pool); executors found: {pools}'
+    )

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -107,9 +107,17 @@ class FileChatTool:
     async def process_chat_with_file_stream(self, question, file_ids: List[str], callback=None):
         """Process chat with file attachments (streaming)"""
         # Offloaded: the Firestore read is sync and blocks the event loop in this async path.
-        files_data = await run_blocking(db_executor, chat_db.get_chat_files_desc, self.uid, files_id=file_ids, limit=9)
-        files = [FileChat(**f) for f in files_data]
-        all_images = all(f.is_image() for f in files) if files else False
+        # If this pre-stream setup fails, signal the streaming callback's end before propagating
+        # (mirrors the _ensure_thread_and_assistant failure path below) so it is not left dangling.
+        try:
+            files_data = await run_blocking(
+                db_executor, chat_db.get_chat_files_desc, self.uid, files_id=file_ids, limit=9
+            )
+            files = [FileChat(**f) for f in files_data]
+            all_images = all(f.is_image() for f in files) if files else False
+        except Exception:
+            callback.end_nowait()
+            raise
 
         if all_images and files:
             logger.info(f"[FileChat] All {len(files)} files are images, using Chat Completions vision API")

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 import database.chat as chat_db
 from models.chat import ChatSession, FileChat
+from utils.executors import db_executor, run_blocking
 import logging
 
 logger = logging.getLogger(__name__)
@@ -105,7 +106,8 @@ class FileChatTool:
 
     async def process_chat_with_file_stream(self, question, file_ids: List[str], callback=None):
         """Process chat with file attachments (streaming)"""
-        files_data = chat_db.get_chat_files_desc(self.uid, files_id=file_ids, limit=9)
+        # Offloaded: the Firestore read is sync and blocks the event loop in this async path.
+        files_data = await run_blocking(db_executor, chat_db.get_chat_files_desc, self.uid, files_id=file_ids, limit=9)
         files = [FileChat(**f) for f in files_data]
         all_images = all(f.is_image() for f in files) if files else False
 


### PR DESCRIPTION
## What

`FileChatTool.process_chat_with_file_stream` in `utils/other/chat_file.py` is an async method on the streaming chat-with-file path. It read the attached files' metadata through the synchronous `chat_db.get_chat_files_desc` (a Firestore read in `database/chat.py`) and called it directly:

```python
files_data = chat_db.get_chat_files_desc(self.uid, files_id=file_ids, limit=9)
```

A synchronous Firestore read on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop. The scanner flagged this as the one remaining blocking call in the file.

## Fix

Offload the read to the `db_executor` pool:

```python
files_data = await run_blocking(db_executor, chat_db.get_chat_files_desc, self.uid, files_id=file_ids, limit=9)
```

`db_executor` is the correct pool for a Firestore read (Firestore/Redis CRUD per the backend async guidance). `process_chat_with_file_stream` is the only blocking async helper in this file, so the added `utils.executors` import does not pull any unrelated pre-existing debt into the async-blocker gate scope.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range.

## Test

Adds `tests/unit/test_chat_file_stream_async.py`, an AST-structural test that parses the source (no import, so no heavy openai or PIL dependency is pulled into the unit suite) and asserts:

- `get_chat_files_desc` is never called directly inside `process_chat_with_file_stream`.
- it is routed through an awaited `run_blocking(db_executor, chat_db.get_chat_files_desc, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The test fails if the offload, the await, or the pool choice is dropped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

