### PR TITLE
fix: skip secret scanner regex on framework binaries

### DIFF
--- a/scripts/scan-public-artifact-secrets.py
+++ b/scripts/scan-public-artifact-secrets.py
@@ -36,6 +36,7 @@ PRIVATE_KEY_MARKERS = (
 ZIP_SUFFIXES = {".zip", ".ipa", ".apk", ".aab", ".jar", ".aar", ".asar"}
 TAR_SUFFIXES = {".tar", ".tgz", ".gz", ".bz2", ".xz"}
 FAIL_CLOSED_SUFFIXES = {".7z", ".rar", ".pkg", ".dmg"}
+FRAMEWORK_DIR_SUFFIXES = (".framework", ".xcframework")
 
 
 def load_policy() -> dict:
@@ -248,10 +249,12 @@ def scan_artifact(path: Path, policy: dict) -> list[str]:
             for name in denied:
                 if name not in allowed and name.encode() in data:
                     errors.append(f"{path}: server-only variable name {name} appears in {rel}")
-            text = data.decode("utf-8", errors="ignore")
-            for token in set(re.findall(r"\b[A-Z][A-Z0-9_]{2,}\b", text)):
-                if token not in allowed and name_is_denied(token, denied, patterns):
-                    errors.append(f"{path}: server-only variable-like token {token} appears in {rel}")
+            in_framework = any(part.endswith(FRAMEWORK_DIR_SUFFIXES) for part in rel.parts)
+            if not in_framework:
+                text = data.decode("utf-8", errors="ignore")
+                for token in set(re.findall(r"\b[A-Z][A-Z0-9_]{2,}\b", text)):
+                    if token not in allowed and name_is_denied(token, denied, patterns):
+                        errors.append(f"{path}: server-only variable-like token {token} appears in {rel}")
             for name, value in secret_values.items():
                 if value and value in data:
                     errors.append(f"{path}: current CI value for {name} appears in {rel}")
@@ -261,8 +264,12 @@ def scan_artifact(path: Path, policy: dict) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("artifacts", nargs="+", type=Path, help="IPA/AAB/APK/app/zip/directory artifacts to scan")
+    parser.add_argument("artifacts", nargs="*", type=Path, help="IPA/AAB/APK/app/zip/directory artifacts to scan")
     args = parser.parse_args()
+
+    if not args.artifacts:
+        print("No artifacts to scan (glob matched nothing).", file=sys.stderr)
+        return 1
 
     policy = load_policy()
     errors: list[str] = []

--- a/scripts/scan-public-artifact-secrets.py
+++ b/scripts/scan-public-artifact-secrets.py
@@ -49,7 +49,9 @@ def denied_patterns(policy: dict) -> list[re.Pattern[str]]:
 
 
 def allowed_names(policy: dict) -> set[str]:
-    return set(policy["public_client_env"]["allowed"]) | set(policy.get("legacy_public_client_env", {}).get("allowed", []))
+    return set(policy["public_client_env"]["allowed"]) | set(
+        policy.get("legacy_public_client_env", {}).get("allowed", [])
+    )
 
 
 def name_is_denied(name: str, exact: set[str], patterns: list[re.Pattern[str]]) -> bool:

--- a/scripts/test-scan-public-artifact-secrets.sh
+++ b/scripts/test-scan-public-artifact-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Test scan-public-artifact-secrets.py against real Codemagic workflow patterns.
+# Run from repo root: bash scripts/test-scan-public-artifact-secrets.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/scan-public-artifact-secrets.py"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+run_expect_pass() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS $name"
+    ((PASS++))
+  else
+    echo "FAIL $name (expected pass, got exit $?)"
+    ((FAIL++))
+  fi
+}
+
+run_expect_fail() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  local out rc
+  out=$("$@" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL $name (expected fail, got pass)"
+    ((FAIL++))
+  elif echo "$out" | grep -q "$pattern"; then
+    echo "PASS $name"
+    ((PASS++))
+  else
+    echo "FAIL $name (failed but pattern '$pattern' not found)"
+    echo "  output: $out"
+    ((FAIL++))
+  fi
+}
+
+make_zip() {
+  local src="$1" dst="$2"
+  (cd "$src" && zip -qr "$dst" .)
+}
+
+# --- Build test artifacts ---
+
+# iOS IPA with framework BoringSSL constants
+mkdir -p "$WORK/ios-fw/Payload/Runner.app/Frameworks/TwilioVoice.framework"
+mkdir -p "$WORK/ios-fw/Payload/Runner.app/Frameworks/Flutter.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nPRIVATE_KEY_ENCODE_ERROR\nSERVER_HANDSHAKE_TRAFFIC_SECRET\nEXPORTER_SECRET' \
+  > "$WORK/ios-fw/Payload/Runner.app/Frameworks/TwilioVoice.framework/TwilioVoice"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nHANDSHAKE_SECRET\nMASTER_SECRET' \
+  > "$WORK/ios-fw/Payload/Runner.app/Frameworks/Flutter.framework/Flutter"
+printf 'normal app binary' > "$WORK/ios-fw/Payload/Runner.app/Runner"
+make_zip "$WORK/ios-fw" "$WORK/framework.ipa"
+
+# iOS IPA with real secret leak outside framework
+mkdir -p "$WORK/ios-leak/Payload/Runner.app/Frameworks/TwilioVoice.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET' \
+  > "$WORK/ios-leak/Payload/Runner.app/Frameworks/TwilioVoice.framework/TwilioVoice"
+printf 'OPENAI_API_KEY=sk-test123' > "$WORK/ios-leak/Payload/Runner.app/leaked.env"
+make_zip "$WORK/ios-leak" "$WORK/leaked.ipa"
+
+# iOS IPA with private key inside framework
+mkdir -p "$WORK/ios-pk/Payload/Runner.app/Frameworks/Bad.framework"
+printf -- '-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----' \
+  > "$WORK/ios-pk/Payload/Runner.app/Frameworks/Bad.framework/Bad"
+make_zip "$WORK/ios-pk" "$WORK/privkey.ipa"
+
+# iOS IPA with exact denied name inside framework
+mkdir -p "$WORK/ios-exact/Payload/Runner.app/Frameworks/Leaked.framework"
+printf 'OPENAI_API_KEY' \
+  > "$WORK/ios-exact/Payload/Runner.app/Frameworks/Leaked.framework/Leaked"
+make_zip "$WORK/ios-exact" "$WORK/exact-denied.ipa"
+
+# iOS IPA with xcframework variant
+mkdir -p "$WORK/ios-xcfw/Payload/Runner.app/Frameworks/BoringSSL.xcframework/ios-arm64/BoringSSL.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nEXPORTER_SECRET' \
+  > "$WORK/ios-xcfw/Payload/Runner.app/Frameworks/BoringSSL.xcframework/ios-arm64/BoringSSL.framework/BoringSSL"
+make_zip "$WORK/ios-xcfw" "$WORK/xcframework.ipa"
+
+# Android AAB
+mkdir -p "$WORK/android/build/app/outputs/bundle/prodRelease"
+mkdir -p "$WORK/aab-content/base"
+printf 'android app bundle content' > "$WORK/aab-content/base/manifest"
+make_zip "$WORK/aab-content" "$WORK/android/build/app/outputs/bundle/prodRelease/app-prod-release.aab"
+
+# Empty build dir for nullglob test
+mkdir -p "$WORK/android-empty/build"
+
+# --- Tests ---
+
+echo "=== Codemagic iOS workflow (line 186: build/ios/ipa/*.ipa) ==="
+run_expect_pass "ios-framework-tokens-pass" \
+  python3 "$SCANNER" "$WORK/framework.ipa"
+
+echo ""
+echo "=== Codemagic Android workflow (lines 430-431: shopt -s globstar nullglob + glob) ==="
+run_expect_pass "android-aab-with-nullglob" \
+  bash -c "cd '$WORK/android' && shopt -s globstar nullglob && python3 '$SCANNER' build/**/outputs/**/*.aab"
+
+echo ""
+echo "=== Android nullglob + no AAB built (the argparse crash case) ==="
+run_expect_fail "android-empty-glob-clear-error" "No artifacts to scan" \
+  bash -c "cd '$WORK/android-empty' && shopt -s globstar nullglob && python3 '$SCANNER' build/**/outputs/**/*.aab"
+
+echo ""
+echo "=== Security: real secret outside framework still caught ==="
+run_expect_fail "secret-outside-framework-caught" "OPENAI_API_KEY" \
+  python3 "$SCANNER" "$WORK/leaked.ipa"
+
+echo ""
+echo "=== Security: private key markers inside framework still caught ==="
+run_expect_fail "private-key-in-framework-caught" "private key material" \
+  python3 "$SCANNER" "$WORK/privkey.ipa"
+
+echo ""
+echo "=== Security: exact denied name inside framework still caught ==="
+run_expect_fail "exact-denied-in-framework-caught" "OPENAI_API_KEY" \
+  python3 "$SCANNER" "$WORK/exact-denied.ipa"
+
+echo ""
+echo "=== xcframework tokens pass (nested .xcframework/.framework) ==="
+run_expect_pass "xcframework-tokens-pass" \
+  python3 "$SCANNER" "$WORK/xcframework.ipa"
+
+echo ""
+echo "=== No arguments at all ==="
+run_expect_fail "no-args-clear-error" "No artifacts to scan" \
+  python3 "$SCANNER"
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes Codemagic iOS and Android build failures caused by the secret scanner script (`scripts/scan-public-artifact-secrets.py`).

### iOS: framework binary false positives
The scanner regex `\b[A-Z][A-Z0-9_]{2,}\b` scans all files including compiled third-party framework binaries. BoringSSL constants in `TwilioVoice.framework` and `Flutter.framework` (e.g. `CLIENT_EARLY_TRAFFIC_SECRET`, `PRIVATE_KEY_ENCODE_ERROR`) match denied patterns `(^|_)SECRET($|_)` and `(^|_)PRIVATE_KEY($|_)`.

**Fix:** Skip the regex variable-like token scan for files inside `.framework/` and `.xcframework/` directories. All other checks still apply (forbidden files, private key markers, env scanning, exact denied names, CI value leak detection).

### Android: argument error on empty glob
`shopt -s nullglob` in codemagic.yaml causes the AAB glob to expand to nothing when no AAB exists. `argparse` crashes with `"the following arguments are required: artifacts"` instead of surfacing the actual build failure.

**Fix:** Change `nargs='+'` to `nargs='*'` with explicit empty-check for a clearer error message.

## Testing
- Python compilation check: PASS
- Black formatting: PASS
- Logic unit tests: framework path detection verified for TwilioVoice.framework, Flutter.xcframework, and non-framework paths
- CODEx review: approved, no blocking issues. Other security checks (forbidden files, private key markers, exact denied names, CI values) still apply inside frameworks.

## Risks
- The framework exemption is broader than just compiled binaries — resource/config files inside `.framework/` dirs also skip the regex token scan. This is an acceptable tradeoff since exact-name and value checks still apply. Issue #8742 asks @Git-on-my-level to revalidate the full script.

Closes #8742

_by AI for @beastoin_