### PR TITLE
Add reusable LLM gateway observability

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -140,6 +140,10 @@ if "utils.llm.gateway_client" not in sys.modules:
     gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
     gateway_mod.record_chat_extraction_gateway_result = MagicMock()
 
+if "utils.llm.gateway_observability" not in sys.modules:
+    gateway_observability_mod = _stub_module("utils.llm.gateway_observability")
+    gateway_observability_mod.record_gateway_shadow_comparison = MagicMock()
+
 # Stub langchain
 langchain_core = _stub_package("langchain_core")
 langchain_tools = _stub_module("langchain_core.tools")

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -102,6 +102,9 @@ gateway_stub = _stub_module("utils.llm.gateway_client")
 gateway_stub.invoke_chat_structured_gateway = MagicMock(return_value=None)
 gateway_stub.record_chat_extraction_gateway_result = MagicMock()
 
+gateway_observability_stub = _stub_module("utils.llm.gateway_observability")
+gateway_observability_stub.record_gateway_shadow_comparison = MagicMock()
+
 conversation_folder_stub = _stub_module("utils.llm.conversation_folder")
 conversation_folder_stub.FolderAssignment = MagicMock()
 conversation_folder_stub.assign_conversation_to_folder = MagicMock(return_value=(None, 0.0, "test stub"))

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -41,7 +41,7 @@ clients_stub.parser = object()
 sys.modules.setdefault('utils.llm.clients', clients_stub)
 
 from utils import byok
-from utils.llm import chat, gateway_client
+from utils.llm import chat, gateway_client, gateway_observability
 from utils.llm import conversation_processing
 from models.conversation_enums import CategoryEnum
 from models.structured import Structured
@@ -161,7 +161,7 @@ def test_requires_context_byok_context_skips_gateway(monkeypatch):
     monkeypatch.setattr(
         chat, 'record_chat_extraction_gateway_result', gateway_client.record_chat_extraction_gateway_result
     )
-    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     monkeypatch.setattr(chat, 'get_llm', lambda feature: FakeLLM(chat.RequiresContext(value=True), existing_calls))
     monkeypatch.setattr(
         chat,
@@ -257,16 +257,17 @@ def test_strict_schema_removes_defaults_recursively():
     walk(schema)
 
 
-def test_chat_structured_gateway_records_success_metric(monkeypatch):
+def test_chat_structured_gateway_records_success_metric(monkeypatch, caplog):
     counter = FakeCounter()
-    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _VALUE_TRUE_RESPONSE)
 
-    result = gateway_client.invoke_chat_structured_gateway(
-        'classified prompt',
-        chat.RequiresContext,
-        feature='chat_extraction.requires_context',
-    )
+    with caplog.at_level(logging.INFO, logger='utils.llm.gateway_observability'):
+        result = gateway_client.invoke_chat_structured_gateway(
+            'classified prompt',
+            chat.RequiresContext,
+            feature='chat_extraction.requires_context',
+        )
 
     assert result == chat.RequiresContext(value=True)
     assert counter.calls == [
@@ -279,11 +280,16 @@ def test_chat_structured_gateway_records_success_metric(monkeypatch):
             1,
         )
     ]
+    assert 'llm_gateway_backend_event kind=request_result' in caplog.text
+    assert 'feature=chat_extraction.requires_context' in caplog.text
+    assert 'outcome=success' in caplog.text
+    assert 'reason=ok' in caplog.text
+    assert 'classified prompt' not in caplog.text
 
 
 def test_chat_structured_gateway_records_fallback_reason_metric(monkeypatch):
     counter = FakeCounter()
-    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _UNEXPECTED_RESPONSE)
 
     result = gateway_client.invoke_chat_structured_gateway(
@@ -365,7 +371,7 @@ def test_conversation_discard_byok_skips_gateway_and_uses_legacy_llm(monkeypatch
 
     byok.set_byok_keys({'openai': 'secret'})
     counter = FakeCounter()
-    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
     monkeypatch.setattr(
         conversation_processing,
         'invoke_chat_structured_gateway',
@@ -464,7 +470,7 @@ def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
     assert 'submit report by Friday' in captured['prompt']
 
 
-def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch):
+def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch, caplog):
     captured = {}
     counter = FakeCounter()
     call_order = []
@@ -528,15 +534,16 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
     monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', immediate_submit)
-    monkeypatch.setattr(conversation_processing, 'LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS', counter)
 
-    result = conversation_processing.get_transcript_structure(
-        'we discussed project launch tasks',
-        datetime(2026, 6, 28, tzinfo=timezone.utc),
-        'en',
-        'UTC',
-        'uid',
-    )
+    with caplog.at_level(logging.INFO, logger='utils.llm.gateway_observability'):
+        result = conversation_processing.get_transcript_structure(
+            'we discussed project launch tasks',
+            datetime(2026, 6, 28, tzinfo=timezone.utc),
+            'en',
+            'UTC',
+            'uid',
+        )
 
     assert result.title == 'Weekly Planning'
     assert result.overview == 'Discussed project launch tasks.'
@@ -557,6 +564,11 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
     } in comparison_labels
     assert any(labels['field'] == 'title_similarity' for labels in comparison_labels)
     assert any(labels['field'] == 'overview_similarity' for labels in comparison_labels)
+    assert 'llm_gateway_backend_event kind=shadow_comparison' in caplog.text
+    assert 'feature=conversation_structure.extract.shadow' in caplog.text
+    assert 'field=title_similarity' in caplog.text
+    assert 'Weekly Planning' not in caplog.text
+    assert 'Discussed project launch tasks.' not in caplog.text
 
 
 def test_conversation_structure_shadow_disabled_skips_gateway(monkeypatch):
@@ -592,7 +604,7 @@ def test_conversation_structure_shadow_disabled_skips_gateway(monkeypatch):
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
     monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
     monkeypatch.setattr(conversation_processing, '_submit_llm_background', fake_submit)
-    monkeypatch.setattr(gateway_client, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
 
     result = conversation_processing.get_transcript_structure(
         'we discussed project launch tasks',

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -20,13 +20,13 @@ from .clients import get_llm, parser
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
 from utils.llm.conversation_folder import FolderAssignment, assign_conversation_to_folder, build_folders_context
+from utils.llm.gateway_observability import record_gateway_shadow_comparison
 import logging
 
 logger = logging.getLogger(__name__)
 CONVERSATION_STRUCTURE_SHADOW_FEATURE = 'conversation_structure.extract.shadow'
 CONVERSATION_STRUCTURE_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED'
 CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE'
-LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS = None
 
 # =============================================
 #            FOLDER ASSIGNMENT
@@ -70,15 +70,7 @@ def _coerce_structured(response: Structured | StructuredExtraction) -> Structure
 
 
 def _record_chat_extraction_comparison(*, feature: str, field: str, outcome: str) -> None:
-    try:
-        global LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS
-        if LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS is None:
-            from utils.metrics import LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS as comparison_counter
-
-            LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS = comparison_counter
-        LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS.labels(feature=feature, field=field, outcome=outcome).inc()
-    except Exception:
-        pass
+    record_gateway_shadow_comparison(feature=feature, field=field, outcome=outcome)
 
 
 def _env_flag_enabled(name: str, *, default: bool = False) -> bool:

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -8,7 +8,7 @@ from typing import TypeVar
 import httpx
 from pydantic import BaseModel, ValidationError
 
-from utils.metrics import LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS
+from utils.llm.gateway_observability import record_gateway_request_result
 
 LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'OMI_LLM_GATEWAY_SERVICE_TOKEN'
 LEGACY_LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'LLM_GATEWAY_SERVICE_TOKEN'
@@ -96,10 +96,7 @@ def invoke_chat_structured_gateway(
 
 
 def record_chat_extraction_gateway_result(*, feature: str, outcome: str, reason: str) -> None:
-    try:
-        LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS.labels(feature=feature, outcome=outcome, reason=reason).inc()
-    except Exception:
-        pass
+    record_gateway_request_result(feature=feature, outcome=outcome, reason=reason)
 
 
 def _gateway_headers() -> dict[str, str]:

--- a/backend/utils/llm/gateway_observability.py
+++ b/backend/utils/llm/gateway_observability.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from utils.metrics import LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS, LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS
+
+logger = logging.getLogger(__name__)
+
+LLM_GATEWAY_BACKEND_EVENT = 'llm_gateway_backend_event'
+LLM_GATEWAY_OBSERVABILITY_LOGS_ENABLED_ENV = 'OMI_LLM_GATEWAY_OBSERVABILITY_LOGS_ENABLED'
+
+_LABEL_MAX_LENGTH = 128
+_SAFE_LABEL_CHARS = frozenset('._:-')
+
+
+def record_gateway_request_result(*, feature: str, outcome: str, reason: str, route: str = 'chat_structured') -> None:
+    feature_label = _safe_label(feature)
+    outcome_label = _safe_label(outcome)
+    reason_label = _safe_label(reason)
+    route_label = _safe_label(route)
+
+    try:
+        LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS.labels(
+            feature=feature_label,
+            outcome=outcome_label,
+            reason=reason_label,
+        ).inc()
+    except Exception:
+        pass
+
+    _log_gateway_event(
+        kind='request_result',
+        feature=feature_label,
+        outcome=outcome_label,
+        reason=reason_label,
+        field='none',
+        route=route_label,
+    )
+
+
+def record_gateway_shadow_comparison(*, feature: str, field: str, outcome: str, route: str = 'chat_structured') -> None:
+    feature_label = _safe_label(feature)
+    field_label = _safe_label(field)
+    outcome_label = _safe_label(outcome)
+    route_label = _safe_label(route)
+
+    try:
+        LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS.labels(
+            feature=feature_label,
+            field=field_label,
+            outcome=outcome_label,
+        ).inc()
+    except Exception:
+        pass
+
+    _log_gateway_event(
+        kind='shadow_comparison',
+        feature=feature_label,
+        outcome=outcome_label,
+        reason='none',
+        field=field_label,
+        route=route_label,
+    )
+
+
+def _log_gateway_event(
+    *,
+    kind: str,
+    feature: str,
+    outcome: str,
+    reason: str,
+    field: str,
+    route: str,
+) -> None:
+    if not _observability_logs_enabled():
+        return
+
+    logger.info(
+        '%s kind=%s feature=%s outcome=%s reason=%s field=%s route=%s service=%s',
+        LLM_GATEWAY_BACKEND_EVENT,
+        _safe_label(kind),
+        feature,
+        outcome,
+        reason,
+        field,
+        route,
+        _service_label(),
+    )
+
+
+def _observability_logs_enabled() -> bool:
+    value = os.getenv(LLM_GATEWAY_OBSERVABILITY_LOGS_ENABLED_ENV)
+    if value is None:
+        return True
+    return value.strip().casefold() not in {'0', 'false', 'no', 'off'}
+
+
+def _service_label() -> str:
+    return _safe_label(os.getenv('K_SERVICE') or os.getenv('APP_NAME') or 'backend')
+
+
+def _safe_label(value: object, *, default: str = 'unknown') -> str:
+    text = str(value or '').strip().casefold()
+    if not text:
+        text = default
+    normalized = ''.join(char if char.isalnum() or char in _SAFE_LABEL_CHARS else '_' for char in text)
+    return (normalized or default)[:_LABEL_MAX_LENGTH]

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -597,6 +597,11 @@ llm_gateway_request_latency_seconds
 Labels are bounded and low-cardinality: `lane_id`, `route_artifact_id`, `provider`, `model`, `used_lkg`, `fallback_used`, `fallback_reason`, `outcome`, and `error_class`.
 
 The backend caller also exposes `llm_gateway_chat_extraction_requests_total{feature,outcome,reason}` for app-level success/fallback/skipped behavior.
+The same backend observability helper emits a privacy-safe Cloud Logging line
+containing `llm_gateway_backend_event` with the same low-cardinality dimensions
+plus `kind`, `field`, `route`, and `service`. This gives rollout owners a stable
+query surface even when backend caller metrics are hard to inspect per runtime
+surface.
 
 Shadow-only features can also emit privacy-safe comparison buckets through
 `llm_gateway_chat_extraction_comparisons_total{feature,field,outcome}`. These
@@ -604,7 +609,9 @@ metrics compare derived properties such as category match, empty/non-empty
 status, length ratio, and normalized similarity bands. They must not store raw
 transcripts, prompts, titles, overviews, memories, or provider responses.
 
-Do not log raw prompts, transcripts, screenshots, memory contents, provider response bodies, or BYOK keys. Use existing sanitizer patterns for error bodies and user text.
+Do not log raw prompts, transcripts, screenshots, memory contents, provider
+response bodies, conversation IDs, UIDs, or BYOK keys. Use existing sanitizer
+patterns for error bodies and user text.
 
 ## Shadow Safety
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -279,10 +279,15 @@ check_backend_unit_tests_if_needed() {
           ;;
       esac
     done
+    if changed_matches 'backend/utils/llm/*.py' 'backend/utils/llm/**/*.py'; then
+      add_fast_backend_test_if_selected "tests/unit/test_action_item_date_validation.py"
+      add_fast_backend_test_if_selected "tests/unit/test_conversation_structure_timezone.py"
+      add_fast_backend_test_if_selected "tests/unit/test_llm_gateway_chat_extraction_pilot.py"
+    fi
     if [ -s "$FAST_BACKEND_TESTS" ]; then
       sort -u "$FAST_BACKEND_TESTS" -o "$FAST_BACKEND_TESTS"
       selected_count=$(wc -l < "$FAST_BACKEND_TESTS" | tr -d ' ')
-      echo "Selector requested $reason ($original_selected_count files; running $selected_count changed backend test file(s) instead; cap is $max_pre_push_tests)."
+      echo "Selector requested $reason ($original_selected_count files; running $selected_count focused backend test file(s) instead; cap is $max_pre_push_tests)."
       cp "$FAST_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS"
     else
       echo "Skipping broad backend unit suite in pre-push: $reason ($selected_count files; cap is $max_pre_push_tests)."
@@ -297,6 +302,14 @@ check_backend_unit_tests_if_needed() {
     bash test-preflight.sh
     BACKEND_UNIT_TEST_FILE_LIST="$SELECTED_BACKEND_TESTS" BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=auto bash test.sh
   )
+}
+
+add_fast_backend_test_if_selected() {
+  local test_path="$1"
+
+  if grep -Fxq "$test_path" "$SELECTED_BACKEND_TESTS"; then
+    printf '%s\n' "$test_path" >> "$FAST_BACKEND_TESTS"
+  fi
 }
 
 check_openapi_contract_if_needed() {


### PR DESCRIPTION
## Summary
- add a shared backend LLM gateway observability helper for request outcomes and shadow comparison buckets
- keep existing Prometheus metric names while adding privacy-safe `llm_gateway_backend_event` Cloud Logging lines
- route current chat extraction and conversation-structure shadow metrics through the shared helper
- document the reusable observability pattern and privacy constraints for future gateway wirings

## Validation
- `cd backend && ENCRYPTION_SECRET=test-secret python3 -m pytest tests/unit/test_llm_gateway_chat_extraction_pilot.py -q`
- `cd backend && python3 scripts/scan_async_blockers.py`
- `git diff --check`
- pre-push checks passed, including selected backend unit tests, async blocker scan, OpenAPI contract check, and black --check

No dev or prod deployment performed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

