### PR TITLE
fix null-check crash in offline mode sheet toggle

### DIFF
--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -360,8 +360,12 @@ class _ProfilePageState extends State<ProfilePage> {
             final enabled = SharedPreferencesUtil().batchModeEnabled;
             Future<void> setEnabled(bool value) async {
               await captureProvider.setBatchMode(value);
-              setSheetState(() {});
-              setState(() {});
+              if (sheetContext.mounted) {
+                setSheetState(() {});
+              }
+              if (mounted) {
+                setState(() {});
+              }
             }
 
             return SafeArea(


### PR DESCRIPTION
## Summary
- Fixes a Crashlytics-reported fatal crash (`Null check operator used on a null value` in `State.setState`) originating from `_ProfilePageState._showOfflineModeSheet`.
- `setEnabled` is async; after `await captureProvider.setBatchMode(value)` resolves, the offline-mode bottom sheet or the profile page itself may already be disposed (user closed the sheet or navigated away), so calling `setSheetState`/`setState` hit a disposed `State`.
- Guards both calls with `mounted` checks (`sheetContext.mounted` for the sheet's `StatefulBuilder`, `mounted` for the outer `_ProfilePageState`).

Crashlytics issue: https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/0685c58070c96ed5989ef2091f644ff4?time=7d&types=crash

## Test plan
- [ ] Open Profile → Offline Mode sheet, toggle the switch, and immediately dismiss the sheet/navigate away before the async `setBatchMode` completes — confirm no crash and no unhandled exception in logs.
- [ ] Toggle the switch normally (staying on the sheet) and confirm state updates as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

