### PR TITLE
fix(desktop): finalize stuck in_progress conversations during reconciliation (#8749)

### DIFF
--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -240,8 +240,13 @@ actor ConversationFinalizationService {
     }
 
     let finishedAt = session.finishedAt ?? session.startedAt.addingTimeInterval(1)
+    // Include `in_progress` so we can discover a backend conversation the timeout task never
+    // processed (e.g. websocket closed before the lifecycle timeout fired). The list endpoint
+    // defaults to processing,completed, so without this a stuck in_progress conversation is
+    // invisible and reconciliation exhausts. See issue #8749.
     let existing = try await APIClient.shared.getConversations(
       limit: 5,
+      statuses: [.inProgress, .processing, .completed],
       includeDiscarded: true,
       startDate: session.startedAt.addingTimeInterval(-5),
       endDate: finishedAt.addingTimeInterval(5)
@@ -253,6 +258,18 @@ actor ConversationFinalizationService {
         sessionStartedAt: session.startedAt
       )
     }) {
+      // A stuck in_progress match needs finalization, not just a status copy — otherwise the
+      // local session would be marked done while the backend conversation never processes.
+      if match.status == .inProgress {
+        if try await completeCloudConversation(
+          id: match.id,
+          sessionId: sessionId,
+          allowForceProcess: true
+        ) {
+          log("ConversationFinalization: Finalized stuck in_progress cloud session \(sessionId) -> \(match.id)")
+          return
+        }
+      }
       let status = LocalConversationStatus(rawValue: match.status.rawValue) ?? .processing
       try await TranscriptionStorage.shared.markSessionCompleted(
         id: sessionId,

--- a/desktop/macos/changelog/unreleased/20260701-reconcile-stuck-inprogress.json
+++ b/desktop/macos/changelog/unreleased/20260701-reconcile-stuck-inprogress.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed recordings that could get stuck and never appear as a conversation by finalizing in-progress conversations during reconciliation"
+}


### PR DESCRIPTION
## Bug
Fixes #8749. Desktop recordings could stream/transcribe successfully but never appear in the conversation list because the backend conversation stayed `in_progress`. Desktop then retried reconciliation and surfaced `Session <n> could not be reconciled after 5 attempts`. Observed in production; the same error shape has appeared for many desktop users over the last two weeks.

## Root cause
In `ConversationFinalizationService.reconcileUnboundCloudSession`, the timestamp-based fallback calls `getConversations(...)` **without a `statuses` argument**. The backend list endpoint (`backend/routers/conversations.py`) defaults to `statuses="processing,completed"`, so a conversation stuck in `in_progress` is invisible to the lookup. Reconciliation therefore never finds the stuck conversation and eventually exhausts.

## Fix (desktop reconciliation layer)
- Pass `statuses: [.inProgress, .processing, .completed]` in the reconciliation query so a stuck `in_progress` conversation can be discovered.
- When the matched conversation is still `in_progress`, route it through the existing `completeCloudConversation(id:sessionId:allowForceProcess:true)` helper, which calls `POST /v1/conversations/{id}/finalize`. That endpoint is purpose-built to process exactly one `in_progress` conversation **without** touching the user's Redis current-in-progress pointer, so desktop retry/rotation can't accidentally finalize a newer recording. Without this, marking the local session done against an `in_progress` backend conversation would leave it unprocessed forever.

Surgical, reuses existing helpers, +20 lines. Compile-checked with `xcrun swift build -c debug` (build complete, exit 0).

## Not included (follow-up)
The issue also proposes a backend defensive layer: finalize non-multichannel `/v4/listen` sessions on normal websocket disconnect in `backend/routers/transcribe.py`. That touches the high-risk WebSocket cleanup/concurrency path and is deliberately left out of this surgical client-side fix. The desktop layer alone recovers stuck conversations for affected users because `finalize` forces backend processing.

🤖 automated by hourly watchdog; opened for review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

