### PR TITLE
Fix desktop recording finalization reconciliation

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -142,6 +142,7 @@ from utils.transcribe_decisions import (  # async-blockers: no-import-scope; asy
     should_initialize_vad_gate,
     should_load_speech_profile,
     should_queue_speaker_embedding,
+    should_process_on_disconnect,
     should_skip_speaker_detection,
     should_spawn_speaker_match,
     stt_buffer_flush_size as calculate_stt_buffer_flush_size,
@@ -963,14 +964,17 @@ async def _stream_handler(
                     logger.warning(
                         f"Pusher not enabled, skipping conversation {conversation_id} (stays in_progress) {uid} {session_id}"
                     )
-                    return
+                    return False
                 # Mark processing + buffer for pusher — never process locally (#6061)
                 conversations_db.update_conversation_status(uid, conversation_id, ConversationStatus.processing)
                 on_conversation_processing_started(conversation_id)
                 await request_conversation_processing(conversation_id)
+                return True
             else:
                 logger.info(f'Clean up the conversation {conversation_id}, reason: no content {uid} {session_id}')
                 conversations_db.delete_conversation(uid, conversation_id)
+                return True
+        return False
 
     # Process existing conversations
     async def _prepare_in_progess_conversations():
@@ -2027,6 +2031,7 @@ async def _stream_handler(
                 # Handle client disconnect
                 if message.get("type") == "websocket.disconnect":
                     close_code = message.get("code", 1000)
+                    session.close_code = close_code
                     close_reason = {
                         1000: "normal_closure",
                         1001: "going_away_os_or_background",
@@ -2452,6 +2457,28 @@ async def _stream_handler(
                 await websocket.close(code=session.close_code)
             except Exception as e:
                 logger.error(f"Error closing Client WebSocket: {e} {uid} {session_id}")
+
+        # Single-channel sessions normally stay open for reconnects/timeouts. If the client closes
+        # cleanly after writing content, submit that exact conversation so desktop can reconcile it.
+        if not is_multi_channel and session.current_conversation_id:
+            try:
+                conversation = conversations_db.get_conversation(uid, session.current_conversation_id)
+                if should_process_on_disconnect(
+                    is_multi_channel=is_multi_channel,
+                    close_code=session.close_code,
+                    conversation_id=session.current_conversation_id,
+                    conversation=conversation,
+                    in_progress_status=ConversationStatus.in_progress,
+                ):
+                    _flush_speaker_assignments(session.current_conversation_id)
+                    processed = await _process_conversation(session.current_conversation_id)
+                    if processed:
+                        redis_db.remove_in_progress_conversation_id(uid)
+                        logger.info(
+                            f"Single-channel conversation {session.current_conversation_id} submitted for processing on disconnect {uid} {session_id}"
+                        )
+            except Exception as e:
+                logger.error(f"Error processing single-channel conversation on disconnect: {e} {uid} {session_id}")
 
         # Multi-channel: process the single conversation at session end
         if is_multi_channel and session.current_conversation_id:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -143,6 +143,7 @@ from utils.transcribe_decisions import (  # async-blockers: no-import-scope; asy
     should_load_speech_profile,
     should_queue_speaker_embedding,
     should_process_on_disconnect,
+    should_remove_in_progress_pointer,
     should_skip_speaker_detection,
     should_spawn_speaker_match,
     stt_buffer_flush_size as calculate_stt_buffer_flush_size,
@@ -2473,7 +2474,12 @@ async def _stream_handler(
                     _flush_speaker_assignments(session.current_conversation_id)
                     processed = await _process_conversation(session.current_conversation_id)
                     if processed:
-                        redis_db.remove_in_progress_conversation_id(uid)
+                        current_in_progress_id = redis_db.get_in_progress_conversation_id(uid)
+                        if should_remove_in_progress_pointer(
+                            current_in_progress_id=current_in_progress_id,
+                            conversation_id=session.current_conversation_id,
+                        ):
+                            redis_db.remove_in_progress_conversation_id(uid)
                         logger.info(
                             f"Single-channel conversation {session.current_conversation_id} submitted for processing on disconnect {uid} {session_id}"
                         )

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -20,6 +20,7 @@ from utils.transcribe_decisions import (
     should_include_speech_profile,
     should_initialize_vad_gate,
     should_load_speech_profile,
+    should_process_on_disconnect,
     should_queue_speaker_embedding,
     should_skip_speaker_detection,
     should_spawn_speaker_match,
@@ -184,6 +185,69 @@ def test_conversation_lifecycle_actions():
             conversation_creation_timeout=120,
         )
         == ConversationLifecycleAction.process_and_create_new
+    )
+
+
+def test_disconnect_processing_only_targets_single_channel_in_progress_with_content():
+    content_conversation = {
+        'status': 'in_progress',
+        'transcript_segments': [{'text': 'synthetic transcript'}],
+        'photos': [],
+    }
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation=content_conversation,
+            in_progress_status='in_progress',
+        )
+        is True
+    )
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=True,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation=content_conversation,
+            in_progress_status='in_progress',
+        )
+        is False
+    )
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1001,
+            conversation_id='conversation-1',
+            conversation=content_conversation,
+            in_progress_status='in_progress',
+        )
+        is False
+    )
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation={**content_conversation, 'status': 'processing'},
+            in_progress_status='in_progress',
+        )
+        is False
+    )
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation={'status': 'in_progress', 'transcript_segments': [], 'photos': []},
+            in_progress_status='in_progress',
+        )
+        is False
     )
 
 

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -22,6 +22,7 @@ from utils.transcribe_decisions import (
     should_load_speech_profile,
     should_process_on_disconnect,
     should_queue_speaker_embedding,
+    should_remove_in_progress_pointer,
     should_skip_speaker_detection,
     should_spawn_speaker_match,
     stt_buffer_flush_size,
@@ -191,6 +192,7 @@ def test_conversation_lifecycle_actions():
 def test_disconnect_processing_only_targets_single_channel_in_progress_with_content():
     content_conversation = {
         'status': 'in_progress',
+        'source': 'desktop',
         'transcript_segments': [{'text': 'synthetic transcript'}],
         'photos': [],
     }
@@ -249,6 +251,62 @@ def test_disconnect_processing_only_targets_single_channel_in_progress_with_cont
         )
         is False
     )
+
+
+def test_disconnect_processing_rejects_non_desktop_clean_close_with_content():
+    phone_conversation = {
+        'status': 'in_progress',
+        'source': 'phone',
+        'transcript_segments': [{'text': 'synthetic transcript'}],
+        'photos': [],
+    }
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation=phone_conversation,
+            in_progress_status='in_progress',
+        )
+        is False
+    )
+
+
+def test_disconnect_processing_accepts_enum_like_desktop_source():
+    class Source:
+        value = 'desktop'
+
+    desktop_conversation = {
+        'status': 'in_progress',
+        'source': Source(),
+        'transcript_segments': [{'text': 'synthetic transcript'}],
+        'photos': [],
+    }
+
+    assert (
+        should_process_on_disconnect(
+            is_multi_channel=False,
+            close_code=1000,
+            conversation_id='conversation-1',
+            conversation=desktop_conversation,
+            in_progress_status='in_progress',
+        )
+        is True
+    )
+
+
+def test_in_progress_pointer_removal_requires_matching_conversation_id():
+    assert (
+        should_remove_in_progress_pointer(current_in_progress_id='conversation-1', conversation_id='conversation-1')
+        is True
+    )
+    assert (
+        should_remove_in_progress_pointer(current_in_progress_id='newer-conversation', conversation_id='conversation-1')
+        is False
+    )
+    assert should_remove_in_progress_pointer(current_in_progress_id='conversation-1', conversation_id=None) is False
+    assert should_remove_in_progress_pointer(current_in_progress_id='', conversation_id='conversation-1') is False
 
 
 def test_vad_gate_override_decisions():

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -137,6 +137,23 @@ def decide_lifecycle_action(
     return ConversationLifecycleAction.continue_current
 
 
+def should_process_on_disconnect(
+    *,
+    is_multi_channel: bool,
+    close_code: int,
+    conversation_id: Optional[str],
+    conversation,
+    in_progress_status,
+) -> bool:
+    if close_code != 1000:
+        return False
+    if is_multi_channel or not conversation_id or not conversation:
+        return False
+    if conversation.get('status') != in_progress_status:
+        return False
+    return bool(conversation.get('transcript_segments') or conversation.get('photos'))
+
+
 def person_id_for_client(person_id: Optional[str], speaker_auto_assign_enabled: bool) -> str:
     if speaker_auto_assign_enabled and person_id:
         return person_id

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -151,7 +151,13 @@ def should_process_on_disconnect(
         return False
     if conversation.get('status') != in_progress_status:
         return False
+    if getattr(conversation.get('source'), 'value', conversation.get('source')) != 'desktop':
+        return False
     return bool(conversation.get('transcript_segments') or conversation.get('photos'))
+
+
+def should_remove_in_progress_pointer(*, current_in_progress_id: Optional[str], conversation_id: Optional[str]) -> bool:
+    return bool(conversation_id) and current_in_progress_id == conversation_id
 
 
 def person_id_for_client(person_id: Optional[str], speaker_auto_assign_enabled: bool) -> str:

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -35,6 +35,7 @@ enum FinishConversationResult {
 enum DesktopConversationMatchPolicy {
   /// Backend and local clocks can differ slightly around WebSocket close/reconnect.
   static let startedAtTolerance: TimeInterval = 10
+  static let cloudReconciliationStatuses: [ConversationStatus] = [.inProgress, .processing, .completed]
 
   static func matchesDesktopConversation(
     startedAt conversationStartedAt: Date?,
@@ -87,6 +88,17 @@ enum DesktopConversationMatchPolicy {
     source: ConversationSource?
   ) -> Bool {
     conversationId == boundBackendId && source == .desktop && status != .inProgress
+  }
+
+  static func shouldFinalizeTimestampMatchedConversation(status: ConversationStatus) -> Bool {
+    status == .inProgress
+  }
+
+  static func canCompleteTimestampMatchedConversation(
+    status: ConversationStatus,
+    source: ConversationSource?
+  ) -> Bool {
+    source == .desktop && status != .inProgress
   }
 
   static func canForceProcessBoundCloudSession(

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -242,25 +242,22 @@ actor ConversationFinalizationService {
     let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
     let existing = try await APIClient.shared.getConversations(
       limit: 5,
+      statuses: DesktopConversationMatchPolicy.cloudReconciliationStatuses,
       includeDiscarded: true,
       startDate: session.startedAt.addingTimeInterval(-5),
       endDate: finishedAt.addingTimeInterval(5)
     )
-    if let match = existing.first(where: { conv in
+    let timestampMatches = existing.filter { conv in
       DesktopConversationMatchPolicy.matchesDesktopConversation(
         startedAt: conv.startedAt,
         source: conv.source,
         sessionStartedAt: session.startedAt
       )
-    }) {
-      let status = LocalConversationStatus(rawValue: match.status.rawValue) ?? .processing
-      try await TranscriptionStorage.shared.markSessionCompleted(
-        id: sessionId,
-        backendId: match.id,
-        conversationStatus: status
-      )
-      log("ConversationFinalization: Reconciled cloud session \(sessionId) by timestamp \(match.id)")
-      return
+    }
+    for match in timestampMatches {
+      if try await completeTimestampMatchedConversation(match, sessionId: sessionId) {
+        return
+      }
     }
 
     if session.retryCount >= maxRetries - 1 {
@@ -279,6 +276,34 @@ actor ConversationFinalizationService {
     }
 
     throw TranscriptionStorageError.invalidState("No matching backend conversation found")
+  }
+
+  private func completeTimestampMatchedConversation(
+    _ match: ServerConversation,
+    sessionId: Int64
+  ) async throws -> Bool {
+    let conversation: ServerConversation
+    if DesktopConversationMatchPolicy.shouldFinalizeTimestampMatchedConversation(status: match.status) {
+      conversation = try await APIClient.shared.finalizeConversation(id: match.id)
+    } else {
+      conversation = match
+    }
+
+    guard DesktopConversationMatchPolicy.canCompleteTimestampMatchedConversation(
+      status: conversation.status,
+      source: conversation.source
+    ), conversation.id == match.id else {
+      return false
+    }
+
+    let status = LocalConversationStatus(rawValue: conversation.status.rawValue) ?? .processing
+    try await TranscriptionStorage.shared.markSessionCompleted(
+      id: sessionId,
+      backendId: conversation.id,
+      conversationStatus: status
+    )
+    log("ConversationFinalization: Reconciled cloud session \(sessionId) by timestamp \(conversation.id)")
+    return true
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -112,6 +112,38 @@ final class StopReconciliationTests: XCTestCase {
         XCTAssertTrue(matches, "9.99s offset should match")
     }
 
+    func testTimestampReconciliationQueriesInProgressProcessingAndCompleted() {
+        XCTAssertEqual(
+            DesktopConversationMatchPolicy.cloudReconciliationStatuses,
+            [.inProgress, .processing, .completed]
+        )
+    }
+
+    func testTimestampMatchedInProgressConversationUsesSpecificFinalizeBeforeCompletion() {
+        XCTAssertTrue(
+            DesktopConversationMatchPolicy.shouldFinalizeTimestampMatchedConversation(status: .inProgress)
+        )
+        XCTAssertFalse(
+            DesktopConversationMatchPolicy.canCompleteTimestampMatchedConversation(
+                status: .inProgress,
+                source: .desktop
+            ),
+            "Timestamp matches must not complete locally until exact-id finalize returns a non-in-progress status"
+        )
+    }
+
+    func testTimestampMatchedProcessingConversationCanCompleteWithoutFinalize() {
+        XCTAssertFalse(
+            DesktopConversationMatchPolicy.shouldFinalizeTimestampMatchedConversation(status: .processing)
+        )
+        XCTAssertTrue(
+            DesktopConversationMatchPolicy.canCompleteTimestampMatchedConversation(
+                status: .processing,
+                source: .desktop
+            )
+        )
+    }
+
     func testNegativeTimeOffset() {
         let sessionStartTime = Date()
         // Backend conversation started 3s BEFORE local session start (clock skew)

--- a/desktop/macos/changelog/unreleased/20260701-desktop-recording-finalization.json
+++ b/desktop/macos/changelog/unreleased/20260701-desktop-recording-finalization.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop recordings that could stay stuck after the recording window closed"
+}


### PR DESCRIPTION
## Summary
- Finalize/process the current single-channel listen conversation on normal WebSocket disconnect when it has content and is still `in_progress`.
- Include `in_progress`, `processing`, and `completed` in desktop unbound timestamp reconciliation.
- Finalize exact-id `in_progress` timestamp matches before completing the local desktop session.

## Validation
- `python -m pytest backend/tests/unit/test_transcribe_decisions.py -q`
- `python -m py_compile backend/utils/transcribe_decisions.py backend/routers/transcribe.py`
- `xcrun swift test --package-path desktop/macos/Desktop --filter StopReconciliationTests`
- `black --line-length 120 --skip-string-normalization backend/utils/transcribe_decisions.py backend/tests/unit/test_transcribe_decisions.py backend/routers/transcribe.py`
- `python backend/scripts/scan_async_blockers.py`

E2E note: `bash backend/testing/e2e/run.sh -k "transcribe_reconnect_then_finalize"` could not run because backend E2E dependencies are not installed in this worktree.

Fixes #8749


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

