### PR TITLE
[codex] Fix agent connection status labels

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -213,6 +213,7 @@ private struct ConnectOptionCard: View {
         case .completed:
           resultMessage = outcome.taskTitle
         }
+        statuses[destination] = await MemoryExportService.shared.status(for: destination)
       } catch {
         resultMessage = error.localizedDescription
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -227,6 +227,7 @@ struct DashboardPage: View {
     @State private var conversationCount: Int?
     @State private var memoryCount: Int?
     @State private var taskCount: Int?
+    @State private var memoryExportStatuses: [MemoryExportDestination: MemoryExportStatus] = [:]
     @State private var isCaptureMonitoring = false
     @State private var isTogglingCapture = false
     @State private var isTogglingListening = false
@@ -266,9 +267,15 @@ struct DashboardPage: View {
         return importConnectorStatusStore.snapshot(for: connector).isConnected
     }
 
-    /// Whether the hosted MCP key exists — the app's own definition of "configured" for MCP destinations.
-    private var hasMCPDestinationConnected: Bool {
-        MemoryExportService.shared.hasStoredMCPKey
+    private func isMCPDestinationConnected(_ destination: MemoryExportDestination) -> Bool {
+        switch destination {
+        case .claude, .claudeCode:
+            return [.claude, .claudeCode].contains { memoryExportStatuses[$0]?.hasConnection == true }
+        case .chatgpt, .codex:
+            return [.chatgpt, .codex].contains { memoryExportStatuses[$0]?.hasConnection == true }
+        default:
+            return memoryExportStatuses[destination]?.hasConnection == true
+        }
     }
 
     var body: some View {
@@ -313,6 +320,7 @@ struct DashboardPage: View {
             syncCaptureState()
             Task { await loadScreenshotCount() }
             Task { await loadKnowledgeCounts() }
+            Task { await loadMemoryExportStatuses() }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshGoals()
@@ -320,6 +328,7 @@ struct DashboardPage: View {
             syncCaptureState()
             Task { await loadScreenshotCount() }
             Task { await loadKnowledgeCounts() }
+            Task { await loadMemoryExportStatuses() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
             syncCaptureState()
@@ -571,16 +580,16 @@ struct DashboardPage: View {
             }
             .frame(height: 62, alignment: .bottomLeading)
 
-            HomeAIChoiceButton(title: "Claude / Claude Code", brand: .claude, isConnected: hasMCPDestinationConnected) {
+            HomeAIChoiceButton(title: "Claude / Claude Code", brand: .claude, isConnected: isMCPDestinationConnected(.claude)) {
                 openExportDestination(.claudeCode)
             }
-            HomeAIChoiceButton(title: "ChatGPT / Codex", brand: .chatgpt, isConnected: hasMCPDestinationConnected) {
+            HomeAIChoiceButton(title: "ChatGPT / Codex", brand: .chatgpt, isConnected: isMCPDestinationConnected(.chatgpt)) {
                 openExportDestination(.codex)
             }
-            HomeAIChoiceButton(title: "OpenClaw", brand: .openclaw, isConnected: hasMCPDestinationConnected) {
+            HomeAIChoiceButton(title: "OpenClaw", brand: .openclaw, isConnected: isMCPDestinationConnected(.openclaw)) {
                 openExportDestination(.openclaw)
             }
-            HomeAIChoiceButton(title: "Hermes", brand: .hermes, isConnected: hasMCPDestinationConnected) {
+            HomeAIChoiceButton(title: "Hermes", brand: .hermes, isConnected: isMCPDestinationConnected(.hermes)) {
                 openExportDestination(.hermes)
             }
             HomeAIChoiceButton(title: "Ask Omi", usesOmiMark: true) {
@@ -778,6 +787,13 @@ struct DashboardPage: View {
         let stats = await RewindIndexer.shared.getStats()
         await MainActor.run {
             screenshotCount = stats?.total
+        }
+    }
+
+    private func loadMemoryExportStatuses() async {
+        let statuses = await MemoryExportService.shared.allStatuses()
+        await MainActor.run {
+            memoryExportStatuses = statuses
         }
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -22,6 +22,38 @@ struct ExportsSection: View {
     }
   }
 
+  private func status(for destination: MemoryExportDestination) -> MemoryExportStatus {
+    let fallback = MemoryExportStatus(
+      exportedCount: 0,
+      lastExportedAt: nil,
+      detailText: nil,
+      isConfigured: false,
+      hasConnection: false)
+
+    switch destination {
+    case .claude:
+      return aggregateStatus(for: [.claude, .claudeCode], fallback: fallback)
+    case .chatgpt:
+      return aggregateStatus(for: [.chatgpt, .codex], fallback: fallback)
+    default:
+      return statuses[destination] ?? fallback
+    }
+  }
+
+  private func aggregateStatus(
+    for destinations: [MemoryExportDestination],
+    fallback: MemoryExportStatus
+  ) -> MemoryExportStatus {
+    let values = destinations.map { statuses[$0] ?? fallback }
+    return MemoryExportStatus(
+      exportedCount: values.map(\.exportedCount).max() ?? 0,
+      lastExportedAt: values.compactMap(\.lastExportedAt).max(),
+      detailText: values.compactMap(\.detailText).first,
+      isConfigured: values.contains(where: \.hasConnection),
+      hasConnection: values.contains(where: \.hasConnection)
+    )
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       Text("Exports")
@@ -38,9 +70,7 @@ struct ExportsSection: View {
             destination: entry.destination,
             titleOverride: entry.title,
             subtitleOverride: entry.subtitle,
-            status: statuses[entry.destination]
-              ?? MemoryExportStatus(
-                exportedCount: 0, lastExportedAt: nil, detailText: nil, isConfigured: false)
+            status: status(for: entry.destination)
           ) {
             onSelectDestination(entry.destination)
           }
@@ -126,7 +156,7 @@ private struct MemoryExportRow: View {
         Spacer(minLength: 12)
 
         ImportConnectorActionButton(
-          title: actionTitle, isConnected: status.isConfigured || status.exportedCount > 0)
+          title: actionTitle, isConnected: status.hasConnection)
       }
       .padding(.horizontal, 14)
       .padding(.vertical, 11)
@@ -675,7 +705,10 @@ struct MemoryExportDestinationSheet: View {
         .fixedSize(horizontal: false, vertical: true)
 
       Button(model.isExecuting ? "Starting Omi…" : executeButtonTitle) {
-        Task { await model.executeWithOmi(destination: destination) }
+        Task {
+          await model.executeWithOmi(destination: destination)
+          statuses[destination] = await MemoryExportService.shared.status(for: destination)
+        }
       }
       .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
       .disabled(model.isExecuting)

--- a/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
@@ -39,6 +39,7 @@ enum MemoryExportExecutor {
     // file write. Do it deterministically ourselves (idempotent local write).
     if MemoryBankConnector.handles(destination) {
       let message = try MemoryBankConnector.connect(destination, key: key)
+      await MemoryExportService.shared.markConnected(destination)
       return Outcome(taskTitle: message, mode: .completed)
     }
 
@@ -141,6 +142,9 @@ enum MemoryExportExecutor {
       log("Claude cloud setup: native automation attempt \(attempt) result=\(cloudFormFillResultSummary(lastResult))")
       if cloudFormFillSucceeded(lastResult) {
         CloudConnectorFormAutomation.dismissGuidanceOverlay()
+        if lastResult.contains("Claude connector connected.") {
+          await MemoryExportService.shared.markConnected(.claude)
+        }
         return Outcome(
           taskTitle: "Claude connector form submitted. If Claude shows a final consent prompt, approve Omi Memory.",
           mode: .completed)

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -443,6 +443,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
   fileprivate var lastExportedAtKey: String { "memoryExportLastExportedAt.\(rawValue)" }
   fileprivate var detailKey: String { "memoryExportDetail.\(rawValue)" }
   fileprivate var lastExportPathKey: String { "memoryExportLastExportPath.\(rawValue)" }
+  fileprivate var connectedAtKey: String { "memoryExportConnectedAt.\(rawValue)" }
 }
 
 struct MemoryExportStatus: Sendable {
@@ -450,6 +451,7 @@ struct MemoryExportStatus: Sendable {
   let lastExportedAt: Date?
   let detailText: String?
   let isConfigured: Bool
+  let hasConnection: Bool
 }
 
 /// Rendered MCP connection instructions for a single client.
@@ -521,6 +523,7 @@ actor MemoryExportService {
     }
 
     let detailText = defaults.string(forKey: destination.detailKey)
+    let hasConnection = exportedCount > 0 || defaults.double(forKey: destination.connectedAtKey) > 0
     let isConfigured: Bool
     switch destination {
     case .obsidian:
@@ -537,7 +540,8 @@ actor MemoryExportService {
       exportedCount: exportedCount,
       lastExportedAt: lastExportedAt,
       detailText: detailText,
-      isConfigured: isConfigured
+      isConfigured: isConfigured,
+      hasConnection: hasConnection
     )
   }
 
@@ -590,10 +594,16 @@ actor MemoryExportService {
   func testAgentConnections(hostedKey: String, localToken: String) async throws -> AgentConnectionTestResult {
     async let hostedCount = testHostedMCPMemoryCount(key: hostedKey)
     async let localCount = testLocalAgentToolCount(token: localToken)
-    return try await AgentConnectionTestResult(
+    let result = try await AgentConnectionTestResult(
       hostedMemoryCount: hostedCount,
       localToolCount: localCount
     )
+    markConnected(.agents)
+    return result
+  }
+
+  func markConnected(_ destination: MemoryExportDestination) {
+    defaults.set(Date().timeIntervalSince1970, forKey: destination.connectedAtKey)
   }
 
   private func testHostedMCPMemoryCount(key: String) async throws -> Int {

--- a/desktop/macos/Desktop/Sources/OnboardingExportsStepView.swift
+++ b/desktop/macos/Desktop/Sources/OnboardingExportsStepView.swift
@@ -75,7 +75,7 @@ struct OnboardingExportsStepView: View {
     let status =
       statuses[destination]
       ?? MemoryExportStatus(
-        exportedCount: 0, lastExportedAt: nil, detailText: nil, isConfigured: false)
+        exportedCount: 0, lastExportedAt: nil, detailText: nil, isConfigured: false, hasConnection: false)
     let metrics = exportMetrics(for: destination, status: status)
 
     return HStack(alignment: .center, spacing: 12) {

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MemoryExportStatusTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    resetMemoryExportDefaults()
+  }
+
+  override func tearDown() {
+    resetMemoryExportDefaults()
+    super.tearDown()
+  }
+
+  func testStoredMCPKeyDoesNotMarkAgentDestinationsConnected() async {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+
+    let codexStatus = await MemoryExportService.shared.status(for: .codex)
+    let claudeCodeStatus = await MemoryExportService.shared.status(for: .claudeCode)
+
+    XCTAssertTrue(codexStatus.isConfigured)
+    XCTAssertTrue(claudeCodeStatus.isConfigured)
+    XCTAssertFalse(codexStatus.hasConnection)
+    XCTAssertFalse(claudeCodeStatus.hasConnection)
+  }
+
+  func testMarkConnectedIsPerDestination() async {
+    UserDefaults.standard.set("test-key", forKey: "memoryExportMCPApiKey")
+
+    await MemoryExportService.shared.markConnected(.openclaw)
+
+    let openClawStatus = await MemoryExportService.shared.status(for: .openclaw)
+    let hermesStatus = await MemoryExportService.shared.status(for: .hermes)
+
+    XCTAssertTrue(openClawStatus.hasConnection)
+    XCTAssertFalse(hermesStatus.hasConnection)
+  }
+
+  func testMemoryPackExportStillCountsAsConnectionHistory() async {
+    UserDefaults.standard.set(7, forKey: "memoryExportExportedCount.claude")
+
+    let status = await MemoryExportService.shared.status(for: .claude)
+
+    XCTAssertTrue(status.isConfigured)
+    XCTAssertTrue(status.hasConnection)
+  }
+
+  private func resetMemoryExportDefaults() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "memoryExportMCPApiKey")
+    defaults.removeObject(forKey: "localAgentAPIEnabled")
+    defaults.removeObject(forKey: "localAgentAPIToken")
+
+    for destination in MemoryExportDestination.allCases {
+      defaults.removeObject(forKey: "memoryExportExportedCount.\(destination.rawValue)")
+      defaults.removeObject(forKey: "memoryExportLastExportedAt.\(destination.rawValue)")
+      defaults.removeObject(forKey: "memoryExportDetail.\(destination.rawValue)")
+      defaults.removeObject(forKey: "memoryExportLastExportPath.\(destination.rawValue)")
+      defaults.removeObject(forKey: "memoryExportConnectedAt.\(destination.rawValue)")
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/fix-agent-connection-status.json
+++ b/desktop/macos/changelog/unreleased/fix-agent-connection-status.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed Connect your AI rows showing Connected before Omi has evidence that the agent connection was completed"
+  ]
+}


### PR DESCRIPTION
## Summary
- Fixes the Connect your AI rows so they only show `Connected` after Omi has evidence of a completed connection or prior memory-pack export.
- Adds per-destination connection markers for confirmed setup paths instead of treating generic MCP-key presence as connected.
- Aggregates grouped rows so Claude / Claude Code and ChatGPT / Codex reflect a real connection from either child option.

## Root Cause
The Home row rendered `Connected` from `status.isConfigured || status.exportedCount > 0`. For MCP agent destinations, `isConfigured` became true as soon as any hosted MCP key existed, so a new user or unrelated setup state could make Claude, ChatGPT/Codex, OpenClaw, and Hermes appear connected before those clients had ever connected.

## Validation
- `xcrun swift test --package-path Desktop --filter MemoryExportStatusTests`
- `xcrun swift build -c debug --package-path Desktop`
- Launched named bundle with `OMI_APP_NAME="omi-agent-status" OMI_AUTOMATION_PORT=48777 ./run.sh --yolo` and captured `/tmp/omi-agent-status-home.png`; Connect your AI rows no longer showed `Connected` without per-agent connection evidence.
- Pre-push checks passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

