### PR TITLE
fix(desktop): batch ChatGPT/Claude memory-log import writes (#8760)

### DIFF
--- a/desktop/macos/Desktop/Sources/OnboardingMemoryLogImportService.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingMemoryLogImportService.swift
@@ -113,21 +113,38 @@ actor OnboardingMemoryLogImportService {
       }
       let profileSummary = parsed["profile"] as? String ?? ""
 
+      // Batch the extracted memories through POST /v3/memories/batch instead
+      // of fanning out one POST /v3/memories per string. The per-memory loop
+      // could trip the backend `memories:create` limiter (bursts of 429s) and
+      // cause Firestore cross-transaction contention (503s) on import. One
+      // batch request = one Firestore write + one embeddings call + one
+      // Pinecone upsert on the server, regardless of batch size. Mirrors the
+      // accepted local-file import path in OnboardingPagedIntroCoordinator.
+      // Note: the batch model carries content/visibility/category/tags/headline
+      // (source.memorySource info is already reflected in source.tags).
+      let chunkSize = APIClient.memoriesBatchMaxSize
       var memoriesSaved = 0
-      for memory in memoryStrings {
-        do {
-          _ = try await APIClient.shared.createMemory(
+      var index = 0
+      while index < memoryStrings.count {
+        let end = min(index + chunkSize, memoryStrings.count)
+        let chunk = memoryStrings[index..<end].map { memory in
+          MemoryBatchItem(
             content: memory,
             visibility: "private",
             category: .system,
             tags: source.tags,
-            source: source.memorySource,
             headline: source.headline
           )
-          memoriesSaved += 1
+        }
+        index = end
+
+        do {
+          let response = try await APIClient.shared.createMemoriesBatch(Array(chunk))
+          memoriesSaved += response.createdCount
         } catch {
           log(
-            "OnboardingMemoryLogImportService: Failed saving \(source.displayName) memory: \(error)"
+            "OnboardingMemoryLogImportService: Failed saving \(source.displayName) memory batch "
+              + "(\(chunk.count) items): \(error)"
           )
         }
       }

--- a/desktop/macos/changelog/unreleased/20260701-batch-memory-log-import.json
+++ b/desktop/macos/changelog/unreleased/20260701-batch-memory-log-import.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed ChatGPT/Claude memory imports failing partway through by saving extracted memories in a single batched request instead of many individual writes that could hit rate limits"
+}


### PR DESCRIPTION
## Bug (#8760)

ChatGPT/Claude onboarding memory imports could fail partway through after a user pastes an export. The UI reports memories couldn't be created, but the root cause is the **write phase**: `OnboardingMemoryLogImportService` looped `APIClient.createMemory` once per extracted memory (one `POST /v3/memories` each).

On an import burst this:
- trips the backend `memories:create` limiter → bursts of **429**s (issue shows 344/435 requests 429'd in one burst), and
- causes Firestore **cross-transaction contention** → **503**s (`Aborted due to cross-transaction contention`).

## Root cause

Fan-out of N individual `POST /v3/memories` writes from the import path, instead of using the existing batch endpoint.

## Fix

Convert the save loop to chunk the extracted memory strings through `APIClient.createMemoriesBatch` (`POST /v3/memories/batch`), chunked by `APIClient.memoriesBatchMaxSize`. One batch request = one Firestore write + one embeddings call + one Pinecone upsert on the server, regardless of size.

This mirrors the already-accepted local-file import path in `OnboardingPagedIntroCoordinator.importLocalFileMemories`. Metadata preserved: content/visibility/category/tags/headline (the `chatgpt`/`claude`/`memory_log` source info is already carried in `tags`; the batch model has no `source` field, same as the reference path — not a silent drop, documented in a code comment).

Addresses acceptance criterion #1 of the issue (import creates memories through `/v3/memories/batch`, not N individual requests). The broader Apple Notes / Gmail / Calendar audit, UX error-differentiation, and Pinecone `null` metadata items in the issue are intentionally left out of this scoped fix.

## Testing

- `xcrun swift build -c debug --package-path Desktop` → **Build complete** (only pre-existing warnings).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

