### PR TITLE
fix: harden Developer API conversation read limits

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -184,11 +184,15 @@ async def get_uid_from_dev_api_key(api_key: str = Security(api_key_header)) -> s
 
 
 # Scope-specific dependencies
-async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+def _require_conversations_read_scope(auth: ApiKeyAuth):
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_READ):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.CONVERSATIONS_READ}"
         )
+
+
+async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    _require_conversations_read_scope(auth)
     check_api_key_rate_limit(
         prefix="dev",
         uid=auth.uid,
@@ -197,6 +201,29 @@ async def get_auth_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_ke
         policy_name="dev:conversations_read",
     )
     return auth
+
+
+async def get_auth_with_conversation_detail_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
+    _require_conversations_read_scope(auth)
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:conversation_detail_read",
+    )
+    return auth
+
+
+def check_conversation_transcript_read_limit(auth: ApiKeyAuth):
+    _require_conversations_read_scope(auth)
+    check_api_key_rate_limit(
+        prefix="dev",
+        uid=auth.uid,
+        app_id=auth.app_id,
+        key_id=auth.key_id,
+        policy_name="dev:conversation_transcript_read",
+    )
 
 
 async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -92,12 +92,6 @@ FROM_SEGMENTS_CLAIM_STALE_AFTER = timedelta(minutes=15)
 _FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6fdb3fd13')
 
 
-def _developer_read_auth(auth_or_uid) -> ApiKeyAuth:
-    if isinstance(auth_or_uid, ApiKeyAuth):
-        return auth_or_uid
-    return ApiKeyAuth(uid=str(auth_or_uid), scopes=None)
-
-
 def _developer_request_ip(request: Optional[Request]) -> Optional[str]:
     client = getattr(request, 'client', None)
     if not client:
@@ -1364,10 +1358,9 @@ def get_conversations(
     - **folder_id**: Filter by folder ID (must be a non-empty string if provided)
     - **starred**: Filter by starred status (true/false)
     """
-    should_check_transcript_limit = isinstance(uid, ApiKeyAuth)
-    auth = _developer_read_auth(uid)
+    auth = uid
     uid = auth.uid
-    if include_transcript and should_check_transcript_limit:
+    if include_transcript:
         check_conversation_transcript_read_limit(auth)
 
     # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
@@ -1534,10 +1527,9 @@ def get_conversation_endpoint(
     - **conversation_id**: The ID of the conversation to retrieve
     - **include_transcript**: If True, includes full transcript_segments in the response
     """
-    should_check_transcript_limit = isinstance(uid, ApiKeyAuth)
-    auth = _developer_read_auth(uid)
+    auth = uid
     uid = auth.uid
-    if include_transcript and should_check_transcript_limit:
+    if include_transcript:
         check_conversation_transcript_read_limit(auth)
 
     conversation = conversations_db.get_conversation(uid, conversation_id)

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -99,9 +99,14 @@ def _developer_read_auth(auth_or_uid) -> ApiKeyAuth:
 
 
 def _developer_request_ip(request: Optional[Request]) -> Optional[str]:
-    if not request or not request.client:
+    client = getattr(request, 'client', None)
+    if not client:
         return None
-    return request.client.host
+    return client.host
+
+
+def _get_request(request: Request) -> Request:
+    return request
 
 
 def _audit_developer_read(
@@ -116,7 +121,7 @@ def _audit_developer_read(
     returned_count: Optional[int] = None,
     resource_id: Optional[str] = None,
 ):
-    if request is None:
+    if request is None or not hasattr(request, 'url') or not hasattr(request, 'headers'):
         return
     logger.info(
         "developer_api_read operation=%s path=%s status=%s uid=%s app_id=%s key_id=%s remote_ip=%s "
@@ -1341,7 +1346,6 @@ def get_user_folders(uid: str = Depends(get_uid_with_conversations_read)):
     operation_id="listConversations",
 )
 def get_conversations(
-    request: Request = None,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     categories: Optional[str] = None,
@@ -1351,6 +1355,7 @@ def get_conversations(
     folder_id: Optional[str] = Query(default=None, min_length=1),
     starred: Optional[bool] = None,
     uid=Depends(get_auth_with_conversations_read),
+    request=Depends(_get_request),
 ):
     """
     Get conversations with optional transcript inclusion.
@@ -1519,9 +1524,9 @@ def create_conversation(
 )
 def get_conversation_endpoint(
     conversation_id: str,
-    request: Request = None,
     include_transcript: bool = False,
     uid=Depends(get_auth_with_conversation_detail_read),
+    request=Depends(_get_request),
 ):
     """
     Get a single conversation by ID.

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -37,6 +37,10 @@ from utils.conversations.render import populate_speaker_names, populate_folder_n
 from utils.dev_cache import invalidate_developer_cache
 from models.transcript_segment import TranscriptSegment
 from dependencies import (
+    ApiKeyAuth,
+    check_conversation_transcript_read_limit,
+    get_auth_with_conversation_detail_read,
+    get_auth_with_conversations_read,
     get_current_user_id,
     get_uid_with_conversations_read,
     get_uid_with_conversations_write,
@@ -49,6 +53,7 @@ from dependencies import (
     get_uid_with_goals_write,
 )
 from utils.apps import update_personas_async
+from utils.log_sanitizer import sanitize
 from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
@@ -85,6 +90,51 @@ router = APIRouter()
 FROM_SEGMENTS_CLAIM_STALE_AFTER = timedelta(minutes=15)
 
 _FROM_SEGMENTS_CONVERSATION_NAMESPACE = uuid.UUID('fb2f1f36-3c84-47a4-9c62-b3f6fdb3fd13')
+
+
+def _developer_read_auth(auth_or_uid) -> ApiKeyAuth:
+    if isinstance(auth_or_uid, ApiKeyAuth):
+        return auth_or_uid
+    return ApiKeyAuth(uid=str(auth_or_uid), scopes=None)
+
+
+def _developer_request_ip(request: Optional[Request]) -> Optional[str]:
+    if not request or not request.client:
+        return None
+    return request.client.host
+
+
+def _audit_developer_read(
+    *,
+    request: Optional[Request],
+    auth: ApiKeyAuth,
+    operation: str,
+    status: int,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+    include_transcript: Optional[bool] = None,
+    returned_count: Optional[int] = None,
+    resource_id: Optional[str] = None,
+):
+    if request is None:
+        return
+    logger.info(
+        "developer_api_read operation=%s path=%s status=%s uid=%s app_id=%s key_id=%s remote_ip=%s "
+        "user_agent=%s limit=%s offset=%s include_transcript=%s returned_count=%s resource_id=%s",
+        operation,
+        request.url.path,
+        status,
+        auth.uid,
+        auth.app_id or 'unknown_app',
+        auth.key_id or 'unknown_key',
+        _developer_request_ip(request),
+        sanitize(request.headers.get('user-agent')),
+        limit,
+        offset,
+        include_transcript,
+        returned_count,
+        sanitize(resource_id) if resource_id else None,
+    )
 
 
 # ******************************************************
@@ -1291,6 +1341,7 @@ def get_user_folders(uid: str = Depends(get_uid_with_conversations_read)):
     operation_id="listConversations",
 )
 def get_conversations(
+    request: Request = None,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     categories: Optional[str] = None,
@@ -1299,7 +1350,7 @@ def get_conversations(
     include_transcript: bool = False,
     folder_id: Optional[str] = Query(default=None, min_length=1),
     starred: Optional[bool] = None,
-    uid: str = Depends(get_uid_with_conversations_read),
+    uid=Depends(get_auth_with_conversations_read),
 ):
     """
     Get conversations with optional transcript inclusion.
@@ -1308,6 +1359,12 @@ def get_conversations(
     - **folder_id**: Filter by folder ID (must be a non-empty string if provided)
     - **starred**: Filter by starred status (true/false)
     """
+    should_check_transcript_limit = isinstance(uid, ApiKeyAuth)
+    auth = _developer_read_auth(uid)
+    uid = auth.uid
+    if include_transcript and should_check_transcript_limit:
+        check_conversation_transcript_read_limit(auth)
+
     # Clamp pagination so a negative value cannot reach Firestore (which raises -> HTTP 500) and an
     # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
     offset = max(0, offset)
@@ -1358,6 +1415,16 @@ def get_conversations(
                 f"missing/invalid fields {invalid_fields}"
             )
             continue
+    _audit_developer_read(
+        request=request,
+        auth=auth,
+        operation='list_conversations',
+        status=200,
+        limit=limit,
+        offset=offset,
+        include_transcript=include_transcript,
+        returned_count=len(valid_conversations),
+    )
     return valid_conversations
 
 
@@ -1452,8 +1519,9 @@ def create_conversation(
 )
 def get_conversation_endpoint(
     conversation_id: str,
+    request: Request = None,
     include_transcript: bool = False,
-    uid: str = Depends(get_uid_with_conversations_read),
+    uid=Depends(get_auth_with_conversation_detail_read),
 ):
     """
     Get a single conversation by ID.
@@ -1461,12 +1529,36 @@ def get_conversation_endpoint(
     - **conversation_id**: The ID of the conversation to retrieve
     - **include_transcript**: If True, includes full transcript_segments in the response
     """
+    should_check_transcript_limit = isinstance(uid, ApiKeyAuth)
+    auth = _developer_read_auth(uid)
+    uid = auth.uid
+    if include_transcript and should_check_transcript_limit:
+        check_conversation_transcript_read_limit(auth)
+
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if not conversation:
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='get_conversation',
+            status=404,
+            include_transcript=include_transcript,
+            returned_count=0,
+            resource_id=conversation_id,
+        )
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     # Filter out locked conversations
     if conversation.get('is_locked', False):
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='get_conversation',
+            status=404,
+            include_transcript=include_transcript,
+            returned_count=0,
+            resource_id=conversation_id,
+        )
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     # Remove transcript_segments if not requested
@@ -1477,6 +1569,15 @@ def get_conversation_endpoint(
 
     populate_folder_names(uid, [conversation])
 
+    _audit_developer_read(
+        request=request,
+        auth=auth,
+        operation='get_conversation',
+        status=200,
+        include_transcript=include_transcript,
+        returned_count=1,
+        resource_id=conversation_id,
+    )
     return conversation
 
 

--- a/backend/tests/unit/test_dev_api_conversations_poison.py
+++ b/backend/tests/unit/test_dev_api_conversations_poison.py
@@ -151,10 +151,19 @@ from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 import routers.developer as developer_module  # noqa: E402
 from routers.developer import router as developer_router  # noqa: E402
-from dependencies import get_uid_with_conversations_read  # noqa: E402
+from dependencies import ApiKeyAuth, get_auth_with_conversations_read  # noqa: E402
 
 _NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
 _VALID_CATEGORY = next(iter(CategoryEnum)).value
+
+
+def _read_auth():
+    return ApiKeyAuth(
+        uid='uid1',
+        scopes=['conversations:read'],
+        app_id='test-app',
+        key_id='test-key',
+    )
 
 
 def _valid(cid):
@@ -170,7 +179,7 @@ def _valid(cid):
 def _build():
     app = FastAPI()
     app.include_router(developer_router)
-    app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
+    app.dependency_overrides[get_auth_with_conversations_read] = _read_auth
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -194,9 +203,9 @@ def test_pagination_is_clamped_before_firestore():
     with patch.object(conversations_db, 'get_conversations', return_value=[]) as m, patch.object(
         developer_module, 'populate_folder_names', lambda *a, **k: None
     ), patch.object(developer_module, 'populate_speaker_names', lambda *a, **k: None):
-        developer_module.get_conversations(uid='uid1', limit=99999, offset=-1)
-        developer_module.get_conversations(uid='uid1', limit=99999, offset=0, include_transcript=True)
-        developer_module.get_conversations(uid='uid1', limit=0, offset=5)
+        developer_module.get_conversations(uid=_read_auth(), limit=99999, offset=-1)
+        developer_module.get_conversations(uid=_read_auth(), limit=99999, offset=0, include_transcript=True)
+        developer_module.get_conversations(uid=_read_auth(), limit=0, offset=5)
     high = m.call_args_list[0].args
     assert high[1] == 100 and high[2] == 0  # limit 99999 -> 100, offset -1 -> 0
     assert m.call_args_list[1].args[1] == 25  # transcript reads cap tighter

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -112,6 +112,17 @@ folders_db.initialize_system_folders = _mock_initialize_system_folders
 # ---- Helper factories ----
 
 
+def _read_auth():
+    from dependencies import ApiKeyAuth
+
+    return ApiKeyAuth(
+        uid='uid1',
+        scopes=['conversations:read'],
+        app_id='test-app',
+        key_id='test-key',
+    )
+
+
 def _make_folder(folder_id='f1', name='Work'):
     now = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
     return {
@@ -230,7 +241,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id='f1',
             starred=None,
         )
@@ -244,7 +255,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id=None,
             starred=True,
         )
@@ -258,7 +269,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id=None,
             starred=False,
         )
@@ -272,7 +283,7 @@ class TestDevGetConversationsFolderFilters:
         from routers.developer import get_conversations
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             folder_id='f1',
             starred=True,
         )
@@ -303,7 +314,7 @@ class TestDevGetConversationsFolderFilters:
         end = datetime(2025, 1, 31, tzinfo=timezone.utc)
 
         get_conversations(
-            uid='uid1',
+            uid=_read_auth(),
             start_date=start,
             end_date=end,
             categories='work,personal',
@@ -340,7 +351,7 @@ class TestDevGetConversationsFolderFilters:
 
         from routers.developer import get_conversations
 
-        result = get_conversations(uid='uid1', folder_id='nonexistent-folder')
+        result = get_conversations(uid=_read_auth(), folder_id='nonexistent-folder')
 
         assert result == []
 
@@ -355,11 +366,12 @@ def _build_test_app():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from routers.developer import router as developer_router
-    from dependencies import get_uid_with_conversations_read
+    from dependencies import get_auth_with_conversations_read, get_uid_with_conversations_read
 
     app = FastAPI()
     app.include_router(developer_router)
     app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
+    app.dependency_overrides[get_auth_with_conversations_read] = _read_auth
     return app, TestClient(app)
 
 

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -67,6 +67,16 @@ redis_db_stub.check_rate_limit = _check_rate_limit
 from utils.rate_limit_config import RATE_POLICIES, get_effective_limit, RATE_LIMIT_BOOST
 
 
+def _drop_stubbed_endpoints_module():
+    endpoints_module = sys.modules.get('utils.other.endpoints')
+    if endpoints_module is None or getattr(endpoints_module, '__file__', None):
+        return
+    sys.modules.pop('utils.other.endpoints', None)
+    parent = sys.modules.get('utils.other')
+    if parent is not None and getattr(parent, 'endpoints', None) is endpoints_module:
+        delattr(parent, 'endpoints')
+
+
 class TestRatePolicies(unittest.TestCase):
     """Validate rate limit policy definitions."""
 
@@ -175,6 +185,7 @@ class TestEnforceRateLimit(unittest.TestCase):
 
     def setUp(self):
         # Import here after stubs are in place
+        _drop_stubbed_endpoints_module()
         from utils.other import endpoints as ep_mod
 
         self.ep = ep_mod
@@ -266,6 +277,7 @@ class TestWithRateLimitWrapper(unittest.TestCase):
     """Test with_rate_limit() wrapper behavior."""
 
     def setUp(self):
+        _drop_stubbed_endpoints_module()
         from utils.other import endpoints as ep_mod
 
         self.ep = ep_mod

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -480,6 +480,9 @@ class TestRouterWiring(unittest.TestCase):
         ]:
             self.assertIn(policy, source)
 
+    def test_developer_conversation_detail_limit_matches_list_limit(self):
+        self.assertEqual(RATE_POLICIES["dev:conversation_detail_read"], RATE_POLICIES["dev:conversations_read"])
+
     def test_developer_conversation_reads_split_detail_and_transcript_policies(self):
         dependencies_source = open("dependencies.py", encoding='utf-8').read()
         developer_source = open("routers/developer.py", encoding='utf-8').read()

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -405,6 +405,8 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "goals:extract",
             "dev:conversations",
             "dev:conversations_read",
+            "dev:conversation_detail_read",
+            "dev:conversation_transcript_read",
             "dev:action_items_read",
             "dev:action_items_write",
             "dev:goals_read",
@@ -472,9 +474,30 @@ class TestRouterWiring(unittest.TestCase):
             "dev:memories_read",
             "dev:action_items_read",
             "dev:conversations_read",
+            "dev:conversation_detail_read",
+            "dev:conversation_transcript_read",
             "dev:goals_read",
         ]:
             self.assertIn(policy, source)
+
+    def test_developer_conversation_reads_split_detail_and_transcript_policies(self):
+        dependencies_source = open("dependencies.py", encoding='utf-8').read()
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+
+        self.assertIn("policy_name=\"dev:conversation_detail_read\"", dependencies_source)
+        self.assertIn("policy_name=\"dev:conversation_transcript_read\"", dependencies_source)
+        self.assertIn("get_auth_with_conversation_detail_read", developer_source)
+        self.assertIn("check_conversation_transcript_read_limit(auth)", developer_source)
+
+    def test_developer_conversation_reads_emit_sanitized_audit_logs(self):
+        developer_source = open("routers/developer.py", encoding='utf-8').read()
+
+        self.assertIn("developer_api_read operation=%s", developer_source)
+        self.assertIn("auth.app_id or 'unknown_app'", developer_source)
+        self.assertIn("auth.key_id or 'unknown_key'", developer_source)
+        self.assertIn("sanitize(request.headers.get('user-agent'))", developer_source)
+        self.assertNotIn("request.headers.get('Authorization'", developer_source)
+        self.assertNotIn('request.headers.get("Authorization"', developer_source)
 
     def test_goals_router_has_rate_limits(self):
         matches = self._grep_file("routers/goals.py", r"with_rate_limit.*goals:")

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -99,7 +99,7 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "dev:memories_read": (120, 3600),
     "dev:action_items_read": (120, 3600),
     "dev:conversations_read": (60, 3600),
-    "dev:conversation_detail_read": (120, 3600),
+    "dev:conversation_detail_read": (60, 3600),
     "dev:conversation_transcript_read": (25, 3600),
     "dev:goals_read": (120, 3600),
     "dev:conversations": (25, 3600),

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -99,6 +99,8 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "dev:memories_read": (120, 3600),
     "dev:action_items_read": (120, 3600),
     "dev:conversations_read": (60, 3600),
+    "dev:conversation_detail_read": (120, 3600),
+    "dev:conversation_transcript_read": (25, 3600),
     "dev:goals_read": (120, 3600),
     "dev:conversations": (25, 3600),
     "dev:memories": (120, 3600),


### PR DESCRIPTION
Closes #8713

## Summary

This PR hardens Developer API conversation read endpoints against abuse from repeated polling and high-frequency transcript access.

The issue described repeated calls to:
```text
GET /v1/dev/user/conversations?limit=20
```
The existing Developer API write routes already had explicit rate limiting, but read-heavy endpoints needed stronger separation between normal metadata reads, detail reads, and full transcript reads.
This PR focuses on the conversation read surface first.

## What Changed
### Separate read policies
Added two new Developer API rate-limit policies:
- ```dev:conversation_detail_read```
- ```dev:conversation_transcript_read```

The existing list endpoint continues to use:
```dev:conversations_read```

This gives us separate controls for different read costs:
- listing conversations
- fetching a single conversation
- reading full transcript content

### Conversation list reads
```GET /v1/dev/user/conversations``` still uses the normal conversation read policy.
When include_transcript=true, the route now also enforces the stricter transcript read policy.
This means metadata browsing and full transcript reads are no longer treated as the same cost.

### Conversation detail reads
```GET /v1/dev/user/conversations/{conversation_id}``` now uses the new detail-read policy.
When include_transcript=true, this route also enforces the stricter transcript-read policy.
This keeps single-conversation detail access separate from list polling and transcript-heavy access.

### Preserved Developer API auth context
The conversation read routes now keep the full ```ApiKeyAuth``` object instead of immediately collapsing it to only ```uid```.
That matters because Developer API abuse investigations need app/key-level context, not only user-level context.
The existing auth layer already supports:
- uid
- app_id
- key_id
- scopes
This PR keeps that context available in the route.

### Sanitized audit logging
Added audit logs for Developer API conversation reads.
The logs include safe operational metadata:
- operation name
- request path
- status
- uid
- app_id
- key_id
- remote IP
- sanitized user agent
- limit
- offset
- whether transcript was requested
- returned count
- conversation id for detail reads

The logs do not include:
- raw API keys
- authorization headers
- transcript text
- conversation content
- response bodies
This should make repeated same-page polling easier to investigate without exposing sensitive user data.

## Design Choices

### Split read limits by access pattern

I avoided using one broad `dev:conversations_read` bucket for every conversation read path.

A list request, a single detail request, and a full transcript request have different risk profiles. Splitting them gives maintainers separate knobs to tune without changing API behavior.

### Transcript reads get stricter controls

Transcript access is more sensitive and heavier than metadata access, so `include_transcript=true` now consumes a stricter transcript-specific policy in addition to the normal route policy.

This directly addresses the issue requirement that full-content reads should have stricter controls than metadata reads.

### Preserve existing API behavior

No request paths, response schemas, query parameter names, or scopes changed.

Existing clients can keep calling the same endpoints. The only behavioral change is that abusive/high-frequency read patterns can now be limited more precisely.

### Keep logs operational, not content-heavy

The audit logs are intentionally metadata-only. They are meant to answer questions like:

- Which key is polling?
- Which endpoint is being hit?
- Is the same page being requested repeatedly?
- Are transcript reads involved?
- How many items are being returned?

They are not meant to store user content.

## Files Changed

### `backend/utils/rate_limit_config.py`

Added new rate-limit policies:

- `dev:conversation_detail_read`
- `dev:conversation_transcript_read`

### `backend/dependencies.py`

Added conversation-read helpers for:

- shared conversation read scope validation
- detail-read rate limiting
- transcript-read rate limiting

### `backend/routers/developer.py`

Updated Developer API conversation read routes to:

- preserve full `ApiKeyAuth`
- enforce detail-read policy for single conversation reads
- enforce transcript-read policy when `include_transcript=true`
- emit sanitized audit logs for list/detail reads

### `backend/tests/unit/test_rate_limiting.py`

Added regression coverage to verify:

- new policies are registered
- Developer API conversation reads use separate detail/transcript policies
- audit logging keeps app/key identity
- audit logging sanitizes user agent data
- audit logging does not read/log authorization headers

## Testing

Targeted test run:

```bash
cd backend
python -m pytest tests/unit/test_rate_limiting.py -q
```

Additional Tests:

```bash
python -m py_compile \
  backend/dependencies.py \
  backend/routers/developer.py \
  backend/utils/rate_limit_config.py \
  backend/tests/unit/test_rate_limiting.py

git diff --check
```
## Notes
A broader local Developer API route test run could not collect in my local environment because the global Anaconda FastAPI/Starlette versions are incompatible. The failure happened during test collection before these route tests executed.
The focused rate-limit regression suite and syntax checks passed.

## Future Scope
This PR focuses on conversation read hardening.
Possible follow-ups:
- Add similar audit logs for memories, action items, goals, and folders reads
- Add dashboard panels for Developer API read volume by app_id and key_id
- Add alerting for repeated same-page polling patterns
- Document an incident runbook for identifying and revoking abusive API keys
- Add temporary block controls for suspicious app/key identities
- Add endpoint-level integration tests for rate-limit responses once test environment compatibility is stable

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

