### PR TITLE
Fix legacy backfill KG side effects

### DIFF
--- a/backend/tests/unit/test_canonical_kg_promotion.py
+++ b/backend/tests/unit/test_canonical_kg_promotion.py
@@ -93,6 +93,32 @@ def test_extract_kg_on_promotion():
         )
 
 
+def test_extract_kg_can_preserve_item_updated_at():
+    item = _long_term_item()
+    db = MagicMock()
+    with (
+        patch("utils.memory.canonical_kg_promotion.resolve_memory_system", return_value=MemorySystem.CANONICAL),
+        patch(
+            "utils.memory.canonical_kg_promotion.extract_knowledge_from_memory",
+            return_value={"nodes": [], "edges": []},
+        ),
+        patch("utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted") as mock_touching_flag,
+        patch(
+            "utils.memory.canonical_kg_promotion.set_canonical_memory_kg_extracted_without_touching_updated_at"
+        ) as mock_preserving_flag,
+    ):
+        result = extract_kg_for_promoted_memory(
+            "uid-canonical",
+            item,
+            db_client=db,
+            preserve_item_updated_at=True,
+        )
+
+    assert result.success is True
+    mock_touching_flag.assert_not_called()
+    mock_preserving_flag.assert_called_once_with("uid-canonical", "mem_lt", db_client=db)
+
+
 def test_extract_kg_failure_leaves_kg_extracted_false():
     item = _long_term_item(kg_extracted=False)
     db = MagicMock()

--- a/backend/tests/unit/test_canonical_memory_vectors.py
+++ b/backend/tests/unit/test_canonical_memory_vectors.py
@@ -537,7 +537,7 @@ def test_backfill_path_syncs_vector_on_idempotent_skip(monkeypatch):
         "utils.memory.legacy_backfill.sync_atom_keyword_index_for_item",
         return_value=True,
     ):
-        _, written, skip_reason, vector_sync_failed, keyword_sync_succeeded = _apply_one_legacy_row(
+        row_result = _apply_one_legacy_row(
             uid=uid,
             legacy_row={"id": legacy_id, "content": content},
             index=0,
@@ -546,10 +546,10 @@ def test_backfill_path_syncs_vector_on_idempotent_skip(monkeypatch):
             db_client=_BackfillDb(),
         )
 
-    assert written is False
-    assert skip_reason == "idempotent_skip"
-    assert vector_sync_failed is False
-    assert keyword_sync_succeeded is True
+    assert row_result.written is False
+    assert row_result.skip_reason == "idempotent_skip"
+    assert row_result.vector_sync_failed is False
+    assert row_result.keyword_sync_succeeded is True
     assert len(fake_index.upserts) == 1
     assert fake_index.upserts[0]["vectors"][0]["id"] == canonical_memory_id
     assert fake_index.upserts[0]["vectors"][0]["metadata"]["memory_layer"] == "long_term"

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -62,6 +62,7 @@ from models.memories import MemoryCategory
 from models.memory_apply import MemoryControlState
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
 from utils.memory.canonical_memory_adapter import extraction_memory_id, read_canonical_memories
+from utils.memory.canonical_kg_promotion import CanonicalKgPromotionResult
 from utils.memory.legacy_backfill import (
     BackfillCohortGateError,
     LegacyBackfillBucket,
@@ -579,22 +580,125 @@ def test_bucketed_reviewed_apply_writes_long_term_with_legacy_timestamp(_trusted
     db = _canonical_db_with_control(LEGACY_UID)
     _seed_legacy_evidence(db, rows)
 
-    report = backfill_user_bucketed(
-        LEGACY_UID,
-        bucket=LegacyBackfillBucket.reviewed_long_term,
-        dry_run=False,
-        db_client=db,
-        get_non_filtered_memories_fn=get_non_filtered_fn,
-    )
+    def _extract_kg(uid, item, *, db_client=None, preserve_item_updated_at=False, **_kwargs):
+        assert preserve_item_updated_at is True
+        db_client.document(f"users/{uid}/memory_items/{item.memory_id}").set({"kg_extracted": True}, merge=True)
+        return CanonicalKgPromotionResult(attempted=True, success=True, node_count=1, edge_count=1)
+
+    with patch("utils.memory.legacy_backfill.extract_kg_for_promoted_memory", side_effect=_extract_kg) as extract_kg:
+        report = backfill_user_bucketed(
+            LEGACY_UID,
+            bucket=LegacyBackfillBucket.reviewed_long_term,
+            dry_run=False,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+        )
 
     assert report.completed is True
     assert report.verified is True
+    assert report.kg_extraction_failures == 0
     canonical_id = legacy_backfill_memory_id(uid=LEGACY_UID, legacy_memory_id=row["id"])
     stored = db.docs[f"users/{LEGACY_UID}/memory_items/{canonical_id}"]
     assert stored["tier"] == MemoryTier.long_term.value
     assert stored["captured_at"] == created_at
+    assert stored["updated_at"] == created_at
     assert stored["expires_at"] is None
+    assert stored["kg_extracted"] is True
     assert stored["promotion"]["bucket"] == LegacyBackfillBucket.reviewed_long_term.value
+    extract_kg.assert_called_once()
+
+
+def test_bucketed_reviewed_rerun_repairs_missing_kg_on_existing_item(_trusted_account):
+    row = _legacy_row(
+        legacy_id="leg-reviewed-repair",
+        content="User prefers memory bucket repairs",
+        conversation_id="conv-reviewed",
+    )
+    row["user_review"] = True
+    rows = [row]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+
+    def _extract_kg(uid, item, *, db_client=None, preserve_item_updated_at=False, **_kwargs):
+        assert preserve_item_updated_at is True
+        db_client.document(f"users/{uid}/memory_items/{item.memory_id}").set({"kg_extracted": True}, merge=True)
+        return CanonicalKgPromotionResult(attempted=True, success=True, node_count=1, edge_count=0)
+
+    with patch("utils.memory.legacy_backfill.extract_kg_for_promoted_memory", side_effect=_extract_kg):
+        first = backfill_user_bucketed(
+            LEGACY_UID,
+            bucket=LegacyBackfillBucket.reviewed_long_term,
+            dry_run=False,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+        )
+
+    canonical_id = legacy_backfill_memory_id(uid=LEGACY_UID, legacy_memory_id=row["id"])
+    item_path = f"users/{LEGACY_UID}/memory_items/{canonical_id}"
+    assert first.written_count == 1
+    assert db.docs[item_path]["kg_extracted"] is True
+
+    db.docs[item_path]["kg_extracted"] = False
+
+    with patch("utils.memory.legacy_backfill.extract_kg_for_promoted_memory", side_effect=_extract_kg) as extract_kg:
+        repaired = backfill_user_bucketed(
+            LEGACY_UID,
+            bucket=LegacyBackfillBucket.reviewed_long_term,
+            dry_run=False,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+        )
+
+    assert repaired.written_count == 0
+    assert repaired.skipped_already_present == 1
+    assert repaired.kg_extraction_failures == 0
+    assert db.docs[item_path]["kg_extracted"] is True
+    extract_kg.assert_called_once()
+
+
+def test_resume_completed_checkpoint_repairs_missing_kg_side_effect(_trusted_account):
+    row = _legacy_row(legacy_id="leg-resume-kg", content="User prefers local rollout harnesses")
+    rows = [row]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+
+    def _extract_kg(uid, item, *, db_client=None, preserve_item_updated_at=False, **_kwargs):
+        assert preserve_item_updated_at is True
+        db_client.document(f"users/{uid}/memory_items/{item.memory_id}").set({"kg_extracted": True}, merge=True)
+        return CanonicalKgPromotionResult(attempted=True, success=True, node_count=1, edge_count=0)
+
+    with patch("utils.memory.legacy_backfill.extract_kg_for_promoted_memory", side_effect=_extract_kg):
+        first = backfill_user(
+            LEGACY_UID,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+            batch_size=1,
+            resume=False,
+        )
+
+    canonical_id = legacy_backfill_memory_id(uid=LEGACY_UID, legacy_memory_id=row["id"])
+    item_path = f"users/{LEGACY_UID}/memory_items/{canonical_id}"
+    assert first.completed is True
+    assert db.docs[item_path]["kg_extracted"] is True
+
+    db.docs[item_path]["kg_extracted"] = False
+
+    with patch("utils.memory.legacy_backfill.extract_kg_for_promoted_memory", side_effect=_extract_kg) as extract_kg:
+        repaired = backfill_user(
+            LEGACY_UID,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+            batch_size=1,
+            resume=True,
+        )
+
+    assert repaired.resumed_from_index == 1
+    assert repaired.written_count == 0
+    assert repaired.kg_extraction_failures == 0
+    assert db.docs[item_path]["kg_extracted"] is True
+    extract_kg.assert_called_once()
 
 
 def test_bucketed_hold_bucket_never_writes(_trusted_account):

--- a/backend/utils/memory/canonical_kg_promotion.py
+++ b/backend/utils/memory/canonical_kg_promotion.py
@@ -52,12 +52,21 @@ def set_canonical_memory_kg_extracted(uid: str, memory_id: str, *, db_client=Non
     ref.set({"kg_extracted": True, "updated_at": datetime.now(timezone.utc)}, merge=True)
 
 
+def set_canonical_memory_kg_extracted_without_touching_updated_at(uid: str, memory_id: str, *, db_client=None) -> None:
+    """Mark KG extraction complete without changing the product-memory timestamp."""
+    client = db_client if db_client is not None else default_db_client
+    path = f"{MemoryCollections(uid=uid).memory_items}/{memory_id}"
+    ref = client.document(path)
+    ref.set({"kg_extracted": True}, merge=True)
+
+
 def extract_kg_for_promoted_memory(
     uid: str,
     item: MemoryItem,
     *,
     user_name: str = "User",
     db_client=None,
+    preserve_item_updated_at: bool = False,
 ) -> CanonicalKgPromotionResult:
     """Extract KG nodes/edges for a newly promoted long_term memory."""
     client = db_client if db_client is not None else default_db_client
@@ -87,7 +96,10 @@ def extract_kg_for_promoted_memory(
         return CanonicalKgPromotionResult(attempted=True, skipped_reason="exception")
     if result is None:
         return CanonicalKgPromotionResult(attempted=True, skipped_reason="extractor_failed")
-    set_canonical_memory_kg_extracted(uid, item.memory_id, db_client=db_client)
+    if preserve_item_updated_at:
+        set_canonical_memory_kg_extracted_without_touching_updated_at(uid, item.memory_id, db_client=db_client)
+    else:
+        set_canonical_memory_kg_extracted(uid, item.memory_id, db_client=db_client)
     node_count = len(result.get("nodes") or [])
     edge_count = len(result.get("edges") or [])
     logger.info(

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -39,6 +39,7 @@ from models.memory_operations import MemoryOperation, MemoryOperationType
 from models.product_memory import MemoryItemStatus, MemoryLayer, ProcessingState, MemoryItem
 from utils.memory.atom_keyword_index import sync_atom_keyword_index_for_item
 from utils.memory.canonical_memory_adapter import extraction_memory_id
+from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
 from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
@@ -113,6 +114,7 @@ class BackfillReport:
     legacy_rows_touched: int = 0
     vector_sync_failures: int = 0
     keyword_sync_failures: int = 0
+    kg_extraction_failures: int = 0
     cohort_gated: bool = False
     errors: List[str] = field(default_factory=list)
     selected_bucket: Optional[str] = None
@@ -120,6 +122,16 @@ class BackfillReport:
     bucket_samples: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
     skipped_bucket_not_selected: int = 0
     skipped_bucket_not_writable: int = 0
+
+
+@dataclass(frozen=True)
+class LegacyBackfillRowResult:
+    control: MemoryControlState
+    written: bool
+    skip_reason: Optional[str]
+    vector_sync_failed: bool = False
+    keyword_sync_succeeded: bool = True
+    kg_extraction_failed: bool = False
 
 
 def legacy_backfill_memory_id(*, uid: str, legacy_memory_id: str) -> str:
@@ -448,22 +460,34 @@ def _apply_one_legacy_row(
     run_id: str,
     db_client,
     bucket: Optional[LegacyBackfillBucket] = None,
-) -> tuple[MemoryControlState, bool, Optional[str], bool, bool]:
+) -> LegacyBackfillRowResult:
     """Write one canonical item. Returns control, write status, and side-effect status."""
     legacy_id = legacy_row.get("id") or f"legacy_{index}"
     content = (legacy_row.get("content") or "").strip()
     if not content:
-        return control, False, "empty_content", False, True
+        return LegacyBackfillRowResult(control=control, written=False, skip_reason="empty_content")
     if bucket is not None and bucket not in WRITABLE_LEGACY_BACKFILL_BUCKETS:
-        return control, False, "bucket_not_writable", False, True
+        return LegacyBackfillRowResult(control=control, written=False, skip_reason="bucket_not_writable")
 
     canonical_memory_id = legacy_backfill_memory_id(uid=uid, legacy_memory_id=legacy_id)
     existing = _load_canonical_item(uid, canonical_memory_id, db_client=db_client)
     if existing is not None and _is_active_processed_canonical_item(existing):
-        return control, False, "already_present", False, True
+        vector_sync_failed, keyword_sync_succeeded, kg_extraction_failed = _sync_backfill_side_effects(
+            uid=uid,
+            item=existing,
+            db_client=db_client,
+        )
+        return LegacyBackfillRowResult(
+            control=control,
+            written=False,
+            skip_reason="already_present",
+            vector_sync_failed=vector_sync_failed,
+            keyword_sync_succeeded=keyword_sync_succeeded,
+            kg_extraction_failed=kg_extraction_failed,
+        )
 
     if both_store_canonical_duplicate_exists(uid=uid, legacy_row=legacy_row, db_client=db_client):
-        return control, False, "both_store_duplicate", False, True
+        return LegacyBackfillRowResult(control=control, written=False, skip_reason="both_store_duplicate")
 
     evidence = _build_backfill_evidence(uid=uid, legacy_row=legacy_row, index=index)
     _persist_evidence(uid, evidence, db_client=db_client)
@@ -555,30 +579,99 @@ def _apply_one_legacy_row(
         if getattr(snapshot, "exists", False):
             item = MemoryItem(**(snapshot.to_dict() or {}))
 
+    def _record_vector_sync_failure() -> None:
+        nonlocal row_vector_sync_failed
+        row_vector_sync_failed = True
+
+    row_vector_sync_failed = False
+    row_keyword_sync_succeeded = True
+    row_kg_extraction_failed = False
+    if item is not None:
+        row_vector_sync_failed, row_keyword_sync_succeeded, row_kg_extraction_failed = _sync_backfill_side_effects(
+            uid=uid,
+            item=item,
+            db_client=db_client,
+            on_vector_hard_failure=_record_vector_sync_failure,
+        )
+
+    written = result.status == ApplyStatus.committed
+    return LegacyBackfillRowResult(
+        control=result.control_state,
+        written=written,
+        skip_reason=None if written else "idempotent_skip",
+        vector_sync_failed=row_vector_sync_failed,
+        keyword_sync_succeeded=row_keyword_sync_succeeded,
+        kg_extraction_failed=row_kg_extraction_failed,
+    )
+
+
+def _sync_backfill_side_effects(
+    *,
+    uid: str,
+    item: MemoryItem,
+    db_client,
+    on_vector_hard_failure=None,
+) -> tuple[bool, bool, bool]:
+    """Reconcile indexes and KG for a materialized backfill item.
+
+    Backfill is idempotent by memory id. Reruns must still repair side effects for
+    already-present rows, otherwise a partial run can look complete while KG or
+    search indexes are missing.
+    """
+    assert_legal_state(
+        DomainMemoryLayer(item.tier.value),
+        physical_status_to_record_status(item.status.value),
+        MemoryProcessingState(item.processing_state.value),
+    )
+
     vector_sync_failed = False
-    keyword_sync_succeeded = True
 
     def _record_vector_sync_failure() -> None:
         nonlocal vector_sync_failed
         vector_sync_failed = True
+        if on_vector_hard_failure is not None:
+            on_vector_hard_failure()
 
-    if item is not None:
-        assert_legal_state(
-            DomainMemoryLayer(item.tier.value),
-            physical_status_to_record_status(item.status.value),
-            MemoryProcessingState(item.processing_state.value),
+    keyword_sync_succeeded = sync_atom_keyword_index_for_item(item, db_client=db_client)
+    sync_canonical_memory_vector(item, on_hard_failure=_record_vector_sync_failure)
+
+    kg_extraction_failed = False
+    if item.tier == MemoryLayer.long_term:
+        kg_result = extract_kg_for_promoted_memory(uid, item, db_client=db_client, preserve_item_updated_at=True)
+        kg_extraction_failed = kg_result.attempted and not kg_result.success
+
+    return vector_sync_failed, keyword_sync_succeeded, kg_extraction_failed
+
+
+def _reconcile_backfill_side_effects_for_rows(
+    *,
+    uid: str,
+    legacy_rows: Sequence[dict],
+    db_client,
+) -> tuple[int, int, int]:
+    vector_sync_failures = 0
+    keyword_sync_failures = 0
+    kg_extraction_failures = 0
+    for legacy_row in legacy_rows:
+        legacy_id = legacy_row.get("id") or ""
+        if not legacy_id or not (legacy_row.get("content") or "").strip():
+            continue
+        canonical_memory_id = legacy_backfill_memory_id(uid=uid, legacy_memory_id=legacy_id)
+        item = _load_canonical_item(uid, canonical_memory_id, db_client=db_client)
+        if item is None or not _is_active_processed_canonical_item(item):
+            continue
+        row_vector_sync_failed, row_keyword_sync_succeeded, row_kg_extraction_failed = _sync_backfill_side_effects(
+            uid=uid,
+            item=item,
+            db_client=db_client,
         )
-        keyword_sync_succeeded = sync_atom_keyword_index_for_item(item, db_client=db_client)
-        sync_canonical_memory_vector(item, on_hard_failure=_record_vector_sync_failure)
-
-    written = result.status == ApplyStatus.committed
-    return (
-        result.control_state,
-        written,
-        None if written else "idempotent_skip",
-        vector_sync_failed,
-        keyword_sync_succeeded,
-    )
+        if row_vector_sync_failed:
+            vector_sync_failures += 1
+        if not row_keyword_sync_succeeded:
+            keyword_sync_failures += 1
+        if row_kg_extraction_failed:
+            kg_extraction_failures += 1
+    return vector_sync_failures, keyword_sync_failures, kg_extraction_failures
 
 
 def _legacy_row_has_canonical_destination(
@@ -819,6 +912,7 @@ def backfill_user_bucketed(
     skipped_semantic_duplicate = 0
     vector_sync_failures = 0
     keyword_sync_failures = 0
+    kg_extraction_failures = 0
     errors: List[str] = []
     materialized_semantic_keys: set[str] = set()
 
@@ -828,7 +922,7 @@ def backfill_user_bucketed(
             skipped_semantic_duplicate += 1
             continue
         try:
-            control, written, skip_reason, row_vector_sync_failed, row_keyword_sync_succeeded = _apply_one_legacy_row(
+            row_result = _apply_one_legacy_row(
                 uid=uid,
                 legacy_row=legacy_row,
                 index=index,
@@ -837,18 +931,21 @@ def backfill_user_bucketed(
                 db_client=client,
                 bucket=selected_bucket,
             )
-            if written:
+            control = row_result.control
+            if row_result.written:
                 written_count += 1
-            elif skip_reason == "both_store_duplicate":
+            elif row_result.skip_reason == "both_store_duplicate":
                 skipped_both_store_duplicate += 1
-            elif skip_reason in {"already_present", "idempotent_skip"}:
+            elif row_result.skip_reason in {"already_present", "idempotent_skip"}:
                 skipped_already_present += 1
-            if semantic_key is not None and skip_reason not in {"empty_content"}:
+            if semantic_key is not None and row_result.skip_reason not in {"empty_content"}:
                 materialized_semantic_keys.add(semantic_key)
-            if row_vector_sync_failed:
+            if row_result.vector_sync_failed:
                 vector_sync_failures += 1
-            if not row_keyword_sync_succeeded:
+            if not row_result.keyword_sync_succeeded:
                 keyword_sync_failures += 1
+            if row_result.kg_extraction_failed:
+                kg_extraction_failures += 1
         except Exception as exc:
             safe_uid = sanitize_pii(uid)
             safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
@@ -874,6 +971,7 @@ def backfill_user_bucketed(
         legacy_rows_touched=len(selected_rows),
         vector_sync_failures=vector_sync_failures,
         keyword_sync_failures=keyword_sync_failures,
+        kg_extraction_failures=kg_extraction_failures,
         errors=errors,
         selected_bucket=selected_bucket_value,
         bucket_counts=bucket_counts,
@@ -967,8 +1065,16 @@ def backfill_user(
     skipped_semantic_duplicate = 0
     vector_sync_failures = 0
     keyword_sync_failures = 0
+    kg_extraction_failures = 0
     errors: List[str] = []
     materialized_semantic_keys: set[str] = set()
+
+    if resume and start_index >= source_count and source_count > 0:
+        vector_sync_failures, keyword_sync_failures, kg_extraction_failures = _reconcile_backfill_side_effects_for_rows(
+            uid=uid,
+            legacy_rows=eligible_rows,
+            db_client=client,
+        )
 
     processed_index = start_index
     while processed_index < source_count:
@@ -987,7 +1093,7 @@ def backfill_user(
             _persist_control_state(control, db_client=client)
             continue
         try:
-            control, written, skip_reason, row_vector_sync_failed, row_keyword_sync_succeeded = _apply_one_legacy_row(
+            row_result = _apply_one_legacy_row(
                 uid=uid,
                 legacy_row=legacy_row,
                 index=processed_index,
@@ -995,18 +1101,21 @@ def backfill_user(
                 run_id=effective_run_id,
                 db_client=client,
             )
-            if written:
+            control = row_result.control
+            if row_result.written:
                 written_count += 1
-            elif skip_reason == "both_store_duplicate":
+            elif row_result.skip_reason == "both_store_duplicate":
                 skipped_both_store_duplicate += 1
-            elif skip_reason in {"already_present", "idempotent_skip"}:
+            elif row_result.skip_reason in {"already_present", "idempotent_skip"}:
                 skipped_already_present += 1
-            if semantic_key is not None and skip_reason not in {"empty_content"}:
+            if semantic_key is not None and row_result.skip_reason not in {"empty_content"}:
                 materialized_semantic_keys.add(semantic_key)
-            if row_vector_sync_failed:
+            if row_result.vector_sync_failed:
                 vector_sync_failures += 1
-            if not row_keyword_sync_succeeded:
+            if not row_result.keyword_sync_succeeded:
                 keyword_sync_failures += 1
+            if row_result.kg_extraction_failed:
+                kg_extraction_failures += 1
         except Exception as exc:
             safe_uid = sanitize_pii(uid)
             safe_legacy_id = sanitize_pii(legacy_row.get("id") or "unknown")
@@ -1058,5 +1167,6 @@ def backfill_user(
         legacy_rows_touched=0,
         vector_sync_failures=vector_sync_failures,
         keyword_sync_failures=keyword_sync_failures,
+        kg_extraction_failures=kg_extraction_failures,
         errors=errors,
     )


### PR DESCRIPTION
## Summary
- run canonical KG extraction for long-term legacy backfill rows after Firestore/vector/keyword side effects
- reconcile side effects when a deterministic backfill row already exists, so reruns repair missing KG/index state instead of silently skipping
- add `kg_extraction_failures` to the backfill report and regression tests for reviewed-long-term apply + rerun repair

## Root cause
`reviewed_long_term` bucket backfill writes directly to canonical `long_term` items. That path synced Firestore, Pinecone, and Typesense, but never invoked the KG extraction hook used by short-term promotion. Worse, idempotent reruns returned early for already-present active rows, so a partially completed bucket could report present while leaving `kg_extracted=false` forever.

The read/projection gate observed during rollout is separate: dev backend is still in `MEMORY_MODE=write`, so default reads stay gated until rollout control advances.

## Tests
- `cd backend && pytest tests/unit/test_ws_c_backfill.py -q`
- `cd backend && pytest tests/unit/test_canonical_kg_promotion.py -q`
- `cd backend && pytest tests/unit/test_ws_b_short_term_lifecycle.py -q`
- `cd backend && python -m py_compile utils/memory/legacy_backfill.py tests/unit/test_ws_c_backfill.py`
- pre-push fast checks passed, including selected backend unit tests and OpenAPI contract check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

