### PR TITLE
fix(backend): offload blocking Redis calls in the credit-limit notification

### DIFF
--- a/backend/tests/unit/test_credit_limit_notification_async.py
+++ b/backend/tests/unit/test_credit_limit_notification_async.py
@@ -1,0 +1,82 @@
+"""Structural test: the credit-limit notification offloads its blocking Redis calls.
+
+send_credit_limit_notification in utils/notifications.py is an async helper. It read and wrote the
+notification dedup state through the synchronous has_credit_limit_notification_been_sent and
+set_credit_limit_notification_sent (Redis calls in database/redis_db.py), which block the event loop
+for the duration of each call. This test parses the source (no import) and asserts both are routed
+through an awaited run_blocking(db_executor, ...) and never called directly. The await check guards
+against a dangling coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+NOTIFICATIONS = BACKEND_DIR / 'utils' / 'notifications.py'
+TARGET_FN = 'send_credit_limit_notification'
+BLOCKING_CALLS = ('has_credit_limit_notification_been_sent', 'set_credit_limit_notification_sent')
+
+
+def _load_function(name):
+    tree = ast.parse(NOTIFICATIONS.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {NOTIFICATIONS}')
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_redis_calls_are_not_called_directly():
+    fn = _load_function(TARGET_FN)
+    for callee in BLOCKING_CALLS:
+        assert (
+            _direct_calls(fn, callee) == []
+        ), f'{callee} is called directly in {TARGET_FN}; it must be offloaded via run_blocking'
+
+
+def test_redis_calls_are_offloaded_and_awaited():
+    fn = _load_function(TARGET_FN)
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+    for callee in BLOCKING_CALLS:
+        assert callee in targets, (
+            f'{callee} must be offloaded via an AWAITED run_blocking(db_executor, {callee}, ...); '
+            f'awaited run_blocking targets found: {targets}'
+        )
+
+
+def test_offloads_use_db_executor():
+    fn = _load_function(TARGET_FN)
+    for executor, target in _awaited_run_blocking_offloads(fn):
+        if target in BLOCKING_CALLS:
+            assert executor == 'db_executor', (
+                f'{target} is a Redis call and must be offloaded on db_executor (Firestore/Redis '
+                f'CRUD pool); found executor {executor}'
+            )

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -216,8 +216,9 @@ async def send_subscription_paid_personalized_notification(user_id: str, data: d
 
 async def send_credit_limit_notification(user_id: str):
     """Send a personalized credit limit notification if not sent recently"""
-    # Check if notification was sent recently (within 6 hours)
-    if has_credit_limit_notification_been_sent(user_id):
+    # Check if notification was sent recently (within 6 hours). Offloaded: the Redis read is sync
+    # and blocks the event loop in this async path.
+    if await run_blocking(db_executor, has_credit_limit_notification_been_sent, user_id):
         logger.info(f"Credit limit notification already sent recently for user {user_id}")
         return
 
@@ -239,8 +240,9 @@ async def send_credit_limit_notification(user_id: str):
     # Send notification
     send_notification(user_id, title, body)
 
-    # Cache that notification was sent (6 hours TTL)
-    set_credit_limit_notification_sent(user_id)
+    # Cache that notification was sent (6 hours TTL). Offloaded: the Redis write is sync and blocks
+    # the event loop in this async path.
+    await run_blocking(db_executor, set_credit_limit_notification_sent, user_id)
     logger.info(f"Credit limit notification sent to user {user_id}")
 
 


### PR DESCRIPTION
## What

`send_credit_limit_notification` in `utils/notifications.py` is an async helper. It read and wrote the per-user dedup state through two synchronous Redis calls in `database/redis_db.py` and called them directly:

```python
if has_credit_limit_notification_been_sent(user_id):
    ...
set_credit_limit_notification_sent(user_id)
```

A synchronous Redis call on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop.

## Fix

Offload both calls to the `db_executor` pool:

```python
if await run_blocking(db_executor, has_credit_limit_notification_been_sent, user_id):
    ...
await run_blocking(db_executor, set_credit_limit_notification_sent, user_id)
```

`db_executor` is the correct pool for a Redis call (Firestore/Redis CRUD per the backend async guidance). It was already imported and used in this file (by `send_bulk_notification`), so no new import is added and the change does not pull any unrelated pre-existing debt into the async-blocker gate scope.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range.

## Test

Adds `tests/unit/test_credit_limit_notification_async.py`, an AST-structural test that parses the source (no import) and asserts, for both Redis calls:

- the call is never made directly inside `send_credit_limit_notification`.
- it is routed through an awaited `run_blocking(db_executor, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The test fails if either offload, the await, or the pool choice is dropped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

