### PR TITLE
fix unnecessary null-aware operators in device.dart

### DIFF
--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -237,8 +237,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
             onTap: provider.connectedDevice != null
                 ? () {
                     // Route to OmiGlass OTA page for openglass devices
-                    final deviceName = provider.connectedDevice?.name?.toLowerCase() ?? '';
-                    final isOpenGlass = provider.connectedDevice?.type == DeviceType.openglass ||
+                    final deviceName = provider.connectedDevice!.name.toLowerCase();
+                    final isOpenGlass = provider.connectedDevice!.type == DeviceType.openglass ||
                         deviceName.contains('openglass') ||
                         deviceName.contains('omiglass') ||
                         deviceName.contains('glass');


### PR DESCRIPTION
## Summary
- `connectedDevice?.name?.toLowerCase()` and `connectedDevice?.type` inside the `onTap` closure at [device.dart](app/lib/pages/home/device.dart) triggered analyzer errors — the closure only runs when `provider.connectedDevice != null` is already checked, so `?.` short-circuits to `null` and never reaches `.toLowerCase()`.
- `BtDevice.name` is non-nullable, so `?.toLowerCase() ?? ''` was also dead code.

## Test plan
- [x] Analyzer warnings for `invalid_null_aware_operator` at device.dart:240 resolved
- [ ] Manual smoke test of the "product update" OTA routing tap in the app (not run — logic-only diff, no compiled/launched app in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

