### PR TITLE
Add bucketed legacy memory migration

### DIFF
--- a/backend/models/memory_apply.py
+++ b/backend/models/memory_apply.py
@@ -400,7 +400,11 @@ def apply_long_term_patch_transaction(
             extra_item_updates[timestamp_key] = datetime.fromisoformat(
                 extra_item_updates[timestamp_key].replace("Z", "+00:00")
             )
-    if "confidence" in extra_item_updates and not isinstance(extra_item_updates["confidence"], (int, float)):
+    if (
+        "confidence" in extra_item_updates
+        and extra_item_updates["confidence"] is not None
+        and not isinstance(extra_item_updates["confidence"], (int, float))
+    ):
         extra_item_updates.pop("confidence")
     evidence = raw.pop("evidence", None) or [
         MemoryEvidence(

--- a/backend/models/memory_apply.py
+++ b/backend/models/memory_apply.py
@@ -386,16 +386,22 @@ def apply_long_term_patch_transaction(
     for optional_key in (
         "corroboration_count",
         "last_corroborated_at",
+        "captured_at",
+        "updated_at",
+        "expires_at",
         "superseded_by",
         "kg_extracted",
         "confidence",
     ):
         if optional_key in raw:
             extra_item_updates[optional_key] = raw.pop(optional_key)
-    if "last_corroborated_at" in extra_item_updates and isinstance(extra_item_updates["last_corroborated_at"], str):
-        extra_item_updates["last_corroborated_at"] = datetime.fromisoformat(
-            extra_item_updates["last_corroborated_at"].replace("Z", "+00:00")
-        )
+    for timestamp_key in ("last_corroborated_at", "captured_at", "updated_at", "expires_at"):
+        if timestamp_key in extra_item_updates and isinstance(extra_item_updates[timestamp_key], str):
+            extra_item_updates[timestamp_key] = datetime.fromisoformat(
+                extra_item_updates[timestamp_key].replace("Z", "+00:00")
+            )
+    if "confidence" in extra_item_updates and not isinstance(extra_item_updates["confidence"], (int, float)):
+        extra_item_updates.pop("confidence")
     evidence = raw.pop("evidence", None) or [
         MemoryEvidence(
             evidence_id=evidence_id,
@@ -505,6 +511,8 @@ def apply_long_term_patch_transaction(
             account_generation=control_state.account_generation,
             promotion=promotion_metadata,
         )
+        if extra_item_updates:
+            memory_item = MemoryItem(**{**memory_item.model_dump(), **extra_item_updates})
     outbox_events = [
         MemoryOutboxEvent(
             event_id=_event_id(event_type, commit_id, memory_item.memory_id, operation.operation_id),

--- a/backend/scripts/backfill_legacy_memories.py
+++ b/backend/scripts/backfill_legacy_memories.py
@@ -17,8 +17,20 @@ import argparse
 import getpass
 import json
 import sys
+from pathlib import Path
 
-from utils.memory.legacy_backfill import backfill_user
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+BUCKET_CHOICES = [
+    "reviewed_long_term",
+    "manual_required_promotion",
+    "profile_required_promotion",
+    "archive_review",
+    "hold_noise",
+    "hold_sensitive",
+]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -27,6 +39,18 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--dry-run", action="store_true", help="Report intended writes without persisting")
     parser.add_argument("--batch-size", type=int, default=50, help="Checkpoint interval (default: 50)")
     parser.add_argument("--no-resume", action="store_true", help="Ignore prior checkpoint and start from 0")
+    parser.add_argument(
+        "--strategy",
+        choices=["bulk-long-term", "bucketed"],
+        default="bulk-long-term",
+        help="Migration strategy (default: bulk-long-term for backward compatibility)",
+    )
+    parser.add_argument(
+        "--bucket",
+        choices=BUCKET_CHOICES,
+        default=None,
+        help="Bucket to dry-run/apply when --strategy bucketed. Omit for inventory-only dry-run.",
+    )
     parser.add_argument(
         "--allow-admin-override",
         action="store_true",
@@ -48,15 +72,38 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     operator_context = args.operator_context or getpass.getuser()
-    report = backfill_user(
-        args.uid,
-        dry_run=args.dry_run,
-        batch_size=args.batch_size,
-        resume=not args.no_resume,
-        allow_admin_override=args.allow_admin_override,
-        acknowledge_non_canonical_uid=args.i_understand_uid_not_whitelisted,
-        operator_context=operator_context,
-    )
+    if args.strategy == "bucketed":
+        if args.bucket is None and not args.dry_run:
+            print(
+                "--strategy bucketed without --bucket is inventory-only; pass --dry-run or choose a bucket",
+                file=sys.stderr,
+            )
+            return 2
+        from utils.memory.legacy_backfill import backfill_user_bucketed
+
+        report = backfill_user_bucketed(
+            args.uid,
+            bucket=args.bucket,
+            dry_run=args.dry_run,
+            allow_admin_override=args.allow_admin_override,
+            acknowledge_non_canonical_uid=args.i_understand_uid_not_whitelisted,
+            operator_context=operator_context,
+        )
+    else:
+        if args.bucket is not None:
+            print("--bucket requires --strategy bucketed", file=sys.stderr)
+            return 2
+        from utils.memory.legacy_backfill import backfill_user
+
+        report = backfill_user(
+            args.uid,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+            resume=not args.no_resume,
+            allow_admin_override=args.allow_admin_override,
+            acknowledge_non_canonical_uid=args.i_understand_uid_not_whitelisted,
+            operator_context=operator_context,
+        )
     print(json.dumps(report.__dict__, default=str, indent=2))
     if report.cohort_gated:
         return 2

--- a/backend/scripts/backfill_legacy_memories.py
+++ b/backend/scripts/backfill_legacy_memories.py
@@ -23,14 +23,9 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-BUCKET_CHOICES = [
-    "reviewed_long_term",
-    "manual_required_promotion",
-    "profile_required_promotion",
-    "archive_review",
-    "hold_noise",
-    "hold_sensitive",
-]
+from utils.memory.legacy_backfill import LegacyBackfillBucket, backfill_user, backfill_user_bucketed
+
+BUCKET_CHOICES = [bucket.value for bucket in LegacyBackfillBucket]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -79,8 +74,6 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
-        from utils.memory.legacy_backfill import backfill_user_bucketed
-
         report = backfill_user_bucketed(
             args.uid,
             bucket=args.bucket,
@@ -93,8 +86,6 @@ def main(argv: list[str] | None = None) -> int:
         if args.bucket is not None:
             print("--bucket requires --strategy bucketed", file=sys.stderr)
             return 2
-        from utils.memory.legacy_backfill import backfill_user
-
         report = backfill_user(
             args.uid,
             dry_run=args.dry_run,

--- a/backend/tests/unit/test_memory_apply_store.py
+++ b/backend/tests/unit/test_memory_apply_store.py
@@ -288,6 +288,36 @@ def test_firestore_apply_allows_update_when_target_is_authoritative_active_same_
     assert result.status == ApplyStatus.committed
 
 
+def test_firestore_apply_update_allows_explicit_confidence_clear():
+    operation = _operation(
+        target_memory_id="mem1",
+        logical_payload={
+            "decision": "update",
+            "target_memory_id": "mem1",
+            "memory_text": "Updated.",
+            "result_status": "active",
+        },
+    )
+    db = _db_with(operation=operation, target_items=[_target_item(confidence=0.8)])
+    patch = _patch(
+        decision=DurablePatchDecision.update,
+        target_memory_id="mem1",
+        memory_text="Updated.",
+        confidence=None,
+    )
+
+    result = apply_long_term_patch_firestore(
+        uid="u1",
+        operation_id=operation.operation_id,
+        patch_payload=patch,
+        db_client=db,
+    )
+
+    assert result.status == ApplyStatus.committed
+    assert result.memory_items[0].confidence is None
+    assert db.docs["users/u1/memory_items/mem1"]["confidence"] is None
+
+
 def test_firestore_apply_retries_committed_operation_from_stored_result_without_rereading_mutable_evidence_or_target():
     operation = _operation(
         target_memory_id="mem1",

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -519,6 +519,10 @@ def test_bucketed_inventory_dry_run_reports_counts_and_writes_nothing(_trusted_a
     assert report.intended_count == 1
     assert report.written_count == 0
     assert report.bucket_samples[LegacyBackfillBucket.manual_required_promotion.value][0]["id"] == "leg-manual"
+    assert report.bucket_samples[LegacyBackfillBucket.hold_sensitive.value][0]["content"] == (
+        "[redacted sensitive memory content]"
+    )
+    assert "password token" not in report.bucket_samples[LegacyBackfillBucket.hold_sensitive.value][0]["content"]
     assert not any(path.startswith(f"users/{LEGACY_UID}/memory_items/") for path in db.docs)
     assert get_non_filtered_fn(LEGACY_UID, limit=10, offset=0) == rows
     assert active_snapshot == rows

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -33,7 +33,9 @@ def _ws_c_import_isolation():
     saved.update(snapshot_sys_modules(touched))
     from utils.memory.legacy_backfill import (
         _fetch_active_legacy_memories,
+        backfill_user_bucketed,
         backfill_user,
+        classify_legacy_backfill_bucket,
         is_active_legacy_row,
         legacy_backfill_memory_id,
         reconcile_backfill_counts,
@@ -42,6 +44,8 @@ def _ws_c_import_isolation():
     module_globals = globals()
     module_globals["_fetch_active_legacy_memories"] = _fetch_active_legacy_memories
     module_globals["backfill_user"] = backfill_user
+    module_globals["backfill_user_bucketed"] = backfill_user_bucketed
+    module_globals["classify_legacy_backfill_bucket"] = classify_legacy_backfill_bucket
     module_globals["is_active_legacy_row"] = is_active_legacy_row
     module_globals["legacy_backfill_memory_id"] = legacy_backfill_memory_id
     module_globals["reconcile_backfill_counts"] = reconcile_backfill_counts
@@ -60,6 +64,7 @@ from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState,
 from utils.memory.canonical_memory_adapter import extraction_memory_id, read_canonical_memories
 from utils.memory.legacy_backfill import (
     BackfillCohortGateError,
+    LegacyBackfillBucket,
     assert_canonical_cohort_for_backfill,
     both_store_canonical_duplicate_exists,
     live_extraction_memory_id_for_legacy_row,
@@ -462,6 +467,149 @@ def test_dry_run_writes_nothing(_trusted_account):
     assert not any(path.startswith(f"users/{LEGACY_UID}/memory_items/") for path in db.docs)
     assert get_non_filtered_fn(LEGACY_UID, limit=10, offset=0) == rows
     assert active_snapshot == rows
+
+
+def test_bucket_classifier_holds_noise_and_sensitive_rows():
+    sensitive = _legacy_row(legacy_id="leg-sensitive", content="User API key token is stored elsewhere")
+    downloads = _legacy_row(legacy_id="leg-downloads", content="Local downloads include report.pdf")
+    focused = _legacy_row(legacy_id="leg-focused", content="Focused on Safari")
+    manual = _legacy_row(legacy_id="leg-manual", content="User prefers fast code reviews")
+    manual["manually_added"] = True
+    reviewed = _legacy_row(legacy_id="leg-reviewed", content="David uses Omi Beta for daily dogfood")
+    reviewed["user_review"] = True
+    profile = _legacy_row(legacy_id="leg-profile", content="The user wants concise launch checklists")
+    unmatched = _legacy_row(legacy_id="leg-unmatched", content="Coffee near the office was mentioned")
+
+    assert classify_legacy_backfill_bucket(sensitive) == LegacyBackfillBucket.hold_sensitive
+    assert classify_legacy_backfill_bucket(downloads) == LegacyBackfillBucket.hold_noise
+    assert classify_legacy_backfill_bucket(focused) == LegacyBackfillBucket.hold_noise
+    assert classify_legacy_backfill_bucket(manual) == LegacyBackfillBucket.manual_required_promotion
+    assert classify_legacy_backfill_bucket(reviewed) == LegacyBackfillBucket.reviewed_long_term
+    assert classify_legacy_backfill_bucket(profile) == LegacyBackfillBucket.profile_required_promotion
+    assert classify_legacy_backfill_bucket(unmatched) == LegacyBackfillBucket.archive_review
+
+
+def test_bucketed_inventory_dry_run_reports_counts_and_writes_nothing(_trusted_account):
+    rows = [
+        _legacy_row(legacy_id="leg-manual", content="User prefers concise docs", conversation_id="conv-manual"),
+        _legacy_row(
+            legacy_id="leg-sensitive",
+            content="User password token should never migrate",
+            conversation_id="conv-sensitive",
+        ),
+        _legacy_row(
+            legacy_id="leg-noise", content="Local downloads include installer.dmg", conversation_id="conv-noise"
+        ),
+    ]
+    rows[0]["manually_added"] = True
+    get_non_filtered_fn, active_snapshot = _make_non_filtered_store(rows)
+    db = _PromotionFakeDb({})
+
+    report = backfill_user_bucketed(
+        LEGACY_UID,
+        dry_run=True,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+    )
+
+    assert report.dry_run is True
+    assert report.bucket_counts[LegacyBackfillBucket.manual_required_promotion.value] == 1
+    assert report.bucket_counts[LegacyBackfillBucket.hold_sensitive.value] == 1
+    assert report.bucket_counts[LegacyBackfillBucket.hold_noise.value] == 1
+    assert report.intended_count == 1
+    assert report.written_count == 0
+    assert report.bucket_samples[LegacyBackfillBucket.manual_required_promotion.value][0]["id"] == "leg-manual"
+    assert not any(path.startswith(f"users/{LEGACY_UID}/memory_items/") for path in db.docs)
+    assert get_non_filtered_fn(LEGACY_UID, limit=10, offset=0) == rows
+    assert active_snapshot == rows
+
+
+def test_bucketed_manual_apply_writes_required_promotion_with_legacy_timestamps(_trusted_account):
+    created_at = datetime(2024, 3, 4, 5, 6, tzinfo=timezone.utc)
+    updated_at = datetime(2024, 4, 5, 6, 7, tzinfo=timezone.utc)
+    row = _legacy_row(
+        legacy_id="leg-manual-apply", content="User prefers launch checklists", conversation_id="conv-manual"
+    )
+    row["manually_added"] = True
+    row["created_at"] = created_at
+    row["updated_at"] = updated_at
+    rows = [row]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+
+    report = backfill_user_bucketed(
+        LEGACY_UID,
+        bucket=LegacyBackfillBucket.manual_required_promotion,
+        dry_run=False,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+    )
+
+    assert report.completed is True
+    assert report.verified is True
+    assert report.written_count == 1
+    canonical_id = legacy_backfill_memory_id(uid=LEGACY_UID, legacy_memory_id=row["id"])
+    stored = db.docs[f"users/{LEGACY_UID}/memory_items/{canonical_id}"]
+    assert stored["tier"] == MemoryTier.short_term.value
+    assert stored["user_asserted"] is True
+    assert stored["captured_at"] == created_at
+    assert stored["updated_at"] == updated_at
+    assert stored["expires_at"] > datetime.now(timezone.utc)
+    assert stored["promotion"]["required"] is True
+    assert stored["promotion"]["status"] == "pending"
+    assert stored["promotion"]["bucket"] == LegacyBackfillBucket.manual_required_promotion.value
+    assert stored["promotion"]["legacy_memory_id"] == row["id"]
+
+
+def test_bucketed_reviewed_apply_writes_long_term_with_legacy_timestamp(_trusted_account):
+    created_at = datetime(2024, 5, 6, 7, 8, tzinfo=timezone.utc)
+    row = _legacy_row(
+        legacy_id="leg-reviewed-apply", content="David uses Omi Beta daily", conversation_id="conv-reviewed"
+    )
+    row["user_review"] = True
+    row["created_at"] = created_at
+    row["updated_at"] = created_at
+    rows = [row]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+
+    report = backfill_user_bucketed(
+        LEGACY_UID,
+        bucket=LegacyBackfillBucket.reviewed_long_term,
+        dry_run=False,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+    )
+
+    assert report.completed is True
+    assert report.verified is True
+    canonical_id = legacy_backfill_memory_id(uid=LEGACY_UID, legacy_memory_id=row["id"])
+    stored = db.docs[f"users/{LEGACY_UID}/memory_items/{canonical_id}"]
+    assert stored["tier"] == MemoryTier.long_term.value
+    assert stored["captured_at"] == created_at
+    assert stored["expires_at"] is None
+    assert stored["promotion"]["bucket"] == LegacyBackfillBucket.reviewed_long_term.value
+
+
+def test_bucketed_hold_bucket_never_writes(_trusted_account):
+    rows = [_legacy_row(legacy_id="leg-sensitive", content="User secret token should stay held")]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+
+    report = backfill_user_bucketed(
+        LEGACY_UID,
+        bucket=LegacyBackfillBucket.hold_sensitive,
+        dry_run=False,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+    )
+
+    assert report.completed is True
+    assert report.skipped_bucket_not_writable == 1
+    assert report.written_count == 0
+    assert not any(path.startswith(f"users/{LEGACY_UID}/memory_items/") for path in db.docs)
 
 
 def test_resume_after_interruption(_trusted_account):

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -16,8 +16,10 @@ Admin-only: invoke explicitly per uid; no cron, no auto-run.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from database._client import db as default_db_client
@@ -57,6 +59,42 @@ class BackfillCohortGateError(ValueError):
     """Raised when backfill is invoked for a uid outside the canonical cohort."""
 
 
+class LegacyBackfillBucket(str, Enum):
+    reviewed_long_term = "reviewed_long_term"
+    manual_required_promotion = "manual_required_promotion"
+    profile_required_promotion = "profile_required_promotion"
+    archive_review = "archive_review"
+    hold_noise = "hold_noise"
+    hold_sensitive = "hold_sensitive"
+
+
+WRITABLE_LEGACY_BACKFILL_BUCKETS = {
+    LegacyBackfillBucket.reviewed_long_term,
+    LegacyBackfillBucket.manual_required_promotion,
+    LegacyBackfillBucket.profile_required_promotion,
+}
+
+_DOWNLOADS_PATTERN = re.compile(
+    r"(?:\blocal downloads include\b|\bdownloads include\b|~/downloads\b|/downloads/)", re.I
+)
+_FOCUS_PATTERN = re.compile(r"^\s*focused on\b", re.I)
+_IMPERATIVE_PATTERN = re.compile(
+    r"^\s*(address|review|persist|seed|run|make|add|fix|check|confirm|use|build|deploy|merge|push)\b",
+    re.I,
+)
+_SENSITIVE_PATTERN = re.compile(
+    r"\b(api[-_ ]?key|secret|token|password|credential|private key|access key|bearer|oauth|session cookie)\b",
+    re.I,
+)
+_PROFILE_PATTERN = re.compile(
+    r"\b(user|david|david zhang|the user)\b.*\b("
+    r"prefers|uses|wants|does not want|avoids|follows|works|is|has|operates|trusts|"
+    r"primarily|company|team|project|building|likes|dislikes"
+    r")\b",
+    re.I,
+)
+
+
 @dataclass(frozen=True)
 class BackfillReport:
     uid: str
@@ -76,6 +114,11 @@ class BackfillReport:
     vector_sync_failures: int = 0
     cohort_gated: bool = False
     errors: List[str] = field(default_factory=list)
+    selected_bucket: Optional[str] = None
+    bucket_counts: Dict[str, int] = field(default_factory=dict)
+    bucket_samples: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+    skipped_bucket_not_selected: int = 0
+    skipped_bucket_not_writable: int = 0
 
 
 def legacy_backfill_memory_id(*, uid: str, legacy_memory_id: str) -> str:
@@ -185,9 +228,69 @@ def _coerce_aware_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _coerce_optional_legacy_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _coerce_aware_utc(value)
+    if isinstance(value, str):
+        try:
+            return _coerce_aware_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
 def is_active_legacy_row(row: dict) -> bool:
     """Mirror ``get_memories`` default semantics: active, non-user-rejected rows only."""
     return row.get("user_review") is not False and row.get("invalid_at") is None
+
+
+def classify_legacy_backfill_bucket(row: dict) -> LegacyBackfillBucket:
+    """Route a legacy memory into the safest first-pass migration bucket."""
+    content = (row.get("content") or "").strip()
+    if not content:
+        return LegacyBackfillBucket.hold_noise
+    if _SENSITIVE_PATTERN.search(content):
+        return LegacyBackfillBucket.hold_sensitive
+    if _DOWNLOADS_PATTERN.search(content) or _FOCUS_PATTERN.search(content) or _IMPERATIVE_PATTERN.search(content):
+        return LegacyBackfillBucket.hold_noise
+    if row.get("manually_added") is True or row.get("category") == "manual":
+        return LegacyBackfillBucket.manual_required_promotion
+    if _PROFILE_PATTERN.search(content):
+        if row.get("user_review") is True:
+            return LegacyBackfillBucket.reviewed_long_term
+        return LegacyBackfillBucket.profile_required_promotion
+    return LegacyBackfillBucket.archive_review
+
+
+def _legacy_bucket_sample(row: dict) -> Dict[str, Any]:
+    content = " ".join((row.get("content") or "").strip().split())
+    if len(content) > 160:
+        content = f"{content[:157]}..."
+    return {
+        "id": row.get("id"),
+        "category": row.get("category"),
+        "manually_added": row.get("manually_added"),
+        "user_review": row.get("user_review"),
+        "created_at": _coerce_optional_legacy_datetime(row.get("created_at")),
+        "content": content,
+    }
+
+
+def _bucket_counts_and_samples(
+    rows: Sequence[dict],
+    *,
+    sample_size: int = 5,
+) -> tuple[Dict[str, int], Dict[str, List[Dict[str, Any]]]]:
+    counts = {bucket.value: 0 for bucket in LegacyBackfillBucket}
+    samples: Dict[str, List[Dict[str, Any]]] = {bucket.value: [] for bucket in LegacyBackfillBucket}
+    for row in rows:
+        bucket = classify_legacy_backfill_bucket(row)
+        counts[bucket.value] += 1
+        if len(samples[bucket.value]) < sample_size:
+            samples[bucket.value].append(_legacy_bucket_sample(row))
+    return counts, {bucket: sample_rows for bucket, sample_rows in samples.items() if sample_rows}
 
 
 def _fetch_active_legacy_memories(
@@ -297,9 +400,13 @@ def _ensure_backfill_operation(
     run_id: str,
     evidence_ids: List[str],
     db_client,
+    bucket: Optional[LegacyBackfillBucket] = None,
 ) -> MemoryOperation:
     legacy_id = legacy_row.get("id") or canonical_memory_id
     content = (legacy_row.get("content") or "").strip()
+    source_packet_id = f"legacy_backfill_{legacy_id}"
+    if bucket is not None:
+        source_packet_id = f"legacy_backfill_{bucket.value}_{legacy_id}"
     logical_payload = {
         "decision": DurablePatchDecision.add.value,
         "memory_text": content,
@@ -308,7 +415,7 @@ def _ensure_backfill_operation(
     operation = MemoryOperation.new(
         uid=uid,
         operation_type=MemoryOperationType.long_term_apply,
-        source_packet_id=f"legacy_backfill_{legacy_id}",
+        source_packet_id=source_packet_id,
         target_memory_id=None,
         evidence_ids=evidence_ids,
         logical_payload=logical_payload,
@@ -331,16 +438,19 @@ def _apply_one_legacy_row(
     control: MemoryControlState,
     run_id: str,
     db_client,
+    bucket: Optional[LegacyBackfillBucket] = None,
 ) -> tuple[MemoryControlState, bool, Optional[str], bool]:
-    """Write one canonical long_term item. Returns (control, written, skip_reason, vector_sync_failed)."""
+    """Write one canonical item. Returns (control, written, skip_reason, vector_sync_failed)."""
     legacy_id = legacy_row.get("id") or f"legacy_{index}"
     content = (legacy_row.get("content") or "").strip()
     if not content:
         return control, False, "empty_content", False
+    if bucket is not None and bucket not in WRITABLE_LEGACY_BACKFILL_BUCKETS:
+        return control, False, "bucket_not_writable", False
 
     canonical_memory_id = legacy_backfill_memory_id(uid=uid, legacy_memory_id=legacy_id)
     existing = _load_canonical_item(uid, canonical_memory_id, db_client=db_client)
-    if existing is not None and _is_active_processed_backfill_destination(existing):
+    if existing is not None and _is_active_processed_canonical_item(existing):
         return control, False, "already_present", False
 
     if both_store_canonical_duplicate_exists(uid=uid, legacy_row=legacy_row, db_client=db_client):
@@ -357,12 +467,50 @@ def _apply_one_legacy_row(
         run_id=run_id,
         evidence_ids=[evidence.evidence_id],
         db_client=db_client,
+        bucket=bucket,
     )
 
     idempotency_key = legacy_backfill_idempotency_key(uid=uid, legacy_memory_id=legacy_id)
+    initial_tier = MemoryLayer.long_term
+    user_asserted = False
+    promotion = None
+    captured_at = None
+    updated_at = None
+    expires_at = None
+    if bucket is not None:
+        initial_tier = (
+            MemoryLayer.long_term if bucket == LegacyBackfillBucket.reviewed_long_term else MemoryLayer.short_term
+        )
+        user_asserted = bucket == LegacyBackfillBucket.manual_required_promotion
+        now = datetime.now(timezone.utc)
+        captured_at = _coerce_optional_legacy_datetime(legacy_row.get("created_at")) or now
+        updated_at = _coerce_optional_legacy_datetime(legacy_row.get("updated_at")) or captured_at
+        if updated_at < captured_at:
+            updated_at = captured_at
+        expires_at = now + timedelta(days=30) if initial_tier == MemoryLayer.short_term else None
+        promotion = {
+            "source_surface": "legacy_backfill",
+            "migration_strategy": "bucketed_legacy_backfill",
+            "bucket": bucket.value,
+            "legacy_memory_id": legacy_id,
+            "legacy_created_at": captured_at.isoformat(),
+            "legacy_updated_at": updated_at.isoformat(),
+        }
+        if initial_tier == MemoryLayer.short_term:
+            promotion.update(
+                {
+                    "required": True,
+                    "status": "pending",
+                    "reason": "legacy_migration",
+                    "attempt_count": 0,
+                }
+            )
+
     patch_payload = {
         "patch_id": f"patch_lb_{idempotency_key[:24]}",
-        "packet_id": f"legacy_backfill_{legacy_id}",
+        "packet_id": (
+            f"legacy_backfill_{bucket.value}_{legacy_id}" if bucket is not None else f"legacy_backfill_{legacy_id}"
+        ),
         "run_id": run_id,
         "observed_head_commit_id": control.head_commit_id,
         "idempotency_key": idempotency_key,
@@ -373,8 +521,15 @@ def _apply_one_legacy_row(
         "memory_text": content,
         "confidence": "medium",
         "relationship_to_user": "self",
-        "initial_tier": MemoryLayer.long_term.value,
+        "initial_tier": initial_tier.value,
+        "user_asserted": user_asserted,
     }
+    if promotion is not None:
+        patch_payload["promotion"] = promotion
+        patch_payload["captured_at"] = captured_at.isoformat() if captured_at else None
+        patch_payload["updated_at"] = updated_at.isoformat() if updated_at else None
+        if expires_at is not None:
+            patch_payload["expires_at"] = expires_at.isoformat()
 
     result = apply_long_term_patch_firestore(
         uid=uid,
@@ -433,6 +588,46 @@ def _legacy_row_has_canonical_destination(
     return live_item is not None and _is_active_processed_canonical_item(live_item)
 
 
+def _legacy_row_has_any_canonical_destination(
+    *,
+    uid: str,
+    legacy_row: dict,
+    items_by_id: Dict[str, MemoryItem],
+) -> bool:
+    legacy_id = legacy_row.get("id") or ""
+    content = (legacy_row.get("content") or "").strip()
+    if not content:
+        return False
+
+    backfill_id = legacy_backfill_memory_id(uid=uid, legacy_memory_id=legacy_id)
+    backfill_item = items_by_id.get(backfill_id)
+    if backfill_item is not None and _is_active_processed_canonical_item(backfill_item):
+        return True
+
+    live_id = live_extraction_memory_id_for_legacy_row(uid=uid, legacy_row=legacy_row)
+    if live_id is None:
+        return False
+    live_item = items_by_id.get(live_id)
+    return live_item is not None and _is_active_processed_canonical_item(live_item)
+
+
+def _count_any_destination_backfill_items(
+    uid: str,
+    legacy_rows: Sequence[dict],
+    *,
+    db_client,
+) -> int:
+    if not legacy_rows:
+        return 0
+    items = fetch_authoritative_product_memory_items(uid=uid, db_client=db_client)
+    items_by_id = {item.memory_id: item for item in items}
+    return sum(
+        1
+        for row in legacy_rows
+        if _legacy_row_has_any_canonical_destination(uid=uid, legacy_row=row, items_by_id=items_by_id)
+    )
+
+
 def _count_destination_backfill_items(
     uid: str,
     legacy_rows: Sequence[dict],
@@ -468,6 +663,12 @@ def reconcile_backfill_counts(
     return source_count, destination_count, verified, discrepancy
 
 
+def _coerce_legacy_backfill_bucket(value: LegacyBackfillBucket | str | None) -> Optional[LegacyBackfillBucket]:
+    if value is None or isinstance(value, LegacyBackfillBucket):
+        return value
+    return LegacyBackfillBucket(value)
+
+
 def _cohort_gated_report(uid: str, *, dry_run: bool, reason: str = COHORT_GATE_REASON) -> BackfillReport:
     return BackfillReport(
         uid=uid,
@@ -482,6 +683,176 @@ def _cohort_gated_report(uid: str, *, dry_run: bool, reason: str = COHORT_GATE_R
         verified=False,
         cohort_gated=True,
         errors=[reason],
+    )
+
+
+def backfill_user_bucketed(
+    uid: str,
+    *,
+    bucket: LegacyBackfillBucket | str | None = None,
+    dry_run: bool = True,
+    allow_admin_override: bool = False,
+    acknowledge_non_canonical_uid: bool = False,
+    operator_context: Optional[str] = None,
+    db_client=None,
+    get_non_filtered_memories_fn: Callable[..., List[dict]] = get_non_filtered_memories,
+    run_id: Optional[str] = None,
+) -> BackfillReport:
+    """Bucket legacy rows and optionally apply one reviewed bucket.
+
+    ``bucket=None`` is inventory-only. Real writes must name one bucket, and only
+    buckets in ``WRITABLE_LEGACY_BACKFILL_BUCKETS`` are accepted.
+    """
+    selected_bucket = _coerce_legacy_backfill_bucket(bucket)
+    client = db_client if db_client is not None else default_db_client
+    try:
+        assert_canonical_cohort_for_backfill(
+            uid,
+            allow_admin_override=allow_admin_override,
+            acknowledge_non_canonical_uid=acknowledge_non_canonical_uid,
+            operator_context=operator_context,
+            db_client=client,
+        )
+    except BackfillCohortGateError as exc:
+        report = _cohort_gated_report(uid, dry_run=dry_run, reason=str(exc))
+        return report
+
+    effective_run_id = run_id or f"legacy_bucket_backfill_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    legacy_rows = _fetch_active_legacy_memories(uid, get_non_filtered_memories_fn=get_non_filtered_memories_fn)
+    eligible_rows = [row for row in legacy_rows if (row.get("content") or "").strip()]
+    bucket_counts, bucket_samples = _bucket_counts_and_samples(eligible_rows)
+
+    selected_rows = [
+        row
+        for row in eligible_rows
+        if selected_bucket is not None and classify_legacy_backfill_bucket(row) == selected_bucket
+    ]
+    skipped_bucket_not_selected = len(eligible_rows) - len(selected_rows) if selected_bucket is not None else 0
+    selected_bucket_value = selected_bucket.value if selected_bucket is not None else None
+
+    if selected_bucket is None:
+        return BackfillReport(
+            uid=uid,
+            dry_run=True,
+            source_count=len(eligible_rows),
+            intended_count=sum(bucket_counts[bucket.value] for bucket in WRITABLE_LEGACY_BACKFILL_BUCKETS),
+            written_count=0,
+            skipped_already_present=0,
+            skipped_both_store_duplicate=0,
+            skipped_semantic_duplicate=0,
+            destination_count=0,
+            verified=False,
+            completed=False,
+            bucket_counts=bucket_counts,
+            bucket_samples=bucket_samples,
+        )
+
+    if selected_bucket not in WRITABLE_LEGACY_BACKFILL_BUCKETS:
+        return BackfillReport(
+            uid=uid,
+            dry_run=dry_run,
+            source_count=len(eligible_rows),
+            intended_count=0,
+            written_count=0,
+            skipped_already_present=0,
+            skipped_both_store_duplicate=0,
+            skipped_semantic_duplicate=0,
+            destination_count=0,
+            verified=True,
+            completed=True,
+            selected_bucket=selected_bucket_value,
+            bucket_counts=bucket_counts,
+            bucket_samples=bucket_samples,
+            skipped_bucket_not_selected=skipped_bucket_not_selected,
+            skipped_bucket_not_writable=len(selected_rows),
+        )
+
+    destination_count = _count_any_destination_backfill_items(uid, selected_rows, db_client=client)
+    if dry_run:
+        return BackfillReport(
+            uid=uid,
+            dry_run=True,
+            source_count=len(eligible_rows),
+            intended_count=max(0, len(selected_rows) - destination_count),
+            written_count=0,
+            skipped_already_present=0,
+            skipped_both_store_duplicate=0,
+            skipped_semantic_duplicate=0,
+            destination_count=destination_count,
+            verified=destination_count == len(selected_rows),
+            discrepancy=(
+                None
+                if destination_count == len(selected_rows)
+                else f"source={len(selected_rows)} destination={destination_count}"
+            ),
+            completed=False,
+            selected_bucket=selected_bucket_value,
+            bucket_counts=bucket_counts,
+            bucket_samples=bucket_samples,
+            skipped_bucket_not_selected=skipped_bucket_not_selected,
+        )
+
+    control = _read_control_state(uid, db_client=client)
+    written_count = 0
+    skipped_already_present = 0
+    skipped_both_store_duplicate = 0
+    skipped_semantic_duplicate = 0
+    vector_sync_failures = 0
+    errors: List[str] = []
+    materialized_semantic_keys: set[str] = set()
+
+    for index, legacy_row in enumerate(selected_rows):
+        semantic_key = semantic_materialization_key(uid=uid, legacy_row=legacy_row)
+        if semantic_key is not None and semantic_key in materialized_semantic_keys:
+            skipped_semantic_duplicate += 1
+            continue
+        try:
+            control, written, skip_reason, row_vector_sync_failed = _apply_one_legacy_row(
+                uid=uid,
+                legacy_row=legacy_row,
+                index=index,
+                control=control,
+                run_id=effective_run_id,
+                db_client=client,
+                bucket=selected_bucket,
+            )
+            if written:
+                written_count += 1
+            elif skip_reason == "both_store_duplicate":
+                skipped_both_store_duplicate += 1
+            elif skip_reason in {"already_present", "idempotent_skip"}:
+                skipped_already_present += 1
+            if semantic_key is not None and skip_reason not in {"empty_content"}:
+                materialized_semantic_keys.add(semantic_key)
+            if row_vector_sync_failed:
+                vector_sync_failures += 1
+        except Exception as exc:
+            logger.exception("bucketed legacy backfill failed for %s row %s", uid, legacy_row.get("id"))
+            errors.append(f"{legacy_row.get('id')}: {exc}")
+            break
+
+    destination_count = _count_any_destination_backfill_items(uid, selected_rows, db_client=client)
+    verified = destination_count == len(selected_rows)
+    return BackfillReport(
+        uid=uid,
+        dry_run=False,
+        source_count=len(eligible_rows),
+        intended_count=len(selected_rows),
+        written_count=written_count,
+        skipped_already_present=skipped_already_present,
+        skipped_both_store_duplicate=skipped_both_store_duplicate,
+        skipped_semantic_duplicate=skipped_semantic_duplicate,
+        destination_count=destination_count,
+        verified=verified,
+        discrepancy=None if verified else f"source={len(selected_rows)} destination={destination_count}",
+        completed=not errors,
+        legacy_rows_touched=len(selected_rows),
+        vector_sync_failures=vector_sync_failures,
+        errors=errors,
+        selected_bucket=selected_bucket_value,
+        bucket_counts=bucket_counts,
+        bucket_samples=bucket_samples,
+        skipped_bucket_not_selected=skipped_bucket_not_selected,
     )
 
 

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -42,7 +42,7 @@ from utils.memory.canonical_memory_adapter import extraction_memory_id
 from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
-from utils.log_sanitizer import sanitize
+from utils.log_sanitizer import sanitize, sanitize_pii
 
 logger = logging.getLogger(__name__)
 
@@ -264,9 +264,11 @@ def classify_legacy_backfill_bucket(row: dict) -> LegacyBackfillBucket:
     return LegacyBackfillBucket.archive_review
 
 
-def _legacy_bucket_sample(row: dict) -> Dict[str, Any]:
+def _legacy_bucket_sample(row: dict, *, bucket: LegacyBackfillBucket) -> Dict[str, Any]:
     content = " ".join((row.get("content") or "").strip().split())
-    if len(content) > 160:
+    if bucket == LegacyBackfillBucket.hold_sensitive:
+        content = "[redacted sensitive memory content]"
+    elif len(content) > 160:
         content = f"{content[:157]}..."
     return {
         "id": row.get("id"),
@@ -289,7 +291,7 @@ def _bucket_counts_and_samples(
         bucket = classify_legacy_backfill_bucket(row)
         counts[bucket.value] += 1
         if len(samples[bucket.value]) < sample_size:
-            samples[bucket.value].append(_legacy_bucket_sample(row))
+            samples[bucket.value].append(_legacy_bucket_sample(row, bucket=bucket))
     return counts, {bucket: sample_rows for bucket, sample_rows in samples.items() if sample_rows}
 
 
@@ -827,8 +829,10 @@ def backfill_user_bucketed(
             if row_vector_sync_failed:
                 vector_sync_failures += 1
         except Exception as exc:
-            logger.exception("bucketed legacy backfill failed for %s row %s", uid, legacy_row.get("id"))
-            errors.append(f"{legacy_row.get('id')}: {exc}")
+            safe_uid = sanitize_pii(uid)
+            safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
+            logger.exception("bucketed legacy backfill failed for %s row %s", safe_uid, safe_legacy_id)
+            errors.append(f"{safe_legacy_id}: {sanitize(exc)}")
             break
 
     destination_count = _count_any_destination_backfill_items(uid, selected_rows, db_client=client)
@@ -975,8 +979,10 @@ def backfill_user(
             if row_vector_sync_failed:
                 vector_sync_failures += 1
         except Exception as exc:
-            logger.exception("legacy backfill failed for %s row %s", uid, legacy_row.get("id"))
-            errors.append(f"{legacy_row.get('id')}: {exc}")
+            safe_uid = sanitize_pii(uid)
+            safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
+            logger.exception("legacy backfill failed for %s row %s", safe_uid, safe_legacy_id)
+            errors.append(f"{safe_legacy_id}: {sanitize(exc)}")
             break
 
         processed_index += 1

--- a/docs/runbooks/canonical-legacy-backfill.md
+++ b/docs/runbooks/canonical-legacy-backfill.md
@@ -1,8 +1,10 @@
 # Canonical legacy memory backfill (single user)
 
-**Purpose:** Copy a whitelisted user's active legacy `memories` rows into canonical `memory_items` (`layer=long_term`) without mutating or deleting legacy data.
+**Purpose:** Migrate a whitelisted user's active legacy `memories` rows into canonical `memory_items` without mutating or deleting legacy data.
 
-**Library:** `utils.memory.legacy_backfill.backfill_user`
+For first-user dogfood, use the **bucketed** strategy. It inventories the full legacy corpus, then lets an operator apply one reviewed bucket at a time. The older bulk strategy still exists for compatibility, but it copies every active legacy row as `long_term` and should not be used for noisy legacy accounts.
+
+**Library:** `utils.memory.legacy_backfill.backfill_user_bucketed`
 **CLI:** `backend/scripts/backfill_legacy_memories.py`
 
 ## Safety contract
@@ -12,6 +14,7 @@
 - **Cohort gate** — backfill runs only when `uid` is in `CANONICAL_MEMORY_USERS` (or `--allow-admin-override`).
 - **Idempotent** — backfill ids are `mem_` + hash(`uid`, `legacy_memory_id`); apply path honors `idempotency_key`.
 - **Both-store dedup** — if live extraction already wrote the same fact (`extraction_memory_id` from `conversation_id` + `content`), backfill skips that row.
+- **Bucketed dogfood** — bucketed runs preserve legacy timestamps, write selected profile-like rows as either `long_term` or required-promotion `short_term`, and hold noisy/sensitive rows.
 - **Reversible** — remove `uid` from `CANONICAL_MEMORY_USERS` and redeploy to return them to legacy reads; legacy rows remain intact.
 
 ## Preconditions
@@ -28,53 +31,83 @@
 
 ## Procedure
 
-### 1. Dry run (no writes)
+### 1. Bucket inventory dry run (no writes)
 
 ```bash
 cd backend
-python scripts/backfill_legacy_memories.py --uid YOUR_UID --dry-run
+python scripts/backfill_legacy_memories.py --uid YOUR_UID --strategy bucketed --dry-run
 ```
 
 Expect:
 
 - `dry_run: true`
 - `source_count` = active legacy rows with non-empty content
-- `intended_count` = rows still to copy (respects resume checkpoint)
+- `bucket_counts` = full inventory by bucket
+- `bucket_samples` = small row samples for review
 - `written_count: 0`
 - `cohort_gated: false` (if gated, add uid to whitelist first)
 
-### 2. Real run
+Buckets:
+
+| Bucket | Writes? | Destination | Intended use |
+|--------|---------|-------------|--------------|
+| `manual_required_promotion` | Yes | `short_term` with `promotion.required=true` | User/manual memories that should flow through normal promotion |
+| `profile_required_promotion` | Yes | `short_term` with `promotion.required=true` | Profile-like legacy rows that need consolidation/promotion review |
+| `reviewed_long_term` | Yes | `long_term` | Profile-like rows already explicitly user-reviewed |
+| `archive_review` | No | None | Non-obvious rows for later manual/archive policy review |
+| `hold_noise` | No | None | Downloads inventory, focused-app activity, imperative task fragments, empty/low-signal rows |
+| `hold_sensitive` | No | None | Credential/token/password/secret-like rows |
+
+### 2. Bucket dry run (no writes)
+
+Dry-run the first bucket before writing it:
 
 ```bash
-python scripts/backfill_legacy_memories.py --uid YOUR_UID
+python scripts/backfill_legacy_memories.py --uid YOUR_UID --strategy bucketed --bucket manual_required_promotion --dry-run
 ```
 
-Monitor JSON output:
+Expect `intended_count` to match the reviewed bucket size minus existing canonical destinations.
+
+### 3. Apply one bucket
+
+Apply only after reviewing the bucket inventory and samples:
+
+```bash
+python scripts/backfill_legacy_memories.py --uid YOUR_UID --strategy bucketed --bucket manual_required_promotion
+```
+
+Repeat bucket dry-run, review, and apply for the next approved writable bucket. Do not apply hold buckets; the script reports them as non-writable.
+
+Monitor JSON output after each applied bucket:
 
 | Field | Success signal |
 |-------|----------------|
 | `completed` | `true` |
-| `verified` | `true` (`source_count == destination_count`) |
-| `written_count` + `skipped_*` | Should account for all `source_count` rows |
+| `verified` | `true` for the selected bucket |
+| `selected_bucket` | The bucket you intended to apply |
+| `written_count` + `skipped_*` | Should account for the selected bucket rows |
+| `vector_sync_failures` | `0` |
 | `errors` | `[]` |
 
 Re-run is safe: already-present and both-store-duplicate rows are skipped.
 
-### 3. Verification queries
+### 4. Verification queries
 
 **Firestore (console or script):**
 
 - Legacy unchanged: `users/{uid}/memories/*` — same doc count as before; no `invalid_at` changes from backfill.
-- Canonical items: `users/{uid}/memory_items/*` — one active processed item per legacy row (either backfill id or live-write id).
-- Checkpoint: `users/{uid}/memory_control/state` — `legacy_backfill_completed_at` set when `completed=true`.
+- Canonical items: `users/{uid}/memory_items/*` — one active processed item per applied writable-bucket row (either backfill id or live-write id).
+- Required-promotion rows: selected `manual_required_promotion` / `profile_required_promotion` rows are `tier=short_term`, have `promotion.required=true`, `promotion.status=pending`, old `captured_at`, and future `expires_at`.
+- Reviewed long-term rows: selected `reviewed_long_term` rows are `tier=long_term` with old `captured_at`.
+- Control state: `users/{uid}/memory_control/state` exists after a real run.
 
 **Python reconcile (same logic as the library):**
 
 ```python
-from utils.memory.legacy_backfill import backfill_user
+from utils.memory.legacy_backfill import backfill_user_bucketed
 
-report = backfill_user("YOUR_UID", dry_run=True)
-assert report.verified is True
+report = backfill_user_bucketed("YOUR_UID", bucket="manual_required_promotion", dry_run=True)
+assert report.errors == []
 ```
 
 **Read path smoke:** with uid still whitelisted, `GET /v3/memories` (or desktop Memories tab) should show long-term facts without duplicates.
@@ -89,13 +122,13 @@ assert report.verified is True
 ## When *not* to proceed
 
 - `cohort_gated: true` — fix whitelist before real run.
-- `verified: false` after a completed run — inspect `discrepancy`, missing items, or partial checkpoint (`legacy_backfill_processed_count`).
-- `errors` non-empty — fix root cause; resume from checkpoint (`resume=True` default).
+- `verified: false` after a completed bucket run — inspect `discrepancy` and missing selected-bucket items.
+- `errors` non-empty — fix root cause; re-run the same bucket. Bucketed writes are deterministic and idempotent.
 
 ## Operational notes
 
-- **Provenance:** backfilled rows set `user_asserted=False`, `visibility=private`, `captured_at=now` (legacy `created_at` is not copied).
-- **Fingerprint:** checkpoint fingerprint is legacy **id-set only**; editing legacy content under the same id does not re-copy (staleness, not data loss).
+- **Provenance:** bucketed rows preserve legacy `created_at` as `captured_at` and legacy `updated_at` as `updated_at`. Short-term bucketed rows set `expires_at` to migration time + 30 days so promotion can process them.
+- **Bulk compatibility:** `backfill_user` and `--strategy bulk-long-term` still use the legacy id-set checkpoint. Bucketed dogfood does not use that checkpoint; re-runs reconcile by deterministic canonical ids.
 - **Vectors:** backfill syncs Pinecone via `sync_canonical_memory_vector`; vector sync failures increment `vector_sync_failures` but does not roll back Firestore writes.
 
 ## Short-term promotion (canonical cohort)


### PR DESCRIPTION
## Summary
- add a bucketed legacy-memory backfill mode for first-user dogfood instead of bulk-copying noisy legacy rows
- preserve legacy timestamps on bucketed canonical writes and route selected rows into reviewed long-term or required-promotion short-term buckets
- update the backfill CLI and runbook with per-bucket dry-run/apply workflow and hold buckets for noisy or sensitive rows

## Verification
- cd backend && pytest tests/unit/test_ws_c_backfill.py
- cd backend && pytest tests/unit/test_memory_apply_store.py tests/unit/test_ws_i_write_convergence.py tests/unit/test_ws_b_short_term_lifecycle.py
- cd backend && python scripts/scan_async_blockers.py
- cd backend && python scripts/backfill_legacy_memories.py --help
- cd backend && python scripts/backfill_legacy_memories.py --uid test --strategy bucketed  # exits 2 before backend env import, as intended
- pre-push checks passed, including OpenAPI contract check

## Rollout notes
- First run should be inventory-only: python scripts/backfill_legacy_memories.py --uid <uid> --strategy bucketed --dry-run
- Apply only one reviewed writable bucket at a time, starting with manual_required_promotion.
- Hold buckets are intentionally non-writing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

