### PR TITLE
Harden canonical memory side effects

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -266,6 +266,8 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: TYPESENSE_API_KEY
+  - name: MEMORY_TYPESENSE_COLLECTION
+    value: "canonical_memory_atoms"
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: DEEPGRAM_SELF_HOSTED_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -260,6 +260,8 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: TYPESENSE_API_KEY
+  - name: MEMORY_TYPESENSE_COLLECTION
+    value: "canonical_memory_atoms"
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: DEEPGRAM_SELF_HOSTED_URL

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 import uuid
 
-from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
@@ -10,6 +9,10 @@ from ._client import db
 users_collection = 'users'
 knowledge_nodes_collection = 'knowledge_nodes'
 knowledge_edges_collection = 'knowledge_edges'
+
+
+def _firestore_client(db_client=None):
+    return db_client if db_client is not None else db
 
 
 class KnowledgeNode:
@@ -96,26 +99,29 @@ class KnowledgeEdge:
         )
 
 
-def get_knowledge_nodes(uid: str) -> List[Dict[str, Any]]:
-    user_ref = db.collection(users_collection).document(uid)
+def get_knowledge_nodes(uid: str, *, db_client=None) -> List[Dict[str, Any]]:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     nodes_ref = user_ref.collection(knowledge_nodes_collection)
     return [doc.to_dict() for doc in nodes_ref.stream()]
 
 
-def get_knowledge_node(uid: str, node_id: str) -> Optional[Dict[str, Any]]:
-    user_ref = db.collection(users_collection).document(uid)
+def get_knowledge_node(uid: str, node_id: str, *, db_client=None) -> Optional[Dict[str, Any]]:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     node_ref = user_ref.collection(knowledge_nodes_collection).document(node_id)
     doc = node_ref.get()
     return doc.to_dict() if doc.exists else None
 
 
-def upsert_knowledge_node(uid: str, node_data: Dict[str, Any]) -> Dict[str, Any]:
-    user_ref = db.collection(users_collection).document(uid)
+def upsert_knowledge_node(uid: str, node_data: Dict[str, Any], *, db_client=None) -> Dict[str, Any]:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     nodes_ref = user_ref.collection(knowledge_nodes_collection)
 
     node_id = node_data.get('id')
     if not node_id:
-        existing_node = find_node_by_label_or_alias(uid, node_data.get('label', ''))
+        existing_node = find_node_by_label_or_alias(uid, node_data.get('label', ''), db_client=client)
         if existing_node:
             node_id = existing_node['id']
             node_data['id'] = node_id
@@ -127,7 +133,7 @@ def upsert_knowledge_node(uid: str, node_data: Dict[str, Any]) -> Dict[str, Any]
     existing = node_ref.get()
 
     if not existing.exists:
-        existing_node_by_label = find_node_by_label_or_alias(uid, node_data.get('label', ''))
+        existing_node_by_label = find_node_by_label_or_alias(uid, node_data.get('label', ''), db_client=client)
         if existing_node_by_label:
             node_id = existing_node_by_label['id']
             node_data['id'] = node_id
@@ -160,11 +166,12 @@ def upsert_knowledge_node(uid: str, node_data: Dict[str, Any]) -> Dict[str, Any]
     return node_data
 
 
-def find_node_by_label_or_alias(uid: str, label: str) -> Optional[Dict[str, Any]]:
+def find_node_by_label_or_alias(uid: str, label: str, *, db_client=None) -> Optional[Dict[str, Any]]:
     if not label:
         return None
 
-    nodes_ref = db.collection(users_collection).document(uid).collection(knowledge_nodes_collection)
+    client = _firestore_client(db_client)
+    nodes_ref = client.collection(users_collection).document(uid).collection(knowledge_nodes_collection)
     label_lower = label.lower()
 
     query = nodes_ref.where(filter=FieldFilter('label_lower', '==', label_lower)).limit(1)
@@ -180,14 +187,16 @@ def find_node_by_label_or_alias(uid: str, label: str) -> Optional[Dict[str, Any]
     return None
 
 
-def get_knowledge_edges(uid: str) -> List[Dict[str, Any]]:
-    user_ref = db.collection(users_collection).document(uid)
+def get_knowledge_edges(uid: str, *, db_client=None) -> List[Dict[str, Any]]:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     edges_ref = user_ref.collection(knowledge_edges_collection)
     return [doc.to_dict() for doc in edges_ref.stream()]
 
 
-def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any]) -> Dict[str, Any]:
-    user_ref = db.collection(users_collection).document(uid)
+def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client=None) -> Dict[str, Any]:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     edges_ref = user_ref.collection(knowledge_edges_collection)
 
     edge_id = edge_data.get('id')
@@ -214,22 +223,24 @@ def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any]) -> Dict[str, Any]
     return edge_data
 
 
-def get_knowledge_graph(uid: str) -> Dict[str, Any]:
+def get_knowledge_graph(uid: str, *, db_client=None) -> Dict[str, Any]:
+    client = _firestore_client(db_client)
     return {
-        'nodes': get_knowledge_nodes(uid),
-        'edges': get_knowledge_edges(uid),
+        'nodes': get_knowledge_nodes(uid, db_client=client),
+        'edges': get_knowledge_edges(uid, db_client=client),
     }
 
 
-def delete_knowledge_graph(uid: str) -> None:
-    user_ref = db.collection(users_collection).document(uid)
+def delete_knowledge_graph(uid: str, *, db_client=None) -> None:
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
 
     def _batch_delete(coll_ref):
         while True:
             docs = list(coll_ref.limit(500).stream())
             if not docs:
                 break
-            batch = db.batch()
+            batch = client.batch()
             for doc in docs:
                 batch.delete(doc.reference)
             batch.commit()
@@ -241,12 +252,13 @@ def delete_knowledge_graph(uid: str) -> None:
     _batch_delete(edges_ref)
 
 
-def prune_memory_citations_from_kg(uid: str, memory_ids: List[str]) -> int:
+def prune_memory_citations_from_kg(uid: str, memory_ids: List[str], *, db_client=None) -> int:
     """Remove memory_ids from KG nodes/edges; delete entities with no remaining citations."""
     if not memory_ids:
         return 0
     retracted = set(memory_ids)
-    user_ref = db.collection(users_collection).document(uid)
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
     nodes_ref = user_ref.collection(knowledge_nodes_collection)
     edges_ref = user_ref.collection(knowledge_edges_collection)
     pruned = 0

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -37,6 +37,9 @@ environments:
           MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
             value: "false"
             category: memory_rollout
+          MEMORY_TYPESENSE_COLLECTION:
+            value: canonical_memory_atoms
+            category: memory_rollout
     cloud_run:
       workflow_files:
         - .github/workflows/gcp_backend_auto_dev.yml
@@ -74,6 +77,9 @@ environments:
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
+              category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
               category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:
@@ -113,6 +119,9 @@ environments:
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
               category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
+              category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:
               secret: SERVICE_ACCOUNT_JSON
@@ -150,6 +159,9 @@ environments:
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
+              category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
               category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:
@@ -196,6 +208,9 @@ environments:
           MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
             value: "false"
             category: memory_rollout
+          MEMORY_TYPESENSE_COLLECTION:
+            value: canonical_memory_atoms
+            category: memory_rollout
     cloud_run:
       workflow_files:
         - .github/workflows/gcp_backend.yml
@@ -228,6 +243,9 @@ environments:
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
               category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
+              category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:
               secret: SERVICE_ACCOUNT_JSON
@@ -259,6 +277,9 @@ environments:
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
               category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
+              category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:
               secret: SERVICE_ACCOUNT_JSON
@@ -289,6 +310,9 @@ environments:
               category: memory_rollout
             MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED:
               value: "false"
+              category: memory_rollout
+            MEMORY_TYPESENSE_COLLECTION:
+              value: canonical_memory_atoms
               category: memory_rollout
           secrets:
             SERVICE_ACCOUNT_JSON:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -67,6 +67,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
         {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -79,6 +80,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -91,6 +93,7 @@ def test_cloud_run_state_reports_missing_gateway_url(tmp_path):
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -283,6 +286,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -295,6 +299,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -307,6 +312,7 @@ def test_cloud_run_workflow_validation_uses_custom_manifest_for_runtime_env_outp
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN"}}}
@@ -339,6 +345,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "1"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}
@@ -351,6 +358,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}
@@ -363,6 +371,7 @@ def test_cloud_run_state_rejects_old_secret_versions(tmp_path):
         {"name": "OMI_LLM_GATEWAY_URL", "value": "http://172.16.63.232"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED", "value": "true"},
         {"name": "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE", "value": "1.0"},
+        {"name": "MEMORY_TYPESENSE_COLLECTION", "value": "canonical_memory_atoms"},
         {"name": "SERVICE_ACCOUNT_JSON", "valueFrom": {"secretKeyRef": {"name": "SERVICE_ACCOUNT_JSON", "key": "latest"}}},
         {"name": "ENCRYPTION_SECRET", "valueFrom": {"secretKeyRef": {"name": "ENCRYPTION_SECRET", "key": "latest"}}},
         {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "valueFrom": {"secretKeyRef": {"name": "OMI_LLM_GATEWAY_SERVICE_TOKEN", "key": "latest"}}}

--- a/backend/tests/unit/test_canonical_extraction_subject_wiring.py
+++ b/backend/tests/unit/test_canonical_extraction_subject_wiring.py
@@ -176,7 +176,7 @@ def test_kg_promotion_uses_stored_subject_entity_id(monkeypatch_trusted_account)
         ) as mock_extract,
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted"),
     ):
-        assert extract_kg_for_promoted_memory("uid-kg", item) is True
+        assert extract_kg_for_promoted_memory("uid-kg", item).success is True
         mock_extract.assert_called_once()
         kg_content = mock_extract.call_args[0][1]
         assert kg_content == f"[{USER_ENTITY_ID}] resides_in (location=San Francisco): lives in San Francisco"

--- a/backend/tests/unit/test_canonical_kg_promotion.py
+++ b/backend/tests/unit/test_canonical_kg_promotion.py
@@ -13,7 +13,7 @@ os.environ.setdefault(
 
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
-from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult, extract_kg_for_promoted_memory
 from utils.memory.canonical_memory_adapter import invalidate_kg_for_memory_retraction
 from utils.memory.memory_system import MemorySystem
 
@@ -62,7 +62,9 @@ def test_extract_kg_skips_when_already_extracted():
         patch("utils.memory.canonical_kg_promotion.resolve_memory_system", return_value=MemorySystem.CANONICAL),
         patch("utils.memory.canonical_kg_promotion.extract_knowledge_from_memory") as mock_extract,
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item) is False
+        result = extract_kg_for_promoted_memory("uid-canonical", item)
+        assert result.success is False
+        assert result.skipped_reason == "already_extracted"
         mock_extract.assert_not_called()
 
 
@@ -74,11 +76,21 @@ def test_extract_kg_on_promotion():
         patch(
             "utils.memory.canonical_kg_promotion.extract_knowledge_from_memory",
             return_value={"nodes": [{}], "edges": []},
-        ),
+        ) as mock_extract,
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted") as mock_flag,
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item, db_client=db) is True
+        result = extract_kg_for_promoted_memory("uid-canonical", item, db_client=db)
+        assert result.success is True
+        assert result.node_count == 1
         mock_flag.assert_called_once_with("uid-canonical", "mem_lt", db_client=db)
+        mock_extract.assert_called_once_with(
+            "uid-canonical",
+            "User works at Omi",
+            "mem_lt",
+            user_name="User",
+            db_client=db,
+            strict_parse=True,
+        )
 
 
 def test_extract_kg_failure_leaves_kg_extracted_false():
@@ -92,7 +104,9 @@ def test_extract_kg_failure_leaves_kg_extracted_false():
         ),
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted") as mock_flag,
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item, db_client=db) is False
+        result = extract_kg_for_promoted_memory("uid-canonical", item, db_client=db)
+        assert result.success is False
+        assert result.skipped_reason == "exception"
         mock_flag.assert_not_called()
     assert item.kg_extracted is False
 
@@ -104,7 +118,9 @@ def test_extract_kg_none_result_leaves_kg_extracted_false():
         patch("utils.memory.canonical_kg_promotion.extract_knowledge_from_memory", return_value=None),
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted") as mock_flag,
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item) is False
+        result = extract_kg_for_promoted_memory("uid-canonical", item)
+        assert result.success is False
+        assert result.skipped_reason == "extractor_failed"
         mock_flag.assert_not_called()
 
 
@@ -122,7 +138,7 @@ def test_extract_kg_uses_subject_predicate_prefix():
         ) as mock_extract,
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted"),
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item) is True
+        assert extract_kg_for_promoted_memory("uid-canonical", item).success is True
         kg_content = mock_extract.call_args[0][1]
         assert kg_content == "[ent_father] has_condition: has diabetes"
 
@@ -141,7 +157,7 @@ def test_extract_kg_includes_arguments_and_predicate_only_prefix():
         ) as mock_extract,
         patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted"),
     ):
-        assert extract_kg_for_promoted_memory("uid-canonical", item) is True
+        assert extract_kg_for_promoted_memory("uid-canonical", item).success is True
         kg_content = mock_extract.call_args[0][1]
         assert kg_content == "works_at (company=Omi): builds memory products"
 
@@ -155,7 +171,10 @@ def test_update_canonical_memory_content_refreshes_kg_for_long_term():
     with (
         patch("utils.memory.canonical_memory_adapter.resolve_memory_system", return_value=MemorySystem.CANONICAL),
         patch("utils.memory.canonical_memory_adapter.invalidate_kg_for_memory_retraction") as mock_prune,
-        patch("utils.memory.canonical_kg_promotion.extract_kg_for_promoted_memory", return_value=True) as mock_extract,
+        patch(
+            "utils.memory.canonical_kg_promotion.extract_kg_for_promoted_memory",
+            return_value=CanonicalKgPromotionResult(attempted=True, success=True),
+        ) as mock_extract,
         patch("utils.memory.canonical_memory_adapter.sync_atom_keyword_index_for_item"),
         patch("utils.memory.canonical_memory_adapter.sync_canonical_memory_vector"),
     ):
@@ -178,4 +197,6 @@ def test_invalidate_kg_prunes_citations(monkeypatch):
         mock_prune,
     )
     invalidate_kg_for_memory_retraction("uid-canonical", ["mem_a", "mem_b"])
-    mock_prune.assert_called_once_with("uid-canonical", ["mem_a", "mem_b"])
+    mock_prune.assert_called_once()
+    assert mock_prune.call_args.args == ("uid-canonical", ["mem_a", "mem_b"])
+    assert "db_client" in mock_prune.call_args.kwargs

--- a/backend/tests/unit/test_canonical_maintenance_ordering.py
+++ b/backend/tests/unit/test_canonical_maintenance_ordering.py
@@ -16,6 +16,7 @@ os.environ.setdefault(
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
 from utils.memory.canonical_consolidation import ConsolidationReport
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
 from utils.memory.memory_system import MemorySystem
 from utils.memory.short_term_promotion import (
     CanonicalShortTermLifecycleReport,
@@ -234,7 +235,8 @@ def test_promotion_defers_items_not_in_consolidation_batch():
         patch("utils.memory.short_term_promotion.list_fast_track_promotable_items", return_value=[]),
         patch("utils.memory.short_term_promotion._read_control_state") as mock_control,
         patch(
-            "utils.memory.short_term_promotion.promote_short_term_item_via_apply", return_value=(items[0], False)
+            "utils.memory.short_term_promotion.promote_short_term_item_via_apply",
+            return_value=(items[0], False, CanonicalKgPromotionResult(attempted=True, success=True), True),
         ) as mock_promote,
         patch("utils.memory.short_term_promotion._persist_control_state"),
         patch("utils.memory.short_term_promotion._audit_promotion_transition", return_value=MagicMock()),
@@ -276,7 +278,7 @@ def test_fast_track_respects_consolidation_batch_gate():
         patch("utils.memory.short_term_promotion._read_control_state") as mock_control,
         patch(
             "utils.memory.short_term_promotion.promote_short_term_item_via_apply",
-            return_value=(batched_item, False),
+            return_value=(batched_item, False, CanonicalKgPromotionResult(attempted=True, success=True), True),
         ) as mock_promote,
         patch("utils.memory.short_term_promotion._persist_control_state"),
         patch("utils.memory.short_term_promotion._audit_promotion_transition", return_value=MagicMock()),

--- a/backend/tests/unit/test_canonical_memory_vectors.py
+++ b/backend/tests/unit/test_canonical_memory_vectors.py
@@ -52,6 +52,7 @@ from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, So
 from models.memory_apply import ApplyStatus, MemoryControlState
 from models.memory_search_gateway import SearchDecision, SearchMode
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
 
 
 def _item(
@@ -464,9 +465,9 @@ def test_backfill_path_syncs_vector_on_idempotent_skip(monkeypatch):
         return_value=canonical_memory_id,
     ), patch(
         "utils.memory.legacy_backfill.sync_atom_keyword_index_for_item",
-        return_value=None,
+        return_value=True,
     ):
-        _, written, skip_reason, vector_sync_failed = _apply_one_legacy_row(
+        _, written, skip_reason, vector_sync_failed, keyword_sync_succeeded = _apply_one_legacy_row(
             uid=uid,
             legacy_row={"id": legacy_id, "content": content},
             index=0,
@@ -478,6 +479,7 @@ def test_backfill_path_syncs_vector_on_idempotent_skip(monkeypatch):
     assert written is False
     assert skip_reason == "idempotent_skip"
     assert vector_sync_failed is False
+    assert keyword_sync_succeeded is True
     assert len(fake_index.upserts) == 1
     assert fake_index.upserts[0]["vectors"][0]["id"] == canonical_memory_id
     assert fake_index.upserts[0]["vectors"][0]["metadata"]["memory_layer"] == "long_term"
@@ -518,12 +520,12 @@ def test_promotion_path_updates_same_vector_id_layer(monkeypatch):
         return_value=SimpleNamespace(operation_id="op-promo"),
     ), patch(
         "utils.memory.short_term_promotion.sync_atom_keyword_index_for_item",
-        return_value=None,
+        return_value=True,
     ), patch(
         "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
-        return_value=None,
+        return_value=CanonicalKgPromotionResult(attempted=True, success=True),
     ):
-        promoted, _ = promote_short_term_item_via_apply(
+        promoted, _, _, keyword_sync_succeeded = promote_short_term_item_via_apply(
             uid,
             short_item,
             control=control,
@@ -532,6 +534,7 @@ def test_promotion_path_updates_same_vector_id_layer(monkeypatch):
             now=now,
             db_client=_PromotionDb(),
         )
+    assert keyword_sync_succeeded is True
 
     idempotent_apply = SimpleNamespace(
         status=ApplyStatus.idempotent_skip,
@@ -558,12 +561,12 @@ def test_promotion_path_updates_same_vector_id_layer(monkeypatch):
         return_value=SimpleNamespace(operation_id="op-promo-2"),
     ), patch(
         "utils.memory.short_term_promotion.sync_atom_keyword_index_for_item",
-        return_value=None,
+        return_value=True,
     ), patch(
         "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
-        return_value=None,
+        return_value=CanonicalKgPromotionResult(attempted=True, success=True),
     ):
-        promoted, _ = promote_short_term_item_via_apply(
+        promoted, _, _, keyword_sync_succeeded = promote_short_term_item_via_apply(
             uid,
             short_item,
             control=control,
@@ -572,6 +575,7 @@ def test_promotion_path_updates_same_vector_id_layer(monkeypatch):
             now=now,
             db_client=_PromotionDbWithItem(),
         )
+    assert keyword_sync_succeeded is True
 
     vector_ids = [upsert["vectors"][0]["id"] for upsert in fake_index.upserts]
     assert vector_ids == [memory_id, memory_id, memory_id]
@@ -603,15 +607,15 @@ def test_promotion_vector_sync_failure_increments_report(monkeypatch):
     _set_canonical_cohort(monkeypatch, uid)
     monkeypatch.setattr(
         "utils.memory.canonical_memory_adapter.sync_atom_keyword_index_for_item",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: True,
     )
     monkeypatch.setattr(
         "utils.memory.short_term_promotion.sync_atom_keyword_index_for_item",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: True,
     )
     monkeypatch.setattr(
         "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: CanonicalKgPromotionResult(attempted=True, success=True),
     )
     db = _canonical_db_with_control(uid)
     threshold = 25

--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -43,6 +43,7 @@ from utils.memory.canonical_memory_adapter import (
 )
 from utils.memory.required_promotion import required_promotion_payload
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
 from utils.memory.short_term_promotion import (
     DEFAULT_PROMOTION_BATCH_THRESHOLD,
     promotion_batch_threshold,
@@ -207,7 +208,10 @@ def _clear_canonical_cohort_fixture(monkeypatch):
     from tests.unit.canonical_cohort_test_helpers import clear_canonical_cohort
 
     clear_canonical_cohort(monkeypatch)
-    monkeypatch.setattr("utils.memory.short_term_promotion.extract_kg_for_promoted_memory", lambda *_, **__: None)
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
+        lambda *_, **__: CanonicalKgPromotionResult(attempted=True, success=True),
+    )
 
 
 def test_promotion_fires_on_batch_threshold_via_apply(monkeypatch):
@@ -454,7 +458,10 @@ def test_required_promotion_fires_on_first_run_below_batch_threshold(monkeypatch
         lambda **_: _trusted_account_generation(),
     )
     monkeypatch.setattr("utils.memory.short_term_promotion.sync_canonical_memory_vector", lambda *_, **__: None)
-    monkeypatch.setattr("utils.memory.short_term_promotion.extract_kg_for_promoted_memory", lambda *_, **__: None)
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
+        lambda *_, **__: CanonicalKgPromotionResult(attempted=True, success=True),
+    )
     payload = required_promotion_payload(
         {
             "id": "manual-required-2",
@@ -486,7 +493,10 @@ def test_required_promotion_merges_exact_existing_long_term(monkeypatch):
         lambda **_: _trusted_account_generation(),
     )
     monkeypatch.setattr("utils.memory.short_term_promotion.sync_canonical_memory_vector", lambda *_, **__: None)
-    monkeypatch.setattr("utils.memory.short_term_promotion.extract_kg_for_promoted_memory", lambda *_, **__: None)
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.extract_kg_for_promoted_memory",
+        lambda *_, **__: CanonicalKgPromotionResult(attempted=True, success=True),
+    )
 
     existing_payload = {
         "id": "existing-long-term",

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -805,12 +805,32 @@ def test_pagination_regression_would_miss_page_two_with_old_post_filtered_paging
     old_rows = _old_broken_post_filtered_pagination()
     new_rows = _fetch_active_legacy_memories(
         LEGACY_UID,
+        db_client=MagicMock(),
         get_non_filtered_memories_fn=_make_paginated_non_filtered_store(page_size=page_size, pages=[page1, page2]),
         scan_page_size=page_size,
     )
 
     assert len(old_rows) == 1
     assert len(new_rows) == 3
+
+
+def test_fetch_active_legacy_memories_passes_explicit_firestore_client():
+    db_client = MagicMock(name="explicit-db-client")
+    calls = []
+
+    def _source(uid, *, limit, offset, firestore_client):
+        calls.append((uid, limit, offset, firestore_client))
+        return [_legacy_row(legacy_id="active-explicit", content="Active row")] if offset == 0 else []
+
+    rows = _fetch_active_legacy_memories(
+        LEGACY_UID,
+        db_client=db_client,
+        get_non_filtered_memories_fn=_source,
+        scan_page_size=1,
+    )
+
+    assert [row["id"] for row in rows] == ["active-explicit"]
+    assert calls[0][3] is db_client
 
 
 def test_legacy_read_path_unaffected_for_non_canonical_uid(_trusted_account, monkeypatch):

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -316,7 +316,7 @@ def test_canonical_account_delete_purge_emits_neutral_vector_outbox(monkeypatch,
     expected_vector_id = neutral_vector_id_for_memory(memory_id)
     assert expected_vector_id in result["vector_ids"]
     assert expected_vector_id in deleted_vector_ids
-    delete_graph.assert_called_once_with(uid)
+    delete_graph.assert_called_once_with(uid, db_client=canonical_db)
 
     outbox_paths = [path for path in canonical_db.docs if f"users/{uid}/memory_outbox/" in path]
     assert outbox_paths, "account delete should enqueue durable vector purge outbox records"

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -81,6 +81,7 @@ from utils.memory.atom_keyword_index import (
     build_atom_keyword_document,
     is_indexable_long_term_atom,
     keyword_search_memory_ids,
+    memories_collection_name,
     merge_memory_search_ids,
     rebuild_atom_keyword_index,
     sync_atom_keyword_index_for_item,
@@ -142,6 +143,13 @@ def _long_term_item(
     )
 
 
+def _data_protection_db(level: str = "enhanced") -> MagicMock:
+    user_doc = MagicMock(exists=True, to_dict=lambda: {"data_protection_level": level})
+    db_client = MagicMock()
+    db_client.document.return_value = MagicMock(get=lambda: user_doc)
+    return db_client
+
+
 @pytest.fixture(autouse=True)
 def _canonical_cohort(monkeypatch):
     from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
@@ -195,7 +203,10 @@ def mock_typesense():
     typesense_client.collections.__getitem__.return_value = memories_collection
     typesense_client.collections.create.return_value = None
 
-    with patch("utils.memory.atom_keyword_index._typesense_client", return_value=typesense_client):
+    with (
+        patch("utils.memory.atom_keyword_index._typesense_client", return_value=typesense_client),
+        patch("utils.memory.atom_keyword_index.default_db_client", _data_protection_db()),
+    ):
         yield typesense_client, docs_store
 
 
@@ -222,6 +233,35 @@ class TestMergeMemorySearchIds:
 
 
 class TestKeywordSearchAndHybrid:
+    def test_canonical_atoms_use_isolated_collection_by_default(self, mock_typesense):
+        typesense_client, _ = mock_typesense
+        upsert_atom_keyword_doc(_long_term_item())
+        assert memories_collection_name() == "canonical_memory_atoms"
+        assert typesense_client.collections.__getitem__.call_args_list[-1].args[0] == "canonical_memory_atoms"
+
+    def test_e2ee_user_skips_index_using_explicit_db_client(self, mock_typesense):
+        _, docs_store = mock_typesense
+        db_client = _data_protection_db("e2ee")
+
+        assert upsert_atom_keyword_doc(_long_term_item(), db_client=db_client) is False
+        assert docs_store == {}
+        db_client.document.assert_called_with(f"users/{CANONICAL_UID}")
+
+    def test_existing_wrong_typesense_schema_does_not_index(self, mock_typesense):
+        typesense_client, docs_store = mock_typesense
+        collection = typesense_client.collections.__getitem__.return_value
+        collection.retrieve.side_effect = None
+        collection.retrieve.return_value = {
+            "fields": [
+                {"name": "userId"},
+                {"name": "transcript_segments"},
+            ]
+        }
+
+        assert upsert_atom_keyword_doc(_long_term_item()) is False
+        assert docs_store == {}
+        typesense_client.collections.create.assert_not_called()
+
     def test_canonical_keyword_search_returns_exact_needle(self, mock_typesense, monkeypatch):
         _, docs_store = mock_typesense
         item = _long_term_item()
@@ -257,6 +297,7 @@ class TestKeywordSearchAndHybrid:
             NEEDLE,
             limit=5,
             vector_query=_empty_vector,
+            db_client=_data_protection_db(),
         )
         assert len(results) == 1
         assert results[0]["memory_id"] == item.memory_id
@@ -275,7 +316,7 @@ class TestKeywordSearchAndHybrid:
 
         monkeypatch.setattr(
             "utils.memory.canonical_memory_adapter.keyword_search_memory_ids",
-            lambda uid, query, limit=5: ["mem_active", "mem_superseded"],
+            lambda uid, query, limit=5, db_client=None: ["mem_active", "mem_superseded"],
         )
         monkeypatch.setattr(
             "utils.memory.canonical_memory_adapter.fetch_authoritative_product_memory_items",
@@ -286,6 +327,7 @@ class TestKeywordSearchAndHybrid:
             NEEDLE,
             limit=5,
             vector_query=_empty_vector,
+            db_client=_data_protection_db(),
         )
         assert [row["memory_id"] for row in results] == ["mem_active"]
 
@@ -388,12 +430,15 @@ class TestPurgeAndRebuild:
             "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
             lambda **_: types.SimpleNamespace(account_generation=1, head_commit_id="head0", read_error_reason=None),
         )
-        monkeypatch.setattr("utils.memory.canonical_memory_adapter.kg_db.delete_knowledge_graph", lambda uid: None)
+        delete_kg = MagicMock()
+        monkeypatch.setattr("utils.memory.canonical_memory_adapter.kg_db.delete_knowledge_graph", delete_kg)
 
-        result = purge_canonical_derived_user_data(CANONICAL_UID, db_client=MagicMock())
+        db_client = MagicMock()
+        result = purge_canonical_derived_user_data(CANONICAL_UID, db_client=db_client)
         assert result["purged"] is True
         assert result["keyword_docs_deleted"] >= 0
         assert item.memory_id not in docs_store
+        delete_kg.assert_called_once_with(CANONICAL_UID, db_client=db_client)
 
     def test_conversation_cascade_deletes_keyword_doc(self, mock_typesense, monkeypatch):
         _, docs_store = mock_typesense
@@ -416,7 +461,7 @@ class TestPurgeAndRebuild:
         )
         monkeypatch.setattr(
             "utils.memory.canonical_memory_adapter.kg_db.prune_memory_citations_from_kg",
-            lambda uid, memory_ids: 0,
+            lambda uid, memory_ids, db_client=None: 0,
         )
 
         retract_conversation_sourced_memories(CANONICAL_UID, "conv-1", db_client=MagicMock())
@@ -457,5 +502,19 @@ class TestDocumentShape:
         doc = build_atom_keyword_document(_long_term_item())
         assert doc["layer"] == MemoryTier.long_term.value
         assert doc["status"] == MemoryItemStatus.active.value
+        assert doc["schema_version"] == 1
         assert doc["userId"] == CANONICAL_UID
         assert NEEDLE in doc["content"]
+
+    def test_build_document_indexes_flat_subject_predicate_arguments(self):
+        item = _long_term_item().model_copy(
+            update={
+                "subject_entity_id": "ent_user",
+                "predicate": "works_at",
+                "arguments": {"company": "Omi"},
+            }
+        )
+        doc = build_atom_keyword_document(item)
+        assert doc["predicate"] == "works_at"
+        assert "ent_user" in doc["entity_terms"]
+        assert "Omi" in doc["entity_terms"]

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -75,9 +75,15 @@ Extract entities and relationships. If no meaningful patterns found, return empt
 
 
 def extract_knowledge_from_memory(
-    uid: str, memory_content: str, memory_id: str, user_name: str = "User"
+    uid: str,
+    memory_content: str,
+    memory_id: str,
+    user_name: str = "User",
+    *,
+    db_client=None,
+    strict_parse: bool = False,
 ) -> Optional[Dict[str, Any]]:
-    existing_nodes = kg_db.get_knowledge_nodes(uid)
+    existing_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
     existing_nodes_summary = []
     for node in existing_nodes:
         existing_nodes_summary.append(
@@ -107,6 +113,8 @@ def extract_knowledge_from_memory(
             extraction: KnowledgeGraphExtraction = parser.parse(response.content)
         except Exception as e:
             logger.error(f"KG extraction parse failed for memory {memory_id}: {type(e).__name__}")
+            if strict_parse:
+                return None
             extraction = KnowledgeGraphExtraction(nodes=[], edges=[])
 
         label_to_node_id = {}
@@ -132,7 +140,7 @@ def extract_knowledge_from_memory(
                 'memory_ids': [memory_id],
             }
 
-            saved_node = kg_db.upsert_knowledge_node(uid, node_data)
+            saved_node = kg_db.upsert_knowledge_node(uid, node_data, db_client=db_client)
             created_nodes.append(saved_node)
             label_to_node_id[node.label.lower()] = node_id
             for alias in node.aliases:
@@ -150,7 +158,7 @@ def extract_knowledge_from_memory(
                     'label': edge.label,
                     'memory_ids': [memory_id],
                 }
-                saved_edge = kg_db.upsert_knowledge_edge(uid, edge_data)
+                saved_edge = kg_db.upsert_knowledge_edge(uid, edge_data, db_client=db_client)
                 created_edges.append(saved_edge)
 
         return {
@@ -163,8 +171,14 @@ def extract_knowledge_from_memory(
         return None
 
 
-def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name: str = "User") -> Dict[str, Any]:
-    kg_db.delete_knowledge_graph(uid)
+def rebuild_knowledge_graph(
+    uid: str,
+    memories: List[Dict[str, Any]],
+    user_name: str = "User",
+    *,
+    db_client=None,
+) -> Dict[str, Any]:
+    kg_db.delete_knowledge_graph(uid, db_client=db_client)
 
     node_lock = threading.Lock()
 
@@ -174,7 +188,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
         if not memory_content:
             return {'nodes': [], 'edges': []}
 
-        existing_nodes = kg_db.get_knowledge_nodes(uid)
+        existing_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
         existing_nodes_summary = []
         for node in existing_nodes:
             existing_nodes_summary.append(
@@ -211,7 +225,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
 
             with node_lock:
                 label_to_node_id = {}
-                current_nodes = kg_db.get_knowledge_nodes(uid)
+                current_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
                 for existing in current_nodes:
                     label_to_node_id[existing['label'].lower()] = existing['id']
                     for alias in existing.get('aliases', []):
@@ -233,7 +247,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
                         'memory_ids': [memory_id],
                     }
 
-                    saved_node = kg_db.upsert_knowledge_node(uid, node_data)
+                    saved_node = kg_db.upsert_knowledge_node(uid, node_data, db_client=db_client)
                     created_nodes.append(saved_node)
                     label_to_node_id[node.label.lower()] = saved_node['id']
                     for alias in node.aliases:
@@ -250,7 +264,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
                             'label': edge.label,
                             'memory_ids': [memory_id],
                         }
-                        saved_edge = kg_db.upsert_knowledge_edge(uid, edge_data)
+                        saved_edge = kg_db.upsert_knowledge_edge(uid, edge_data, db_client=db_client)
                         created_edges.append(saved_edge)
 
             return {'nodes': created_nodes, 'edges': created_edges}
@@ -280,4 +294,4 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
         except Exception:
             logging.exception("Error in concurrent memory extraction")
 
-    return kg_db.get_knowledge_graph(uid)
+    return kg_db.get_knowledge_graph(uid, db_client=db_client)

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -287,7 +287,7 @@ def rebuild_atom_keyword_index(uid: str, *, db_client=None) -> AtomKeywordRebuil
     purge_user_atom_keyword_index(uid, db_client=client)
     indexed = 0
     for item in indexable:
-        if upsert_atom_keyword_doc(item):
+        if upsert_atom_keyword_doc(item, db_client=client):
             indexed += 1
 
     expected = len(indexable)

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -20,14 +20,31 @@ from utils.memory.product_memory_read_service import fetch_authoritative_product
 
 logger = logging.getLogger(__name__)
 
-MEMORIES_COLLECTION = "memories"
+ATOM_KEYWORD_COLLECTION_ENV = "MEMORY_TYPESENSE_COLLECTION"
+MEMORIES_COLLECTION = "canonical_memory_atoms"
 _DEFAULT_CATEGORY = "interesting"
+_REQUIRED_SCHEMA_FIELDS = {
+    "memory_id",
+    "userId",
+    "content",
+    "category",
+    "layer",
+    "status",
+    "schema_version",
+    "entity_terms",
+    "predicate",
+    "created_at",
+}
 
 
 def _typesense_client():
     from utils.conversations.search import client
 
     return client
+
+
+def memories_collection_name() -> str:
+    return os.getenv(ATOM_KEYWORD_COLLECTION_ENV, MEMORIES_COLLECTION).strip() or MEMORIES_COLLECTION
 
 
 @dataclass(frozen=True)
@@ -53,9 +70,10 @@ def user_allows_atom_keyword_index(uid: str, *, db_client=None) -> bool:
     """Canonical cohort + conversation-Typesense-compatible data protection."""
     if resolve_memory_system(uid, db_client=db_client) != MemorySystem.CANONICAL:
         return False
-    from database.users import get_data_protection_level
-
-    return get_data_protection_level(uid) != "e2ee"
+    client = db_client if db_client is not None else default_db_client
+    user_doc = client.document(f"users/{uid}").get()
+    user_data = user_doc.to_dict() if getattr(user_doc, "exists", False) else {}
+    return (user_data or {}).get("data_protection_level", "enhanced") != "e2ee"
 
 
 def _created_at_epoch(item: MemoryItem) -> int:
@@ -68,6 +86,12 @@ def _created_at_epoch(item: MemoryItem) -> int:
 def _entity_terms_for_item(item: MemoryItem) -> str:
     """Flatten any structured hints on the item into searchable tokens."""
     terms: List[str] = []
+    subject_entity_id = getattr(item, "subject_entity_id", None)
+    if isinstance(subject_entity_id, str) and subject_entity_id.strip():
+        terms.append(subject_entity_id.strip())
+    arguments = getattr(item, "arguments", None) or {}
+    if isinstance(arguments, dict):
+        terms.extend(str(value).strip() for value in arguments.values() if str(value).strip())
     promotion = item.promotion or {}
     for key in ("entity", "entity_name", "subject"):
         value = promotion.get(key)
@@ -76,13 +100,16 @@ def _entity_terms_for_item(item: MemoryItem) -> str:
     aliases = promotion.get("aliases")
     if isinstance(aliases, list):
         terms.extend(str(alias).strip() for alias in aliases if str(alias).strip())
-    return " ".join(terms)
+    return " ".join(dict.fromkeys(terms))
 
 
 def _predicate_for_item(item: MemoryItem) -> str:
+    predicate = getattr(item, "predicate", None)
+    if isinstance(predicate, str) and predicate.strip():
+        return predicate.strip()
     promotion = item.promotion or {}
-    predicate = promotion.get("predicate")
-    return predicate.strip() if isinstance(predicate, str) else ""
+    promotion_predicate = promotion.get("predicate")
+    return promotion_predicate.strip() if isinstance(promotion_predicate, str) else ""
 
 
 def build_atom_keyword_document(item: MemoryItem) -> Dict[str, Any]:
@@ -95,6 +122,7 @@ def build_atom_keyword_document(item: MemoryItem) -> Dict[str, Any]:
         "category": _DEFAULT_CATEGORY,
         "layer": MemoryLayer.long_term.value,
         "status": MemoryItemStatus.active.value,
+        "schema_version": 1,
         "entity_terms": _entity_terms_for_item(item),
         "predicate": _predicate_for_item(item),
         "created_at": _created_at_epoch(item),
@@ -107,41 +135,49 @@ def merge_memory_search_ids(keyword_ids: List[str], vector_ids: List[str]) -> Li
 
 
 def ensure_memories_collection() -> None:
-    """Create the ``memories`` Typesense collection when missing (idempotent)."""
+    """Create the canonical atom Typesense collection when missing (idempotent)."""
+    collection_name = memories_collection_name()
     try:
-        _typesense_client().collections[MEMORIES_COLLECTION].retrieve()
-        return
+        schema = _typesense_client().collections[collection_name].retrieve()
     except Exception:
-        pass
+        schema = {
+            "name": collection_name,
+            "fields": [
+                {"name": "memory_id", "type": "string"},
+                {"name": "userId", "type": "string", "facet": True},
+                {"name": "content", "type": "string"},
+                {"name": "category", "type": "string", "facet": True, "optional": True},
+                {"name": "layer", "type": "string", "facet": True},
+                {"name": "status", "type": "string", "facet": True},
+                {"name": "schema_version", "type": "int32", "facet": True},
+                {"name": "entity_terms", "type": "string", "optional": True},
+                {"name": "predicate", "type": "string", "optional": True},
+                {"name": "created_at", "type": "int64"},
+            ],
+            "default_sorting_field": "created_at",
+        }
+        _typesense_client().collections.create(schema)
+        return
 
-    schema = {
-        "name": MEMORIES_COLLECTION,
-        "fields": [
-            {"name": "memory_id", "type": "string"},
-            {"name": "userId", "type": "string", "facet": True},
-            {"name": "content", "type": "string"},
-            {"name": "category", "type": "string", "facet": True, "optional": True},
-            {"name": "layer", "type": "string", "facet": True},
-            {"name": "status", "type": "string", "facet": True},
-            {"name": "entity_terms", "type": "string", "optional": True},
-            {"name": "predicate", "type": "string", "optional": True},
-            {"name": "created_at", "type": "int64"},
-        ],
-        "default_sorting_field": "created_at",
-    }
-    _typesense_client().collections.create(schema)
+    actual_fields = {field.get("name") for field in schema.get("fields", [])}
+    missing = sorted(_REQUIRED_SCHEMA_FIELDS - actual_fields)
+    if missing:
+        raise RuntimeError(
+            f"Typesense collection {collection_name!r} is incompatible with canonical memory atoms; "
+            f"missing fields: {missing}"
+        )
 
 
-def upsert_atom_keyword_doc(item: MemoryItem) -> bool:
+def upsert_atom_keyword_doc(item: MemoryItem, *, db_client=None) -> bool:
     """Upsert one long-term atom when indexable; no-op otherwise."""
-    if not user_allows_atom_keyword_index(item.uid):
+    if not user_allows_atom_keyword_index(item.uid, db_client=db_client):
         return False
     if not is_indexable_long_term_atom(item):
         return False
     try:
         ensure_memories_collection()
         doc = build_atom_keyword_document(item)
-        _typesense_client().collections[MEMORIES_COLLECTION].documents.upsert(doc)
+        _typesense_client().collections[memories_collection_name()].documents.upsert(doc)
         return True
     except Exception as exc:
         logger.warning(
@@ -153,38 +189,42 @@ def upsert_atom_keyword_doc(item: MemoryItem) -> bool:
         return False
 
 
-def delete_atom_keyword_doc(uid: str, memory_id: str) -> None:
+def delete_atom_keyword_doc(uid: str, memory_id: str, *, db_client=None) -> None:
     """Remove one keyword doc. Canonical-gated; legacy users are no-ops."""
-    if not user_allows_atom_keyword_index(uid):
+    if not user_allows_atom_keyword_index(uid, db_client=db_client):
         return
     if not memory_id:
         return
     try:
-        _typesense_client().collections[MEMORIES_COLLECTION].documents[memory_id].delete()
+        _typesense_client().collections[memories_collection_name()].documents[memory_id].delete()
     except Exception as exc:
         logger.warning("delete_atom_keyword_doc failed uid=%s memory_id=%s: %s", uid, memory_id, exc)
 
 
-def purge_user_atom_keyword_index(uid: str) -> int:
+def purge_user_atom_keyword_index(uid: str, *, db_client=None, force: bool = False) -> int:
     """Delete all keyword docs for a canonical user. Returns deleted count when available."""
-    if not user_allows_atom_keyword_index(uid):
+    if not force and not user_allows_atom_keyword_index(uid, db_client=db_client):
         return 0
     try:
-        result = _typesense_client().collections[MEMORIES_COLLECTION].documents.delete({"filter_by": f"userId:={uid}"})
+        result = (
+            _typesense_client()
+            .collections[memories_collection_name()]
+            .documents.delete({"filter_by": f"userId:={uid}"})
+        )
         return int(result.get("num_deleted") or 0)
     except Exception as exc:
         logger.warning("purge_user_atom_keyword_index failed uid=%s: %s", uid, exc)
         return 0
 
 
-def sync_atom_keyword_index_for_item(item: MemoryItem, *, db_client=None) -> None:
+def sync_atom_keyword_index_for_item(item: MemoryItem, *, db_client=None) -> bool:
     """Index or purge one atom based on its current authoritative state."""
     if not user_allows_atom_keyword_index(item.uid, db_client=db_client):
-        return
+        return True
     if is_indexable_long_term_atom(item):
-        upsert_atom_keyword_doc(item)
-    else:
-        delete_atom_keyword_doc(item.uid, item.memory_id)
+        return upsert_atom_keyword_doc(item, db_client=db_client)
+    delete_atom_keyword_doc(item.uid, item.memory_id, db_client=db_client)
+    return True
 
 
 def keyword_search_memory_ids(
@@ -194,17 +234,21 @@ def keyword_search_memory_ids(
     limit: int = 5,
     start_date: int = None,
     end_date: int = None,
+    db_client=None,
 ) -> List[str]:
     """Typesense keyword search returning memory ids for hybrid retrieval.
 
     Fail-open: any search error returns [] so callers can fall back to vector-only results.
     """
-    if not user_allows_atom_keyword_index(uid):
+    if not user_allows_atom_keyword_index(uid, db_client=db_client):
         return []
     if not (query or "").strip():
         return []
     try:
-        filter_by = f"userId:={uid} && layer:={MemoryLayer.long_term.value} && status:={MemoryItemStatus.active.value}"
+        filter_by = (
+            f"userId:={uid} && layer:={MemoryLayer.long_term.value} "
+            f"&& status:={MemoryItemStatus.active.value} && schema_version:=1"
+        )
         if start_date is not None:
             filter_by = filter_by + f" && created_at:>={start_date}"
         if end_date is not None:
@@ -218,7 +262,7 @@ def keyword_search_memory_ids(
             "per_page": max(1, min(limit, 60)),
             "page": 1,
         }
-        results = _typesense_client().collections[MEMORIES_COLLECTION].documents.search(search_parameters)
+        results = _typesense_client().collections[memories_collection_name()].documents.search(search_parameters)
         memory_ids: List[str] = []
         for hit in results.get("hits", []):
             doc = hit.get("document") or {}
@@ -240,7 +284,7 @@ def rebuild_atom_keyword_index(uid: str, *, db_client=None) -> AtomKeywordRebuil
     items = fetch_authoritative_product_memory_items(uid=uid, db_client=client)
     indexable = [item for item in items if is_indexable_long_term_atom(item)]
 
-    purge_user_atom_keyword_index(uid)
+    purge_user_atom_keyword_index(uid, db_client=client)
     indexed = 0
     for item in indexable:
         if upsert_atom_keyword_doc(item):

--- a/backend/utils/memory/canonical_consolidation.py
+++ b/backend/utils/memory/canonical_consolidation.py
@@ -579,10 +579,10 @@ def _apply_superseded_item(
         if getattr(snapshot, "exists", False):
             item = MemoryItem(**(snapshot.to_dict() or {}))
     if item is not None and item.tier == MemoryLayer.long_term:
-        delete_atom_keyword_doc(uid, item.memory_id)
+        delete_atom_keyword_doc(uid, item.memory_id, db_client=db_client)
     delete_canonical_memory_vector(uid, memory_id)
-    invalidate_kg_for_memory_retraction(uid, [memory_id])
-    purge_stale_review_conflicts_for_memories(uid, [memory_id], reason="memory_superseded")
+    invalidate_kg_for_memory_retraction(uid, [memory_id], db_client=db_client)
+    purge_stale_review_conflicts_for_memories(uid, [memory_id], reason="memory_superseded", db_client=db_client)
 
 
 def _escalate_to_review_queue(

--- a/backend/utils/memory/canonical_kg_promotion.py
+++ b/backend/utils/memory/canonical_kg_promotion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from dataclasses import dataclass
 from typing import Optional
 
 from database._client import db as default_db_client
@@ -13,6 +14,19 @@ from utils.llm.knowledge_graph import extract_knowledge_from_memory
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CanonicalKgPromotionResult:
+    attempted: bool = False
+    success: bool = False
+    skipped_reason: Optional[str] = None
+    node_count: int = 0
+    edge_count: int = 0
+
+    @property
+    def empty(self) -> bool:
+        return self.success and self.node_count == 0 and self.edge_count == 0
 
 
 def _content_for_kg_extraction(item: MemoryItem) -> str:
@@ -44,34 +58,43 @@ def extract_kg_for_promoted_memory(
     *,
     user_name: str = "User",
     db_client=None,
-) -> bool:
-    """Extract KG nodes/edges for a newly promoted long_term memory. Returns True on success."""
+) -> CanonicalKgPromotionResult:
+    """Extract KG nodes/edges for a newly promoted long_term memory."""
     client = db_client if db_client is not None else default_db_client
     if resolve_memory_system(uid, db_client=client) != MemorySystem.CANONICAL:
-        return False
+        return CanonicalKgPromotionResult(skipped_reason="not_canonical_cohort")
     if item.tier != MemoryLayer.long_term:
-        return False
+        return CanonicalKgPromotionResult(skipped_reason="not_long_term")
     if getattr(item, "kg_extracted", False):
-        return False
+        return CanonicalKgPromotionResult(skipped_reason="already_extracted")
     content = (item.content or "").strip()
     if not content:
-        return False
+        return CanonicalKgPromotionResult(skipped_reason="empty_content")
 
     content_for_kg = _content_for_kg_extraction(item)
 
     try:
-        result = extract_knowledge_from_memory(uid, content_for_kg, item.memory_id, user_name=user_name)
+        result = extract_knowledge_from_memory(
+            uid,
+            content_for_kg,
+            item.memory_id,
+            user_name=user_name,
+            db_client=client,
+            strict_parse=True,
+        )
     except Exception:
         logger.exception("kg_extraction_failed uid=%s memory_id=%s", uid, item.memory_id)
-        return False
+        return CanonicalKgPromotionResult(attempted=True, skipped_reason="exception")
     if result is None:
-        return False
+        return CanonicalKgPromotionResult(attempted=True, skipped_reason="extractor_failed")
     set_canonical_memory_kg_extracted(uid, item.memory_id, db_client=db_client)
+    node_count = len(result.get("nodes") or [])
+    edge_count = len(result.get("edges") or [])
     logger.info(
         "kg_extracted_on_promotion uid=%s memory_id=%s nodes=%d edges=%d",
         uid,
         item.memory_id,
-        len(result.get("nodes") or []),
-        len(result.get("edges") or []),
+        node_count,
+        edge_count,
     )
-    return True
+    return CanonicalKgPromotionResult(attempted=True, success=True, node_count=node_count, edge_count=edge_count)

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -65,7 +65,7 @@ def invalidate_kg_for_memory_retraction(uid: str, memory_ids: List[str], *, db_c
     client = db_client if db_client is not None else default_db_client
     if resolve_memory_system(uid, db_client=client) != MemorySystem.CANONICAL:
         return
-    pruned = kg_db.prune_memory_citations_from_kg(uid, memory_ids)
+    pruned = kg_db.prune_memory_citations_from_kg(uid, memory_ids, db_client=client)
     logger.info(
         "kg_citations_pruned uid=%s retracted_memory_count=%d pruned_entities=%d",
         uid,
@@ -219,7 +219,7 @@ def search_canonical_memories(
             for memory in memories[:capped_limit]
         ]
 
-    keyword_ids = keyword_search_memory_ids(uid, normalized_query, limit=fetch_limit)
+    keyword_ids = keyword_search_memory_ids(uid, normalized_query, limit=fetch_limit, db_client=client)
     if vector_query is None:
         from database.vector_db import query_memory_vector_candidates
 
@@ -629,7 +629,8 @@ def update_canonical_memory_content(uid: str, memory_id: str, content: str, *, d
         client.document(item_path).set({"kg_extracted": False, "updated_at": now}, merge=True)
         from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
 
-        if extract_kg_for_promoted_memory(uid, updated, db_client=client):
+        kg_result = extract_kg_for_promoted_memory(uid, updated, db_client=client)
+        if kg_result.success:
             updated = updated.model_copy(update={"kg_extracted": True})
     sync_atom_keyword_index_for_item(updated, db_client=client)
     sync_canonical_memory_vector(updated)
@@ -739,7 +740,7 @@ def _tombstone_memory_item(uid: str, item: MemoryItem, *, db_client, reason: str
     for record in build_vector_repair_purge_outbox_records(uid=uid, candidates=purge_candidates):
         db_client.document(record["outbox_path"]).set(record)
 
-    delete_atom_keyword_doc(uid, item.memory_id)
+    delete_atom_keyword_doc(uid, item.memory_id, db_client=db_client)
     purge_stale_review_conflicts_for_memories(uid, [item.memory_id], reason=reason, db_client=db_client)
 
 
@@ -811,8 +812,8 @@ def purge_canonical_derived_user_data(uid: str, *, db_client=None) -> Dict[str, 
 
         delete_pinecone_memory_vectors_by_id(vector_ids)
 
-    keyword_deleted = purge_user_atom_keyword_index(uid)
-    kg_db.delete_knowledge_graph(uid)
+    keyword_deleted = purge_user_atom_keyword_index(uid, db_client=client, force=True)
+    kg_db.delete_knowledge_graph(uid, db_client=client)
 
     trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=client)
     account_generation = trusted.account_generation if trusted.read_error_reason is None else 1

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -112,6 +112,7 @@ class BackfillReport:
     completed: bool = False
     legacy_rows_touched: int = 0
     vector_sync_failures: int = 0
+    keyword_sync_failures: int = 0
     cohort_gated: bool = False
     errors: List[str] = field(default_factory=list)
     selected_bucket: Optional[str] = None
@@ -298,6 +299,7 @@ def _bucket_counts_and_samples(
 def _fetch_active_legacy_memories(
     uid: str,
     *,
+    db_client,
     get_non_filtered_memories_fn: Callable[..., List[dict]],
     scan_page_size: int = LEGACY_SCAN_PAGE_SIZE,
 ) -> List[dict]:
@@ -311,7 +313,12 @@ def _fetch_active_legacy_memories(
     offset = 0
     page_size = scan_page_size
     while True:
-        page = get_non_filtered_memories_fn(uid, limit=page_size, offset=offset)
+        try:
+            page = get_non_filtered_memories_fn(uid, limit=page_size, offset=offset, firestore_client=db_client)
+        except TypeError as exc:
+            if "firestore_client" not in str(exc):
+                raise
+            page = get_non_filtered_memories_fn(uid, limit=page_size, offset=offset)
         if not page:
             break
         for row in page:
@@ -441,22 +448,22 @@ def _apply_one_legacy_row(
     run_id: str,
     db_client,
     bucket: Optional[LegacyBackfillBucket] = None,
-) -> tuple[MemoryControlState, bool, Optional[str], bool]:
-    """Write one canonical item. Returns (control, written, skip_reason, vector_sync_failed)."""
+) -> tuple[MemoryControlState, bool, Optional[str], bool, bool]:
+    """Write one canonical item. Returns control, write status, and side-effect status."""
     legacy_id = legacy_row.get("id") or f"legacy_{index}"
     content = (legacy_row.get("content") or "").strip()
     if not content:
-        return control, False, "empty_content", False
+        return control, False, "empty_content", False, True
     if bucket is not None and bucket not in WRITABLE_LEGACY_BACKFILL_BUCKETS:
-        return control, False, "bucket_not_writable", False
+        return control, False, "bucket_not_writable", False, True
 
     canonical_memory_id = legacy_backfill_memory_id(uid=uid, legacy_memory_id=legacy_id)
     existing = _load_canonical_item(uid, canonical_memory_id, db_client=db_client)
     if existing is not None and _is_active_processed_canonical_item(existing):
-        return control, False, "already_present", False
+        return control, False, "already_present", False, True
 
     if both_store_canonical_duplicate_exists(uid=uid, legacy_row=legacy_row, db_client=db_client):
-        return control, False, "both_store_duplicate", False
+        return control, False, "both_store_duplicate", False, True
 
     evidence = _build_backfill_evidence(uid=uid, legacy_row=legacy_row, index=index)
     _persist_evidence(uid, evidence, db_client=db_client)
@@ -549,6 +556,7 @@ def _apply_one_legacy_row(
             item = MemoryItem(**(snapshot.to_dict() or {}))
 
     vector_sync_failed = False
+    keyword_sync_succeeded = True
 
     def _record_vector_sync_failure() -> None:
         nonlocal vector_sync_failed
@@ -560,11 +568,17 @@ def _apply_one_legacy_row(
             physical_status_to_record_status(item.status.value),
             MemoryProcessingState(item.processing_state.value),
         )
-        sync_atom_keyword_index_for_item(item, db_client=db_client)
+        keyword_sync_succeeded = sync_atom_keyword_index_for_item(item, db_client=db_client)
         sync_canonical_memory_vector(item, on_hard_failure=_record_vector_sync_failure)
 
     written = result.status == ApplyStatus.committed
-    return result.control_state, written, None if written else "idempotent_skip", vector_sync_failed
+    return (
+        result.control_state,
+        written,
+        None if written else "idempotent_skip",
+        vector_sync_failed,
+        keyword_sync_succeeded,
+    )
 
 
 def _legacy_row_has_canonical_destination(
@@ -720,7 +734,11 @@ def backfill_user_bucketed(
         return report
 
     effective_run_id = run_id or f"legacy_bucket_backfill_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
-    legacy_rows = _fetch_active_legacy_memories(uid, get_non_filtered_memories_fn=get_non_filtered_memories_fn)
+    legacy_rows = _fetch_active_legacy_memories(
+        uid,
+        db_client=client,
+        get_non_filtered_memories_fn=get_non_filtered_memories_fn,
+    )
     eligible_rows = [row for row in legacy_rows if (row.get("content") or "").strip()]
     bucket_counts, bucket_samples = _bucket_counts_and_samples(eligible_rows)
 
@@ -800,6 +818,7 @@ def backfill_user_bucketed(
     skipped_both_store_duplicate = 0
     skipped_semantic_duplicate = 0
     vector_sync_failures = 0
+    keyword_sync_failures = 0
     errors: List[str] = []
     materialized_semantic_keys: set[str] = set()
 
@@ -809,7 +828,7 @@ def backfill_user_bucketed(
             skipped_semantic_duplicate += 1
             continue
         try:
-            control, written, skip_reason, row_vector_sync_failed = _apply_one_legacy_row(
+            control, written, skip_reason, row_vector_sync_failed, row_keyword_sync_succeeded = _apply_one_legacy_row(
                 uid=uid,
                 legacy_row=legacy_row,
                 index=index,
@@ -828,6 +847,8 @@ def backfill_user_bucketed(
                 materialized_semantic_keys.add(semantic_key)
             if row_vector_sync_failed:
                 vector_sync_failures += 1
+            if not row_keyword_sync_succeeded:
+                keyword_sync_failures += 1
         except Exception as exc:
             safe_uid = sanitize_pii(uid)
             safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
@@ -852,6 +873,7 @@ def backfill_user_bucketed(
         completed=not errors,
         legacy_rows_touched=len(selected_rows),
         vector_sync_failures=vector_sync_failures,
+        keyword_sync_failures=keyword_sync_failures,
         errors=errors,
         selected_bucket=selected_bucket_value,
         bucket_counts=bucket_counts,
@@ -892,7 +914,11 @@ def backfill_user(
         return _cohort_gated_report(uid, dry_run=dry_run, reason=str(exc))
 
     effective_run_id = run_id or f"legacy_backfill_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
-    legacy_rows = _fetch_active_legacy_memories(uid, get_non_filtered_memories_fn=get_non_filtered_memories_fn)
+    legacy_rows = _fetch_active_legacy_memories(
+        uid,
+        db_client=client,
+        get_non_filtered_memories_fn=get_non_filtered_memories_fn,
+    )
     fingerprint = legacy_source_fingerprint(legacy_rows)
     eligible_rows = [row for row in legacy_rows if (row.get("content") or "").strip()]
     source_count = len(eligible_rows)
@@ -940,6 +966,7 @@ def backfill_user(
     skipped_both_store_duplicate = 0
     skipped_semantic_duplicate = 0
     vector_sync_failures = 0
+    keyword_sync_failures = 0
     errors: List[str] = []
     materialized_semantic_keys: set[str] = set()
 
@@ -960,7 +987,7 @@ def backfill_user(
             _persist_control_state(control, db_client=client)
             continue
         try:
-            control, written, skip_reason, row_vector_sync_failed = _apply_one_legacy_row(
+            control, written, skip_reason, row_vector_sync_failed, row_keyword_sync_succeeded = _apply_one_legacy_row(
                 uid=uid,
                 legacy_row=legacy_row,
                 index=processed_index,
@@ -978,6 +1005,8 @@ def backfill_user(
                 materialized_semantic_keys.add(semantic_key)
             if row_vector_sync_failed:
                 vector_sync_failures += 1
+            if not row_keyword_sync_succeeded:
+                keyword_sync_failures += 1
         except Exception as exc:
             safe_uid = sanitize_pii(uid)
             safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
@@ -1028,5 +1057,6 @@ def backfill_user(
         completed=completed,
         legacy_rows_touched=0,
         vector_sync_failures=vector_sync_failures,
+        keyword_sync_failures=keyword_sync_failures,
         errors=errors,
     )

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -57,7 +57,7 @@ from utils.memory.required_promotion import (
     REQUIRED_PROMOTION_STATUS_PROMOTED,
     REQUIRED_PROMOTION_STATUSES,
 )
-from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult, extract_kg_for_promoted_memory
 from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.memory.short_term_lifecycle import ShortTermDisposition, evaluate_short_term_lifecycle
@@ -303,14 +303,15 @@ def promote_short_term_item_via_apply(
     trigger_reason: str,
     now: datetime,
     db_client=None,
-) -> tuple[MemoryItem, bool]:
+) -> tuple[MemoryItem, bool, CanonicalKgPromotionResult, bool]:
     """Promote one short_term item to long_term through the authoritative apply path.
 
-    Returns ``(promoted_item, vector_sync_failed)``. Firestore promotion commits even when
-    vector sync fails; the bool is True when Pinecone upsert hard-failed.
+    Firestore promotion commits even when external side effects fail. The returned
+    vector bool is True when Pinecone upsert hard-failed, and the KG result exposes
+    extraction failures or empty-but-successful extractions for rollout auditing.
     """
     if item.tier == MemoryLayer.long_term:
-        return item, False
+        return item, False, CanonicalKgPromotionResult(skipped_reason="already_long_term"), True
     if not is_promotable_short_term_item(item, now=now):
         raise ValueError(f"memory item {item.memory_id} is not promotable")
 
@@ -387,7 +388,7 @@ def promote_short_term_item_via_apply(
     )
     if promoted.tier != MemoryLayer.long_term:
         raise RuntimeError(f"promotion did not land long_term for {item.memory_id}")
-    sync_atom_keyword_index_for_item(promoted, db_client=client)
+    keyword_sync_succeeded = sync_atom_keyword_index_for_item(promoted, db_client=client)
     vector_sync_failed = False
 
     def _record_vector_sync_failure() -> None:
@@ -395,8 +396,8 @@ def promote_short_term_item_via_apply(
         vector_sync_failed = True
 
     sync_canonical_memory_vector(promoted, on_hard_failure=_record_vector_sync_failure)
-    extract_kg_for_promoted_memory(uid, promoted, db_client=client)
-    return promoted, vector_sync_failed
+    kg_result = extract_kg_for_promoted_memory(uid, promoted, db_client=client)
+    return promoted, vector_sync_failed, kg_result, keyword_sync_succeeded
 
 
 def _audit_promotion_transition(
@@ -425,6 +426,11 @@ class ShortTermPromotionReport:
     promoted_memory_ids: List[str] = field(default_factory=list)
     transition_records: List[ShortTermLifecycleTransitionRecord] = field(default_factory=list)
     vector_sync_failures: int = 0
+    keyword_sync_failures: int = 0
+    kg_extraction_failures: int = 0
+    kg_extraction_empty: int = 0
+    kg_nodes_created: int = 0
+    kg_edges_created: int = 0
     last_promotion_run_at: Optional[datetime] = None
 
     @property
@@ -519,7 +525,7 @@ def run_canonical_short_term_promotion(
 
     for item in promotable:
         control = _read_control_state(uid, db_client=client)
-        promoted, vector_sync_failed = promote_short_term_item_via_apply(
+        promoted, vector_sync_failed, kg_result, keyword_sync_succeeded = promote_short_term_item_via_apply(
             uid,
             item,
             control=control,
@@ -530,6 +536,14 @@ def run_canonical_short_term_promotion(
         )
         if vector_sync_failed:
             report.vector_sync_failures += 1
+        if not keyword_sync_succeeded:
+            report.keyword_sync_failures += 1
+        if kg_result.attempted and not kg_result.success:
+            report.kg_extraction_failures += 1
+        if kg_result.empty:
+            report.kg_extraction_empty += 1
+        report.kg_nodes_created += kg_result.node_count
+        report.kg_edges_created += kg_result.edge_count
         report.promoted_memory_ids.append(promoted.memory_id)
         report.transition_records.append(
             _audit_promotion_transition(item, store=transition_store, run_id=run_id, now=current_time)

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -166,7 +166,7 @@ def _merge_required_promotion_duplicate(
     trigger_reason: str,
     now: datetime,
     db_client,
-) -> MemoryItem:
+) -> tuple[MemoryItem, bool]:
     collections = MemoryCollections(uid=uid)
     evidence_by_id = {evidence.evidence_id: evidence for evidence in existing.evidence}
     for evidence in item.evidence:
@@ -198,8 +198,8 @@ def _merge_required_promotion_duplicate(
     )
     db_client.document(f"{collections.memory_items}/{existing.memory_id}").set(merged_existing.model_dump(mode="json"))
     db_client.document(f"{collections.memory_items}/{item.memory_id}").set(superseded_source.model_dump(mode="json"))
-    sync_atom_keyword_index_for_item(merged_existing, db_client=db_client)
-    return merged_existing
+    keyword_sync_succeeded = sync_atom_keyword_index_for_item(merged_existing, db_client=db_client)
+    return merged_existing, keyword_sync_succeeded
 
 
 def list_fast_track_promotable_items(
@@ -322,16 +322,19 @@ def promote_short_term_item_via_apply(
     if is_required_promotion_item(item):
         existing_duplicate = _exact_long_term_duplicate(uid, item, db_client=client)
         if existing_duplicate is not None:
+            merged_item, keyword_sync_succeeded = _merge_required_promotion_duplicate(
+                uid,
+                item,
+                existing_duplicate,
+                trigger_reason=trigger_reason,
+                now=current_time,
+                db_client=client,
+            )
             return (
-                _merge_required_promotion_duplicate(
-                    uid,
-                    item,
-                    existing_duplicate,
-                    trigger_reason=trigger_reason,
-                    now=current_time,
-                    db_client=client,
-                ),
+                merged_item,
                 False,
+                CanonicalKgPromotionResult(skipped_reason="merged_into_existing"),
+                keyword_sync_succeeded,
             )
     operation = _ensure_promotion_operation(uid=uid, item=item, control=control, run_id=run_id, db_client=client)
     idempotency_key = deterministic_contract_id(


### PR DESCRIPTION
## Summary
- Thread explicit Firestore clients through canonical KG extraction, pruning, purge, and legacy backfill source reads so dev/prod split runs do not write side effects into a different project.
- Move canonical memory keyword atoms to an isolated Typesense collection (`MEMORY_TYPESENSE_COLLECTION`, default `canonical_memory_atoms`) with schema validation and schema-version filtering.
- Surface keyword/KG side-effect failures in promotion/backfill reports and keep KG parse failures from marking memories as extracted.
- Update runtime env manifests/Helm values and add regression coverage for the identified rollout footguns.

## Oracle review
Ran an Oracle review focused on implicit global clients, project/account split mistakes, shared index collisions, and silent side-effect failures. This PR addresses the P0/P1 findings that directly affect the current rollout path: KG client propagation, legacy backfill source reads, Typesense collection isolation/schema validation, keyword gating with explicit db clients, force purge for derived cleanup, strict KG parse behavior, and side-effect counters.

## Verification
- `cd backend && pytest -q tests/unit/test_canonical_kg_promotion.py tests/unit/test_canonical_memory_vectors.py tests/unit/test_ws_m_atom_keyword_index.py tests/unit/test_ws_c_backfill.py tests/unit/test_canonical_consolidation.py tests/unit/test_canonical_consolidation_apply.py`
- `python backend/scripts/validate-backend-runtime-env.py --env dev && python backend/scripts/validate-backend-runtime-env.py --env prod`
- `python backend/scripts/scan_async_blockers.py`
- `git diff --check`
- Pre-push hook passed, including selected backend unit tests and OpenAPI contract check.
