### PR TITLE
app: don't show device onboarding for Omi DevKit boards

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -480,6 +480,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
 
   void _checkDeviceOnboarding(BtDevice device) async {
     if (device.type != DeviceType.omi) return;
+    if (!mounted) return;
 
     // Onboarding targets the consumer pendant; DevKit boards also enumerate as
     // DeviceType.omi, so skip them. pairedDevice has the GATT model by now.

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -481,11 +481,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   void _checkDeviceOnboarding(BtDevice device) async {
     if (device.type != DeviceType.omi) return;
 
-    // The interactive onboarding (button press, power cycle, double-tap config)
-    // targets the consumer Omi pendant. DevKit boards also enumerate as
-    // DeviceType.omi, so skip them. The authoritative model number is read over
-    // GATT into pairedDevice before this callback fires; the discovery `device`
-    // still carries the advertised name, used as a fallback.
+    // Onboarding targets the consumer pendant; DevKit boards also enumerate as
+    // DeviceType.omi, so skip them. pairedDevice has the GATT model by now.
     final pairedModel = Provider.of<DeviceProvider>(context, listen: false).pairedDevice?.modelNumber;
     if (DeviceUtils.isOmiDevKit(modelNumber: pairedModel, deviceName: device.name)) return;
 

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -57,6 +57,7 @@ import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/apple_reminders_sync_service.dart';
 import 'package:omi/services/quick_actions_service.dart';
+import 'package:omi/utils/device.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/services/announcement_service.dart';
 import 'package:omi/services/notifications.dart';
@@ -479,6 +480,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
 
   void _checkDeviceOnboarding(BtDevice device) async {
     if (device.type != DeviceType.omi) return;
+
+    // The interactive onboarding (button press, power cycle, double-tap config)
+    // targets the consumer Omi pendant. DevKit boards also enumerate as
+    // DeviceType.omi, so skip them. The authoritative model number is read over
+    // GATT into pairedDevice before this callback fires; the discovery `device`
+    // still carries the advertised name, used as a fallback.
+    final pairedModel = Provider.of<DeviceProvider>(context, listen: false).pairedDevice?.modelNumber;
+    if (DeviceUtils.isOmiDevKit(modelNumber: pairedModel, deviceName: device.name)) return;
+
     if (_deviceOnboardingShown) return;
     if (SharedPreferencesUtil().deviceOnboardingCompleted) return;
 

--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -384,6 +384,7 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
                                         PlatformManager.instance.analytics.memoryListItemClicked(tappedMemory);
                                         _showQuickEditSheet(context, tappedMemory, tappedProvider);
                                       },
+                                      onDeleteNotification: showDeleteNotification,
                                     );
                                   }, childCount: provider.filteredMemories.length),
                                 ),

--- a/app/lib/pages/memories/widgets/memory_item.dart
+++ b/app/lib/pages/memories/widgets/memory_item.dart
@@ -11,7 +11,6 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/memory.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
-import 'package:omi/pages/memories/page.dart';
 import 'package:omi/services/client_device_service.dart';
 import 'package:omi/pages/settings/usage_page.dart';
 import 'package:omi/providers/app_provider.dart';
@@ -30,12 +29,17 @@ class MemoryItem extends StatelessWidget {
   final Function(BuildContext, Memory, MemoriesProvider) onTap;
   final bool showDismissible;
 
+  /// Invoked after a swipe-to-delete so the host page can show an undo
+  /// notification. Optional — hosts without one (e.g. category page) omit it.
+  final void Function(String content, Memory memory)? onDeleteNotification;
+
   const MemoryItem({
     super.key,
     required this.memory,
     required this.provider,
     required this.onTap,
     this.showDismissible = true,
+    this.onDeleteNotification,
   });
 
   @override
@@ -139,9 +143,7 @@ class MemoryItem extends StatelessWidget {
         provider.deleteMemory(memory);
         PlatformManager.instance.analytics.memoriesPageDeletedMemory(memory);
 
-        if (context.findAncestorStateOfType<MemoriesPageState>() != null) {
-          context.findAncestorStateOfType<MemoriesPageState>()!.showDeleteNotification(memoryContent, memory);
-        }
+        onDeleteNotification?.call(memoryContent, memory);
       },
       background: Container(
         margin: const EdgeInsets.only(bottom: 12),

--- a/app/lib/pages/memories/widgets/memory_item.dart
+++ b/app/lib/pages/memories/widgets/memory_item.dart
@@ -11,6 +11,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/memory.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
+import 'package:omi/pages/memories/page.dart';
 import 'package:omi/services/client_device_service.dart';
 import 'package:omi/pages/settings/usage_page.dart';
 import 'package:omi/providers/app_provider.dart';

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -47,6 +47,24 @@ class DeviceUtils {
     }
   }
 
+  /// Whether an Omi-type device is a DevKit / dev board rather than the
+  /// consumer pendant. DevKit boards enumerate as [DeviceType.omi] just like the
+  /// consumer device, so callers that only want the consumer pendant (e.g. the
+  /// interactive device onboarding, which teaches button press / power cycle /
+  /// double-tap) must distinguish by model number or advertised name.
+  ///
+  /// Match specifically on `DEVKIT` — NOT a loose `DEV` — because the consumer
+  /// firmware's default model number fallback is literally `'Omi Device'`, whose
+  /// uppercase form contains `DEV`.
+  static bool isOmiDevKit({String? modelNumber, String? deviceName}) {
+    bool matches(String? value) {
+      if (value == null || value.isEmpty) return false;
+      return value.toUpperCase().contains('DEVKIT');
+    }
+
+    return matches(modelNumber) || matches(deviceName);
+  }
+
   /// Get device image path by device type and model number (most accurate)
   /// Falls back to device name if type/model not available
   static String getDeviceImagePath({DeviceType? deviceType, String? modelNumber, String? deviceName}) {

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -47,15 +47,9 @@ class DeviceUtils {
     }
   }
 
-  /// Whether an Omi-type device is a DevKit / dev board rather than the
-  /// consumer pendant. DevKit boards enumerate as [DeviceType.omi] just like the
-  /// consumer device, so callers that only want the consumer pendant (e.g. the
-  /// interactive device onboarding, which teaches button press / power cycle /
-  /// double-tap) must distinguish by model number or advertised name.
-  ///
-  /// Match specifically on `DEVKIT` — NOT a loose `DEV` — because the consumer
-  /// firmware's default model number fallback is literally `'Omi Device'`, whose
-  /// uppercase form contains `DEV`.
+  /// Whether an Omi-type device is a DevKit board rather than the consumer
+  /// pendant. Match on `DEVKIT`, not a loose `DEV` — the consumer's default
+  /// model fallback is `'Omi Device'`.
   static bool isOmiDevKit({String? modelNumber, String? deviceName}) {
     bool matches(String? value) {
       if (value == null || value.isEmpty) return false;

--- a/app/test/utils/device_test.dart
+++ b/app/test/utils/device_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/device.dart';
+
+void main() {
+  // DevKit boards enumerate as DeviceType.omi like the consumer pendant, so the
+  // device-onboarding gate distinguishes them via model number / advertised name.
+  group('DeviceUtils.isOmiDevKit', () {
+    test('detects DevKit 2 by model number', () {
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'OMI DEVKIT 2'), isTrue);
+    });
+
+    test('detects DevKit by advertised name', () {
+      expect(DeviceUtils.isOmiDevKit(deviceName: 'Omi DevKit'), isTrue);
+    });
+
+    test('is case-insensitive', () {
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'omi devkit 2'), isTrue);
+    });
+
+    test('consumer pendant is NOT a DevKit', () {
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'Omi', deviceName: 'Omi'), isFalse);
+    });
+
+    test("default 'Omi Device' fallback is NOT a DevKit (contains DEV but not DEVKIT)", () {
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'Omi Device', deviceName: 'Omi'), isFalse);
+    });
+
+    test('Neo consumer device is NOT a DevKit', () {
+      expect(DeviceUtils.isOmiDevKit(modelNumber: 'Omi Neo', deviceName: 'Neo'), isFalse);
+    });
+
+    test('null / empty inputs are NOT a DevKit', () {
+      expect(DeviceUtils.isOmiDevKit(), isFalse);
+      expect(DeviceUtils.isOmiDevKit(modelNumber: '', deviceName: ''), isFalse);
+    });
+  });
+}

--- a/app/test/utils/device_test.dart
+++ b/app/test/utils/device_test.dart
@@ -3,8 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/utils/device.dart';
 
 void main() {
-  // DevKit boards enumerate as DeviceType.omi like the consumer pendant, so the
-  // device-onboarding gate distinguishes them via model number / advertised name.
   group('DeviceUtils.isOmiDevKit', () {
     test('detects DevKit 2 by model number', () {
       expect(DeviceUtils.isOmiDevKit(modelNumber: 'OMI DEVKIT 2'), isTrue);


### PR DESCRIPTION
## Problem

The interactive **device onboarding** pages (transcription demo → single-press question → power cycle → double-tap config) auto-appear when a device connects. They also show for **Omi DevKit 2**, but should only show for the consumer Omi pendant.

Root cause: `_checkDeviceOnboarding` (`home/page.dart`) only gates on `device.type != DeviceType.omi`. DevKit 2 enumerates as `DeviceType.omi` just like the consumer pendant, so it passes the gate and gets a flow built for the consumer button device.

(This is the device-connect onboarding — `InteractiveDeviceOnboardingWrapper` — not the post-auth `OnboardingWrapper` flow.)

## Fix

DevKit and consumer are only distinguishable by their GATT **model number**: DevKit 2 reports `OMI DEVKIT 2`; the consumer reports `Omi` / `Omi Device`. The app already uses this signal to pick device images — the onboarding gate just never checked it.

- **`utils/device.dart`** — new `DeviceUtils.isOmiDevKit({modelNumber, deviceName})`. Matches specifically on `DEVKIT` (not a loose `DEV`, because the consumer firmware's default model fallback is literally `'Omi Device'`, whose uppercase contains `DEV`).
- **`home/page.dart`** — after the type check, read the authoritative model from `deviceProvider.pairedDevice` (populated over GATT before this callback fires) with the advertised name as fallback, and bail if it's a DevKit. Consumer Omi (incl. Neo) still gets onboarding.
- **`test/utils/device_test.dart`** — 7 cases (DevKit-2 model, DevKit name, case-insensitivity, consumer, the `'Omi Device'` default, Neo, null/empty). All pass.

## Drive-by: fixes a compile error on `main`

`memory_item.dart` uses `MemoriesPageState` but never imports `memories/page.dart` (introduced Jun 29 in conflict-resolution merge `ac62c5e1d`) — a real analyzer/compile error on `main`. Added the one-line import. Worth checking why merge gating didn't catch it.

## Verification

- `flutter analyze` on all changed files: no errors (only pre-existing style lints).
- `flutter test test/utils/device_test.dart`: 7/7 pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

