### PR TITLE
Bump version to 1.0.542+970 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.542+969
+version: 1.0.542+970
 
 
 environment:


### PR DESCRIPTION
Re-bump build number from 969 to 970. Build 969 tag failed to re-trigger Codemagic after the scanner fix (#8741) — re-tagging the same name doesn't generate a new webhook, and the tag-triggered workflows parse `CM_TAG` for the build number so it must be purely numeric.

This creates a clean new tag target at the new main HEAD (includes scanner fix).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

