### PR TITLE
[codex] Fix pusher image config package copy

### DIFF
--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -64,6 +64,7 @@ RUN ldconfig && \
 COPY --from=builder /opt/venv /opt/venv
 
 # Whitelist-copy only the modules pusher reaches
+COPY backend/config/ ./config/
 COPY backend/database/ ./database/
 COPY backend/models/ ./models/
 COPY backend/routers/ ./routers/

--- a/backend/tests/unit/test_pusher_docker_context.py
+++ b/backend/tests/unit/test_pusher_docker_context.py
@@ -1,0 +1,39 @@
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+PUSHER_DOCKERFILE = BACKEND_DIR / 'pusher' / 'Dockerfile'
+
+
+def _pusher_runtime_copy_dirs() -> list[str]:
+    pattern = re.compile(r'^COPY\s+backend/([^/\s]+)/\s+\./\1/$')
+    copied_dirs: list[str] = []
+    for line in PUSHER_DOCKERFILE.read_text(encoding='utf-8').splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            copied_dirs.append(match.group(1))
+    return copied_dirs
+
+
+def test_pusher_image_layout_includes_backend_config_imports(tmp_path):
+    copied_dirs = _pusher_runtime_copy_dirs()
+    assert 'config' in copied_dirs
+
+    for dirname in copied_dirs:
+        shutil.copytree(BACKEND_DIR / dirname, tmp_path / dirname)
+
+    env = {**os.environ, 'PYTHONPATH': str(tmp_path)}
+    result = subprocess.run(
+        [sys.executable, '-c', 'import config.memory_confidence'],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Copy `backend/config/` into the pusher image runtime layout.
- Add a focused unit smoke that mirrors the pusher Dockerfile whitelist copy and imports `config.memory_confidence`.

## Root cause
The backend image copies the full `backend/` tree, so `config.memory_confidence` is available there. The pusher image uses a whitelist copy and omitted `backend/config/`. After `database.memories` imported `config.memory_confidence`, `routers.pusher` could crash at startup with `ModuleNotFoundError: No module named 'config'`.

## Validation
- `pytest tests/unit/test_pusher_docker_context.py`
- `pytest tests/unit/test_pusher_private_cloud_data_protection.py tests/unit/test_memories_stale_updates.py tests/unit/test_memory_contracts.py`
- `docker build --platform linux/amd64 -f backend/pusher/Dockerfile -t omi-pusher-config-smoke:a175243 .`
- `docker run --rm --platform linux/amd64 --entrypoint python omi-pusher-config-smoke:a175243 -c "import config.memory_confidence; print('config import ok')"`
- pre-push hook against `origin/main` passed, including selected backend unit test and OpenAPI check.

## Deployment note
After merge, rerun the development workflow `Auto Deploy Backend Pusher to GKE (Development)` to roll a fixed pusher image. No deployment was run from this branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

