### PR TITLE
fix(backend): offload the blocking task-sync Firestore calls off the event loop

### DIFF
--- a/backend/tests/unit/test_task_sync_async.py
+++ b/backend/tests/unit/test_task_sync_async.py
@@ -1,0 +1,79 @@
+"""Structural test: the task-sync helpers offload their blocking Firestore calls.
+
+The auto-sync helpers in utils/task_sync.py (auto_sync_action_item, _sync_to_cloud_service,
+auto_sync_action_items_batch) are async and run the task-integration sync off the request path. They
+read the user's task integration and marked the action item exported through synchronous Firestore
+calls (users_db.get_default_task_integration, users_db.get_task_integration,
+action_items_db.update_action_item), each of which blocks the event loop for the duration of the call.
+This test parses the source (no import) and asserts each is routed through an awaited
+run_blocking(db_executor, ...) and never called directly. The await check guards against a dangling
+coroutine (offloaded but not awaited).
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+TASK_SYNC = BACKEND_DIR / 'utils' / 'task_sync.py'
+BLOCKING_CALLS = ('get_default_task_integration', 'get_task_integration', 'update_action_item')
+
+
+def _module():
+    return ast.parse(TASK_SYNC.read_text(encoding='utf-8'))
+
+
+def _ref_name(node):
+    """Name for an ast.Name (.id) or ast.Attribute (.attr); None otherwise."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _direct_calls(tree, callee):
+    return [n for n in ast.walk(tree) if isinstance(n, ast.Call) and _ref_name(n.func) == callee]
+
+
+def _awaited_run_blocking_offloads(tree):
+    """Yield (executor_name, target_name) for each AWAITED run_blocking(executor, target, ...) call.
+
+    Only awaited calls count: a bare run_blocking(...) without await is a dangling coroutine that
+    never runs, so the offload would silently do nothing.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Await):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or _ref_name(call.func) != 'run_blocking':
+            continue
+        if len(call.args) >= 2:
+            yield _ref_name(call.args[0]), _ref_name(call.args[1])
+
+
+def test_blocking_calls_are_not_called_directly():
+    tree = _module()
+    for callee in BLOCKING_CALLS:
+        assert (
+            _direct_calls(tree, callee) == []
+        ), f'{callee} is called directly in task_sync.py; it must be offloaded via run_blocking'
+
+
+def test_blocking_calls_are_offloaded_and_awaited():
+    tree = _module()
+    targets = [target for _executor, target in _awaited_run_blocking_offloads(tree)]
+    for callee in BLOCKING_CALLS:
+        assert callee in targets, (
+            f'{callee} must be offloaded via an AWAITED run_blocking(db_executor, ...); '
+            f'awaited run_blocking targets found: {targets}'
+        )
+
+
+def test_offloads_use_db_executor():
+    tree = _module()
+    for executor, target in _awaited_run_blocking_offloads(tree):
+        if target in BLOCKING_CALLS:
+            assert executor == 'db_executor', (
+                f'{target} is a Firestore call and must be offloaded on db_executor (Firestore/Redis '
+                f'CRUD pool); found executor {executor}'
+            )

--- a/backend/utils/task_sync.py
+++ b/backend/utils/task_sync.py
@@ -5,6 +5,7 @@ import httpx
 
 import database.users as users_db
 import database.action_items as action_items_db
+from utils.executors import db_executor, run_blocking
 from utils.notifications import send_apple_reminders_sync_push
 import logging
 
@@ -24,11 +25,11 @@ async def auto_sync_action_item(uid: str, action_item: dict, skip_apple_reminder
         dict: {"synced": bool, "platform": str, "external_task_id": str, "error": str}
     """
     try:
-        default_app = users_db.get_default_task_integration(uid)
+        default_app = await run_blocking(db_executor, users_db.get_default_task_integration, uid)
         if not default_app:
             return {"synced": False, "reason": "no_default_integration"}
 
-        integration = users_db.get_task_integration(uid, default_app)
+        integration = await run_blocking(db_executor, users_db.get_task_integration, uid, default_app)
         if not integration:
             return {"synced": False, "reason": "integration_not_found"}
 
@@ -64,7 +65,9 @@ async def _sync_to_cloud_service(uid: str, app_key: str, integration: dict, acti
 
     if result.get("success"):
         # Mark action item as exported
-        action_items_db.update_action_item(
+        await run_blocking(
+            db_executor,
+            action_items_db.update_action_item,
             uid,
             action_item["id"],
             {
@@ -102,11 +105,11 @@ async def auto_sync_action_items_batch(uid: str, action_items: list) -> list:
         return []
 
     try:
-        default_app = users_db.get_default_task_integration(uid)
+        default_app = await run_blocking(db_executor, users_db.get_default_task_integration, uid)
         if not default_app:
             return [{"synced": False, "reason": "no_default_integration"}] * len(action_items)
 
-        integration = users_db.get_task_integration(uid, default_app)
+        integration = await run_blocking(db_executor, users_db.get_task_integration, uid, default_app)
         if not integration:
             return [{"synced": False, "reason": "integration_not_found"}] * len(action_items)
 


### PR DESCRIPTION
## What

The auto-sync helpers in `utils/task_sync.py` (`auto_sync_action_item`, `_sync_to_cloud_service`, `auto_sync_action_items_batch`) are async and run the task-integration sync (Todoist, Microsoft Tasks) off the request path. They read the user's task integration and marked the action item exported through three synchronous Firestore calls, made directly:

```python
default_app = users_db.get_default_task_integration(uid)
integration = users_db.get_task_integration(uid, default_app)
...
action_items_db.update_action_item(uid, action_item["id"], {...})
```

A synchronous Firestore call on the event loop blocks it for the duration of the call, stalling health checks and every other connection sharing the loop.

## Fix

Offload all three to the `db_executor` pool:

```python
default_app = await run_blocking(db_executor, users_db.get_default_task_integration, uid)
integration = await run_blocking(db_executor, users_db.get_task_integration, uid, default_app)
...
await run_blocking(db_executor, action_items_db.update_action_item, uid, action_item["id"], {...})
```

`db_executor` is the correct pool for these Firestore reads/writes (Firestore/Redis CRUD per the backend async guidance). The three flagged async helpers are the only ones in this file, so it is fully de-blocked.

After the change, `python scripts/scan_async_blockers.py --dirs routers utils --diff-base origin/main` reports 0 selected findings for the changed range.

## Test

Adds `tests/unit/test_task_sync_async.py`, an AST-structural test that parses the source (no import) and asserts, for each of the three Firestore calls:

- the call is never made directly in `task_sync.py`.
- it is routed through an awaited `run_blocking(db_executor, ...)`.
- the executor used is `db_executor`.

The await check matters: a bare `run_blocking(...)` without `await` is a dangling coroutine that never runs, so the offload would silently do nothing. The test fails if any offload, the await, or the pool choice is dropped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

