### PR TITLE
[codex] Wire Google OAuth secrets into backend runtime

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -135,6 +135,16 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: GOOGLE_MAPS_API_KEY
+  - name: GOOGLE_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GOOGLE_CLIENT_ID
+  - name: GOOGLE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GOOGLE_CLIENT_SECRET
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -173,6 +173,16 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: GOOGLE_MAPS_API_KEY
+  - name: GOOGLE_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: GOOGLE_CLIENT_ID
+  - name: GOOGLE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: GOOGLE_CLIENT_SECRET
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: BUCKET_TEMPORAL_SYNC_LOCAL

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -28,6 +28,10 @@ externalSecret:
       remoteKey: OMI_LLM_GATEWAY_SERVICE_TOKEN
     - secretKey: GOOGLE_MAPS_API_KEY
       remoteKey: GOOGLE_MAPS_API_KEY
+    - secretKey: GOOGLE_CLIENT_ID
+      remoteKey: GOOGLE_CLIENT_ID
+    - secretKey: GOOGLE_CLIENT_SECRET
+      remoteKey: GOOGLE_CLIENT_SECRET
     - secretKey: GITHUB_TOKEN
       remoteKey: GITHUB_TOKEN
     - secretKey: PINECONE_API_KEY

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -40,6 +40,10 @@ externalSecret:
       remoteKey: MODULATE_API_KEY
     - secretKey: GOOGLE_MAPS_API_KEY
       remoteKey: GOOGLE_MAPS_API_KEY
+    - secretKey: GOOGLE_CLIENT_ID
+      remoteKey: GOOGLE_CLIENT_ID
+    - secretKey: GOOGLE_CLIENT_SECRET
+      remoteKey: GOOGLE_CLIENT_SECRET
     - secretKey: GOOGLE_APPLICATION_CREDENTIALS
       remoteKey: GOOGLE_APPLICATION_CREDENTIALS
     - secretKey: SERVICE_ACCOUNT_JSON

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -138,6 +138,16 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: GOOGLE_MAPS_API_KEY
+  - name: GOOGLE_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GOOGLE_CLIENT_ID
+  - name: GOOGLE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GOOGLE_CLIENT_SECRET
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: BUCKET_TEMPORAL_SYNC_LOCAL

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -143,6 +143,16 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: GOOGLE_MAPS_API_KEY
+  - name: GOOGLE_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: GOOGLE_CLIENT_ID
+  - name: GOOGLE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: GOOGLE_CLIENT_SECRET
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: BUCKET_TEMPORAL_SYNC_LOCAL


### PR DESCRIPTION
## Summary

- Sync `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` into dev/prod backend Kubernetes secrets via `backend-secrets` ExternalSecret values.
- Inject those OAuth env vars into dev/prod `backend-listen` and `pusher` deployments.

## Why

Fixes #8719. The Google OAuth values were rotated in Secret Manager, but the runtime Kubernetes secret and service env wiring did not include them, so Google Calendar/account integration paths could fail token refresh with missing `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.

## Validation

- `python backend/scripts/validate-backend-runtime-env.py --env dev`
- `python backend/scripts/validate-backend-runtime-env.py --env prod`
- Parsed all six edited values files with `yaml.safe_load`.
- Rendered affected Helm charts with required placeholder render-time values and confirmed `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` appear in the dev/prod ExternalSecret, `backend-listen`, and `pusher` manifests.

## Notes

- Did not wire `GOOGLE_MAPS_ANDROID_API_KEY`; no backend runtime consumer was visible in this chart path, so this PR keeps the fix scoped to the OAuth secrets used by `google_utils.py`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

