### PR TITLE
Harden LLM gateway dev deploy guardrails

### DIFF
--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -118,33 +118,13 @@ jobs:
       - name: Deploy backend-secrets to GKE
         env:
           BACKEND_SECRETS_GSA: ${{ vars.BACKEND_SECRETS_GSA }}
+          ENVIRONMENT: ${{ vars.ENV }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
+          REGION: ${{ env.REGION }}
         run: |
-          if [[ -n "${BACKEND_SECRETS_GSA}" ]]; then
-            gsa_name="${BACKEND_SECRETS_GSA}"
-          else
-            gsa_name="${{ vars.ENV }}-omi-backend-eso-gsa@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
-          fi
           python3 -m pip install -q pyyaml
-          helm -n ${{ vars.ENV }}-omi-backend upgrade --install \
-            ${{ vars.ENV }}-omi-backend-secrets \
-            ./backend/charts/backend-secrets \
-            -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml \
-            --set gke.projectID=${{ vars.GCP_PROJECT_ID }} \
-            --set gke.clusterLocation=${{ env.REGION }} \
-            --set gke.clusterName=${{ vars.GKE_CLUSTER }} \
-            --set gsa.name="${gsa_name}"
-          force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
-            ${{ vars.ENV }}-omi-backend-external-secret \
-            force-sync="${force_sync_at}" --overwrite
-          python3 backend/scripts/wait_external_secret_refresh.py \
-            --namespace ${{ vars.ENV }}-omi-backend \
-            --name ${{ vars.ENV }}-omi-backend-external-secret \
-            --min-refresh-time "${force_sync_at}" \
-            --timeout-seconds 120
-          kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
-            | python3 backend/scripts/verify_k8s_secret_keys.py \
-                ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
+          backend/scripts/deploy-backend-secrets.sh
 
       - name: Deploy ${{ env.SERVICE }}-listen to GKE
         run: |

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -47,6 +47,10 @@ jobs:
             echo "Invalid service: ${{ env.SERVICE }}. Must be 'pusher' or 'llm-gateway'."
             exit 1
           fi
+          if [[ "${{ env.SERVICE }}" == "llm-gateway" && "${{ github.event.inputs.environment }}" != "development" ]]; then
+            echo "LLM Gateway deploys are dev-only until the prod launch checklist is explicitly completed."
+            exit 1
+          fi
 
       # To workaround "no space left on device" issue of GitHub-hosted runner
       - name: Delete huge unnecessary tools folder
@@ -129,32 +133,19 @@ jobs:
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Deploy Pusher to GKE cluster using Helm
+        env:
+          BACKEND_SECRETS_GSA: ${{ vars.BACKEND_SECRETS_GSA }}
+          ENVIRONMENT: ${{ vars.ENV }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
+          REGION: ${{ env.REGION }}
         run: |
           if [[ "${{ env.SERVICE }}" == "llm-gateway" ]]; then
             python3 -m pip install -q pyyaml
             python3 backend/scripts/validate-llm-gateway-env.py \
               backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
               backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml
-            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
-              ./backend/charts/backend-secrets \
-              -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
-            force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
-              ${{ vars.ENV }}-omi-backend-external-secret \
-              force-sync="${force_sync_at}" --overwrite
-            python3 backend/scripts/wait_external_secret_refresh.py \
-              --namespace ${{ vars.ENV }}-omi-backend \
-              --name ${{ vars.ENV }}-omi-backend-external-secret \
-              --min-refresh-time "${force_sync_at}" \
-              --timeout-seconds 120
-            kubectl -n ${{ vars.ENV }}-omi-backend get secret ${{ vars.ENV }}-omi-backend-secrets -o json \
-              | python3 backend/scripts/verify_k8s_secret_keys.py \
-                  ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
-            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-llm-gateway \
-              ./backend/charts/llm-gateway \
-              -f ./backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml \
-              --set "image.tag=${GITHUB_SHA::7}"
-            if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-llm-gateway --timeout=300s; then
+            if ! IMAGE_TAG="${GITHUB_SHA::7}" backend/scripts/deploy-llm-gateway.sh; then
               python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service llm-gateway || true
               echo "=== llm-gateway deployment ==="
               kubectl -n ${{ vars.ENV }}-omi-backend describe deploy/${{ vars.ENV }}-omi-llm-gateway || true

--- a/.github/workflows/gcp_llm_gateway_auto_dev.yml
+++ b/.github/workflows/gcp_llm_gateway_auto_dev.yml
@@ -1,16 +1,18 @@
-name: Deploy LLM Gateway to GKE
+name: Auto Deploy LLM Gateway to GKE (Development)
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Select the environment to deploy to'
-        required: true
-        default: 'development'
-      branch:
-        description: 'Branch to deploy from'
-        required: true
-        default: 'main'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'backend/llm_gateway/**'
+      - 'backend/charts/llm-gateway/**'
+      - 'backend/charts/backend-secrets/**'
+      - 'backend/scripts/deploy-backend-secrets.sh'
+      - 'backend/scripts/deploy-llm-gateway.sh'
+      - 'backend/scripts/smoke-llm-gateway.py'
+      - 'backend/scripts/validate-llm-gateway-env.py'
+      - 'backend/Dockerfile'
+      - '.github/workflows/gcp_llm_gateway*.yml'
 
 env:
   SERVICE: llm-gateway
@@ -18,27 +20,18 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
 
     runs-on: ubuntu-latest
     steps:
-      - name: Validate Environment Input
-        run: |
-          if [[ "${{ github.event.inputs.environment }}" != "development" ]]; then
-            echo "Invalid environment: ${{ github.event.inputs.environment }}. LLM Gateway deploys are dev-only until the prod launch checklist is explicitly completed."
-            exit 1
-          fi
-
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Google Auth
         id: auth
@@ -54,9 +47,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Google Service Account
-        run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./backend/google-credentials.json
 
       - name: Install Helm
         uses: azure/setup-helm@v3
@@ -100,4 +90,4 @@ jobs:
             --command -- sh -c 'python scripts/smoke-llm-gateway.py --url "$SMOKE_URL" --token "$SMOKE_TOKEN"'
 
       - name: Show Output
-        run: echo "LLM Gateway deployed to ${{ github.event.inputs.environment }}"
+        run: echo "LLM Gateway deployed to development"

--- a/backend/scripts/deploy-backend-secrets.sh
+++ b/backend/scripts/deploy-backend-secrets.sh
@@ -12,6 +12,8 @@ NAMESPACE="${NAMESPACE:-}"
 RELEASE_NAME="${RELEASE_NAME:-}"
 DRY_RUN="${DRY_RUN:-false}"
 WAIT_EXTERNAL_SECRET="${WAIT_EXTERNAL_SECRET:-true}"
+EXTERNAL_SECRET_NAME="${EXTERNAL_SECRET_NAME:-}"
+TARGET_SECRET_NAME="${TARGET_SECRET_NAME:-}"
 
 if [[ -z "$ENVIRONMENT" ]]; then
   echo "ERROR: ENVIRONMENT or ENV is required" >&2
@@ -48,6 +50,44 @@ if [[ ! -f "$VALUES_FILE" ]]; then
   exit 2
 fi
 
+read_values_field() {
+  local field_path="$1"
+  python3 - "$VALUES_FILE" "$field_path" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+values_path = Path(sys.argv[1])
+field_path = sys.argv[2].split('.')
+with values_path.open('r', encoding='utf-8') as handle:
+    value = yaml.safe_load(handle)
+for part in field_path:
+    if not isinstance(value, dict):
+        value = None
+        break
+    value = value.get(part)
+if value is None:
+    value = ''
+print(value)
+PY
+}
+
+if [[ -z "$EXTERNAL_SECRET_NAME" ]]; then
+  EXTERNAL_SECRET_NAME="$(read_values_field externalSecret.name)"
+fi
+if [[ -z "$TARGET_SECRET_NAME" ]]; then
+  TARGET_SECRET_NAME="$(read_values_field externalSecret.targetSecretName)"
+fi
+if [[ -z "$EXTERNAL_SECRET_NAME" ]]; then
+  echo "ERROR: externalSecret.name is required in $VALUES_FILE or EXTERNAL_SECRET_NAME" >&2
+  exit 2
+fi
+if [[ -z "$TARGET_SECRET_NAME" ]]; then
+  echo "ERROR: externalSecret.targetSecretName is required in $VALUES_FILE or TARGET_SECRET_NAME" >&2
+  exit 2
+fi
+
 HELM_ARGS=(
   "$RELEASE_NAME"
   "$CHART_DIR"
@@ -68,14 +108,14 @@ fi
 helm -n "$NAMESPACE" upgrade --install "${HELM_ARGS[@]}"
 force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 kubectl -n "$NAMESPACE" annotate externalsecret \
-  "${ENVIRONMENT}-omi-backend-external-secret" \
+  "$EXTERNAL_SECRET_NAME" \
   force-sync="${force_sync_at}" --overwrite
 if [[ "$WAIT_EXTERNAL_SECRET" == "true" ]]; then
   python3 backend/scripts/wait_external_secret_refresh.py \
     --namespace "$NAMESPACE" \
-    --name "${ENVIRONMENT}-omi-backend-external-secret" \
+    --name "$EXTERNAL_SECRET_NAME" \
     --min-refresh-time "${force_sync_at}" \
     --timeout-seconds 120
-  kubectl -n "$NAMESPACE" get secret "${ENVIRONMENT}-omi-backend-secrets" -o json \
+  kubectl -n "$NAMESPACE" get secret "$TARGET_SECRET_NAME" -o json \
     | python3 backend/scripts/verify_k8s_secret_keys.py "$VALUES_FILE"
 fi

--- a/backend/scripts/deploy-backend-secrets.sh
+++ b/backend/scripts/deploy-backend-secrets.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="${ENVIRONMENT:-${ENV:-}}"
+GCP_PROJECT_ID="${GCP_PROJECT_ID:-}"
+GKE_CLUSTER="${GKE_CLUSTER:-}"
+REGION="${REGION:-}"
+BACKEND_SECRETS_GSA="${BACKEND_SECRETS_GSA:-}"
+CHART_DIR="${CHART_DIR:-backend/charts/backend-secrets}"
+VALUES_FILE="${VALUES_FILE:-}"
+NAMESPACE="${NAMESPACE:-}"
+RELEASE_NAME="${RELEASE_NAME:-}"
+DRY_RUN="${DRY_RUN:-false}"
+WAIT_EXTERNAL_SECRET="${WAIT_EXTERNAL_SECRET:-true}"
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "ERROR: ENVIRONMENT or ENV is required" >&2
+  exit 2
+fi
+if [[ -z "$GCP_PROJECT_ID" ]]; then
+  echo "ERROR: GCP_PROJECT_ID is required" >&2
+  exit 2
+fi
+if [[ -z "$GKE_CLUSTER" ]]; then
+  echo "ERROR: GKE_CLUSTER is required" >&2
+  exit 2
+fi
+if [[ -z "$REGION" ]]; then
+  echo "ERROR: REGION is required" >&2
+  exit 2
+fi
+
+if [[ -z "$VALUES_FILE" ]]; then
+  VALUES_FILE="backend/charts/backend-secrets/${ENVIRONMENT}_omi_backend_secrets_values.yaml"
+fi
+if [[ -z "$NAMESPACE" ]]; then
+  NAMESPACE="${ENVIRONMENT}-omi-backend"
+fi
+if [[ -z "$RELEASE_NAME" ]]; then
+  RELEASE_NAME="${ENVIRONMENT}-omi-backend-secrets"
+fi
+if [[ -z "$BACKEND_SECRETS_GSA" ]]; then
+  BACKEND_SECRETS_GSA="${ENVIRONMENT}-omi-backend-eso-gsa@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+fi
+
+if [[ ! -f "$VALUES_FILE" ]]; then
+  echo "ERROR: backend-secrets values file not found: $VALUES_FILE" >&2
+  exit 2
+fi
+
+HELM_ARGS=(
+  "$RELEASE_NAME"
+  "$CHART_DIR"
+  -f "$VALUES_FILE"
+  --set "gke.projectID=${GCP_PROJECT_ID}"
+  --set "gke.clusterLocation=${REGION}"
+  --set "gke.clusterName=${GKE_CLUSTER}"
+  --set "gsa.name=${BACKEND_SECRETS_GSA}"
+)
+
+helm template "${HELM_ARGS[@]}" >/dev/null
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "backend-secrets render preflight OK for ${RELEASE_NAME} in ${NAMESPACE}"
+  exit 0
+fi
+
+helm -n "$NAMESPACE" upgrade --install "${HELM_ARGS[@]}"
+force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+kubectl -n "$NAMESPACE" annotate externalsecret \
+  "${ENVIRONMENT}-omi-backend-external-secret" \
+  force-sync="${force_sync_at}" --overwrite
+if [[ "$WAIT_EXTERNAL_SECRET" == "true" ]]; then
+  python3 backend/scripts/wait_external_secret_refresh.py \
+    --namespace "$NAMESPACE" \
+    --name "${ENVIRONMENT}-omi-backend-external-secret" \
+    --min-refresh-time "${force_sync_at}" \
+    --timeout-seconds 120
+  kubectl -n "$NAMESPACE" get secret "${ENVIRONMENT}-omi-backend-secrets" -o json \
+    | python3 backend/scripts/verify_k8s_secret_keys.py "$VALUES_FILE"
+fi

--- a/backend/scripts/deploy-llm-gateway.sh
+++ b/backend/scripts/deploy-llm-gateway.sh
@@ -42,7 +42,15 @@ python backend/scripts/validate-llm-gateway-env.py \
   "$VALUES_FILE"
 
 if [[ "$SKIP_BACKEND_SECRETS" != "true" ]]; then
-  backend/scripts/deploy-backend-secrets.sh
+  env -u CHART_DIR -u VALUES_FILE -u RELEASE_NAME \
+    ENVIRONMENT="$ENVIRONMENT" \
+    NAMESPACE="$NAMESPACE" \
+    DRY_RUN="$DRY_RUN" \
+    GCP_PROJECT_ID="${GCP_PROJECT_ID:-}" \
+    GKE_CLUSTER="${GKE_CLUSTER:-}" \
+    REGION="${REGION:-}" \
+    BACKEND_SECRETS_GSA="${BACKEND_SECRETS_GSA:-}" \
+    backend/scripts/deploy-backend-secrets.sh
   if [[ "$DRY_RUN" != "true" ]]; then
     sleep 10
   fi

--- a/backend/scripts/deploy-llm-gateway.sh
+++ b/backend/scripts/deploy-llm-gateway.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="${ENVIRONMENT:-${ENV:-}}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+CHART_DIR="${CHART_DIR:-backend/charts/llm-gateway}"
+VALUES_FILE="${VALUES_FILE:-}"
+NAMESPACE="${NAMESPACE:-}"
+RELEASE_NAME="${RELEASE_NAME:-}"
+DRY_RUN="${DRY_RUN:-false}"
+SKIP_BACKEND_SECRETS="${SKIP_BACKEND_SECRETS:-false}"
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "ERROR: ENVIRONMENT or ENV is required" >&2
+  exit 2
+fi
+if [[ "$ENVIRONMENT" != "dev" ]]; then
+  echo "ERROR: LLM Gateway deploys are dev-only until the prod launch checklist is explicitly completed" >&2
+  exit 2
+fi
+if [[ -z "$IMAGE_TAG" ]]; then
+  echo "ERROR: IMAGE_TAG is required" >&2
+  exit 2
+fi
+if [[ -z "$VALUES_FILE" ]]; then
+  VALUES_FILE="backend/charts/llm-gateway/${ENVIRONMENT}_omi_llm_gateway_values.yaml"
+fi
+if [[ -z "$NAMESPACE" ]]; then
+  NAMESPACE="${ENVIRONMENT}-omi-backend"
+fi
+if [[ -z "$RELEASE_NAME" ]]; then
+  RELEASE_NAME="${ENVIRONMENT}-omi-llm-gateway"
+fi
+
+if [[ ! -f "$VALUES_FILE" ]]; then
+  echo "ERROR: llm-gateway values file not found: $VALUES_FILE" >&2
+  exit 2
+fi
+
+python backend/scripts/validate-llm-gateway-env.py \
+  "backend/charts/backend-listen/${ENVIRONMENT}_omi_backend_listen_values.yaml" \
+  "$VALUES_FILE"
+
+if [[ "$SKIP_BACKEND_SECRETS" != "true" ]]; then
+  backend/scripts/deploy-backend-secrets.sh
+  if [[ "$DRY_RUN" != "true" ]]; then
+    sleep 10
+  fi
+fi
+
+HELM_ARGS=(
+  "$RELEASE_NAME"
+  "$CHART_DIR"
+  -f "$VALUES_FILE"
+  --set "image.tag=${IMAGE_TAG}"
+)
+
+helm template "${HELM_ARGS[@]}" >/dev/null
+
+adopt_for_helm() {
+  local kind="$1"
+  local name="$2"
+  local owner_release
+  local owner_namespace
+
+  if ! kubectl -n "$NAMESPACE" get "$kind" "$name" >/dev/null 2>&1; then
+    return
+  fi
+
+  owner_release="$(kubectl -n "$NAMESPACE" get "$kind" "$name" -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)"
+  owner_namespace="$(kubectl -n "$NAMESPACE" get "$kind" "$name" -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' 2>/dev/null || true)"
+  if [[ -n "$owner_release" && "$owner_release" != "$RELEASE_NAME" ]]; then
+    echo "ERROR: $kind/$name is already owned by Helm release $owner_release" >&2
+    exit 1
+  fi
+  if [[ -n "$owner_namespace" && "$owner_namespace" != "$NAMESPACE" ]]; then
+    echo "ERROR: $kind/$name is already owned by Helm namespace $owner_namespace" >&2
+    exit 1
+  fi
+
+  kubectl -n "$NAMESPACE" label "$kind" "$name" app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl -n "$NAMESPACE" annotate "$kind" "$name" \
+    "meta.helm.sh/release-name=${RELEASE_NAME}" \
+    "meta.helm.sh/release-namespace=${NAMESPACE}" \
+    --overwrite
+}
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "llm-gateway render preflight OK for ${RELEASE_NAME} in ${NAMESPACE}"
+  exit 0
+fi
+
+# The first dev ingress and BackendConfig were bootstrapped manually before this
+# chart owned them. Adopt only these known chart resources so future deploys
+# converge through Helm.
+adopt_for_helm ingress "$RELEASE_NAME"
+adopt_for_helm backendconfig "${ENVIRONMENT}-llm-gateway-backend-config"
+
+helm -n "$NAMESPACE" upgrade --install "${HELM_ARGS[@]}"
+kubectl -n "$NAMESPACE" rollout status "deploy/${RELEASE_NAME}" --timeout=300s

--- a/docs/doc/developer/backend/llm_gateway.mdx
+++ b/docs/doc/developer/backend/llm_gateway.mdx
@@ -42,6 +42,12 @@ BYOK requests skip gateway routing until BYOK forwarding is implemented for the 
 
 The backend exposes the Prometheus counter `llm_gateway_chat_extraction_requests_total{feature,outcome,reason}` for structured gateway callers. Outcomes are bounded classes such as `success`, `fallback`, and `skipped`; reasons are bounded classes such as `ok`, `timeout`, `request_error`, `http_503`, `invalid_json`, `schema_validation`, `unexpected_error`, and `byok`.
 
+## Deployment
+
+Development LLM Gateway deploys are intentionally allowed before production deploys. The dedicated manual workflow and the automatic workflow deploy only to development until the production rollout checklist is explicitly completed and the workflow guard is removed.
+
+Gateway deploys must go through `backend/scripts/deploy-llm-gateway.sh`. The helper validates backend/gateway env wiring, deploys backend secrets through `backend/scripts/deploy-backend-secrets.sh`, adopts the known development ingress if it was bootstrapped before Helm owned it, and then runs the Helm upgrade. Do not copy raw `helm upgrade` commands into workflows; that bypasses the dev-only guardrail and required secret/env preflight.
+
 Primary user chat should follow later as a separate lane, likely:
 
 ```text


### PR DESCRIPTION
## Summary
- add a dev-only LLM Gateway deploy helper that validates env wiring, deploys backend secrets, adopts known bootstrapped dev resources, and runs Helm rollout from one path
- add automatic dev-only LLM Gateway deploy on main changes to gateway/chart/deploy files
- route manual gateway deploy and the legacy backend-pusher gateway path through the shared helper
- fold the newer ExternalSecret wait/verify flow into the backend-secrets helper so workflows do not drift
- document that gateway deploys remain dev-only until the prod launch checklist is explicitly completed

## Verification
- `DRY_RUN=true ENVIRONMENT=dev GCP_PROJECT_ID=based-hardware-dev GKE_CLUSTER=dev-omi-gke REGION=us-central1 IMAGE_TAG=test backend/scripts/deploy-llm-gateway.sh`
- `DRY_RUN=true ENVIRONMENT=prod GCP_PROJECT_ID=based-hardware GKE_CLUSTER=prod-omi-gke REGION=us-central1 IMAGE_TAG=test backend/scripts/deploy-llm-gateway.sh` exits 2 with the dev-only guard
- parsed edited GitHub workflows with Python YAML loader
- `python backend/scripts/validate-llm-gateway-env.py` for dev and prod values
- `git diff --check origin/main...HEAD`
- pre-push checks passed, including selected backend unit tests, OpenAPI contract check, workflow checks, and desktop Rust check
- manual dev-only workflow run succeeded and smoked gateway after rebase: https://github.com/BasedHardware/omi/actions/runs/28541000227
- live dev gateway image after deploy: `gcr.io/based-hardware-dev/llm-gateway:c6fb64f`, 1/1 pod ready

## Notes
- prod gateway deploys are still blocked in the helper and workflows
- local gitignored prod rollout checklist updated under `.coordination/llm-gateway-rollout-plan.md` with the prod enablement gate
