### PR TITLE
[codex] Enforce API key rate limits

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -49,14 +49,15 @@ async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> s
     user_data = mcp_api_key_db.get_user_and_scopes_by_api_key(token)
     if not user_data:
         raise HTTPException(status_code=401, detail="Invalid API Key")
+    user_id = user_data["user_id"]
     check_api_key_rate_limit(
         prefix="mcp",
-        uid=user_data["user_id"],
+        uid=user_id,
         app_id=user_data.get("app_id"),
         key_id=user_data.get("key_id"),
         policy_name="mcp:read",
     )
-    return user_data["user_id"]
+    return user_id
 
 
 async def get_mcp_api_key_auth(api_key: str = Security(api_key_header)) -> "ApiKeyAuth":
@@ -122,6 +123,13 @@ async def get_mcp_memory_default_memory_write_context(
         raise HTTPException(status_code=403, detail="Insufficient permissions. Required scope: memories.write")
     if not auth.app_id or not auth.key_id:
         raise HTTPException(status_code=403, detail="Missing MCP API app/key identity for memory memory authorization")
+    check_api_key_rate_limit(
+        prefix="mcp",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="mcp:memories_write",
+    )
     return build_mcp_default_memory_write_context(
         McpVerifiedAuth(
             uid=auth.uid,
@@ -192,8 +200,8 @@ async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_ke
 
 
 async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_conversations_read(auth)
-    return auth_data.uid
+    await get_auth_with_conversations_read(auth)
+    return auth.uid
 
 
 async def get_auth_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -212,8 +220,8 @@ async def get_auth_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_k
 
 
 async def get_uid_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_conversations_write(auth)
-    return auth_data.uid
+    await get_auth_with_conversations_write(auth)
+    return auth.uid
 
 
 async def get_auth_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -230,8 +238,8 @@ async def get_auth_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_aut
 
 
 async def get_uid_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_memories_read(auth)
-    return auth_data.uid
+    await get_auth_with_memories_read(auth)
+    return auth.uid
 
 
 async def get_auth_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -250,8 +258,8 @@ async def get_auth_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_au
 
 
 async def get_uid_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_memories_write(auth)
-    return auth_data.uid
+    await get_auth_with_memories_write(auth)
+    return auth.uid
 
 
 async def get_auth_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -270,8 +278,8 @@ async def get_auth_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key
 
 
 async def get_uid_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_action_items_read(auth)
-    return auth_data.uid
+    await get_auth_with_action_items_read(auth)
+    return auth.uid
 
 
 async def get_auth_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -290,8 +298,8 @@ async def get_auth_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_ke
 
 
 async def get_uid_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_action_items_write(auth)
-    return auth_data.uid
+    await get_auth_with_action_items_write(auth)
+    return auth.uid
 
 
 async def get_auth_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -308,8 +316,8 @@ async def get_auth_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth))
 
 
 async def get_uid_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_goals_read(auth)
-    return auth_data.uid
+    await get_auth_with_goals_read(auth)
+    return auth.uid
 
 
 async def get_auth_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
@@ -326,8 +334,8 @@ async def get_auth_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)
 
 
 async def get_uid_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    auth_data = await get_auth_with_goals_write(auth)
-    return auth_data.uid
+    await get_auth_with_goals_write(auth)
+    return auth.uid
 
 
 DEVELOPER_TO_MEMORY_SCOPES = {
@@ -370,7 +378,7 @@ async def get_developer_memory_default_memory_read_context(
     )
 
 
-async def get_developer_memory_default_memory_write_context(
+async def get_developer_memory_default_memory_write_auth_context(
     auth: ApiKeyAuth = Depends(get_api_key_auth),
 ) -> ProductAuthorizationContext:
     if not has_scope(auth.scopes, Scopes.MEMORIES_WRITE):
@@ -381,13 +389,6 @@ async def get_developer_memory_default_memory_write_context(
         raise HTTPException(
             status_code=403, detail="Missing Developer API app/key identity for memory memory authorization"
         )
-    check_api_key_rate_limit(
-        prefix="dev",
-        uid=auth.uid,
-        app_id=auth.app_id,
-        key_id=auth.key_id,
-        policy_name="dev:memories",
-    )
     return ProductAuthorizationContext(
         uid=auth.uid,
         consumer='developer_api',
@@ -398,8 +399,21 @@ async def get_developer_memory_default_memory_write_context(
     )
 
 
+async def get_developer_memory_default_memory_write_context(
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_auth_context),
+) -> ProductAuthorizationContext:
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth_context.uid,
+        app_id=auth_context.app_id,
+        key_id=auth_context.key_id,
+        policy_name="dev:memories",
+    )
+    return auth_context
+
+
 async def get_developer_memory_default_memory_batch_write_context(
-    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_context),
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_auth_context),
 ) -> ProductAuthorizationContext:
     check_api_key_rate_limit(
         prefix="dev",

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -13,6 +13,7 @@ from utils.mcp_memories import (
     build_mcp_default_memory_read_context,
     build_mcp_default_memory_write_context,
 )
+from utils.other.endpoints import check_api_key_rate_limit
 import logging
 
 logger = logging.getLogger(__name__)
@@ -45,10 +46,17 @@ async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> s
         )
 
     token = api_key.replace("Bearer ", "")
-    user_id = mcp_api_key_db.get_user_id_by_api_key(token)
-    if not user_id:
+    user_data = mcp_api_key_db.get_user_and_scopes_by_api_key(token)
+    if not user_data:
         raise HTTPException(status_code=401, detail="Invalid API Key")
-    return user_id
+    check_api_key_rate_limit(
+        prefix="mcp",
+        uid=user_data["user_id"],
+        app_id=user_data.get("app_id"),
+        key_id=user_data.get("key_id"),
+        policy_name="mcp:read",
+    )
+    return user_data["user_id"]
 
 
 async def get_mcp_api_key_auth(api_key: str = Security(api_key_header)) -> "ApiKeyAuth":
@@ -84,6 +92,13 @@ async def get_mcp_memory_default_memory_read_context(
         raise HTTPException(status_code=403, detail="Insufficient permissions. Required scope: memories.read")
     if not auth.app_id or not auth.key_id:
         raise HTTPException(status_code=403, detail="Missing MCP API app/key identity for memory memory authorization")
+    check_api_key_rate_limit(
+        prefix="mcp",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="mcp:memories_read",
+    )
     return build_mcp_default_memory_read_context(
         McpVerifiedAuth(
             uid=auth.uid,
@@ -161,26 +176,158 @@ async def get_uid_from_dev_api_key(api_key: str = Security(api_key_header)) -> s
 
 
 # Scope-specific dependencies
-async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_READ):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.CONVERSATIONS_READ}"
         )
-    return auth.uid
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:conversations_read",
+    )
+    return auth
 
 
-async def get_uid_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_conversations_read(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_WRITE):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.CONVERSATIONS_WRITE}"
         )
-    return auth.uid
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:conversations",
+    )
+    return auth
+
+
+async def get_uid_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_conversations_write(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.MEMORIES_READ):
+        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_READ}")
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:memories_read",
+    )
+    return auth
 
 
 async def get_uid_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.MEMORIES_READ):
-        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_READ}")
-    return auth.uid
+    auth_data = await get_auth_with_memories_read(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.MEMORIES_WRITE):
+        raise HTTPException(
+            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_WRITE}"
+        )
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:memories",
+    )
+    return auth
+
+
+async def get_uid_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_memories_write(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.ACTION_ITEMS_READ):
+        raise HTTPException(
+            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.ACTION_ITEMS_READ}"
+        )
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:action_items_read",
+    )
+    return auth
+
+
+async def get_uid_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_action_items_read(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.ACTION_ITEMS_WRITE):
+        raise HTTPException(
+            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.ACTION_ITEMS_WRITE}"
+        )
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:action_items_write",
+    )
+    return auth
+
+
+async def get_uid_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_action_items_write(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.GOALS_READ):
+        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.GOALS_READ}")
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:goals_read",
+    )
+    return auth
+
+
+async def get_uid_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_goals_read(auth)
+    return auth_data.uid
+
+
+async def get_auth_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    if not has_scope(auth.scopes, Scopes.GOALS_WRITE):
+        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.GOALS_WRITE}")
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:goals_write",
+    )
+    return auth
+
+
+async def get_uid_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+    auth_data = await get_auth_with_goals_write(auth)
+    return auth_data.uid
 
 
 DEVELOPER_TO_MEMORY_SCOPES = {
@@ -206,6 +353,13 @@ async def get_developer_memory_default_memory_read_context(
         raise HTTPException(
             status_code=403, detail="Missing Developer API app/key identity for memory memory authorization"
         )
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:memories_read",
+    )
     return ProductAuthorizationContext(
         uid=auth.uid,
         consumer='developer_api',
@@ -227,6 +381,13 @@ async def get_developer_memory_default_memory_write_context(
         raise HTTPException(
             status_code=403, detail="Missing Developer API app/key identity for memory memory authorization"
         )
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:memories",
+    )
     return ProductAuthorizationContext(
         uid=auth.uid,
         consumer='developer_api',
@@ -237,37 +398,14 @@ async def get_developer_memory_default_memory_write_context(
     )
 
 
-async def get_uid_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.MEMORIES_WRITE):
-        raise HTTPException(
-            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_WRITE}"
-        )
-    return auth.uid
-
-
-async def get_uid_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.ACTION_ITEMS_READ):
-        raise HTTPException(
-            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.ACTION_ITEMS_READ}"
-        )
-    return auth.uid
-
-
-async def get_uid_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.ACTION_ITEMS_WRITE):
-        raise HTTPException(
-            status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.ACTION_ITEMS_WRITE}"
-        )
-    return auth.uid
-
-
-async def get_uid_with_goals_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.GOALS_READ):
-        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.GOALS_READ}")
-    return auth.uid
-
-
-async def get_uid_with_goals_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
-    if not has_scope(auth.scopes, Scopes.GOALS_WRITE):
-        raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.GOALS_WRITE}")
-    return auth.uid
+async def get_developer_memory_default_memory_batch_write_context(
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_context),
+) -> ProductAuthorizationContext:
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth_context.uid,
+        app_id=auth_context.app_id,
+        key_id=auth_context.key_id,
+        policy_name="dev:memories_batch",
+    )
+    return auth_context

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -40,6 +40,7 @@ from dependencies import (
     get_current_user_id,
     get_uid_with_conversations_read,
     get_uid_with_conversations_write,
+    get_developer_memory_default_memory_batch_write_context,
     get_developer_memory_default_memory_read_context,
     get_developer_memory_default_memory_write_context,
     get_uid_with_action_items_read,
@@ -48,7 +49,7 @@ from dependencies import (
     get_uid_with_goals_write,
 )
 from utils.apps import update_personas_async
-from utils.other.endpoints import with_rate_limit, with_rate_limit_context, get_current_user_uid
+from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
 from utils.notifications import send_action_item_data_message, sync_action_item_reminder
@@ -497,9 +498,7 @@ def search_memories_vector(
 @router.post("/v1/dev/user/memories", response_model=DeveloperMemory, tags=["Memories"], operation_id="createMemory")
 def create_memory(
     request: CreateMemoryRequest,
-    auth_context: ProductAuthorizationContext = Depends(
-        with_rate_limit_context(get_developer_memory_default_memory_write_context, "dev:memories")
-    ),
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_context),
 ):
     """
     Create a new memory for the authenticated user.
@@ -596,9 +595,7 @@ def create_memory(
 )
 def create_memories_batch(
     request: BatchMemoriesRequest,
-    auth_context: ProductAuthorizationContext = Depends(
-        with_rate_limit_context(get_developer_memory_default_memory_write_context, "dev:memories_batch")
-    ),
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_batch_write_context),
 ):
     """
     Create multiple memories in a batch.
@@ -1314,7 +1311,7 @@ def get_conversations(
     # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
     # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
     offset = max(0, offset)
-    limit = max(1, min(limit, 1000))
+    limit = max(1, min(limit, 25 if include_transcript else 100))
     try:
         category_list = [CategoryEnum(c.strip()) for c in categories.split(",") if c.strip()] if categories else []
     except ValueError as e:
@@ -1372,7 +1369,7 @@ def get_conversations(
 )
 def create_conversation(
     request: CreateConversationRequest,
-    uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
+    uid: str = Depends(get_uid_with_conversations_write),
 ):
     """
     Create a new conversation from text for the authenticated user.
@@ -1707,7 +1704,7 @@ def create_conversation_from_segments_user(
 def create_conversation_from_segments(
     request: CreateConversationFromTranscriptRequest,
     http_request: Request,
-    uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
+    uid: str = Depends(get_uid_with_conversations_write),
 ):
     """
     Create a new conversation from structured transcript segments.

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -532,7 +532,10 @@ def search_conversations(
     response_model=FullConversation,
     tags=["mcp"],
 )
-def get_conversation_by_id(conversation_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_conversation_by_id(
+    conversation_id: str,
+    uid: str = Depends(get_uid_from_mcp_api_key),
+):
     logger.info(f"get_conversation_by_id {uid} {conversation_id}")
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -605,7 +608,11 @@ def _action_item_write_error(exc: Exception) -> HTTPException:
 
 
 @router.get("/v1/mcp/action-items/search", response_model=List[SimpleActionItem], tags=["mcp"])
-def search_action_items(query: str, limit: int = 10, uid: str = Depends(get_uid_from_mcp_api_key)):
+def search_action_items(
+    query: str,
+    limit: int = 10,
+    uid: str = Depends(get_uid_from_mcp_api_key),
+):
     logger.info(f"search_action_items {uid} limit={limit}")
     try:
         return mcp_action_items.search_action_items(uid, query, limit=limit)
@@ -628,7 +635,11 @@ def create_action_item(
 
 
 @router.post("/v1/mcp/action-items/{action_item_id}/complete", response_model=SimpleActionItem, tags=["mcp"])
-def complete_action_item(action_item_id: str, completed: bool = True, uid: str = Depends(get_uid_from_mcp_api_key)):
+def complete_action_item(
+    action_item_id: str,
+    completed: bool = True,
+    uid: str = Depends(with_rate_limit(get_uid_from_mcp_api_key, "action_items:write")),
+):
     logger.info(f"complete_action_item {uid} id={action_item_id} completed={completed}")
     try:
         return mcp_action_items.set_completed(uid, action_item_id, completed=completed)
@@ -637,7 +648,11 @@ def complete_action_item(action_item_id: str, completed: bool = True, uid: str =
 
 
 @router.patch("/v1/mcp/action-items/{action_item_id}", response_model=SimpleActionItem, tags=["mcp"])
-def update_action_item(action_item_id: str, body: McpUpdateActionItem, uid: str = Depends(get_uid_from_mcp_api_key)):
+def update_action_item(
+    action_item_id: str,
+    body: McpUpdateActionItem,
+    uid: str = Depends(with_rate_limit(get_uid_from_mcp_api_key, "action_items:write")),
+):
     logger.info(f"update_action_item {uid} id={action_item_id}")
     try:
         return mcp_action_items.update_action_item(
@@ -650,7 +665,10 @@ def update_action_item(action_item_id: str, body: McpUpdateActionItem, uid: str 
 
 
 @router.delete("/v1/mcp/action-items/{action_item_id}", tags=["mcp"])
-def delete_action_item(action_item_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
+def delete_action_item(
+    action_item_id: str,
+    uid: str = Depends(with_rate_limit(get_uid_from_mcp_api_key, "action_items:write")),
+):
     logger.info(f"delete_action_item {uid} id={action_item_id}")
     try:
         mcp_action_items.delete_action_item(uid, action_item_id)
@@ -665,7 +683,10 @@ def delete_action_item(action_item_id: str, uid: str = Depends(get_uid_from_mcp_
 
 
 @router.get("/v1/mcp/goals", tags=["mcp"])
-def get_goals(include_inactive: bool = False, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_goals(
+    include_inactive: bool = False,
+    uid: str = Depends(get_uid_from_mcp_api_key),
+):
     logger.info(f"get_goals {uid} include_inactive={include_inactive}")
     return goals_db.get_all_goals(uid, include_inactive=include_inactive)
 
@@ -684,7 +705,11 @@ class SimpleChatMessage(BaseModel):
 
 
 @router.get("/v1/mcp/chat", response_model=List[SimpleChatMessage], tags=["mcp"])
-def get_chat_messages(limit: int = 50, offset: int = 0, uid: str = Depends(get_uid_from_mcp_api_key)):
+def get_chat_messages(
+    limit: int = 50,
+    offset: int = 0,
+    uid: str = Depends(get_uid_from_mcp_api_key),
+):
     logger.info(f"get_chat_messages {uid} limit={limit} offset={offset}")
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
@@ -727,7 +752,7 @@ def get_screen_activity(
     logger.info(f"get_screen_activity {uid} summary={summary} app={app} limit={limit}")
     if summary:
         return screen_activity_db.get_screen_activity_summary(uid, start_date=start_date, end_date=end_date)
-    limit = max(1, min(limit, 1000))
+    limit = max(1, min(limit, 200))
     rows = screen_activity_db.get_screen_activity(
         uid, start_date=start_date, end_date=end_date, app_filter=app, limit=limit
     )

--- a/backend/tests/unit/test_deferred_blob_janitor.py
+++ b/backend/tests/unit/test_deferred_blob_janitor.py
@@ -14,6 +14,8 @@ import os
 import threading
 import time
 
+import pytest
+
 from utils.other.deferred_delete import DeferredDeleter
 
 
@@ -88,6 +90,7 @@ class TestDeferredDeleterBehavior:
         assert d._thread is first_thread
         assert _wait_for(lambda: d.pending_count() == 0)
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_janitor_restarts_if_killed_by_base_exception(self):
         """SystemExit/MemoryError bypass the except-Exception catch and kill the
         thread; the next schedule() must notice and start a fresh janitor."""

--- a/backend/tests/unit/test_dev_api_action_items_poison.py
+++ b/backend/tests/unit/test_dev_api_action_items_poison.py
@@ -125,6 +125,8 @@ if not hasattr(_endpoints, 'with_rate_limit'):
     _endpoints.with_rate_limit = lambda dependency, _policy: dependency
 if not hasattr(_endpoints, 'with_rate_limit_context'):
     setattr(_endpoints, 'with_rate_limit_context', lambda dependency, _policy: dependency)
+if not hasattr(_endpoints, 'check_api_key_rate_limit'):
+    _endpoints.check_api_key_rate_limit = MagicMock()
 if not hasattr(_endpoints, 'get_user'):
     _endpoints.get_user = MagicMock()
 

--- a/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
+++ b/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
@@ -112,6 +112,8 @@ if not hasattr(_endpoints, 'with_rate_limit'):
     _endpoints.with_rate_limit = _fake_with_rate_limit
 if not hasattr(_endpoints, 'with_rate_limit_context'):
     setattr(_endpoints, 'with_rate_limit_context', _fake_with_rate_limit)
+if not hasattr(_endpoints, 'check_api_key_rate_limit'):
+    _endpoints.check_api_key_rate_limit = MagicMock()
 if not hasattr(_endpoints, 'get_user'):
     _endpoints.get_user = MagicMock()
 

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -126,6 +126,8 @@ if not hasattr(_endpoints, 'with_rate_limit'):
     _endpoints.with_rate_limit = lambda dependency, _policy: dependency
 if not hasattr(_endpoints, 'with_rate_limit_context'):
     setattr(_endpoints, 'with_rate_limit_context', lambda dependency, _policy: dependency)
+if not hasattr(_endpoints, 'check_api_key_rate_limit'):
+    _endpoints.check_api_key_rate_limit = MagicMock()
 if not hasattr(_endpoints, 'get_user'):
     _endpoints.get_user = MagicMock()
 
@@ -193,7 +195,9 @@ def test_pagination_is_clamped_before_firestore():
         developer_module, 'populate_folder_names', lambda *a, **k: None
     ), patch.object(developer_module, 'populate_speaker_names', lambda *a, **k: None):
         developer_module.get_conversations(uid='uid1', limit=99999, offset=-1)
+        developer_module.get_conversations(uid='uid1', limit=99999, offset=0, include_transcript=True)
         developer_module.get_conversations(uid='uid1', limit=0, offset=5)
     high = m.call_args_list[0].args
-    assert high[1] == 1000 and high[2] == 0  # limit 99999 -> 1000, offset -1 -> 0
-    assert m.call_args_list[1].args[1] == 1  # limit 0 -> 1
+    assert high[1] == 100 and high[2] == 0  # limit 99999 -> 100, offset -1 -> 0
+    assert m.call_args_list[1].args[1] == 25  # transcript reads cap tighter
+    assert m.call_args_list[2].args[1] == 1  # limit 0 -> 1

--- a/backend/tests/unit/test_dev_api_memories_pagination.py
+++ b/backend/tests/unit/test_dev_api_memories_pagination.py
@@ -149,6 +149,8 @@ if not hasattr(_endpoints, 'with_rate_limit'):
     _endpoints.with_rate_limit = _fake_with_rate_limit
 if not hasattr(_endpoints, 'with_rate_limit_context'):
     setattr(_endpoints, 'with_rate_limit_context', _fake_with_rate_limit)
+if not hasattr(_endpoints, 'check_api_key_rate_limit'):
+    _endpoints.check_api_key_rate_limit = MagicMock()
 if not hasattr(_endpoints, 'get_user'):
     _endpoints.get_user = MagicMock()
 

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -117,6 +117,7 @@ if _endpoints is None:
 _endpoints.get_current_user_uid = lambda: 'uid1'
 _endpoints.with_rate_limit = lambda dependency, _policy: dependency
 _endpoints.with_rate_limit_context = lambda dependency, _policy: dependency
+_endpoints.check_api_key_rate_limit = MagicMock()
 _endpoints.get_user = MagicMock()
 
 _ensure_package_path('models', BACKEND_DIR / 'models')

--- a/backend/tests/unit/test_mcp_api_key_auth_context.py
+++ b/backend/tests/unit/test_mcp_api_key_auth_context.py
@@ -53,6 +53,7 @@ setattr(_fake_client, 'get_firestore_client', lambda: SimpleNamespace())
 sys.modules['database._client'] = _fake_client
 
 import database.mcp_api_key as mcp_api_key_db
+import dependencies as dependencies_module
 from dependencies import get_mcp_api_key_auth, get_mcp_memory_default_memory_read_context
 from utils.mcp_memories import McpVerifiedAuth, build_mcp_default_memory_read_context
 from utils.memory.product_authorization import authorize_memory_external_default_memory_read
@@ -254,6 +255,7 @@ def test_persisted_mcp_app_key_scopes_build_verified_memory_context_without_arch
 
 
 def test_mcp_auth_dependency_preserves_uid_scope_identity_shape(monkeypatch):
+    monkeypatch.setattr(dependencies_module, 'check_api_key_rate_limit', lambda **_kwargs: None)
     monkeypatch.setattr(
         mcp_api_key_db,
         'get_user_and_scopes_by_api_key',

--- a/backend/tests/unit/test_mcp_api_key_auth_context.py
+++ b/backend/tests/unit/test_mcp_api_key_auth_context.py
@@ -34,13 +34,21 @@ except ImportError:
     sys.modules.setdefault('fastapi', _fake_fastapi)
     sys.modules.setdefault('fastapi.security', _fake_fastapi_security)
 _fake_firebase_admin = ModuleType('firebase_admin')
-setattr(_fake_firebase_admin, 'auth', SimpleNamespace(verify_id_token=lambda _token: {'uid': 'unused'}))
+_fake_firebase_auth = ModuleType('firebase_admin.auth')
+setattr(_fake_firebase_auth, 'verify_id_token', lambda _token: {'uid': 'unused'})
+setattr(_fake_firebase_auth, 'CertificateFetchError', type('CertificateFetchError', (Exception,), {}))
+setattr(_fake_firebase_auth, 'ExpiredIdTokenError', type('ExpiredIdTokenError', (Exception,), {}))
+setattr(_fake_firebase_auth, 'InvalidIdTokenError', type('InvalidIdTokenError', (Exception,), {}))
+setattr(_fake_firebase_auth, 'RevokedIdTokenError', type('RevokedIdTokenError', (Exception,), {}))
+setattr(_fake_firebase_admin, 'auth', _fake_firebase_auth)
 sys.modules.setdefault('firebase_admin', _fake_firebase_admin)
+sys.modules.setdefault('firebase_admin.auth', _fake_firebase_auth)
 
 from fastapi import HTTPException
 
 _fake_client = ModuleType('database._client')
 setattr(_fake_client, 'db', SimpleNamespace())
+setattr(_fake_client, 'document_id_from_seed', lambda seed: 'id-' + str(abs(hash(seed)) % (10**12)))
 setattr(_fake_client, 'get_firestore_client', lambda: SimpleNamespace())
 sys.modules['database._client'] = _fake_client
 

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -134,6 +134,7 @@ sys.modules['utils.other.endpoints'].with_rate_limit_context = MagicMock(
     side_effect=lambda dependency, _policy: dependency
 )
 sys.modules['utils.other.endpoints'].check_rate_limit_inline = MagicMock()
+sys.modules['utils.other.endpoints'].check_api_key_rate_limit = MagicMock()
 sys.modules['utils.apps'].update_personas_async = MagicMock()
 sys.modules['utils.executors'].db_executor = MagicMock()
 sys.modules['utils.executors'].postprocess_executor = MagicMock()

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -283,6 +283,23 @@ class TestWithRateLimitWrapper(unittest.TestCase):
         self.ep.check_rate_limit_inline("app1:uid1", "integration:memories")
         mock_enforce.assert_called_once_with("app1:uid1", "integration:memories")
 
+    def test_rate_limit_key_for_context_prefers_app_key_identity(self):
+        context = types.SimpleNamespace(uid="uid1", app_id="app1", key_id="key1")
+
+        self.assertEqual(self.ep.rate_limit_key_for_context(context), "app:app1:key:key1")
+
+    def test_rate_limit_key_for_context_falls_back_to_uid(self):
+        context = types.SimpleNamespace(uid="uid1")
+
+        self.assertEqual(self.ep.rate_limit_key_for_context(context), "uid1")
+
+    def test_rate_limit_key_for_context_rejects_missing_api_key_identity(self):
+        context = types.SimpleNamespace(uid="uid1", app_id=None, key_id=None)
+
+        with self.assertRaises(HTTPException) as ctx:
+            self.ep.rate_limit_key_for_context(context)
+        self.assertEqual(ctx.exception.status_code, 403)
+
     @patch('utils.other.endpoints._enforce_rate_limit')
     def test_with_rate_limit_dependency_calls_enforce_and_returns_uid(self, mock_enforce):
         """Execute the async dependency closure and verify it enforces + returns uid."""
@@ -303,6 +320,41 @@ class TestWithRateLimitWrapper(unittest.TestCase):
         with self.assertRaises(HTTPException) as ctx:
             asyncio.run(dep_func(uid="user123"))
         self.assertEqual(ctx.exception.status_code, 429)
+
+    @patch('utils.other.endpoints._enforce_rate_limit')
+    def test_with_rate_limit_context_uses_app_key_identity(self, mock_enforce):
+        import asyncio
+
+        dep_func = self.ep.with_rate_limit_context(lambda: "unused", "dev:conversations_read")
+        context = types.SimpleNamespace(uid="uid1", app_id="app1", key_id="key1")
+
+        result = asyncio.run(dep_func(auth_context=context))
+
+        mock_enforce.assert_called_once_with("app:app1:key:key1", "dev:conversations_read", fail_closed=True)
+        self.assertIs(result, context)
+
+    @patch('utils.other.endpoints._enforce_rate_limit')
+    def test_check_api_key_rate_limit_uses_key_identity_and_fails_closed(self, mock_enforce):
+        self.ep.check_api_key_rate_limit(
+            prefix="dev",
+            uid="uid1",
+            app_id="app1",
+            key_id="key1",
+            policy_name="dev:conversations_read",
+        )
+
+        mock_enforce.assert_called_once_with("dev:uid1:app1:key1", "dev:conversations_read", fail_closed=True)
+
+    def test_check_api_key_rate_limit_rejects_missing_key_id(self):
+        with self.assertRaises(HTTPException) as ctx:
+            self.ep.check_api_key_rate_limit(
+                prefix="dev",
+                uid="uid1",
+                app_id="app1",
+                key_id=None,
+                policy_name="dev:conversations_read",
+            )
+        self.assertEqual(ctx.exception.status_code, 403)
 
 
 class TestBoostEnvVar(unittest.TestCase):
@@ -347,8 +399,16 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "goals:advice",
             "goals:extract",
             "dev:conversations",
+            "dev:conversations_read",
+            "dev:action_items_read",
+            "dev:action_items_write",
+            "dev:goals_read",
+            "dev:goals_write",
             "dev:memories",
+            "dev:memories_read",
             "dev:memories_batch",
+            "mcp:read",
+            "mcp:memories_read",
             "knowledge_graph:rebuild",
             "wrapped:generate",
             "integration:conversations",
@@ -393,10 +453,22 @@ class TestRouterWiring(unittest.TestCase):
         matches = self._grep_file("routers/chat.py", r"with_rate_limit.*file:upload")
         self.assertEqual(len(matches), 2, f"chat.py expected 2 file:upload limits (v1+v2), got {len(matches)}")
 
-    def test_developer_router_has_rate_limits(self):
-        matches = self._grep_file("routers/developer.py", r"with_rate_limit.*dev:")
-        # create_memory, batch, create_conversation, from_segments = 4
-        self.assertEqual(len(matches), 4, f"developer.py expected 4 rate limits, got {len(matches)}")
+    def test_developer_dependencies_have_rate_limits(self):
+        source = open("dependencies.py", encoding='utf-8').read()
+        matches = [line for line in source.splitlines() if "policy_name=\"dev:" in line]
+        self.assertGreaterEqual(
+            len(matches), 8, f"dependencies.py expected broad dev API rate limits, got {len(matches)}"
+        )
+
+    def test_developer_dependencies_have_read_rate_limits(self):
+        source = open("dependencies.py", encoding='utf-8').read()
+        for policy in [
+            "dev:memories_read",
+            "dev:action_items_read",
+            "dev:conversations_read",
+            "dev:goals_read",
+        ]:
+            self.assertIn(policy, source)
 
     def test_goals_router_has_rate_limits(self):
         matches = self._grep_file("routers/goals.py", r"with_rate_limit.*goals:")
@@ -408,8 +480,15 @@ class TestRouterWiring(unittest.TestCase):
         self.assertGreaterEqual(len(matches), 1, "mcp_sse.py missing rate limit wiring")
 
     def test_mcp_router_has_rate_limit(self):
-        matches = self._grep_file("routers/mcp.py", r"with_rate_limit.*memories:")
-        self.assertGreaterEqual(len(matches), 1, "mcp.py missing rate limit wiring")
+        source = open("dependencies.py", encoding='utf-8').read()
+        self.assertIn("mcp:read", source, "MCP API-key UID dependency missing read rate limit")
+        self.assertIn("mcp:memories_read", source, "MCP memory auth dependency missing memory read rate limit")
+
+    def test_sensitive_read_page_caps(self):
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+        mcp_source = open("routers/mcp.py", encoding='utf-8').read()
+        self.assertIn("min(limit, 25 if include_transcript else 100)", developer_source)
+        self.assertIn("min(limit, 200)", mcp_source)
 
     def test_integration_router_has_rate_limits(self):
         matches = self._grep_file("routers/integration.py", r"check_rate_limit_inline.*integration:")

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -293,8 +293,13 @@ class TestWithRateLimitWrapper(unittest.TestCase):
 
         self.assertEqual(self.ep.rate_limit_key_for_context(context), "uid1")
 
-    def test_rate_limit_key_for_context_rejects_missing_api_key_identity(self):
+    def test_rate_limit_key_for_context_falls_back_to_uid_when_api_key_identity_absent(self):
         context = types.SimpleNamespace(uid="uid1", app_id=None, key_id=None)
+
+        self.assertEqual(self.ep.rate_limit_key_for_context(context), "uid1")
+
+    def test_rate_limit_key_for_context_rejects_partial_api_key_identity(self):
+        context = types.SimpleNamespace(uid="uid1", app_id="app1", key_id=None)
 
         with self.assertRaises(HTTPException) as ctx:
             self.ep.rate_limit_key_for_context(context)
@@ -409,6 +414,7 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "dev:memories_batch",
             "mcp:read",
             "mcp:memories_read",
+            "mcp:memories_write",
             "knowledge_graph:rebuild",
             "wrapped:generate",
             "integration:conversations",
@@ -483,6 +489,7 @@ class TestRouterWiring(unittest.TestCase):
         source = open("dependencies.py", encoding='utf-8').read()
         self.assertIn("mcp:read", source, "MCP API-key UID dependency missing read rate limit")
         self.assertIn("mcp:memories_read", source, "MCP memory auth dependency missing memory read rate limit")
+        self.assertIn("mcp:memories_write", source, "MCP memory auth dependency missing memory write rate limit")
 
     def test_sensitive_read_page_caps(self):
         developer_source = open("routers/developer.py", encoding='utf-8').read()

--- a/backend/tests/unit/test_ws_i_write_convergence.py
+++ b/backend/tests/unit/test_ws_i_write_convergence.py
@@ -203,7 +203,7 @@ def _stored_item(item: MemoryItem) -> dict:
 
 
 def _fresh_short_term_item(*, uid: str, memory_id: str, conversation_id: str, content: str) -> MemoryItem:
-    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
     evidence = MemoryEvidence(
         evidence_id="ev1",
         source_type="conversation",

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -340,7 +340,7 @@ def rate_limit_dependency(endpoint: str = "", requests_per_window: int = 60, win
     return rate_limit
 
 
-def _enforce_rate_limit(key: str, policy_name: str):
+def _enforce_rate_limit(key: str, policy_name: str, *, fail_closed: bool = False):
     """Shared rate limit enforcement. Raises HTTPException(429) or logs in shadow mode.
 
     One Redis round-trip per call (Lua script). Fail-open on Redis errors.
@@ -349,7 +349,9 @@ def _enforce_rate_limit(key: str, policy_name: str):
     try:
         allowed, remaining, retry_after = check_rate_limit(key, policy_name, max_requests, window)
     except redis_pkg.exceptions.RedisError as e:
-        logger.error(f"Rate limit Redis error (allowing request): {e}")
+        logger.error(f"Rate limit Redis error policy={policy_name} key={key}: {e}")
+        if fail_closed:
+            raise HTTPException(status_code=503, detail="Rate limiter unavailable")
         return
 
     if not allowed:
@@ -367,11 +369,41 @@ def _enforce_rate_limit(key: str, policy_name: str):
         )
 
 
+def rate_limit_key_for_context(auth_context) -> str:
+    """Return the narrowest stable rate-limit subject for an auth context."""
+    app_id = getattr(auth_context, 'app_id', None)
+    key_id = getattr(auth_context, 'key_id', None)
+    uid = getattr(auth_context, 'uid', None)
+    if app_id and key_id:
+        return f"app:{app_id}:key:{key_id}"
+    if hasattr(auth_context, 'app_id') or hasattr(auth_context, 'key_id'):
+        raise HTTPException(status_code=403, detail="Missing API key identity")
+    if key_id:
+        return f"key:{key_id}"
+    if uid:
+        return str(uid)
+    raise HTTPException(status_code=401, detail="Authenticated subject missing")
+
+
+def check_api_key_rate_limit(
+    *,
+    prefix: str,
+    uid: str,
+    app_id: str | None,
+    key_id: str | None,
+    policy_name: str,
+):
+    if not key_id:
+        raise HTTPException(status_code=403, detail="Missing API key identity")
+    key = f"{prefix}:{uid}:{app_id or 'unknown_app'}:{key_id}"
+    _enforce_rate_limit(key, policy_name, fail_closed=True)
+
+
 def with_rate_limit(auth_dependency, policy_name: str):
     """Wrap an auth dependency with per-UID rate limiting.
 
     After auth succeeds, checks the rate limit for that UID.
-    One Redis call per request. Fail-open on Redis errors.
+    One Redis call per request. Fail-open on Redis errors for first-party user paths.
 
     Args:
         auth_dependency: FastAPI dependency that returns a UID string.
@@ -388,10 +420,11 @@ def with_rate_limit(auth_dependency, policy_name: str):
 
 
 def with_rate_limit_context(auth_context_dependency, policy_name: str):
-    """Wrap a context-returning auth dependency with per-UID rate limiting.
+    """Wrap a context-returning auth dependency with per-subject rate limiting.
 
-    After auth succeeds, checks the rate limit for that context's UID.
-    One Redis call per request. Fail-open on Redis errors.
+    After auth succeeds, checks the rate limit for app/key identity when present,
+    falling back to UID for first-party or legacy auth contexts.
+    One Redis call per request. Fail-closed on Redis errors for API-key paths.
 
     Args:
         auth_context_dependency: FastAPI dependency that returns an auth context
@@ -402,10 +435,15 @@ def with_rate_limit_context(auth_context_dependency, policy_name: str):
         raise ValueError(f"Unknown rate limit policy: {policy_name}")
 
     async def dependency(auth_context=Depends(auth_context_dependency)):
-        _enforce_rate_limit(auth_context.uid, policy_name)
+        _enforce_rate_limit(rate_limit_key_for_context(auth_context), policy_name, fail_closed=True)
         return auth_context
 
     return dependency
+
+
+def check_rate_limit_context(auth_context, policy_name: str):
+    """Check rate limit inline for an already-authenticated context."""
+    _enforce_rate_limit(rate_limit_key_for_context(auth_context), policy_name, fail_closed=True)
 
 
 def check_rate_limit_inline(key: str, policy_name: str):

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -376,10 +376,8 @@ def rate_limit_key_for_context(auth_context) -> str:
     uid = getattr(auth_context, 'uid', None)
     if app_id and key_id:
         return f"app:{app_id}:key:{key_id}"
-    if hasattr(auth_context, 'app_id') or hasattr(auth_context, 'key_id'):
+    if app_id or key_id:
         raise HTTPException(status_code=403, detail="Missing API key identity")
-    if key_id:
-        return f"key:{key_id}"
     if uid:
         return str(uid)
     raise HTTPException(status_code=401, detail="Authenticated subject missing")

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -93,10 +93,21 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "integration:memories": (60, 3600),
     # Phone verification uses IP-based rate_limit_dependency (pre-auth, no UID).
     # Not migrated to per-UID Lua limiter intentionally.
-    # Dev API
+    # Dev API. Read limits are intentionally separate from write limits so a
+    # polling client cannot consume the processing/write budget. Developer and
+    # MCP API-key contexts are keyed by app/key identity when available.
+    "dev:memories_read": (120, 3600),
+    "dev:action_items_read": (120, 3600),
+    "dev:conversations_read": (60, 3600),
+    "dev:goals_read": (120, 3600),
     "dev:conversations": (25, 3600),
     "dev:memories": (120, 3600),
     "dev:memories_batch": (15, 3600),
+    "dev:action_items_write": (120, 3600),
+    "dev:goals_write": (120, 3600),
+    # MCP REST data API
+    "mcp:read": (300, 3600),
+    "mcp:memories_read": (120, 3600),
     # Test
     "test:prompt": (30, 3600),
     # Apps

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -108,6 +108,7 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # MCP REST data API
     "mcp:read": (300, 3600),
     "mcp:memories_read": (120, 3600),
+    "mcp:memories_write": (120, 3600),
     # Test
     "test:prompt": (30, 3600),
     # Apps


### PR DESCRIPTION
## Summary
- enforce Developer and MCP API-key rate limits at the auth dependency layer
- key abuse limits by API key identity and fail closed for API-key limiter outages
- add read-specific policies and cap high-exfiltration page sizes for conversation transcripts and MCP data reads

## Context
This implements the Oracle-recommended emergency mitigation for the active abuse case: enforce immediately across prod and dev API-key endpoints without a staged rollout, while preserving existing first-party user rate-limit behavior.

## Validation
- `python3 -m py_compile backend/dependencies.py backend/utils/other/endpoints.py backend/utils/rate_limit_config.py backend/routers/developer.py backend/routers/mcp.py`
- `python3 -m pytest tests/unit/test_rate_limiting.py -q`
- `python3 -m pytest tests/unit/test_dev_api_folder_filters.py tests/unit/test_dev_api_memories_pagination.py tests/unit/test_dev_api_canonical_grant_ordering.py tests/unit/test_dev_api_action_items_poison.py tests/unit/test_dev_api_conversations_poison.py tests/unit/test_mcp_data_endpoints.py tests/unit/test_developer_from_segments_idempotency.py -q`
- pre-push checks passed, including selected backend unit tests, OpenAPI contract check, async blocker audit, and black check

## Operational note
Known abused API keys should still be revoked immediately; this PR limits ongoing abuse but does not invalidate leaked credentials by itself.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

