### PR TITLE
[codex] Add onboarding PTT volume check

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/SystemAudioMuteController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/SystemAudioMuteController.swift
@@ -13,6 +13,17 @@ import Foundation
 final class SystemAudioMuteController {
   static let shared = SystemAudioMuteController()
 
+  enum OutputReadiness: Equatable {
+    case audible
+    case muted
+    case zeroVolume
+    case unavailable
+
+    var shouldAskUserToTurnUpVolume: Bool {
+      self == .muted || self == .zeroVolume
+    }
+  }
+
   /// The device we muted, or nil if we currently hold no mute.
   private var mutedDevice: AudioDeviceID?
   /// Per-channel volumes to restore when the fallback path was used.
@@ -47,6 +58,18 @@ final class SystemAudioMuteController {
       usedVolumeFallback = true
       log("SystemAudioMuteController: muted via volume fallback on device \(device)")
     }
+  }
+
+  /// Current readiness of the default output device for hearing PTT responses.
+  func defaultOutputReadiness() -> OutputReadiness {
+    if mutedDevice != nil { return .audible }
+    guard let device = Self.defaultOutputDevice() else { return .unavailable }
+    if Self.deviceIsMuted(device) == true { return .muted }
+
+    let volumes = Self.readOutputVolumes(device)
+    guard !volumes.isEmpty else { return .unavailable }
+
+    return volumes.contains(where: { $0 > 0.001 }) ? .audible : .zeroVolume
   }
 
   /// Restore whatever `muteForListening()` changed. No-op if we hold no mute.
@@ -163,5 +186,16 @@ final class SystemAudioMuteController {
       }
     }
     return saved
+  }
+
+  private static func readOutputVolumes(_ device: AudioDeviceID) -> [Float32] {
+    let main = kAudioObjectPropertyElementMain
+    if let mainVolume = getVolume(device, channel: main) {
+      return [mainVolume]
+    }
+
+    return [UInt32(1), UInt32(2)].compactMap { channel in
+      getVolume(device, channel: channel)
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingVoiceDemoView.swift
@@ -16,6 +16,7 @@ struct OnboardingVoiceDemoView: View {
     @State private var waitingForResponse = false
     @State private var showContinue = false
     @State private var previousTranscriptionMode: ShortcutSettings.PTTTranscriptionMode?
+    @State private var outputReadiness: SystemAudioMuteController.OutputReadiness = .unavailable
 
     var body: some View {
         VStack(spacing: 0) {
@@ -52,7 +53,10 @@ struct OnboardingVoiceDemoView: View {
                         .multilineTextAlignment(.center)
                 }
 
-                if !observedShortcutPress {
+                if outputReadiness.shouldAskUserToTurnUpVolume {
+                    volumeWarning
+                        .transition(.opacity)
+                } else if !observedShortcutPress {
                     VStack(spacing: 12) {
                         Text("Hold the shortcut, speak, then release")
                             .font(.system(size: 13))
@@ -101,6 +105,7 @@ struct OnboardingVoiceDemoView: View {
         .onAppear {
             FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
             resetFloatingBarConversation()
+            refreshOutputReadiness()
             if let barState = FloatingControlBarManager.shared.barState {
                 PushToTalkManager.shared.setup(barState: barState)
             }
@@ -115,7 +120,12 @@ struct OnboardingVoiceDemoView: View {
             resetFloatingBarConversation()
             PushToTalkManager.shared.cleanup()
         }
+        .task {
+            await pollOutputReadiness()
+        }
         .onChange(of: pttManager.state) { _, newState in
+            refreshOutputReadiness()
+            guard !outputReadiness.shouldAskUserToTurnUpVolume else { return }
             if newState != .idle {
                 observedShortcutPress = true
             }
@@ -126,6 +136,51 @@ struct OnboardingVoiceDemoView: View {
                 waitingForResponse = true
                 Task { await waitForResponse() }
             }
+        }
+    }
+
+    private var volumeWarning: some View {
+        VStack(spacing: 12) {
+            Text(volumeWarningTitle)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(OmiColors.textPrimary)
+                .multilineTextAlignment(.center)
+
+            Text("Turn up your Mac volume so you can hear Omi respond, then try push-to-talk.")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+                .multilineTextAlignment(.center)
+
+            Button(action: refreshOutputReadiness) {
+                Text("I turned it up")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.white)
+                    )
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(18)
+        .frame(maxWidth: 420)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(OmiColors.backgroundSecondary)
+        )
+        .padding(.top, 4)
+    }
+
+    private var volumeWarningTitle: String {
+        switch outputReadiness {
+        case .muted:
+            return "Your Mac volume is muted"
+        case .zeroVolume:
+            return "Your Mac volume is at 0"
+        case .audible, .unavailable:
+            return ""
         }
     }
 
@@ -171,6 +226,18 @@ struct OnboardingVoiceDemoView: View {
         barState.chatHistory = []
         barState.isVoiceFollowUp = false
         barState.voiceFollowUpTranscript = ""
+    }
+
+    private func refreshOutputReadiness() {
+        outputReadiness = SystemAudioMuteController.shared.defaultOutputReadiness()
+    }
+
+    @MainActor
+    private func pollOutputReadiness() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            refreshOutputReadiness()
+        }
     }
 
     private func keyCap(_ label: String) -> some View {

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -95,7 +95,7 @@ export function failureFromProcessExit(input: {
 function classifyAdapterProcessFailure(
   adapterId: ProductionAdapterId,
   diagnostic: string
-): Partial<RuntimeFailure> | undefined {
+): (Pick<RuntimeFailure, "code" | "userMessage"> & Partial<RuntimeFailure>) | undefined {
   if (adapterId === "openclaw" && isOpenClawInvalidConfig(diagnostic)) {
     return {
       code: "adapter_config_invalid",

--- a/desktop/macos/changelog/unreleased/20260701-onboarding-ptt-volume-check.json
+++ b/desktop/macos/changelog/unreleased/20260701-onboarding-ptt-volume-check.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added an onboarding prompt to turn up muted or zero Mac volume before trying push-to-talk"
+}


### PR DESCRIPTION
## Summary

- Adds a CoreAudio-backed default output readiness check for muted or zero-volume Mac audio
- Gates the onboarding PTT voice demo with a turn-up-volume prompt before asking users to try push-to-talk
- Fixes an agent-runtime TypeScript return type that blocked the desktop named-bundle build
- Adds the required desktop changelog fragment

<img width="490" height="320" alt="image" src="https://github.com/user-attachments/assets/ef2ce97e-c5fd-4e8f-8d0b-63be987fd8a4" />


## Validation

- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop`
- `cd desktop/macos/agent && npm run build`
- `OMI_APP_NAME="omi-onboarding-volume" OMI_SKIP_AUTH_SEED=1 OMI_SKIP_SETTINGS_SEED=1 ./run.sh --yolo`
- Verified `/Applications/omi-onboarding-volume.app` launched in onboarding with `hasCompletedOnboarding=false` and `onboardingStep=0`
- Pre-push checks passed, including desktop changelog validation and focused agent tests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

