### PR TITLE
Speed up backend unit test lane

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,3 +5,7 @@ skip-string-normalization = true
 [tool.pytest.ini_options]
 pythonpath = ["."]
 asyncio_mode = "auto"
+markers = [
+    "integration: live or credentialed tests that are not run by backend/test.sh",
+    "slow: tests that are intentionally slower than normal unit tests",
+]

--- a/backend/test-preflight.sh
+++ b/backend/test-preflight.sh
@@ -19,6 +19,11 @@ ok()   { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass + 1)); }
 skip() { echo -e "  ${YELLOW}⚠${NC} $1"; warn=$((warn + 1)); }
 bad()  { echo -e "  ${RED}✗${NC} $1"; fail=$((fail + 1)); }
 
+EXPECTED_PYTHON_VERSION=""
+if [[ -f .python-version ]]; then
+  EXPECTED_PYTHON_VERSION="$(tr -d '[:space:]' < .python-version)"
+fi
+
 # ── Tools ──
 echo "Tools:"
 
@@ -38,7 +43,16 @@ done
 PYTHON_BIN="${PYTHON_BIN:-$FIRST_PYTHON_BIN}"
 
 if [[ -n "$PYTHON_BIN" ]]; then
-  ok "$PYTHON_BIN $("$PYTHON_BIN" --version 2>&1 | awk '{print $2}')"
+  python_version="$("$PYTHON_BIN" --version 2>&1 | awk '{print $2}')"
+  ok "$PYTHON_BIN $python_version"
+  if [[ -n "$EXPECTED_PYTHON_VERSION" ]]; then
+    if [[ "$python_version" == "$EXPECTED_PYTHON_VERSION" ]]; then
+      ok "Python version matches .python-version ($EXPECTED_PYTHON_VERSION)"
+    else
+      bad "Python version mismatch: expected $EXPECTED_PYTHON_VERSION from .python-version, got $python_version from $PYTHON_BIN"
+      echo -e "  ${YELLOW}→${NC} Run: ./scripts/sync-python-deps.sh, then PYTHON=.venv/bin/python bash test-preflight.sh"
+    fi
+  fi
 else
   bad "python not found"
 fi

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -6,9 +6,73 @@ cd "$ROOT_DIR"
 
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 export OPENAI_API_KEY="test-openai-key-not-real"
+PYTHON_BIN="${PYTHON:-python3}"
 
 pytest() {
-  python3 -m pytest "$@"
+  "$PYTHON_BIN" -m pytest "$@"
+}
+
+run_test_files() {
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+
+  if [[ -n "${BACKEND_PYTEST_XDIST:-}" && "${BACKEND_PYTEST_XDIST:-}" != "0" ]]; then
+    "$PYTHON_BIN" - "$@" <<'PY'
+from __future__ import annotations
+
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+import os
+import subprocess
+import sys
+
+
+def _worker_count(test_count: int) -> int:
+    raw = os.environ.get('BACKEND_PYTEST_WORKERS') or os.environ.get('BACKEND_PYTEST_XDIST') or 'auto'
+    if raw == 'auto':
+        return max(1, min(test_count, os.cpu_count() or 1))
+    try:
+        return max(1, min(test_count, int(raw)))
+    except ValueError:
+        return 1
+
+
+def _run_test(test_path: str) -> tuple[str, int, str]:
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pytest', test_path, '-v'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return test_path, proc.returncode, proc.stdout
+
+
+tests = sys.argv[1:]
+workers = _worker_count(len(tests))
+print(f'Running {len(tests)} backend unit test file(s) with {workers} isolated worker process(es).', flush=True)
+
+failed = False
+with ThreadPoolExecutor(max_workers=workers) as executor:
+    pending = {executor.submit(_run_test, test_path) for test_path in tests}
+    while pending:
+        done, pending = wait(pending, return_when=FIRST_COMPLETED)
+        for future in done:
+            test_path, returncode, output = future.result()
+            print(f'::group::{test_path}', flush=True)
+            print(output, end='' if output.endswith('\n') else '\n')
+            print('::endgroup::', flush=True)
+            if returncode:
+                failed = True
+
+if failed:
+    raise SystemExit(1)
+PY
+    return
+  fi
+
+  for test_path in "$@"; do
+    pytest "$test_path" -v
+  done
 }
 
 if [[ -n "${BACKEND_UNIT_TEST_FILE_LIST:-}" ]]; then
@@ -28,378 +92,16 @@ if [[ -n "${BACKEND_UNIT_TEST_FILE_LIST:-}" ]]; then
   fi
 
   echo "Running ${#selected_tests[@]} selected backend unit test file(s)."
-  for test_path in "${selected_tests[@]}"; do
-    pytest "$test_path" -v
-  done
+  run_test_files "${selected_tests[@]}"
   exit 0
 fi
 
-pytest tests/unit/test_transcript_segment.py -v
-pytest tests/unit/test_import_job_status_detail_enum.py -v
-pytest tests/unit/test_text_similarity.py -v
-pytest tests/unit/test_text_containment.py -v
-pytest tests/unit/test_speaker_sample.py -v
-pytest tests/unit/test_speaker_sample_migration.py -v
-pytest tests/unit/test_short_audio_embedding.py -v
-pytest tests/unit/test_users_add_sample_transaction.py -v
-pytest tests/unit/test_users_webhook_url_validation.py -v
-pytest tests/unit/test_voice_message_language.py -v
-pytest tests/unit/test_speaker_assignment.py -v
-pytest tests/unit/test_speaker_id_pipeline.py -v
-pytest tests/unit/test_user_speaker_embedding.py -v
-pytest tests/unit/test_parakeet_diarization.py -v
-pytest tests/unit/test_diarizer_embedding_decoder_bypass.py -v
-pytest tests/unit/test_parakeet_prerecorded.py -v
-pytest tests/unit/test_parakeet_nim.py -v
-pytest tests/unit/test_parakeet_stream_session.py -v
-pytest tests/unit/test_parakeet_gpu_worker.py -v
-pytest tests/unit/test_parakeet_batch_engine.py -v
-pytest tests/unit/test_flush_pending_batch1.py -v
-pytest tests/unit/test_gpu_worker_submit_lock.py -v
-pytest tests/unit/test_vram_batch.py -v
-pytest tests/unit/test_oom_reproduction.py -v
-pytest tests/unit/test_parakeet_batch_routing.py -v
-pytest tests/unit/test_parakeet_builtin_embedding.py -v
-pytest tests/unit/test_parakeet_endpoints.py -v
-pytest tests/unit/test_audiobuffer_guard.py -v
-pytest tests/unit/test_memory_leak_buffers.py -v
-pytest tests/unit/test_mcp_search_memories.py -v
-pytest tests/unit/test_mcp_search_conversations_poison.py -v
-pytest tests/unit/test_mcp_memory_filters.py -v
-pytest tests/unit/test_mcp_client_tool_result.py -v
-pytest tests/unit/test_mcp_data_endpoints.py -v
-pytest tests/unit/test_mcp_api_key_full_access.py -v
-pytest tests/unit/test_mcp_oauth.py -v
-pytest tests/unit/test_mcp_action_item_writes.py -v
-pytest tests/unit/test_mcp_conversations_poison.py -v
-pytest tests/unit/test_mcp_profile_contact.py -v
-pytest tests/unit/test_memory_temporal_brain.py -v
-pytest tests/unit/test_memory_category_auto.py -v
-pytest tests/unit/test_memories_validation.py -v
-pytest tests/unit/test_memory_domain.py -v
-pytest tests/unit/test_memory_system_cohort.py -v
-pytest tests/unit/test_canonical_memory_vectors.py -v
-pytest tests/unit/test_no_module_level_sys_modules_stub.py -v
-pytest tests/unit/test_ws_k_layer_field.py -v
-pytest tests/unit/test_memory_service_parity.py -v
-pytest tests/unit/test_ws_i_write_convergence.py -v
-pytest tests/unit/test_ws_i_hardening.py -v
-pytest tests/unit/test_ws_b_short_term_lifecycle.py -v
-pytest tests/unit/test_canonical_consolidation.py -v
-pytest tests/unit/test_canonical_consolidation_apply.py -v
-pytest tests/unit/test_canonical_kg_promotion.py -v
-pytest tests/unit/test_canonical_extraction_subject_wiring.py -v
-pytest tests/unit/test_review_queue_cascade_purge.py -v
-pytest tests/unit/test_canonical_maintenance_ordering.py -v
-pytest tests/unit/test_canonical_short_term_maintenance_cron.py -v
-pytest tests/unit/test_ws_c_backfill.py -v
-pytest tests/unit/test_ws_j_delete_privacy.py -v
-pytest tests/unit/test_ws_l_surface_routing.py -v
-pytest tests/unit/test_ws_g_module_aliases.py -v
-pytest tests/unit/test_ws_m_atom_keyword_index.py -v
-pytest tests/unit/test_ws_n_graph_traversal.py -v
-pytest tests/unit/test_upstream_boundary.py -v
-pytest tests/unit/test_memories_user_review.py -v
-pytest tests/unit/test_announcement_malformed_type.py -v
-pytest tests/unit/test_short_term_lifecycle.py -v
-pytest tests/unit/test_product_memory_items.py -v
-pytest tests/unit/test_product_memory_read_service.py -v
-pytest tests/unit/test_default_read_rollout_decision.py -v
-pytest tests/unit/test_rollout_schema_readiness.py -v
-pytest tests/unit/test_chat_memory_adapter.py -v
-pytest tests/unit/test_chat_memory_tool_caller.py -v
-pytest tests/unit/test_tools_agent_route_response_shape.py -v
-pytest tests/unit/test_tools_rest_memory_runtime_adapter.py -v
-pytest tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py -v
-pytest tests/unit/test_developer_memory_adapter.py -v
-pytest tests/unit/test_mcp_memory_adapter.py -v
-pytest tests/unit/test_product_memory_router.py -v
-pytest tests/unit/test_product_authorization.py -v
-pytest tests/unit/test_memory_app_key_grants.py -v
-pytest tests/unit/test_app_key_memory_grant_assignment_readiness.py -v
-pytest tests/unit/test_developer_auth_context_static.py -v
-pytest tests/unit/test_mcp_auth_context_static.py -v
-pytest tests/unit/test_mcp_api_key_auth_context.py -v
-pytest tests/unit/test_mcp_api_key_scope_readiness.py -v
-pytest tests/unit/test_short_term_lifecycle_worker.py -v
-pytest tests/unit/test_short_term_lifecycle_firestore_store.py -v
-pytest tests/unit/test_memory_contracts.py -v
-pytest tests/unit/test_working_observations_extractor.py -v
-pytest tests/unit/test_durable_memory_patches.py -v
-pytest tests/unit/test_patch_adapter.py -v
-pytest tests/unit/test_memory_read_api.py -v
-pytest tests/unit/test_projections.py -v
-pytest tests/unit/test_vector_metadata.py -v
-pytest tests/unit/test_vector_filters.py -v
-pytest tests/unit/test_vector_search_service.py -v
-pytest tests/unit/test_vector_repair_outbox_worker.py -v
-pytest tests/unit/test_vector_repair_outbox_infra.py -v
-pytest tests/unit/test_firestore_rules_iam_proof.py -v
-pytest tests/unit/test_pinecone_repair_validation_readiness.py -v
-pytest tests/unit/test_shared_ns2_legacy_isolation_readiness.py -v
-pytest tests/unit/test_vector_search_provider_readiness.py -v
-# /v3 router behavioral probes (replaces readiness gate framework).
-pytest tests/unit/test_v3_fastapi_route_contract.py -v
-pytest tests/unit/test_v3_get_dependency_auth.py -v
-pytest tests/unit/test_v3_real_router_dependency_map.py -v
-pytest tests/unit/test_v3_real_router_get_testclient.py -v
-pytest tests/unit/test_v3_real_router_fail_closed_matrix.py -v
-pytest tests/unit/test_v3_route_signature_integration.py -v
-pytest tests/unit/test_v3_canary_approval_production_read.py -v
-pytest tests/unit/test_v3_cursor_secret_production_read.py -v
-pytest tests/unit/test_v3_projection_write_convergence_read.py -v
-pytest tests/unit/test_v3_runtime_config_source_read.py -v
-pytest tests/unit/test_v3_compatibility.py -v
-pytest tests/unit/test_v3_cursor.py -v
-pytest tests/unit/test_v3_projection_readiness.py -v
-pytest tests/unit/test_v3_memory_read_service.py -v
-pytest tests/unit/test_v3_write_convergence.py -v
-pytest tests/unit/test_v3_response_adapter.py -v
-pytest tests/unit/test_v3_request_adapter.py -v
-pytest tests/unit/test_v3_route_planner.py -v
-pytest tests/unit/test_v3_get_dependency_seam.py -v
-pytest tests/unit/test_v3_archive_visibility_readiness.py -v
-pytest tests/unit/test_v3_local_telemetry.py -v
-# memory /v3 canary approval schema + fake-injectable reader readiness seam.
-pytest tests/unit/test_v3_canary_approval_artifact.py -v
-pytest tests/unit/test_v3_control_reader_contract.py -v
-pytest tests/unit/test_v3_control_state_adapter.py -v
-pytest tests/unit/test_v3_account_generation_source.py -v
-pytest tests/unit/test_v3_compatibility_projection.py -v
-pytest tests/unit/test_v3_production_runtime_wiring.py -v
-pytest tests/unit/test_v3_limited_rollout_config.py -v
-pytest tests/unit/test_v3_f5_real_service_evidence_readiness.py -v
-pytest tests/unit/test_v3_gcp_evidence_config.py -v
-pytest tests/unit/test_v3_gcp_evidence_run_record.py -v
-pytest tests/unit/test_v3_gcp_evidence_redaction.py -v
-pytest tests/unit/test_v3_f6_readonly_contracts.py -v
-pytest tests/unit/test_v3_f6_pre_gcp_aggregate.py -v
-pytest tests/unit/test_v3_dev_cloud_readiness.py -v
-pytest tests/unit/test_cutover_evidence_readiness.py -v
-pytest tests/unit/test_firestore_indexes.py -v
-pytest tests/unit/test_firestore_index_config.py -v
-pytest tests/unit/test_normative_foundations.py -v
-pytest tests/unit/test_typed_synthesis.py -v
-pytest tests/unit/test_memory_operations.py -v
-pytest tests/unit/test_atomic_apply.py -v
-pytest tests/unit/test_memory_search_gateway.py -v
-pytest tests/unit/test_memory_apply_store.py -v
-pytest tests/unit/test_firestore_security_rules.py -v
-pytest tests/unit/test_firestore_emulator_harness_wiring.py -v
-pytest tests/unit/test_firestore_iam_deployment_doc.py -v
-pytest tests/unit/test_non_active_routes.py -v
-pytest tests/unit/test_non_active_route_audit.py -v
-pytest tests/unit/test_non_active_route_report.py -v
-pytest tests/unit/test_non_active_route_admin_endpoint.py -v
-pytest tests/unit/test_review_queue_non_active_routes.py -v
-pytest tests/unit/test_l2_promotion_agent_v2.py -v
-pytest tests/unit/test_memory_tools.py -v
-pytest tests/unit/test_memory_ingestion_pipeline.py -v
-pytest tests/unit/test_working_memory_candidate_schema.py -v
-pytest tests/unit/test_llm_gateway_service.py -v
-pytest tests/unit/test_llm_gateway_config.py -v
-pytest tests/unit/test_llm_gateway_auth.py -v
-pytest tests/unit/test_llm_gateway_credentials.py -v
-pytest tests/unit/test_llm_gateway_validator.py -v
-pytest tests/unit/test_llm_gateway_resolver.py -v
-pytest tests/unit/test_llm_gateway_executor.py -v
-pytest tests/unit/test_llm_gateway_openai_provider.py -v
-pytest tests/unit/test_llm_gateway_openai_compatible.py -v
-pytest tests/unit/test_llm_gateway_readiness.py -v
-pytest tests/unit/test_llm_gateway_client_config.py -v
-pytest tests/unit/test_llm_gateway_route_refs.py -v
-pytest tests/unit/test_llm_gateway_dependencies.py -v
-pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -v
-pytest tests/unit/test_backend_runtime_env_validator.py -v
-pytest tests/unit/test_google_credentials.py -v
-pytest tests/unit/test_llm_usage_tracker.py -v
-pytest tests/unit/test_llm_provider_plugin_structure.py -v
-pytest tests/unit/test_process_conversation_usage_context.py -v
-pytest tests/unit/test_high_priority_usage_tracking.py -v
-pytest tests/unit/test_new_usage_tracking_gaps.py -v
-pytest tests/unit/test_llm_usage_db.py -v
-pytest tests/unit/test_user_usage.py -v
-pytest tests/unit/test_llm_usage_endpoints.py -v
-pytest tests/unit/test_app_uid_keyerror.py -v
-pytest tests/unit/test_create_persona_user_none.py -v
-pytest tests/unit/test_daily_summary_race_condition.py -v
-pytest tests/unit/test_daily_summary_regenerate.py -v
-pytest tests/unit/test_chat_tools_messages.py -v
-pytest tests/unit/test_chat_tool_parameters_json.py -v
-pytest tests/unit/test_prompt_caching.py -v
-pytest tests/unit/test_mentor_notifications.py -v
-# Canonical memory system tests (added with the new 2-layer runtime).
-pytest tests/unit/test_claim_dedup.py -v
-pytest tests/unit/test_client_device_provenance.py -v
-pytest tests/unit/test_memory_ledger.py -v
-pytest tests/unit/test_memory_rollout.py -v
-pytest tests/unit/test_v3_composed_get_service.py -v
-pytest tests/unit/test_v3_get_runtime_snapshot.py -v
-pytest tests/unit/test_proactive_notification_language.py -v
-pytest tests/unit/test_notification_token_cleanup.py -v
-pytest tests/unit/test_integration_notification_validation.py -v
-pytest tests/unit/test_conversations_to_string.py -v
-pytest tests/unit/test_location_maps_status_guard.py -v
-pytest tests/unit/test_conversation_render_factory.py -v
-pytest tests/unit/test_conversation_redact_enrich.py -v
-pytest tests/unit/test_retrieval_semantics.py -v
-pytest tests/unit/test_folder_name_enrichment.py -v
-pytest tests/unit/test_folder_conversations_malformed.py -v
-pytest tests/unit/test_conversations_count.py -v
-pytest tests/unit/test_calendar_autolink_invalid_timestamp.py -v
-pytest tests/unit/test_prompt_cache_optimization.py -v
-pytest tests/unit/test_prompt_cache_integration.py -v
-pytest tests/unit/test_firestore_cache.py -v
-pytest tests/unit/test_firestore_invariant_helpers.py -v
-pytest tests/unit/test_task_sharing.py -v
-pytest tests/unit/test_action_items_conversation_list_malformed.py -v
-pytest tests/unit/test_firmware_pagination.py -v
-pytest tests/unit/test_vad_gate.py -v
-pytest tests/unit/test_vad_onnx.py -v
-pytest tests/unit/test_log_sanitizer.py -v
-pytest tests/unit/test_hume_callback_malformed.py -v
-pytest tests/unit/test_file_upload_security.py -v
-pytest tests/unit/test_file_upload_endpoint_security.py -v
-pytest tests/unit/test_auth_redirect_uri.py -v
-pytest tests/unit/test_pusher_heartbeat.py -v
-pytest tests/unit/test_pusher_conversation_retry.py -v
-pytest tests/unit/utils/test_listen_pusher_session.py -v
-pytest tests/unit/test_listen_fallback_removal.py -v
-pytest tests/unit/test_desktop_updates.py -v
-pytest tests/unit/test_translation_optimization.py -v
-pytest tests/unit/test_translation_cost_optimization.py -v
-pytest tests/unit/test_translation_dedup_edge_cases.py -v
-pytest tests/unit/test_conversation_source_unknown.py -v
-pytest tests/unit/test_conversation_model_split.py -v
-pytest tests/unit/test_transcribe_conversation_cache.py -v
-pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
-pytest tests/unit/test_pusher_batch_upload.py -v
-pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
-pytest tests/unit/test_optional_audio_codecs.py -v
-pytest tests/unit/test_storage_opus_encoding.py -v
-pytest tests/unit/test_speech_profile_existence.py -v
-pytest tests/unit/test_speech_profile_wav_decode.py -v
-pytest tests/unit/test_storage_fanout_limits.py -v
-pytest tests/unit/test_deferred_blob_janitor.py -v
-pytest tests/unit/test_audio_merge_tasks.py -v
-pytest tests/unit/test_sync_playback_service.py -v
-pytest tests/unit/test_people_conversations_500s.py -v
-pytest tests/unit/test_import_jobs_malformed.py -v
-pytest tests/unit/test_firestore_read_ops_cache.py -v
-pytest tests/unit/test_ws_auth_handshake.py -v
-pytest tests/unit/test_streaming_deepgram_backoff.py -v
-pytest tests/unit/test_executors.py -v
-pytest tests/unit/test_modulate_stt.py -v
-pytest tests/unit/test_batch_upload_storage.py -v
-pytest tests/unit/test_action_item_date_validation.py -v
-pytest tests/unit/test_request_validation_contracts.py -v
-pytest tests/unit/test_conversation_structure_timezone.py -v
-pytest tests/unit/test_action_item_dedup.py -v
-pytest tests/unit/test_action_item_reminder_cancel_on_complete.py -v
-pytest tests/unit/test_action_item_idempotency.py -v
-pytest tests/unit/test_goals_id_fallback.py -v
-pytest tests/unit/test_tools_router.py -v
-pytest tests/unit/test_kg_user_type_mismatch.py -v
-pytest tests/unit/test_kg_edge_id_sanitization.py -v
-pytest tests/unit/test_kg_prune_memory_citations.py -v
-pytest tests/unit/test_goal_extraction_batch.py -v
-pytest tests/unit/test_listen_pipeline.py -v
-pytest tests/unit/test_resample_pcm_divzero.py -v
-pytest tests/unit/test_fair_use_models.py -v
-pytest tests/unit/test_fair_use_flagged_limit_clamp.py -v
-pytest tests/unit/test_fair_use_engine.py -v
-pytest tests/unit/test_fair_use_classifier.py -v
-pytest tests/unit/test_fair_use_async.py -v
-pytest tests/unit/test_dg_usage_batch.py -v
-pytest tests/unit/test_billable_transcription_seconds.py -v
-pytest tests/unit/test_sync_fair_use_gate.py -v
-pytest tests/unit/test_sync_pcm_decode.py -v
-pytest tests/unit/test_sync_opus_decode.py -v
-pytest tests/unit/test_transcribe_lc3_optional.py -v
-pytest tests/unit/test_sync_silent_failure.py -v
-pytest tests/unit/test_sync_ordered_assignment.py -v
-pytest tests/unit/test_fair_use_free_tier.py -v
-pytest tests/unit/test_fair_use_upgrade.py -v
-pytest tests/unit/test_skip_classifier_restrict.py -v
-pytest tests/unit/test_timeout_middleware.py -v
-pytest tests/unit/test_pusher_circuit_breaker.py -v
-pytest tests/unit/test_pusher_ghost_connections.py -v
-pytest tests/unit/test_async_tasks.py -v
-pytest tests/unit/test_async_resource_correctness.py -v
-pytest tests/unit/test_lock_bypass_fixes.py -v
-pytest tests/unit/test_integration_malformed_records.py -v
-pytest tests/unit/test_oauth_callback_uid_guard.py -v
-pytest tests/unit/test_dev_api_lock_bypass.py -v
-pytest tests/unit/test_dev_api_folder_filters.py -v
-pytest tests/unit/test_dev_api_conversations_poison.py -v
-pytest tests/unit/test_dev_api_memories_pagination.py -v
-pytest tests/unit/test_env_loader.py -v
-pytest tests/unit/test_dev_api_action_items_poison.py -v
-pytest tests/unit/test_rate_limiting.py -v
-pytest tests/unit/test_rate_limit_json_failopen.py -v
-pytest tests/unit/test_memories_batch.py -v
-pytest tests/unit/test_memories_create.py -v
-pytest tests/unit/test_memories_pagination_clamp.py -v
-pytest tests/unit/test_sync_v2.py -v
-pytest tests/unit/test_sync_file_paths_filename_none.py -v
-pytest tests/unit/test_sync_cloud_tasks.py -v
-pytest tests/unit/test_sync_transcription_prefs.py -v
-pytest tests/unit/test_sync_record_usage.py -v
-pytest tests/unit/test_vision_stream_async.py -v
-pytest tests/unit/test_desktop_transcribe.py -v
-pytest tests/unit/test_desktop_migration.py -v
-pytest tests/unit/test_staged_tasks_batch_scores.py -v
-pytest tests/unit/test_staged_tasks_dedup.py -v
-pytest tests/unit/test_dg_start_guard.py -v
-pytest tests/unit/test_available_plans_resilience.py -v
-pytest tests/unit/test_subscription_restructure.py -v
-pytest tests/unit/test_chat_quota.py -v
-pytest tests/unit/test_voice_message_filename_none.py -v
-pytest tests/unit/test_subscription_plans.py -v
-pytest tests/unit/test_payment_available_plans_source.py -v
-pytest tests/unit/test_payment_promotion_codes.py -v
-pytest tests/unit/test_stripe_webhook_none_guard.py -v
-pytest tests/unit/test_stripe_webhook_behavioral.py -v
-pytest tests/unit/test_voice_duration_limiter.py -v
-pytest tests/unit/test_async_webhooks.py -v
-pytest tests/unit/test_async_app_integrations.py -v
-pytest tests/unit/test_async_realtime_integrations_offload.py -v
-pytest tests/unit/test_async_geocoding.py -v
-pytest tests/unit/test_geocoding_cache.py -v
-pytest tests/unit/test_realtime_integrations_usage_tracking.py -v
-pytest tests/unit/test_async_auth.py -v
-pytest tests/unit/test_thread_join_elimination.py -v
-pytest tests/unit/test_async_http_infrastructure.py -v
-pytest tests/unit/test_clean_sweep_migrations.py -v
-pytest tests/unit/test_omi_qos_tiers.py -v
-pytest tests/unit/test_byok_security.py -v
-pytest tests/unit/test_paywall_reconnect_gate.py -v
-pytest tests/unit/test_trial_metadata.py -v
-pytest tests/unit/test_neo_desktop_grandfather.py -v
-pytest tests/unit/test_vertex_ai_system_role.py -v
-pytest tests/unit/test_tts.py -v
-pytest tests/unit/test_webhook_auto_disable.py -v
-pytest tests/unit/test_merge_validation.py -v
-pytest tests/unit/test_phone_calls.py -v
-pytest tests/unit/test_twilio_service.py -v
-pytest tests/unit/test_twilio_account_deletion.py -v
-pytest tests/unit/test_phone_verification_created_at.py -v
-pytest tests/unit/test_conversation_search_date_validation.py -v
-pytest tests/unit/test_conversation_events_bounds.py -v
-pytest tests/unit/test_conversation_hybrid_search.py -v
-pytest tests/unit/test_delete_account_stripe_cancel.py -v
-pytest tests/unit/test_delete_account_purge_storage.py -v
-pytest tests/unit/test_claim_deletion_wipe_txn.py -v
-pytest tests/services/users/test_account_deletion.py -v
-pytest tests/services/users/test_data_export.py -v
-pytest tests/routers/test_users.py -v
-pytest tests/unit/test_apps_review_reply_validation.py -v
-pytest tests/unit/test_apps_create_app_json.py -v
-
-# Fair-use integration tests (require Redis; skip gracefully if unavailable)
-if redis-cli ping >/dev/null 2>&1; then
-  pytest tests/integration/test_fair_use_live.py -v
-  pytest tests/integration/test_fair_use_api.py -v
-else
-  echo "SKIP: fair-use integration tests (Redis not available)"
-fi
+selected_tests=()
+selected_tests_file="$(mktemp "${TMPDIR:-/tmp}/backend-unit-tests.XXXXXX")"
+trap 'rm -f "$selected_tests_file"' EXIT
+"$PYTHON_BIN" scripts/select_backend_unit_tests.py --all > "$selected_tests_file"
+while IFS= read -r test_path; do
+  [[ -n "$test_path" ]] && selected_tests+=("$test_path")
+done < "$selected_tests_file"
+echo "Running ${#selected_tests[@]} backend unit test file(s)."
+run_test_files "${selected_tests[@]}"

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,0 +1,33 @@
+# Backend Tests
+
+## Unit Tests
+
+`bash test.sh` is the CI source of truth for backend unit tests. It gets its file list from
+`scripts/select_backend_unit_tests.py --all`, which covers:
+
+- `tests/unit/test_*.py`
+- `tests/services/**/test_*.py`
+- `tests/routers/**/test_*.py`
+- top-level `tests/test_*.py` files that are still part of the unit suite
+
+For changed-file runs, use:
+
+```bash
+python scripts/select_backend_unit_tests.py --changed-files /tmp/changed-files --output /tmp/backend-tests
+BACKEND_UNIT_TEST_FILE_LIST=/tmp/backend-tests bash test.sh
+```
+
+`BACKEND_PYTEST_TIMING_SUMMARY=1` is enabled by default for multi-file unit pytest sessions and prints the top
+slow test files. `test.sh` currently runs one pytest process per file, so it stays quiet there.
+
+Set `BACKEND_FAST_UNIT_MAX_SECONDS=<seconds>` to fail unit test files whose pytest runtime exceeds the limit.
+Intentional exceptions must be listed in `tests/fast_unit_duration_allowlist.txt`.
+
+## Integration Tests
+
+Integration tests live under `tests/integration/` and are not run by `bash test.sh`. They may require Redis,
+Firebase credentials, API keys, or live external services. Run them explicitly with pytest after reading
+`tests/integration/README.md`.
+
+Use `bash test-preflight.sh` before test runs. It validates dependencies and verifies that the selected Python
+interpreter matches `.python-version`.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,10 @@
 """Shared pytest hooks for the whole backend test tree."""
 
+from collections import defaultdict
 import os
 import sys
 from pathlib import Path
+import time
 from types import ModuleType
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
@@ -32,16 +34,122 @@ if 'tiktoken' not in sys.modules:
 from testing.hermetic_network import block_outbound_network
 
 _network_guard = None
+_test_file_durations = defaultdict(float)
+_collected_unit_files = set()
+
+_UNIT_TEST_ROOTS = (
+    BACKEND_DIR / 'tests' / 'unit',
+    BACKEND_DIR / 'tests' / 'services',
+    BACKEND_DIR / 'tests' / 'routers',
+)
+_FAST_UNIT_ALLOWLIST = BACKEND_DIR / 'tests' / 'fast_unit_duration_allowlist.txt'
+
+
+def _env_enabled(name, default='1'):
+    return os.environ.get(name, default).lower() not in {'0', 'false', 'no', 'off'}
+
+
+def _backend_relative(path):
+    try:
+        return Path(path).resolve().relative_to(BACKEND_DIR).as_posix()
+    except ValueError:
+        return None
+
+
+def _is_unit_test_path(path):
+    resolved = Path(path).resolve()
+    return any(resolved.is_relative_to(root) for root in _UNIT_TEST_ROOTS)
+
+
+def _read_duration_allowlist():
+    if not _FAST_UNIT_ALLOWLIST.exists():
+        return set()
+    entries = set()
+    for line in _FAST_UNIT_ALLOWLIST.read_text().splitlines():
+        entry = line.split('#', 1)[0].strip()
+        if entry:
+            entries.add(entry.removeprefix('backend/'))
+    return entries
 
 
 def pytest_sessionstart(session):
     global _network_guard
     _network_guard = block_outbound_network()
     _network_guard.__enter__()
+    session.config._backend_test_start_time = time.perf_counter()
+
+
+def pytest_collection_finish(session):
+    _collected_unit_files.clear()
+    for item in session.items:
+        if _is_unit_test_path(item.path):
+            test_file = _backend_relative(item.path)
+            if test_file is not None:
+                _collected_unit_files.add(test_file)
+
+
+def pytest_runtest_logreport(report):
+    if report.when not in {'setup', 'call', 'teardown'}:
+        return
+    test_file = _backend_relative(report.fspath)
+    if test_file is not None and test_file in _collected_unit_files:
+        _test_file_durations[test_file] += report.duration
 
 
 def pytest_sessionfinish(session, exitstatus):
     global _network_guard
+    _enforce_fast_unit_duration_guard(session)
     if _network_guard is not None:
         _network_guard.__exit__(None, None, None)
         _network_guard = None
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not _env_enabled('BACKEND_PYTEST_TIMING_SUMMARY'):
+        return
+    if len(_collected_unit_files) <= 1:
+        return
+    if not _test_file_durations:
+        return
+
+    limit = int(os.environ.get('BACKEND_PYTEST_SLOW_FILE_LIMIT', '10'))
+    terminalreporter.section('Backend unit test file durations')
+    slow_files = sorted(_test_file_durations.items(), key=lambda item: item[1], reverse=True)[:limit]
+    for test_file, seconds in slow_files:
+        terminalreporter.line(f'{seconds:7.2f}s  {test_file}')
+
+    session_start = getattr(config, '_backend_test_start_time', None)
+    if session_start is not None:
+        terminalreporter.line(f'{time.perf_counter() - session_start:7.2f}s  total pytest session wall time')
+
+
+def _enforce_fast_unit_duration_guard(session):
+    raw_limit = os.environ.get('BACKEND_FAST_UNIT_MAX_SECONDS')
+    if not raw_limit or not _collected_unit_files:
+        return
+    try:
+        limit = float(raw_limit)
+    except ValueError:
+        terminalreporter = session.config.pluginmanager.get_plugin('terminalreporter')
+        if terminalreporter is not None:
+            terminalreporter.section('Backend fast unit duration guard failures')
+            terminalreporter.line(f'Invalid BACKEND_FAST_UNIT_MAX_SECONDS value: {raw_limit}')
+        session.exitstatus = 1
+        return
+
+    allowlist = _read_duration_allowlist()
+    offenders = [
+        (test_file, seconds)
+        for test_file, seconds in sorted(_test_file_durations.items(), key=lambda item: item[1], reverse=True)
+        if seconds > limit and test_file not in allowlist
+    ]
+    if not offenders:
+        return
+
+    terminalreporter = session.config.pluginmanager.get_plugin('terminalreporter')
+    if terminalreporter is not None:
+        terminalreporter.section('Backend fast unit duration guard failures')
+        for test_file, seconds in offenders:
+            terminalreporter.line(f'{seconds:7.2f}s > {limit:.2f}s  {test_file}')
+        terminalreporter.line(f'Allow intentional exceptions in {_FAST_UNIT_ALLOWLIST.relative_to(BACKEND_DIR)}.')
+    session.exitstatus = 1

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -1,0 +1,2 @@
+# Backend-relative unit test files that may exceed BACKEND_FAST_UNIT_MAX_SECONDS.
+# Keep this list small and add a reason beside each entry.

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -52,6 +52,11 @@ sys.modules["utils.notifications"].send_notification = MagicMock()
 from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook, day_summary_webhook
 
 
+@pytest.fixture(autouse=True)
+def _disable_webhook_retry_sleeps(monkeypatch):
+    monkeypatch.setenv("DEV_WEBHOOK_RETRY_DELAYS", "")
+
+
 class TestRealtimeTranscriptWebhook:
     """Test realtime_transcript_webhook uses httpx async."""
 

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -881,6 +881,7 @@ class _FakeParakeetWebSocket:
         if data == 'finalize':
             await self._messages.put(json.dumps({'text': 'hello', 'speaker': 'SPEAKER_00', 'start': 0, 'end': 1}))
             await self._messages.put(None)
+            await self._messages.put(None)
 
     async def close(self):
         await self._messages.put(None)
@@ -914,15 +915,16 @@ class TestProcessAudioParakeet(unittest.TestCase):
                     ws, enter_started, allow_enter
                 )
 
-                socket_task = asyncio.create_task(process_audio_parakeet(segments.extend, 'en', 16000, 1))
-                await asyncio.wait_for(enter_started.wait(), timeout=1)
-                await asyncio.sleep(0)
-                self.assertFalse(socket_task.done())
+                with patch('utils.stt.streaming.asyncio.sleep', AsyncMock()):
+                    socket_task = asyncio.create_task(process_audio_parakeet(segments.extend, 'en', 16000, 1))
+                    await asyncio.wait_for(enter_started.wait(), timeout=1)
+                    await asyncio.sleep(0)
+                    self.assertFalse(socket_task.done())
 
-                allow_enter.set()
-                sock = await asyncio.wait_for(socket_task, timeout=1)
-                sock.send(b'pcm')
-                await sock.drain_and_close()
+                    allow_enter.set()
+                    sock = await asyncio.wait_for(socket_task, timeout=1)
+                    sock.send(b'pcm')
+                    await sock.drain_and_close()
 
                 self.assertEqual(ws.sent, [b'pcm', 'finalize'])
                 self.assertEqual(segments, [{'text': 'hello', 'speaker': 'SPEAKER_00', 'start': 0, 'end': 1}])

--- a/backend/tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py
+++ b/backend/tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py
@@ -121,7 +121,13 @@ def test_tools_fastapi_testclient_readiness_pins_exact_dependency_and_install_bl
 def test_tools_fastapi_testclient_readiness_registered_and_documented():
     test_sh = TEST_SH.read_text()
     evidence_markers_doc = EVIDENCE_MARKERS_DOC.read_text()
+    selected_tests = subprocess.check_output(
+        [sys.executable, str(REPO_ROOT / 'backend' / 'scripts' / 'select_backend_unit_tests.py'), '--all'],
+        text=True,
+        cwd=REPO_ROOT / 'backend',
+    ).splitlines()
 
-    assert 'test_p1_5_tools_fastapi_testclient_readiness.py' in test_sh
+    assert 'scripts/select_backend_unit_tests.py --all' in test_sh
+    assert 'tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py' in selected_tests
     assert 'p1_5_tools_fastapi_testclient_readiness.py' in evidence_markers_doc
     assert 'FastAPI `TestClient` production-dependency proof remains BLOCKED/NOT_RUN' in evidence_markers_doc

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -205,11 +205,8 @@ class TestGPUWorkerQueueFull:
         worker = GPUWorker()
         worker._running = True
         worker._ready.set()
-        for _ in range(512):
-            try:
-                worker._queue.put_nowait(WorkItem(WorkType.BATCH_TRANSCRIBE, {}))
-            except queue.Full:
-                break
+        worker._queue = MagicMock()
+        worker._queue.put.side_effect = queue.Full
 
         with pytest.raises(RuntimeError, match="GPU queue full"):
             worker.submit_sync({"audio_paths": ["/tmp/a.wav"]}, timeout=0.1)

--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -16,6 +16,7 @@ import time
 import pytest
 from starlette.testclient import TestClient
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
@@ -29,7 +30,7 @@ def _make_app(methods_timeout=None):
         return PlainTextResponse("ok")
 
     async def slow_endpoint(request):
-        await asyncio.sleep(10)
+        await asyncio.Event().wait()
         return PlainTextResponse("slow")
 
     app = Starlette(
@@ -40,6 +41,26 @@ def _make_app(methods_timeout=None):
     )
     app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout or {})
     return app
+
+
+def _make_request(method: str = "GET", path: str = "/slow") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "query_string": b"",
+        }
+    )
+
+
+async def _never_returns(request):
+    await asyncio.Event().wait()
+    return PlainTextResponse("slow")
 
 
 def test_fresh_request_passes():
@@ -176,50 +197,30 @@ def test_zero_skew_allowance_original_behavior(monkeypatch):
     assert response.status_code == 408
 
 
-def test_timeout_returns_504():
+@pytest.mark.asyncio
+async def test_timeout_returns_504():
     """Request exceeding timeout returns 504."""
-    app = _make_app(methods_timeout={"GET": 0.1})
-    client = TestClient(app)
-    response = client.get("/slow")
+    middleware = TimeoutMiddleware(Starlette(), methods_timeout={"GET": 0.001})
+    response = await middleware.dispatch(_make_request(), _never_returns)
     assert response.status_code == 504
 
 
-def test_post_timeout_override():
+@pytest.mark.asyncio
+async def test_post_timeout_override():
     """POST requests use HTTP_POST_TIMEOUT when set (#5941)."""
-
-    async def slow_post(request):
-        await asyncio.sleep(10)
-        return PlainTextResponse("slow post")
-
-    app = Starlette(
-        routes=[
-            Route("/upload", slow_post, methods=["POST"]),
-        ],
-    )
-    app.add_middleware(TimeoutMiddleware, methods_timeout={"POST": 0.1})
-    client = TestClient(app)
-    response = client.post("/upload")
+    middleware = TimeoutMiddleware(Starlette(), methods_timeout={"POST": 0.001})
+    response = await middleware.dispatch(_make_request(method="POST", path="/upload"), _never_returns)
     assert response.status_code == 504
 
 
-def test_post_timeout_none_falls_back_to_default(monkeypatch):
+@pytest.mark.asyncio
+async def test_post_timeout_none_falls_back_to_default(monkeypatch):
     """POST with None timeout falls back to HTTP_DEFAULT_TIMEOUT (#5941)."""
-    monkeypatch.setenv("HTTP_DEFAULT_TIMEOUT", "0.1")
-
-    async def slow_post(request):
-        await asyncio.sleep(10)
-        return PlainTextResponse("slow post")
-
-    app = Starlette(
-        routes=[
-            Route("/upload", slow_post, methods=["POST"]),
-        ],
-    )
+    monkeypatch.setenv("HTTP_DEFAULT_TIMEOUT", "0.001")
     # POST: None mirrors main.py when HTTP_POST_TIMEOUT env var is unset.
-    # _parse_methods_timeout skips None → falls back to default (0.1s)
-    app.add_middleware(TimeoutMiddleware, methods_timeout={"POST": None})
-    client = TestClient(app)
-    response = client.post("/upload")
+    # _parse_methods_timeout skips None and falls back to HTTP_DEFAULT_TIMEOUT.
+    middleware = TimeoutMiddleware(Starlette(), methods_timeout={"POST": None})
+    response = await middleware.dispatch(_make_request(method="POST", path="/upload"), _never_returns)
     assert response.status_code == 504
 
 

--- a/backend/tests/unit/test_v3_f5_real_service_evidence_readiness.py
+++ b/backend/tests/unit/test_v3_f5_real_service_evidence_readiness.py
@@ -1,4 +1,6 @@
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -226,7 +228,14 @@ def test_f4_risk_confirmations_are_required_before_any_real_read():
 
 def test_docs_test_runner_and_parent_readiness_link_f5_preparation():
     root = ROOT.parent
-    assert "test_v3_f5_real_service_evidence_readiness.py" in (ROOT / "test.sh").read_text(encoding="utf-8")
+    test_sh = (ROOT / "test.sh").read_text(encoding="utf-8")
+    selected_tests = subprocess.check_output(
+        [sys.executable, str(ROOT / "scripts" / "select_backend_unit_tests.py"), "--all"],
+        text=True,
+        cwd=ROOT,
+    ).splitlines()
+    assert "scripts/select_backend_unit_tests.py --all" in test_sh
+    assert "tests/unit/test_v3_f5_real_service_evidence_readiness.py" in selected_tests
     f5_script = (ROOT / "scripts" / "v3_f5_real_service_evidence_readiness.py").read_text(encoding="utf-8")
     f5_utils = (ROOT / "testing" / "memory" / "v3_f5_evidence.py").read_text(encoding="utf-8")
     assert "memory-V3-F5 real-service read-only evidence preparation" in f5_script

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -11,9 +11,8 @@ Covers:
 import os
 import struct
 import tempfile
-import time
 from fractions import Fraction
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -116,70 +115,57 @@ class TestWAVDurationReader:
     def test_valid_wav_120s(self):
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        path = _make_wav(120.0)
-        try:
-            duration = read_wav_duration_ms(path)
-            assert duration is not None
-            assert abs(duration - 120000) <= 1
-        finally:
-            os.unlink(path)
+        mock_container = MagicMock()
+        mock_container.duration = 120 * 1_000_000
+        mock_container.streams.audio = [MagicMock()]
+        mock_container.__enter__ = MagicMock(return_value=mock_container)
+        mock_container.__exit__ = MagicMock(return_value=False)
+
+        with patch('utils.voice_duration_limiter.av.open', return_value=mock_container):
+            duration = read_wav_duration_ms('/tmp/fake.wav')
+
+        assert duration is not None
+        assert abs(duration - 120000) <= 1
 
     def test_stereo_48khz(self):
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        path = _make_wav(5.0, sample_rate=48000, channels=2)
-        try:
-            duration = read_wav_duration_ms(path)
-            assert duration is not None
-            assert abs(duration - 5000) <= 1
-        finally:
-            os.unlink(path)
+        mock_container = MagicMock()
+        mock_container.duration = 5 * 1_000_000
+        mock_container.streams.audio = [MagicMock()]
+        mock_container.__enter__ = MagicMock(return_value=mock_container)
+        mock_container.__exit__ = MagicMock(return_value=False)
+
+        with patch('utils.voice_duration_limiter.av.open', return_value=mock_container):
+            duration = read_wav_duration_ms('/tmp/fake.wav')
+
+        assert duration is not None
+        assert abs(duration - 5000) <= 1
 
     def test_invalid_file_returns_none(self):
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        fd, path = tempfile.mkstemp()
-        with os.fdopen(fd, 'wb') as f:
-            f.write(b'not a wav file')
-        try:
-            assert read_wav_duration_ms(path) is None
-        finally:
-            os.unlink(path)
+        with patch('utils.voice_duration_limiter.av.open', side_effect=ValueError('invalid audio')):
+            assert read_wav_duration_ms('/tmp/invalid.wav') is None
 
     def test_nonexistent_file_returns_none(self):
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        assert read_wav_duration_ms('/tmp/nonexistent_wav_12345.wav') is None
+        with patch('utils.voice_duration_limiter.av.open', side_effect=FileNotFoundError('missing audio')):
+            assert read_wav_duration_ms('/tmp/nonexistent_wav_12345.wav') is None
 
     def test_empty_file_returns_none(self):
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        try:
-            assert read_wav_duration_ms(path) is None
-        finally:
-            os.unlink(path)
+        with patch('utils.voice_duration_limiter.av.open', side_effect=ValueError('empty audio')):
+            assert read_wav_duration_ms('/tmp/empty.wav') is None
 
     def test_corrupted_wav_returns_none(self):
         """Truncated/corrupted WAV should return None (av raises, we catch)."""
         from utils.voice_duration_limiter import read_wav_duration_ms
 
-        buf = bytearray()
-        buf.extend(b'RIFF')
-        buf.extend(struct.pack('<I', 26))
-        buf.extend(b'WAVE')
-        buf.extend(b'fmt ')
-        buf.extend(struct.pack('<I', 10))  # truncated fmt
-        buf.extend(b'\x00' * 10)
-
-        fd, path = tempfile.mkstemp(suffix='.wav')
-        with os.fdopen(fd, 'wb') as f:
-            f.write(buf)
-        try:
-            assert read_wav_duration_ms(path) is None
-        finally:
-            os.unlink(path)
+        with patch('utils.voice_duration_limiter.av.open', side_effect=ValueError('corrupted audio')):
+            assert read_wav_duration_ms('/tmp/corrupted.wav') is None
 
     def test_container_duration_none_falls_back_to_stream(self):
         """When container.duration is None, fall back to stream.duration * stream.time_base."""

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -295,7 +295,7 @@ check_backend_unit_tests_if_needed() {
   (
     cd backend
     bash test-preflight.sh
-    BACKEND_UNIT_TEST_FILE_LIST="$SELECTED_BACKEND_TESTS" bash test.sh
+    BACKEND_UNIT_TEST_FILE_LIST="$SELECTED_BACKEND_TESTS" BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=auto bash test.sh
   )
 }
 


### PR DESCRIPTION
## Summary

- make `backend/test.sh` selector-driven and unit-only, with isolated per-file pytest processes and opt-in parallel execution for pre-push
- remove real sleeps / large decode work from slow unit tests so the backend unit lane is fast and deterministic
- add backend test docs, pytest markers, timing summaries, an opt-in fast-unit duration guard, and Python version validation in preflight

## Validation

- `PYTHON=.venv/bin/python bash test-preflight.sh` (17 passed, 8 optional warnings, 0 failed)
- `PYTHON=.venv/bin/python BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=8 ./test.sh` (full backend unit suite, 270 files, passed in 33s)
- pre-push hook with `PYTHON=.venv/bin/python` (full 270-file backend unit suite, async blocker scan, format checks, passed)
- `black --check --line-length 120 --skip-string-normalization ...`
- `bash -n backend/test.sh backend/test-preflight.sh scripts/pre-push && git diff --check`

Integration tests are intentionally not part of `backend/test.sh`; they remain explicit/manual or promotion-lane work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

