### PR TITLE
Add release process guardrails

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Fail fast on release/process contracts that otherwise break late."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(check_desktop_codemagic_release())
+    errors.extend(check_docs_workflow_scripts())
+    errors.extend(check_python_cli_release_version_source())
+    errors.extend(check_react_native_release_tags())
+    errors.extend(check_firmware_release_metadata())
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("release process guard checks passed")
+    return 0
+
+
+def check_desktop_codemagic_release() -> list[str]:
+    path = ROOT / "codemagic.yaml"
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    if "omi-desktop-swift-release:" not in text:
+        errors.append("codemagic.yaml is missing the omi-desktop-swift-release workflow")
+
+    if "os.environ['BUILD_NAME']" in text or 'os.environ["BUILD_NAME"]' in text:
+        errors.append("desktop Firestore bridge reads BUILD_NAME, but desktop release sets VERSION")
+
+    if "edSignature: ${ED_SIGNATURE}" in text:
+        empty_signature_block = re.search(
+            r'if \[ -z "\$ED_SIGNATURE" \]; then(?:(?!\bfi\b).)*\bexit 1\b',
+            text,
+            flags=re.DOTALL,
+        )
+        if empty_signature_block is None:
+            errors.append("desktop release can publish an empty Sparkle EdDSA signature")
+
+    required_files = [
+        "desktop/macos/scripts/prepare-agent-runtime.sh",
+        "desktop/macos/scripts/test-tool-surfaces.sh",
+        "desktop/macos/Desktop/Omi-Release.entitlements",
+        "desktop/macos/Desktop/Node.entitlements",
+        "desktop/macos/dmg-assets/dmgbuild_settings.py",
+        "scripts/scan-public-artifact-secrets.py",
+        ".github/scripts/desktop-changelog.py",
+    ]
+    for required_file in required_files:
+        if not (ROOT / required_file).exists():
+            errors.append(f"desktop release references missing file: {required_file}")
+
+    return errors
+
+
+def check_docs_workflow_scripts() -> list[str]:
+    workflow = ROOT / ".github/workflows/deploy_docs.yml"
+    package_json = ROOT / "docs/package.json"
+    if not workflow.exists() or not package_json.exists():
+        return []
+
+    text = workflow.read_text(encoding="utf-8")
+    scripts = json.loads(package_json.read_text(encoding="utf-8")).get("scripts", {})
+    errors = []
+    for script in sorted(set(re.findall(r"npm run ([A-Za-z0-9:_-]+)", text))):
+        if script not in scripts:
+            errors.append(f"deploy_docs.yml runs npm script {script!r}, but docs/package.json does not define it")
+    return errors
+
+
+def check_python_cli_release_version_source() -> list[str]:
+    release_script = ROOT / "sdks/python-cli/release.sh"
+    if not release_script.exists():
+        return []
+
+    text = release_script.read_text(encoding="utf-8")
+    if "['project']['version']" in text or '["project"]["version"]' in text:
+        return ["sdks/python-cli/release.sh reads project.version, but pyproject.toml uses dynamic versioning"]
+    if "import omi_cli" not in text or "__version__" not in text:
+        return ["sdks/python-cli/release.sh must resolve the version from omi_cli.__version__"]
+    return []
+
+
+def check_react_native_release_tags() -> list[str]:
+    package_json = ROOT / "sdks/react-native/package.json"
+    podspec = ROOT / "sdks/react-native/omi-react-native.podspec"
+    if not package_json.exists() or not podspec.exists():
+        return []
+
+    package = json.loads(package_json.read_text(encoding="utf-8"))
+    release_tag = package.get("release-it", {}).get("git", {}).get("tagName")
+    podspec_text = podspec.read_text(encoding="utf-8")
+    if release_tag == "v${version}" and ':tag => "v#{s.version}"' not in podspec_text:
+        return ["React Native podspec tag must match release-it tagName v${version}"]
+    return []
+
+
+def check_firmware_release_metadata() -> list[str]:
+    script = ROOT / "omi/firmware/scripts/ci/make-release-body.sh"
+    workflow = ROOT / ".github/workflows/firmware_release.yml"
+    if not script.exists():
+        return []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output = Path(temp_dir) / "body.md"
+        env = {
+            "TITLE": "Omi CV1 Firmware v9.8.7",
+            "VER": "9.8.7",
+            "CHANGELOG": "Guard smoke test",
+            "MIN_FW": "3.0.6",
+            "MIN_APP": "1.0.74",
+            "MIN_APP_CODE": "438",
+            "OTA_STEPS": "battery,internet",
+            "IS_LEGACY_SECURE_DFU": "False",
+            "OUT": str(output),
+        }
+        completed = subprocess.run(
+            ["bash", str(script)],
+            cwd=ROOT,
+            env={**os.environ, **env},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            return [f"firmware release body smoke failed: {completed.stderr.strip() or completed.stdout.strip()}"]
+        body = output.read_text(encoding="utf-8")
+
+    kv = extract_key_value_pairs(body)
+    errors = []
+    if kv.get("release_firmware_version") != "9.8.7":
+        errors.append("firmware release body must include release_firmware_version")
+    if kv.get("minimum_firmware_required") != "3.0.6":
+        errors.append("firmware release body must include minimum_firmware_required")
+    if kv.get("minimum_app_version") != "1.0.74":
+        errors.append("firmware release body must include minimum_app_version")
+    if kv.get("minimum_app_version_code") != "438":
+        errors.append("firmware release body must include minimum_app_version_code")
+    if kv.get("is_legacy_secure_dfu") != "False":
+        errors.append("CV1 firmware release body must emit is_legacy_secure_dfu:False")
+    if "ota_update_steps" not in kv:
+        errors.append("firmware release body must include ota_update_steps when provided")
+    if workflow.exists():
+        workflow_text = workflow.read_text(encoding="utf-8")
+        ota_asset = r'Omi_CV1_OTA_v$VER.zip'
+        if ota_asset not in workflow_text:
+            errors.append("firmware release workflow must stage and publish an OTA .zip asset")
+    return errors
+
+
+def extract_key_value_pairs(markdown_content: str) -> dict[str, str]:
+    match = re.search(r"<!-- KEY_VALUE_START\s*(.*?)\s*KEY_VALUE_END -->", markdown_content, re.DOTALL)
+    if not match:
+        return {}
+
+    result: dict[str, str] = {}
+    for line in match.group(1).strip().split("\n"):
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,11 +33,15 @@ jobs:
           echo "has_arb=$(echo "$FILES" | grep -q '\.arb$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_firmware=$(echo "$FILES" | grep -qE '^(omi|omiGlass)/.*\.(c|cpp|cc|cxx|h|hpp)$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_frontend=$(echo "$FILES" | grep -q '^web/frontend/' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_web_app=$(echo "$FILES" | grep -q '^web/app/' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_admin=$(echo "$FILES" | grep -q '^web/admin/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_personas=$(echo "$FILES" | grep -q '^web/personas-open-source/' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_workflows=$(echo "$FILES" | grep -qE '^\.github/workflows/.*\.ya?ml$|^\.github/actionlint\.ya?ml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_backend_runtime_env=$(echo "$FILES" | grep -qE '^backend/deploy/runtime_env\.yaml$|^backend/charts/backend-listen/.*_values\.yaml$|^backend/scripts/validate-backend-runtime-env\.py$|^\.github/workflows/gcp_backend.*\.ya?ml$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_backend_async_gate=$(echo "$FILES" | grep -qE '^backend/.*\.py$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_desktop_agent_runtime=$(echo "$FILES" | grep -qE '^desktop/macos/agent/|^desktop/macos/pi-mono-extension/|^desktop/macos/run\.sh$|^desktop/macos/scripts/(prepare-agent-runtime|test-tool-surfaces)\.sh$|^codemagic\.yaml$|^scripts/pre-push$|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_app_codegen=$(echo "$FILES" | grep -qE '^app/lib/|^app/pubspec\.yaml$|^app/pubspec\.lock$|^app/build\.yaml$|^app/assets/' && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "has_app_l10n=$(echo "$FILES" | grep -qE '^app/lib/l10n/.*\.arb$|^app/l10n\.yaml$' && echo true || echo false)" >> $GITHUB_OUTPUT
           # Also run the Rust check when this workflow changes so CI PRs dogfood
           # the new guard instead of only validating YAML syntax.
           echo "has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/lint\.yml$' && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -79,12 +83,15 @@ jobs:
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
 
+      - name: Check release process guards
+        run: python3 .github/scripts/check-release-process-guards.py
+
       - name: Check backend runtime env manifest
         if: steps.changed.outputs.has_backend_runtime_env == 'true'
         run: |
           python3 -m pip install -q pyyaml
           python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
-          python3 backend/scripts/validate-backend-runtime-env.py --env prod
+          python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows
 
       - name: Summarize deferred-work markers
         continue-on-error: true
@@ -101,15 +108,45 @@ jobs:
 
       # -- Dart --
       - name: Setup Flutter
-        if: steps.changed.outputs.has_dart == 'true'
+        if: steps.changed.outputs.has_dart == 'true' || steps.changed.outputs.has_app_codegen == 'true' || steps.changed.outputs.has_app_l10n == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
 
       - name: Resolve Flutter dependencies
-        if: steps.changed.outputs.has_dart == 'true'
+        if: steps.changed.outputs.has_dart == 'true' || steps.changed.outputs.has_app_codegen == 'true' || steps.changed.outputs.has_app_l10n == 'true'
         working-directory: app
         run: flutter pub get
+
+      - name: Check Flutter generated code
+        if: steps.changed.outputs.has_app_codegen == 'true'
+        working-directory: app
+        run: |
+          dart run build_runner build --delete-conflicting-outputs
+          git diff --exit-code -- lib || {
+            echo "Generated Dart files are stale. Run: cd app && dart run build_runner build --delete-conflicting-outputs"
+            exit 1
+          }
+          if [ -n "$(git ls-files --others --exclude-standard -- lib)" ]; then
+            echo "Generated Dart files are stale; untracked generated files were produced:"
+            git ls-files --others --exclude-standard -- lib
+            exit 1
+          fi
+
+      - name: Check Flutter l10n
+        if: steps.changed.outputs.has_app_l10n == 'true'
+        working-directory: app
+        run: |
+          flutter gen-l10n
+          git diff --exit-code -- lib/l10n || {
+            echo "Generated localization files are stale. Run: cd app && flutter gen-l10n"
+            exit 1
+          }
+          if [ -n "$(git ls-files --others --exclude-standard -- lib/l10n)" ]; then
+            echo "Generated localization files are stale; untracked generated files were produced:"
+            git ls-files --others --exclude-standard -- lib/l10n
+            exit 1
+          fi
 
       - name: Check Dart formatting
         if: steps.changed.outputs.has_dart == 'true'
@@ -225,13 +262,15 @@ jobs:
 
       # -- Frontend --
       - name: Setup Node.js
-        if: steps.changed.outputs.has_frontend == 'true' || steps.changed.outputs.has_personas == 'true'
+        if: steps.changed.outputs.has_frontend == 'true' || steps.changed.outputs.has_personas == 'true' || steps.changed.outputs.has_web_app == 'true' || steps.changed.outputs.has_admin == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: |
             web/frontend/package-lock.json
+            web/app/package-lock.json
+            web/admin/package-lock.json
             web/personas-open-source/package-lock.json
 
       - name: Lint Frontend
@@ -248,3 +287,35 @@ jobs:
         run: |
           npm ci --legacy-peer-deps
           npm run lint
+
+      - name: Build Web App
+        if: steps.changed.outputs.has_web_app == 'true'
+        working-directory: ./web/app
+        env:
+          NEXT_PUBLIC_FIREBASE_API_KEY: dummy
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: dummy.firebaseapp.com
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: dummy
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: dummy.appspot.com
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "123456789"
+          NEXT_PUBLIC_FIREBASE_APP_ID: "1:123456789:web:dummy"
+          NEXT_PUBLIC_FIREBASE_VAPID_KEY: dummy
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Admin Dashboard
+        if: steps.changed.outputs.has_admin == 'true'
+        working-directory: ./web/admin
+        env:
+          NEXT_PUBLIC_FIREBASE_API_KEY: dummy
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: dummy.firebaseapp.com
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: dummy
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: dummy.appspot.com
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "123456789"
+          NEXT_PUBLIC_FIREBASE_APP_ID: "1:123456789:web:dummy"
+          NEXT_PUBLIC_FIREBASE_VAPID_KEY: dummy
+          NEXT_PUBLIC_PLUGINS_APP_ID: dummy
+          NEXT_PUBLIC_OMI_API_URL: https://api.omiapi.com
+        run: |
+          npm ci
+          npm run build

--- a/app/.client.env.example
+++ b/app/.client.env.example
@@ -1,0 +1,10 @@
+PUBLIC_API_BASE_URL=https://api.omiapi.com/
+PUBLIC_STAGING_API_URL=
+PUBLIC_USE_WEB_AUTH=false
+PUBLIC_USE_AUTH_CUSTOM_TOKEN=false
+PUBLIC_GOOGLE_MAPS_API_KEY=public-google-maps-key
+PUBLIC_GOOGLE_CLIENT_ID=public-google-oauth-client-id.apps.googleusercontent.com
+PUBLIC_POSTHOG_API_KEY=public-posthog-ingestion-key
+PUBLIC_INTERCOM_APP_ID=public-intercom-app-id
+PUBLIC_INTERCOM_IOS_API_KEY=public-intercom-ios-key
+PUBLIC_INTERCOM_ANDROID_API_KEY=public-intercom-android-key

--- a/app/config/client_env_policy.yaml
+++ b/app/config/client_env_policy.yaml
@@ -1,0 +1,171 @@
+{
+  "public_client_env": {
+    "allowed": [
+      "PUBLIC_API_BASE_URL",
+      "PUBLIC_STAGING_API_URL",
+      "PUBLIC_USE_WEB_AUTH",
+      "PUBLIC_USE_AUTH_CUSTOM_TOKEN",
+      "PUBLIC_GOOGLE_MAPS_API_KEY",
+      "PUBLIC_GOOGLE_CLIENT_ID",
+      "PUBLIC_POSTHOG_API_KEY",
+      "PUBLIC_INTERCOM_APP_ID",
+      "PUBLIC_INTERCOM_IOS_API_KEY",
+      "PUBLIC_INTERCOM_ANDROID_API_KEY"
+    ]
+  },
+  "legacy_public_client_env": {
+    "allowed": [
+      "FIREBASE_API_KEY",
+      "MIXPANEL_PROJECT_TOKEN",
+      "OMI_DESKTOP_API_URL",
+      "OMI_PYTHON_API_URL"
+    ]
+  },
+  "public_web_build_args": {
+    "allowed": [
+      "API_URL",
+      "NEXT_PUBLIC_API_BASE_URL",
+      "NEXT_PUBLIC_FIREBASE_API_KEY",
+      "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+      "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+      "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+      "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+      "NEXT_PUBLIC_FIREBASE_APP_ID",
+      "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID",
+      "NEXT_PUBLIC_FIREBASE_VAPID_KEY",
+      "NEXT_PUBLIC_MIXPANEL_TOKEN",
+      "NEXT_PUBLIC_EXTRA_PROMPT_RULES",
+      "NEXT_PUBLIC_PLUGINS_APP_ID",
+      "NEXT_PUBLIC_OMI_API_URL"
+    ]
+  },
+  "public_client_env_sources": {
+    "allowed": [
+      "STAGING_API_URL"
+    ]
+  },
+  "restricted_public_client_keys": {
+    "PUBLIC_GOOGLE_MAPS_API_KEY": {
+      "owner": "mobile-platform",
+      "purpose": "Google Maps rendering in the public mobile client",
+      "restriction": "Must be restricted in Google Cloud by the released iOS bundle id, Android package/certificate, and Maps APIs only.",
+      "revocation": "Rotate in Google Cloud, update the mobile_public_config CI group, and rebuild affected releases."
+    },
+    "PUBLIC_POSTHOG_API_KEY": {
+      "owner": "growth",
+      "purpose": "Public PostHog event ingestion from the mobile client",
+      "restriction": "Project ingestion token only; no admin/read capability.",
+      "revocation": "Rotate in PostHog, update the mobile_public_config CI group, and rebuild affected releases."
+    },
+    "PUBLIC_INTERCOM_IOS_API_KEY": {
+      "owner": "support",
+      "purpose": "Public Intercom iOS SDK key",
+      "restriction": "Client SDK key only; no admin/read capability.",
+      "revocation": "Rotate in Intercom, update the mobile_public_config CI group, and rebuild affected releases."
+    },
+    "PUBLIC_INTERCOM_ANDROID_API_KEY": {
+      "owner": "support",
+      "purpose": "Public Intercom Android SDK key",
+      "restriction": "Client SDK key only; no admin/read capability.",
+      "revocation": "Rotate in Intercom, update the mobile_public_config CI group, and rebuild affected releases."
+    },
+    "PUBLIC_USE_AUTH_CUSTOM_TOKEN": {
+      "owner": "mobile-platform",
+      "purpose": "Public boolean feature flag selecting custom-token auth flow.",
+      "restriction": "Boolean config only; never a credential value.",
+      "revocation": "Set false in public client config and rebuild affected releases."
+    }
+  },
+  "server_secret_env": {
+    "denied_exact": [
+      "OPENAI_API_KEY",
+      "OPENROUTER_API_KEY",
+      "CLAUDE_API_KEY",
+      "SLIDESGPT_API_KEY",
+      "GOOGLE_CLIENT_SECRET",
+      "GEMINI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "DEEPGRAM_API_KEY",
+      "PINECONE_API_KEY",
+      "SUPABASE_KEY",
+      "UPSTASH_REDIS_PASSWORD",
+      "GOOGLE_CALENDAR_API_KEY",
+      "JWT_SECRET",
+      "OMI_APP_SECRET",
+      "DECK_APP_SECRET",
+      "RESEND_API_KEY",
+      "SENTRY_AUTH_TOKEN",
+      "REDIS_DB_PASSWORD",
+      "DESKTOP_DEEPGRAM_API_KEY",
+      "DESKTOP_ANTHROPIC_API_KEY",
+      "DESKTOP_GOOGLE_CALENDAR_API_KEY",
+      "SPARKLE_PRIVATE_KEY",
+      "APP_STORE_CONNECT_PRIVATE_KEY",
+      "FIREBASE_SERVICE_ACCOUNT_KEY",
+      "FIREBASE_SERVICE_ACCOUNT_DEV_KEY",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "SERVICE_ACCOUNT_JSON",
+      "ADMIN_KEY",
+      "ENCRYPTION_SECRET"
+    ],
+    "denied_name_patterns": [
+      "(^|_)SECRET($|_)",
+      "(^|_)PRIVATE_KEY($|_)",
+      "(^|_)SERVICE_ACCOUNT($|_)",
+      "(^|_)ADMIN_KEY($|_)",
+      "(^|_)WEBHOOK_SECRET($|_)",
+      "(^|_)API_KEY($|_)",
+      "(^|_)TOKEN($|_)",
+      "(^|_)PASSWORD($|_)",
+      "(^|_)CREDENTIALS?($|_)",
+      "(^|_)KEYSTORE($|_)",
+      "(^|_)P12($|_)"
+    ]
+  },
+  "allowed_build_secret_source_references": [
+    "CM_KEYSTORE_PATH",
+    "CM_KEYSTORE_PASSWORD",
+    "CM_KEY_PASSWORD",
+    "MATCH_PASSWORD"
+  ],
+  "allowed_public_client_tokens": [
+    "INTERCOM_APP_ID",
+    "INTERCOM_ANDROID_API_KEY"
+  ],
+  "direct_provider_domains_denied_in_app": [
+    "api.openai.com",
+    "api.anthropic.com",
+    "generativelanguage.googleapis.com",
+    "api.deepgram.com"
+  ],
+  "legacy_direct_provider_domain_exceptions": {
+    "app/lib/models/stt_provider.dart": {
+      "owner": "mobile-platform",
+      "reason": "Legacy user-supplied custom STT templates. New provider integrations must go through backend-owned secret storage and a provider proxy.",
+      "migration": "Replace direct BYOK STT calls with backend BYOK references before adding new provider domains.",
+      "allowed_occurrences": {
+        "api.openai.com": 2,
+        "api.deepgram.com": 2,
+        "generativelanguage.googleapis.com": 2
+      }
+    },
+    "app/lib/services/sockets/transcription_polling_service.dart": {
+      "owner": "mobile-platform",
+      "reason": "Legacy user-supplied custom STT polling implementation. New provider integrations must go through backend-owned secret storage and a provider proxy.",
+      "migration": "Replace direct BYOK STT calls with backend BYOK references before adding new provider domains.",
+      "allowed_occurrences": {
+        "api.openai.com": 2,
+        "api.deepgram.com": 1,
+        "generativelanguage.googleapis.com": 1
+      }
+    },
+    "app/lib/services/sockets/pure_streaming_stt.dart": {
+      "owner": "mobile-platform",
+      "reason": "Legacy user-supplied Gemini streaming STT implementation. New provider integrations must go through backend-owned secret storage and a provider proxy.",
+      "migration": "Replace direct BYOK STT calls with backend BYOK references before adding new provider domains.",
+      "allowed_occurrences": {
+        "generativelanguage.googleapis.com": 1
+      }
+    }
+  }
+}

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -184,6 +184,7 @@ workflows:
             --build-number=$BUILD_NUMBER \
             --flavor prod \
             --export-options-plist=$HOME/export_options.plist
+          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -428,6 +429,8 @@ workflows:
             --build-name=$BUILD_NAME \
             --build-number=$BUILD_NUMBER \
             --flavor prod
+          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
+          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
 
     artifacts:
       - build/**/outputs/**/*.aab
@@ -579,6 +582,7 @@ workflows:
             --build-number=$BUILD_NUMBER \
             --flavor prod \
             --export-options-plist=$HOME/export_options.plist
+          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -981,6 +985,8 @@ workflows:
             --build-name=$BUILD_NAME \
             --build-number=$BUILD_NUMBER \
             --flavor prod
+          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
+          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
 
 
     artifacts:
@@ -1129,6 +1135,7 @@ workflows:
           shorebird patch ios \
             --flavor prod -- \
             --export-options-plist=$HOME/export_options.plist
+          ../scripts/scan-public-artifact-secrets.py build/ios/ipa/*.ipa
     artifacts:
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
@@ -1897,6 +1904,8 @@ workflows:
           # Should use bump version automatically by CI
           shorebird patch android \
             --flavor prod
+          AAB_ARTIFACTS=$(find build -path '*/outputs/*.aab' -print)
+          ../scripts/scan-public-artifact-secrets.py $AAB_ARTIFACTS
     artifacts:
       - build/**/outputs/**/*.aab
       - build/**/outputs/**/mapping.txt
@@ -2628,11 +2637,11 @@ workflows:
             fi
           fi
 
-          if [ -n "$ED_SIGNATURE" ]; then
-            echo "EdDSA signature: $ED_SIGNATURE"
-          else
-            echo "WARNING: Could not generate EdDSA signature — Sparkle auto-update will not work"
+          if [ -z "$ED_SIGNATURE" ]; then
+            echo "ERROR: Could not generate EdDSA signature — Sparkle auto-update will not work"
+            exit 1
           fi
+          echo "EdDSA signature: $ED_SIGNATURE"
           echo "ED_SIGNATURE=$ED_SIGNATURE" >> $CM_ENV
 
       - name: Create GitHub release
@@ -2745,7 +2754,7 @@ workflows:
           RELEASE_JSON=$(python3 -c "
           import json, os
           data = {
-            'version':      os.environ['BUILD_NAME'],
+            'version':      os.environ['VERSION'],
             'build_number': int(os.environ['BUILD_NUMBER']),
             'download_url': os.environ.get('DOWNLOAD_URL', ''),
             'ed_signature': os.environ.get('ED_SIGNATURE', ''),

--- a/desktop/macos/changelog/unreleased/release-process-guards.json
+++ b/desktop/macos/changelog/unreleased/release-process-guards.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop release checks so agent runtime packaging issues are caught before release"
+}

--- a/desktop/macos/scripts/test-tool-surfaces.sh
+++ b/desktop/macos/scripts/test-tool-surfaces.sh
@@ -16,6 +16,43 @@ ensure_npm_deps() {
   )
 }
 
+node_supports_strip_types() {
+  "$1" --experimental-strip-types -e '0' >/dev/null 2>&1
+}
+
+select_node22() {
+  local node_bin
+  local -a candidates=(
+    "$DESKTOP_DIR/Desktop/Sources/Resources/node"
+    "/opt/homebrew/opt/node@22/bin/node"
+    "/usr/local/opt/node@22/bin/node"
+  )
+
+  if command -v brew >/dev/null 2>&1; then
+    node_bin="$(brew --prefix node@22 2>/dev/null || true)"
+    if [[ -n "$node_bin" ]]; then
+      candidates+=("$node_bin/bin/node")
+    fi
+  fi
+
+  node_bin="$(command -v node 2>/dev/null || true)"
+  [[ -n "$node_bin" ]] && candidates+=("$node_bin")
+
+  for node_bin in "${candidates[@]}"; do
+    if [[ -x "$node_bin" ]] && node_supports_strip_types "$node_bin"; then
+      printf '%s\n' "$node_bin"
+      return
+    fi
+  done
+
+  echo "ERROR: Node.js 22.6+ with --experimental-strip-types is required for desktop agent tool-surface tests." >&2
+  echo "Install Node 22 or run desktop/macos/scripts/prepare-agent-runtime.sh first." >&2
+  return 1
+}
+
+NODE22="$(select_node22)"
+export PATH="$(dirname "$NODE22"):$PATH"
+
 ensure_npm_deps "$DESKTOP_DIR/agent"
 
 (
@@ -25,7 +62,12 @@ ensure_npm_deps "$DESKTOP_DIR/agent"
 
 (
   cd "$DESKTOP_DIR/agent"
-  npm test -- --run \
+  npm run build --silent
+)
+
+(
+  cd "$DESKTOP_DIR/agent"
+  "$NODE22" node_modules/vitest/vitest.mjs run \
     tests/omi-tool-manifest.test.ts \
     tests/control-tools.test.ts \
     tests/node-tools.test.ts \
@@ -35,13 +77,5 @@ ensure_npm_deps "$DESKTOP_DIR/agent"
 ensure_npm_deps "$DESKTOP_DIR/pi-mono-extension"
 (
   cd "$DESKTOP_DIR/pi-mono-extension"
-  node_bin="$DESKTOP_DIR/Desktop/Sources/Resources/node"
-  if [[ -x "$node_bin" ]]; then
-    "$node_bin" --experimental-strip-types --test index.test.ts
-  elif node --experimental-strip-types --test index.test.ts; then
-    echo "pi-mono-extension tests passed (native Node --experimental-strip-types)"
-  else
-    echo "Falling back to npx tsx for older Node versions..."
-    npx --yes tsx@4.19.2 --test index.test.ts
-  fi
+  "$NODE22" --experimental-strip-types --test index.test.ts
 )

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "mkdir -p build && cp -R api-reference assets doc epics images logo memory onboarding operational rollout runbooks superpowers docs.json favicon.ico getstartedwithomi.mdx quickstart.mdx IMG_5299.JPG omi-devkit-without-rope.png omi-glass.png omi-without-rope.png build/"
+  },
   "dependencies": {
     "@mintlify/scraping": "^4.0.164"
   }

--- a/scripts/check-public-client-secrets.py
+++ b/scripts/check-public-client-secrets.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""Guard public client builds from server-only secrets.
+
+This script enforces the policy in app/config/client_env_policy.yaml. It is
+deliberately stdlib-only so it can run in git hooks, Codemagic, and GitHub
+Actions before language-specific setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "app" / "config" / "client_env_policy.yaml"
+APP_LIB = ROOT / "app" / "lib"
+LEGACY_DIRECT_PROVIDER_ALLOW_COMMENT = "public-client-secret-boundary: legacy-direct-provider"
+
+
+def load_policy() -> dict:
+    with POLICY_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def compile_patterns(policy: dict) -> list[re.Pattern[str]]:
+    patterns = policy["server_secret_env"]["denied_name_patterns"]
+    return [re.compile(pattern) for pattern in patterns]
+
+
+def denied_names(policy: dict) -> set[str]:
+    return set(policy["server_secret_env"]["denied_exact"])
+
+
+def allowed_names(policy: dict) -> set[str]:
+    return set(policy["public_client_env"]["allowed"]) | set(
+        policy.get("legacy_public_client_env", {}).get("allowed", [])
+    )
+
+
+def allowed_public_names(policy: dict) -> set[str]:
+    return allowed_names(policy) | set(policy.get("public_web_build_args", {}).get("allowed", []))
+
+
+def name_is_denied(name: str, exact: set[str], patterns: list[re.Pattern[str]]) -> bool:
+    return name in exact or any(pattern.search(name) for pattern in patterns)
+
+
+def variable_like_tokens(text: str) -> set[str]:
+    return set(re.findall(r"\b[A-Z][A-Z0-9_]{2,}\b", text))
+
+
+def line_reads_env_or_config(line: str) -> bool:
+    lowered = line.lower()
+    return any(marker in lowered for marker in ("env", "getenv", "process.env", "platform.environment", "buildconfig"))
+
+
+def git_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def denied_env_values(policy: dict) -> dict[str, str]:
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if value
+        and len(value) >= 8
+        and not name.startswith(("PUBLIC_", "NEXT_PUBLIC_"))
+        and name_is_denied(name, exact, patterns)
+    }
+
+
+def check_duplicate_yaml_keys(path: Path) -> list[str]:
+    errors: list[str] = []
+    seen_by_indent: dict[int, set[str]] = {}
+    block_scalar_indent: int | None = None
+    key_re = re.compile(r"^(\s*)(?:[\"']?)([A-Za-z0-9_.-]+)(?:[\"']?):(?:\s.*)?$")
+
+    for lineno, raw in enumerate(read_text(path).splitlines(), start=1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if block_scalar_indent is not None:
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+        if raw.lstrip().startswith("- "):
+            for existing_indent in list(seen_by_indent):
+                if existing_indent > indent:
+                    del seen_by_indent[existing_indent]
+
+        match = key_re.match(raw)
+        if not match:
+            continue
+        key = match.group(2)
+        line_tail = raw.split(":", 1)[1].strip()
+        if line_tail in {"|", "|-", "|+", ">", ">-", ">+"}:
+            block_scalar_indent = indent
+
+        for existing_indent in list(seen_by_indent):
+            if existing_indent > indent:
+                del seen_by_indent[existing_indent]
+        seen = seen_by_indent.setdefault(indent, set())
+        if key in seen:
+            errors.append(f"{display_path(path)}:{lineno}: duplicate YAML key {key!r} at indent {indent}")
+        seen.add(key)
+
+    return errors
+
+
+def check_policy_shape(policy: dict) -> list[str]:
+    errors: list[str] = []
+    allowed = allowed_names(policy)
+    public_prefixed = set(policy["public_client_env"]["allowed"])
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    restricted = policy.get("restricted_public_client_keys", {})
+    direct_provider_exceptions = policy.get("legacy_direct_provider_domain_exceptions", {})
+    allowed_build_secret_source_refs = set(policy.get("allowed_build_secret_source_references", []))
+
+    for name in sorted(public_prefixed):
+        if not name.startswith("PUBLIC_"):
+            errors.append(f"{POLICY_PATH}: public client env name must use PUBLIC_ prefix: {name}")
+        if name_is_denied(name, exact, patterns) and name not in restricted:
+            errors.append(f"{POLICY_PATH}: denied-looking public client env name {name} needs restricted metadata")
+    for name, metadata in sorted(restricted.items()):
+        if name not in allowed:
+            errors.append(f"{POLICY_PATH}: restricted public key {name} must also be in public_client_env.allowed")
+        for field in ("owner", "purpose", "restriction", "revocation"):
+            if not str(metadata.get(field, "")).strip():
+                errors.append(f"{POLICY_PATH}: restricted public key {name} is missing {field}")
+
+    for path, metadata in sorted(direct_provider_exceptions.items()):
+        exception_path = ROOT / path
+        if not exception_path.exists():
+            errors.append(f"{POLICY_PATH}: legacy direct-provider exception points at missing file: {path}")
+        for field in ("owner", "reason", "migration"):
+            if not str(metadata.get(field, "")).strip():
+                errors.append(f"{POLICY_PATH}: legacy direct-provider exception {path} is missing {field}")
+        allowed_occurrences = metadata.get("allowed_occurrences")
+        if not isinstance(allowed_occurrences, dict) or not allowed_occurrences:
+            errors.append(f"{POLICY_PATH}: legacy direct-provider exception {path} must pin allowed_occurrences")
+        else:
+            for domain, count in allowed_occurrences.items():
+                if domain not in policy.get("direct_provider_domains_denied_in_app", []):
+                    errors.append(
+                        f"{POLICY_PATH}: legacy direct-provider exception {path} pins unknown domain {domain}"
+                    )
+                if not isinstance(count, int) or count < 0:
+                    errors.append(
+                        f"{POLICY_PATH}: legacy direct-provider exception {path} has invalid count for {domain}"
+                    )
+            if exception_path.exists():
+                text = read_text(exception_path)
+                for domain in policy.get("direct_provider_domains_denied_in_app", []):
+                    actual = text.count(domain)
+                    expected = int(allowed_occurrences.get(domain, 0))
+                    if actual != expected:
+                        errors.append(
+                            f"{path}: legacy direct-provider domain {domain} count changed: expected {expected}, found {actual}"
+                        )
+                for lineno, line in enumerate(text.splitlines(), start=1):
+                    for domain in policy.get("direct_provider_domains_denied_in_app", []):
+                        if domain in line and LEGACY_DIRECT_PROVIDER_ALLOW_COMMENT not in line:
+                            errors.append(
+                                f"{path}:{lineno}: legacy direct-provider domain {domain} needs inline allow comment"
+                            )
+
+    for name in sorted(allowed_build_secret_source_refs):
+        if not name_is_denied(name, exact, patterns):
+            errors.append(f"{POLICY_PATH}: allowed build secret source reference is not denied by policy: {name}")
+
+    return errors
+
+
+def check_env_file(path: Path, policy: dict) -> list[str]:
+    errors: list[str] = []
+    allowed = allowed_names(policy)
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    private_values = denied_env_values(policy)
+
+    if not path.exists():
+        return errors
+
+    for lineno, raw in enumerate(read_text(path).splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name = line.split("=", 1)[0].strip()
+        if not name:
+            continue
+        if name not in allowed:
+            errors.append(f"{path}:{lineno}: {name} is not in public_client_env.allowed")
+        if name not in allowed and name_is_denied(name, exact, patterns):
+            errors.append(f"{path}:{lineno}: {name} is server-only and cannot enter public client env")
+        value = line.split("=", 1)[1] if "=" in line else ""
+        for env_name, private_value in private_values.items():
+            if value == private_value:
+                errors.append(f"{path}:{lineno}: value matches current private env value {env_name}")
+
+    return errors
+
+
+def check_app_source(policy: dict) -> list[str]:
+    errors: list[str] = []
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    denied_domains = set(policy.get("direct_provider_domains_denied_in_app", []))
+    legacy_domain_exceptions = set(policy.get("legacy_direct_provider_domain_exceptions", {}).keys())
+    allowed_build_secret_source_refs = set(policy.get("allowed_build_secret_source_references", []))
+    allowed_public = allowed_public_names(policy) | set(policy.get("allowed_public_client_tokens", []))
+    source_roots = [
+        APP_LIB,
+        ROOT / "app" / "ios",
+        ROOT / "app" / "android",
+        ROOT / "app" / "macos",
+        ROOT / "app" / "setup",
+        ROOT / "app" / "setup.sh",
+        ROOT / "app" / "initialsetup.bash",
+    ]
+    suffixes = {
+        ".dart",
+        ".swift",
+        ".kt",
+        ".java",
+        ".m",
+        ".mm",
+        ".h",
+        ".plist",
+        ".xml",
+        ".gradle",
+        ".sh",
+        ".bash",
+        ".ps1",
+        ".json",
+        ".env",
+    }
+
+    files = [
+        path
+        for path in git_files()
+        if path.exists()
+        if path in source_roots
+        or any(path.is_relative_to(root) for root in source_roots if root.is_dir())
+        and path.suffix in suffixes
+        and not path.name.endswith(".g.dart")
+        and not path.name.endswith(".gen.dart")
+    ]
+
+    for path in files:
+        text = read_text(path)
+        rel = path.relative_to(ROOT)
+        rel_text = str(rel)
+        for name in exact:
+            if name in text and name not in allowed_build_secret_source_refs and name not in allowed_public:
+                errors.append(f"{rel}: references server-only env name {name}")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if not line_reads_env_or_config(line):
+                continue
+            for token in variable_like_tokens(line):
+                if (
+                    token not in allowed_build_secret_source_refs
+                    and token not in allowed_public
+                    and name_is_denied(token, exact, patterns)
+                ):
+                    errors.append(f"{rel}:{lineno}: references server-only env-like token {token}")
+        for domain in denied_domains:
+            if domain in text and rel_text not in legacy_domain_exceptions:
+                errors.append(f"{rel}: directly references denied provider domain {domain}")
+    generated = [ROOT / "app" / "lib" / "env" / "prod_env.g.dart", ROOT / "app" / "lib" / "env" / "dev_env.g.dart"]
+    for path in generated:
+        if not path.exists():
+            continue
+        text = read_text(path)
+        rel = path.relative_to(ROOT)
+        for name in exact:
+            if name in text and name not in allowed_public:
+                errors.append(f"{rel}: generated Envied output contains server-only env name {name}")
+        for token in variable_like_tokens(text):
+            if token not in allowed_public and name_is_denied(token, exact, patterns):
+                errors.append(f"{rel}: generated Envied output contains server-only env-like token {token}")
+
+    return errors
+
+
+PUBLIC_ENV_FILE_RE = re.compile(r"(?:^|/)(?:\.client(?:\.dev)?\.env|\.env)(?:[\"']|\s|$)")
+ENV_WRITE_RE = re.compile(
+    r"\b(?:echo|printf)\b.*(?:>|>>)\s*[\"']?(?:[^\"'\s>]*/)?(\.client(?:\.dev)?\.env|\.env)[\"']?"
+)
+PUBLIC_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?(PUBLIC_[A-Z0-9_]*)=(.+?)(?:\s*\\)?$")
+PUBLIC_ASSIGNMENT_ANYWHERE_RE = re.compile(r"(?:^|\s)(PUBLIC_[A-Z0-9_]*)=(\"[^\"]*\"|'[^']*'|[^\s\\]+)")
+ENV_REF_RE = re.compile(r"\$(?:\{?([A-Z][A-Z0-9_]*)\}?|{{\s*secrets\.([A-Z][A-Z0-9_]*)\s*}})")
+PRINTENV_REF_RE = re.compile(r"printenv\s+([A-Z][A-Z0-9_]*)")
+GITHUB_SECRET_RE = re.compile(r"secrets(?:\.|\[['\"])([A-Z][A-Z0-9_]*)")
+SHELL_ASSIGNMENT_RE = re.compile(r"(?:^|\s)([A-Z][A-Z0-9_]*)=(\"[^\"]*\"|'[^']*'|[^\s\\]+)")
+PUBLIC_ENV_TARGET_RE = re.compile(
+    r"(?:^|[\s/\"'])(?:\.client(?:\.dev)?\.env|\.env|\.env\.production|\.env\.local)(?:[\"']|\s|$)"
+)
+SENSITIVE_ECHO_RE = re.compile(r"\b(?:echo|printf)\b")
+SHELL_TRACE_RE = re.compile(r"(^|\s|[;&|]\s*)set\s+(?:-[A-Za-z]*x[A-Za-z]*|-o\s+xtrace)(\s|$|[;&|])")
+SHELL_TRACE_OFF_RE = re.compile(r"(^|\s|[;&|]\s*)set\s+\+x(\s|$)")
+STDOUT_REDIRECT_RE = re.compile(r"(^|\s|[;&|]\s*)(?:1?>|1?>>|&>|&>>)\s*\S")
+SAFE_STDIN_SECRET_SINK_RE = re.compile(
+    r"\|\s*(?:\"[^\"]*sign_update\"|\S*sign_update)\b[^|]*--ed-key-file\s+-"
+    r"|\|\s*docker\s+login\b[^|]*--password-stdin"
+)
+
+
+def check_codemagic(policy: dict) -> list[str]:
+    errors: list[str] = []
+    path = ROOT / "codemagic.yaml"
+    if not path.exists():
+        return errors
+
+    allowed = allowed_names(policy)
+    allowed_public = allowed_public_names(policy)
+    allowed_public_sources = set(policy.get("public_client_env_sources", {}).get("allowed", []))
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    text = read_text(path)
+    pending_public_assignments: list[tuple[int, str, str]] = []
+
+    errors.extend(check_duplicate_yaml_keys(path))
+
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        assignment_match = PUBLIC_ASSIGNMENT_RE.match(line)
+        if assignment_match:
+            pending_public_assignments.append((lineno, assignment_match.group(1), assignment_match.group(2)))
+
+        if "create-public-client-env.sh" in line:
+            for inline_assignment in PUBLIC_ASSIGNMENT_ANYWHERE_RE.finditer(line):
+                pending_public_assignments.append((lineno, inline_assignment.group(1), inline_assignment.group(2)))
+            for assignment_lineno, public_name, rhs in pending_public_assignments:
+                if public_name not in allowed_public:
+                    errors.append(
+                        f"{path.relative_to(ROOT)}:{assignment_lineno}: {public_name} is not allowlisted public config"
+                    )
+                if "$(" in rhs or "`" in rhs:
+                    errors.append(
+                        f"{path.relative_to(ROOT)}:{assignment_lineno}: {public_name} uses command substitution"
+                    )
+                for printenv_match in PRINTENV_REF_RE.finditer(rhs):
+                    ref_name = printenv_match.group(1)
+                    if ref_name != public_name and ref_name not in allowed_public_sources:
+                        errors.append(
+                            f"{path.relative_to(ROOT)}:{assignment_lineno}: maps non-approved source {ref_name} into {public_name}"
+                        )
+                for ref_match in ENV_REF_RE.finditer(rhs):
+                    ref_name = ref_match.group(1) or ref_match.group(2)
+                    if not ref_name:
+                        continue
+                    if ref_name != public_name and ref_name not in allowed_public_sources:
+                        errors.append(
+                            f"{path.relative_to(ROOT)}:{assignment_lineno}: maps non-approved source {ref_name} into {public_name}"
+                        )
+                    if (
+                        ref_name not in allowed_public
+                        and ref_name not in allowed_public_sources
+                        and name_is_denied(ref_name, exact, patterns)
+                    ):
+                        errors.append(
+                            f"{path.relative_to(ROOT)}:{assignment_lineno}: maps server-only {ref_name} into {public_name}"
+                        )
+            pending_public_assignments.clear()
+        elif line.strip() and not line.rstrip().endswith("\\") and not assignment_match:
+            pending_public_assignments.clear()
+
+        env_write = ENV_WRITE_RE.search(line) or ("tee" in line and PUBLIC_ENV_FILE_RE.search(line))
+        if env_write or PUBLIC_ENV_FILE_RE.search(line):
+            for token in variable_like_tokens(line):
+                if token in allowed_public:
+                    continue
+                if name_is_denied(token, exact, patterns):
+                    errors.append(f"{path.relative_to(ROOT)}:{lineno}: public env write references server-only {token}")
+            for ref_match in ENV_REF_RE.finditer(line):
+                ref_name = ref_match.group(1) or ref_match.group(2)
+                if ref_name and ref_name not in allowed_public and name_is_denied(ref_name, exact, patterns):
+                    errors.append(f"{path.relative_to(ROOT)}:{lineno}: public env write reads server-only {ref_name}")
+
+        if "Set up App .env" in line:
+            errors.append(
+                f"{path.relative_to(ROOT)}:{lineno}: use Generate public client config, not hand-written App .env"
+            )
+
+    return errors
+
+
+def line_env_refs(line: str) -> set[str]:
+    refs: set[str] = set()
+    for ref_match in ENV_REF_RE.finditer(line):
+        ref_name = ref_match.group(1) or ref_match.group(2)
+        if ref_name:
+            refs.add(ref_name)
+    for secret_match in GITHUB_SECRET_RE.finditer(line):
+        refs.add(secret_match.group(1))
+    return refs
+
+
+def denied_refs_in_line(
+    line: str,
+    exact: set[str],
+    patterns: list[re.Pattern[str]],
+    allowed_public: set[str],
+    allowed_secret_sources: set[str],
+) -> set[str]:
+    refs = set(line_env_refs(line))
+    for assignment_match in SHELL_ASSIGNMENT_RE.finditer(line):
+        refs.add(assignment_match.group(1))
+    return {
+        ref
+        for ref in refs
+        if ref not in allowed_public
+        and ref not in allowed_secret_sources
+        and not ref.endswith(("_NAME", "_PATH", "_FILE"))
+        and name_is_denied(ref, exact, patterns)
+    }
+
+
+def release_hygiene_files() -> list[Path]:
+    files: list[Path] = []
+    for path in git_files():
+        if not path.exists():
+            continue
+        rel = path.relative_to(ROOT)
+        if rel == Path("codemagic.yaml"):
+            files.append(path)
+        elif path.match(".github/workflows/*.y*ml"):
+            files.append(path)
+        elif path.name == "release.sh" and (
+            path.is_relative_to(ROOT / "app")
+            or path.is_relative_to(ROOT / "mcp")
+            or path.is_relative_to(ROOT / "plugins")
+            or path.is_relative_to(ROOT / "sdks")
+            or path.is_relative_to(ROOT / "web")
+        ):
+            files.append(path)
+    return files
+
+
+def logical_shell_line(lines: list[str], line_index: int) -> str:
+    command_parts = [lines[line_index]]
+    for next_line in lines[line_index + 1 : line_index + 8]:
+        if not command_parts[-1].rstrip().endswith("\\"):
+            break
+        command_parts[-1] = command_parts[-1].rstrip()[:-1]
+        command_parts.append(next_line)
+    return " ".join(part.strip() for part in command_parts)
+
+
+def redirects_stdout(line: str) -> bool:
+    return bool(STDOUT_REDIRECT_RE.search(line))
+
+
+def check_release_log_secret_hygiene(policy: dict) -> list[str]:
+    errors: list[str] = []
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    allowed_public = allowed_public_names(policy)
+    allowed_secret_sources = set(policy.get("allowed_build_secret_source_references", []))
+
+    for path in release_hygiene_files():
+        rel = path.relative_to(ROOT)
+        lines = read_text(path).splitlines()
+        for line_index, line in enumerate(lines):
+            lineno = line_index + 1
+            denied_refs = denied_refs_in_line(line, exact, patterns, allowed_public, allowed_secret_sources)
+            if PUBLIC_ENV_TARGET_RE.search(line) and denied_refs:
+                errors.append(
+                    f"{rel}:{lineno}: public env file write references server-only {', '.join(sorted(denied_refs))}"
+                )
+            logical_line = logical_shell_line(lines, line_index)
+            writes_to_stdout = not redirects_stdout(logical_line) and not SAFE_STDIN_SECRET_SINK_RE.search(logical_line)
+            if SENSITIVE_ECHO_RE.search(line) and denied_refs and writes_to_stdout and "::add-mask::" not in line:
+                errors.append(
+                    f"{rel}:{lineno}: shell output command references server-only {', '.join(sorted(denied_refs))}"
+                )
+            if not SHELL_TRACE_RE.search(line):
+                continue
+
+            trace_refs: set[str] = set()
+            for offset, traced_line in enumerate(lines[lineno:], start=lineno + 1):
+                if SHELL_TRACE_OFF_RE.search(traced_line):
+                    break
+                if offset - lineno > 80:
+                    break
+                trace_refs.update(
+                    denied_refs_in_line(traced_line, exact, patterns, allowed_public, allowed_secret_sources)
+                )
+            if trace_refs:
+                errors.append(f"{rel}:{lineno}: set -x traces nearby server-only refs {', '.join(sorted(trace_refs))}")
+
+    return errors
+
+
+LEGACY_SETUP_ENV_RE = re.compile(
+    r"(?:^|[\s/\"'>=:\\(])(?:\.env|\.dev\.env|\.prod\.env|\.env\.local|\.env\.production)(?=[\"'\s),;]|$)"
+)
+APPROVED_SETUP_ENV_RE = re.compile(r"(?:^|[\s/\"'>=:\\(])\.client(?:\.dev)?\.env(?=[\"'\s),;]|$)")
+ENV_WRITE_COMMAND_RE = re.compile(
+    r"\b(?:echo|printf|cat|cp|copy|copy-item|set-content|out-file|tee|writealltext)\b", re.IGNORECASE
+)
+
+
+def check_setup_env_writes() -> list[str]:
+    errors: list[str] = []
+    setup_paths = [
+        ROOT / "app" / "setup.sh",
+        ROOT / "app" / "initialsetup.bash",
+        ROOT / "app" / "setup" / "scripts" / "setup.ps1",
+        ROOT / "app" / "setup" / "scripts" / "initialsetup.ps1",
+    ]
+    for path in setup_paths:
+        if not path.exists():
+            continue
+        rel = path.relative_to(ROOT)
+        for lineno, line in enumerate(read_text(path).splitlines(), start=1):
+            if not ENV_WRITE_COMMAND_RE.search(line):
+                continue
+            if LEGACY_SETUP_ENV_RE.search(line):
+                errors.append(f"{rel}:{lineno}: setup scripts must not write legacy public env files")
+            if ".client" in line and not APPROVED_SETUP_ENV_RE.search(line):
+                errors.append(f"{rel}:{lineno}: setup scripts may only write .client.env or .client.dev.env")
+    return errors
+
+
+def check_public_templates(policy: dict) -> list[str]:
+    errors: list[str] = []
+    exact = denied_names(policy)
+    templates = [ROOT / "app" / ".env.template", ROOT / "app" / ".client.env.example"]
+    for path in templates:
+        if not path.exists():
+            continue
+        text = read_text(path)
+        rel = path.relative_to(ROOT)
+        for name in exact:
+            if name in text:
+                errors.append(f"{rel}: public app env template references server-only {name}")
+        for token in variable_like_tokens(text):
+            if token not in allowed_names(policy) and name_is_denied(token, exact, compile_patterns(policy)):
+                errors.append(f"{rel}: public app env template references server-only env-like token {token}")
+    return errors
+
+
+def check_docker_secret_baking(policy: dict) -> list[str]:
+    errors: list[str] = []
+    exact = denied_names(policy)
+    patterns = compile_patterns(policy)
+    allowed_public = allowed_public_names(policy)
+    allowed_build_secret_source_refs = set(policy.get("allowed_build_secret_source_references", []))
+
+    dockerfiles = [
+        path
+        for path in git_files()
+        if path.exists()
+        and (path.name == "Dockerfile" or path.name.startswith("Dockerfile."))
+        and (
+            path.is_relative_to(ROOT / "web")
+            or path.is_relative_to(ROOT / "plugins")
+            or path.is_relative_to(ROOT / "mcp")
+            or path.is_relative_to(ROOT / "desktop")
+        )
+    ]
+    for path in dockerfiles:
+        text = read_text(path)
+        rel = path.relative_to(ROOT)
+        secret_args: set[str] = set()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            for token in variable_like_tokens(stripped):
+                if token in allowed_public or token in allowed_build_secret_source_refs:
+                    continue
+                if name_is_denied(token, exact, patterns):
+                    errors.append(f"{rel}:{lineno}: Dockerfile references server-only env-like token {token}")
+            if (
+                re.search(r"--(?:secret|ssh|build-context)(?:\s|=|$)", stripped)
+                or "type=secret" in stripped
+                or "type=ssh" in stripped
+            ):
+                errors.append(
+                    f"{rel}:{lineno}: Docker build-time secret/context mount is not allowed in public client images"
+                )
+            arg_match = re.match(r"(?i)^ARG\s+([A-Z0-9_]+)(?:=.*)?$", stripped)
+            if arg_match:
+                name = arg_match.group(1)
+                if name not in allowed_public:
+                    errors.append(f"{rel}:{lineno}: build ARG {name} is not allowlisted as public client config")
+                if name not in allowed_public and name_is_denied(name, exact, patterns):
+                    secret_args.add(name)
+                    errors.append(f"{rel}:{lineno}: server-only build ARG {name} can leak through image history")
+            if re.match(r"(?i)^ENV\s+", stripped):
+                for name in exact | secret_args:
+                    if name in stripped and name not in allowed_public:
+                        errors.append(f"{rel}:{lineno}: server-only {name} is promoted into final image ENV")
+
+    workflow_files = [path for path in git_files() if path.exists() and path.match(".github/workflows/*.y*ml")]
+    for path in workflow_files:
+        text = read_text(path)
+        rel = path.relative_to(ROOT)
+        errors.extend(check_duplicate_yaml_keys(path))
+        in_docker_build = False
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "docker build" in line or "docker/build-push-action" in line:
+                in_docker_build = True
+            if in_docker_build and re.search(r"--(?:secret|ssh|build-context)(?:\s|=|$)", line):
+                errors.append(
+                    f"{rel}:{lineno}: docker build secret/context flags are not allowed for public client builds"
+                )
+            if "--build-arg" not in line:
+                if in_docker_build and not line.rstrip().endswith("\\"):
+                    in_docker_build = False
+                continue
+            for name in exact:
+                if name in line and name not in allowed_public:
+                    errors.append(f"{rel}:{lineno}: server-only {name} is passed as docker build-arg")
+            for match in re.finditer(r"--build-arg(?:=|\s+)([A-Z0-9_]+)(?:=(.*?))?(?=\s+-{1,2}[A-Za-z]|\s*\\?$)", line):
+                name = match.group(1)
+                rhs = match.group(2) or f"${name}"
+                if name not in allowed_public:
+                    errors.append(f"{rel}:{lineno}: build arg {name} is not allowlisted as public client config")
+                if name not in allowed_public and name_is_denied(name, exact, patterns):
+                    errors.append(f"{rel}:{lineno}: server-only {name} is passed as docker build-arg")
+                for ref_match in ENV_REF_RE.finditer(rhs):
+                    ref_name = ref_match.group(1) or ref_match.group(2)
+                    if ref_name and ref_name not in allowed_public and name_is_denied(ref_name, exact, patterns):
+                        errors.append(f"{rel}:{lineno}: build arg {name} reads server-only {ref_name}")
+                for secret_match in GITHUB_SECRET_RE.finditer(rhs):
+                    ref_name = secret_match.group(1)
+                    if ref_name != name:
+                        errors.append(f"{rel}:{lineno}: build arg {name} reads non-matching GitHub secret {ref_name}")
+            if in_docker_build and not line.rstrip().endswith("\\"):
+                in_docker_build = False
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", action="append", default=[], help="public client env file to validate")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="run the full legacy-baseline scan; default hook mode checks only clean policy/env-file contracts",
+    )
+    args = parser.parse_args()
+
+    policy = load_policy()
+    errors: list[str] = []
+
+    env_files = [Path(raw).resolve() for raw in args.env_file]
+    env_files.extend(
+        [ROOT / "app" / ".client.env", ROOT / "app" / ".client.dev.env", ROOT / "app" / ".client.env.example"]
+    )
+    for path in env_files:
+        errors.extend(check_env_file(path, policy))
+
+    if args.strict:
+        errors.extend(check_policy_shape(policy))
+        errors.extend(check_app_source(policy))
+        errors.extend(check_codemagic(policy))
+        errors.extend(check_setup_env_writes())
+        errors.extend(check_public_templates(policy))
+        errors.extend(check_release_log_secret_hygiene(policy))
+        errors.extend(check_docker_secret_baking(policy))
+
+    if errors:
+        print("Public client secret boundary check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Public client secret boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/create-public-client-env.sh
+++ b/scripts/create-public-client-env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$ROOT/app/.client.env}"
+TMP="$(mktemp "${TMPDIR:-/tmp}/omi-public-client-env.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+umask 077
+
+emit() {
+  local name="$1"
+  local value="${!name:-}"
+  if [ -n "$value" ]; then
+    case "$value" in
+      *$'\n'*|*$'\r'*)
+        echo "ERROR: $name contains a newline and cannot be written to $OUT" >&2
+        exit 1
+        ;;
+    esac
+    printf '%s=%s\n' "$name" "$value" >> "$TMP"
+  fi
+}
+
+# Every value emitted here is compiled into public client binaries.
+emit PUBLIC_API_BASE_URL
+emit PUBLIC_STAGING_API_URL
+emit PUBLIC_USE_WEB_AUTH
+emit PUBLIC_USE_AUTH_CUSTOM_TOKEN
+emit PUBLIC_GOOGLE_MAPS_API_KEY
+emit PUBLIC_GOOGLE_CLIENT_ID
+emit PUBLIC_POSTHOG_API_KEY
+emit PUBLIC_INTERCOM_APP_ID
+emit PUBLIC_INTERCOM_IOS_API_KEY
+emit PUBLIC_INTERCOM_ANDROID_API_KEY
+
+python3 "$ROOT/scripts/check-public-client-secrets.py" --env-file "$TMP"
+mkdir -p "$(dirname "$OUT")"
+mv "$TMP" "$OUT"
+trap - EXIT

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -221,7 +221,11 @@ check_backend_runtime_env_if_needed() {
   fi
 
   python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
-  python3 backend/scripts/validate-backend-runtime-env.py --env prod
+  python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows
+}
+
+check_release_process_guards() {
+  python3 .github/scripts/check-release-process-guards.py
 }
 
 check_backend_async_blockers_if_needed() {
@@ -427,7 +431,7 @@ check_desktop_tool_surfaces_if_needed() {
   local file
   for file in "${CHANGED_FILES[@]}"; do
     case "$file" in
-      desktop/macos/agent/*|desktop/macos/agent/**/*|desktop/macos/pi-mono-extension/*|desktop/macos/pi-mono-extension/**/*|desktop/macos/run.sh|desktop/macos/scripts/prepare-agent-runtime.sh|desktop/macos/scripts/test-tool-surfaces.sh|codemagic.yaml)
+      desktop/macos/agent/*|desktop/macos/agent/**/*|desktop/macos/pi-mono-extension/*|desktop/macos/pi-mono-extension/**/*|desktop/macos/run.sh|desktop/macos/scripts/prepare-agent-runtime.sh|desktop/macos/scripts/test-tool-surfaces.sh|codemagic.yaml|scripts/pre-push)
         desktop/macos/scripts/test-tool-surfaces.sh
         return
         ;;
@@ -435,8 +439,71 @@ check_desktop_tool_surfaces_if_needed() {
   done
 }
 
+check_flutter_generated_if_needed() {
+  if ! changed_matches \
+    'app/lib/*' \
+    'app/lib/**/*' \
+    'app/pubspec.yaml' \
+    'app/pubspec.lock' \
+    'app/build.yaml' \
+    'app/assets/*' \
+    'app/assets/**/*'
+  then
+    return
+  fi
+
+  if ! command -v dart >/dev/null 2>&1; then
+    echo "FAIL: dart is required to check generated Flutter files for app changes." >&2
+    return 1
+  fi
+
+  (
+    cd app
+    dart run build_runner build --delete-conflicting-outputs
+    git diff --exit-code -- lib || {
+      echo "FAIL: Generated Dart files are stale. Run: cd app && dart run build_runner build --delete-conflicting-outputs" >&2
+      return 1
+    }
+    if [ -n "$(git ls-files --others --exclude-standard -- lib)" ]; then
+      echo "FAIL: Generated Dart files are stale; untracked generated files were produced:" >&2
+      git ls-files --others --exclude-standard -- lib >&2
+      return 1
+    fi
+  )
+}
+
+check_flutter_l10n_if_needed() {
+  if ! changed_matches \
+    'app/lib/l10n/*.arb' \
+    'app/lib/l10n/**/*.arb' \
+    'app/l10n.yaml'
+  then
+    return
+  fi
+
+  if ! command -v flutter >/dev/null 2>&1; then
+    echo "FAIL: flutter is required to check generated localization files for l10n changes." >&2
+    return 1
+  fi
+
+  (
+    cd app
+    flutter gen-l10n
+    git diff --exit-code -- lib/l10n || {
+      echo "FAIL: Generated localization files are stale. Run: cd app && flutter gen-l10n" >&2
+      return 1
+    }
+    if [ -n "$(git ls-files --others --exclude-standard -- lib/l10n)" ]; then
+      echo "FAIL: Generated localization files are stale; untracked generated files were produced:" >&2
+      git ls-files --others --exclude-standard -- lib/l10n >&2
+      return 1
+    fi
+  )
+}
+
 run_step check_merge_conflicts
 run_step check_arch_guardrails
+run_step check_release_process_guards
 run_step python3 .github/scripts/desktop-changelog.py validate
 
 if [[ "$CURRENT_BRANCH" == changelog/v* ]]; then
@@ -456,6 +523,8 @@ run_step check_workflows_if_needed
 run_step check_desktop_rust_if_needed
 run_step check_desktop_launcher_tests_if_needed
 run_step check_desktop_tool_surfaces_if_needed
+run_step check_flutter_generated_if_needed
+run_step check_flutter_l10n_if_needed
 run_step check_optional_formatters
 
 echo "Fast pre-push checks passed."

--- a/scripts/scan-public-artifact-secrets.py
+++ b/scripts/scan-public-artifact-secrets.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Scan public release artifacts for server-only secret material."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "app" / "config" / "client_env_policy.yaml"
+FORBIDDEN_FILENAMES = {
+    ".dev.env",
+    ".prod.env",
+    ".client.env",
+    ".client.dev.env",
+    "google-credentials.json",
+    "service-account.json",
+}
+FORBIDDEN_SUFFIXES = {".pem", ".p12", ".keystore", ".jks", ".p8"}
+PRIVATE_KEY_MARKERS = (
+    b"-----BEGIN PRIVATE KEY-----",
+    b"-----BEGIN RSA PRIVATE KEY-----",
+    b"-----BEGIN EC PRIVATE KEY-----",
+    b'"private_key"',
+    b"'private_key'",
+)
+SECRET_VALUE_PATTERNS = (
+    (re.compile(rb"\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{16,}\b"), "OpenAI-shaped secret"),
+    (re.compile(rb"\bsk-ant-[A-Za-z0-9_-]{16,}\b"), "Anthropic-shaped secret"),
+    (re.compile(rb"\bdg_[0-9A-Za-z]{20,}\b"), "Deepgram-shaped secret"),
+    (re.compile(rb"\bxox[baprs]-[0-9A-Za-z-]{20,}\b"), "Slack token-shaped secret"),
+)
+ALLOWED_PLACEHOLDER_TOKENS = {"YOUR_API_KEY"}
+ZIP_SUFFIXES = {".zip", ".ipa", ".apk", ".aab", ".jar", ".aar"}
+TAR_SUFFIXES = {".tar", ".tgz"}
+FAIL_CLOSED_SUFFIXES = {".7z", ".rar", ".pkg", ".dmg"}
+FRAMEWORK_DIR_SUFFIXES = (".framework", ".xcframework")
+
+
+def load_policy() -> dict:
+    with POLICY_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def denied_patterns(policy: dict) -> list[re.Pattern[str]]:
+    return [re.compile(pattern) for pattern in policy["server_secret_env"]["denied_name_patterns"]]
+
+
+def allowed_names(policy: dict) -> set[str]:
+    return set(policy["public_client_env"]["allowed"]) | set(
+        policy.get("legacy_public_client_env", {}).get("allowed", [])
+    )
+
+
+def allowed_public_token_names(policy: dict) -> set[str]:
+    return allowed_names(policy) | set(policy.get("allowed_public_client_tokens", []))
+
+
+def name_is_denied(name: str, exact: set[str], patterns: list[re.Pattern[str]]) -> bool:
+    return name in exact or any(pattern.search(name) for pattern in patterns)
+
+
+def is_public_firebase_config(rel: Path) -> bool:
+    return rel.name in {"GoogleService-Info.plist", "google-services.json"}
+
+
+def extract_zip(path: Path, dest: Path) -> None:
+    with zipfile.ZipFile(path) as archive:
+        dest_root = dest.resolve()
+        for member in archive.infolist():
+            member_path = Path(member.filename)
+            target = (dest / member.filename).resolve()
+            if member_path.is_absolute() or ".." in member_path.parts or not target.is_relative_to(dest_root):
+                raise ValueError(f"unsafe zip member path: {member.filename}")
+        archive.extractall(dest)
+
+
+def looks_like_tar(path: Path) -> bool:
+    lower_path = str(path).lower()
+    return path.suffix.lower() in TAR_SUFFIXES or lower_path.endswith((".tar.gz", ".tar.bz2", ".tar.xz"))
+
+
+def extract_tar(path: Path, dest: Path) -> None:
+    with tarfile.open(path) as archive:
+        dest_root = dest.resolve()
+        for member in archive.getmembers():
+            member_path = Path(member.name)
+            target = (dest / member.name).resolve()
+            if member_path.is_absolute() or ".." in member_path.parts or not target.is_relative_to(dest_root):
+                raise ValueError(f"unsafe tar member path: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"tar member links are not allowed: {member.name}")
+        archive.extractall(dest)
+
+
+def extract_dmg(path: Path, dest: Path, errors: list[str]) -> Path:
+    target = dest / path.name
+    target.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "darwin" or not shutil.which("hdiutil"):
+        errors.append(f"{path}: cannot inspect DMG on this runner; scan must fail closed")
+        return target
+
+    mountpoint = dest / f"{path.stem}.mount"
+    mountpoint.mkdir(parents=True, exist_ok=True)
+    attached = False
+    try:
+        subprocess.run(
+            [
+                "hdiutil",
+                "attach",
+                "-readonly",
+                "-nobrowse",
+                "-mountpoint",
+                str(mountpoint),
+                str(path),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        attached = True
+        for child in mountpoint.iterdir():
+            destination = target / child.name
+            if child.is_dir():
+                shutil.copytree(child, destination, symlinks=True)
+            else:
+                shutil.copy2(child, destination, follow_symlinks=False)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        errors.append(f"{path}: failed to inspect DMG: {exc}")
+    finally:
+        if attached:
+            subprocess.run(["hdiutil", "detach", str(mountpoint)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return target
+
+
+def materialize(path: Path, dest: Path, errors: list[str]) -> Path:
+    target = dest / path.name
+    if path.is_dir():
+        shutil.copytree(path, target)
+        return target
+    if path.suffix.lower() == ".dmg":
+        return extract_dmg(path, dest, errors)
+    suffix = path.suffix.lower()
+    if suffix in FAIL_CLOSED_SUFFIXES:
+        target.mkdir(parents=True, exist_ok=True)
+        errors.append(f"{path}: cannot inspect {suffix} directly; scan the source bundle before packaging")
+        return target
+    if zipfile.is_zipfile(path) or suffix in ZIP_SUFFIXES:
+        target.mkdir(parents=True, exist_ok=True)
+        if zipfile.is_zipfile(path):
+            try:
+                extract_zip(path, target)
+            except (OSError, ValueError, zipfile.BadZipFile) as exc:
+                errors.append(f"{path}: failed to inspect zip archive: {exc}")
+        else:
+            errors.append(f"{path}: {suffix} is expected to be zip-compatible but could not be opened")
+        return target
+    if looks_like_tar(path):
+        target.mkdir(parents=True, exist_ok=True)
+        try:
+            extract_tar(path, target)
+        except (tarfile.TarError, ValueError) as exc:
+            errors.append(f"{path}: failed to inspect tar archive: {exc}")
+        return target
+    target.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, target / path.name)
+    return target
+
+
+def iter_files(root: Path):
+    for path in root.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+def read_bytes(path: Path, errors: list[str], root_artifact: Path, rel: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        errors.append(f"{root_artifact}: failed to read bundled file {rel}: {exc}")
+        return b""
+
+
+def scan_artifact(path: Path, policy: dict) -> list[str]:
+    errors: list[str] = []
+    denied = set(policy["server_secret_env"]["denied_exact"])
+    patterns = denied_patterns(policy)
+    allowed = allowed_names(policy)
+    allowed_public_tokens = allowed_public_token_names(policy)
+    secret_values = {
+        name: value.encode()
+        for name, value in os.environ.items()
+        if value
+        and len(value) >= 8
+        and not name.startswith(("PUBLIC_", "NEXT_PUBLIC_"))
+        and name not in allowed_public_tokens
+        and name_is_denied(name, denied, patterns)
+    }
+
+    with tempfile.TemporaryDirectory(prefix="omi-public-artifact-scan-") as raw_tmp:
+        extracted_root = materialize(path, Path(raw_tmp), errors)
+        processed_archives: set[Path] = set()
+        while True:
+            nested_archives = [
+                p
+                for p in iter_files(extracted_root)
+                if p not in processed_archives
+                and (p.suffix.lower() in ZIP_SUFFIXES or looks_like_tar(p) or p.suffix.lower() in FAIL_CLOSED_SUFFIXES)
+            ]
+            if not nested_archives:
+                break
+            for archive_path in nested_archives:
+                processed_archives.add(archive_path)
+                nested_dest = archive_path.with_suffix(archive_path.suffix + ".extracted")
+                nested_dest.mkdir(exist_ok=True)
+                rel_archive = archive_path.relative_to(extracted_root)
+                if archive_path.suffix.lower() == ".dmg":
+                    errors.append(f"{path}: nested DMG must not be bundled in public artifact: {rel_archive}")
+                elif zipfile.is_zipfile(archive_path):
+                    try:
+                        extract_zip(archive_path, nested_dest)
+                    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+                        errors.append(f"{path}: failed to inspect nested zip archive {rel_archive}: {exc}")
+                elif looks_like_tar(archive_path):
+                    try:
+                        extract_tar(archive_path, nested_dest)
+                    except (tarfile.TarError, ValueError) as exc:
+                        errors.append(f"{path}: failed to inspect nested tar archive {rel_archive}: {exc}")
+                else:
+                    errors.append(f"{path}: unsupported nested archive {rel_archive}")
+
+            # Continue until newly extracted archives have also been inspected.
+
+        for file_path in iter_files(extracted_root):
+            lower_name = file_path.name.lower()
+            rel = file_path.relative_to(extracted_root)
+            if lower_name in FORBIDDEN_FILENAMES or file_path.suffix.lower() in FORBIDDEN_SUFFIXES:
+                errors.append(f"{path}: forbidden file bundled in public artifact: {rel}")
+                continue
+
+            data = read_bytes(file_path, errors, path, rel)
+            if not data:
+                continue
+            for marker in PRIVATE_KEY_MARKERS:
+                if marker in data:
+                    errors.append(f"{path}: private key material appears in {rel}")
+            for pattern, label in SECRET_VALUE_PATTERNS:
+                if pattern.search(data):
+                    errors.append(f"{path}: {label} appears in {rel}")
+            if file_path.name.endswith(".env") or file_path.name == ".env":
+                for lineno, raw_line in enumerate(data.decode("utf-8", errors="ignore").splitlines(), start=1):
+                    line = raw_line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    name = line.split("=", 1)[0].strip()
+                    if name not in allowed_public_tokens:
+                        errors.append(f"{path}: non-allowlisted variable name {name} appears in {rel}:{lineno}")
+                    if name not in allowed_public_tokens and name_is_denied(name, denied, patterns):
+                        errors.append(f"{path}: server-only variable name {name} appears in {rel}:{lineno}")
+            for name in denied:
+                if name not in allowed_public_tokens and name.encode() in data:
+                    errors.append(f"{path}: server-only variable name {name} appears in {rel}")
+            in_framework = any(part.endswith(FRAMEWORK_DIR_SUFFIXES) for part in rel.parts)
+            if not in_framework and not is_public_firebase_config(rel):
+                text = data.decode("utf-8", errors="ignore")
+                for token in set(re.findall(r"\b[A-Z][A-Z0-9_]{2,}\b", text)):
+                    if token in ALLOWED_PLACEHOLDER_TOKENS:
+                        continue
+                    if token not in allowed_public_tokens and name_is_denied(token, denied, patterns):
+                        errors.append(f"{path}: server-only variable-like token {token} appears in {rel}")
+            for name, value in secret_values.items():
+                if value and value in data:
+                    errors.append(f"{path}: current CI value for {name} appears in {rel}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifacts", nargs="*", type=Path, help="IPA/AAB/APK/app/zip/directory artifacts to scan")
+    args = parser.parse_args()
+
+    if not args.artifacts:
+        print("No artifacts to scan (glob matched nothing).", file=sys.stderr)
+        return 1
+
+    policy = load_policy()
+    errors: list[str] = []
+    for artifact in args.artifacts:
+        if not artifact.exists():
+            errors.append(f"{artifact}: artifact does not exist")
+            continue
+        errors.extend(scan_artifact(artifact, policy))
+
+    if errors:
+        print("Public artifact secret scan failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Public artifact secret scan passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-public-secret-scanners.py
+++ b/scripts/test-public-secret-scanners.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for public release secret scanners.
+
+Fixtures use fake sentinel values only. They are shaped like release mistakes
+without containing provider credentials.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = load_module("check_public_client_secrets", REPO_ROOT / "scripts" / "check-public-client-secrets.py")
+ARTIFACT_SCANNER = load_module(
+    "scan_public_artifact_secrets", REPO_ROOT / "scripts" / "scan-public-artifact-secrets.py"
+)
+
+
+POLICY_JSON = """{
+  "public_client_env": {"allowed": ["PUBLIC_API_BASE_URL"]},
+  "legacy_public_client_env": {"allowed": []},
+  "public_web_build_args": {"allowed": ["NEXT_PUBLIC_FIREBASE_API_KEY"]},
+  "public_client_env_sources": {"allowed": []},
+  "restricted_public_client_keys": {},
+  "server_secret_env": {
+    "denied_exact": ["OPENAI_API_KEY", "GOOGLE_CLIENT_SECRET"],
+    "denied_name_patterns": [
+      "(^|_)SECRET($|_)",
+      "(^|_)PRIVATE_KEY($|_)",
+      "(^|_)API_KEY($|_)",
+      "(^|_)TOKEN($|_)",
+      "(^|_)PASSWORD($|_)",
+      "(^|_)CREDENTIALS?($|_)"
+    ]
+  },
+  "allowed_build_secret_source_references": [],
+  "allowed_public_client_tokens": [],
+  "direct_provider_domains_denied_in_app": [],
+  "legacy_direct_provider_domain_exceptions": {}
+}"""
+
+
+class ScannerFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory(prefix="omi-secret-scanner-test-")
+        self.root = Path(self.tmp.name)
+        (self.root / "app" / "config").mkdir(parents=True)
+        (self.root / "app" / "config" / "client_env_policy.yaml").write_text(POLICY_JSON)
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        self.old_checker_root = CHECKER.ROOT
+        self.old_checker_policy = CHECKER.POLICY_PATH
+        self.old_checker_app_lib = CHECKER.APP_LIB
+        self.old_artifact_root = ARTIFACT_SCANNER.ROOT
+        self.old_artifact_policy = ARTIFACT_SCANNER.POLICY_PATH
+        CHECKER.ROOT = self.root
+        CHECKER.POLICY_PATH = self.root / "app" / "config" / "client_env_policy.yaml"
+        CHECKER.APP_LIB = self.root / "app" / "lib"
+        ARTIFACT_SCANNER.ROOT = self.root
+        ARTIFACT_SCANNER.POLICY_PATH = self.root / "app" / "config" / "client_env_policy.yaml"
+
+    def tearDown(self) -> None:
+        CHECKER.ROOT = self.old_checker_root
+        CHECKER.POLICY_PATH = self.old_checker_policy
+        CHECKER.APP_LIB = self.old_checker_app_lib
+        ARTIFACT_SCANNER.ROOT = self.old_artifact_root
+        ARTIFACT_SCANNER.POLICY_PATH = self.old_artifact_policy
+        self.tmp.cleanup()
+
+    def track(self, relative_path: str, text: str) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        subprocess.run(["git", "add", relative_path], cwd=self.root, check=True)
+        return path
+
+    def test_release_hygiene_flags_secret_echo_public_env_and_trace(self) -> None:
+        self.track(
+            ".github/workflows/release.yml",
+            """
+name: release
+jobs:
+  release:
+    steps:
+      - run: |
+          set -x
+          echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
+""",
+        )
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        joined = "\n".join(errors)
+        self.assertIn("public env file write references server-only OPENAI_API_KEY", joined)
+        self.assertIn("set -x traces nearby server-only refs OPENAI_API_KEY", joined)
+
+    def test_release_hygiene_allows_password_stdin_without_log_echo(self) -> None:
+        self.track("mcp/release.sh", 'echo "$DOCKER_ACCESS_TOKEN" | docker login --password-stdin\n')
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertEqual(errors, [])
+
+    def test_release_hygiene_allows_multiline_stdin_secret_sink(self) -> None:
+        self.track(
+            "mcp/release.sh",
+            """
+echo "$GOOGLE_CLIENT_SECRET" | \\
+  "$SPARKLE_BIN/sign_update" "$SPARKLE_ZIP_PATH" --ed-key-file - 2>/dev/null | \\
+  grep "sparkle:edSignature"
+""",
+        )
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertEqual(errors, [])
+
+    def test_release_hygiene_flags_piped_secret_echo_to_log(self) -> None:
+        self.track("mcp/release.sh", 'echo "$OPENAI_API_KEY" | cat\nprintf "$GOOGLE_CLIENT_SECRET" | tee /dev/stderr\n')
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        joined = "\n".join(errors)
+        self.assertIn("shell output command references server-only OPENAI_API_KEY", joined)
+        self.assertIn("shell output command references server-only GOOGLE_CLIENT_SECRET", joined)
+
+    def test_release_hygiene_flags_trace_option_variants(self) -> None:
+        self.track(
+            "mcp/release.sh",
+            """
+set -euxo pipefail
+export OPENAI_API_KEY="$OPENAI_API_KEY"
+""",
+        )
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertIn("set -x traces nearby server-only refs OPENAI_API_KEY", "\n".join(errors))
+
+    def test_release_hygiene_flags_long_xtrace_option(self) -> None:
+        self.track(
+            "mcp/release.sh",
+            """
+set -o xtrace
+export OPENAI_API_KEY="$OPENAI_API_KEY"
+""",
+        )
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertIn("set -x traces nearby server-only refs OPENAI_API_KEY", "\n".join(errors))
+
+    def test_release_hygiene_flags_secret_echo_with_stderr_only_redirect(self) -> None:
+        self.track("mcp/release.sh", 'echo "$OPENAI_API_KEY" 2>/dev/null\n')
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertIn("shell output command references server-only OPENAI_API_KEY", "\n".join(errors))
+
+    def test_release_hygiene_allows_secret_echo_with_stdout_redirect(self) -> None:
+        self.track("mcp/release.sh", 'echo "$OPENAI_API_KEY" >/tmp/private-build-input\n')
+
+        errors = CHECKER.check_release_log_secret_hygiene(CHECKER.load_policy())
+
+        self.assertNotIn("shell output command references server-only OPENAI_API_KEY", "\n".join(errors))
+
+    def test_public_dockerfiles_reject_server_only_build_args(self) -> None:
+        self.track("web/app/Dockerfile", "FROM node:20\nARG OPENAI_API_KEY\nENV OPENAI_API_KEY=$OPENAI_API_KEY\n")
+
+        errors = CHECKER.check_docker_secret_baking(CHECKER.load_policy())
+
+        joined = "\n".join(errors)
+        self.assertIn("server-only build ARG OPENAI_API_KEY", joined)
+        self.assertIn("server-only OPENAI_API_KEY is promoted into final image ENV", joined)
+
+    def test_artifact_scanner_detects_fake_sentinel_secret_value(self) -> None:
+        artifact = self.root / "public.zip"
+        fake_secret = "fake-sentinel-openai-value-8726-not-real"
+        with zipfile.ZipFile(artifact, "w") as archive:
+            archive.writestr("build.log", f"provider={fake_secret}\n")
+
+        old_value = os.environ.get("OPENAI_API_KEY")
+        os.environ["OPENAI_API_KEY"] = fake_secret
+        try:
+            errors = ARTIFACT_SCANNER.scan_artifact(artifact, ARTIFACT_SCANNER.load_policy())
+        finally:
+            if old_value is None:
+                os.environ.pop("OPENAI_API_KEY", None)
+            else:
+                os.environ["OPENAI_API_KEY"] = old_value
+
+        self.assertIn("current CI value for OPENAI_API_KEY appears in build.log", "\n".join(errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-scan-public-artifact-secrets.sh
+++ b/scripts/test-scan-public-artifact-secrets.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Test scan-public-artifact-secrets.py against real Codemagic workflow patterns.
+# Run from repo root: bash scripts/test-scan-public-artifact-secrets.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/scan-public-artifact-secrets.py"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+run_expect_pass() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS $name"
+    ((PASS++))
+  else
+    echo "FAIL $name (expected pass, got exit $?)"
+    ((FAIL++))
+  fi
+}
+
+run_expect_fail() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  local out rc
+  out=$("$@" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL $name (expected fail, got pass)"
+    ((FAIL++))
+  elif echo "$out" | grep -q "$pattern"; then
+    echo "PASS $name"
+    ((PASS++))
+  else
+    echo "FAIL $name (failed but pattern '$pattern' not found)"
+    echo "  output: $out"
+    ((FAIL++))
+  fi
+}
+
+make_zip() {
+  local src="$1" dst="$2"
+  (cd "$src" && zip -qr "$dst" .)
+}
+
+# --- Build test artifacts ---
+
+# iOS IPA with framework BoringSSL constants
+mkdir -p "$WORK/ios-fw/Payload/Runner.app/Frameworks/TwilioVoice.framework"
+mkdir -p "$WORK/ios-fw/Payload/Runner.app/Frameworks/Flutter.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nPRIVATE_KEY_ENCODE_ERROR\nSERVER_HANDSHAKE_TRAFFIC_SECRET\nEXPORTER_SECRET' \
+  > "$WORK/ios-fw/Payload/Runner.app/Frameworks/TwilioVoice.framework/TwilioVoice"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nHANDSHAKE_SECRET\nMASTER_SECRET' \
+  > "$WORK/ios-fw/Payload/Runner.app/Frameworks/Flutter.framework/Flutter"
+printf 'normal app binary' > "$WORK/ios-fw/Payload/Runner.app/Runner"
+make_zip "$WORK/ios-fw" "$WORK/framework.ipa"
+
+# iOS IPA with real secret leak outside framework
+mkdir -p "$WORK/ios-leak/Payload/Runner.app/Frameworks/TwilioVoice.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET' \
+  > "$WORK/ios-leak/Payload/Runner.app/Frameworks/TwilioVoice.framework/TwilioVoice"
+printf 'OPENAI_API_KEY=sk-test123' > "$WORK/ios-leak/Payload/Runner.app/leaked.env"
+make_zip "$WORK/ios-leak" "$WORK/leaked.ipa"
+
+# iOS IPA with private key inside framework
+mkdir -p "$WORK/ios-pk/Payload/Runner.app/Frameworks/Bad.framework"
+printf -- '-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----' \
+  > "$WORK/ios-pk/Payload/Runner.app/Frameworks/Bad.framework/Bad"
+make_zip "$WORK/ios-pk" "$WORK/privkey.ipa"
+
+# iOS IPA with exact denied name inside framework
+mkdir -p "$WORK/ios-exact/Payload/Runner.app/Frameworks/Leaked.framework"
+printf 'OPENAI_API_KEY' \
+  > "$WORK/ios-exact/Payload/Runner.app/Frameworks/Leaked.framework/Leaked"
+make_zip "$WORK/ios-exact" "$WORK/exact-denied.ipa"
+
+# iOS IPA with a raw provider-shaped secret but no env var name
+mkdir -p "$WORK/ios-shaped/Payload/Runner.app"
+printf 'Authorization: Bearer sk-fake-not-real-release-guard-sentinel' \
+  > "$WORK/ios-shaped/Payload/Runner.app/config.txt"
+make_zip "$WORK/ios-shaped" "$WORK/shaped-secret.ipa"
+
+# iOS IPA with xcframework variant
+mkdir -p "$WORK/ios-xcfw/Payload/Runner.app/Frameworks/BoringSSL.xcframework/ios-arm64/BoringSSL.framework"
+printf 'CLIENT_EARLY_TRAFFIC_SECRET\nEXPORTER_SECRET' \
+  > "$WORK/ios-xcfw/Payload/Runner.app/Frameworks/BoringSSL.xcframework/ios-arm64/BoringSSL.framework/BoringSSL"
+make_zip "$WORK/ios-xcfw" "$WORK/xcframework.ipa"
+
+# Android AAB
+mkdir -p "$WORK/android/build/app/outputs/bundle/prodRelease"
+mkdir -p "$WORK/aab-content/base"
+printf 'android app bundle content YOUR_API_KEY' > "$WORK/aab-content/base/manifest"
+make_zip "$WORK/aab-content" "$WORK/android/build/app/outputs/bundle/prodRelease/app-prod-release.aab"
+
+# Android AAB with an intentionally public SDK key value from CI env.
+mkdir -p "$WORK/android-public-token"
+mkdir -p "$WORK/aab-public-token/base"
+printf 'BuildConfig INTERCOM_ANDROID_API_KEY public-intercom-android-token' > "$WORK/aab-public-token/base/classes.dex"
+make_zip "$WORK/aab-public-token" "$WORK/android-public-token/app-prod-release.aab"
+
+# Archive containing benign opaque resources that are not zip/tar payloads.
+mkdir -p "$WORK/opaque/Payload/Runner.app"
+printf 'asar payload bytes' > "$WORK/opaque/Payload/Runner.app/app.asar"
+printf 'plain compressed data' > "$WORK/opaque/Payload/Runner.app/cache.gz"
+printf '<plist><dict><key>API_KEY</key><string>AIzaFakePublicFirebaseKeyForReleaseGuard</string></dict></plist>' \
+  > "$WORK/opaque/Payload/Runner.app/GoogleService-Info.plist"
+make_zip "$WORK/opaque" "$WORK/opaque-resources.ipa"
+
+# Empty build dir for nullglob test
+mkdir -p "$WORK/android-empty/build"
+
+# --- Tests ---
+
+echo "=== Codemagic iOS workflow (line 186: build/ios/ipa/*.ipa) ==="
+run_expect_pass "ios-framework-tokens-pass" \
+  python3 "$SCANNER" "$WORK/framework.ipa"
+
+echo ""
+echo "=== Codemagic Android workflow (release AAB glob) ==="
+run_expect_pass "android-aab-with-nullglob" \
+  bash -c "cd '$WORK/android' && AAB_ARTIFACTS=\$(find build -path '*/outputs/*.aab' -print) && python3 '$SCANNER' \$AAB_ARTIFACTS"
+
+echo ""
+echo "=== Android public SDK token env value is allowed ==="
+run_expect_pass "android-public-sdk-token-pass" \
+  env INTERCOM_ANDROID_API_KEY=public-intercom-android-token python3 "$SCANNER" "$WORK/android-public-token/app-prod-release.aab"
+
+echo ""
+echo "=== Android no AAB built (the argparse crash case) ==="
+run_expect_fail "android-empty-glob-clear-error" "No artifacts to scan" \
+  bash -c "cd '$WORK/android-empty' && AAB_ARTIFACTS=\$(find build -path '*/outputs/*.aab' -print) && python3 '$SCANNER' \$AAB_ARTIFACTS"
+
+echo ""
+echo "=== Security: real secret outside framework still caught ==="
+run_expect_fail "secret-outside-framework-caught" "OPENAI_API_KEY" \
+  python3 "$SCANNER" "$WORK/leaked.ipa"
+
+echo ""
+echo "=== Security: private key markers inside framework still caught ==="
+run_expect_fail "private-key-in-framework-caught" "private key material" \
+  python3 "$SCANNER" "$WORK/privkey.ipa"
+
+echo ""
+echo "=== Security: exact denied name inside framework still caught ==="
+run_expect_fail "exact-denied-in-framework-caught" "OPENAI_API_KEY" \
+  python3 "$SCANNER" "$WORK/exact-denied.ipa"
+
+echo ""
+echo "=== Security: raw provider-shaped secret still caught ==="
+run_expect_fail "provider-shaped-secret-caught" "OpenAI-shaped secret" \
+  python3 "$SCANNER" "$WORK/shaped-secret.ipa"
+
+echo ""
+echo "=== Opaque resources and public Google client keys pass ==="
+run_expect_pass "opaque-resources-pass" \
+  python3 "$SCANNER" "$WORK/opaque-resources.ipa"
+
+echo ""
+echo "=== xcframework tokens pass (nested .xcframework/.framework) ==="
+run_expect_pass "xcframework-tokens-pass" \
+  python3 "$SCANNER" "$WORK/xcframework.ipa"
+
+echo ""
+echo "=== No arguments at all ==="
+run_expect_fail "no-args-clear-error" "No artifacts to scan" \
+  python3 "$SCANNER"
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/sdks/python-cli/release.sh
+++ b/sdks/python-cli/release.sh
@@ -46,19 +46,15 @@ if ! python -m pip show build &> /dev/null; then
 fi
 
 CURRENT_VERSION=$(python -c "
-import sys
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])
+import omi_cli
+print(omi_cli.__version__)
 ")
 echo "📋 Current version: ${CURRENT_VERSION}"
 
 echo "🔍 Checking if version exists on PyPI..."
 if pip index versions omi-cli 2>/dev/null | grep -q "${CURRENT_VERSION}"; then
     echo "❌ Error: Version ${CURRENT_VERSION} already exists on PyPI."
-    echo "💡 Bump the version in pyproject.toml first."
+    echo "💡 Bump omi_cli.__version__ first."
     exit 1
 fi
 

--- a/sdks/react-native/omi-react-native.podspec
+++ b/sdks/react-native/omi-react-native.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "13.0" }
-  s.source       = { :git => "https://github.com/BasedHardware/omi.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/BasedHardware/omi.git", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 


### PR DESCRIPTION
## Summary
- add a release-process guard script and wire it into lint CI and pre-push
- fail desktop releases on missing Sparkle EdDSA signatures and use VERSION for the Firestore bridge release record
- add mobile public artifact secret scanning for IPA/AAB outputs, plus scanner policy/tests
- add CI/pre-push checks for docs build scripts, Python CLI dynamic versioning, React Native podspec tags, desktop agent runtime packaging, Flutter generated output, and backend runtime workflow alignment

## Validation
- python3 .github/scripts/check-release-process-guards.py
- python3 scripts/check-public-client-secrets.py
- python3 scripts/test-public-secret-scanners.py
- bash scripts/test-scan-public-artifact-secrets.sh
- python3 -m py_compile .github/scripts/check-release-process-guards.py scripts/check-public-client-secrets.py scripts/scan-public-artifact-secrets.py
- actionlint -shellcheck '\ .github/workflows/lint.yml
- python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
- python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows
- npm --prefix docs run build
- desktop/macos/scripts/test-tool-surfaces.sh
- scripts/pre-push origin main


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

