### PR TITLE
fix(backend): offload blocking Firestore in the Twilio TwiML voice webhook

### DIFF
--- a/backend/routers/phone_calls.py
+++ b/backend/routers/phone_calls.py
@@ -16,6 +16,7 @@ import database.phone_call_usage as phone_call_usage_db
 from utils.phone_calls import check_call_access, check_destination_allowed, get_quota_snapshot
 from utils.other import endpoints as auth
 from utils.other.endpoints import rate_limit_dependency
+from utils.executors import db_executor, run_blocking
 from utils.twilio_service import (
     generate_access_token,
     start_caller_id_verification,
@@ -263,7 +264,8 @@ async def twiml_voice_webhook(request: Request):
     caller_number = None
 
     if uid:
-        primary = phone_calls_db.get_primary_phone_number(uid)
+        # Offloaded: the Firestore read is sync and blocks the event loop in this async handler.
+        primary = await run_blocking(db_executor, phone_calls_db.get_primary_phone_number, uid)
         if primary:
             caller_number = primary.get('phone_number')
 
@@ -310,7 +312,8 @@ async def twiml_voice_webhook(request: Request):
     # attempts don't eat the user's quota.
     try:
         if not snapshot.is_paid:
-            phone_call_usage_db.increment_current_month(uid)
+            # Offloaded: the Firestore write is sync and blocks the event loop in this async handler.
+            await run_blocking(db_executor, phone_call_usage_db.increment_current_month, uid)
     except Exception:
         traceback.print_exc()
 

--- a/backend/tests/unit/test_phone_twiml_async.py
+++ b/backend/tests/unit/test_phone_twiml_async.py
@@ -1,0 +1,83 @@
+"""Structural test: the Twilio TwiML voice webhook offloads its blocking Firestore calls.
+
+twiml_voice_webhook in routers/phone_calls.py is the async handler Twilio POSTs to when a VoIP call
+starts, so it sits on the real-time call path. It read the caller's verified number and incremented
+the monthly usage counter through the synchronous phone_calls_db.get_primary_phone_number and
+phone_call_usage_db.increment_current_month (Firestore calls in database/), which block the event
+loop. This test parses the source (no import) and asserts both are routed through an awaited
+run_blocking(db_executor, ...) and never called directly. The await check guards against a dangling
+coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+PHONE_CALLS = BACKEND_DIR / 'routers' / 'phone_calls.py'
+TARGET_FN = 'twiml_voice_webhook'
+BLOCKING_CALLS = ('get_primary_phone_number', 'increment_current_month')
+
+
+def _load_function(name):
+    tree = ast.parse(PHONE_CALLS.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f'{name} not found in {PHONE_CALLS}')
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(fn_node, callee):
+    return [n for n in ast.walk(fn_node) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(fn_node):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(fn_node):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_firestore_calls_are_not_called_directly():
+    fn = _load_function(TARGET_FN)
+    for callee in BLOCKING_CALLS:
+        assert (
+            _direct_calls(fn, callee) == []
+        ), f'{callee} is called directly in {TARGET_FN}; it must be offloaded via run_blocking'
+
+
+def test_firestore_calls_are_offloaded_and_awaited():
+    fn = _load_function(TARGET_FN)
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(fn)]
+    for callee in BLOCKING_CALLS:
+        assert callee in targets, (
+            f'{callee} must be offloaded via an AWAITED run_blocking(db_executor, {callee}, ...); '
+            f'awaited run_blocking targets found: {targets}'
+        )
+
+
+def test_offloads_use_db_executor():
+    fn = _load_function(TARGET_FN)
+    for executor, target in _awaited_run_blocking_offloads(fn):
+        if target in BLOCKING_CALLS:
+            assert executor == 'db_executor', (
+                f'{target} is a Firestore call and must be offloaded on db_executor (Firestore/Redis '
+                f'CRUD pool); found executor {executor}'
+            )


### PR DESCRIPTION
## What

`twiml_voice_webhook` in `routers/phone_calls.py` is the async handler Twilio POSTs to when a VoIP call starts, so it runs on the real-time call path. It read the caller's verified number and incremented the monthly usage counter through two synchronous Firestore calls, made directly:

```python
primary = phone_calls_db.get_primary_phone_number(uid)
...
phone_call_usage_db.increment_current_month(uid)
```

A synchronous Firestore call on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop.

## Fix

Offload both calls to the `db_executor` pool:

```python
primary = await run_blocking(db_executor, phone_calls_db.get_primary_phone_number, uid)
...
await run_blocking(db_executor, phone_call_usage_db.increment_current_month, uid)
```

`db_executor` is the correct pool for a Firestore read/write (Firestore/Redis CRUD per the backend async guidance). `twiml_voice_webhook` is the only async handler in this file with flagged blocking calls, so the added `utils.executors` import does not surface any unrelated pre-existing debt.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range.

## Test

Adds `tests/unit/test_phone_twiml_async.py`, an AST-structural test that parses the source and asserts, for both Firestore calls:

- the call is never made directly inside `twiml_voice_webhook`.
- it is routed through an awaited `run_blocking(db_executor, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The change is behavior preserving (the same functions are called with the same arguments, just on the executor), so the existing `test_phone_calls.py` webhook tests continue to pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

