### PR TITLE
Harden backend rollout status reporting

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -10,4 +10,6 @@ These rules apply to GitHub Actions workflows and custom actions under `.github/
 - Every GKE Deployment deploy must wait for rollout completion with `kubectl rollout status ... --timeout=...` and fail on timeout.
 - For chart-only backend-listen deploys, fail if the current deployed image tag is missing or `latest`; use the backend deploy workflow to establish an immutable tag first.
 - Keep rollout checks close to the deploy step they verify, especially for `backend-listen`, `pusher`, `agent-proxy`, `llm-gateway`, `parakeet`, `diarizer`, and `vad`.
+- Use `backend/scripts/deploy_status_report.py` as a strict gate on success paths; use it with `|| true` only after a primary rollout/traffic command already failed.
+- Before restarting GKE workloads that depend on `backend-secrets`, wait for ExternalSecret Ready and run `backend/scripts/verify_k8s_secret_keys.py`; never print secret values.
 - When editing workflows, keep `actionlint` coverage in CI so YAML and GitHub expression mistakes fail before merge.

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -148,6 +148,7 @@ jobs:
           else
             gsa_name="${{ vars.ENV }}-omi-backend-eso-gsa@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
           fi
+          python3 -m pip install -q pyyaml
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets ./backend/charts/backend-secrets \
             -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml \
             --set gke.projectID=${{ vars.GCP_PROJECT_ID }} \
@@ -157,7 +158,12 @@ jobs:
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="$(date +%s)" --overwrite
-          sleep 10
+          kubectl -n ${{ vars.ENV }}-omi-backend wait \
+            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
+            --for=condition=Ready --timeout=120s
+          kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
+            | python3 backend/scripts/verify_k8s_secret_keys.py \
+                ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
 
       - name: Deploy ${{ env.SERVICE }}-listen to GKE using Helm
         run: |
@@ -167,7 +173,11 @@ jobs:
             --set gcpProjectId=${{ vars.GCP_PROJECT_ID }} \
             --set runtimeGcpProjectId=${{ vars.RUNTIME_GCP_PROJECT_ID }} \
             --set image.tag=${{ steps.image-tag.outputs.short_sha }}
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen
 
       - name: Deploy ${{ env.SERVICE }}-integration to Cloud Run
         id: deploy-backend-integration
@@ -202,9 +212,20 @@ jobs:
 
       - name: Shift Cloud Run traffic to validated revisions
         run: |
-          gcloud run services update-traffic backend --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-revision.outputs.revision }}=100 --quiet
-          gcloud run services update-traffic backend-sync --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-sync-revision.outputs.revision }}=100 --quiet
-          gcloud run services update-traffic backend-integration --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-integration-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend-sync --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-sync-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend-integration --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-integration-revision.outputs.revision }}=100 --quiet
+          python3 backend/scripts/deploy_status_report.py \
+            --env ${{ vars.ENV }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ env.REGION }} \
+            --include-cloud-run \
+            --cloud-run-service backend \
+            --cloud-run-service backend-sync \
+            --cloud-run-service backend-integration \
+            --expect-cloud-run-traffic backend=${{ steps.capture-backend-revision.outputs.revision }} \
+            --expect-cloud-run-traffic backend-sync=${{ steps.capture-backend-sync-revision.outputs.revision }} \
+            --expect-cloud-run-traffic backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }}
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -155,7 +155,7 @@ jobs:
             --set gke.clusterLocation=${{ env.REGION }} \
             --set gke.clusterName=${{ vars.GKE_CLUSTER }} \
             --set gsa.name="${gsa_name}"
-          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="${force_sync_at}" --overwrite

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -155,12 +155,15 @@ jobs:
             --set gke.clusterLocation=${{ env.REGION }} \
             --set gke.clusterName=${{ vars.GKE_CLUSTER }} \
             --set gsa.name="${gsa_name}"
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
-            force-sync="$(date +%s)" --overwrite
-          kubectl -n ${{ vars.ENV }}-omi-backend wait \
-            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
-            --for=condition=Ready --timeout=120s
+            force-sync="${force_sync_at}" --overwrite
+          python3 backend/scripts/wait_external_secret_refresh.py \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --name ${{ vars.ENV }}-omi-backend-external-secret \
+            --min-refresh-time "${force_sync_at}" \
+            --timeout-seconds 120
           kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
             | python3 backend/scripts/verify_k8s_secret_keys.py \
                 ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml

--- a/.github/workflows/gcp_backend_agent_proxy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy.yml
@@ -70,7 +70,11 @@ jobs:
       - name: Deploy Agent Proxy to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-agent-proxy ./backend/charts/agent-proxy -f ./backend/charts/agent-proxy/${{ vars.ENV }}_omi_agent_proxy_values.yaml --set "image.tag=${GITHUB_SHA::7}"
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service agent-proxy || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service agent-proxy
 
       - name: Show Output
         run: echo "Agent proxy deployed to ${{ github.event.inputs.environment }}"

--- a/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_agent_proxy_auto_deploy.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Deploy Agent Proxy to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-agent-proxy ./backend/charts/agent-proxy -f ./backend/charts/agent-proxy/${{ vars.ENV }}_omi_agent_proxy_values.yaml --set "image.tag=${GITHUB_SHA::7}"
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-agent-proxy --timeout=300s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service agent-proxy || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service agent-proxy
 
       - name: Show Output
         run: echo "Agent proxy deployed to development environment"

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -133,7 +133,7 @@ jobs:
             --set gke.clusterLocation=${{ env.REGION }} \
             --set gke.clusterName=${{ vars.GKE_CLUSTER }} \
             --set gsa.name="${gsa_name}"
-          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="${force_sync_at}" --overwrite

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -124,6 +124,7 @@ jobs:
           else
             gsa_name="${{ vars.ENV }}-omi-backend-eso-gsa@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
           fi
+          python3 -m pip install -q pyyaml
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install \
             ${{ vars.ENV }}-omi-backend-secrets \
             ./backend/charts/backend-secrets \
@@ -135,7 +136,12 @@ jobs:
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="$(date +%s)" --overwrite
-          sleep 10
+          kubectl -n ${{ vars.ENV }}-omi-backend wait \
+            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
+            --for=condition=Ready --timeout=120s
+          kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
+            | python3 backend/scripts/verify_k8s_secret_keys.py \
+                ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
 
       - name: Deploy ${{ env.SERVICE }}-listen to GKE
         run: |
@@ -147,7 +153,11 @@ jobs:
             --set gcpProjectId=${{ vars.GCP_PROJECT_ID }} \
             --set runtimeGcpProjectId=${{ vars.RUNTIME_GCP_PROJECT_ID }} \
             --set image.tag=${{ steps.image-tag.outputs.short_sha }}
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen
 
       - name: Deploy ${{ env.SERVICE }}-integration to Cloud Run
         id: deploy-backend-integration
@@ -182,9 +192,20 @@ jobs:
 
       - name: Shift Cloud Run traffic to validated revisions
         run: |
-          gcloud run services update-traffic backend --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-revision.outputs.revision }}=100 --quiet
-          gcloud run services update-traffic backend-sync --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-sync-revision.outputs.revision }}=100 --quiet
-          gcloud run services update-traffic backend-integration --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-integration-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend-sync --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-sync-revision.outputs.revision }}=100 --quiet
+          gcloud run services update-traffic backend-integration --project=${{ vars.GCP_PROJECT_ID }} --region=${{ env.REGION }} --to-revisions=${{ steps.capture-backend-integration-revision.outputs.revision }}=100 --quiet
+          python3 backend/scripts/deploy_status_report.py \
+            --env dev \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ env.REGION }} \
+            --include-cloud-run \
+            --cloud-run-service backend \
+            --cloud-run-service backend-sync \
+            --cloud-run-service backend-integration \
+            --expect-cloud-run-traffic backend=${{ steps.capture-backend-revision.outputs.revision }} \
+            --expect-cloud-run-traffic backend-sync=${{ steps.capture-backend-sync-revision.outputs.revision }} \
+            --expect-cloud-run-traffic backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }}
 
       - name: Show Output
         run: echo "Backend deployed to development environment"

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -133,12 +133,15 @@ jobs:
             --set gke.clusterLocation=${{ env.REGION }} \
             --set gke.clusterName=${{ vars.GKE_CLUSTER }} \
             --set gsa.name="${gsa_name}"
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
-            force-sync="$(date +%s)" --overwrite
-          kubectl -n ${{ vars.ENV }}-omi-backend wait \
-            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
-            --for=condition=Ready --timeout=120s
+            force-sync="${force_sync_at}" --overwrite
+          python3 backend/scripts/wait_external_secret_refresh.py \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --name ${{ vars.ENV }}-omi-backend-external-secret \
+            --min-refresh-time "${force_sync_at}" \
+            --timeout-seconds 120
           kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
             | python3 backend/scripts/verify_k8s_secret_keys.py \
                 ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -115,12 +115,15 @@ jobs:
             --set gsa.name="${gsa_name}"
           # Trigger an immediate sync so newly-listed keys are pulled before the
           # listen deployment restarts (otherwise its env refs resolve empty).
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
-            force-sync="$(date +%s)" --overwrite
-          kubectl -n ${{ vars.ENV }}-omi-backend wait \
-            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
-            --for=condition=Ready --timeout=120s
+            force-sync="${force_sync_at}" --overwrite
+          python3 backend/scripts/wait_external_secret_refresh.py \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --name ${{ vars.ENV }}-omi-backend-external-secret \
+            --min-refresh-time "${force_sync_at}" \
+            --timeout-seconds 120
           kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
             | python3 backend/scripts/verify_k8s_secret_keys.py \
                 ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -105,6 +105,7 @@ jobs:
           else
             gsa_name="${{ vars.ENV }}-omi-backend-eso-gsa@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
           fi
+          python3 -m pip install -q pyyaml
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
             ./backend/charts/backend-secrets \
             -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml \
@@ -117,7 +118,12 @@ jobs:
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="$(date +%s)" --overwrite
-          sleep 10
+          kubectl -n ${{ vars.ENV }}-omi-backend wait \
+            externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
+            --for=condition=Ready --timeout=120s
+          kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
+            | python3 backend/scripts/verify_k8s_secret_keys.py \
+                ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
 
       - name: Upgrade backend-listen Helm chart
         run: |
@@ -131,7 +137,11 @@ jobs:
 
       - name: Verify rollout
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen
 
       - name: Show pod status
         if: always()

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -115,7 +115,7 @@ jobs:
             --set gsa.name="${gsa_name}"
           # Trigger an immediate sync so newly-listed keys are pulled before the
           # listen deployment restarts (otherwise its env refs resolve empty).
-          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
             ${{ vars.ENV }}-omi-backend-external-secret \
             force-sync="${force_sync_at}" --overwrite

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -131,7 +131,8 @@ jobs:
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
           if [[ "${{ env.SERVICE }}" == "llm-gateway" ]]; then
-            python backend/scripts/validate-llm-gateway-env.py \
+            python3 -m pip install -q pyyaml
+            python3 backend/scripts/validate-llm-gateway-env.py \
               backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
               backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
@@ -140,12 +141,18 @@ jobs:
             kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
               ${{ vars.ENV }}-omi-backend-external-secret \
               force-sync="$(date +%s)" --overwrite
-            sleep 10
+            kubectl -n ${{ vars.ENV }}-omi-backend wait \
+              externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
+              --for=condition=Ready --timeout=120s
+            kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
+              | python3 backend/scripts/verify_k8s_secret_keys.py \
+                  ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-llm-gateway \
               ./backend/charts/llm-gateway \
               -f ./backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml \
               --set "image.tag=${GITHUB_SHA::7}"
             if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s; then
+              python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service llm-gateway || true
               echo "=== llm-gateway deployment ==="
               kubectl -n ${{ vars.ENV }}-omi-backend describe deploy/${{ vars.ENV }}-omi-llm-gateway || true
               echo "=== llm-gateway pods ==="
@@ -162,9 +169,14 @@ jobs:
               kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data}' | python -c 'import json,sys; print("\\n".join(sorted(json.load(sys.stdin).keys())))' || true
               exit 1
             fi
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service llm-gateway
           else
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set "image.tag=${GITHUB_SHA::7}"
-            kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s
+            if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s; then
+              python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher || true
+              exit 1
+            fi
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher
           fi
 
       - name: Smoke LLM Gateway

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -138,7 +138,7 @@ jobs:
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
               ./backend/charts/backend-secrets \
               -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
-            force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+            force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
               ${{ vars.ENV }}-omi-backend-external-secret \
               force-sync="${force_sync_at}" --overwrite

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -138,12 +138,15 @@ jobs:
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
               ./backend/charts/backend-secrets \
               -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
+            force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
             kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
               ${{ vars.ENV }}-omi-backend-external-secret \
-              force-sync="$(date +%s)" --overwrite
-            kubectl -n ${{ vars.ENV }}-omi-backend wait \
-              externalsecret/${{ vars.ENV }}-omi-backend-external-secret \
-              --for=condition=Ready --timeout=120s
+              force-sync="${force_sync_at}" --overwrite
+            python3 backend/scripts/wait_external_secret_refresh.py \
+              --namespace ${{ vars.ENV }}-omi-backend \
+              --name ${{ vars.ENV }}-omi-backend-external-secret \
+              --min-refresh-time "${force_sync_at}" \
+              --timeout-seconds 120
             kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
               | python3 backend/scripts/verify_k8s_secret_keys.py \
                   ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml

--- a/.github/workflows/gcp_diarizer.yml
+++ b/.github/workflows/gcp_diarizer.yml
@@ -76,7 +76,11 @@ jobs:
 
       - name: Verify rollout
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service ${{ env.SERVICE }} || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service ${{ env.SERVICE }}
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_models.yml
+++ b/.github/workflows/gcp_models.yml
@@ -79,7 +79,11 @@ jobs:
 
       - name: Verify rollout
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-vad --timeout=600s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-vad --timeout=600s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service vad || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service vad
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_parakeet.yml
+++ b/.github/workflows/gcp_parakeet.yml
@@ -71,7 +71,11 @@ jobs:
 
       - name: Verify rollout
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-${{ env.SERVICE }} --timeout=600s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service ${{ env.SERVICE }} || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service ${{ env.SERVICE }}
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/backend/deploy/secret_consumer_registry.yaml
+++ b/backend/deploy/secret_consumer_registry.yaml
@@ -391,6 +391,12 @@ secrets:
     category: service_token
     owner: backend
     rotation_verification: "Run backend-to-llm-gateway smoke after rolling all consumers."
+  LLM_GATEWAY_SERVICE_TOKEN:
+    description: "Legacy env name for the backend to llm-gateway shared service token."
+    category: service_token
+    owner: backend
+    status: code_only
+    rotation_verification: "Run backend-to-llm-gateway smoke after rolling all consumers."
   OPENAI_API_KEY:
     description: "OpenAI provider API key for backend, gateway, desktop backend, and automation."
     category: provider_api_key

--- a/backend/scripts/deploy_status_report.py
+++ b/backend/scripts/deploy_status_report.py
@@ -32,6 +32,12 @@ class Finding:
     message: str
 
 
+@dataclass(frozen=True)
+class CloudRunFetchError:
+    service: str
+    exit_code: int
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description='Read-only deploy rollout/status reporter for Omi services.')
     parser.add_argument('--env', choices=('dev', 'prod'), required=True)
@@ -191,6 +197,7 @@ def render_cloud_run_report(
     expected_traffic: dict[str, str],
 ) -> tuple[str, list[Finding]]:
     service_map = normalize_cloud_run_services(state)
+    fetch_errors = cloud_run_fetch_errors_by_service(state)
     lines = [
         'Cloud Run revision status',
         '| Service | Latest created | Latest ready | Traffic | Template image | Status |',
@@ -202,7 +209,25 @@ def render_cloud_run_report(
         service = service_map.get(service_name)
         if not service:
             lines.append(f'| `{service_name}` | - | - | - | - | missing |')
-            findings.append(Finding('WARN', service_name, 'Cloud Run service not found in report input'))
+            fetch_error = fetch_errors.get(service_name)
+            if fetch_error:
+                findings.append(
+                    Finding(
+                        'FAIL',
+                        service_name,
+                        f'gcloud run services describe failed with exit code {fetch_error.exit_code}',
+                    )
+                )
+            elif service_name in expected_traffic:
+                findings.append(
+                    Finding(
+                        'FAIL',
+                        service_name,
+                        f'expected revision {expected_traffic[service_name]} to serve 100% traffic, but service data is missing',
+                    )
+                )
+            else:
+                findings.append(Finding('WARN', service_name, 'Cloud Run service not found in report input'))
             continue
 
         status = service.get('status', {})
@@ -325,6 +350,7 @@ def fetch_k8s_state(namespace: str) -> dict[str, Any]:
 
 def fetch_cloud_run_state(*, project: str, region: str, services: list[str]) -> dict[str, Any]:
     fetched = []
+    errors = []
     for service in services:
         command = [
             'gcloud',
@@ -339,7 +365,9 @@ def fetch_cloud_run_state(*, project: str, region: str, services: list[str]) -> 
         result = subprocess.run(command, check=False, capture_output=True, text=True)
         if result.returncode == 0:
             fetched.append(json.loads(result.stdout))
-    return {'services': fetched}
+        else:
+            errors.append({'service': service, 'exitCode': result.returncode})
+    return {'services': fetched, 'errors': errors}
 
 
 def kubectl_json(namespace: str, resource: str) -> dict[str, Any]:
@@ -384,6 +412,21 @@ def normalize_cloud_run_services(state: dict[str, Any]) -> dict[str, dict[str, A
             name = object_name(service)
             if name:
                 result[name] = service
+    return result
+
+
+def cloud_run_fetch_errors_by_service(state: dict[str, Any]) -> dict[str, CloudRunFetchError]:
+    raw_errors = state.get('errors') or state.get('fetchErrors') or []
+    if not isinstance(raw_errors, list):
+        return {}
+    result = {}
+    for error in raw_errors:
+        if not isinstance(error, dict):
+            continue
+        service = str(error.get('service') or '')
+        if not service:
+            continue
+        result[service] = CloudRunFetchError(service=service, exit_code=int(error.get('exitCode') or 1))
     return result
 
 

--- a/backend/scripts/deploy_status_report.py
+++ b/backend/scripts/deploy_status_report.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REGION = 'us-central1'
+DEFAULT_GKE_SERVICES = (
+    'backend-listen',
+    'pusher',
+    'llm-gateway',
+    'agent-proxy',
+    'parakeet',
+    'diarizer',
+    'vad',
+)
+DEFAULT_CLOUD_RUN_SERVICES = ('backend', 'backend-sync', 'backend-integration', 'desktop-backend')
+BAD_WAITING_REASONS = {'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'CreateContainerConfigError'}
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    scope: str
+    message: str
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Read-only deploy rollout/status reporter for Omi services.')
+    parser.add_argument('--env', choices=('dev', 'prod'), required=True)
+    parser.add_argument('--project', help='GCP project id for live Cloud Run reads.')
+    parser.add_argument('--region', default=DEFAULT_REGION)
+    parser.add_argument('--namespace', help='Kubernetes namespace. Defaults to <env>-omi-backend.')
+    parser.add_argument('--include-gke', action='store_true')
+    parser.add_argument('--include-cloud-run', action='store_true')
+    parser.add_argument('--gke-service', action='append', dest='gke_services')
+    parser.add_argument('--cloud-run-service', action='append', dest='cloud_run_services')
+    parser.add_argument('--stale-rs-threshold-minutes', type=int, default=15)
+    parser.add_argument('--expect-cloud-run-traffic', action='append', default=[], metavar='SERVICE=REVISION')
+    parser.add_argument('--k8s-state', type=Path, help='Offline Kubernetes state JSON fixture.')
+    parser.add_argument('--cloud-run-state', type=Path, help='Offline Cloud Run state JSON fixture.')
+    parser.add_argument('--now', help='ISO timestamp used by tests for age calculations.')
+    args = parser.parse_args()
+
+    include_gke = args.include_gke or bool(args.k8s_state)
+    include_cloud_run = args.include_cloud_run or bool(args.cloud_run_state)
+    if not include_gke and not include_cloud_run:
+        include_gke = True
+        include_cloud_run = True
+
+    now = parse_timestamp(args.now) if args.now else datetime.now(timezone.utc)
+    namespace = args.namespace or f'{args.env}-omi-backend'
+    findings: list[Finding] = []
+    sections: list[str] = []
+
+    if include_gke:
+        k8s_state = load_json(args.k8s_state) if args.k8s_state else fetch_k8s_state(namespace)
+        gke_services = args.gke_services or list(DEFAULT_GKE_SERVICES)
+        section, gke_findings = render_gke_report(
+            k8s_state,
+            namespace=namespace,
+            services=gke_services,
+            now=now,
+            stale_rs_threshold_minutes=args.stale_rs_threshold_minutes,
+        )
+        sections.append(section)
+        findings.extend(gke_findings)
+
+    if include_cloud_run:
+        if args.cloud_run_state:
+            cloud_run_state = load_json(args.cloud_run_state)
+        else:
+            if not args.project:
+                print('--project is required for live Cloud Run reads', file=sys.stderr)
+                return 2
+            cloud_run_state = fetch_cloud_run_state(
+                project=args.project,
+                region=args.region,
+                services=args.cloud_run_services or list(DEFAULT_CLOUD_RUN_SERVICES),
+            )
+        cloud_run_services = args.cloud_run_services or list(DEFAULT_CLOUD_RUN_SERVICES)
+        expected_traffic = parse_expected_traffic(args.expect_cloud_run_traffic)
+        section, cloud_findings = render_cloud_run_report(
+            cloud_run_state,
+            services=cloud_run_services,
+            expected_traffic=expected_traffic,
+        )
+        sections.append(section)
+        findings.extend(cloud_findings)
+
+    print('\n\n'.join(sections))
+    if findings:
+        print('\nFindings')
+        for finding in findings:
+            print(f'- {finding.severity} [{finding.scope}] {finding.message}')
+
+    return 1 if any(f.severity == 'FAIL' for f in findings) else 0
+
+
+def render_gke_report(
+    state: dict[str, Any],
+    *,
+    namespace: str,
+    services: list[str],
+    now: datetime,
+    stale_rs_threshold_minutes: int,
+) -> tuple[str, list[Finding]]:
+    deployments = items_by_name(state.get('deployments'))
+    replica_sets = state.get('replicaSets', [])
+    pods = state.get('pods', [])
+    events = state.get('events', [])
+    lines = [
+        f'GKE rollout status ({namespace})',
+        '| Deployment | Desired | Updated | Available | Image | Status |',
+        '|---|---:|---:|---:|---|---|',
+    ]
+    findings: list[Finding] = []
+    release_prefix = namespace.removesuffix('-backend')
+
+    for service in services:
+        deployment_name = service if service.startswith(release_prefix) else f'{release_prefix}-{service}'
+        if service == 'backend-listen':
+            deployment_name = f'{release_prefix}-backend-listen'
+        deployment = deployments.get(deployment_name)
+        if not deployment:
+            lines.append(f'| `{deployment_name}` | - | - | - | - | missing |')
+            findings.append(Finding('WARN', deployment_name, 'deployment not found in report input'))
+            continue
+
+        spec = deployment.get('spec', {})
+        metadata = deployment.get('metadata', {})
+        status = deployment.get('status', {})
+        desired = int(spec.get('replicas') or 0)
+        updated = int(status.get('updatedReplicas') or 0)
+        available = int(status.get('availableReplicas') or 0)
+        unavailable = int(status.get('unavailableReplicas') or 0)
+        generation = int(metadata.get('generation') or 0)
+        observed_generation = int(status.get('observedGeneration') or 0)
+        image = first_container_image(deployment)
+        deploy_status = 'ok'
+        if desired and (updated < desired or available < desired):
+            deploy_status = 'degraded'
+            findings.append(
+                Finding(
+                    'FAIL',
+                    deployment_name,
+                    f'rollout incomplete: desired={desired} updated={updated} available={available}',
+                )
+            )
+        if unavailable > 0:
+            deploy_status = 'degraded'
+            findings.append(Finding('FAIL', deployment_name, f'unavailable replicas remain: {unavailable}'))
+        if generation and observed_generation < generation:
+            deploy_status = 'stale-controller'
+            findings.append(
+                Finding(
+                    'FAIL',
+                    deployment_name,
+                    f'controller has not observed latest generation: generation={generation} observed={observed_generation}',
+                )
+            )
+        lines.append(f'| `{deployment_name}` | {desired} | {updated} | {available} | `{image}` | {deploy_status} |')
+
+        findings.extend(find_bad_pods(deployment_name, pods))
+        findings.extend(
+            find_stale_replica_sets(
+                deployment,
+                replica_sets,
+                now=now,
+                threshold_minutes=stale_rs_threshold_minutes,
+            )
+        )
+
+    event_lines = summarize_events(events)
+    lines.extend(['', 'Recent warning events'])
+    lines.extend(event_lines or ['- none'])
+    return '\n'.join(lines), findings
+
+
+def render_cloud_run_report(
+    state: dict[str, Any],
+    *,
+    services: list[str],
+    expected_traffic: dict[str, str],
+) -> tuple[str, list[Finding]]:
+    service_map = normalize_cloud_run_services(state)
+    lines = [
+        'Cloud Run revision status',
+        '| Service | Latest created | Latest ready | Traffic | Template image | Status |',
+        '|---|---|---|---|---|---|',
+    ]
+    findings: list[Finding] = []
+
+    for service_name in services:
+        service = service_map.get(service_name)
+        if not service:
+            lines.append(f'| `{service_name}` | - | - | - | - | missing |')
+            findings.append(Finding('WARN', service_name, 'Cloud Run service not found in report input'))
+            continue
+
+        status = service.get('status', {})
+        latest_created = str(status.get('latestCreatedRevisionName') or '')
+        latest_ready = str(status.get('latestReadyRevisionName') or '')
+        traffic = status.get('traffic') or []
+        traffic_text = format_cloud_run_traffic(traffic)
+        image = cloud_run_image(service)
+        ready_status = 'ok' if latest_ready and latest_ready == latest_created else 'not-ready'
+        if latest_created and latest_ready != latest_created:
+            findings.append(
+                Finding(
+                    'FAIL',
+                    service_name,
+                    f'latest created revision {latest_created} is not latest ready ({latest_ready or "missing"})',
+                )
+            )
+
+        expected_revision = expected_traffic.get(service_name)
+        if expected_revision:
+            served = traffic_percent_for_revision(traffic, expected_revision)
+            if served != 100:
+                findings.append(
+                    Finding(
+                        'FAIL',
+                        service_name,
+                        f'expected revision {expected_revision} to serve 100% traffic, observed {served}%',
+                    )
+                )
+            elif latest_ready != expected_revision:
+                findings.append(
+                    Finding(
+                        'FAIL',
+                        service_name,
+                        f'expected served revision {expected_revision} to be latest ready, observed {latest_ready or "missing"}',
+                    )
+                )
+
+        lines.append(
+            f'| `{service_name}` | `{latest_created or "-"}` | `{latest_ready or "-"}` | {traffic_text} | `{image}` | {ready_status} |'
+        )
+
+    return '\n'.join(lines), findings
+
+
+def find_bad_pods(deployment_name: str, pods: Any) -> list[Finding]:
+    findings: list[Finding] = []
+    if not isinstance(pods, list):
+        return findings
+    for pod in pods:
+        if not isinstance(pod, dict) or owner_name(pod) != deployment_name and deployment_name not in pod_name(pod):
+            continue
+        statuses = pod.get('status', {}).get('containerStatuses') or []
+        for status in statuses:
+            state = status.get('state') or {}
+            waiting = state.get('waiting') or {}
+            reason = waiting.get('reason')
+            if reason in BAD_WAITING_REASONS:
+                findings.append(Finding('FAIL', pod_name(pod), f'container waiting reason {reason}'))
+    return findings
+
+
+def find_stale_replica_sets(
+    deployment: dict[str, Any],
+    replica_sets: Any,
+    *,
+    now: datetime,
+    threshold_minutes: int,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    if not isinstance(replica_sets, list):
+        return findings
+    deployment_name = object_name(deployment)
+    current_revision = deployment.get('metadata', {}).get('annotations', {}).get('deployment.kubernetes.io/revision')
+    for rs in replica_sets:
+        if not isinstance(rs, dict) or owner_name(rs) != deployment_name:
+            continue
+        replicas = int(rs.get('status', {}).get('replicas') or 0)
+        if replicas <= 0:
+            continue
+        rs_revision = rs.get('metadata', {}).get('annotations', {}).get('deployment.kubernetes.io/revision')
+        if current_revision and rs_revision == current_revision:
+            continue
+        age_minutes = age_in_minutes(rs.get('metadata', {}).get('creationTimestamp'), now)
+        if age_minutes is not None and age_minutes >= threshold_minutes:
+            findings.append(
+                Finding(
+                    'WARN',
+                    object_name(rs),
+                    f'old ReplicaSet still has {replicas} replica(s) after {age_minutes}m',
+                )
+            )
+    return findings
+
+
+def summarize_events(events: Any) -> list[str]:
+    if not isinstance(events, list):
+        return []
+    counter: Counter[tuple[str, str]] = Counter()
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get('type') or event.get('regarding', {}).get('type')
+        if event_type and event_type != 'Warning':
+            continue
+        reason = str(event.get('reason') or 'Unknown')
+        message = str(event.get('message') or '').replace('\n', ' ')
+        counter[(reason, message[:140])] += int(event.get('count') or 1)
+    return [f'- {count}x `{reason}`: {message}' for (reason, message), count in counter.most_common(8)]
+
+
+def fetch_k8s_state(namespace: str) -> dict[str, Any]:
+    return {
+        'deployments': kubectl_json(namespace, 'deployments').get('items', []),
+        'replicaSets': kubectl_json(namespace, 'replicasets').get('items', []),
+        'pods': kubectl_json(namespace, 'pods').get('items', []),
+        'events': kubectl_json(namespace, 'events').get('items', []),
+    }
+
+
+def fetch_cloud_run_state(*, project: str, region: str, services: list[str]) -> dict[str, Any]:
+    fetched = []
+    for service in services:
+        command = [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            service,
+            f'--project={project}',
+            f'--region={region}',
+            '--format=json',
+        ]
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        if result.returncode == 0:
+            fetched.append(json.loads(result.stdout))
+    return {'services': fetched}
+
+
+def kubectl_json(namespace: str, resource: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ['kubectl', '-n', namespace, 'get', resource, '-o', 'json'],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def load_json(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f'{path} must contain a JSON object')
+    return loaded
+
+
+def parse_expected_traffic(entries: list[str]) -> dict[str, str]:
+    result = {}
+    for entry in entries:
+        if '=' not in entry:
+            raise ValueError(f'expected traffic entry must be SERVICE=REVISION: {entry}')
+        service, revision = entry.split('=', 1)
+        result[service] = revision
+    return result
+
+
+def normalize_cloud_run_services(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_services = state.get('services', [])
+    if isinstance(raw_services, dict):
+        return {str(name): service for name, service in raw_services.items() if isinstance(service, dict)}
+    if not isinstance(raw_services, list):
+        return {}
+    result = {}
+    for service in raw_services:
+        if isinstance(service, dict):
+            name = object_name(service)
+            if name:
+                result[name] = service
+    return result
+
+
+def items_by_name(items: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(items, list):
+        return {}
+    return {object_name(item): item for item in items if isinstance(item, dict) and object_name(item)}
+
+
+def object_name(obj: dict[str, Any]) -> str:
+    return str(obj.get('metadata', {}).get('name') or '')
+
+
+def pod_name(pod: dict[str, Any]) -> str:
+    return object_name(pod)
+
+
+def owner_name(obj: dict[str, Any]) -> str:
+    owners = obj.get('metadata', {}).get('ownerReferences') or []
+    if isinstance(owners, list) and owners:
+        first = owners[0]
+        if isinstance(first, dict):
+            return str(first.get('name') or '')
+    return ''
+
+
+def first_container_image(deployment: dict[str, Any]) -> str:
+    containers = deployment.get('spec', {}).get('template', {}).get('spec', {}).get('containers') or []
+    if containers and isinstance(containers[0], dict):
+        return str(containers[0].get('image') or '-')
+    return '-'
+
+
+def cloud_run_image(service: dict[str, Any]) -> str:
+    containers = service.get('spec', {}).get('template', {}).get('spec', {}).get('containers') or []
+    image = '-'
+    if containers and isinstance(containers[0], dict):
+        image = str(containers[0].get('image') or '-')
+        digest = containers[0].get('imageDigest')
+        if isinstance(digest, str) and digest:
+            return f'{image}@{digest}'
+    digest = service.get('status', {}).get('imageDigest')
+    if isinstance(digest, str) and digest:
+        return f'{image}@{digest}'
+    return image
+
+
+def format_cloud_run_traffic(traffic: Any) -> str:
+    if not isinstance(traffic, list) or not traffic:
+        return '-'
+    parts = []
+    for target in traffic:
+        if not isinstance(target, dict):
+            continue
+        revision = target.get('revisionName') or ('latest' if target.get('latestRevision') else '-')
+        parts.append(f'`{revision}`={int(target.get("percent") or 0)}%')
+    return ', '.join(parts) or '-'
+
+
+def traffic_percent_for_revision(traffic: Any, revision: str) -> int:
+    if not isinstance(traffic, list):
+        return 0
+    total = 0
+    for target in traffic:
+        if isinstance(target, dict) and target.get('revisionName') == revision:
+            total += int(target.get('percent') or 0)
+    return total
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def age_in_minutes(timestamp: Any, now: datetime) -> int | None:
+    if not isinstance(timestamp, str) or not timestamp:
+        return None
+    created_at = parse_timestamp(timestamp)
+    return int((now - created_at).total_seconds() // 60)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/verify-secret-consumer-registry.py
+++ b/backend/scripts/verify-secret-consumer-registry.py
@@ -32,6 +32,7 @@ SOURCE_ENV_RE = re.compile(r'''(?x)
         | process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]
     )
     ''')
+GENERATED_SOURCE_DIR_NAMES = {'.openapi-venv', '.venv', '__pycache__', 'build', 'dist', 'node_modules'}
 
 
 @dataclass(frozen=True)
@@ -384,7 +385,7 @@ def _discover_registered_code_references(root: Path, registry_names: set[str]) -
         if not search_root.exists():
             continue
         for path in sorted(search_root.rglob('*.py')):
-            if '.venv' in path.parts or '__pycache__' in path.parts:
+            if _is_generated_source_path(path):
                 continue
             text = _read_text(path)
             for name, pattern in patterns.items():
@@ -412,7 +413,7 @@ def _discover_source_env_references(root: Path) -> list[Consumer]:
         for path in sorted(search_root.rglob('*')):
             if path.suffix not in suffixes:
                 continue
-            if any(part in {'.venv', '__pycache__', 'node_modules', 'build', 'dist'} for part in path.parts):
+            if _is_generated_source_path(path):
                 continue
             text = _read_text(path)
             for match in SOURCE_ENV_RE.findall(text):
@@ -585,6 +586,10 @@ def _mapping_items(value: Any) -> list[tuple[str, dict[str, Any]]]:
 
 def _is_high_risk_name(name: str, patterns: list[re.Pattern[str]]) -> bool:
     return any(pattern.search(name) for pattern in patterns)
+
+
+def _is_generated_source_path(path: Path) -> bool:
+    return any(part in GENERATED_SOURCE_DIR_NAMES for part in path.parts)
 
 
 def _compile_valid_patterns(value: Any) -> list[re.Pattern[str]]:

--- a/backend/scripts/verify_k8s_secret_keys.py
+++ b/backend/scripts/verify_k8s_secret_keys.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Verify expected Kubernetes Secret keys without printing values.')
+    parser.add_argument('values_file', type=Path)
+    parser.add_argument('--secret-json', type=Path, help='Kubernetes Secret JSON. Defaults to stdin.')
+    args = parser.parse_args()
+
+    expected = expected_keys(args.values_file)
+    secret = load_json(args.secret_json)
+    present = set((secret.get('data') or {}).keys())
+    missing = sorted(expected - present)
+    if missing:
+        print(f'ERROR: Kubernetes Secret is missing expected key(s): {", ".join(missing)}', file=sys.stderr)
+        return 1
+    print(f'Kubernetes Secret key presence OK: {len(expected)} expected key(s) present')
+    return 0
+
+
+def expected_keys(values_file: Path) -> set[str]:
+    with values_file.open('r', encoding='utf-8') as handle:
+        values = yaml.safe_load(handle)
+    keys = values.get('externalSecret', {}).get('secretKeys', []) if isinstance(values, dict) else []
+    expected = {entry.get('secretKey') for entry in keys if isinstance(entry, dict) and entry.get('secretKey')}
+    if not expected:
+        raise ValueError(f'{values_file} does not define externalSecret.secretKeys')
+    return {str(key) for key in expected}
+
+
+def load_json(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        loaded = json.load(sys.stdin)
+    else:
+        with path.open('r', encoding='utf-8') as handle:
+            loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError('secret JSON must be an object')
+    return loaded
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/wait_external_secret_refresh.py
+++ b/backend/scripts/wait_external_secret_refresh.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Wait for an ExternalSecret refresh observed after a force-sync.')
+    parser.add_argument('--namespace', required=True)
+    parser.add_argument('--name', required=True)
+    parser.add_argument(
+        '--min-refresh-time', required=True, help='Unix epoch seconds or ISO timestamp before annotation.'
+    )
+    parser.add_argument('--timeout-seconds', type=int, default=120)
+    parser.add_argument('--interval-seconds', type=float, default=2.0)
+    parser.add_argument('--state-json', type=Path, help='Offline ExternalSecret JSON for tests.')
+    args = parser.parse_args()
+
+    min_refresh_time = parse_timestamp(args.min_refresh_time)
+    deadline = time.monotonic() + args.timeout_seconds
+    last_reason = 'ExternalSecret status unavailable'
+
+    while True:
+        state = load_json(args.state_json) if args.state_json else fetch_external_secret(args.namespace, args.name)
+        observed, reason = external_secret_refresh_observed(state, min_refresh_time)
+        if observed:
+            print(f'ExternalSecret refresh observed: {reason}')
+            return 0
+        last_reason = reason
+        if args.state_json or time.monotonic() >= deadline:
+            break
+        time.sleep(args.interval_seconds)
+
+    print(
+        f'ERROR: timed out waiting for ExternalSecret refresh after {min_refresh_time.isoformat()}: {last_reason}',
+        file=sys.stderr,
+    )
+    return 1
+
+
+def fetch_external_secret(namespace: str, name: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ['kubectl', '-n', namespace, 'get', f'externalsecret/{name}', '-o', 'json'],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def load_json(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open('r', encoding='utf-8') as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f'{path} must contain a JSON object')
+    return loaded
+
+
+def external_secret_refresh_observed(state: dict[str, Any], min_refresh_time: datetime) -> tuple[bool, str]:
+    status = state.get('status') if isinstance(state, dict) else {}
+    if not isinstance(status, dict):
+        return False, 'ExternalSecret status missing'
+
+    refresh_time = parse_optional_timestamp(status.get('refreshTime'))
+    if refresh_time is None:
+        return False, 'status.refreshTime missing'
+    if refresh_time < min_refresh_time:
+        return False, f'status.refreshTime {refresh_time.isoformat()} is older than requested refresh'
+
+    if not is_ready(status.get('conditions')):
+        return False, f'status.refreshTime {refresh_time.isoformat()} observed but Ready condition is not true'
+
+    return True, f'status.refreshTime={refresh_time.isoformat()}'
+
+
+def is_ready(conditions: Any) -> bool:
+    if not isinstance(conditions, list):
+        return False
+    return any(
+        isinstance(condition, dict)
+        and condition.get('type') == 'Ready'
+        and str(condition.get('status') or '').lower() == 'true'
+        for condition in conditions
+    )
+
+
+def parse_optional_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return parse_timestamp(value)
+
+
+def parse_timestamp(value: str) -> datetime:
+    if value.isdigit():
+        return datetime.fromtimestamp(int(value), tz=timezone.utc)
+    parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/wait_external_secret_refresh.py
+++ b/backend/scripts/wait_external_secret_refresh.py
@@ -73,6 +73,7 @@ def external_secret_refresh_observed(state: dict[str, Any], min_refresh_time: da
     refresh_time = parse_optional_timestamp(status.get('refreshTime'))
     if refresh_time is None:
         return False, 'status.refreshTime missing'
+    min_refresh_time = to_kubernetes_timestamp_precision(min_refresh_time)
     if refresh_time < min_refresh_time:
         return False, f'status.refreshTime {refresh_time.isoformat()} is older than requested refresh'
 
@@ -106,6 +107,10 @@ def parse_timestamp(value: str) -> datetime:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def to_kubernetes_timestamp_precision(value: datetime) -> datetime:
+    return value.astimezone(timezone.utc).replace(microsecond=0)
 
 
 if __name__ == '__main__':

--- a/backend/tests/fixtures/deploy_status/backend_secrets_values.yaml
+++ b/backend/tests/fixtures/deploy_status/backend_secrets_values.yaml
@@ -1,0 +1,6 @@
+externalSecret:
+  secretKeys:
+    - secretKey: OPENAI_API_KEY
+      remoteKey: OPENAI_API_KEY
+    - secretKey: SENTINEL_FAKE_ONLY
+      remoteKey: SENTINEL_FAKE_ONLY

--- a/backend/tests/fixtures/deploy_status/cloud_run_traffic_problem.json
+++ b/backend/tests/fixtures/deploy_status/cloud_run_traffic_problem.json
@@ -1,0 +1,57 @@
+{
+  "services": [
+    {
+      "metadata": {
+        "name": "backend"
+      },
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "image": "gcr.io/example/backend:abc1234"
+              }
+            ]
+          }
+        }
+      },
+      "status": {
+        "latestCreatedRevisionName": "backend-abc1234-1",
+        "latestReadyRevisionName": "backend-abc1234-1",
+        "imageDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "traffic": [
+          {
+            "revisionName": "backend-old9999-1",
+            "percent": 100
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "backend-sync"
+      },
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "image": "gcr.io/example/backend:abc1234"
+              }
+            ]
+          }
+        }
+      },
+      "status": {
+        "latestCreatedRevisionName": "backend-sync-abc1234-1",
+        "latestReadyRevisionName": "backend-sync-old9999-1",
+        "traffic": [
+          {
+            "revisionName": "backend-sync-old9999-1",
+            "percent": 100
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/backend/tests/fixtures/deploy_status/k8s_rollout_problem.json
+++ b/backend/tests/fixtures/deploy_status/k8s_rollout_problem.json
@@ -1,0 +1,91 @@
+{
+  "deployments": [
+    {
+      "metadata": {
+        "name": "prod-omi-backend-listen",
+        "generation": 43,
+        "annotations": {
+          "deployment.kubernetes.io/revision": "42"
+        }
+      },
+      "spec": {
+        "replicas": 3,
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "name": "backend",
+                "image": "gcr.io/example/backend:abc1234"
+              }
+            ]
+          }
+        }
+      },
+      "status": {
+        "observedGeneration": 42,
+        "updatedReplicas": 2,
+        "availableReplicas": 1,
+        "unavailableReplicas": 2
+      }
+    }
+  ],
+  "replicaSets": [
+    {
+      "metadata": {
+        "name": "prod-omi-backend-listen-old",
+        "creationTimestamp": "2026-07-01T12:00:00Z",
+        "annotations": {
+          "deployment.kubernetes.io/revision": "41"
+        },
+        "ownerReferences": [
+          {
+            "kind": "Deployment",
+            "name": "prod-omi-backend-listen"
+          }
+        ]
+      },
+      "status": {
+        "replicas": 1
+      }
+    }
+  ],
+  "pods": [
+    {
+      "metadata": {
+        "name": "prod-omi-backend-listen-abc-pod",
+        "ownerReferences": [
+          {
+            "kind": "ReplicaSet",
+            "name": "prod-omi-backend-listen-abc"
+          }
+        ]
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "backend",
+            "state": {
+              "waiting": {
+                "reason": "CrashLoopBackOff"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "type": "Warning",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container backend",
+      "count": 3
+    },
+    {
+      "type": "Normal",
+      "reason": "Pulled",
+      "message": "Container image already present",
+      "count": 5
+    }
+  ]
+}

--- a/backend/tests/fixtures/deploy_status/k8s_secret.json
+++ b/backend/tests/fixtures/deploy_status/k8s_secret.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "OPENAI_API_KEY": "ZmFrZS1zZW50aW5lbC1ub3QtYS1zZWNyZXQ=",
+    "SENTINEL_FAKE_ONLY": "ZmFrZS1zZW50aW5lbC1ub3QtYS1zZWNyZXQ="
+  }
+}

--- a/backend/tests/unit/test_deploy_status_report.py
+++ b/backend/tests/unit/test_deploy_status_report.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from scripts.deploy_status_report import (
+    Finding,
+    load_json,
+    parse_expected_traffic,
+    render_cloud_run_report,
+    render_gke_report,
+)
+from scripts.verify_k8s_secret_keys import expected_keys
+
+FIXTURES = BACKEND_ROOT / 'tests' / 'fixtures' / 'deploy_status'
+
+
+def test_gke_report_flags_incomplete_rollout_bad_pod_and_stale_replicaset() -> None:
+    state = load_json(FIXTURES / 'k8s_rollout_problem.json')
+
+    report, findings = render_gke_report(
+        state,
+        namespace='prod-omi-backend',
+        services=['backend-listen'],
+        now=datetime(2026, 7, 1, 12, 45, tzinfo=timezone.utc),
+        stale_rs_threshold_minutes=15,
+    )
+
+    assert '| `prod-omi-backend-listen` | 3 | 2 | 1 | `gcr.io/example/backend:abc1234` | stale-controller |' in report
+    assert '- 3x `BackOff`: Back-off restarting failed container backend' in report
+    assert (
+        Finding(
+            'FAIL',
+            'prod-omi-backend-listen',
+            'rollout incomplete: desired=3 updated=2 available=1',
+        )
+        in findings
+    )
+    assert Finding('FAIL', 'prod-omi-backend-listen-abc-pod', 'container waiting reason CrashLoopBackOff') in findings
+    assert (
+        Finding(
+            'WARN',
+            'prod-omi-backend-listen-old',
+            'old ReplicaSet still has 1 replica(s) after 45m',
+        )
+        in findings
+    )
+    assert Finding('FAIL', 'prod-omi-backend-listen', 'unavailable replicas remain: 2') in findings
+    assert (
+        Finding(
+            'FAIL',
+            'prod-omi-backend-listen',
+            'controller has not observed latest generation: generation=43 observed=42',
+        )
+        in findings
+    )
+
+
+def test_cloud_run_report_requires_ready_revision_to_serve_expected_traffic() -> None:
+    state = load_json(FIXTURES / 'cloud_run_traffic_problem.json')
+
+    report, findings = render_cloud_run_report(
+        state,
+        services=['backend', 'backend-sync'],
+        expected_traffic=parse_expected_traffic(
+            [
+                'backend=backend-abc1234-1',
+                'backend-sync=backend-sync-abc1234-1',
+            ]
+        ),
+    )
+
+    assert '`backend-old9999-1`=100%' in report
+    assert (
+        '`gcr.io/example/backend:abc1234@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`'
+        in report
+    )
+    assert '`backend-sync-abc1234-1` | `backend-sync-old9999-1`' in report
+    assert (
+        Finding(
+            'FAIL',
+            'backend',
+            'expected revision backend-abc1234-1 to serve 100% traffic, observed 0%',
+        )
+        in findings
+    )
+    assert (
+        Finding(
+            'FAIL',
+            'backend-sync',
+            'latest created revision backend-sync-abc1234-1 is not latest ready (backend-sync-old9999-1)',
+        )
+        in findings
+    )
+
+
+def test_secret_key_verifier_reads_expected_keys_without_secret_values() -> None:
+    assert expected_keys(FIXTURES / 'backend_secrets_values.yaml') == {'OPENAI_API_KEY', 'SENTINEL_FAKE_ONLY'}

--- a/backend/tests/unit/test_deploy_status_report.py
+++ b/backend/tests/unit/test_deploy_status_report.py
@@ -98,5 +98,34 @@ def test_cloud_run_report_requires_ready_revision_to_serve_expected_traffic() ->
     )
 
 
+def test_cloud_run_report_fails_when_expected_service_is_missing() -> None:
+    report, findings = render_cloud_run_report(
+        {'services': []},
+        services=['backend'],
+        expected_traffic=parse_expected_traffic(['backend=backend-abc1234-1']),
+    )
+
+    assert '| `backend` | - | - | - | - | missing |' in report
+    assert (
+        Finding(
+            'FAIL',
+            'backend',
+            'expected revision backend-abc1234-1 to serve 100% traffic, but service data is missing',
+        )
+        in findings
+    )
+
+
+def test_cloud_run_report_fails_when_describe_failed() -> None:
+    report, findings = render_cloud_run_report(
+        {'services': [], 'errors': [{'service': 'backend', 'exitCode': 1}]},
+        services=['backend'],
+        expected_traffic=parse_expected_traffic(['backend=backend-abc1234-1']),
+    )
+
+    assert '| `backend` | - | - | - | - | missing |' in report
+    assert Finding('FAIL', 'backend', 'gcloud run services describe failed with exit code 1') in findings
+
+
 def test_secret_key_verifier_reads_expected_keys_without_secret_values() -> None:
     assert expected_keys(FIXTURES / 'backend_secrets_values.yaml') == {'OPENAI_API_KEY', 'SENTINEL_FAKE_ONLY'}

--- a/backend/tests/unit/test_secret_consumer_registry.py
+++ b/backend/tests/unit/test_secret_consumer_registry.py
@@ -246,6 +246,23 @@ def test_source_high_risk_env_reference_requires_registry_entry(tmp_path):
     assert 'source env reference' in report['issues'][0]['message']
 
 
+def test_openapi_venv_source_env_references_are_ignored(tmp_path):
+    verifier = _load_verifier()
+    registry = _base_registry()
+    registry_path = tmp_path / 'backend/deploy/secret_consumer_registry.yaml'
+    _write_yaml(registry_path, registry)
+
+    source = tmp_path / 'backend/.openapi-venv/lib/python3.11/site-packages/provider/client.py'
+    source.parent.mkdir(parents=True)
+    env_name = 'PROVIDER_' + 'TOKEN'
+    source.write_text(f'import os\nvalue = os.getenv("{env_name}")\n', encoding='utf-8')
+
+    report = verifier.build_report(root=tmp_path, registry_path=registry_path)
+
+    assert report['status'] == 'PASS'
+    assert report['issues'] == []
+
+
 def test_dynamic_workflow_secret_lookup_fails_closed(tmp_path):
     verifier = _load_verifier()
     registry = _base_registry()

--- a/backend/tests/unit/test_wait_external_secret_refresh.py
+++ b/backend/tests/unit/test_wait_external_secret_refresh.py
@@ -35,6 +35,21 @@ def test_external_secret_refresh_rejects_stale_ready_condition() -> None:
     assert 'older than requested refresh' in reason
 
 
+def test_external_secret_refresh_matches_kubernetes_second_precision() -> None:
+    observed, reason = external_secret_refresh_observed(
+        {
+            'status': {
+                'refreshTime': '2026-07-01T17:01:00Z',
+                'conditions': [{'type': 'Ready', 'status': 'True'}],
+            }
+        },
+        datetime(2026, 7, 1, 17, 1, 0, 987654, tzinfo=timezone.utc),
+    )
+
+    assert observed is True
+    assert 'status.refreshTime=2026-07-01T17:01:00+00:00' == reason
+
+
 def test_external_secret_refresh_rejects_not_ready_after_refresh() -> None:
     observed, reason = external_secret_refresh_observed(
         {

--- a/backend/tests/unit/test_wait_external_secret_refresh.py
+++ b/backend/tests/unit/test_wait_external_secret_refresh.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scripts.wait_external_secret_refresh import external_secret_refresh_observed
+
+
+def test_external_secret_refresh_requires_ready_after_requested_time() -> None:
+    observed, reason = external_secret_refresh_observed(
+        {
+            'status': {
+                'refreshTime': '2026-07-01T17:01:00Z',
+                'conditions': [{'type': 'Ready', 'status': 'True'}],
+            }
+        },
+        datetime(2026, 7, 1, 17, 0, tzinfo=timezone.utc),
+    )
+
+    assert observed is True
+    assert 'status.refreshTime=2026-07-01T17:01:00+00:00' == reason
+
+
+def test_external_secret_refresh_rejects_stale_ready_condition() -> None:
+    observed, reason = external_secret_refresh_observed(
+        {
+            'status': {
+                'refreshTime': '2026-07-01T16:59:59Z',
+                'conditions': [{'type': 'Ready', 'status': 'True'}],
+            }
+        },
+        datetime(2026, 7, 1, 17, 0, tzinfo=timezone.utc),
+    )
+
+    assert observed is False
+    assert 'older than requested refresh' in reason
+
+
+def test_external_secret_refresh_rejects_not_ready_after_refresh() -> None:
+    observed, reason = external_secret_refresh_observed(
+        {
+            'status': {
+                'refreshTime': '2026-07-01T17:01:00Z',
+                'conditions': [{'type': 'Ready', 'status': 'False'}],
+            }
+        },
+        datetime(2026, 7, 1, 17, 0, tzinfo=timezone.utc),
+    )
+
+    assert observed is False
+    assert 'Ready condition is not true' in reason

--- a/docs/runbooks/backend-deploy-rollout-safety.md
+++ b/docs/runbooks/backend-deploy-rollout-safety.md
@@ -1,0 +1,73 @@
+# Backend Deploy Rollout Safety
+
+Use this runbook when a backend deploy may have produced stale runtime, partial traffic shifts, or GKE pods serving an old ReplicaSet. All commands below are read-only unless explicitly marked as a template for a future deploy workflow.
+
+## Read GKE rollout state
+
+```bash
+python3 backend/scripts/deploy_status_report.py \
+  --env prod \
+  --include-gke \
+  --gke-service backend-listen \
+  --gke-service pusher \
+  --gke-service llm-gateway \
+  --gke-service parakeet \
+  --gke-service diarizer \
+  --gke-service vad
+```
+
+Interpretation:
+
+- `desired`, `updated`, and `available` should match for every active deployment.
+- `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, and `CreateContainerConfigError` are deploy blockers.
+- An old ReplicaSet with replicas beyond the threshold means stale runtime may still be serving while the new rollout is unhealthy.
+- Recent warning events are summaries only; inspect the named deployment/pod in an operator shell if the report flags a blocker.
+
+## Read Cloud Run traffic state
+
+```bash
+python3 backend/scripts/deploy_status_report.py \
+  --env prod \
+  --project based-hardware \
+  --include-cloud-run \
+  --cloud-run-service backend \
+  --cloud-run-service backend-sync \
+  --cloud-run-service backend-integration
+```
+
+Interpretation:
+
+- `latest created` must equal `latest ready` before a revision is safe to serve.
+- The traffic column is the serving truth. A newly created ready revision with 0% traffic is not live.
+- Image fields show the configured image/tag when Cloud Run exposes it through `services describe`; do not treat checked-in config as proof of a live deploy.
+
+## Verify a planned Cloud Run traffic shift
+
+Future deploy workflows should verify traffic immediately after `gcloud run services update-traffic`:
+
+```bash
+python3 backend/scripts/deploy_status_report.py \
+  --env prod \
+  --project based-hardware \
+  --include-cloud-run \
+  --cloud-run-service backend \
+  --expect-cloud-run-traffic backend=backend-abcdef0-1
+```
+
+The command fails if the expected revision is not both latest ready and serving 100% traffic.
+
+## Secret-first GKE rollout gate
+
+Before restarting any GKE workload that consumes `backend-secrets`, workflows should apply/sync the ExternalSecret, wait for `Ready`, then verify key presence without printing values:
+
+```bash
+kubectl -n prod-omi-backend wait \
+  externalsecret/prod-omi-backend-external-secret \
+  --for=condition=Ready --timeout=120s
+
+kubectl -n prod-omi-backend get secret prod-omi-backend-secrets -o json \
+  | python3 backend/scripts/verify_k8s_secret_keys.py \
+      ./backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+```
+
+This checks only key names. It must not decode, log, or store secret values.


### PR DESCRIPTION
## Summary

- Adds a read-only GKE rollout/status reporter for backend deployments, pods, ReplicaSets, and warning events.
- Adds a read-only Cloud Run reporter for latest created/ready revisions, traffic split, and image/tag/digest when exposed by service state.
- Adds a Kubernetes Secret key-presence verifier for backend ExternalSecret rollouts without decoding or printing secret values.
- Wires deploy workflows to run secret-first key checks, rollout diagnostics, strict success-path reports, and Cloud Run traffic verification after backend traffic shifts.
- Documents operator interpretation in `docs/runbooks/backend-deploy-rollout-safety.md`.

References #8724 and #8725.

## Validation

- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/deploy-status-tests.txt PYTHON=/Users/dazheng/.hermes/hermes-agent/venv/bin/python3 ./test.sh` from `backend/`: 3 passed.
- `python3 -m black --check --line-length 120 --skip-string-normalization backend/scripts/deploy_status_report.py backend/scripts/verify_k8s_secret_keys.py backend/tests/unit/test_deploy_status_report.py`: passed.
- `python3 -m py_compile backend/scripts/deploy_status_report.py backend/scripts/verify_k8s_secret_keys.py`: passed.
- `git diff --check`: passed.
- PyYAML parse over touched workflows: passed.
- `actionlint` via temporary Go install over touched workflows: passed.
- Offline reporter smoke fixtures intentionally produced failure diagnostics for stale GKE rollout and Cloud Run stale traffic.

## Secret safety

- No raw secrets were read, printed, stored, or committed.
- Fixtures use fake sentinel values only.
- Secret verifier compares expected key names to Kubernetes Secret `.data` keys and prints only counts or missing key names.

## Oracle review

Consulted Oracle before publication. Addressed low-risk actionable items in this PR: removed the desktop workflow edits from scope, switched llm-gateway validation to `python3`, added `--project` to backend Cloud Run traffic shifts, made failure-path reporters best-effort, clarified reporter gate semantics, and added unavailable/observed-generation checks.

Known follow-ups from Oracle that remain intentionally out of this draft because they need broader deploy-design work:

- Desktop backend workflows/Dockerfile still bake a service-account JSON into the image path; migrate to Cloud Run service identity or runtime secret mounting in a dedicated PR.
- Pin GKE `kubectl rollout status` to the exact deployment revision created by each Helm upgrade.
- Wait for ExternalSecret `status.refreshTime` to advance after `force-sync`, not just `Ready=True`.
- Add optional expected image/digest gates for GKE and Cloud Run once workflows expose build digests consistently.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

