### PR TITLE
Improve LLM gateway schema harness

### DIFF
--- a/backend/llm_gateway/config/feature_bundles.yaml
+++ b/backend/llm_gateway/config/feature_bundles.yaml
@@ -22,3 +22,14 @@ feature_bundles:
       overview_empty_regression: none
       p95_latency_ms: "<= LKG + 10%"
       cost_per_success: "<= LKG + 15%"
+  - feature: conversation_action_items.extract.shadow
+    lane_id: omi:auto:chat-structured
+    prompt_version: conversation_action_items.extract.v1
+    parser_version: ActionItemsExtraction.v1
+    eval_suite: conversation_action_items_extract.v1
+    promotion_gates:
+      schema_valid_rate: ">= 99.5%"
+      action_item_count_regression: none
+      due_at_parse_regression: none
+      p95_latency_ms: "<= LKG + 10%"
+      cost_per_success: "<= LKG + 15%"

--- a/backend/openapi-requirements.txt
+++ b/backend/openapi-requirements.txt
@@ -7,6 +7,7 @@ annotated-types==0.7.0
 annotated-doc==0.0.4
 anthropic==0.111.0
 anyio==4.4.0
+attrs==24.1.0
 av==12.0.0
 CacheControl==0.14.0
 cachetools==5.5.0
@@ -56,6 +57,8 @@ Jinja2==3.1.6
 jiter==0.15.0
 jsonpatch==1.33
 jsonpointer==3.0.0
+jsonschema==4.23.0
+jsonschema-specifications==2023.12.1
 langchain-core==1.3.3
 langchain-google-genai==3.2.0
 langchain-openai==1.1.14
@@ -95,9 +98,11 @@ python-multipart==0.0.27
 python-ulid==3.0.0
 pytz==2024.1
 redis==5.0.8
+referencing==0.35.1
 regex==2024.7.24
 requests==2.33.0
 requests-toolbelt==1.0.0
+rpds-py==0.20.0
 rsa==4.9
 scipy==1.14.0
 six==1.16.0

--- a/backend/scripts/smoke-llm-gateway-openai-schemas.py
+++ b/backend/scripts/smoke-llm-gateway-openai-schemas.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from llm_gateway.gateway.auth import ServiceCaller
+from llm_gateway.gateway.credentials import build_omi_managed_credential_context
+from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
+from llm_gateway.gateway.schemas import ProviderRef
+from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
+from utils.llm.gateway_client import _chat_structured_payload
+
+PROVIDER_REF = ProviderRef(provider='openai', model='gpt-4.1-mini')
+SMOKE_FEATURES = (
+    ('conversation_structure.extract.shadow', ConversationStructureExtraction),
+    ('conversation_action_items.extract.shadow', ActionItemsExtraction),
+)
+
+
+async def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description='Smoke-test live OpenAI acceptance of LLM gateway structured-output schemas.'
+    )
+    parser.add_argument(
+        '--timeout-ms',
+        type=int,
+        default=8000,
+        help='Per-request timeout in milliseconds. Defaults to 8000.',
+    )
+    args = parser.parse_args(argv)
+
+    if not os.getenv('OPENAI_API_KEY'):
+        parser.error('OPENAI_API_KEY is required')
+
+    provider = OpenAICompatibleChatCompletionProvider()
+    try:
+        for feature, output_model in SMOKE_FEATURES:
+            request = _chat_structured_payload(
+                'Return the smallest valid JSON object for this schema. Do not include prose.',
+                output_model,
+                feature=feature,
+            )
+            request['model'] = PROVIDER_REF.model
+            request['max_completion_tokens'] = 128
+            request.pop('metadata', None)
+            response = await provider.create_chat_completion(
+                request,
+                provider_ref=PROVIDER_REF,
+                credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+                timeout_ms=args.timeout_ms,
+            )
+            content = response['choices'][0]['message']['content']
+            if not isinstance(content, str) or not content.strip():
+                raise RuntimeError(f'{feature}: provider returned empty content')
+            print(f'{feature}: ok')
+    finally:
+        await provider.aclose()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -5,8 +5,10 @@ import types
 import logging
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
+import yaml
 
 for module_name in (
     'database.auth',
@@ -46,6 +48,12 @@ from utils.llm import conversation_processing
 from models.conversation_enums import CategoryEnum
 from models.structured import Structured
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
+
+GATEWAY_FEATURE_MODELS = {
+    'chat_extraction.requires_context': chat.RequiresContext,
+    'conversation_structure.extract.shadow': ConversationStructureExtraction,
+    'conversation_action_items.extract.shadow': ActionItemsExtraction,
+}
 
 
 class FakeParser:
@@ -128,6 +136,7 @@ def _mock_gateway_client(monkeypatch, fake_post):
 
 _VALUE_TRUE_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"value": true}'}}]})
 _UNEXPECTED_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"unexpected": true}'}}]})
+_UNEXPECTED_STRUCTURE_RESPONSE = FakeGatewayResponse({'choices': [{'message': {'content': '{"answer": "ok"}'}}]})
 
 
 def test_requires_context_gateway_success_returns_parsed_result(monkeypatch):
@@ -192,6 +201,30 @@ def test_requires_context_invalid_gateway_content_falls_back(monkeypatch):
     assert existing_calls == [chat.RequiresContext]
 
 
+def test_gateway_validation_rejects_conversation_structure_defaults_masking_missing_fields(monkeypatch):
+    counter = FakeCounter()
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
+    _mock_gateway_client(monkeypatch, lambda *args, **kwargs: _UNEXPECTED_STRUCTURE_RESPONSE)
+
+    result = gateway_client.invoke_chat_structured_gateway(
+        'extract structure',
+        ConversationStructureExtraction,
+        feature='conversation_structure.extract.shadow',
+    )
+
+    assert result is None
+    assert counter.calls == [
+        (
+            {
+                'feature': 'conversation_structure.extract.shadow',
+                'outcome': 'fallback',
+                'reason': 'schema_validation',
+            },
+            1,
+        )
+    ]
+
+
 def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeypatch):
     monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://gateway.test/')
     monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
@@ -240,6 +273,9 @@ def test_strict_schema_keeps_conversation_structure_shadow_contract_narrow():
     assert set(schema['properties']) == {'title', 'overview', 'emoji', 'category'}
     assert 'action_items' not in schema['properties']
     assert 'events' not in schema['properties']
+    assert '$ref' not in schema['properties']['category']
+    assert schema['properties']['category']['type'] == 'string'
+    assert 'enum' in schema['properties']['category']
 
 
 def test_strict_schema_removes_defaults_recursively():
@@ -253,6 +289,59 @@ def test_strict_schema_removes_defaults_recursively():
         elif isinstance(node, list):
             for value in node:
                 walk(value)
+
+    walk(schema)
+
+
+@pytest.mark.parametrize(('feature', 'output_model'), sorted(GATEWAY_FEATURE_MODELS.items()))
+def test_gateway_feature_payloads_use_openai_strict_schema_subset(feature, output_model):
+    payload = gateway_client._chat_structured_payload('fixture prompt', output_model, feature=feature)
+    schema = payload['response_format']['json_schema']['schema']
+
+    assert payload['model'] == 'omi:auto:chat-structured'
+    assert payload['response_format']['json_schema']['strict'] is True
+    assert payload['metadata']['omi_feature'] == feature
+    _assert_openai_strict_schema_subset(schema)
+
+
+def test_feature_bundles_have_gateway_payload_contract_coverage():
+    config_path = Path(__file__).resolve().parents[2] / 'llm_gateway' / 'config' / 'feature_bundles.yaml'
+    configured = {bundle['feature'] for bundle in yaml.safe_load(config_path.read_text())['feature_bundles']}
+
+    assert configured <= set(GATEWAY_FEATURE_MODELS)
+
+
+def _assert_openai_strict_schema_subset(schema):
+    unsupported_keys = {
+        'allOf',
+        'oneOf',
+        'not',
+        'if',
+        'then',
+        'else',
+        'dependentRequired',
+        'dependentSchemas',
+        'patternProperties',
+    }
+
+    def walk(node, path='$'):
+        if isinstance(node, dict):
+            for key in unsupported_keys:
+                assert key not in node, f'{path} contains unsupported strict schema key: {key}'
+            if '$ref' in node:
+                siblings = set(node) - {'$ref'}
+                assert not siblings, f'{path} has $ref sibling keys: {sorted(siblings)}'
+            if node.get('type') == 'object':
+                assert node.get('additionalProperties') is False, f'{path} must set additionalProperties=false'
+                properties = node.get('properties')
+                if isinstance(properties, dict):
+                    assert node.get('required') == list(properties.keys()), f'{path} must require every property'
+            assert 'default' not in node, f'{path} must not contain default'
+            for key, value in node.items():
+                walk(value, f'{path}.{key}')
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f'{path}[{index}]')
 
     walk(schema)
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -6,7 +6,7 @@ from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import FakeChatCompletionProvider
 from llm_gateway.main import app
 from llm_gateway.routers import dependencies
-from models.structured_extraction import ActionItemsExtraction
+from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
 from utils.llm.gateway_client import _chat_structured_payload
 
 LANE_ID = 'omi:auto:chat-structured'
@@ -72,6 +72,30 @@ def test_chat_completions_forwards_action_item_extraction_strict_schema(monkeypa
     assert action_item_schema['additionalProperties'] is False
     assert action_item_schema['required'] == ['description', 'due_at']
     assert 'default' not in action_item_schema['properties']['due_at']
+
+
+def test_chat_completions_forwards_conversation_structure_extraction_strict_schema(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    provider = FakeChatCompletionProvider()
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    try:
+        request = _chat_structured_payload(
+            'Extract conversation structure.',
+            ConversationStructureExtraction,
+            feature='conversation_structure.extract.shadow',
+        )
+        response = TestClient(app).post('/v1/chat/completions', json=request, headers=auth_headers())
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    forwarded_schema = provider.calls[0].request['response_format']['json_schema']['schema']
+    assert forwarded_schema['required'] == ['title', 'overview', 'emoji', 'category']
+    category_schema = forwarded_schema['properties']['category']
+    assert category_schema['type'] == 'string'
+    assert 'enum' in category_schema
+    assert '$ref' not in category_schema
+    assert category_schema['description'] == 'A category for this conversation'
 
 
 def test_chat_completions_rejects_unknown_auto_lane(monkeypatch):

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import TypeVar
 
 import httpx
+from jsonschema import ValidationError as JsonSchemaValidationError
+from jsonschema import validate as validate_json_schema
 from pydantic import BaseModel, ValidationError
 
 from utils.llm.gateway_observability import record_gateway_request_result
@@ -87,7 +90,7 @@ def invoke_chat_structured_gateway(
     except httpx.RequestError:
         record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='request_error')
         return None
-    except ValidationError:
+    except (ValidationError, JsonSchemaValidationError):
         record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='schema_validation')
         return None
     except Exception:
@@ -140,6 +143,7 @@ def _strict_model_json_schema(output_model: type[BaseModel]) -> dict:
     """
     schema = output_model.model_json_schema()
     _normalize_strict_schema(schema)
+    _inline_ref_siblings(schema)
     return schema
 
 
@@ -171,6 +175,45 @@ def _normalize_strict_schema(schema: dict) -> None:
                 _normalize_strict_schema(alt_schema)
 
 
+def _inline_ref_siblings(schema: dict) -> None:
+    """Inline local ``$ref`` schemas that carry sibling metadata.
+
+    Pydantic emits enum fields as ``{"$ref": "#/$defs/Enum", "description": ...}``.
+    That is valid JSON Schema, but OpenAI strict structured outputs reject some
+    ``$ref`` nodes with sibling keywords. Pure local refs are left intact because
+    nested object refs are accepted and keep large schemas compact.
+    """
+
+    definitions = schema.get('$defs') or schema.get('definitions') or {}
+    if not isinstance(definitions, dict):
+        definitions = {}
+
+    def resolve_ref(ref: str) -> dict | None:
+        prefix = '#/$defs/'
+        if not ref.startswith(prefix):
+            return None
+        target = definitions.get(ref.removeprefix(prefix))
+        return deepcopy(target) if isinstance(target, dict) else None
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            ref = node.get('$ref')
+            if isinstance(ref, str) and len(node) > 1:
+                resolved = resolve_ref(ref)
+                if resolved is not None:
+                    siblings = {key: value for key, value in node.items() if key != '$ref'}
+                    node.clear()
+                    node.update(resolved)
+                    node.update(siblings)
+            for value in list(node.values()):
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(schema)
+
+
 def _extract_choice_content(response_body: object) -> object:
     if not isinstance(response_body, Mapping):
         return None
@@ -190,4 +233,5 @@ def _validate_output_model(
     output_model: type[StructuredOutput],
     decoded: Mapping[str, object],
 ) -> StructuredOutput:
+    validate_json_schema(instance=decoded, schema=_strict_model_json_schema(output_model))
     return output_model.model_validate(decoded)


### PR DESCRIPTION
## Summary
- add OpenAI strict-schema subset coverage for every configured gateway feature bundle
- inline local enum refs with sibling metadata so conversation structure schemas are accepted by OpenAI strict structured outputs
- validate raw gateway JSON against the emitted schema before Pydantic defaults can mask missing fields
- add a standalone live OpenAI schema smoke script for future rollout checks
- pin jsonschema dependencies in the OpenAPI export runner environment so pre-push/CI stay aligned

## What this surfaced
- ConversationStructureExtraction.category emitted a local enum `` plus a sibling description; the harness now catches and fixes that provider-compatibility risk.
- ConversationStructureExtraction defaults could turn invalid raw provider output like `{"answer": "ok"}` into a valid-looking model; raw JSON Schema validation now rejects it first.
- The OpenAPI mini-env was missing `jsonschema`, which pre-push caught and this PR pins.

## Verification
- Consulted Oracle with source context: gateway client, provider, structured models, feature bundles, lanes, route artifacts, and existing gateway tests.
- `cd backend && ./test-preflight.sh`
- `cd backend && pytest tests/unit/test_llm_gateway_*.py -q` -> 152 passed
- `cd backend && python scripts/scan_async_blockers.py` -> selected blocking findings: 0
- `cd backend && ./scripts/openapi_runner.sh scripts/export_openapi.py --check`
- live provider smoke using dev OpenAI secret: `conversation_structure.extract.shadow: ok`, `conversation_action_items.extract.shadow: ok`
- pre-push checks passed on push

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

