### PR TITLE
feat(llm_gateway): R5b — mtime-watched config hot-reload (v.0.3)

### DIFF
--- a/backend/llm_gateway/config/lanes.yaml
+++ b/backend/llm_gateway/config/lanes.yaml
@@ -27,3 +27,447 @@ lanes:
         - invalid_config
     active_route: route.chat_structured.2026_06_27.001
     last_known_good: route.chat_structured.2026_06_20.001
+
+  # R0: 14 new LaneConfig entries (shadow-mode, percent=0, last_known_good == active_route).
+  # See .aidlc/spec.md for objective weights + capability flags per lane.
+  # Day-one invariant: each new lane's active_route == last_known_good, sourced from
+  # backend/utils/llm/model_config.py MODEL_QOS_PROFILES["premium"] (or the documented
+  # placeholder for STT/transcription/embedding lanes — those land in R3).
+  #
+  # Naming: route.<capability>.<YYYY_MM_DD>.001 — the date suffix is the R0 emission
+  # date. R1's emitter will use the same pattern with a rolling date.
+
+  - lane_id: omi:auto:chat-extraction
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.55
+      latency: 0.20
+      cost: 0.25
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.chat_extraction.2026_07_01.001
+    last_known_good: route.chat_extraction.2026_07_01.001
+
+  - lane_id: omi:auto:daily-summary
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.50
+      latency: 0.25
+      cost: 0.25
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.daily_summary.2026_07_01.001
+    last_known_good: route.daily_summary.2026_07_01.001
+
+  - lane_id: omi:auto:memories-extraction
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.55
+      latency: 0.20
+      cost: 0.25
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.memories_extraction.2026_07_01.001
+    last_known_good: route.memories_extraction.2026_07_01.001
+
+  - lane_id: omi:auto:memory-graph
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.60
+      latency: 0.20
+      cost: 0.20
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.memory_graph.2026_07_01.001
+    last_known_good: route.memory_graph.2026_07_01.001
+
+  - lane_id: omi:auto:conv-action-items
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.55
+      latency: 0.20
+      cost: 0.25
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.conv_action_items.2026_07_01.001
+    last_known_good: route.conv_action_items.2026_07_01.001
+
+  - lane_id: omi:auto:conv-structure
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.55
+      latency: 0.20
+      cost: 0.25
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.conv_structure.2026_07_01.001
+    last_known_good: route.conv_structure.2026_07_01.001
+
+  - lane_id: omi:auto:general-assistant
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: true
+    objective:
+      quality: 0.50
+      latency: 0.30
+      cost: 0.20
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.general_assistant.2026_07_01.001
+    last_known_good: route.general_assistant.2026_07_01.001
+
+  - lane_id: omi:auto:reasoning
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.70
+      latency: 0.20
+      cost: 0.10
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.reasoning.2026_07_01.001
+    last_known_good: route.reasoning.2026_07_01.001
+
+  - lane_id: omi:auto:stt-realtime
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    objective:
+      quality: 0.40
+      latency: 0.50
+      cost: 0.10
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.stt_realtime.2026_07_01.001
+    last_known_good: route.stt_realtime.2026_07_01.001
+
+  - lane_id: omi:auto:transcription
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    objective:
+      quality: 0.40
+      latency: 0.50
+      cost: 0.10
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.transcription.2026_07_01.001
+    last_known_good: route.transcription.2026_07_01.001
+
+  - lane_id: omi:auto:screenshot-understanding
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_object
+      tools: false
+    objective:
+      quality: 0.55
+      latency: 0.25
+      cost: 0.20
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.screenshot_understanding.2026_07_01.001
+    last_known_good: route.screenshot_understanding.2026_07_01.001
+
+  - lane_id: omi:auto:screenshot-embedding
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    objective:
+      quality: 0.40
+      latency: 0.30
+      cost: 0.30
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.screenshot_embedding.2026_07_01.001
+    last_known_good: route.screenshot_embedding.2026_07_01.001
+
+  - lane_id: omi:auto:realtime-ptt
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: true
+    objective:
+      quality: 0.65
+      latency: 0.25
+      cost: 0.10
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.realtime_ptt.2026_07_01.001
+    last_known_good: route.realtime_ptt.2026_07_01.001
+
+  - lane_id: omi:auto:persona-chat
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: false
+    objective:
+      quality: 0.45
+      latency: 0.35
+      cost: 0.20
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.persona_chat.2026_07_01.001
+    last_known_good: route.persona_chat.2026_07_01.001
+
+  - lane_id: omi:auto:notification-classifier
+    surface: openai.chat_completions
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    objective:
+      quality: 0.40
+      latency: 0.30
+      cost: 0.30
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+        - timeout_before_output
+        - provider_429_omi_paid
+        - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+        - byok_auth
+        - byok_quota
+        - byok_rate_limit
+        - byok_unsupported_provider
+        - missing_byok_key
+        - capability_mismatch
+        - invalid_config
+    active_route: route.notification_classifier.2026_07_01.001
+    last_known_good: route.notification_classifier.2026_07_01.001

--- a/backend/llm_gateway/config/lanes.yaml
+++ b/backend/llm_gateway/config/lanes.yaml
@@ -28,8 +28,7 @@ lanes:
     active_route: route.chat_structured.2026_06_27.001
     last_known_good: route.chat_structured.2026_06_20.001
 
-  # R0: 14 new LaneConfig entries (shadow-mode, percent=0, last_known_good == active_route).
-  # See .aidlc/spec.md for objective weights + capability flags per lane.
+  # R0: 15 new LaneConfig entries (shadow-mode, percent=0, last_known_good == active_route).
   # Day-one invariant: each new lane's active_route == last_known_good, sourced from
   # backend/utils/llm/model_config.py MODEL_QOS_PROFILES["premium"] (or the documented
   # placeholder for STT/transcription/embedding lanes — those land in R3).

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:c4c393fc3e915b2ecc41d4ef4cce5abd30c6439076814f55e29578eab6232e31
+    artifact_digest: sha256:33d1dd522069f9a343dcafd0c86ac9847166609630b1595d2c9d3cd5c3753bca
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -56,7 +56,7 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:1d46ec82568f2d523da23e1df4b0956cfe876cc6ece9d05dbfb7e0edc7eda74b
+    artifact_digest: sha256:16698e8bd9c456bf0e4effc13dbb515f62615a5509d9269c306164c915fbf07f
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so
@@ -164,7 +164,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:9ffa51e797f342a72a927a5e4a08bc8a128e7b47914965fb48c7a21e328bb845
+    artifact_digest: sha256:be8d2f093508b1af7347ecb4662a07f54b1e2c7c2de60215dcaf6632d3e4cffb
   - route_artifact_id: route.daily_summary.2026_07_01.001
     lane_id: omi:auto:daily-summary
     surface: openai.chat_completions
@@ -217,7 +217,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:d38d583c27788bed44fba4e777be6cf984e0afc26f3899153757b6ba60bc61b3
+    artifact_digest: sha256:d21a8f23775108af6ede4867160dbd14f57f5aa3e9bebe751ce4d23a9959cb79
   - route_artifact_id: route.memories_extraction.2026_07_01.001
     lane_id: omi:auto:memories-extraction
     surface: openai.chat_completions
@@ -270,7 +270,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:4cf68098f5f76ee76ae0c54dcf5d38544dd0a96c827072c28ac500f7e7c29924
+    artifact_digest: sha256:ca6bd969e045a97716da064d46ecb8a23a1d768745937235809b81a2a360b92d
   - route_artifact_id: route.memory_graph.2026_07_01.001
     lane_id: omi:auto:memory-graph
     surface: openai.chat_completions
@@ -323,7 +323,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:98513a22ab0207022d734acb84e0a112fea440ccb995627dfb46645370786901
+    artifact_digest: sha256:36d4d5245641cb6634824603a3d8b71b078f4f10271babaf322c0d7a1f1d69bb
   - route_artifact_id: route.conv_action_items.2026_07_01.001
     lane_id: omi:auto:conv-action-items
     surface: openai.chat_completions
@@ -376,7 +376,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:ceae186e7ffae6bae10264941596b004d5c90dab426729d4322c214070835acc
+    artifact_digest: sha256:8358b486faddf6e208dbb4d50a9d067ce7136098125605d478dc1a4bb152669c
   - route_artifact_id: route.conv_structure.2026_07_01.001
     lane_id: omi:auto:conv-structure
     surface: openai.chat_completions
@@ -429,7 +429,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:ab80dc3fbc00c4d9a8909206950b2cb0b7f8cfcb20bb6f11bbf0863e4944b280
+    artifact_digest: sha256:1c647e0494145fdbb142fa68f60076a1f5dcbbc96c7c9a6b9f9a24a42840b8f7
   - route_artifact_id: route.general_assistant.2026_07_01.001
     lane_id: omi:auto:general-assistant
     surface: openai.chat_completions
@@ -482,7 +482,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:d60aa6dcc1c4b90e879373009ee45492a7eb5a0014ce1629163e9154a4b378a1
+    artifact_digest: sha256:40dbf874765810695327e13b576d4e1aaa46bca2952a22fc6fb1e34949102827
   - route_artifact_id: route.reasoning.2026_07_01.001
     lane_id: omi:auto:reasoning
     surface: openai.chat_completions
@@ -535,7 +535,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:ca8a7ceed1ea4048c0a762c7fdb0c6a6a22058b3c96988e0c43388fe08e02c40
+    artifact_digest: sha256:f0705307570a2f8f748f49ad5daf3523349257780e08b7f548230d5ec4dc3b74
   - route_artifact_id: route.stt_realtime.2026_07_01.001
     lane_id: omi:auto:stt-realtime
     surface: openai.chat_completions
@@ -556,7 +556,8 @@ route_artifacts:
       benchmark_snapshot: bench.omi.stt_realtime.2026_07_01
       eval_report: eval.stt_realtime.v1
       benchmark_source: omi_eval
-      dev_only: true
+      dev_only: false
+      placeholder: true
     rollout:
       stage: shadow
       percent: 0
@@ -588,7 +589,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:9723d514993ff8c2dea12868fb5c894129157af164c6fd56fa3322448cb9c6f2
+    artifact_digest: sha256:3e18f3defb653f66a8b53891ba62eb65cd209055bc5186969539eb38804a245c
   - route_artifact_id: route.transcription.2026_07_01.001
     lane_id: omi:auto:transcription
     surface: openai.chat_completions
@@ -609,7 +610,8 @@ route_artifacts:
       benchmark_snapshot: bench.omi.transcription.2026_07_01
       eval_report: eval.transcription.v1
       benchmark_source: omi_eval
-      dev_only: true
+      dev_only: false
+      placeholder: true
     rollout:
       stage: shadow
       percent: 0
@@ -641,7 +643,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:9fbb5b1f61a53d6aeaa72ee4a1f8bb0cfaf1194bb6f3d6e5dc64803e082acb01
+    artifact_digest: sha256:04437dc6c9471925959ccd127fc7701f5eff0f4056b3b1424fe4ef3eaa747a27
   - route_artifact_id: route.screenshot_understanding.2026_07_01.001
     lane_id: omi:auto:screenshot-understanding
     surface: openai.chat_completions
@@ -694,7 +696,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:5cf21d14ef658ab11e82a8d374c4f59b6f20e8de68874cbd6b02e61441c1421c
+    artifact_digest: sha256:80a2e7d287a92cc780f8aea58314a562a34dca0868a909a6967c00bc05bb1fb3
   - route_artifact_id: route.screenshot_embedding.2026_07_01.001
     lane_id: omi:auto:screenshot-embedding
     surface: openai.chat_completions
@@ -715,7 +717,8 @@ route_artifacts:
       benchmark_snapshot: bench.omi.screenshot_embedding.2026_07_01
       eval_report: eval.screenshot_embedding.v1
       benchmark_source: omi_eval
-      dev_only: true
+      dev_only: false
+      placeholder: true
     rollout:
       stage: shadow
       percent: 0
@@ -747,7 +750,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:7567fe06367cdc09f768feb274c0208520471f5b764bbb93e1a0ba9a184ead6b
+    artifact_digest: sha256:9c98b53d1fa0bcc9a3d0a7d4276c7fb7e6a8a783b3de7fd6980b9a536ef736bd
   - route_artifact_id: route.realtime_ptt.2026_07_01.001
     lane_id: omi:auto:realtime-ptt
     surface: openai.chat_completions
@@ -800,7 +803,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:8296a9cefa387f304c9652a7eb9b763587de132582b1052910774203556e69bb
+    artifact_digest: sha256:372c9ef1b0d57fa370faa7a571525a5810f5be45cecde58c45c400540ce8307a
   - route_artifact_id: route.persona_chat.2026_07_01.001
     lane_id: omi:auto:persona-chat
     surface: openai.chat_completions
@@ -853,7 +856,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:c6fa711b349f3b4f18bf74aa087b2fe2115f41008de34c26f0c4399d756bb3c3
+    artifact_digest: sha256:57a4b71fc3e9d300a614d8a4d86be43d167e7603adb83403bcac7313c4a8a1d5
   - route_artifact_id: route.notification_classifier.2026_07_01.001
     lane_id: omi:auto:notification-classifier
     surface: openai.chat_completions
@@ -906,5 +909,5 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:c2d54291023d04bb10bab2b7eef48c48d58335756987c20956ece7cbe7be92d5
+    artifact_digest: sha256:506e4a0c6f3d9423058ed09f72c3d57de7bafb6bbac148ab383f5ef8fe6e9b92
 

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -556,7 +556,7 @@ route_artifacts:
       benchmark_snapshot: bench.omi.stt_realtime.2026_07_01
       eval_report: eval.stt_realtime.v1
       benchmark_source: omi_eval
-      dev_only: false
+      dev_only: true
     rollout:
       stage: shadow
       percent: 0
@@ -588,7 +588,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:641ab66fc106abad7e32d13180bd89dd0954b6816c3840da476b31f4c8f0bdc8
+    artifact_digest: sha256:9723d514993ff8c2dea12868fb5c894129157af164c6fd56fa3322448cb9c6f2
   - route_artifact_id: route.transcription.2026_07_01.001
     lane_id: omi:auto:transcription
     surface: openai.chat_completions
@@ -609,7 +609,7 @@ route_artifacts:
       benchmark_snapshot: bench.omi.transcription.2026_07_01
       eval_report: eval.transcription.v1
       benchmark_source: omi_eval
-      dev_only: false
+      dev_only: true
     rollout:
       stage: shadow
       percent: 0
@@ -641,7 +641,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:d7956f52439fde970c88bc3232dc890355542c64dfec99bd889e264f0ffa2f2e
+    artifact_digest: sha256:9fbb5b1f61a53d6aeaa72ee4a1f8bb0cfaf1194bb6f3d6e5dc64803e082acb01
   - route_artifact_id: route.screenshot_understanding.2026_07_01.001
     lane_id: omi:auto:screenshot-understanding
     surface: openai.chat_completions
@@ -715,7 +715,7 @@ route_artifacts:
       benchmark_snapshot: bench.omi.screenshot_embedding.2026_07_01
       eval_report: eval.screenshot_embedding.v1
       benchmark_source: omi_eval
-      dev_only: false
+      dev_only: true
     rollout:
       stage: shadow
       percent: 0
@@ -747,7 +747,7 @@ route_artifacts:
       - missing_byok_key
       - capability_mismatch
       - invalid_config
-    artifact_digest: sha256:dfff7c0f04c0c28ae6fad5ce6ed374a6f72b734a7fcffb7bf1847536ba62e996
+    artifact_digest: sha256:7567fe06367cdc09f768feb274c0208520471f5b764bbb93e1a0ba9a184ead6b
   - route_artifact_id: route.realtime_ptt.2026_07_01.001
     lane_id: omi:auto:realtime-ptt
     surface: openai.chat_completions

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -112,3 +112,799 @@ route_artifacts:
         - missing_byok_key
         - capability_mismatch
         - invalid_config
+  - route_artifact_id: route.chat_extraction.2026_07_01.001
+    lane_id: omi:auto:chat-extraction
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.chat_extraction.2026_07_01
+      eval_report: eval.chat_extraction.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:9ffa51e797f342a72a927a5e4a08bc8a128e7b47914965fb48c7a21e328bb845
+  - route_artifact_id: route.daily_summary.2026_07_01.001
+    lane_id: omi:auto:daily-summary
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.daily_summary.2026_07_01
+      eval_report: eval.daily_summary.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:d38d583c27788bed44fba4e777be6cf984e0afc26f3899153757b6ba60bc61b3
+  - route_artifact_id: route.memories_extraction.2026_07_01.001
+    lane_id: omi:auto:memories-extraction
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.memories_extraction.2026_07_01
+      eval_report: eval.memories_extraction.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:4cf68098f5f76ee76ae0c54dcf5d38544dd0a96c827072c28ac500f7e7c29924
+  - route_artifact_id: route.memory_graph.2026_07_01.001
+    lane_id: omi:auto:memory-graph
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.memory_graph.2026_07_01
+      eval_report: eval.memory_graph.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:98513a22ab0207022d734acb84e0a112fea440ccb995627dfb46645370786901
+  - route_artifact_id: route.conv_action_items.2026_07_01.001
+    lane_id: omi:auto:conv-action-items
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.conv_action_items.2026_07_01
+      eval_report: eval.conv_action_items.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:ceae186e7ffae6bae10264941596b004d5c90dab426729d4322c214070835acc
+  - route_artifact_id: route.conv_structure.2026_07_01.001
+    lane_id: omi:auto:conv-structure
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.conv_structure.2026_07_01
+      eval_report: eval.conv_structure.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:ab80dc3fbc00c4d9a8909206950b2cb0b7f8cfcb20bb6f11bbf0863e4944b280
+  - route_artifact_id: route.general_assistant.2026_07_01.001
+    lane_id: omi:auto:general-assistant
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: true
+    evidence:
+      benchmark_snapshot: bench.omi.general_assistant.2026_07_01
+      eval_report: eval.general_assistant.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:d60aa6dcc1c4b90e879373009ee45492a7eb5a0014ce1629163e9154a4b378a1
+  - route_artifact_id: route.reasoning.2026_07_01.001
+    lane_id: omi:auto:reasoning
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.reasoning.2026_07_01
+      eval_report: eval.reasoning.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:ca8a7ceed1ea4048c0a762c7fdb0c6a6a22058b3c96988e0c43388fe08e02c40
+  - route_artifact_id: route.stt_realtime.2026_07_01.001
+    lane_id: omi:auto:stt-realtime
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.stt_realtime.2026_07_01
+      eval_report: eval.stt_realtime.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:641ab66fc106abad7e32d13180bd89dd0954b6816c3840da476b31f4c8f0bdc8
+  - route_artifact_id: route.transcription.2026_07_01.001
+    lane_id: omi:auto:transcription
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.transcription.2026_07_01
+      eval_report: eval.transcription.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:d7956f52439fde970c88bc3232dc890355542c64dfec99bd889e264f0ffa2f2e
+  - route_artifact_id: route.screenshot_understanding.2026_07_01.001
+    lane_id: omi:auto:screenshot-understanding
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_object
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.screenshot_understanding.2026_07_01
+      eval_report: eval.screenshot_understanding.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:5cf21d14ef658ab11e82a8d374c4f59b6f20e8de68874cbd6b02e61441c1421c
+  - route_artifact_id: route.screenshot_embedding.2026_07_01.001
+    lane_id: omi:auto:screenshot-embedding
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: none
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.screenshot_embedding.2026_07_01
+      eval_report: eval.screenshot_embedding.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:dfff7c0f04c0c28ae6fad5ce6ed374a6f72b734a7fcffb7bf1847536ba62e996
+  - route_artifact_id: route.realtime_ptt.2026_07_01.001
+    lane_id: omi:auto:realtime-ptt
+    surface: openai.chat_completions
+    primary:
+      provider: anthropic
+      model: claude-sonnet-4-6
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: true
+    evidence:
+      benchmark_snapshot: bench.omi.realtime_ptt.2026_07_01
+      eval_report: eval.realtime_ptt.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:8296a9cefa387f304c9652a7eb9b763587de132582b1052910774203556e69bb
+  - route_artifact_id: route.persona_chat.2026_07_01.001
+    lane_id: omi:auto:persona-chat
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-4.1-nano
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: true
+      structured_output: json_object
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.persona_chat.2026_07_01
+      eval_report: eval.persona_chat.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:c6fa711b349f3b4f18bf74aa087b2fe2115f41008de34c26f0c4399d756bb3c3
+  - route_artifact_id: route.notification_classifier.2026_07_01.001
+    lane_id: omi:auto:notification-classifier
+    surface: openai.chat_completions
+    primary:
+      provider: openai
+      model: gpt-5.4-mini
+    fallbacks: []
+    timeouts:
+      request_ms: 8000
+    retry:
+      max_attempts: 1
+    capabilities:
+      text_input: true
+      streaming: false
+      structured_output: json_schema
+      tools: false
+    evidence:
+      benchmark_snapshot: bench.omi.notification_classifier.2026_07_01
+      eval_report: eval.notification_classifier.v1
+      benchmark_source: omi_eval
+      dev_only: false
+    rollout:
+      stage: shadow
+      percent: 0
+    credential_policy:
+      mode: omi_paid
+      allow_byok_to_omi_paid_fallback: false
+      fallback_eligible_failure_classes:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_failure_classes:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    fallback_policy:
+      fallback_on:
+      - timeout_before_output
+      - provider_429_omi_paid
+      - provider_5xx_omi_paid
+      never_fallback_on:
+      - byok_auth
+      - byok_quota
+      - byok_rate_limit
+      - byok_unsupported_provider
+      - missing_byok_key
+      - capability_mismatch
+      - invalid_config
+    artifact_digest: sha256:c2d54291023d04bb10bab2b7eef48c48d58335756987c20956ece7cbe7be92d5
+

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -54,7 +54,10 @@ def _load_config_list(path: Path, top_level_key: str) -> list[dict[str, Any]]:
         raise ConfigValidationError(f'missing gateway config file: {path}')
 
     with path.open('r', encoding='utf-8') as handle:
-        loaded = yaml.safe_load(handle)
+        try:
+            loaded = yaml.safe_load(handle)
+        except yaml.YAMLError as e:
+            raise ConfigValidationError(f'malformed YAML in {path}: {e}') from e
 
     if loaded is None:
         return []

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 import yaml
 from pydantic import BaseModel, ConfigDict
@@ -25,7 +25,25 @@ class GatewayConfig(BaseModel):
     feature_bundles: dict[str, FeatureBundle]
 
 
-def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool | None = None) -> GatewayConfig:
+def load_gateway_config(
+    config_dir: str | Path | None = None,
+    *,
+    prod_mode: bool | None = None,
+    required_lane_ids: Iterable[str] | None = None,
+) -> GatewayConfig:
+    """Load the gateway config from `config_dir`.
+
+    Parameters:
+        config_dir: Directory containing lanes.yaml, route_artifacts.yaml,
+            feature_bundles.yaml. Defaults to the gateway's package config dir.
+        prod_mode: If True, reject dev-only artifacts (production readiness check).
+            If None, defer to the OMI_LLM_GATEWAY_PROD env var.
+        required_lane_ids: Optional iterable of lane ids that MUST exist in
+            lanes.yaml after load. Missing ids raise ConfigValidationError.
+            Defaults to None (no cross-validation). The gateway's startup
+            path passes SUPPORTED_AUTO_LANE_IDS here to fail fast if a
+            supported lane is missing from YAML.
+    """
     resolved_config_dir = Path(config_dir) if config_dir is not None else DEFAULT_CONFIG_DIR
     resolved_prod_mode = _resolve_prod_mode(prod_mode)
 
@@ -39,6 +57,8 @@ def load_gateway_config(config_dir: str | Path | None = None, *, prod_mode: bool
 
     _validate_lane_routes(lanes, route_artifacts)
     _validate_feature_bundles(feature_bundles, lanes)
+    if required_lane_ids is not None:
+        _validate_required_lane_ids(required_lane_ids, lanes)
 
     return GatewayConfig(lanes=lanes, route_artifacts=route_artifacts, feature_bundles=feature_bundles)
 
@@ -151,3 +171,23 @@ def _validate_feature_bundles(feature_bundles: dict[str, FeatureBundle], lanes: 
     for bundle in feature_bundles.values():
         if bundle.lane_id not in lanes:
             raise ConfigValidationError(f'feature bundle {bundle.feature} references unknown lane: {bundle.lane_id}')
+
+
+def _validate_required_lane_ids(
+    required_lane_ids: Iterable[str],
+    lanes: dict[str, LaneConfig],
+) -> None:
+    """Cross-check that every required lane id has a corresponding lanes.yaml entry.
+
+    Per PLAN.md §R5b + cubic-dev-ai review on PR #8744: if a lane is in
+    SUPPORTED_AUTO_LANE_IDS but missing from lanes.yaml, the config loads
+    successfully and the failure is deferred to runtime. Cross-validate
+    here so the failure surfaces at startup (or at the next reload).
+    """
+    required = set(required_lane_ids)
+    missing = sorted(required - set(lanes.keys()))
+    if missing:
+        raise ConfigValidationError(
+            f'lanes.yaml is missing required lane ids: {missing}. '
+            f'Add them to lanes.yaml or remove them from the supported allowlist.'
+        )

--- a/backend/llm_gateway/gateway/config_reload.py
+++ b/backend/llm_gateway/gateway/config_reload.py
@@ -13,6 +13,7 @@ instead of 'restart the pod.'"
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Optional
@@ -23,6 +24,7 @@ from llm_gateway.gateway.config_loader import (
     load_gateway_config,
 )
 from llm_gateway.gateway.daily_refresh import DailyRefreshCache
+from llm_gateway.gateway.resolver import SUPPORTED_AUTO_LANE_IDS
 
 logger = logging.getLogger(__name__)
 
@@ -81,11 +83,21 @@ class GatewayConfigReloader:
     async def _load(self) -> GatewayConfig:
         """Loader passed to DailyRefreshCache; runs under the cache lock.
 
+        Config loading is sync (yaml.safe_load + Pydantic validation) and
+        can take ~10-50ms on cold start. To avoid blocking the event loop
+        while the request handler is awaiting `get()`, the sync load runs
+        in a threadpool via `asyncio.to_thread`.
+
         Raises ConfigValidationError on bad config; DailyRefreshCache does
         the stale-fallback dance (returns last good value if available,
         propagates if first-call).
         """
-        cfg = load_gateway_config(self.config_dir, prod_mode=None)
+        cfg = await asyncio.to_thread(
+            load_gateway_config,
+            self.config_dir,
+            prod_mode=None,
+            required_lane_ids=SUPPORTED_AUTO_LANE_IDS,
+        )
         self._cached = cfg
         return cfg
 

--- a/backend/llm_gateway/gateway/config_reload.py
+++ b/backend/llm_gateway/gateway/config_reload.py
@@ -1,0 +1,101 @@
+"""Hot-reload gateway config on YAML mtime change (R5b).
+
+Wraps `DailyRefreshCache` (TTL + `asyncio.Lock` + stale-fallback) with
+mtime polling so the gateway picks up YAML changes on the next request
+after merge — no pod restart required. The reloader runs ONCE per
+request (mtime check is fast, `os.stat()`); only invokes the loader on
+cache miss or mtime change.
+
+Per PLAN.md §R5b: "the cache invalidation path is what makes 'nightly
+rotation' mean 'the next request after merge sees the new artifact'
+instead of 'restart the pod.'"
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from llm_gateway.gateway.config_loader import (
+    ConfigValidationError,
+    GatewayConfig,
+    load_gateway_config,
+)
+from llm_gateway.gateway.daily_refresh import DailyRefreshCache
+
+logger = logging.getLogger(__name__)
+
+
+# YAML files the reloader watches. Must match what `load_gateway_config`
+# loads from. Adding a file here without adding it to the loader is a no-op;
+# removing one without updating the loader would silently miss changes.
+_CONFIG_FILES = ("lanes.yaml", "route_artifacts.yaml", "feature_bundles.yaml")
+
+
+def _max_mtime(config_dir: Path) -> float:
+    """Return the max mtime across the config files (or 0.0 if none exist)."""
+    mtimes = []
+    for fname in _CONFIG_FILES:
+        path = config_dir / fname
+        if path.exists():
+            mtimes.append(path.stat().st_mtime)
+    return max(mtimes) if mtimes else 0.0
+
+
+class GatewayConfigReloader:
+    """mtime-watched config reloader.
+
+    Behavior:
+    - First call: load from disk, cache the result + mtime.
+    - Subsequent calls: stat the config files; if max-mtime unchanged,
+      return the cached config object (same instance — no reload).
+    - On mtime change: invalidate the cache, reload from disk.
+    - On reload error: return last good cached config (stale fallback)
+      if present; otherwise propagate the exception.
+    - Concurrent calls serialize via `DailyRefreshCache`'s `asyncio.Lock`
+      (double-checked locking — only one loader invocation per cache miss).
+    """
+
+    def __init__(self, config_dir: Path, *, ttl_seconds: float = 60.0):
+        self.config_dir = config_dir
+        # The mtime we last observed; on mismatch, force a refresh.
+        self._mtime: Optional[float] = None
+        # Last successfully loaded config, kept for stale fallback even
+        # after the cache is invalidated.
+        self._cached: Optional[GatewayConfig] = None
+        self._cache: DailyRefreshCache[GatewayConfig] = DailyRefreshCache(ttl_seconds=ttl_seconds)
+
+    async def get(self) -> GatewayConfig:
+        """Return the current config, reloading if any config file's mtime changed."""
+        current_mtime = _max_mtime(self.config_dir)
+        if self._cached is None or self._mtime != current_mtime:
+            # Mtime changed (or first call). Force the cache to refresh on
+            # the next get_or_refresh — preserves stale value in DailyRefreshCache
+            # for the fallback path. The loader populates self._cached on
+            # success; on failure DailyRefreshCache returns the stale value.
+            self._cache.invalidate()
+            self._mtime = current_mtime
+        return await self._cache.get_or_refresh(self._load)
+
+    async def _load(self) -> GatewayConfig:
+        """Loader passed to DailyRefreshCache; runs under the cache lock.
+
+        Raises ConfigValidationError on bad config; DailyRefreshCache does
+        the stale-fallback dance (returns last good value if available,
+        propagates if first-call).
+        """
+        cfg = load_gateway_config(self.config_dir, prod_mode=None)
+        self._cached = cfg
+        return cfg
+
+    def invalidate(self) -> None:
+        """Force the next get() to reload. Test helper + admin path."""
+        self._mtime = None
+        self._cached = None
+        self._cache.invalidate()
+
+    @property
+    def last_loaded_config(self) -> Optional[GatewayConfig]:
+        """The most recently successfully loaded config (for diagnostics)."""
+        return self._cached

--- a/backend/llm_gateway/gateway/daily_refresh.py
+++ b/backend/llm_gateway/gateway/daily_refresh.py
@@ -26,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+# Private sentinel used to distinguish "no value cached" from "value is None".
+# Using `None` as the empty-cache signal made it impossible to cache legitimate
+# None payloads (loader was re-invoked on every call, stale fallback never
+# triggered). Fix from cubic-dev-ai review.
+_MISSING = object()
+
 
 class DailyRefreshCache(Generic[T]):
     """A TTL-bounded cache for an async loader.
@@ -56,7 +62,9 @@ class DailyRefreshCache(Generic[T]):
             raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds}")
         self._ttl = ttl_seconds
         self._clock = clock
-        self._value: Optional[T] = None
+        # `_value` uses a sentinel (not `None`) so legitimate `None` payloads
+        # can be cached. See `_MISSING` above.
+        self._value: T | object = _MISSING
         self._last_loaded_at: Optional[float] = None
         self._lock = asyncio.Lock()
         # Counter for tests to verify how many times loader was actually invoked.
@@ -73,9 +81,10 @@ class DailyRefreshCache(Generic[T]):
     def last_loaded_at(self) -> Optional[float]:
         """Monotonic timestamp of the last successful load, or None if never loaded.
 
-        Combine with the clock function to convert to wall-clock time:
-            wall_time = last_loaded_at + (monotonic_now() - last_loaded_at)
-        For most use cases, prefer `last_loaded_wall_time()` which does this for you.
+        The monotonic clock has no wall-clock meaning, so this value cannot be
+        directly converted to wall-clock time. Use `last_loaded_wall_time()`
+        for an approximation (best-effort, ±a few seconds), or have the loader
+        itself record `time.time()` and store it if exact wall-clock is needed.
         """
         return self._last_loaded_at
 
@@ -99,11 +108,11 @@ class DailyRefreshCache(Generic[T]):
     @property
     def has_value(self) -> bool:
         """True if a value is currently cached (even if stale)."""
-        return self._value is not None
+        return self._value is not _MISSING
 
     def _is_fresh(self) -> bool:
         """True if cache is non-empty AND within TTL window."""
-        if self._value is None or self._last_loaded_at is None:
+        if self._value is _MISSING or self._last_loaded_at is None:
             return False
         return (self._clock() - self._last_loaded_at) < self._ttl
 
@@ -120,13 +129,13 @@ class DailyRefreshCache(Generic[T]):
         """
         # Fast path: cache is fresh, no lock needed.
         if self._is_fresh():
-            assert self._value is not None  # guaranteed by _is_fresh()
+            assert self._value is not _MISSING  # guaranteed by _is_fresh()
             return self._value
 
         async with self._lock:
             # Double-check inside the lock: another caller may have just refreshed.
             if self._is_fresh():
-                assert self._value is not None
+                assert self._value is not _MISSING
                 return self._value
 
             # Cache is stale or empty — invoke the loader.
@@ -136,7 +145,7 @@ class DailyRefreshCache(Generic[T]):
                 self._last_loaded_at = self._clock()
                 return self._value
             except Exception as e:
-                if self._value is not None:
+                if self._value is not _MISSING:
                     age_str = f"{self.age_seconds:.1f}s" if self.age_seconds is not None else "unknown"
                     logger.warning(
                         f"DailyRefreshCache: loader raised ({type(e).__name__}: {e}), "

--- a/backend/llm_gateway/gateway/daily_refresh.py
+++ b/backend/llm_gateway/gateway/daily_refresh.py
@@ -1,0 +1,159 @@
+"""Daily-refresh cache: TTL + asyncio.Lock + stale-fallback.
+
+Wraps an async loader function with three behaviors:
+1. **TTL**: loader runs at most once per TTL window (default 24h, matching upstream
+   `/v1/auto/model-pick`).
+2. **`asyncio.Lock()`**: concurrent callers serialize. Only one loader call fires
+   on a cache miss; other callers wait and then read the fresh value (double-checked
+   locking pattern).
+3. **Stale fallback**: if the loader raises during refresh, return the last good
+   cached value instead of propagating. On the first-ever call with no cached
+   value and the loader raises, the exception propagates (nothing to fall back to).
+
+Mirrors upstream's pattern in `backend/routers/auto_model.py` (`_cache_lock` +
+24h `TTL_SECONDS`).
+
+The clock function is injectable for testability (default `time.monotonic`).
+"""
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Generic, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class DailyRefreshCache(Generic[T]):
+    """A TTL-bounded cache for an async loader.
+
+    Concurrency model:
+        - First call (or post-expiry call) acquires the lock.
+        - Subsequent concurrent callers wait for the lock, then DOUBLE-CHECK
+          the cache. If the first caller just refreshed, they get the fresh
+          value without re-running the loader.
+        - This is the standard double-checked-locking pattern; safe because
+          `asyncio.Lock` provides exclusive access within a single event loop.
+
+    Failure model:
+        - Loader raises → return last good cached value if present, else
+          propagate the exception.
+        - Stale fallback is logged at WARNING level (not error) because it's a
+          degraded-but-functional state.
+    """
+
+    DEFAULT_TTL_SECONDS = 24 * 60 * 60  # 24h, matching upstream auto_model.py
+
+    def __init__(
+        self,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds}")
+        self._ttl = ttl_seconds
+        self._clock = clock
+        self._value: Optional[T] = None
+        self._last_loaded_at: Optional[float] = None
+        self._lock = asyncio.Lock()
+        # Counter for tests to verify how many times loader was actually invoked.
+        self.loader_call_count = 0
+
+    @property
+    def age_seconds(self) -> Optional[float]:
+        """Seconds since last successful load, or None if never loaded."""
+        if self._last_loaded_at is None:
+            return None
+        return max(0.0, self._clock() - self._last_loaded_at)
+
+    @property
+    def last_loaded_at(self) -> Optional[float]:
+        """Monotonic timestamp of the last successful load, or None if never loaded.
+
+        Combine with the clock function to convert to wall-clock time:
+            wall_time = last_loaded_at + (monotonic_now() - last_loaded_at)
+        For most use cases, prefer `last_loaded_wall_time()` which does this for you.
+        """
+        return self._last_loaded_at
+
+    def last_loaded_wall_time(self) -> Optional[datetime]:
+        """Wall-clock time of the last successful load (UTC), or None if never loaded.
+
+        Returns a `datetime` (UTC) by converting from the monotonic clock.
+        Note: monotonic clock has no wall-clock meaning, so we use the wall clock
+        at construction + elapsed time as an approximation. For exact wall-clock
+        timestamps, the loader itself should record `time.time()` and store it.
+        """
+        if self._last_loaded_at is None:
+            return None
+        # Approximation: the wall clock at "monotonic = self._last_loaded_at"
+        # is roughly wall_at_init + (self._last_loaded_at - monotonic_at_init).
+        # We didn't capture init times, so this is best-effort.
+        # For most use cases (display), ±a few seconds is fine.
+        elapsed = self._clock() - self._last_loaded_at
+        return datetime.now(timezone.utc) - timedelta(seconds=elapsed)
+
+    @property
+    def has_value(self) -> bool:
+        """True if a value is currently cached (even if stale)."""
+        return self._value is not None
+
+    def _is_fresh(self) -> bool:
+        """True if cache is non-empty AND within TTL window."""
+        if self._value is None or self._last_loaded_at is None:
+            return False
+        return (self._clock() - self._last_loaded_at) < self._ttl
+
+    async def get_or_refresh(self, loader: Callable[[], Awaitable[T]]) -> T:
+        """Return the cached value, refreshing if stale.
+
+        Concurrent callers serialize via the lock; only the first caller on a
+        cache miss invokes the loader. If the loader raises:
+        - With a previously cached value: return the stale value (degraded).
+        - Without a cached value: propagate the exception.
+
+        The loader's invocation count is tracked in `loader_call_count` for
+        test introspection (verifying lock contention behavior).
+        """
+        # Fast path: cache is fresh, no lock needed.
+        if self._is_fresh():
+            assert self._value is not None  # guaranteed by _is_fresh()
+            return self._value
+
+        async with self._lock:
+            # Double-check inside the lock: another caller may have just refreshed.
+            if self._is_fresh():
+                assert self._value is not None
+                return self._value
+
+            # Cache is stale or empty — invoke the loader.
+            self.loader_call_count += 1
+            try:
+                self._value = await loader()
+                self._last_loaded_at = self._clock()
+                return self._value
+            except Exception as e:
+                if self._value is not None:
+                    age_str = f"{self.age_seconds:.1f}s" if self.age_seconds is not None else "unknown"
+                    logger.warning(
+                        f"DailyRefreshCache: loader raised ({type(e).__name__}: {e}), "
+                        f"returning stale value (age {age_str})"
+                    )
+                    # Advance the timestamp so refreshIfStale respects the TTL
+                    # even after a failing refresh. Without this, every subsequent
+                    # call would re-fire the loader (the cache is stale AND
+                    # the timestamp is still old), creating a tight retry loop
+                    # against the failing backend.
+                    self._last_loaded_at = self._clock()
+                    return self._value
+                # No prior value — propagate.
+                raise
+
+    def invalidate(self) -> None:
+        """Force the next call to refresh (does not clear the cached value —
+        next call may still fall back to it on loader failure).
+        """
+        self._last_loaded_at = None

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -17,14 +17,23 @@ from llm_gateway.gateway.validator import ValidatedChatCompletionRequest, valida
 
 # R0 lane taxonomy (see .aidlc/spec.md and PLAN.md §R0):
 #   - 1 existing lane: chat-structured (the gateway's pilot lane)
-#   - 15 new lanes: every AI capability in Omi, shipped in shadow mode
+#   - 12 new chat-completion lanes: shadow-mode; resolvable via this gateway
+#   - 3 non-chat lanes (stt-realtime, transcription, screenshot-embedding):
+#     exist in lanes.yaml + route_artifacts.yaml as R3 placeholders but are NOT
+#     in SUPPORTED_AUTO_LANE_IDS because they belong on different surfaces
+#     (audio / embedding), not openai.chat_completions. R3 will introduce
+#     those surfaces and add them here.
+#
 # The frozenset is the only gate between product code and lane resolution.
-# Adding a lane here without it being in lanes.yaml + route_artifacts.yaml is
-# a hard error at config load (load_gateway_config fails).
+# Lanes here MUST exist in lanes.yaml AND have at least one valid
+# RouteArtifact in route_artifacts.yaml — load_gateway_config enforces both
+# (it validates active_route + last_known_good resolve to real artifacts).
+# Adding a lane here that is missing from config is a hard error at config
+# load.
 SUPPORTED_AUTO_LANE_IDS = frozenset(
     {
         'omi:auto:chat-structured',  # existing — pilot lane
-        # R0 new lanes (15):
+        # R0 new chat-completion lanes (12):
         'omi:auto:chat-extraction',
         'omi:auto:daily-summary',
         'omi:auto:memories-extraction',
@@ -33,13 +42,17 @@ SUPPORTED_AUTO_LANE_IDS = frozenset(
         'omi:auto:conv-structure',
         'omi:auto:general-assistant',
         'omi:auto:reasoning',
-        'omi:auto:stt-realtime',
-        'omi:auto:transcription',
         'omi:auto:screenshot-understanding',
-        'omi:auto:screenshot-embedding',
         'omi:auto:realtime-ptt',
         'omi:auto:persona-chat',
         'omi:auto:notification-classifier',
+        # R3 placeholders (3): audio + embedding — NOT in this set. They
+        # belong on surfaces the gateway doesn't support yet (STT,
+        # embedding endpoints). R3 wires those surfaces and adds them here.
+        # See R0 spec: ".aidlc/spec.md" lane table note.
+        # 'omi:auto:stt-realtime',
+        # 'omi:auto:transcription',
+        # 'omi:auto:screenshot-embedding',
     }
 )
 AUTO_LANE_PREFIX = 'omi:auto:'

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -15,7 +15,33 @@ from llm_gateway.gateway.errors import (
 from llm_gateway.gateway.schemas import FailureClass, LaneConfig, RouteArtifact, Surface
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest, validate_chat_completion_request
 
-SUPPORTED_AUTO_LANE_IDS = frozenset({'omi:auto:chat-structured'})
+# R0 lane taxonomy (see .aidlc/spec.md and PLAN.md §R0):
+#   - 1 existing lane: chat-structured (the gateway's pilot lane)
+#   - 15 new lanes: every AI capability in Omi, shipped in shadow mode
+# The frozenset is the only gate between product code and lane resolution.
+# Adding a lane here without it being in lanes.yaml + route_artifacts.yaml is
+# a hard error at config load (load_gateway_config fails).
+SUPPORTED_AUTO_LANE_IDS = frozenset(
+    {
+        'omi:auto:chat-structured',  # existing — pilot lane
+        # R0 new lanes (15):
+        'omi:auto:chat-extraction',
+        'omi:auto:daily-summary',
+        'omi:auto:memories-extraction',
+        'omi:auto:memory-graph',
+        'omi:auto:conv-action-items',
+        'omi:auto:conv-structure',
+        'omi:auto:general-assistant',
+        'omi:auto:reasoning',
+        'omi:auto:stt-realtime',
+        'omi:auto:transcription',
+        'omi:auto:screenshot-understanding',
+        'omi:auto:screenshot-embedding',
+        'omi:auto:realtime-ptt',
+        'omi:auto:persona-chat',
+        'omi:auto:notification-classifier',
+    }
+)
 AUTO_LANE_PREFIX = 'omi:auto:'
 NEVER_LKG_FAILURE_CLASSES = frozenset(
     {

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -109,8 +109,18 @@ class Evidence(StrictBaseModel):
     eval_report: str = Field(min_length=1)
     benchmark_source: BenchmarkSource
     dev_only: bool = False
+    # `placeholder: true` marks an artifact as a stop-gap that future promotion
+    # logic (R1 emitter, R4 cron) should replace before promoting to active.
+    # Distinct from `dev_only` (which excludes the artifact from production
+    # loading entirely). A placeholder is fully servable — it just shouldn't
+    # be the long-term primary. See R0 spec + PR #8739 review (cubic P1).
+    placeholder: bool = False
 
     def is_prod_eligible(self) -> bool:
+        # NOTE: `placeholder` does NOT affect prod eligibility. A placeholder
+        # artifact is loadable in any prod_mode (preserving the day-one
+        # shadow-mode contract). Future promotion logic reads `evidence.placeholder`
+        # separately to decide whether to replace it.
         return not self.dev_only and self.benchmark_source not in {
             BenchmarkSource.MOCK,
             BenchmarkSource.DEV_FIXTURE,

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -1,19 +1,47 @@
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
+from pathlib import Path
 
-from llm_gateway.gateway.config_loader import GatewayConfig, load_gateway_config
+from llm_gateway.gateway.config_loader import (
+    DEFAULT_CONFIG_DIR,
+    GatewayConfig,
+)
+from llm_gateway.gateway.config_reload import GatewayConfigReloader
 from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
 
+logger = logging.getLogger(__name__)
 
-@lru_cache(maxsize=1)
-def get_gateway_config() -> GatewayConfig:
-    # Respect OMI_LLM_GATEWAY_PROD env var. In dev/staging (env unset) we accept
-    # dev_only placeholders; in prod (env set) we reject them. Hard-coding True
-    # here would break /ready and the openai_compatible request path in dev,
-    # where R0's day-one placeholders are intentional.
-    return load_gateway_config(prod_mode=None)
+
+# Singleton reloader. Reads from the gateway's default config dir at module
+# import time; replaces the previous @lru_cache(maxsize=1) pattern so the
+# gateway picks up YAML changes on the next request after merge (R5b).
+# The reloader is process-wide (one per gateway process); for tests, create
+# a local GatewayConfigReloader pointing at a tmp_path config dir.
+_config_reloader = GatewayConfigReloader(Path(DEFAULT_CONFIG_DIR))
+
+
+async def get_gateway_config() -> GatewayConfig:
+    """Return the current gateway config, hot-reloading on YAML mtime change.
+
+    R5b: replaces the previous `@lru_cache(maxsize=1)` pattern (which only
+    loaded once at startup) with the mtime-watched `GatewayConfigReloader`.
+    This means nightly rotation PRs (R4) take effect on the next request
+    after merge — no pod restart required.
+
+    prod_mode=None means the OMI_LLM_GATEWAY_PROD env var decides. In
+    dev/staging (env unset) all configs load; in prod (env set) configs
+    with dev_only artifacts are rejected.
+    """
+    return await _config_reloader.get()
+
+
+def reset_gateway_config_reloader() -> None:
+    """Test helper + admin path: invalidate the reloader so the next get()
+    reloads from disk (bypasses mtime check)."""
+    _config_reloader.invalidate()
 
 
 @lru_cache(maxsize=1)

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -9,7 +9,11 @@ from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
 
 @lru_cache(maxsize=1)
 def get_gateway_config() -> GatewayConfig:
-    return load_gateway_config(prod_mode=True)
+    # Respect OMI_LLM_GATEWAY_PROD env var. In dev/staging (env unset) we accept
+    # dev_only placeholders; in prod (env set) we reject them. Hard-coding True
+    # here would break /ready and the openai_compatible request path in dev,
+    # where R0's day-one placeholders are intentional.
+    return load_gateway_config(prod_mode=None)
 
 
 @lru_cache(maxsize=1)

--- a/backend/llm_gateway/routers/dependencies.py
+++ b/backend/llm_gateway/routers/dependencies.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from llm_gateway.gateway.config_loader import (
     DEFAULT_CONFIG_DIR,
     GatewayConfig,
+    load_gateway_config,
 )
 from llm_gateway.gateway.config_reload import GatewayConfigReloader
 from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
+from llm_gateway.gateway.resolver import SUPPORTED_AUTO_LANE_IDS
 
 logger = logging.getLogger(__name__)
 

--- a/backend/llm_gateway/routers/health.py
+++ b/backend/llm_gateway/routers/health.py
@@ -14,9 +14,9 @@ def get_health():
 
 
 @router.get('/ready')
-def get_ready(caller: ServiceAuthDependency):
+async def get_ready(caller: ServiceAuthDependency):
     try:
-        config = get_gateway_config()
+        config = await get_gateway_config()
     except (ConfigValidationError, ValidationError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/tests/unit/llm_gateway/test_config_reload.py
+++ b/backend/tests/unit/llm_gateway/test_config_reload.py
@@ -1,0 +1,239 @@
+"""Tests for the R5b mtime-watched config reloader.
+
+The reloader wraps DailyRefreshCache (TTL + lock + stale-fallback) with
+mtime polling. Tests cover:
+- First-call load
+- Cached on unchanged mtime
+- Reload on mtime change
+- Stale fallback on ConfigValidationError
+- First-call error propagation
+- Concurrent get() serialization
+- Integration with load_gateway_config (uses the real default config in some tests)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from llm_gateway.gateway.config_loader import (
+    ConfigValidationError,
+    load_gateway_config,
+)
+from llm_gateway.gateway.config_reload import (
+    GatewayConfigReloader,
+    _CONFIG_FILES,
+    _max_mtime,
+)
+
+DEFAULT_CONFIG_DIR = Path(__file__).resolve().parents[3] / "llm_gateway" / "config"
+
+
+def _copy_default_config_to(tmp_path: Path) -> Path:
+    """Snapshot the default config into tmp_path so tests can mutate freely."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    for fname in _CONFIG_FILES:
+        src = DEFAULT_CONFIG_DIR / fname
+        dst = config_dir / fname
+        dst.write_text(src.read_text())
+    return config_dir
+
+
+def _bump_mtime(path: Path) -> None:
+    """Ensure mtime advances past the previous value (some FS have 1s resolution)."""
+    time.sleep(0.05)
+    path.touch()
+
+
+# ---------------------------------------------------------------------------
+# _max_mtime helper
+# ---------------------------------------------------------------------------
+
+
+class TestMaxMtime:
+    def test_max_mtime_returns_zero_when_no_files_exist(self, tmp_path):
+        assert _max_mtime(tmp_path) == 0.0
+
+    def test_max_mtime_returns_max_of_existing_files(self, tmp_path):
+        f1 = tmp_path / "lanes.yaml"
+        f2 = tmp_path / "route_artifacts.yaml"
+        f1.write_text("a")
+        time.sleep(0.05)
+        f2.write_text("b")
+        # Both files exist; _max_mtime returns the larger mtime (f2).
+        assert _max_mtime(tmp_path) == f2.stat().st_mtime
+
+    def test_max_mtime_ignores_unrelated_files(self, tmp_path):
+        f1 = tmp_path / "lanes.yaml"
+        f1.write_text("a")
+        # Unrelated file with a future mtime should NOT affect the result
+        unrelated = tmp_path / "unrelated.yaml"
+        unrelated.write_text("x")
+        future = time.time() + 3600
+        os.utime(unrelated, (future, future))
+        assert _max_mtime(tmp_path) == f1.stat().st_mtime
+
+
+# ---------------------------------------------------------------------------
+# First-call load
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_loads_on_first_call(tmp_path):
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg = await reloader.get()
+    assert len(cfg.lanes) == 16
+    assert len(cfg.route_artifacts) == 17
+    # Last-loaded config is exposed for diagnostics
+    assert reloader.last_loaded_config is cfg
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_returns_cached_when_mtime_unchanged(tmp_path):
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg1 = await reloader.get()
+    cfg2 = await reloader.get()
+    # Same object — no reload, no second load call
+    assert cfg1 is cfg2
+
+
+@pytest.mark.asyncio
+async def test_reloader_reloads_on_mtime_change(tmp_path):
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg1 = await reloader.get()
+    # Bump mtime on one of the config files
+    _bump_mtime(config_dir / "lanes.yaml")
+    cfg2 = await reloader.get()
+    # New instance — reloaded because mtime changed
+    assert cfg1 is not cfg2
+
+
+@pytest.mark.asyncio
+async def test_reloader_reloads_when_any_of_three_files_change(tmp_path):
+    """mtime is the max across all 3 files; bumping any one triggers reload."""
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg_initial = await reloader.get()
+    for fname in ("lanes.yaml", "route_artifacts.yaml", "feature_bundles.yaml"):
+        _bump_mtime(config_dir / fname)
+        cfg_after = await reloader.get()
+        assert cfg_after is not cfg_initial, f"reload did not happen after {fname} mtime change"
+        cfg_initial = cfg_after
+
+
+# ---------------------------------------------------------------------------
+# Stale fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_stale_fallback_on_config_validation_error(tmp_path):
+    """After a successful load, corrupting the config returns the cached value."""
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg_good = await reloader.get()
+    # Corrupt lanes.yaml so the next load fails
+    _bump_mtime(config_dir / "lanes.yaml")
+    # Unbalanced flow sequence — YAML parser raises.
+    (config_dir / "lanes.yaml").write_text("- item1\n- item2\n- [unclosed")
+    # Mtime changed; next get() fails to load. DailyRefreshCache's stale
+    # fallback returns the previously cached value (cfg_good).
+    cfg_stale = await reloader.get()
+    assert cfg_stale is cfg_good
+
+
+@pytest.mark.asyncio
+async def test_reloader_propagates_first_call_error(tmp_path):
+    """On first call, if the loader raises and there's no cached value, propagate."""
+    config_dir = _copy_default_config_to(tmp_path)
+    # Corrupt BEFORE any successful load
+    (config_dir / "lanes.yaml").write_text("- item1\n- [unclosed")
+    reloader = GatewayConfigReloader(config_dir)
+    with pytest.raises(ConfigValidationError):
+        await reloader.get()
+
+
+@pytest.mark.asyncio
+async def test_reloader_recovers_after_first_call_error_then_success(tmp_path):
+    """After a first-call failure, fixing the file + bumping mtime succeeds."""
+    config_dir = _copy_default_config_to(tmp_path)
+    (config_dir / "lanes.yaml").write_text("- item1\n- [unclosed")
+    reloader = GatewayConfigReloader(config_dir)
+    with pytest.raises(ConfigValidationError):
+        await reloader.get()
+    # Restore the file
+    _bump_mtime(config_dir / "lanes.yaml")
+    (config_dir / "lanes.yaml").write_text((DEFAULT_CONFIG_DIR / "lanes.yaml").read_text())
+    cfg = await reloader.get()
+    assert len(cfg.lanes) == 16
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_serializes_concurrent_get_calls(tmp_path):
+    """5 concurrent get() calls — only one loader invocation."""
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    results = await asyncio.gather(*[reloader.get() for _ in range(5)])
+    assert all(r is results[0] for r in results)
+    # The DailyRefreshCache's loader_call_count should be 1
+    assert reloader._cache.loader_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# invalidate()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_invalidate_forces_reload(tmp_path):
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    cfg1 = await reloader.get()
+    reloader.invalidate()
+    cfg2 = await reloader.get()
+    assert cfg1 is not cfg2
+
+
+@pytest.mark.asyncio
+async def test_reloader_invalidate_clears_last_loaded(tmp_path):
+    config_dir = _copy_default_config_to(tmp_path)
+    reloader = GatewayConfigReloader(config_dir)
+    await reloader.get()
+    assert reloader.last_loaded_config is not None
+    reloader.invalidate()
+    assert reloader.last_loaded_config is None
+
+
+# ---------------------------------------------------------------------------
+# Integration with the real default config (smoke test against the actual files)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reloader_works_against_real_default_config():
+    """End-to-end: load the real default config via the reloader."""
+    reloader = GatewayConfigReloader(DEFAULT_CONFIG_DIR)
+    cfg = await reloader.get()
+    assert len(cfg.lanes) == 16
+    assert len(cfg.route_artifacts) == 17
+    # No prod_mode rejection: the new placeholder field is the marker, not dev_only
+    assert all(cfg.route_artifacts[rid].evidence.is_prod_eligible() for rid in cfg.route_artifacts)

--- a/backend/tests/unit/llm_gateway/test_daily_refresh.py
+++ b/backend/tests/unit/llm_gateway/test_daily_refresh.py
@@ -1,15 +1,21 @@
 """Parity tests for the cherry-picked daily_refresh.py (R5b).
 
-The DailyRefreshCache[T] primitive is byte-equivalent to v3's
-`backend/utils/auto_router/daily_refresh.py` (sha256 verified). These
-tests pin the critical behaviors so any drift between v3 and this copy
-(e.g. from a future re-cherry-pick) is caught by CI.
+The DailyRefreshCache[T] primitive is sourced from v3's
+`backend/utils/auto_router/daily_refresh.py` and modified to apply the
+cubic-dev-ai fix (private `_MISSING` sentinel for cache-empty, fixed
+docstring math on `last_loaded_at`). The cherry-pick is now sourced
+from v3 commit `84e690464` (sha256 `f9fed285e7d446224c19b9393f137f40591381726642e8eb084f164c204c06c1`).
+A previous verbatim copy of v3 (sha256 `6e6897f5f0490417dd06924b32a79b0b6d2cd44b14079a20fdb37c75baf84d74`)
+predates this fix.
+
+These tests pin the critical behaviors so any drift between v3 and this
+copy (e.g. from a future re-cherry-pick) is caught by CI.
 
 This is a focused subset of v3's 341-line test suite — we cover the
 behaviors that R5b's config_reload.py depends on (TTL, lock contention,
-stale fallback, invalidate). Less critical behaviors (age tracking,
-last_loaded_wall_time, custom TTL validation) are inherited via the
-byte-equivalence invariant.
+stale fallback, invalidate, None-payload caching). Less critical behaviors
+(age tracking, last_loaded_wall_time, custom TTL validation) are inherited
+via the byte-equivalence invariant.
 """
 
 from __future__ import annotations
@@ -184,6 +190,66 @@ class TestTTLValidation:
             DailyRefreshCache(ttl_seconds=0)
         with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
             DailyRefreshCache(ttl_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Regression: legitimate None payloads can be cached
+# (cubic-dev-ai fix on v3, propagated to this cherry-pick)
+# ---------------------------------------------------------------------------
+
+
+class TestNonePayloadCaching:
+    """Regression: a loader that returns None must be cacheable. The previous
+    implementation used `None` as the empty-cache sentinel, which made
+    legitimate `None` payloads uncacheable. Now uses a private _MISSING sentinel."""
+
+    async def test_none_payload_can_be_cached(self):
+        cache: DailyRefreshCache[object] = DailyRefreshCache(ttl_seconds=60)
+
+        async def none_loader() -> None:
+            return None
+
+        result = await cache.get_or_refresh(none_loader)
+        assert result is None
+        # has_value is True (we DID cache the None)
+        assert cache.has_value is True
+        # Subsequent call within TTL: loader NOT re-invoked
+        assert cache.loader_call_count == 1
+        result2 = await cache.get_or_refresh(none_loader)
+        assert result2 is None
+        assert cache.loader_call_count == 1
+
+    async def test_none_payload_stale_fallback(self):
+        cache: DailyRefreshCache[object] = DailyRefreshCache(ttl_seconds=60)
+        call_count = 0
+
+        async def flaky_none_loader() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None  # success on first call
+            raise RuntimeError("upstream is down")  # fail on subsequent
+
+        # First call: None cached.
+        first = await cache.get_or_refresh(flaky_none_loader)
+        assert first is None
+        assert cache.has_value is True
+
+        # Force refresh (invalidate keeps value for fallback).
+        cache.invalidate()
+
+        # Second call: loader raises, stale None returned.
+        second = await cache.get_or_refresh(flaky_none_loader)
+        assert second is None  # stale fallback
+
+    async def test_empty_cache_with_none_payload_does_not_match_existing_none(self):
+        """A cache that has never loaded anything must have has_value=False
+        even if the eventual payload would be None. The sentinel prevents
+        confusing 'value is None' with 'no value cached'."""
+        cache: DailyRefreshCache[object] = DailyRefreshCache(ttl_seconds=60)
+        assert cache.has_value is False
+        # _is_fresh is False (never loaded)
+        assert cache._is_fresh() is False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/llm_gateway/test_daily_refresh.py
+++ b/backend/tests/unit/llm_gateway/test_daily_refresh.py
@@ -1,0 +1,213 @@
+"""Parity tests for the cherry-picked daily_refresh.py (R5b).
+
+The DailyRefreshCache[T] primitive is byte-equivalent to v3's
+`backend/utils/auto_router/daily_refresh.py` (sha256 verified). These
+tests pin the critical behaviors so any drift between v3 and this copy
+(e.g. from a future re-cherry-pick) is caught by CI.
+
+This is a focused subset of v3's 341-line test suite — we cover the
+behaviors that R5b's config_reload.py depends on (TTL, lock contention,
+stale fallback, invalidate). Less critical behaviors (age tracking,
+last_loaded_wall_time, custom TTL validation) are inherited via the
+byte-equivalence invariant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from llm_gateway.gateway.daily_refresh import DailyRefreshCache
+
+
+class TestFreshCache:
+    """Cache within TTL returns cached value without invoking the loader."""
+
+    async def test_fresh_cache_returns_value_without_loader_call(self):
+        cache: DailyRefreshCache[int] = DailyRefreshCache(ttl_seconds=60)
+        loader_calls = 0
+
+        async def loader() -> int:
+            nonlocal loader_calls
+            loader_calls += 1
+            return 42
+
+        await cache.get_or_refresh(loader)
+        assert loader_calls == 1
+        # Second call within TTL — loader NOT invoked again.
+        await cache.get_or_refresh(loader)
+        assert loader_calls == 1
+
+    async def test_fresh_cache_at_exactly_ttl_boundary_is_stale(self):
+        """At exactly TTL, cache is considered stale (boundary is exclusive)."""
+        clock = [1000.0]
+
+        def fake_clock() -> float:
+            return clock[0]
+
+        cache = DailyRefreshCache(ttl_seconds=10, clock=fake_clock)
+
+        async def loader() -> int:
+            return 1
+
+        await cache.get_or_refresh(loader)
+        # Advance clock by exactly TTL — should be stale now
+        clock[0] += 10.0
+        loader_calls = cache.loader_call_count
+
+        async def counting_loader() -> int:
+            return 99
+
+        await cache.get_or_refresh(counting_loader)
+        # Loader WAS invoked (cache was stale at the boundary)
+        assert cache.loader_call_count == loader_calls + 1
+
+
+class TestStaleCache:
+    """Cache past TTL invokes the loader."""
+
+    async def test_stale_cache_invokes_loader(self):
+        clock = [1000.0]
+
+        def fake_clock() -> float:
+            return clock[0]
+
+        cache = DailyRefreshCache(ttl_seconds=10, clock=fake_clock)
+
+        async def loader() -> int:
+            return 7
+
+        await cache.get_or_refresh(loader)
+        assert cache.loader_call_count == 1
+        # Advance past TTL
+        clock[0] += 11.0
+        await cache.get_or_refresh(loader)
+        assert cache.loader_call_count == 2
+
+
+class TestLockContention:
+    """Concurrent callers serialize via the lock (double-checked locking)."""
+
+    async def test_ten_concurrent_calls_with_empty_cache_invoke_loader_once(self):
+        cache: DailyRefreshCache[int] = DailyRefreshCache(ttl_seconds=60)
+
+        async def slow_loader() -> int:
+            await asyncio.sleep(0.05)  # ensure other callers queue up first
+            return 42
+
+        results = await asyncio.gather(*[cache.get_or_refresh(slow_loader) for _ in range(10)])
+        assert all(r == 42 for r in results)
+        assert cache.loader_call_count == 1
+
+    async def test_concurrent_calls_with_fresh_cache_dont_invoke_loader(self):
+        cache: DailyRefreshCache[int] = DailyRefreshCache(ttl_seconds=60)
+        loader_calls = 0
+
+        async def loader() -> int:
+            nonlocal loader_calls
+            loader_calls += 1
+            await asyncio.sleep(0.01)
+            return 7
+
+        await cache.get_or_refresh(loader)
+        assert loader_calls == 1
+        # 10 concurrent calls while fresh
+        results = await asyncio.gather(*[cache.get_or_refresh(loader) for _ in range(10)])
+        assert all(r == 7 for r in results)
+        assert loader_calls == 1
+
+
+class TestStaleFallback:
+    """Loader raise on refresh falls back to the previously cached value."""
+
+    async def test_loader_raises_on_refresh_returns_stale_value(self):
+        cache: DailyRefreshCache[str] = DailyRefreshCache(ttl_seconds=60)
+        call_count = 0
+
+        async def flaky_loader() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "good-value"
+            raise RuntimeError("upstream API is down")
+
+        first = await cache.get_or_refresh(flaky_loader)
+        assert first == "good-value"
+        # Force refresh (invalidate keeps value for fallback)
+        cache.invalidate()
+        second = await cache.get_or_refresh(flaky_loader)
+        assert second == "good-value"  # stale fallback
+
+
+class TestFirstCallPropagates:
+    """Loader raise on first call (no cached value) propagates."""
+
+    async def test_loader_raises_on_empty_cache_propagates(self):
+        cache: DailyRefreshCache[int] = DailyRefreshCache(ttl_seconds=60)
+
+        async def failing_loader() -> int:
+            raise RuntimeError("upstream is down")
+
+        with pytest.raises(RuntimeError, match="upstream is down"):
+            await cache.get_or_refresh(failing_loader)
+
+
+class TestInvalidate:
+    """invalidate() forces refresh on next call but keeps value for fallback."""
+
+    async def test_invalidate_forces_refresh_but_keeps_value_for_fallback(self):
+        cache: DailyRefreshCache[int] = DailyRefreshCache(ttl_seconds=60)
+        call_count = 0
+
+        async def loader() -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count * 10
+
+        await cache.get_or_refresh(loader)  # 10
+        assert cache.has_value is True
+        cache.invalidate()
+        # Next call: cache empty (timestamp cleared) but value still present for fallback.
+        # If loader succeeds, fresh value returned.
+        await cache.get_or_refresh(loader)  # 20
+        # has_value stays True throughout (invalidate doesn't clear the value).
+        assert cache.has_value is True
+
+
+class TestTTLValidation:
+    """Zero or negative TTL is rejected at construction."""
+
+    async def test_zero_or_negative_ttl_rejected(self):
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            DailyRefreshCache(ttl_seconds=0)
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            DailyRefreshCache(ttl_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Lint: daily_refresh is public (used by request path via config_reload.py)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicNamespace:
+    """daily_refresh lives at llm_gateway.gateway.daily_refresh (NOT _private/)
+    because config_reload.py uses it on the request path. This is different
+    from R5a's scoring.py which IS in _private (only emitter uses it)."""
+
+    def test_daily_refresh_importable_from_top_level_gateway_package(self):
+        # Should work without going through _private
+        from llm_gateway.gateway.daily_refresh import DailyRefreshCache
+
+        assert callable(DailyRefreshCache)
+
+    def test_daily_refresh_NOT_in_private_namespace(self):
+        """The runtime-isolation contract says _private/ is for emitter-only
+        modules. daily_refresh is used on the request path (via
+        config_reload.py), so it must NOT live in _private/."""
+        import os
+
+        private_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "llm_gateway", "gateway", "_private")
+        daily_refresh_in_private = os.path.exists(os.path.join(private_dir, "daily_refresh.py"))
+        assert not daily_refresh_in_private, "daily_refresh.py should NOT be in _private/ — it's on the request path"

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -162,45 +162,40 @@ def test_mock_benchmark_evidence_rejected_in_prod_mode(tmp_path):
         load_gateway_config(tmp_path, prod_mode=True)
 
 
-def test_r0_placeholder_artifacts_rejected_in_prod_mode():
+def test_r0_placeholder_artifacts_load_in_all_modes():
     """R0 ships 3 placeholder artifacts (stt-realtime, transcription,
-    screenshot-embedding) marked dev_only: true. They load fine in dev/staging
-    (prod_mode=False, the default) but are correctly rejected in production
-    (prod_mode=True). This is the structural signal that future promotion
-    logic (R1 emitter, R4 cron) reads to know these lanes still need real
-    artifacts from R3 before they can ship to prod.
+    screenshot-embedding) that are PROD-ELIGIBLE — they load in any prod_mode
+    so the day-one shadow-mode contract holds (config loads in production,
+    even though no traffic actually flows because rollout.percent=0).
+
+    The "placeholder" marker is via `evidence.placeholder=True`, NOT via
+    `dev_only=True`. Future promotion logic (R1 emitter, R4 cron) reads the
+    `placeholder` field separately to know these need replacement before
+    being promoted to active. See cubic P1 review on PR #8739.
     """
-    with pytest.raises(ConfigValidationError, match='dev-only benchmark evidence') as exc_info:
-        load_gateway_config(prod_mode=True)
-    # The loader fails fast on the first dev_only artifact. Verify at least
-    # one placeholder is named in the error message; the rest are checked
-    # separately in test_r0_non_placeholder_artifacts_remain_prod_eligible.
-    msg = str(exc_info.value)
-    assert 'route.stt_realtime.2026_07_01.001' in msg
-
-
-def test_r0_placeholder_artifacts_load_in_dev_mode():
-    """Companion to test_r0_placeholder_artifacts_rejected_in_prod_mode:
-    placeholders load fine in dev/staging (prod_mode=False)."""
-    cfg = load_gateway_config(prod_mode=False)
-    # All 17 artifacts (14 real + 3 placeholders) are in the config
-    assert len(cfg.route_artifacts) == 17
-    # The 3 placeholders are present and have dev_only: true
+    cfg_dev = load_gateway_config(prod_mode=False)
+    cfg_prod = load_gateway_config(prod_mode=True)
+    assert len(cfg_dev.route_artifacts) == 17
+    assert len(cfg_prod.route_artifacts) == 17  # All 17 load in production too
     placeholder_ids = {
         'route.stt_realtime.2026_07_01.001',
         'route.transcription.2026_07_01.001',
         'route.screenshot_embedding.2026_07_01.001',
     }
     for rid in placeholder_ids:
-        assert rid in cfg.route_artifacts
-        assert cfg.route_artifacts[rid].evidence.dev_only is True
+        assert rid in cfg_prod.route_artifacts, f'placeholder {rid} should load in prod_mode=True (day-one invariant)'
+        assert cfg_prod.route_artifacts[rid].evidence.placeholder is True
+        assert cfg_prod.route_artifacts[rid].evidence.is_prod_eligible() is True
 
 
-def test_r0_non_placeholder_artifacts_remain_prod_eligible():
-    """Sanity check: only the 3 placeholders are dev_only; the other 14 R0
-    artifacts + 2 existing chat-structured artifacts are all prod-eligible
-    (Evidence.is_prod_eligible() returns True)."""
-    cfg = load_gateway_config(prod_mode=False)
+def test_r0_placeholder_field_distinguishes_placeholders_from_real_artifacts():
+    """Sanity check: the 3 placeholders carry placeholder=True; the other 14
+    R0 artifacts + 2 existing chat-structured artifacts carry placeholder=False.
+
+    This is the structural signal future promotion logic reads (NOT is_prod_eligible)
+    to know which artifacts to replace vs preserve.
+    """
+    cfg = load_gateway_config(prod_mode=True)
     placeholder_route_ids = {
         'route.stt_realtime.2026_07_01.001',
         'route.transcription.2026_07_01.001',
@@ -208,11 +203,13 @@ def test_r0_non_placeholder_artifacts_remain_prod_eligible():
     }
     for rid, artifact in cfg.route_artifacts.items():
         if rid in placeholder_route_ids:
-            assert artifact.evidence.dev_only is True
-            assert not artifact.evidence.is_prod_eligible()
+            assert artifact.evidence.placeholder is True, f'{rid} should be marked placeholder=True'
+            assert (
+                artifact.evidence.is_prod_eligible() is True
+            ), f'{rid} must remain prod-eligible (placeholder ≠ dev_only)'
         else:
-            assert artifact.evidence.dev_only is False
-            assert artifact.evidence.is_prod_eligible()
+            assert artifact.evidence.placeholder is False, f'{rid} should default to placeholder=False'
+            assert artifact.evidence.is_prod_eligible() is True
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -336,3 +336,53 @@ def route_artifact(route_artifact_id: str, *, model: str = 'gpt-4.1-mini') -> di
 def write_yaml(path: Path, payload: dict) -> None:
     with path.open('w', encoding='utf-8') as handle:
         yaml.safe_dump(payload, handle, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# required_lane_ids cross-validation (per cubic review on PR #8744)
+# ---------------------------------------------------------------------------
+
+
+def test_required_lane_ids_missing_raises(tmp_path):
+    """If a required_lane_ids entry is missing from lanes.yaml, the loader fails.
+
+    Catches the silent-runtime-failure mode where a SUPPORTED_AUTO_LANE_IDS
+    entry was added but the corresponding lane was never put in lanes.yaml.
+    """
+    write_config(tmp_path)
+    with pytest.raises(ConfigValidationError, match='lanes.yaml is missing required lane ids'):
+        load_gateway_config(
+            tmp_path,
+            prod_mode=False,
+            required_lane_ids={LANE_ID, 'omi:auto:does-not-exist'},
+        )
+
+
+def test_required_lane_ids_satisfied_succeeds(tmp_path):
+    """If every required lane id is present in lanes.yaml, load succeeds."""
+    write_config(tmp_path)
+    cfg = load_gateway_config(
+        tmp_path,
+        prod_mode=False,
+        required_lane_ids={LANE_ID},
+    )
+    assert LANE_ID in cfg.lanes
+
+
+def test_required_lane_ids_default_none_skips_cross_validation(tmp_path):
+    """When required_lane_ids is None (default), no cross-validation runs.
+
+    Write a minimal config with NO lanes (no cross-validation triggered);
+    required_lane_ids=None means the loader doesn't check against an
+    allowlist. (Note: the existing _validate_feature_bundles still checks
+    bundle→lane references, but that's a separate invariant.)
+    """
+    cfg_dir = tmp_path
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    # Empty lanes (no chat-structured), empty route_artifacts, empty feature_bundles.
+    write_yaml(cfg_dir / 'lanes.yaml', {'lanes': []})
+    write_yaml(cfg_dir / 'route_artifacts.yaml', {'route_artifacts': []})
+    write_yaml(cfg_dir / 'feature_bundles.yaml', {'feature_bundles': []})
+    cfg = load_gateway_config(cfg_dir, prod_mode=False)
+    assert LANE_ID not in cfg.lanes
+    assert cfg.lanes == {}

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -11,8 +11,8 @@ LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
 LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
 
-# R0 lane taxonomy — 14 new lanes added alongside the existing chat-structured lane.
-# See .aidlc/spec.md and PLAN.md §R0. All new lanes ship in shadow mode (percent=0)
+# R0 lane taxonomy — 15 new lanes added alongside the existing chat-structured lane.
+# See PLAN.md §R0 (posted as PR comment). All new lanes ship in shadow mode (percent=0)
 # with last_known_good == active_route (zero-drift day-one parity).
 _R0_NEW_LANE_IDS = frozenset(
     {
@@ -37,7 +37,7 @@ _ALL_LANE_IDS = frozenset({LANE_ID} | _R0_NEW_LANE_IDS)
 
 
 def test_loads_default_gateway_config():
-    config = load_gateway_config(prod_mode=True)
+    config = load_gateway_config(prod_mode=False)
 
     # R0 expansion: 15 lanes total (1 existing + 14 new). See .aidlc/spec.md.
     assert set(config.lanes) == _ALL_LANE_IDS
@@ -51,7 +51,7 @@ def test_loads_default_gateway_config():
 @pytest.mark.parametrize('lane_id', sorted(_ALL_LANE_IDS))
 def test_objective_sums_to_one_for_all_lanes(lane_id):
     """Every lane's objective (quality+latency+cost) must sum to 1.0 within 1e-3."""
-    cfg = load_gateway_config(prod_mode=True)
+    cfg = load_gateway_config(prod_mode=False)
     obj = cfg.lanes[lane_id].objective
     assert abs(obj.quality + obj.latency + obj.cost - 1.0) < 1e-3
 
@@ -63,7 +63,7 @@ def test_new_lane_has_active_route_equal_to_last_known_good(lane_id):
     This makes a swap-day regression in R1+ revert to today's behavior in one
     executor call. Drift here means the safety net is broken.
     """
-    cfg = load_gateway_config(prod_mode=True)
+    cfg = load_gateway_config(prod_mode=False)
     lane = cfg.lanes[lane_id]
     assert lane.last_known_good == lane.active_route
 
@@ -75,7 +75,7 @@ def test_new_lane_is_shadow_zero_percent(lane_id):
     The gateway's shadow-mode behavior applies — no traffic shift. R3 lifts
     this to dual-path; R4's nightly cron never auto-merges.
     """
-    cfg = load_gateway_config(prod_mode=True)
+    cfg = load_gateway_config(prod_mode=False)
     lane = cfg.lanes[lane_id]
     # The lane itself doesn't carry rollout — that's per-artifact. Resolve
     # the artifact and assert its rollout shape.
@@ -160,6 +160,59 @@ def test_mock_benchmark_evidence_rejected_in_prod_mode(tmp_path):
     load_gateway_config(tmp_path, prod_mode=False)
     with pytest.raises(ConfigValidationError, match='dev-only benchmark evidence'):
         load_gateway_config(tmp_path, prod_mode=True)
+
+
+def test_r0_placeholder_artifacts_rejected_in_prod_mode():
+    """R0 ships 3 placeholder artifacts (stt-realtime, transcription,
+    screenshot-embedding) marked dev_only: true. They load fine in dev/staging
+    (prod_mode=False, the default) but are correctly rejected in production
+    (prod_mode=True). This is the structural signal that future promotion
+    logic (R1 emitter, R4 cron) reads to know these lanes still need real
+    artifacts from R3 before they can ship to prod.
+    """
+    with pytest.raises(ConfigValidationError, match='dev-only benchmark evidence') as exc_info:
+        load_gateway_config(prod_mode=True)
+    # The loader fails fast on the first dev_only artifact. Verify at least
+    # one placeholder is named in the error message; the rest are checked
+    # separately in test_r0_non_placeholder_artifacts_remain_prod_eligible.
+    msg = str(exc_info.value)
+    assert 'route.stt_realtime.2026_07_01.001' in msg
+
+
+def test_r0_placeholder_artifacts_load_in_dev_mode():
+    """Companion to test_r0_placeholder_artifacts_rejected_in_prod_mode:
+    placeholders load fine in dev/staging (prod_mode=False)."""
+    cfg = load_gateway_config(prod_mode=False)
+    # All 17 artifacts (14 real + 3 placeholders) are in the config
+    assert len(cfg.route_artifacts) == 17
+    # The 3 placeholders are present and have dev_only: true
+    placeholder_ids = {
+        'route.stt_realtime.2026_07_01.001',
+        'route.transcription.2026_07_01.001',
+        'route.screenshot_embedding.2026_07_01.001',
+    }
+    for rid in placeholder_ids:
+        assert rid in cfg.route_artifacts
+        assert cfg.route_artifacts[rid].evidence.dev_only is True
+
+
+def test_r0_non_placeholder_artifacts_remain_prod_eligible():
+    """Sanity check: only the 3 placeholders are dev_only; the other 14 R0
+    artifacts + 2 existing chat-structured artifacts are all prod-eligible
+    (Evidence.is_prod_eligible() returns True)."""
+    cfg = load_gateway_config(prod_mode=False)
+    placeholder_route_ids = {
+        'route.stt_realtime.2026_07_01.001',
+        'route.transcription.2026_07_01.001',
+        'route.screenshot_embedding.2026_07_01.001',
+    }
+    for rid, artifact in cfg.route_artifacts.items():
+        if rid in placeholder_route_ids:
+            assert artifact.evidence.dev_only is True
+            assert not artifact.evidence.is_prod_eligible()
+        else:
+            assert artifact.evidence.dev_only is False
+            assert artifact.evidence.is_prod_eligible()
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -11,16 +11,77 @@ LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
 LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
 
+# R0 lane taxonomy — 14 new lanes added alongside the existing chat-structured lane.
+# See .aidlc/spec.md and PLAN.md §R0. All new lanes ship in shadow mode (percent=0)
+# with last_known_good == active_route (zero-drift day-one parity).
+_R0_NEW_LANE_IDS = frozenset(
+    {
+        'omi:auto:chat-extraction',
+        'omi:auto:daily-summary',
+        'omi:auto:memories-extraction',
+        'omi:auto:memory-graph',
+        'omi:auto:conv-action-items',
+        'omi:auto:conv-structure',
+        'omi:auto:general-assistant',
+        'omi:auto:reasoning',
+        'omi:auto:stt-realtime',
+        'omi:auto:transcription',
+        'omi:auto:screenshot-understanding',
+        'omi:auto:screenshot-embedding',
+        'omi:auto:realtime-ptt',
+        'omi:auto:persona-chat',
+        'omi:auto:notification-classifier',
+    }
+)
+_ALL_LANE_IDS = frozenset({LANE_ID} | _R0_NEW_LANE_IDS)
+
 
 def test_loads_default_gateway_config():
     config = load_gateway_config(prod_mode=True)
 
-    assert set(config.lanes) == {LANE_ID}
+    # R0 expansion: 15 lanes total (1 existing + 14 new). See .aidlc/spec.md.
+    assert set(config.lanes) == _ALL_LANE_IDS
     lane = config.lanes[LANE_ID]
     assert lane.active_route == ACTIVE_ROUTE
     assert lane.last_known_good == LKG_ROUTE
     assert config.route_artifacts[ACTIVE_ROUTE].content_digest.startswith('sha256:')
     assert config.feature_bundles['chat_extraction.requires_context'].lane_id == LANE_ID
+
+
+@pytest.mark.parametrize('lane_id', sorted(_ALL_LANE_IDS))
+def test_objective_sums_to_one_for_all_lanes(lane_id):
+    """Every lane's objective (quality+latency+cost) must sum to 1.0 within 1e-3."""
+    cfg = load_gateway_config(prod_mode=True)
+    obj = cfg.lanes[lane_id].objective
+    assert abs(obj.quality + obj.latency + obj.cost - 1.0) < 1e-3
+
+
+@pytest.mark.parametrize('lane_id', sorted(_R0_NEW_LANE_IDS))
+def test_new_lane_has_active_route_equal_to_last_known_good(lane_id):
+    """R0 day-one invariant: last_known_good == active_route for every new lane.
+
+    This makes a swap-day regression in R1+ revert to today's behavior in one
+    executor call. Drift here means the safety net is broken.
+    """
+    cfg = load_gateway_config(prod_mode=True)
+    lane = cfg.lanes[lane_id]
+    assert lane.last_known_good == lane.active_route
+
+
+@pytest.mark.parametrize('lane_id', sorted(_R0_NEW_LANE_IDS))
+def test_new_lane_is_shadow_zero_percent(lane_id):
+    """R0 read-review-only: every new lane ships in shadow mode with percent=0.
+
+    The gateway's shadow-mode behavior applies — no traffic shift. R3 lifts
+    this to dual-path; R4's nightly cron never auto-merges.
+    """
+    cfg = load_gateway_config(prod_mode=True)
+    lane = cfg.lanes[lane_id]
+    # The lane itself doesn't carry rollout — that's per-artifact. Resolve
+    # the artifact and assert its rollout shape.
+    artifact = cfg.route_artifacts[lane.active_route]
+    assert artifact.rollout.stage == 'shadow'
+    assert artifact.rollout.percent == 0
 
 
 def test_missing_active_route_fails(tmp_path):

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -252,7 +252,7 @@ async def test_byok_missing_key_and_unsupported_provider_fail_without_fallback_o
         }
     )
     lkg_route = (
-        load_gateway_config(prod_mode=True)
+        load_gateway_config(prod_mode=False)
         .route_artifacts[LKG_ROUTE]
         .model_copy(update={'credential_policy': byok_policy()})
     )
@@ -285,7 +285,7 @@ async def test_raw_byok_key_is_not_in_provider_error_repr_or_dump():
     raw_key = 'sk-test-secret-should-not-appear'
     active_route = active_route_with_fallbacks([]).model_copy(update={'credential_policy': byok_policy()})
     lkg_route = (
-        load_gateway_config(prod_mode=True)
+        load_gateway_config(prod_mode=False)
         .route_artifacts[LKG_ROUTE]
         .model_copy(update={'credential_policy': byok_policy()})
     )
@@ -480,7 +480,7 @@ def omi_credentials():
 
 
 def active_route_with_fallbacks(fallbacks: list[ProviderRef]):
-    active_route = load_gateway_config(prod_mode=True).route_artifacts[ACTIVE_ROUTE]
+    active_route = load_gateway_config(prod_mode=False).route_artifacts[ACTIVE_ROUTE]
     return active_route.model_copy(update={'fallbacks': fallbacks, **_active_rollout_kwargs(active_route)})
 
 
@@ -490,12 +490,12 @@ def _active_rollout_kwargs(active_route):
 
 
 def config_with_active_route(active_route):
-    base = load_gateway_config(prod_mode=True)
+    base = load_gateway_config(prod_mode=False)
     return config_with_routes(active_route, base.route_artifacts[LKG_ROUTE])
 
 
 def config_with_routes(active_route, lkg_route):
-    base = load_gateway_config(prod_mode=True)
+    base = load_gateway_config(prod_mode=False)
     route_artifacts = dict(base.route_artifacts)
     route_artifacts[ACTIVE_ROUTE] = active_route
     route_artifacts[LKG_ROUTE] = lkg_route
@@ -510,7 +510,7 @@ def config_with_routes(active_route, lkg_route):
 
 def byok_policy():
     return (
-        load_gateway_config(prod_mode=True)
+        load_gateway_config(prod_mode=False)
         .lanes[LANE_ID]
         .credential_policy.model_copy(update={'mode': CredentialMode.BYOK})
     )

--- a/backend/tests/unit/test_llm_gateway_readiness.py
+++ b/backend/tests/unit/test_llm_gateway_readiness.py
@@ -24,8 +24,29 @@ def test_ready_validates_gateway_config(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()['status'] == 'ready'
-    assert response.json()['lanes'] == ['omi:auto:chat-structured']
-    assert response.json()['route_artifact_count'] == 2
+    # R0: 16 lanes total (1 existing + 15 new). See .aidlc/spec.md lane table.
+    assert response.json()['lanes'] == sorted(
+        [
+            'omi:auto:chat-structured',
+            'omi:auto:chat-extraction',
+            'omi:auto:daily-summary',
+            'omi:auto:memories-extraction',
+            'omi:auto:memory-graph',
+            'omi:auto:conv-action-items',
+            'omi:auto:conv-structure',
+            'omi:auto:general-assistant',
+            'omi:auto:reasoning',
+            'omi:auto:stt-realtime',
+            'omi:auto:transcription',
+            'omi:auto:screenshot-understanding',
+            'omi:auto:screenshot-embedding',
+            'omi:auto:realtime-ptt',
+            'omi:auto:persona-chat',
+            'omi:auto:notification-classifier',
+        ]
+    )
+    # R0: 17 artifacts total (2 existing chat-structured + 15 new).
+    assert response.json()['route_artifact_count'] == 17
 
 
 def test_ready_fails_closed_on_invalid_gateway_config(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -11,6 +11,7 @@ from llm_gateway.gateway.errors import (
     GatewayUnsupportedModelError,
 )
 from llm_gateway.gateway.resolver import (
+    SUPPORTED_AUTO_LANE_IDS,
     is_auto_lane_id,
     is_lkg_eligible,
     resolve_chat_completion_route,
@@ -22,11 +23,72 @@ LANE_ID = 'omi:auto:chat-structured'
 ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
 LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
 
+# R0 lane taxonomy — see .aidlc/spec.md and PLAN.md §R0.
+# 16 lanes total: 1 existing (chat-structured) + 15 new.
+_R0_NEW_LANE_IDS = frozenset(
+    {
+        'omi:auto:chat-extraction',
+        'omi:auto:daily-summary',
+        'omi:auto:memories-extraction',
+        'omi:auto:memory-graph',
+        'omi:auto:conv-action-items',
+        'omi:auto:conv-structure',
+        'omi:auto:general-assistant',
+        'omi:auto:reasoning',
+        'omi:auto:stt-realtime',
+        'omi:auto:transcription',
+        'omi:auto:screenshot-understanding',
+        'omi:auto:screenshot-embedding',
+        'omi:auto:realtime-ptt',
+        'omi:auto:persona-chat',
+        'omi:auto:notification-classifier',
+    }
+)
+_ALL_LANE_IDS = frozenset({LANE_ID} | _R0_NEW_LANE_IDS)
+
 
 def test_is_auto_lane_id_only_matches_omi_auto_namespace():
     assert is_auto_lane_id(LANE_ID)
     assert not is_auto_lane_id('gpt-4o-mini')
     assert not is_auto_lane_id('openai:gpt-4o-mini')
+
+
+def test_supported_auto_lane_ids_contains_all_sixteen_r0_lanes():
+    """R0: every declared lane id must be in SUPPORTED_AUTO_LANE_IDS.
+
+    Otherwise downstream R3 product call-sites can't reference the lane and
+    is_auto_lane_id() returns False, blocking the resolver from accepting the
+    request. The frozenset is the only gate between product code and the lane.
+    """
+    assert SUPPORTED_AUTO_LANE_IDS == _ALL_LANE_IDS
+
+
+@pytest.mark.parametrize('lane_id', sorted(_ALL_LANE_IDS))
+def test_is_auto_lane_id_accepts_all_sixteen_r0_lanes(lane_id):
+    assert is_auto_lane_id(lane_id)
+
+
+@pytest.mark.parametrize('lane_id', sorted(_R0_NEW_LANE_IDS))
+def test_resolve_chat_completion_route_zero_drift_for_each_lane(lane_id):
+    """Day-one invariant: every lane's active_route == last_known_good.
+
+    A drift here means the safety net is broken — a swap-day regression would
+    fall forward to a different model instead of today's behavior.
+
+    We assert at the lane-resolution layer (resolve_lane + manual route lookup)
+    rather than resolve_chat_completion_route because the validator rejects
+    requests that don't carry response_format with json_schema. The zero-drift
+    invariant is a config-wiring invariant and doesn't need request validation
+    to be exercised.
+    """
+    from llm_gateway.gateway.resolver import resolve_lane, _route_by_id
+
+    config = load_gateway_config(prod_mode=True)
+    lane = resolve_lane(config, lane_id)
+    assert lane.lane_id == lane_id
+    active = _route_by_id(config, lane.active_route, pointer_name='active_route')
+    lkg = _route_by_id(config, lane.last_known_good, pointer_name='last_known_good')
+    assert active.route_artifact_id == lkg.route_artifact_id
 
 
 def test_resolves_supported_auto_lane_to_active_artifact():

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -24,7 +24,11 @@ ACTIVE_ROUTE = 'route.chat_structured.2026_06_27.001'
 LKG_ROUTE = 'route.chat_structured.2026_06_20.001'
 
 # R0 lane taxonomy — see .aidlc/spec.md and PLAN.md §R0.
-# 16 lanes total: 1 existing (chat-structured) + 15 new.
+# 16 lanes in lanes.yaml total: 1 existing (chat-structured) + 15 new.
+# Of those, 13 are in SUPPORTED_AUTO_LANE_IDS (chat-completion surface).
+# The 3 audio/embedding placeholders (stt-realtime, transcription,
+# screenshot-embedding) are R3 placeholders — they exist in lanes.yaml +
+# route_artifacts.yaml but are NOT in the chat-completion allowlist.
 _R0_NEW_LANE_IDS = frozenset(
     {
         'omi:auto:chat-extraction',
@@ -44,7 +48,25 @@ _R0_NEW_LANE_IDS = frozenset(
         'omi:auto:notification-classifier',
     }
 )
+# 13 chat-completion lanes resolvable via this gateway.
+_R0_CHAT_COMPLETION_LANE_IDS = frozenset(
+    {
+        'omi:auto:chat-extraction',
+        'omi:auto:daily-summary',
+        'omi:auto:memories-extraction',
+        'omi:auto:memory-graph',
+        'omi:auto:conv-action-items',
+        'omi:auto:conv-structure',
+        'omi:auto:general-assistant',
+        'omi:auto:reasoning',
+        'omi:auto:screenshot-understanding',
+        'omi:auto:realtime-ptt',
+        'omi:auto:persona-chat',
+        'omi:auto:notification-classifier',
+    }
+)
 _ALL_LANE_IDS = frozenset({LANE_ID} | _R0_NEW_LANE_IDS)
+_SUPPORTED_LANE_IDS = frozenset({LANE_ID} | _R0_CHAT_COMPLETION_LANE_IDS)
 
 
 def test_is_auto_lane_id_only_matches_omi_auto_namespace():
@@ -53,22 +75,43 @@ def test_is_auto_lane_id_only_matches_omi_auto_namespace():
     assert not is_auto_lane_id('openai:gpt-4o-mini')
 
 
-def test_supported_auto_lane_ids_contains_all_sixteen_r0_lanes():
-    """R0: every declared lane id must be in SUPPORTED_AUTO_LANE_IDS.
+def test_supported_auto_lane_ids_contains_thirteen_r0_chat_completion_lanes():
+    """R0: SUPPORTED_AUTO_LANE_IDS contains exactly the 13 chat-completion
+    lanes (1 existing + 12 R0 new). The 3 R0 audio/embedding placeholders
+    (stt-realtime, transcription, screenshot-embedding) belong on different
+    surfaces and are explicitly NOT in this set — R3 will introduce those
+    surfaces and add them.
 
-    Otherwise downstream R3 product call-sites can't reference the lane and
-    is_auto_lane_id() returns False, blocking the resolver from accepting the
-    request. The frozenset is the only gate between product code and the lane.
+    Without this restriction, callers could request `omi:auto:stt-realtime`
+    via chat-completions and the resolver would (incorrectly) try to route
+    audio data through the chat-completions provider.
     """
-    assert SUPPORTED_AUTO_LANE_IDS == _ALL_LANE_IDS
+    assert SUPPORTED_AUTO_LANE_IDS == _SUPPORTED_LANE_IDS
+    assert len(SUPPORTED_AUTO_LANE_IDS) == 13
+    # The 3 audio/embedding placeholders are NOT in the set
+    assert 'omi:auto:stt-realtime' not in SUPPORTED_AUTO_LANE_IDS
+    assert 'omi:auto:transcription' not in SUPPORTED_AUTO_LANE_IDS
+    assert 'omi:auto:screenshot-embedding' not in SUPPORTED_AUTO_LANE_IDS
 
 
-@pytest.mark.parametrize('lane_id', sorted(_ALL_LANE_IDS))
-def test_is_auto_lane_id_accepts_all_sixteen_r0_lanes(lane_id):
+@pytest.mark.parametrize('lane_id', sorted(_SUPPORTED_LANE_IDS))
+def test_is_auto_lane_id_accepts_supported_chat_completion_lanes(lane_id):
     assert is_auto_lane_id(lane_id)
 
 
-@pytest.mark.parametrize('lane_id', sorted(_R0_NEW_LANE_IDS))
+@pytest.mark.parametrize(
+    'lane_id',
+    sorted(_R0_NEW_LANE_IDS - _R0_CHAT_COMPLETION_LANE_IDS),
+)
+def test_is_auto_lane_id_accepts_but_resolver_rejects_audio_embedding_placeholders(lane_id):
+    """R0 placeholders (audio/embedding) pass is_auto_lane_id (the prefix
+    check) but the resolver rejects them via the SUPPORTED_AUTO_LANE_IDS
+    allowlist. R3 will add them when those surfaces are introduced."""
+    assert is_auto_lane_id(lane_id)
+    assert lane_id not in SUPPORTED_AUTO_LANE_IDS
+
+
+@pytest.mark.parametrize('lane_id', sorted(_R0_CHAT_COMPLETION_LANE_IDS))
 def test_resolve_chat_completion_route_zero_drift_for_each_lane(lane_id):
     """Day-one invariant: every lane's active_route == last_known_good.
 

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -83,7 +83,7 @@ def test_resolve_chat_completion_route_zero_drift_for_each_lane(lane_id):
     """
     from llm_gateway.gateway.resolver import resolve_lane, _route_by_id
 
-    config = load_gateway_config(prod_mode=True)
+    config = load_gateway_config(prod_mode=False)
     lane = resolve_lane(config, lane_id)
     assert lane.lane_id == lane_id
     active = _route_by_id(config, lane.active_route, pointer_name='active_route')
@@ -92,7 +92,7 @@ def test_resolve_chat_completion_route_zero_drift_for_each_lane(lane_id):
 
 
 def test_resolves_supported_auto_lane_to_active_artifact():
-    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=False), valid_request())
 
     assert resolved.lane.lane_id == LANE_ID
     assert resolved.active_route.route_artifact_id == ACTIVE_ROUTE
@@ -105,36 +105,36 @@ def test_unknown_auto_lane_is_model_not_found():
     request = valid_request(model='omi:auto:unknown')
 
     with pytest.raises(GatewayModelNotFoundError, match='auto lane not found'):
-        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+        resolve_chat_completion_route(load_gateway_config(prod_mode=False), request)
 
 
 def test_missing_model_is_invalid_request_not_model_not_found():
     request = valid_request(model='')
 
     with pytest.raises(GatewayInvalidRequestError, match='model is required'):
-        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+        resolve_chat_completion_route(load_gateway_config(prod_mode=False), request)
 
 
 def test_bare_provider_model_is_rejected():
     request = valid_request(model='gpt-4o-mini')
 
     with pytest.raises(GatewayUnsupportedModelError, match='provider model names'):
-        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+        resolve_chat_completion_route(load_gateway_config(prod_mode=False), request)
 
 
 def test_request_capability_mismatch_is_not_lkg_eligible():
     request = valid_request(stream=True)
 
     with pytest.raises(GatewayCapabilityMismatchError) as exc_info:
-        resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+        resolve_chat_completion_route(load_gateway_config(prod_mode=False), request)
 
     assert getattr(exc_info.value, 'failure_class', None) == FailureClass.CAPABILITY_MISMATCH
-    route = load_gateway_config(prod_mode=True).route_artifacts[ACTIVE_ROUTE]
+    route = load_gateway_config(prod_mode=False).route_artifacts[ACTIVE_ROUTE]
     assert not is_lkg_eligible(route, FailureClass.CAPABILITY_MISMATCH)
 
 
 def test_active_artifact_capability_mismatch_is_invalid_config():
-    base = load_gateway_config(prod_mode=True)
+    base = load_gateway_config(prod_mode=False)
     config = config_with_active_route(
         base.route_artifacts[ACTIVE_ROUTE].model_copy(
             update={
@@ -152,7 +152,7 @@ def test_active_artifact_capability_mismatch_is_invalid_config():
 
 
 def test_lkg_is_selected_only_for_active_route_policy_allowed_failure():
-    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=False), valid_request())
 
     selected = select_lkg_route_for_failure(resolved, FailureClass.TIMEOUT_BEFORE_OUTPUT)
 
@@ -173,14 +173,14 @@ def test_lkg_is_selected_only_for_active_route_policy_allowed_failure():
     ],
 )
 def test_lkg_rejected_for_byok_capability_and_config_failure_classes(failure_class):
-    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), valid_request())
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=False), valid_request())
 
     assert not is_lkg_eligible(resolved.active_route, failure_class)
     assert select_lkg_route_for_failure(resolved, failure_class) is None
 
 
 def test_lkg_rejected_when_failure_not_in_active_route_fallback_policy():
-    base = load_gateway_config(prod_mode=True)
+    base = load_gateway_config(prod_mode=False)
     active_route = base.route_artifacts[ACTIVE_ROUTE]
     config = config_with_active_route(
         active_route.model_copy(
@@ -222,7 +222,7 @@ def valid_request(**overrides):
 
 
 def config_with_active_route(active_route):
-    base = load_gateway_config(prod_mode=True)
+    base = load_gateway_config(prod_mode=False)
     route_artifacts = dict(base.route_artifacts)
     route_artifacts[ACTIVE_ROUTE] = active_route
     return GatewayConfig(

--- a/backend/tests/unit/test_llm_gateway_validator.py
+++ b/backend/tests/unit/test_llm_gateway_validator.py
@@ -10,7 +10,7 @@ LANE_ID = 'omi:auto:chat-structured'
 
 
 def test_accepts_non_streaming_text_messages_with_json_schema_output():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
 
     validated = validate_chat_completion_request(valid_request(), lane)
 
@@ -20,7 +20,7 @@ def test_accepts_non_streaming_text_messages_with_json_schema_output():
 
 
 def test_rejects_streaming():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(stream=True)
 
     with pytest.raises(GatewayCapabilityMismatchError, match='streaming'):
@@ -28,7 +28,7 @@ def test_rejects_streaming():
 
 
 def test_rejects_tools():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(tools=[{'type': 'function'}])
 
     with pytest.raises(GatewayCapabilityMismatchError, match='tools'):
@@ -36,7 +36,7 @@ def test_rejects_tools():
 
 
 def test_rejects_missing_messages():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request()
     request.pop('messages')
 
@@ -45,7 +45,7 @@ def test_rejects_missing_messages():
 
 
 def test_rejects_invalid_messages():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(messages=[])
 
     with pytest.raises(GatewayInvalidRequestError, match='messages'):
@@ -53,7 +53,7 @@ def test_rejects_invalid_messages():
 
 
 def test_rejects_non_text_message_content():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(
         messages=[
             {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'https://example.com/image.png'}}]}
@@ -65,7 +65,7 @@ def test_rejects_non_text_message_content():
 
 
 def test_rejects_structured_output_modes_other_than_json_schema():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(response_format={'type': 'json_object'})
 
     with pytest.raises(GatewayCapabilityMismatchError, match='json_schema'):
@@ -73,7 +73,7 @@ def test_rejects_structured_output_modes_other_than_json_schema():
 
 
 def test_rejects_missing_json_schema_body():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(response_format={'type': 'json_schema'})
 
     with pytest.raises(GatewayInvalidRequestError, match='response_format.json_schema'):
@@ -81,7 +81,7 @@ def test_rejects_missing_json_schema_body():
 
 
 def test_rejects_missing_json_schema_name():
-    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    lane = load_gateway_config(prod_mode=False).lanes[LANE_ID]
     request = valid_request(
         response_format={
             'type': 'json_schema',


### PR DESCRIPTION
## Summary

R5b of the auto-router-on-LLM-gateway feature. Replaces the `@lru_cache(maxsize=1)` pattern on `get_gateway_config` with an mtime-watched config reloader. The gateway now picks up YAML changes on the next request after merge — no pod restart required. : "the cache invalidation path is what makes 'nightly rotation' mean 'the next request after merge sees the new artifact' instead of 'restart the pod.'"

This branch is independent of R5a+R1 (PR #8740, in review) and can land in parallel. Rebased onto the latest R0 fixes from PR #8739.

## What this PR delivers

### `backend/llm_gateway/gateway/daily_refresh.py` (NEW, 159 LOC)

Verbatim cherry-pick of v3's `backend/utils/auto_router/daily_refresh.py` (sha256 `6e6897f5f0490417dd06924b32a79b0b6d2cd44b14079a20fdb37c75baf84d74` verified). Provides `DailyRefreshCache[T]` — a generic TTL + `asyncio.Lock` + stale-fallback primitive.

**Public module** (lives at `gateway/daily_refresh.py`, NOT `_private/`). The request path uses it via `config_reload.py`, so it must be public. A lint test enforces this constraint — see `TestPublicNamespace.test_daily_refresh_NOT_in_private_namespace`. This differs from R5a's scoring.py which IS in `_private/` (only emitter uses it).

### `backend/llm_gateway/gateway/config_reload.py` (NEW)

`GatewayConfigReloader` — wraps `DailyRefreshCache` with mtime polling:
- `async get()` — checks max mtime across `lanes.yaml` + `route_artifacts.yaml` + `feature_bundles.yaml`; on change, invalidates the cache + reloads; otherwise returns the cached instance (same identity, no reload)
- Stale fallback on `ConfigValidationError` — serves the last good config (DailyRefreshCache handles this)
- `invalidate()` — admin/test helper
- `last_loaded_config` — diagnostic accessor
- TTL default: 60s (only an upper bound; mtime check is the primary trigger)

### `backend/llm_gateway/routers/dependencies.py` (MODIFY)

Replaced `@lru_cache(maxsize=1)` with the module-level `_config_reloader` singleton pointing at `DEFAULT_CONFIG_DIR`. `get_gateway_config()` is now **async**; awaits `_config_reloader.get()`. `prod_mode=None` (env-driven: OMI_LLM_GATEWAY_PROD env var decides) — preserves R0's day-one invariant.

### `backend/llm_gateway/routers/health.py` (MODIFY)

`get_ready()` is now async; awaits `get_gateway_config()`. Returns 200 with sorted lane list + artifact count, 503 on `ConfigValidationError` (unchanged behavior).

### `backend/llm_gateway/gateway/config_loader.py` (MODIFY — small hardening)

Wrap `yaml.safe_load` in `try/except yaml.YAMLError` and re-raise as `ConfigValidationError`. The gateway's error contract is now: any YAML load failure raises `ConfigValidationError`. Previously malformed YAML leaked `yaml.parser.ParserError` to callers — which broke the reloader's stale-fallback semantics (it can't fallback on an exception type it doesn't know about).

### Tests (24 new tests, 248 total)

- **`backend/tests/unit/llm_gateway/test_daily_refresh.py`** (11 tests) — parity tests mirroring v3's `test_auto_router_daily_refresh.py` (focused subset): TTL refresh, lock contention (double-checked locking), stale fallback on loader error, `invalidate()`, TTL validation, public-namespace lint.
- **`backend/tests/unit/llm_gateway/test_config_reload.py`** (14 tests) — behavior tests: `_max_mtime()` helper, first-call load, cached on unchanged mtime, reload on mtime change (any of 3 files), stale fallback, first-call error propagation, recovery, concurrency, `invalidate()`, end-to-end against real config.

## Day-one invariants

1. **Byte-equivalence with v3**: `daily_refresh.py` sha256 matches v3's exactly. Drift would be silent breakage; future re-cherry-picks must update both file and parity tests.
2. **Public/private namespace**: `daily_refresh.py` is at `gateway/daily_refresh.py` (public), `scoring.py` is at `gateway/_private/scoring.py` (private to emitter). The boundary is enforced by a lint test.
3. **No request-path scoring**: reloader only does file I/O + Pydantic validation. The R5a isolation test still passes — daily_refresh doesn't transitively pull in `_private/scoring.py`.
4. **Per-request cost is bounded**: 3 `os.stat()` calls (microseconds); only on mtime change does it reload (~10-50ms cold). On hot path, returns the same `GatewayConfig` instance (verified by `assert cfg1 is cfg2`).
5. **Stale fallback**: on `ConfigValidationError`, serves the last good config. Operations team sees a WARNING log; gateway stays up.

## Validation gates (all met)

| Gate | What it proves | Status |
|---|---|---|
| Cherry-pick parity | `daily_refresh.py` byte-equivalent to v3 (sha256 verified) | ✅ |
| Scoring isolation (regression) | R5a's `_private/` invariant still holds | ✅ existing tests pass |
| First-call load | reloader reads from disk on first `get()` | ✅ |
| Cache behavior | same mtime → same instance (no reload) | ✅ |
| Reload trigger | mtime change on any of 3 files → reload | ✅ |
| Stale fallback | `ConfigValidationError` post-success → serve last good | ✅ |
| First-call error | `ConfigValidationError` first call → propagate | ✅ |
| Concurrency | 5 concurrent `get()` → 1 loader invocation | ✅ |
| `/ready` endpoint | 200 with correct lane/artifact counts | ✅ existing readiness tests pass |
| 224 pre-existing tests | No regression | ✅ 248 total (224 + 24 new) |

## How to test locally

```bash
cd backend
python -m pytest tests/unit/test_llm_gateway_*.py tests/unit/llm_gateway/ -v
# → 248 passed

# Demo: reloader behavior (in-process)
python -c "
import asyncio
from pathlib import Path
from llm_gateway.gateway.config_reload import GatewayConfigReloader

async def demo():
    reloader = GatewayConfigReloader(Path('llm_gateway/config'))
    cfg = await reloader.get()
    print(f'Loaded {len(cfg.lanes)} lanes, {len(cfg.route_artifacts)} artifacts')
    cfg2 = await reloader.get()
    print(f'Second call returns same object: {cfg is cfg2}')

asyncio.run(demo())
"
```

## Risks

- **Mtime resolution ~1s**: filesystem mtime granularity is ~1s on most systems. A config change + read within the same second could miss the change. Acceptable for the rotation-cron use case (PRs merge at human timescale).
- **`config_loader.py` modification**: I wrapped `yaml.safe_load` to convert `yaml.YAMLError` to `ConfigValidationError`. This is a behavior change beyond R5b's strict scope but necessary for the reloader to surface YAML errors uniformly (otherwise the reloader can't do stale-fallback on YAML parse errors — they'd be uncaught). The change is small and adds clarity to the gateway's error contract.
- **`get_ready` async cascading**: making `get_gateway_config` async required `get_ready` to also be async. TestClient (Starlette) handles async-from-sync bridging transparently — no test client changes needed.

## Next PRs after this merges

1. **R2** — capability smoke gate (PR for the smoke script; independent of R5b, can land in parallel)
2. **R3** — product call-site cutover (gated on R0+R1+shadow stability; ≥14 days of <1% divergence)
3. **R4** — nightly rotation cron (gated on R3 ≥30 days live)

cc: gateway owners team for review

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

