### PR TITLE
[codex] Fix desktop chat quota accounting

### DIFF
--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional, List, Dict, Any
 
+from google.api_core.exceptions import AlreadyExists, Conflict
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -675,15 +676,36 @@ def update_chat_session(uid: str, session_id: str, title: str = None, starred: b
 
 
 def save_message(
-    uid: str, text: str, sender: str, app_id: str = None, session_id: str = None, metadata: str = None
+    uid: str,
+    text: str,
+    sender: str,
+    app_id: str = None,
+    session_id: str = None,
+    metadata: str = None,
+    client_message_id: str = None,
 ) -> dict:
     """Save a chat message for the desktop app.
 
     Writes all fields expected by chat.py's Message model so messages are
     visible across platforms.  Auto-acquires a session if none provided.
     """
-    msg_id = str(uuid.uuid4())
+    msg_id = client_message_id or str(uuid.uuid4())
     now = datetime.now(timezone.utc)
+
+    message_ref = db.collection('users').document(uid).collection('messages').document(msg_id)
+    if client_message_id:
+        existing_message = message_ref.get()
+        if existing_message.exists:
+            existing = existing_message.to_dict() or {}
+            existing_created_at = existing.get('created_at')
+            if hasattr(existing_created_at, 'isoformat'):
+                existing_created_at = existing_created_at.isoformat()
+            return {
+                'id': msg_id,
+                'created_at': existing_created_at or now.isoformat(),
+                'session_id': existing.get('chat_session_id') or existing.get('session_id'),
+                'created': False,
+            }
 
     # Auto-acquire session (matches Rust backend behavior)
     if not session_id:
@@ -705,10 +727,27 @@ def save_message(
         'memories_id': [],
         'metadata': metadata,
     }
-    db.collection('users').document(uid).collection('messages').document(msg_id).set(doc)
+    created = True
+    if client_message_id:
+        try:
+            message_ref.create(doc)
+        except (AlreadyExists, Conflict):
+            existing = message_ref.get().to_dict() or {}
+            existing_created_at = existing.get('created_at')
+            if hasattr(existing_created_at, 'isoformat'):
+                existing_created_at = existing_created_at.isoformat()
+            return {
+                'id': msg_id,
+                'created_at': existing_created_at or now.isoformat(),
+                'session_id': existing.get('chat_session_id') or existing.get('session_id'),
+                'created': False,
+            }
+    else:
+        message_ref.set(doc)
 
-    # Update session message_count and preview (skip if session was deleted)
-    if session_id:
+    # Update session message_count and preview (skip if session was deleted).
+    # Retried client_message_id saves are idempotent and must not bump counters.
+    if session_id and created:
         session_ref = db.collection('users').document(uid).collection('chat_sessions').document(session_id)
         if session_ref.get().exists:
             session_ref.update(
@@ -719,7 +758,7 @@ def save_message(
                 }
             )
 
-    return {'id': msg_id, 'created_at': now.isoformat()}
+    return {'id': msg_id, 'created_at': now.isoformat(), 'session_id': session_id, 'created': created}
 
 
 def delete_messages(uid: str, app_id: str = None, session_id: str = None) -> int:

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -683,6 +683,7 @@ def save_message(
     session_id: str = None,
     metadata: str = None,
     client_message_id: str = None,
+    message_source: str = 'desktop_chat',
 ) -> dict:
     """Save a chat message for the desktop app.
 
@@ -726,6 +727,7 @@ def save_message(
         'reported': False,
         'memories_id': [],
         'metadata': metadata,
+        'message_source': message_source,
     }
     created = True
     if client_message_id:

--- a/backend/database/llm_usage.py
+++ b/backend/database/llm_usage.py
@@ -5,12 +5,15 @@ Stores and queries LLM token usage by feature in Firestore.
 Schema: users/{uid}/llm_usage/{date} -> {feature -> {model -> {input_tokens, output_tokens}}}
 """
 
+import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 from google.cloud import firestore
 
 from ._client import db
+
+transactional = getattr(firestore, 'transactional', lambda fn: fn)
 
 
 def record_llm_usage(
@@ -66,6 +69,70 @@ def record_llm_usage(
     }
 
     usage_ref.set(update_data, merge=True)
+
+
+@transactional
+def _record_chat_quota_question_transaction(
+    transaction,
+    usage_ref,
+    event_ref,
+    event_data: dict,
+    doc_id: str,
+) -> bool:
+    event_snapshot = event_ref.get(transaction=transaction)
+    if event_snapshot.exists:
+        return False
+
+    now = datetime.now(timezone.utc)
+    transaction.set(event_ref, event_data)
+    transaction.set(
+        usage_ref,
+        {
+            'backend_chat.quota_questions': firestore.Increment(1),
+            'date': doc_id,
+            'last_updated': now,
+        },
+        merge=True,
+    )
+    return True
+
+
+def record_chat_quota_question(
+    uid: str,
+    idempotency_key: str,
+    source: str,
+    message_id: Optional[str] = None,
+    chat_session_id: Optional[str] = None,
+    platform: Optional[str] = None,
+) -> bool:
+    """Record one accepted visible backend chat question exactly once.
+
+    This is the product-boundary quota counter for mobile/backend chat. It is
+    intentionally separate from ``chat.*.call_count``, which is LLM telemetry
+    and can vary with implementation details.
+    """
+    if not idempotency_key:
+        raise ValueError('idempotency_key is required')
+
+    now = datetime.now(timezone.utc)
+    doc_id = now.strftime('%Y-%m-%d')
+    event_id = hashlib.sha256(f'{uid}:{idempotency_key}'.encode('utf-8')).hexdigest()
+
+    user_ref = db.collection('users').document(uid)
+    usage_ref = user_ref.collection('llm_usage').document(doc_id)
+    event_ref = user_ref.collection('chat_quota_events').document(event_id)
+    event_data = {
+        'idempotency_key': idempotency_key,
+        'source': source,
+        'message_id': message_id,
+        'chat_session_id': chat_session_id,
+        'platform': platform,
+        'created_at': now,
+        'date': doc_id,
+    }
+
+    transaction = db.transaction()
+    return _record_chat_quota_question_transaction(transaction, usage_ref, event_ref, event_data, doc_id)
 
 
 def get_daily_usage(uid: str, date: Optional[datetime] = None) -> Dict:

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -32,10 +32,6 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
         if not snap.exists:
             continue
         data = snap.to_dict() or {}
-        has_flat_desktop_quota_questions = 'desktop_chat.quota_questions' in data
-        has_desktop_quota_questions = has_flat_desktop_quota_questions or (
-            isinstance(data.get('desktop_chat'), dict) and 'quota_questions' in data['desktop_chat']
-        )
         has_desktop_realtime_quota_questions = 'desktop_chat_realtime.quota_questions' in data or (
             isinstance(data.get('desktop_chat_realtime'), dict) and 'quota_questions' in data['desktop_chat_realtime']
         )
@@ -51,17 +47,9 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
             # `quota_questions`, incremented once per visible desktop user turn.
             if isinstance(value, dict):
                 if key == 'desktop_chat':
-                    if 'quota_questions' in value:
-                        questions += int(value.get('quota_questions', 0) or 0)
-                    else:
-                        # Already-released desktop backends only wrote call_count.
-                        questions += int(value.get('call_count', 0) or 0)
+                    questions += int(value.get('quota_questions', 0) or 0)
                     cost_usd += float(value.get('cost_usd', 0) or 0)
-                elif (
-                    key == 'desktop_chat_realtime'
-                    and has_desktop_quota_questions
-                    and not has_desktop_realtime_quota_questions
-                ):
+                elif key == 'desktop_chat_realtime' and not has_desktop_realtime_quota_questions:
                     # Rollout bridge: old managed realtime turns only wrote
                     # call_count. New realtime writes both the grand-total
                     # desktop_chat.quota_questions counter and this breakdown's
@@ -75,13 +63,7 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
             if key.startswith('desktop_chat'):
                 if key == 'desktop_chat.quota_questions':
                     questions += int(value)
-                elif key == 'desktop_chat.call_count' and not has_flat_desktop_quota_questions:
-                    questions += int(value)
-                elif (
-                    key == 'desktop_chat_realtime.call_count'
-                    and has_desktop_quota_questions
-                    and not has_desktop_realtime_quota_questions
-                ):
+                elif key == 'desktop_chat_realtime.call_count' and not has_desktop_realtime_quota_questions:
                     questions += int(value)
                 elif key.endswith('.cost_usd'):
                     cost_usd += float(value)

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -12,7 +12,7 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
     """Sum current-month chat usage from `users/{uid}/llm_usage/{YYYY-MM-DD}` docs.
 
     Returns keys:
-      - questions: total user-initiated chat calls (desktop_chat* + backend `chat.*`)
+      - questions: total user-initiated chat calls (desktop/backend quota counters + legacy backend `chat.*`)
       - cost_usd:  total desktop_chat* cost_usd (backend GPT/Gemini chat has no cost field)
       - reset_at:  unix seconds of the start of next UTC month (when the bucket resets)
 
@@ -32,27 +32,64 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
         if not snap.exists:
             continue
         data = snap.to_dict() or {}
+        has_flat_desktop_quota_questions = 'desktop_chat.quota_questions' in data
+        has_desktop_quota_questions = has_flat_desktop_quota_questions or (
+            isinstance(data.get('desktop_chat'), dict) and 'quota_questions' in data['desktop_chat']
+        )
+        has_desktop_realtime_quota_questions = 'desktop_chat_realtime.quota_questions' in data or (
+            isinstance(data.get('desktop_chat_realtime'), dict) and 'quota_questions' in data['desktop_chat_realtime']
+        )
+        has_backend_quota_questions = any(
+            (key == 'backend_chat' and isinstance(value, dict) and 'quota_questions' in value)
+            or (key == 'backend_chat.quota_questions')
+            for key, value in data.items()
+        )
         for key, value in data.items():
             # The Rust desktop-backend commits desktop_chat usage via dotted Firestore
-            # fieldPaths (e.g. "desktop_chat.call_count"), which Firestore materializes
-            # as a NESTED map ({desktop_chat: {call_count, cost_usd, ...}}) — not the flat
-            # dotted string keys the Python backend writes. Read the grand-total
-            # `desktop_chat` map here; the `desktop_chat_*` prefixed maps (per-account /
-            # realtime breakdowns) are already summed into it, so don't double-count them.
+            # fieldPaths, which Firestore materializes as a NESTED map. Keep
+            # `call_count` as internal generation telemetry; quota enforcement uses
+            # `quota_questions`, incremented once per visible desktop user turn.
             if isinstance(value, dict):
                 if key == 'desktop_chat':
-                    questions += int(value.get('call_count', 0) or 0)
+                    if 'quota_questions' in value:
+                        questions += int(value.get('quota_questions', 0) or 0)
+                    else:
+                        # Already-released desktop backends only wrote call_count.
+                        questions += int(value.get('call_count', 0) or 0)
                     cost_usd += float(value.get('cost_usd', 0) or 0)
+                elif (
+                    key == 'desktop_chat_realtime'
+                    and has_desktop_quota_questions
+                    and not has_desktop_realtime_quota_questions
+                ):
+                    # Rollout bridge: old managed realtime turns only wrote
+                    # call_count. New realtime writes both the grand-total
+                    # desktop_chat.quota_questions counter and this breakdown's
+                    # quota_questions, so only fall back when the breakdown is absent.
+                    questions += int(value.get('call_count', 0) or 0)
+                elif key == 'backend_chat':
+                    questions += int(value.get('quota_questions', 0) or 0)
                 continue
             if not isinstance(value, (int, float)):
                 continue
             if key.startswith('desktop_chat'):
-                if key.endswith('.call_count'):
+                if key == 'desktop_chat.quota_questions':
+                    questions += int(value)
+                elif key == 'desktop_chat.call_count' and not has_flat_desktop_quota_questions:
+                    questions += int(value)
+                elif (
+                    key == 'desktop_chat_realtime.call_count'
+                    and has_desktop_quota_questions
+                    and not has_desktop_realtime_quota_questions
+                ):
                     questions += int(value)
                 elif key.endswith('.cost_usd'):
                     cost_usd += float(value)
-            elif key.startswith('chat.') and key.endswith('.call_count'):
-                # user-initiated backend chat (any model)
+            elif key == 'backend_chat.quota_questions':
+                questions += int(value)
+            elif key.startswith('chat.') and key.endswith('.call_count') and not has_backend_quota_questions:
+                # Legacy user-initiated backend chat (any model). New writes use
+                # backend_chat.quota_questions so LLM telemetry no longer drives quota.
                 questions += int(value)
 
     # Compute end-of-month boundary in UTC for the reset timestamp.

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,4 +1,5 @@
 import asyncio
+import binascii
 import json
 import tempfile
 import uuid
@@ -27,6 +28,7 @@ from multipart.multipart import shutil
 
 import database.chat as chat_db
 import database.conversations as conversations_db
+import database.llm_usage as llm_usage_db
 from database.apps import record_app_usage
 from models.app import App, UsageHistoryType
 from models.chat import (
@@ -172,6 +174,28 @@ def _build_quota_exceeded_reply(
     return ResponseMessage(**ai_msg.dict(), ask_for_nps=False)
 
 
+def _record_chat_quota_question_safe(
+    uid: str,
+    *,
+    idempotency_key: str,
+    source: str,
+    message_id: Optional[str] = None,
+    chat_session_id: Optional[str] = None,
+    platform: Optional[str] = None,
+):
+    try:
+        llm_usage_db.record_chat_quota_question(
+            uid,
+            idempotency_key=idempotency_key,
+            source=source,
+            message_id=message_id,
+            chat_session_id=chat_session_id,
+            platform=platform,
+        )
+    except Exception:
+        logger.exception('Failed to record chat quota question source=%s uid=%s', source, uid)
+
+
 @router.post('/v2/messages', tags=['chat'], response_model=ResponseMessage)
 def send_message(
     data: SendMessageRequest,
@@ -244,6 +268,14 @@ def send_message(
         chat_db.add_message_to_chat_session(uid, chat_session.id, message.id)
 
     chat_db.add_message(uid, message.dict())
+    _record_chat_quota_question_safe(
+        uid,
+        idempotency_key=f'v2_messages:{message.id}',
+        source='v2_messages',
+        message_id=message.id,
+        chat_session_id=message.chat_session_id,
+        platform=x_app_platform,
+    )
 
     # Check for goal progress (background) — rate-limited to one call per user per 5 min
     if try_acquire_goal_extraction_lock(uid):
@@ -443,7 +475,25 @@ def create_voice_message_stream(
 
     # process
     async def generate_stream():
+        quota_recorded = False
         async for chunk in process_voice_message_segment_stream(first_wav, uid, language=resolved_language):
+            if not quota_recorded and chunk.startswith('message: '):
+                payload = chunk.removeprefix('message: ').strip()
+                try:
+                    message_data = json.loads(base64.b64decode(payload).decode('utf-8'))
+                    await run_blocking(
+                        db_executor,
+                        _record_chat_quota_question_safe,
+                        uid,
+                        idempotency_key=f"v2_voice_messages:{message_data.get('id') or first_wav}",
+                        source='v2_voice_messages',
+                        message_id=message_data.get('id'),
+                        chat_session_id=message_data.get('chat_session_id'),
+                        platform=x_app_platform,
+                    )
+                    quota_recorded = True
+                except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+                    logger.warning('Failed to record voice chat quota question: %s', exc)
             yield chunk
 
     return StreamingResponse(generate_stream(), media_type="text/event-stream")

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -48,6 +48,7 @@ class SaveMessageRequest(BaseModel):
     session_id: str | None = Field(None, max_length=200)
     metadata: str | None = None
     client_message_id: str | None = Field(None, pattern=r'^[A-Za-z0-9_-]{1,128}$')
+    message_source: str = Field('desktop_chat', pattern=r'^(desktop_chat|realtime_voice)$')
 
 
 class RateMessageRequest(BaseModel):
@@ -147,8 +148,9 @@ def save_message(
         session_id=request.session_id,
         metadata=request.metadata,
         client_message_id=request.client_message_id,
+        message_source=request.message_source,
     )
-    if request.sender == 'human':
+    if request.sender == 'human' and request.message_source == 'desktop_chat':
         try:
             llm_usage_db.record_chat_quota_question(
                 uid,

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -11,10 +11,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 import database.chat as chat_db
+import database.llm_usage as llm_usage_db
 from database.users import set_chat_message_rating_score
 from utils.chat import initial_message_util
 from utils.llm.clients import get_llm
@@ -46,6 +47,7 @@ class SaveMessageRequest(BaseModel):
     app_id: str | None = Field(None, max_length=200)
     session_id: str | None = Field(None, max_length=200)
     metadata: str | None = None
+    client_message_id: str | None = Field(None, pattern=r'^[A-Za-z0-9_-]{1,128}$')
 
 
 class RateMessageRequest(BaseModel):
@@ -134,16 +136,31 @@ def delete_chat_session(
 @router.post('/v2/desktop/messages', tags=['chat-sessions'])
 def save_message(
     request: SaveMessageRequest,
+    x_app_platform: str | None = Header(None),
     uid: str = Depends(auth.get_current_user_uid),
 ):
-    return chat_db.save_message(
+    saved = chat_db.save_message(
         uid,
         text=request.text,
         sender=request.sender,
         app_id=request.app_id,
         session_id=request.session_id,
         metadata=request.metadata,
+        client_message_id=request.client_message_id,
     )
+    if request.sender == 'human':
+        try:
+            llm_usage_db.record_chat_quota_question(
+                uid,
+                idempotency_key=f'desktop_messages:{saved["id"]}',
+                source='desktop_messages',
+                message_id=saved['id'],
+                chat_session_id=saved.get('session_id'),
+                platform=x_app_platform,
+            )
+        except Exception:
+            logger.exception('Failed to record desktop chat quota question uid=%s message_id=%s', uid, saved['id'])
+    return saved
 
 
 @router.get('/v2/desktop/messages', tags=['chat-sessions'])

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -137,8 +137,11 @@ if "utils.byok" not in sys.modules:
 
 if "utils.llm.gateway_client" not in sys.modules:
     gateway_mod = _stub_module("utils.llm.gateway_client")
-    gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
-    gateway_mod.record_chat_extraction_gateway_result = MagicMock()
+else:
+    gateway_mod = sys.modules["utils.llm.gateway_client"]
+gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
+gateway_mod.record_chat_extraction_gateway_result = MagicMock()
+gateway_mod.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
 
 if "utils.llm.gateway_observability" not in sys.modules:
     gateway_observability_mod = _stub_module("utils.llm.gateway_observability")

--- a/backend/tests/unit/test_chat_quota_counting_router.py
+++ b/backend/tests/unit/test_chat_quota_counting_router.py
@@ -1,0 +1,318 @@
+"""Router tests for explicit backend chat quota question counting."""
+
+import base64
+import importlib.util
+import io
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _install_package(name: str, path: Path) -> ModuleType:
+    module = ModuleType(name)
+    module.__path__ = [str(path)]
+    sys.modules[name] = module
+    return module
+
+
+def _install_module(name: str, module=None):
+    module = module or MagicMock()
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _load_real_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_chat_client():
+    saved = {k: v for k, v in sys.modules.items()}
+
+    _install_package('models', BACKEND_DIR / 'models')
+    _install_package('database', BACKEND_DIR / 'database')
+    _install_package('utils', BACKEND_DIR / 'utils')
+    _install_package('utils.other', BACKEND_DIR / 'utils' / 'other')
+    _install_package('utils.sync', BACKEND_DIR / 'utils' / 'sync')
+    _install_package('utils.stt', BACKEND_DIR / 'utils' / 'stt')
+    _install_package('utils.llm', BACKEND_DIR / 'utils' / 'llm')
+    _install_package('utils.retrieval', BACKEND_DIR / 'utils' / 'retrieval')
+
+    _load_real_module('models.chat', BACKEND_DIR / 'models' / 'chat.py')
+    _install_module('models.app')
+
+    chat_db = _install_module('database.chat')
+    chat_db.get_chat_session = MagicMock(return_value=None)
+    chat_db.get_messages = MagicMock(return_value=[])
+    chat_db.add_message = MagicMock(side_effect=lambda uid, message_data: message_data)
+    chat_db.add_message_to_chat_session = MagicMock()
+    _install_module('database.conversations')
+    apps_db = _install_module('database.apps')
+    apps_db.record_app_usage = MagicMock()
+    llm_usage_db = _install_module('database.llm_usage')
+    llm_usage_db.record_chat_quota_question = MagicMock(return_value=True)
+    users_db = _install_module('database.users')
+    users_db.set_chat_message_rating_score = MagicMock()
+    redis_db = _install_module('database.redis_db')
+    redis_db.try_acquire_goal_extraction_lock = MagicMock(return_value=False)
+    redis_db.check_rate_limit = MagicMock(return_value=(True, 99, 0))
+    redis_db.store_chat_share = MagicMock()
+    redis_db.get_chat_share = MagicMock(return_value=None)
+
+    executors = _install_module('utils.executors', ModuleType('utils.executors'))
+    executors.critical_executor = MagicMock()
+    executors.db_executor = MagicMock()
+    executors.llm_executor = MagicMock()
+    executors.storage_executor = MagicMock()
+    executors.sync_executor = MagicMock()
+
+    async def run_blocking_side_effect(_executor, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    executors.run_blocking = AsyncMock(side_effect=run_blocking_side_effect)
+
+    utils_apps = _install_module('utils.apps', ModuleType('utils.apps'))
+    utils_apps.get_available_app_by_id = MagicMock(return_value=None)
+    helpers = _install_module('utils.conversation_helpers', ModuleType('utils.conversation_helpers'))
+    helpers.extract_memory_ids = MagicMock(return_value=[])
+    goals = _install_module('utils.llm.goals', ModuleType('utils.llm.goals'))
+    goals.extract_and_update_goal_progress = MagicMock()
+    users = _install_module('utils.users', ModuleType('utils.users'))
+    users.get_user_display_name = MagicMock(return_value='Test User')
+    sanitizer = _install_module('utils.log_sanitizer', ModuleType('utils.log_sanitizer'))
+    sanitizer.sanitize_pii = lambda value: value
+    observability = _install_module('utils.observability', ModuleType('utils.observability'))
+    observability.submit_langsmith_feedback = MagicMock()
+
+    rate_limit = _install_module('utils.rate_limit_config', ModuleType('utils.rate_limit_config'))
+    rate_limit.get_effective_limit = MagicMock(return_value=(100, 60))
+    rate_limit.RATE_LIMIT_SHADOW = False
+    subscription = _install_module('utils.subscription', ModuleType('utils.subscription'))
+    subscription.enforce_chat_quota = MagicMock()
+    subscription.is_trial_paywalled = MagicMock(return_value=False)
+
+    auth = _install_module('utils.other.endpoints', ModuleType('utils.other.endpoints'))
+
+    def get_current_user_uid():
+        return 'test-uid'
+
+    def with_rate_limit(func, _policy):
+        return func
+
+    auth.get_current_user_uid = get_current_user_uid
+    auth.get_current_user_uid_ws_listen = get_current_user_uid
+    auth.with_rate_limit = with_rate_limit
+    storage = _install_module('utils.other.storage', ModuleType('utils.other.storage'))
+    storage.get_syncing_file_temporal_signed_url = MagicMock(return_value='https://example.test/audio.wav')
+    storage.schedule_syncing_temporal_file_deletion = MagicMock()
+    chat_file = _install_module('utils.other.chat_file', ModuleType('utils.other.chat_file'))
+    chat_file.FileChatTool = MagicMock()
+
+    chat_utils = _install_module('utils.chat', ModuleType('utils.chat'))
+    chat_utils.acquire_chat_session = MagicMock()
+    chat_utils.initial_message_util = MagicMock()
+    chat_utils.process_voice_message_segment = MagicMock()
+    chat_utils.resolve_voice_message_language = MagicMock(return_value='en')
+    chat_utils.transcribe_voice_message_segment = MagicMock()
+    chat_utils.transcribe_pcm_bytes = MagicMock()
+
+    async def default_voice_stream(*args, **kwargs):
+        if False:
+            yield None
+
+    chat_utils.process_voice_message_segment_stream = MagicMock(side_effect=default_voice_stream)
+
+    sync_files = _install_module('utils.sync.files', ModuleType('utils.sync.files'))
+    sync_files.retrieve_file_paths = MagicMock(return_value=[])
+    sync_files.decode_files_to_wav = MagicMock(return_value=[])
+    stt_streaming = _install_module('utils.stt.streaming', ModuleType('utils.stt.streaming'))
+    stt_streaming.process_audio_dg = MagicMock()
+    stt_streaming.get_stt_service_for_language = MagicMock()
+
+    usage_tracker = _install_module('utils.llm.usage_tracker', ModuleType('utils.llm.usage_tracker'))
+    usage_tracker.set_usage_context = MagicMock(return_value='usage-token')
+    usage_tracker.reset_usage_context = MagicMock()
+
+    class Features:
+        CHAT = 'chat'
+
+    usage_tracker.Features = Features
+
+    graph = _install_module('utils.retrieval.graph', ModuleType('utils.retrieval.graph'))
+
+    async def fake_execute_chat_stream(*args, **kwargs):
+        kwargs['callback_data']['answer'] = 'hello back'
+        yield ''
+
+    graph.execute_chat_stream = fake_execute_chat_stream
+    graph.execute_graph_chat = MagicMock()
+    graph.execute_persona_chat_stream = MagicMock()
+
+    limiter = _install_module('utils.voice_duration_limiter', ModuleType('utils.voice_duration_limiter'))
+    limiter.compute_pcm_duration_ms = MagicMock(return_value=1000)
+    limiter.read_wav_duration_ms = MagicMock(return_value=1000)
+    limiter.try_consume_budget = MagicMock(return_value=(True, 1000, 7199000))
+    limiter.check_budget = MagicMock(return_value=(True, 0, 7200000))
+    limiter.record_actual_duration = MagicMock()
+
+    multipart = _install_module('multipart', ModuleType('multipart'))
+    multipart.__version__ = '0.0.20'
+    multipart_sub = _install_module('multipart.multipart', ModuleType('multipart.multipart'))
+    import shutil
+
+    multipart_sub.shutil = shutil
+
+    sys.modules.pop('routers.chat', None)
+    spec = importlib.util.spec_from_file_location('routers.chat', BACKEND_DIR / 'routers' / 'chat.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['routers.chat'] = module
+    spec.loader.exec_module(module)
+
+    app = FastAPI()
+    app.include_router(module.router)
+    client = TestClient(app)
+    return client, module, saved
+
+
+def _cleanup(saved):
+    for name in [k for k in sys.modules if k not in saved]:
+        del sys.modules[name]
+    for name, module in saved.items():
+        sys.modules[name] = module
+
+
+def test_v2_messages_records_quota_question_after_human_message_persisted():
+    client, module, saved = _make_chat_client()
+    try:
+        with patch.object(module.uuid, 'uuid4', side_effect=['human-msg-id', 'ai-msg-id']):
+            response = client.post(
+                '/v2/messages',
+                json={'text': 'hello', 'file_ids': []},
+                headers={'X-App-Platform': 'ios'},
+            )
+
+        assert response.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
+            'test-uid',
+            idempotency_key='v2_messages:human-msg-id',
+            source='v2_messages',
+            message_id='human-msg-id',
+            chat_session_id=None,
+            platform='ios',
+        )
+        first_message = module.chat_db.add_message.call_args_list[0].args[1]
+        assert first_message['id'] == 'human-msg-id'
+        assert first_message['sender'] == 'human'
+    finally:
+        _cleanup(saved)
+
+
+def test_v2_messages_quota_exceeded_reply_does_not_record_quota_question():
+    client, module, saved = _make_chat_client()
+    try:
+        quota_detail = {
+            'error': 'quota_exceeded',
+            'plan': 'Free',
+            'unit': 'questions',
+            'used': 30,
+            'limit': 30,
+        }
+        module.enforce_chat_quota.side_effect = module.HTTPException(status_code=402, detail=quota_detail)
+
+        response = client.post(
+            '/v2/messages',
+            json={'text': 'hello', 'file_ids': []},
+            headers={'X-App-Platform': 'ios'},
+        )
+
+        assert response.status_code == 200
+        assert 'done: ' in response.text
+        module.llm_usage_db.record_chat_quota_question.assert_not_called()
+    finally:
+        _cleanup(saved)
+
+
+def test_v2_voice_messages_records_quota_question_from_visible_message_chunk():
+    client, module, saved = _make_chat_client()
+    try:
+        human_message = module.Message(
+            id='voice-human-msg-id',
+            text='voice hello',
+            created_at=module.datetime.now(module.timezone.utc),
+            sender='human',
+            type='text',
+            chat_session_id='voice-session-id',
+        )
+        encoded = base64.b64encode(bytes(human_message.model_dump_json(), 'utf-8')).decode('utf-8')
+
+        async def fake_voice_stream(*args, **kwargs):
+            yield f'message: {encoded}\n\n'
+            yield 'done: e30=\n\n'
+
+        with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/upload.wav']):
+            with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/decoded.wav']):
+                with patch.object(module, 'process_voice_message_segment_stream', side_effect=fake_voice_stream):
+                    response = client.post(
+                        '/v2/voice-messages',
+                        files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                        headers={'X-App-Platform': 'ios'},
+                    )
+
+        assert response.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
+            'test-uid',
+            idempotency_key='v2_voice_messages:voice-human-msg-id',
+            source='v2_voice_messages',
+            message_id='voice-human-msg-id',
+            chat_session_id='voice-session-id',
+            platform='ios',
+        )
+    finally:
+        _cleanup(saved)
+
+
+def test_v2_voice_messages_without_visible_message_does_not_record_quota_question():
+    client, module, saved = _make_chat_client()
+    try:
+
+        async def fake_voice_stream(*args, **kwargs):
+            yield 'done: e30=\n\n'
+
+        with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/upload.wav']):
+            with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/decoded.wav']):
+                with patch.object(module, 'process_voice_message_segment_stream', side_effect=fake_voice_stream):
+                    response = client.post(
+                        '/v2/voice-messages',
+                        files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                        headers={'X-App-Platform': 'ios'},
+                    )
+
+        assert response.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_not_called()
+    finally:
+        _cleanup(saved)

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -101,6 +101,7 @@ byok_stub.has_byok_keys = MagicMock(return_value=False)
 gateway_stub = _stub_module("utils.llm.gateway_client")
 gateway_stub.invoke_chat_structured_gateway = MagicMock(return_value=None)
 gateway_stub.record_chat_extraction_gateway_result = MagicMock()
+gateway_stub.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
 
 gateway_observability_stub = _stub_module("utils.llm.gateway_observability")
 gateway_observability_stub.record_gateway_shadow_comparison = MagicMock()

--- a/backend/tests/unit/test_desktop_message_quota_router.py
+++ b/backend/tests/unit/test_desktop_message_quota_router.py
@@ -108,6 +108,7 @@ def test_desktop_human_message_records_quota_once_after_persistence_acceptance()
             session_id=None,
             metadata=None,
             client_message_id='client-msg-1',
+            message_source='desktop_chat',
         )
         module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
             'test-uid',
@@ -134,6 +135,16 @@ def test_desktop_duplicate_human_message_retries_idempotent_quota_record():
             json={'text': 'hello', 'sender': 'human', 'client_message_id': 'client-msg-1'},
         )
         assert duplicate.status_code == 200
+        module.chat_db.save_message.assert_called_once_with(
+            'test-uid',
+            text='hello',
+            sender='human',
+            app_id=None,
+            session_id=None,
+            metadata=None,
+            client_message_id='client-msg-1',
+            message_source='desktop_chat',
+        )
         module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
             'test-uid',
             idempotency_key='desktop_messages:client-msg-1',
@@ -159,6 +170,39 @@ def test_desktop_ai_message_does_not_record_quota():
             json={'text': 'hello back', 'sender': 'ai', 'client_message_id': 'ai-msg-1'},
         )
         assert ai.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_not_called()
+    finally:
+        _cleanup(saved)
+
+
+def test_realtime_voice_human_message_does_not_record_desktop_message_quota():
+    client, module, saved = _make_client()
+    try:
+        module.chat_db.save_message.return_value = {
+            'id': 'voice-msg-1',
+            'created_at': '2026-07-02T00:00:00+00:00',
+            'created': True,
+        }
+        response = client.post(
+            '/v2/desktop/messages',
+            json={
+                'text': 'voice transcript',
+                'sender': 'human',
+                'client_message_id': 'voice-msg-1',
+                'message_source': 'realtime_voice',
+            },
+        )
+        assert response.status_code == 200
+        module.chat_db.save_message.assert_called_once_with(
+            'test-uid',
+            text='voice transcript',
+            sender='human',
+            app_id=None,
+            session_id=None,
+            metadata=None,
+            client_message_id='voice-msg-1',
+            message_source='realtime_voice',
+        )
         module.llm_usage_db.record_chat_quota_question.assert_not_called()
     finally:
         _cleanup(saved)

--- a/backend/tests/unit/test_desktop_message_quota_router.py
+++ b/backend/tests/unit/test_desktop_message_quota_router.py
@@ -1,0 +1,164 @@
+"""Router tests for desktop message persistence quota accounting."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _install_package(name: str, path: Path) -> ModuleType:
+    module = ModuleType(name)
+    module.__path__ = [str(path)]
+    sys.modules[name] = module
+    return module
+
+
+def _install_module(name: str, module=None):
+    module = module or MagicMock()
+    sys.modules[name] = module
+    if '.' in name:
+        parent_name, attr_name = name.rsplit('.', 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr_name, module)
+    return module
+
+
+def _make_client():
+    saved = {k: v for k, v in sys.modules.items()}
+
+    _install_package('database', BACKEND_DIR / 'database')
+    _install_package('utils', BACKEND_DIR / 'utils')
+    _install_package('utils.other', BACKEND_DIR / 'utils' / 'other')
+    _install_package('utils.llm', BACKEND_DIR / 'utils' / 'llm')
+
+    chat_db = _install_module('database.chat')
+    chat_db.save_message = MagicMock(
+        return_value={'id': 'client-msg-1', 'created_at': '2026-07-02T00:00:00+00:00', 'created': True}
+    )
+    chat_db.get_messages = MagicMock(return_value=[])
+    chat_db.delete_messages = MagicMock(return_value=0)
+    chat_db.create_chat_session = MagicMock()
+    chat_db.get_chat_sessions = MagicMock()
+    chat_db.get_chat_session_by_id = MagicMock()
+    chat_db.update_chat_session = MagicMock()
+    chat_db.delete_chat_session = MagicMock()
+    chat_db.update_message_rating = MagicMock()
+    chat_db.get_message_count = MagicMock(return_value=0)
+
+    llm_usage_db = _install_module('database.llm_usage')
+    llm_usage_db.record_chat_quota_question = MagicMock(return_value=True)
+    users_db = _install_module('database.users')
+    users_db.set_chat_message_rating_score = MagicMock()
+
+    chat_utils = _install_module('utils.chat', ModuleType('utils.chat'))
+    chat_utils.initial_message_util = MagicMock()
+    llm_clients = _install_module('utils.llm.clients', ModuleType('utils.llm.clients'))
+    llm_clients.get_llm = MagicMock()
+
+    auth = _install_module('utils.other.endpoints', ModuleType('utils.other.endpoints'))
+    auth.get_current_user_uid = lambda: 'test-uid'
+    auth.with_rate_limit = lambda func, _policy: func
+
+    sys.modules.pop('routers.chat_sessions', None)
+    spec = importlib.util.spec_from_file_location('routers.chat_sessions', BACKEND_DIR / 'routers' / 'chat_sessions.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['routers.chat_sessions'] = module
+    spec.loader.exec_module(module)
+
+    app = FastAPI()
+    app.include_router(module.router)
+    return TestClient(app), module, saved
+
+
+def _cleanup(saved):
+    for name in [k for k in sys.modules if k not in saved]:
+        del sys.modules[name]
+    for name, module in saved.items():
+        sys.modules[name] = module
+
+
+def test_desktop_human_message_records_quota_once_after_persistence_acceptance():
+    client, module, saved = _make_client()
+    try:
+        response = client.post(
+            '/v2/desktop/messages',
+            json={'text': 'hello', 'sender': 'human', 'client_message_id': 'client-msg-1'},
+            headers={'X-App-Platform': 'macos'},
+        )
+
+        assert response.status_code == 200
+        module.chat_db.save_message.assert_called_once_with(
+            'test-uid',
+            text='hello',
+            sender='human',
+            app_id=None,
+            session_id=None,
+            metadata=None,
+            client_message_id='client-msg-1',
+        )
+        module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
+            'test-uid',
+            idempotency_key='desktop_messages:client-msg-1',
+            source='desktop_messages',
+            message_id='client-msg-1',
+            chat_session_id=None,
+            platform='macos',
+        )
+    finally:
+        _cleanup(saved)
+
+
+def test_desktop_duplicate_human_message_retries_idempotent_quota_record():
+    client, module, saved = _make_client()
+    try:
+        module.chat_db.save_message.return_value = {
+            'id': 'client-msg-1',
+            'created_at': '2026-07-02T00:00:00+00:00',
+            'created': False,
+        }
+        duplicate = client.post(
+            '/v2/desktop/messages',
+            json={'text': 'hello', 'sender': 'human', 'client_message_id': 'client-msg-1'},
+        )
+        assert duplicate.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_called_once_with(
+            'test-uid',
+            idempotency_key='desktop_messages:client-msg-1',
+            source='desktop_messages',
+            message_id='client-msg-1',
+            chat_session_id=None,
+            platform=None,
+        )
+    finally:
+        _cleanup(saved)
+
+
+def test_desktop_ai_message_does_not_record_quota():
+    client, module, saved = _make_client()
+    try:
+        module.chat_db.save_message.return_value = {
+            'id': 'ai-msg-1',
+            'created_at': '2026-07-02T00:00:00+00:00',
+            'created': True,
+        }
+        ai = client.post(
+            '/v2/desktop/messages',
+            json={'text': 'hello back', 'sender': 'ai', 'client_message_id': 'ai-msg-1'},
+        )
+        assert ai.status_code == 200
+        module.llm_usage_db.record_chat_quota_question.assert_not_called()
+    finally:
+        _cleanup(saved)

--- a/backend/tests/unit/test_llm_usage_db.py
+++ b/backend/tests/unit/test_llm_usage_db.py
@@ -26,6 +26,11 @@ _google_cloud_module = sys.modules.setdefault("google.cloud", types.ModuleType("
 _google_firestore_module = types.ModuleType("google.cloud.firestore")
 _google_firestore_module.Increment = lambda x: {"__increment": x}
 sys.modules.setdefault("google.cloud.firestore", _google_firestore_module)
+_google_firestore_v1_module = sys.modules.get("google.cloud.firestore_v1") or types.ModuleType(
+    "google.cloud.firestore_v1"
+)
+_google_firestore_v1_module.transactional = lambda fn: fn
+sys.modules["google.cloud.firestore_v1"] = _google_firestore_v1_module
 setattr(_google_module, "cloud", _google_cloud_module)
 setattr(_google_cloud_module, "firestore", _google_firestore_module)
 
@@ -50,6 +55,9 @@ class _FakeDocRef:
 
     def get(self):
         return _FakeDocSnapshot({}, exists=False)
+
+    def collection(self, name):
+        return _FakeCollection()
 
 
 class _FakeCollection:
@@ -136,6 +144,93 @@ def test_record_llm_usage_skips_zero_tokens():
         )
 
     assert len(doc_ref.set_calls) == 0
+
+
+def test_record_chat_quota_question_public_wrapper_uses_transaction():
+    usage_ref = MagicMock()
+    event_ref = MagicMock()
+    events_collection = MagicMock()
+    events_collection.document.return_value = event_ref
+    usage_collection = MagicMock()
+    usage_collection.document.return_value = usage_ref
+    user_ref = MagicMock()
+
+    def collection_for_name(name):
+        if name == 'llm_usage':
+            return usage_collection
+        if name == 'chat_quota_events':
+            return events_collection
+        raise AssertionError(f'unexpected collection {name}')
+
+    user_ref.collection.side_effect = collection_for_name
+    transaction = MagicMock()
+
+    with patch.object(llm_usage, 'db') as patched_db:
+        patched_db.collection.return_value.document.return_value = user_ref
+        patched_db.transaction.return_value = transaction
+        with patch.object(llm_usage, '_record_chat_quota_question_transaction', return_value=True) as mock_record:
+            recorded = llm_usage.record_chat_quota_question(
+                'test-user',
+                idempotency_key='v2_messages:msg-1',
+                source='v2_messages',
+                message_id='msg-1',
+                chat_session_id='session-1',
+                platform='ios',
+            )
+
+    assert recorded is True
+    event_data = mock_record.call_args.args[3]
+    assert mock_record.call_args.args[0] is transaction
+    assert mock_record.call_args.args[1] is usage_ref
+    assert mock_record.call_args.args[2] is event_ref
+    assert mock_record.call_args.args[4].count('-') == 2
+    assert event_data['idempotency_key'] == 'v2_messages:msg-1'
+    assert event_data['source'] == 'v2_messages'
+    assert event_data['message_id'] == 'msg-1'
+    assert event_data['chat_session_id'] == 'session-1'
+    assert event_data['platform'] == 'ios'
+
+
+def test_record_chat_quota_question_transaction_is_idempotent_when_event_exists():
+    transaction = MagicMock()
+    usage_ref = MagicMock()
+    event_ref = MagicMock()
+    event_ref.get.return_value = _FakeDocSnapshot({}, exists=True)
+
+    recorded = llm_usage._record_chat_quota_question_transaction(
+        transaction,
+        usage_ref,
+        event_ref,
+        {'idempotency_key': 'v2_messages:msg-1'},
+        '2026-06-23',
+    )
+
+    assert recorded is False
+    transaction.set.assert_not_called()
+
+
+def test_record_chat_quota_question_transaction_increments_backend_quota_once():
+    transaction = MagicMock()
+    usage_ref = MagicMock()
+    event_ref = MagicMock()
+    event_ref.get.return_value = _FakeDocSnapshot({}, exists=False)
+    event_data = {'idempotency_key': 'v2_messages:msg-1'}
+
+    recorded = llm_usage._record_chat_quota_question_transaction(
+        transaction,
+        usage_ref,
+        event_ref,
+        event_data,
+        '2026-06-23',
+    )
+
+    assert recorded is True
+    transaction.set.assert_any_call(event_ref, event_data)
+    usage_call = transaction.set.call_args_list[1]
+    assert usage_call.args[0] is usage_ref
+    assert usage_call.kwargs['merge'] is True
+    assert usage_call.args[1]['backend_chat.quota_questions'] == {'__increment': 1}
+    assert usage_call.args[1]['date'] == '2026-06-23'
 
 
 def test_get_daily_usage_returns_empty_when_not_exists():

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -3,9 +3,9 @@
 Regression coverage for the nested-vs-flat bug: the Rust desktop-backend commits
 desktop_chat usage via dotted Firestore fieldPaths, which Firestore materializes as a
 NESTED map ({desktop_chat: {call_count, ...}}), whereas the Python backend writes flat
-dotted keys ("chat.<model>.call_count"). The reader must count both, count the
-grand-total `desktop_chat` map only (not its `desktop_chat_*` per-account/realtime
-breakdowns, which would double-count), and exclude company-driven keys (conv_*, memories.*).
+dotted keys ("chat.<model>.call_count"). The reader must count desktop
+`quota_questions` rather than internal generation `call_count`, count backend chat,
+and exclude company-driven keys (conv_*, memories.*).
 """
 
 import os
@@ -22,6 +22,13 @@ mock_db = MagicMock()
 _mock_client_module = MagicMock()
 _mock_client_module.db = mock_db
 sys.modules["database._client"] = _mock_client_module
+_mock_google_cloud_module = MagicMock()
+_mock_google_cloud_module.firestore = MagicMock()
+_mock_firestore_v1_module = MagicMock()
+_mock_firestore_v1_module.FieldFilter = MagicMock()
+sys.modules["google.cloud"] = _mock_google_cloud_module
+sys.modules["google.cloud.firestore"] = _mock_google_cloud_module.firestore
+sys.modules["google.cloud.firestore_v1"] = _mock_firestore_v1_module
 sys.modules["stripe"] = MagicMock()
 
 from database import user_usage  # noqa: E402
@@ -55,30 +62,86 @@ def _setup_docs(docs):
 NOW = datetime(2026, 6, 23, tzinfo=timezone.utc)
 
 
-def test_counts_nested_desktop_chat_plus_flat_backend_chat():
+def test_counts_nested_desktop_quota_questions_plus_flat_backend_chat():
     _setup_docs(
         {
             "2026-06-23": {
-                "desktop_chat": {"call_count": 5, "cost_usd": 1.5},  # nested (Rust) — counted
-                "desktop_chat_omi": {"call_count": 3},  # breakdown — must NOT double-count
-                "desktop_chat_realtime": {"call_count": 2},  # PTT breakdown — must NOT double-count
+                "desktop_chat": {
+                    "call_count": 5,  # internal generations — must NOT count as questions
+                    "quota_questions": 2,  # visible user turns — counted
+                    "cost_usd": 1.5,
+                },
+                "desktop_chat_omi": {"call_count": 3},
+                "desktop_chat_realtime": {"call_count": 2},
                 "chat.gpt-4.call_count": 4,  # flat backend chat — counted
                 "conv_apps.gpt-5.call_count": 100,  # proactive/processing — excluded
                 "memories.gpt-4.call_count": 50,  # excluded
                 "date": "2026-06-23",
             },
-            "2026-05-30": {"desktop_chat": {"call_count": 999}},  # other month — excluded
+            "2026-05-30": {"desktop_chat": {"quota_questions": 999}},  # other month — excluded
         }
     )
     r = user_usage.get_monthly_chat_usage("uid", now=NOW)
-    # 5 (grand-total desktop_chat) + 4 (flat chat.*); breakdowns + proactive excluded; other month excluded
-    assert r["questions"] == 9, r
+    # 2 (desktop quota questions) + 2 (legacy realtime turns) + 4 (flat chat.*);
+    # internal generations + proactive excluded.
+    assert r["questions"] == 8, r
     assert r["cost_usd"] == 1.5, r
 
 
-def test_realtime_ptt_included_via_grand_total():
-    # A pure-PTT month: only realtime turns. record_llm_usage always bumps the grand-total
-    # desktop_chat too, so it must be counted even with zero typed chat.
+def test_backend_quota_questions_supersede_legacy_chat_call_count():
+    _setup_docs(
+        {
+            "2026-06-23": {
+                "backend_chat": {"quota_questions": 3},
+                "chat.gpt-4.call_count": 9,  # legacy LLM telemetry — ignored when explicit counter exists
+                "date": "2026-06-23",
+            },
+            "2026-06-24": {
+                "backend_chat.quota_questions": 2,
+                "chat.gpt-4.call_count": 8,
+                "date": "2026-06-24",
+            },
+        }
+    )
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    assert r["questions"] == 5, r
+
+
+def test_realtime_usage_cost_does_not_count_internal_generations_as_questions():
+    _setup_docs(
+        {
+            "2026-06-10": {
+                "desktop_chat": {"call_count": 7, "quota_questions": 0, "cost_usd": 0.4},
+                "desktop_chat_realtime": {"call_count": 7, "quota_questions": 0},
+            }
+        }
+    )
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    assert r["questions"] == 0
+    assert r["cost_usd"] == 0.4
+
+
+def test_realtime_quota_breakdown_prevents_legacy_call_count_double_count():
+    _setup_docs(
+        {
+            "2026-06-10": {
+                "desktop_chat": {"call_count": 10, "quota_questions": 4, "cost_usd": 0.4},
+                "desktop_chat_realtime": {"call_count": 3, "quota_questions": 3},
+            },
+            "2026-06-11": {
+                "desktop_chat.quota_questions": 2,
+                "desktop_chat_realtime.call_count": 5,
+                "desktop_chat_realtime.quota_questions": 5,
+                "desktop_chat.cost_usd": 0.2,
+            },
+        }
+    )
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    assert r["questions"] == 6
+    assert r["cost_usd"] == 0.6
+
+
+def test_falls_back_to_old_desktop_call_count_when_quota_questions_missing():
     _setup_docs(
         {
             "2026-06-10": {
@@ -87,7 +150,24 @@ def test_realtime_ptt_included_via_grand_total():
             }
         }
     )
-    assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 7
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    assert r["questions"] == 7
+    assert r["cost_usd"] == 0.4
+
+
+def test_flat_old_desktop_call_count_fallback_uses_only_grand_total():
+    _setup_docs(
+        {
+            "2026-06-10": {
+                "desktop_chat.call_count": 7,
+                "desktop_chat_realtime.call_count": 7,
+                "desktop_chat.cost_usd": 0.4,
+            }
+        }
+    )
+    r = user_usage.get_monthly_chat_usage("uid", now=NOW)
+    assert r["questions"] == 7
+    assert r["cost_usd"] == 0.4
 
 
 def test_only_proactive_counts_zero():

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -141,21 +141,21 @@ def test_realtime_quota_breakdown_prevents_legacy_call_count_double_count():
     assert r["cost_usd"] == 0.6
 
 
-def test_falls_back_to_old_desktop_call_count_when_quota_questions_missing():
+def test_desktop_helper_only_call_count_does_not_count_as_questions():
     _setup_docs(
         {
             "2026-06-10": {
                 "desktop_chat": {"call_count": 7, "cost_usd": 0.4},
-                "desktop_chat_realtime": {"call_count": 7},
+                "desktop_chat_omi": {"call_count": 7},
             }
         }
     )
     r = user_usage.get_monthly_chat_usage("uid", now=NOW)
-    assert r["questions"] == 7
+    assert r["questions"] == 0
     assert r["cost_usd"] == 0.4
 
 
-def test_flat_old_desktop_call_count_fallback_uses_only_grand_total():
+def test_legacy_realtime_call_count_fallback_uses_realtime_breakdown_only():
     _setup_docs(
         {
             "2026-06-10": {

--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -1091,35 +1091,11 @@ async fn log_usage(state: &AppState, user: &AuthUser, usage: &AnthropicUsage, co
     }
 }
 
-async fn record_desktop_chat_quota_question(
-    State(state): State<AppState>,
-    user: PaywalledAuthUser,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    let user: AuthUser = user.into();
-    state
-        .firestore
-        .record_desktop_chat_quota_question(&user.uid)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "desktop_chat_quota: quota question log failed for {}: {}",
-                user.uid,
-                e
-            );
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    Ok(Json(json!({"status": "ok"})))
-}
-
 // ── Route registration ──────────────────────────────────────────────────────
 
 pub fn chat_completions_routes() -> Router<AppState> {
     Router::new()
         .route("/v2/chat/completions", post(chat_completions))
-        .route(
-            "/v2/desktop-chat/quota-question",
-            post(record_desktop_chat_quota_question),
-        )
         .layer(DefaultBodyLimit::max(CHAT_COMPLETIONS_MAX_BODY_SIZE))
 }
 

--- a/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat_completions.rs
@@ -1091,11 +1091,35 @@ async fn log_usage(state: &AppState, user: &AuthUser, usage: &AnthropicUsage, co
     }
 }
 
+async fn record_desktop_chat_quota_question(
+    State(state): State<AppState>,
+    user: PaywalledAuthUser,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let user: AuthUser = user.into();
+    state
+        .firestore
+        .record_desktop_chat_quota_question(&user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "desktop_chat_quota: quota question log failed for {}: {}",
+                user.uid,
+                e
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(json!({"status": "ok"})))
+}
+
 // ── Route registration ──────────────────────────────────────────────────────
 
 pub fn chat_completions_routes() -> Router<AppState> {
     Router::new()
         .route("/v2/chat/completions", post(chat_completions))
+        .route(
+            "/v2/desktop-chat/quota-question",
+            post(record_desktop_chat_quota_question),
+        )
         .layer(DefaultBodyLimit::max(CHAT_COMPLETIONS_MAX_BODY_SIZE))
 }
 
@@ -1104,6 +1128,29 @@ pub fn chat_completions_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_request(messages: Vec<ChatMessage>) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "omi-sonnet".to_string(),
+            messages,
+            stream: false,
+            temperature: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
+    fn user_message(text: &str) -> ChatMessage {
+        ChatMessage {
+            role: "user".to_string(),
+            content: Some(json!(text)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
 
     #[test]
     fn transient_statuses_retry() {

--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -274,7 +274,8 @@ async fn mint_gemini(state: &AppState, uid: &str) -> Result<MintResponse, MintEr
 // The realtime WS is client↔provider direct, so the backend never sees usage inline.
 // As a first pass, the CLIENT reports the provider's own per-turn token counts here and
 // we price + record them into the same llm_usage ledger chat uses (account "realtime"),
-// so realtime spend counts toward the user's quota. This is CLIENT-TRUSTED (a tampered
+// and separately increment the explicit desktop question quota counter for the
+// accepted managed turn. This is CLIENT-TRUSTED (a tampered
 // client could under-report) — acceptable for v1; the eventual hardening is server-side
 // reconciliation against the provider Usage API (OpenAI exposes per-user usage via the
 // OpenAI-Safety-Identifier; the minted realtime_sessions records are the audit trail).
@@ -367,6 +368,18 @@ async fn report_usage(
         .await
     {
         tracing::error!("realtime usage record failed for uid={}: {}", user.uid, e);
+        return StatusCode::BAD_GATEWAY;
+    }
+    if let Err(e) = state
+        .firestore
+        .record_desktop_chat_quota_question_with_account(&user.uid, Some("realtime"))
+        .await
+    {
+        tracing::error!(
+            "realtime quota question record failed for uid={}: {}",
+            user.uid,
+            e
+        );
         return StatusCode::BAD_GATEWAY;
     }
     tracing::info!(

--- a/desktop/macos/Backend-Rust/src/services/firestore/llm_usage_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/llm_usage_repository.rs
@@ -64,16 +64,6 @@ impl FirestoreService {
         Ok(())
     }
 
-    /// Increment the quota-specific desktop question counter once for a user-visible
-    /// desktop chat request. Internal generation counts stay in `record_llm_usage`.
-    pub async fn record_desktop_chat_quota_question(
-        &self,
-        uid: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.record_desktop_chat_quota_question_with_account(uid, None)
-            .await
-    }
-
     /// Increment the total desktop question counter and, when provided, an
     /// account-specific quota counter for rollout-safe breakdown fallback.
     pub async fn record_desktop_chat_quota_question_with_account(

--- a/desktop/macos/Backend-Rust/src/services/firestore/llm_usage_repository.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore/llm_usage_repository.rs
@@ -64,6 +64,60 @@ impl FirestoreService {
         Ok(())
     }
 
+    /// Increment the quota-specific desktop question counter once for a user-visible
+    /// desktop chat request. Internal generation counts stay in `record_llm_usage`.
+    pub async fn record_desktop_chat_quota_question(
+        &self,
+        uid: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.record_desktop_chat_quota_question_with_account(uid, None)
+            .await
+    }
+
+    /// Increment the total desktop question counter and, when provided, an
+    /// account-specific quota counter for rollout-safe breakdown fallback.
+    pub async fn record_desktop_chat_quota_question_with_account(
+        &self,
+        uid: &str,
+        account: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let date_key = Utc::now().format("%Y-%m-%d").to_string();
+        let doc_path = format!(
+            "projects/{}/databases/(default)/documents/{}/{}/{}/{}",
+            self.project_id, USERS_COLLECTION, uid, LLM_USAGE_SUBCOLLECTION, date_key
+        );
+        let commit_url = format!(
+            "https://firestore.googleapis.com/v1/projects/{}/databases/(default)/documents:commit",
+            self.project_id
+        );
+        let mut field_transforms = vec![
+            json!({ "fieldPath": "desktop_chat.quota_questions", "increment": { "integerValue": "1" } }),
+        ];
+        if let Some(account) = account {
+            field_transforms.push(
+                json!({ "fieldPath": format!("desktop_chat_{}.quota_questions", account), "increment": { "integerValue": "1" } }),
+            );
+        }
+        let body = json!({
+            "writes": [{
+                "transform": {
+                    "document": doc_path,
+                    "fieldTransforms": field_transforms
+                }
+            }]
+        });
+        let resp = self
+            .build_request(reqwest::Method::POST, &commit_url)
+            .await?
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Err(resp.text().await?.into());
+        }
+        Ok(())
+    }
+
     /// Sum all daily desktop_chat.cost_usd values for a user across all llm_usage documents.
     pub async fn get_total_llm_cost(
         &self,

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -292,33 +292,6 @@ actor APIClient {
     }
   }
 
-  /// Record one accepted user-visible desktop chat question. This is the
-  /// product-boundary quota counter; token/cost telemetry stays with individual
-  /// LLM calls.
-  func recordDesktopChatQuotaQuestion(source: String) async {
-    let base = rustBackendURL
-    guard !base.isEmpty else { return }
-    let normalized = base.hasSuffix("/") ? base : base + "/"
-    guard let url = URL(string: normalized + "v2/desktop-chat/quota-question") else { return }
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.timeoutInterval = 10
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    do {
-      let headers = try await buildHeaders(requireAuth: true, includeBYOK: false)
-      for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
-      request.httpBody = try JSONSerialization.data(withJSONObject: ["source": source])
-      let (_, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-        let code = (response as? HTTPURLResponse)?.statusCode ?? -1
-        log("APIClient: desktop chat quota question record failed HTTP \(code)")
-        return
-      }
-    } catch {
-      log("APIClient: desktop chat quota question record failed: \(error.localizedDescription)")
-    }
-  }
-
   func delete(
     _ endpoint: String,
     requireAuth: Bool = true,
@@ -4635,7 +4608,8 @@ extension APIClient {
     sender: String,
     appId: String? = nil,
     sessionId: String? = nil,
-    metadata: String? = nil
+    metadata: String? = nil,
+    clientMessageId: String? = nil
   ) async throws -> SaveMessageResponse {
     struct SaveRequest: Encodable {
       let text: String
@@ -4643,9 +4617,16 @@ extension APIClient {
       let app_id: String?
       let session_id: String?
       let metadata: String?
+      let client_message_id: String?
     }
     let body = SaveRequest(
-      text: text, sender: sender, app_id: appId, session_id: sessionId, metadata: metadata)
+      text: text,
+      sender: sender,
+      app_id: appId,
+      session_id: sessionId,
+      metadata: metadata,
+      client_message_id: clientMessageId
+    )
     return try await post("v2/desktop/messages", body: body)
   }
 
@@ -4937,10 +4918,14 @@ struct InitialMessageResponse: Codable {
 struct SaveMessageResponse: Codable {
   let id: String
   let createdAt: Date
+  let sessionId: String?
+  let created: Bool?
 
   enum CodingKeys: String, CodingKey {
     case id
     case createdAt = "created_at"
+    case sessionId = "session_id"
+    case created
   }
 }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -253,7 +253,7 @@ actor APIClient {
   }
 
   /// Report a managed realtime turn's token usage so the backend can price it and record
-  /// it into the llm_usage ledger (counts toward quota). Fire-and-forget; failures are
+  /// it into the llm_usage cost ledger. Fire-and-forget; failures are
   /// logged and dropped (the backend reconciler is the eventual safety net). Only called
   /// for managed (ephemeral) sessions — BYOK users pay the provider directly.
   func reportRealtimeUsage(
@@ -289,6 +289,33 @@ actor APIClient {
       _ = try await session.data(for: request)
     } catch {
       log("APIClient: realtime usage report failed: \(error.localizedDescription)")
+    }
+  }
+
+  /// Record one accepted user-visible desktop chat question. This is the
+  /// product-boundary quota counter; token/cost telemetry stays with individual
+  /// LLM calls.
+  func recordDesktopChatQuotaQuestion(source: String) async {
+    let base = rustBackendURL
+    guard !base.isEmpty else { return }
+    let normalized = base.hasSuffix("/") ? base : base + "/"
+    guard let url = URL(string: normalized + "v2/desktop-chat/quota-question") else { return }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.timeoutInterval = 10
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    do {
+      let headers = try await buildHeaders(requireAuth: true, includeBYOK: false)
+      for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
+      request.httpBody = try JSONSerialization.data(withJSONObject: ["source": source])
+      let (_, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+        let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+        log("APIClient: desktop chat quota question record failed HTTP \(code)")
+        return
+      }
+    } catch {
+      log("APIClient: desktop chat quota question record failed: \(error.localizedDescription)")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -4609,7 +4609,8 @@ extension APIClient {
     appId: String? = nil,
     sessionId: String? = nil,
     metadata: String? = nil,
-    clientMessageId: String? = nil
+    clientMessageId: String? = nil,
+    messageSource: String = "desktop_chat"
   ) async throws -> SaveMessageResponse {
     struct SaveRequest: Encodable {
       let text: String
@@ -4618,6 +4619,7 @@ extension APIClient {
       let session_id: String?
       let metadata: String?
       let client_message_id: String?
+      let message_source: String
     }
     let body = SaveRequest(
       text: text,
@@ -4625,7 +4627,8 @@ extension APIClient {
       app_id: appId,
       session_id: sessionId,
       metadata: metadata,
-      client_message_id: clientMessageId
+      client_message_id: clientMessageId,
+      message_source: messageSource
     )
     return try await post("v2/desktop/messages", body: body)
   }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2611,7 +2611,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     text: trimmedText,
                     sender: "human",
                     appId: capturedAppId,
-                    sessionId: capturedSessionId
+                    sessionId: capturedSessionId,
+                    clientMessageId: localId
                 )
                 await MainActor.run {
                     if let index = self?.messages.firstIndex(where: { $0.id == localId }) {
@@ -2657,7 +2658,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     text: trimmedText,
                     sender: "ai",
                     appId: capturedAppId,
-                    sessionId: capturedSessionId
+                    sessionId: capturedSessionId,
+                    clientMessageId: localId
                 )
                 await MainActor.run {
                     if let index = self?.messages.firstIndex(where: { $0.id == localId }) {
@@ -2742,7 +2744,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     ) async {
         do {
             let response = try await APIClient.shared.saveMessage(
-                text: text, sender: sender, appId: appId, sessionId: sessionId)
+                text: text, sender: sender, appId: appId, sessionId: sessionId, clientMessageId: message.id)
             await MainActor.run {
                 if let index = self.messages.firstIndex(where: { $0.id == message.id }) {
                     self.messages[index].id = response.id
@@ -3003,10 +3005,6 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
         if isUsingOmiAccountProvider {
             usageLimiter.recordQuery()
-            let quotaSource = surfaceRef?.surfaceKind ?? (sessionKey == "floating" ? "floating_bar" : "main_chat")
-            Task.detached(priority: .background) {
-                await APIClient.shared.recordDesktopChatQuotaQuestion(source: quotaSource)
-            }
         }
 
         // Save user message to backend and add to UI.
@@ -3036,7 +3034,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         sender: "human",
                         appId: capturedAppId,
                         sessionId: capturedSessionId,
-                        metadata: attachmentMetadataJSON
+                        metadata: attachmentMetadataJSON,
+                        clientMessageId: userMessageId
                     )
                     // Adopt the server ID (local UUID → server ID) and mark synced.
                     // isSynced=true enables rating buttons on the message bubble.
@@ -3489,7 +3488,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         sender: "ai",
                         appId: capturedAppId,
                         sessionId: capturedSessionId,
-                        metadata: toolMetadata
+                        metadata: toolMetadata,
+                        clientMessageId: aiMessageId
                     )
                     // Adopt the server ID so future polls find this message by ID
                     // (existingIds check in pollForNewMessages). isSynced=true enables
@@ -3540,9 +3540,9 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             )
 
             // Skip client-side cost telemetry for piMono because /v2/chat/completions
-            // already logs Omi-account token/cost usage server-side. The question
-            // quota is recorded separately at send acceptance above, so model calls
-            // and helper calls cannot double-count messages. Local harnesses
+            // already logs Omi-account token/cost usage server-side. Question
+            // quota is recorded by the backend when the accepted human message
+            // is persisted, so model calls and helper calls cannot double-count. Local harnesses
             // (Hermes/OpenClaw) skip telemetry entirely; use the actual harness, not
             // @AppStorage bridgeMode, because directed Hermes/OpenClaw pills can
             // override the harness without changing the user's global preference.
@@ -3625,7 +3625,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                                 sender: "ai",
                                 appId: capturedAppId,
                                 sessionId: capturedSessionId,
-                                metadata: partialToolMetadata
+                                metadata: partialToolMetadata,
+                                clientMessageId: aiMessageId
                             )
                             await MainActor.run {
                                 if let syncIndex = self?.messages.firstIndex(where: { $0.id == aiMessageId }) {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2682,7 +2682,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Appends both messages to the in-memory provider session immediately, then
     /// persists them sequentially in the background so later follow-ups retain context.
     @discardableResult
-    func recordCompletedTurn(userText: String, assistantText: String, logLabel: String = "completed") -> (
+    func recordCompletedTurn(
+        userText: String,
+        assistantText: String,
+        logLabel: String = "completed",
+        messageSource: String = "desktop_chat"
+    ) -> (
         user: ChatMessage?, assistant: ChatMessage?
     ) {
         let user = userText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2713,12 +2718,12 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             if let userMessage {
                 await self?.persistRecordedTurnMessage(
                     userMessage, text: user, sender: "human",
-                    appId: capturedAppId, sessionId: capturedSessionId, logLabel: logLabel)
+                    appId: capturedAppId, sessionId: capturedSessionId, logLabel: logLabel, messageSource: messageSource)
             }
             if let aiMessage {
                 await self?.persistRecordedTurnMessage(
                     aiMessage, text: assistant, sender: "ai",
-                    appId: capturedAppId, sessionId: capturedSessionId, logLabel: logLabel)
+                    appId: capturedAppId, sessionId: capturedSessionId, logLabel: logLabel, messageSource: messageSource)
             }
             await MainActor.run { self?.pendingSaves.end() }
         }
@@ -2733,14 +2738,25 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// or sync to the backend. Empty sides are skipped (a tool-only turn with no
     /// spoken reply still records the user's request).
     func recordVoiceTurn(userText: String, assistantText: String) {
-        recordCompletedTurn(userText: userText, assistantText: assistantText, logLabel: "voice")
+        recordCompletedTurn(
+            userText: userText,
+            assistantText: assistantText,
+            logLabel: "voice",
+            messageSource: "realtime_voice"
+        )
     }
 
     /// Persist one recorded-turn message and sync its server ID back into `messages` so a
     /// subsequent poll doesn't duplicate it. Failures leave the in-memory copy unsynced
     /// (matches the existing saveMessage sites — no retry).
     private func persistRecordedTurnMessage(
-        _ message: ChatMessage, text: String, sender: String, appId: String?, sessionId: String?, logLabel: String
+        _ message: ChatMessage,
+        text: String,
+        sender: String,
+        appId: String?,
+        sessionId: String?,
+        logLabel: String,
+        messageSource: String
     ) async {
         do {
             let response = try await APIClient.shared.saveMessage(
@@ -2749,7 +2765,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 appId: appId,
                 sessionId: sessionId,
                 clientMessageId: message.id,
-                messageSource: "realtime_voice"
+                messageSource: messageSource
             )
             await MainActor.run {
                 if let index = self.messages.firstIndex(where: { $0.id == message.id }) {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2915,7 +2915,6 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 )
                 return nil
             }
-            usageLimiter.recordQuery()
         }
 
         // QueryTracer: picked up from the TaskLocal context established by the
@@ -3001,6 +3000,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         let attachmentMetadataJSON = attachmentsForMessage.isEmpty
             ? nil
             : encodeAttachmentsMetadata(attachmentsForMessage)
+
+        if isUsingOmiAccountProvider {
+            usageLimiter.recordQuery()
+            let quotaSource = surfaceRef?.surfaceKind ?? (sessionKey == "floating" ? "floating_bar" : "main_chat")
+            Task.detached(priority: .background) {
+                await APIClient.shared.recordDesktopChatQuotaQuestion(source: quotaSource)
+            }
+        }
 
         // Save user message to backend and add to UI.
         // (skip for follow-ups — sendFollowUp already did both)
@@ -3532,15 +3539,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 messageLength: responseLength
             )
 
-            // Skip client-side usage recording for piMono (the backend already
-            // logs usage server-side via POST /v2/chat/completions, so recording
-            // here would double-count) and for local harnesses (Hermes/OpenClaw).
-            // The backend's record_llm_usage_bucket always increments the
-            // grand-total desktop_chat bucket regardless of the account
-            // parameter, and /usage-quota sums that bucket regardless of account,
-            // so any POST — even with account="local" — still depletes the user's
-            // Omi/pi-mono quota. The client-side quota gates already skip local
-            // providers, so skip the POST here too. Use the actual harness, not
+            // Skip client-side cost telemetry for piMono because /v2/chat/completions
+            // already logs Omi-account token/cost usage server-side. The question
+            // quota is recorded separately at send acceptance above, so model calls
+            // and helper calls cannot double-count messages. Local harnesses
+            // (Hermes/OpenClaw) skip telemetry entirely; use the actual harness, not
             // @AppStorage bridgeMode, because directed Hermes/OpenClaw pills can
             // override the harness without changing the user's global preference.
             let effectiveHarness = activeBridgeHarness

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2744,7 +2744,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     ) async {
         do {
             let response = try await APIClient.shared.saveMessage(
-                text: text, sender: sender, appId: appId, sessionId: sessionId, clientMessageId: message.id)
+                text: text,
+                sender: sender,
+                appId: appId,
+                sessionId: sessionId,
+                clientMessageId: message.id,
+                messageSource: "realtime_voice"
+            )
             await MainActor.run {
                 if let index = self.messages.firstIndex(where: { $0.id == message.id }) {
                     self.messages[index].id = response.id

--- a/desktop/macos/changelog/unreleased/20260702-fix-chat-quota-counting.json
+++ b/desktop/macos/changelog/unreleased/20260702-fix-chat-quota-counting.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Free chat quota counting so internal desktop AI tool loops no longer consume multiple questions"
+}

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -339,6 +339,9 @@ check_backend_unit_tests_if_needed() {
       add_fast_backend_test_if_selected "tests/unit/test_conversation_structure_timezone.py"
       add_fast_backend_test_if_selected "tests/unit/test_llm_gateway_chat_extraction_pilot.py"
     fi
+    if changed_matches 'backend/database/llm_usage.py'; then
+      add_fast_backend_test_if_selected "tests/unit/test_llm_usage_tracker.py"
+    fi
     if [ -s "$FAST_BACKEND_TESTS" ]; then
       sort -u "$FAST_BACKEND_TESTS" -o "$FAST_BACKEND_TESTS"
       selected_count=$(wc -l < "$FAST_BACKEND_TESTS" | tr -d ' ')

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -357,8 +357,12 @@ check_backend_unit_tests_if_needed() {
   echo "Selected $selected_count backend unit test file(s): $reason"
   (
     cd backend
-    bash test-preflight.sh
-    BACKEND_UNIT_TEST_FILE_LIST="$SELECTED_BACKEND_TESTS" BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=auto bash test.sh
+    backend_python="${PYTHON:-}"
+    if [ -z "$backend_python" ] && [ -x ".venv/bin/python" ]; then
+      backend_python=".venv/bin/python"
+    fi
+    PYTHON="${backend_python:-python3}" bash test-preflight.sh
+    PYTHON="${backend_python:-python3}" BACKEND_UNIT_TEST_FILE_LIST="$SELECTED_BACKEND_TESTS" BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=auto bash test.sh
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes #8763.

This splits desktop chat quota accounting from desktop LLM generation telemetry:

- keeps `desktop_chat.call_count` as internal upstream generation telemetry
- adds `desktop_chat.quota_questions` for user-visible desktop chat quota counting
- updates backend quota reads to use the quota-specific desktop counter plus existing backend `chat.*.call_count`
- skips desktop helper requests such as pill routing, title/ack generation, and realtime escalation via `X-Omi-Quota-Behavior: internal`
- keeps desktop/realtime cost telemetry in `desktop_chat.cost_usd`

## Validation

- `backend/.venv/bin/python -m pytest tests/unit/test_user_usage.py -q`
- `cargo test --manifest-path desktop/macos/Backend-Rust/Cargo.toml chat_completions`
- `xcrun swift build -c debug --package-path Desktop`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH ./scripts/agent-logic-harness.sh`
- pre-push hook passed, including selected backend unit test, OpenAPI check, and desktop Rust check

## Notes

The first harness attempt used the default Node 20 and failed because `node:sqlite` and `--experimental-strip-types` require the installed Node 22 runtime. Rerunning with Node 22 passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

