### PR TITLE
Bump version to 1.0.542+969 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.538+900
+version: 1.0.542+969
 
 
 environment:


### PR DESCRIPTION
## Summary
- Bumps version from `1.0.538+900` to `1.0.542+969` for mobile release
- Version bump: `1.0.538` → `1.0.542` (stores are at `1.0.541`)
- Build bump: `900` → `969` (max store build is `968` on Google Play internal)

## Store versions at time of bump
| Track | Version | Build |
|-------|---------|-------|
| iOS App Store (prod) | 1.0.540 | — |
| iOS TestFlight | 1.0.541 | 966 |
| Google Play (prod) | 1.0.540 | 949 |
| Google Play (internal) | 1.0.541 | 968 |

Deploys automatically via Codemagic auto-deploy on merge to main. No manual steps required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

