### PR TITLE
[codex] Fix agent runtime OOM classification

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -11,6 +11,13 @@ actor AgentRuntimeProcess {
     useExtension && !token.isEmpty && targetHasExtension
   }
 
+  nonisolated static func isConfirmedOutOfMemoryDiagnostic(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("fatalprocessoutofmemory")
+      || lower.contains("javascript heap out of memory")
+      || lower.contains("failed to reserve virtual memory")
+  }
+
   struct WarmupSessionConfig {
     let key: String
     let model: String?
@@ -125,6 +132,7 @@ actor AgentRuntimeProcess {
   private var activeRequests: [RuntimeMessage.RequestKey: ActiveRequest] = [:]
   private var activeControlRequests: [RuntimeMessage.RequestKey: ActiveControlRequest] = [:]
   private var initContinuations: [CheckedContinuation<Void, Error>] = []
+  private let oomDiagnosticLatch = AgentRuntimeOOMDiagnosticLatch()
   private var receivedInit = false
   private var isRestarting = false
 
@@ -518,22 +526,18 @@ actor AgentRuntimeProcess {
     stderrPipe = stderr
     process = proc
 
-    stderr.fileHandleForReading.readabilityHandler = { [weak self] handle in
+    processGeneration &+= 1
+    let expectedGeneration = processGeneration
+    oomDiagnosticLatch.reset(generation: expectedGeneration)
+    let oomDiagnosticLatch = oomDiagnosticLatch
+    stderr.fileHandleForReading.readabilityHandler = { handle in
       let data = handle.availableData
       if !data.isEmpty, let text = String(data: data, encoding: .utf8) {
         log("AgentRuntimeProcess stderr: \(text.trimmingCharacters(in: .whitespacesAndNewlines))")
-        if text.contains("FatalProcessOutOfMemory")
-          || text.contains("JavaScript heap out of memory")
-          || text.contains("Failed to reserve virtual memory")
-          || text.contains("out of memory")
-        {
-          Task { await self?.markOOM() }
-        }
+        oomDiagnosticLatch.markIfConfirmed(text, generation: expectedGeneration)
       }
     }
 
-    processGeneration &+= 1
-    let expectedGeneration = processGeneration
     proc.terminationHandler = { [weak self] terminatedProc in
       let code = terminatedProc.terminationStatus
       let reason = terminatedProc.terminationReason
@@ -688,6 +692,9 @@ actor AgentRuntimeProcess {
 
   private func stopProcess(resumeRequestsWith error: BridgeError) async {
     let proc = process
+    processGeneration &+= 1
+    lastExitWasOOM = false
+    oomDiagnosticLatch.reset(generation: processGeneration)
     sendJson(["type": "stop"])
     try? stdinPipe?.fileHandleForWriting.close()
     proc?.terminate()
@@ -707,6 +714,8 @@ actor AgentRuntimeProcess {
 
     process = nil
     closePipes()
+    lastExitWasOOM = false
+    oomDiagnosticLatch.reset(generation: processGeneration)
     isRunning = false
     receivedInit = false
     resumeAllRequests(throwing: error)
@@ -977,10 +986,6 @@ actor AgentRuntimeProcess {
     return value
   }
 
-  private func markOOM() {
-    lastExitWasOOM = true
-  }
-
   private func handleTermination(
     exitCode: Int32 = -1,
     reason: Process.TerminationReason = .exit,
@@ -996,18 +1001,17 @@ actor AgentRuntimeProcess {
       let remaining = stderrHandle.availableData
       if !remaining.isEmpty, let text = String(data: remaining, encoding: .utf8) {
         log("AgentRuntimeProcess stderr (final): \(text.trimmingCharacters(in: .whitespacesAndNewlines))")
-        if text.contains("out of memory") || text.contains("Failed to reserve virtual memory") {
+        if Self.isConfirmedOutOfMemoryDiagnostic(text) {
           lastExitWasOOM = true
+          oomDiagnosticLatch.markConfirmed(generation: processGeneration)
         }
       }
     }
 
-    let likelyOOM =
-      lastExitWasOOM
-      || (reason == .uncaughtSignal
-        && (exitCode == 134 || exitCode == 133 || exitCode == 5 || exitCode == 6))
+    let likelyOOM = lastExitWasOOM || oomDiagnosticLatch.isConfirmed(generation: processGeneration)
     let error: BridgeError = likelyOOM ? .outOfMemory : .processExited
     lastExitWasOOM = false
+    oomDiagnosticLatch.reset(generation: processGeneration)
 
     log("AgentRuntimeProcess: process terminated (code=\(exitCode), error=\(error))")
     isRunning = false
@@ -1163,5 +1167,36 @@ actor AgentRuntimeProcess {
     }
 
     return nil
+  }
+}
+
+private final class AgentRuntimeOOMDiagnosticLatch: @unchecked Sendable {
+  private let lock = NSLock()
+  private var generation: UInt64?
+  private var confirmed = false
+
+  func reset(generation: UInt64) {
+    lock.withLock {
+      self.generation = generation
+      confirmed = false
+    }
+  }
+
+  func markIfConfirmed(_ text: String, generation: UInt64) {
+    guard AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(text) else { return }
+    markConfirmed(generation: generation)
+  }
+
+  func markConfirmed(generation: UInt64) {
+    lock.withLock {
+      guard self.generation == generation else { return }
+      confirmed = true
+    }
+  }
+
+  func isConfirmed(generation: UInt64) -> Bool {
+    lock.withLock {
+      self.generation == generation && confirmed
+    }
   }
 }

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -293,4 +293,74 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(source.contains("resumeInitContinuations(throwing: BridgeError.timeout)"))
     XCTAssertFalse(source.contains("withThrowingTaskGroup(of: Void.self)"))
   }
+
+  func testOutOfMemoryDiagnosticRequiresConfirmedRuntimeSignature() {
+    XCTAssertTrue(
+      AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(
+        "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"
+      )
+    )
+    XCTAssertTrue(
+      AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(
+        "FatalProcessOutOfMemory: Zone Allocation failed"
+      )
+    )
+    XCTAssertTrue(
+      AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(
+        "Failed to reserve virtual memory for CodeRange"
+      )
+    )
+
+    XCTAssertFalse(
+      AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(
+        "Provider returned: the requested model is out of memory for this prompt"
+      )
+    )
+    XCTAssertFalse(
+      AgentRuntimeProcess.isConfirmedOutOfMemoryDiagnostic(
+        "The browser extension reported out of memory while reading a page"
+      )
+    )
+  }
+
+  func testRuntimeDoesNotTreatGenericAbortSignalsAsOutOfMemory() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(source.contains("let likelyOOM = lastExitWasOOM || oomDiagnosticLatch.isConfirmed(generation: processGeneration)"))
+    XCTAssertFalse(source.contains("exitCode == 134"))
+    XCTAssertFalse(source.contains("exitCode == 133"))
+  }
+
+  func testStderrOutOfMemoryLatchIsSynchronousAndGenerationScoped() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(source.contains("oomDiagnosticLatch.markIfConfirmed(text, generation: expectedGeneration)"))
+    XCTAssertTrue(source.contains("private final class AgentRuntimeOOMDiagnosticLatch: @unchecked Sendable"))
+    XCTAssertTrue(source.contains("guard self.generation == generation else { return }"))
+    XCTAssertFalse(source.contains("Task { await self?.markOOM"))
+  }
+
+  func testIntentionalStopInvalidatesOldProcessGenerationBeforeTerminating() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(source.contains("""
+  private func stopProcess(resumeRequestsWith error: BridgeError) async {
+    let proc = process
+    processGeneration &+= 1
+    lastExitWasOOM = false
+    oomDiagnosticLatch.reset(generation: processGeneration)
+"""))
+  }
 }

--- a/desktop/macos/changelog/unreleased/fix-agent-oom-classification.json
+++ b/desktop/macos/changelog/unreleased/fix-agent-oom-classification.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed AI connection setup showing a misleading memory-pressure error after non-memory agent runtime crashes"
+  ]
+}


### PR DESCRIPTION
## Summary
- tighten desktop agent runtime OOM detection to known fatal Node/V8 signatures
- guard stderr OOM latching by process generation and clear stale OOM state during intentional stops/restarts
- add regression coverage for generic "out of memory" text and generic abort signals
- add a desktop changelog fragment

## Root cause
The browser extension setup test restarts the shared agent runtime to pick up the Playwright token. The runtime previously latched any stderr containing broad text like "out of memory" and also treated generic abort signals as OOM. That could surface "Not enough memory for AI chat" even when macOS memory pressure was normal.

## Subagent sweep
A parallel sweep found other broad matching risks in AgentBridge agentError fallback mapping, GeminiClient API error mapping, CredentialHealthManager close classification, BrowserExtensionSetup timeout text matching, RawWebSocket status-line parsing, and ChatToolExecutor SQL keyword checks. I kept this PR scoped to the confirmed OOM false-positive path.

## Validation
- xcrun swift test --package-path desktop/macos/Desktop --filter AgentRuntimeProcessTests (21 tests, 0 failures)
- python3 .github/scripts/desktop-changelog.py validate
- python3 .github/scripts/check-desktop-changelog.py --base a4a38d6780c3bb307a42f21ef22c8fad59aa095a --head HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

