### PR TITLE
[WIN] Hosted MCP key storage/setup

### DIFF
--- a/desktop/windows/.gitignore
+++ b/desktop/windows/.gitignore
@@ -50,3 +50,4 @@ resources/win-ocr-helper/*.pdb
 src/main/automation/helper/bin/
 src/main/automation/helper/obj/
 resources/win-automation-helper/*.pdb
+resources/koffi/

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -19,6 +19,11 @@ asarUnpack:
   # koffi loads its native .node at runtime, resolved relative to its own package
   # dir — it must live outside the asar archive or the foreground monitor fails.
   - node_modules/koffi/**
+extraResources:
+  - from: resources/koffi
+    to: koffi
+    filter:
+      - '**/*'
 win:
   executableName: omi-windows
   target:

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,15 +16,17 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs",
-    "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "npm run build && electron-builder --win --x64",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
+    "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/bench/run.mjs",
-    "bench:anim": "node scripts/bench/anim.mjs"
+    "bench:anim": "node scripts/bench/anim.mjs",
+    "prepare:koffi": "node scripts/ensure-koffi-win32-native.mjs",
+    "verify:win-koffi": "node scripts/verify-win-koffi-native.mjs"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,7 +16,7 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && node scripts/ensure-koffi-win32-native.mjs",
     "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
     "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",

--- a/desktop/windows/pnpm-workspace.yaml
+++ b/desktop/windows/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ allowBuilds:
   onnxruntime-node: true
   protobufjs: true
   sharp: true
+supportedArchitectures:
+  os:
+    - current
+    - win32
+  cpu:
+    - current
+    - x64
+  libc:
+    - current

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -1,0 +1,47 @@
+import { copyFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
+const koffiEntry = requireFromRoot.resolve('koffi')
+const koffiRoot = dirname(koffiEntry)
+const koffiRequire = createRequire(koffiEntry)
+
+const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
+const koffiPackage = readJson(join(koffiRoot, 'package.json'))
+
+let nativePackageJson
+let source
+try {
+  const nativeEntry = koffiRequire.resolve('@koromix/koffi-win32-x64')
+  nativePackageJson = join(dirname(nativeEntry), 'package.json')
+  source = join(dirname(nativeEntry), 'win32_x64', 'koffi.node')
+} catch (error) {
+  throw new Error(
+    [
+      'Missing @koromix/koffi-win32-x64.',
+      'Run npm install from desktop/windows on Windows so npm installs win32/x64 optional dependencies.'
+    ].join(' '),
+    { cause: error }
+  )
+}
+
+const nativePackage = readJson(nativePackageJson)
+if (nativePackage.version !== koffiPackage.version) {
+  throw new Error(
+    `Koffi native package version mismatch: koffi=${koffiPackage.version}, @koromix/koffi-win32-x64=${nativePackage.version}`
+  )
+}
+
+const sourceSize = statSync(source).size
+if (sourceSize <= 0) {
+  throw new Error(`Koffi native module is empty: ${source}`)
+}
+
+const targetDir = join(projectRoot, 'resources', 'koffi', 'win32_x64')
+const target = join(targetDir, 'koffi.node')
+mkdirSync(targetDir, { recursive: true })
+copyFileSync(source, target)
+console.log(`[ensure-koffi-win32-native] staged ${target} (${sourceSize} bytes)`)

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -3,6 +3,11 @@ import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+if (process.platform !== 'win32') {
+  console.log('[ensure-koffi-win32-native] skipped: Windows-only native staging')
+  process.exit(0)
+}
+
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
 const koffiEntry = requireFromRoot.resolve('koffi')

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -1,0 +1,43 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageRoots =
+  process.argv.length > 2
+    ? process.argv.slice(2).map((path) => resolve(path))
+    : [join(projectRoot, 'dist', 'win-unpacked')]
+
+const verifyPeFile = (file) => {
+  const stat = statSync(file)
+  if (stat.size <= 0) {
+    throw new Error(`Koffi native module is empty: ${file}`)
+  }
+
+  const fd = openSync(file, 'r')
+  const header = Buffer.alloc(2)
+  try {
+    readSync(fd, header, 0, 2, 0)
+  } finally {
+    closeSync(fd)
+  }
+  if (header.toString('ascii') !== 'MZ') {
+    throw new Error(`Koffi native module is not a Windows binary: ${file}`)
+  }
+  return stat.size
+}
+
+const tried = []
+for (const root of packageRoots) {
+  const file = join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node')
+  tried.push(file)
+  try {
+    const size = verifyPeFile(file)
+    console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
+    process.exit(0)
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+
+throw new Error(`Missing packaged Koffi native module. Checked: ${tried.join(', ')}`)

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   stopAutomationTargetTracker
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
+import { registerMcpKeyHandlers } from './ipc/mcpKey'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -286,6 +287,7 @@ app.whenReady().then(async () => {
   registerMemoryExportHandlers()
   registerKgHandlers()
   registerIntegrationsHandlers()
+  registerMcpKeyHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/integrations/mcpKeyStore.test.ts
+++ b/desktop/windows/src/main/integrations/mcpKeyStore.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+import { clearMcpKey, loadMcpKey, saveMcpKey } from './mcpKeyStore'
+
+describe('mcpKeyStore', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-mcp-key-'))
+    electronState.encryptionAvailable = true
+  })
+
+  afterEach(() => {
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('stores and loads the MCP key without writing the raw key', () => {
+    saveMcpKey({ id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' })
+
+    const rawFile = readFileSync(join(electronState.userData, 'mcp-key.json'), 'utf8')
+    expect(rawFile).not.toContain('omi_live_secret')
+    expect(loadMcpKey()).toEqual({
+      id: 'key_123',
+      name: 'Omi Windows',
+      key: 'omi_live_secret'
+    })
+  })
+
+  it('overwrites an existing stored key on regenerate', () => {
+    saveMcpKey({ id: 'key_old', name: 'Omi Windows', key: 'old_secret' })
+    saveMcpKey({ id: 'key_new', name: 'Omi Windows', key: 'new_secret' })
+
+    expect(loadMcpKey()).toEqual({
+      id: 'key_new',
+      name: 'Omi Windows',
+      key: 'new_secret'
+    })
+  })
+
+  it('deletes the stored key', () => {
+    saveMcpKey({ id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' })
+    clearMcpKey()
+
+    expect(loadMcpKey()).toBeNull()
+  })
+
+  it('refuses to save when secure storage is unavailable', () => {
+    electronState.encryptionAvailable = false
+
+    expect(() =>
+      saveMcpKey({ id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' })
+    ).toThrow('Secure storage is unavailable on this system')
+  })
+})

--- a/desktop/windows/src/main/integrations/mcpKeyStore.test.ts
+++ b/desktop/windows/src/main/integrations/mcpKeyStore.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -70,5 +70,11 @@ describe('mcpKeyStore', () => {
     expect(() =>
       saveMcpKey({ id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' })
     ).toThrow('Secure storage is unavailable on this system')
+  })
+
+  it('surfaces invalid stored key files', () => {
+    writeFileSync(join(electronState.userData, 'mcp-key.json'), '{"id":"key_123"}', 'utf8')
+
+    expect(() => loadMcpKey()).toThrow('Stored MCP key is invalid')
   })
 })

--- a/desktop/windows/src/main/integrations/mcpKeyStore.ts
+++ b/desktop/windows/src/main/integrations/mcpKeyStore.ts
@@ -1,0 +1,65 @@
+// Persist the hosted MCP key encrypted at rest via Electron safeStorage
+// (DPAPI on Windows). The raw key is only returned to explicit IPC callers.
+import { app, safeStorage } from 'electron'
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import type { McpKeyRecord } from '../../shared/types'
+
+type StoredMcpKeyFile = {
+  id: string
+  name: string
+  key: string
+}
+
+function file(): string {
+  return join(app.getPath('userData'), 'mcp-key.json')
+}
+
+function isMcpKeyRecord(value: unknown): value is McpKeyRecord {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<McpKeyRecord>
+  return (
+    typeof candidate.id === 'string' &&
+    candidate.id.length > 0 &&
+    typeof candidate.name === 'string' &&
+    candidate.name.length > 0 &&
+    typeof candidate.key === 'string' &&
+    candidate.key.length > 0
+  )
+}
+
+export function saveMcpKey(record: McpKeyRecord): void {
+  if (!isMcpKeyRecord(record)) {
+    throw new Error('Invalid MCP key record')
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('Secure storage is unavailable on this system')
+  }
+  const enc = safeStorage.encryptString(record.key).toString('base64')
+  writeFileSync(
+    file(),
+    JSON.stringify({ id: record.id, name: record.name, key: enc } satisfies StoredMcpKeyFile),
+    'utf8'
+  )
+}
+
+export function loadMcpKey(): McpKeyRecord | null {
+  const f = file()
+  if (!existsSync(f)) return null
+  try {
+    const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredMcpKeyFile
+    if (!raw.id || !raw.name || !raw.key) return null
+    const key = safeStorage.decryptString(Buffer.from(raw.key, 'base64'))
+    return { id: raw.id, name: raw.name, key }
+  } catch {
+    return null
+  }
+}
+
+export function clearMcpKey(): void {
+  try {
+    rmSync(file(), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}

--- a/desktop/windows/src/main/integrations/mcpKeyStore.ts
+++ b/desktop/windows/src/main/integrations/mcpKeyStore.ts
@@ -1,5 +1,5 @@
 // Persist the hosted MCP key encrypted at rest via Electron safeStorage
-// (DPAPI on Windows). The raw key is only returned to explicit IPC callers.
+// (DPAPI on Windows). Keep the raw key in main-process callers only.
 import { app, safeStorage } from 'electron'
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
@@ -46,14 +46,10 @@ export function saveMcpKey(record: McpKeyRecord): void {
 export function loadMcpKey(): McpKeyRecord | null {
   const f = file()
   if (!existsSync(f)) return null
-  try {
-    const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredMcpKeyFile
-    if (!raw.id || !raw.name || !raw.key) return null
-    const key = safeStorage.decryptString(Buffer.from(raw.key, 'base64'))
-    return { id: raw.id, name: raw.name, key }
-  } catch {
-    return null
-  }
+  const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredMcpKeyFile
+  if (!raw.id || !raw.name || !raw.key) throw new Error('Stored MCP key is invalid')
+  const key = safeStorage.decryptString(Buffer.from(raw.key, 'base64'))
+  return { id: raw.id, name: raw.name, key }
 }
 
 export function clearMcpKey(): void {

--- a/desktop/windows/src/main/ipc/mcpKey.test.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.test.ts
@@ -1,0 +1,275 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type IpcHandler = (event: unknown, ...args: unknown[]) => Promise<unknown>
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  handlers: new Map<string, IpcHandler>(),
+  clipboardText: '',
+  clipboardWrites: [] as string[],
+  clipboardClears: 0,
+  // Index of the dialog button to "press": 0 = Copy, 1 = Cancel.
+  dialogResponse: 1,
+  dialogCalls: [] as Array<Record<string, unknown>>
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => true,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  },
+  ipcMain: {
+    handle: (channel: string, handler: IpcHandler): void => {
+      electronState.handlers.set(channel, handler)
+    }
+  },
+  clipboard: {
+    writeText: (text: string): void => {
+      electronState.clipboardText = text
+      electronState.clipboardWrites.push(text)
+    },
+    readText: (): string => electronState.clipboardText,
+    clear: (): void => {
+      electronState.clipboardText = ''
+      electronState.clipboardClears += 1
+    }
+  },
+  dialog: {
+    showMessageBox: async (options: Record<string, unknown>): Promise<{ response: number }> => {
+      electronState.dialogCalls.push(options)
+      return { response: electronState.dialogResponse }
+    }
+  },
+  BrowserWindow: {
+    fromWebContents: (): null => null
+  }
+}))
+
+import { registerMcpKeyHandlers } from './mcpKey'
+import type { McpKeyMetadata } from '../../shared/types'
+
+registerMcpKeyHandlers()
+
+const trustedEvent = { sender: {}, senderFrame: { url: 'file:///C:/app/index.html' } }
+const untrustedEvent = { sender: {}, senderFrame: { url: 'https://evil.example/index.html' } }
+
+const RAW_KEY = 'omi_live_super_secret_key_1234'
+const API_RECORD = { id: 'key_123', name: 'Omi Windows', key: RAW_KEY }
+const MASKED = 'omi_li********1234'
+
+function invoke(channel: string, event: unknown, ...args: unknown[]): Promise<unknown> {
+  const handler = electronState.handlers.get(channel)
+  if (!handler) throw new Error(`no handler registered for ${channel}`)
+  return handler(event, ...args)
+}
+
+function stubFetchWithKeyRecord(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ ...API_RECORD })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function createStoredKey(): Promise<McpKeyMetadata> {
+  stubFetchWithKeyRecord()
+  const metadata = (await invoke(
+    'mcpKey:createAndStore',
+    trustedEvent,
+    'firebase-token'
+  )) as McpKeyMetadata
+  vi.unstubAllGlobals()
+  return metadata
+}
+
+describe('mcpKey IPC handlers', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-mcp-ipc-'))
+    electronState.clipboardText = ''
+    electronState.clipboardWrites = []
+    electronState.clipboardClears = 0
+    electronState.dialogResponse = 1
+    electronState.dialogCalls = []
+  })
+
+  afterEach(() => {
+    rmSync(electronState.userData, { recursive: true, force: true })
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  describe('sender validation', () => {
+    it.each([
+      ['mcpKey:createAndStore', ['firebase-token']],
+      ['mcpKey:read', []],
+      ['mcpKey:copy', [{ kind: 'key' }]],
+      ['mcpKey:test', []],
+      ['mcpKey:delete', []]
+    ])('rejects untrusted senders on %s', async (channel, args) => {
+      await expect(invoke(channel, untrustedEvent, ...args)).rejects.toThrow(
+        'MCP key IPC is not available from this renderer'
+      )
+    })
+  })
+
+  describe('mcpKey:createAndStore', () => {
+    it('creates the key in main and returns metadata only — never the raw key', async () => {
+      const fetchMock = stubFetchWithKeyRecord()
+
+      const result = await invoke('mcpKey:createAndStore', trustedEvent, 'firebase-token')
+
+      expect(result).toEqual({ id: 'key_123', name: 'Omi Windows', maskedKey: MASKED })
+      expect(JSON.stringify(result)).not.toContain(RAW_KEY)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.omi.me/v1/mcp/keys',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: 'Bearer firebase-token' }),
+          body: JSON.stringify({ name: 'Omi Windows' })
+        })
+      )
+      // Persisted encrypted at rest — the raw key must not appear on disk.
+      const storedFile = readFileSync(join(electronState.userData, 'mcp-key.json'), 'utf8')
+      expect(storedFile).not.toContain(RAW_KEY)
+    })
+
+    it('rejects a missing or empty auth token before any network call', async () => {
+      const fetchMock = stubFetchWithKeyRecord()
+
+      await expect(invoke('mcpKey:createAndStore', trustedEvent, '')).rejects.toThrow(
+        'Invalid auth token for MCP key creation'
+      )
+      await expect(invoke('mcpKey:createAndStore', trustedEvent, undefined)).rejects.toThrow(
+        'Invalid auth token for MCP key creation'
+      )
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('surfaces HTTP failures without storing anything', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }))
+
+      await expect(invoke('mcpKey:createAndStore', trustedEvent, 'firebase-token')).rejects.toThrow(
+        'MCP key creation returned HTTP 401.'
+      )
+      expect(await invoke('mcpKey:read', trustedEvent)).toBeNull()
+    })
+
+    it('rejects malformed key records from the API', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'key_123', name: 'Omi Windows' })
+        })
+      )
+
+      await expect(invoke('mcpKey:createAndStore', trustedEvent, 'firebase-token')).rejects.toThrow(
+        'MCP key creation returned an invalid key record.'
+      )
+    })
+  })
+
+  describe('mcpKey:read', () => {
+    it('returns metadata with a masked key and no raw key material', async () => {
+      await createStoredKey()
+
+      const result = await invoke('mcpKey:read', trustedEvent)
+
+      expect(result).toEqual({ id: 'key_123', name: 'Omi Windows', maskedKey: MASKED })
+      expect(result).not.toHaveProperty('key')
+      expect(JSON.stringify(result)).not.toContain(RAW_KEY)
+    })
+
+    it('returns null when no key is stored', async () => {
+      expect(await invoke('mcpKey:read', trustedEvent)).toBeNull()
+    })
+  })
+
+  describe('mcpKey:copy confirmation', () => {
+    it('does not touch the clipboard when the user cancels', async () => {
+      await createStoredKey()
+      electronState.dialogResponse = 1
+
+      const result = await invoke('mcpKey:copy', trustedEvent, { kind: 'key' })
+
+      expect(result).toEqual({ copied: false, canceled: true })
+      expect(electronState.dialogCalls).toHaveLength(1)
+      expect(electronState.clipboardWrites).toHaveLength(0)
+    })
+
+    it('copies the raw key only after the user confirms', async () => {
+      await createStoredKey()
+      electronState.dialogResponse = 0
+
+      const result = await invoke('mcpKey:copy', trustedEvent, { kind: 'key' })
+
+      expect(result).toEqual({ copied: true })
+      expect(electronState.clipboardWrites).toEqual([RAW_KEY])
+    })
+
+    it('substitutes the placeholder in confirmed setup-text copies', async () => {
+      await createStoredKey()
+      electronState.dialogResponse = 0
+
+      const result = await invoke('mcpKey:copy', trustedEvent, {
+        kind: 'text',
+        text: 'Authorization: Bearer YOUR_OMI_MCP_KEY'
+      })
+
+      expect(result).toEqual({ copied: true })
+      expect(electronState.clipboardWrites).toEqual([`Authorization: Bearer ${RAW_KEY}`])
+    })
+
+    it('rejects malformed copy requests', async () => {
+      await createStoredKey()
+
+      await expect(invoke('mcpKey:copy', trustedEvent, { kind: 'text' })).rejects.toThrow(
+        'Invalid MCP key copy request'
+      )
+      expect(electronState.dialogCalls).toHaveLength(0)
+    })
+  })
+
+  describe('clipboard auto-clear', () => {
+    it('clears the clipboard after the timeout when it still holds the copied secret', async () => {
+      await createStoredKey()
+      electronState.dialogResponse = 0
+      vi.useFakeTimers()
+
+      await invoke('mcpKey:copy', trustedEvent, { kind: 'key' })
+      expect(electronState.clipboardText).toBe(RAW_KEY)
+
+      vi.advanceTimersByTime(60_000)
+
+      expect(electronState.clipboardClears).toBe(1)
+      expect(electronState.clipboardText).toBe('')
+    })
+
+    it('leaves the clipboard alone when the user has since copied something else', async () => {
+      await createStoredKey()
+      electronState.dialogResponse = 0
+      vi.useFakeTimers()
+
+      await invoke('mcpKey:copy', trustedEvent, { kind: 'key' })
+      electronState.clipboardText = 'unrelated user content'
+
+      vi.advanceTimersByTime(60_000)
+
+      expect(electronState.clipboardClears).toBe(0)
+      expect(electronState.clipboardText).toBe('unrelated user content')
+    })
+  })
+})

--- a/desktop/windows/src/main/ipc/mcpKey.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.ts
@@ -12,6 +12,7 @@ const MCP_KEY_PLACEHOLDER = 'YOUR_OMI_MCP_KEY'
 const DEFAULT_OMI_API_BASE = 'https://api.omi.me'
 const HOSTED_MCP_TIMEOUT_MS = 15_000
 const MCP_KEY_CLIPBOARD_CLEAR_MS = 60_000
+const MCP_KEY_NAME = 'Omi Windows'
 
 let clipboardClearTimer: NodeJS.Timeout | null = null
 
@@ -113,6 +114,62 @@ function parseHostedMcpMemoryCount(payload: unknown): number {
   return memories.length
 }
 
+function parseCreatedMcpKey(payload: unknown): McpKeyRecord {
+  const record = payload as Partial<McpKeyRecord> | null
+  if (
+    !record ||
+    typeof record !== 'object' ||
+    typeof record.id !== 'string' ||
+    record.id.length === 0 ||
+    typeof record.name !== 'string' ||
+    record.name.length === 0 ||
+    typeof record.key !== 'string' ||
+    record.key.length === 0
+  ) {
+    throw new Error('MCP key creation returned an invalid key record.')
+  }
+  return { id: record.id, name: record.name, key: record.key }
+}
+
+// Create a hosted MCP key against the Omi API and persist it — entirely in the
+// main process. The renderer only supplies the Firebase ID token and only ever
+// receives masked metadata back; the raw bearer key never crosses IPC toward
+// renderer code (the confirmed mcpKey:copy path is the sole way it leaves main).
+// Deliberately no retries: POST /v1/mcp/keys is non-idempotent.
+async function createAndStoreMcpKey(token: string): Promise<McpKeyMetadata> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), HOSTED_MCP_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(`${mcpBaseURL()}v1/mcp/keys`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ name: MCP_KEY_NAME })
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('MCP key creation timed out.')
+    }
+    throw new Error(`MCP key creation failed: ${(error as Error).message}`)
+  } finally {
+    clearTimeout(timeout)
+  }
+  if (!response.ok) throw new Error(`MCP key creation returned HTTP ${response.status}.`)
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new Error('MCP key creation returned invalid JSON.')
+  }
+  const record = parseCreatedMcpKey(payload)
+  saveMcpKey(record)
+  return metadataFor(record)
+}
+
 async function testHostedMcpConnection(key: string): Promise<McpKeyTestResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), HOSTED_MCP_TIMEOUT_MS)
@@ -154,10 +211,16 @@ async function testHostedMcpConnection(key: string): Promise<McpKeyTestResult> {
 }
 
 export function registerMcpKeyHandlers(): void {
-  ipcMain.handle('mcpKey:create', async (event, record: McpKeyRecord): Promise<void> => {
-    assertTrustedSender(event)
-    saveMcpKey(record)
-  })
+  ipcMain.handle(
+    'mcpKey:createAndStore',
+    async (event, token: unknown): Promise<McpKeyMetadata> => {
+      assertTrustedSender(event)
+      if (typeof token !== 'string' || token.length === 0) {
+        throw new Error('Invalid auth token for MCP key creation')
+      }
+      return createAndStoreMcpKey(token)
+    }
+  )
 
   ipcMain.handle('mcpKey:read', async (event): Promise<McpKeyMetadata | null> => {
     assertTrustedSender(event)

--- a/desktop/windows/src/main/ipc/mcpKey.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron'
+import type { McpKeyRecord } from '../../shared/types'
+import { clearMcpKey, loadMcpKey, saveMcpKey } from '../integrations/mcpKeyStore'
+
+export function registerMcpKeyHandlers(): void {
+  ipcMain.handle('mcpKey:create', async (_e, record: McpKeyRecord): Promise<void> => {
+    saveMcpKey(record)
+  })
+
+  ipcMain.handle('mcpKey:read', async (): Promise<McpKeyRecord | null> => loadMcpKey())
+
+  ipcMain.handle('mcpKey:delete', async (): Promise<void> => {
+    clearMcpKey()
+  })
+}

--- a/desktop/windows/src/main/ipc/mcpKey.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.ts
@@ -1,15 +1,151 @@
-import { ipcMain } from 'electron'
-import type { McpKeyRecord } from '../../shared/types'
+import { clipboard, ipcMain, type IpcMainInvokeEvent } from 'electron'
+import type {
+  McpKeyCopyRequest,
+  McpKeyMetadata,
+  McpKeyRecord,
+  McpKeyTestResult
+} from '../../shared/types'
 import { clearMcpKey, loadMcpKey, saveMcpKey } from '../integrations/mcpKeyStore'
 
+const MCP_KEY_PLACEHOLDER = 'YOUR_OMI_MCP_KEY'
+const DEFAULT_OMI_API_BASE = 'https://api.omi.me'
+const HOSTED_MCP_TIMEOUT_MS = 15_000
+
+function assertTrustedSender(event: IpcMainInvokeEvent): void {
+  const url = event.senderFrame?.url ?? ''
+  if (
+    url.startsWith('file://') ||
+    url.startsWith('http://localhost:') ||
+    url.startsWith('http://127.0.0.1:') ||
+    (process.env.ELECTRON_RENDERER_URL && url.startsWith(process.env.ELECTRON_RENDERER_URL))
+  ) {
+    return
+  }
+  throw new Error('MCP key IPC is not available from this renderer')
+}
+
+function maskMcpKey(key: string): string {
+  if (key.length <= 10) return '********'
+  return `${key.slice(0, 6)}********${key.slice(-4)}`
+}
+
+function metadataFor(record: McpKeyRecord): McpKeyMetadata {
+  return { id: record.id, name: record.name, maskedKey: maskMcpKey(record.key) }
+}
+
+function loadRequiredMcpKey(): McpKeyRecord {
+  const record = loadMcpKey()
+  if (!record) throw new Error('Generate an MCP key first')
+  return record
+}
+
+function normalizeCopyRequest(value: unknown): McpKeyCopyRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid MCP key copy request')
+  }
+  const request = value as Partial<McpKeyCopyRequest>
+  if (request.kind === 'key') return { kind: 'key' }
+  if (request.kind === 'text' && typeof request.text === 'string') {
+    return { kind: 'text', text: request.text }
+  }
+  throw new Error('Invalid MCP key copy request')
+}
+
+function mcpBaseURL(): string {
+  const raw = process.env.OMI_API_BASE || DEFAULT_OMI_API_BASE
+  return raw.endsWith('/') ? raw : `${raw}/`
+}
+
+function parseHostedMcpMemoryCount(payload: unknown): number {
+  const rpc = payload as {
+    error?: { message?: unknown }
+    result?: { content?: Array<{ text?: unknown }> }
+  }
+  if (rpc.error) {
+    const message = typeof rpc.error.message === 'string' ? rpc.error.message : 'Unknown error'
+    throw new Error(`Hosted MCP failed: ${message}`)
+  }
+  const text = rpc.result?.content?.find((item) => typeof item.text === 'string')?.text
+  if (typeof text !== 'string') throw new Error('Hosted MCP did not return memory data.')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('Hosted MCP returned unreadable memory data.')
+  }
+  const memories = (parsed as { memories?: unknown }).memories
+  if (!Array.isArray(memories)) throw new Error('Hosted MCP did not return memory data.')
+  return memories.length
+}
+
+async function testHostedMcpConnection(key: string): Promise<McpKeyTestResult> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), HOSTED_MCP_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(`${mcpBaseURL()}v1/mcp/sse`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'get_memories',
+          arguments: { limit: 5 }
+        }
+      })
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Hosted MCP request timed out.')
+    }
+    throw new Error(`Hosted MCP request failed: ${(error as Error).message}`)
+  } finally {
+    clearTimeout(timeout)
+  }
+  if (!response.ok) throw new Error(`Hosted MCP returned HTTP ${response.status}.`)
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new Error('Hosted MCP returned invalid JSON.')
+  }
+  return { memoryCount: parseHostedMcpMemoryCount(payload) }
+}
+
 export function registerMcpKeyHandlers(): void {
-  ipcMain.handle('mcpKey:create', async (_e, record: McpKeyRecord): Promise<void> => {
+  ipcMain.handle('mcpKey:create', async (event, record: McpKeyRecord): Promise<void> => {
+    assertTrustedSender(event)
     saveMcpKey(record)
   })
 
-  ipcMain.handle('mcpKey:read', async (): Promise<McpKeyRecord | null> => loadMcpKey())
+  ipcMain.handle('mcpKey:read', async (event): Promise<McpKeyMetadata | null> => {
+    assertTrustedSender(event)
+    const record = loadMcpKey()
+    return record ? metadataFor(record) : null
+  })
 
-  ipcMain.handle('mcpKey:delete', async (): Promise<void> => {
+  ipcMain.handle('mcpKey:copy', async (event, rawRequest: unknown): Promise<void> => {
+    assertTrustedSender(event)
+    const record = loadRequiredMcpKey()
+    const request = normalizeCopyRequest(rawRequest)
+    const text =
+      request.kind === 'key' ? record.key : request.text.replaceAll(MCP_KEY_PLACEHOLDER, record.key)
+    clipboard.writeText(text)
+  })
+
+  ipcMain.handle('mcpKey:test', async (event): Promise<McpKeyTestResult> => {
+    assertTrustedSender(event)
+    return testHostedMcpConnection(loadRequiredMcpKey().key)
+  })
+
+  ipcMain.handle('mcpKey:delete', async (event): Promise<void> => {
+    assertTrustedSender(event)
     clearMcpKey()
   })
 }

--- a/desktop/windows/src/main/ipc/mcpKey.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.ts
@@ -11,6 +11,18 @@ import { clearMcpKey, loadMcpKey, saveMcpKey } from '../integrations/mcpKeyStore
 const MCP_KEY_PLACEHOLDER = 'YOUR_OMI_MCP_KEY'
 const DEFAULT_OMI_API_BASE = 'https://api.omi.me'
 const HOSTED_MCP_TIMEOUT_MS = 15_000
+const MCP_KEY_CLIPBOARD_CLEAR_MS = 60_000
+
+let clipboardClearTimer: NodeJS.Timeout | null = null
+
+function scheduleClipboardClear(copiedText: string): void {
+  if (clipboardClearTimer) clearTimeout(clipboardClearTimer)
+  clipboardClearTimer = setTimeout(() => {
+    clipboardClearTimer = null
+    if (clipboard.readText() === copiedText) clipboard.clear()
+  }, MCP_KEY_CLIPBOARD_CLEAR_MS)
+  clipboardClearTimer.unref?.()
+}
 
 function assertTrustedSender(event: IpcMainInvokeEvent): void {
   const url = event.senderFrame?.url ?? ''
@@ -66,7 +78,7 @@ async function confirmMcpKeyCopy(
     title: 'Copy MCP key?',
     message: `Copy ${label} to the clipboard?`,
     detail:
-      'Anything on your clipboard may be readable by other apps. Only copy this when you are ready to paste it into a trusted destination.'
+      'Anything on your clipboard may be readable by other apps. The clipboard is cleared automatically after 60 seconds. Only copy this when you are ready to paste it into a trusted destination.'
   }
   const choice = parent
     ? await dialog.showMessageBox(parent, options)
@@ -161,6 +173,7 @@ export function registerMcpKeyHandlers(): void {
     const text =
       request.kind === 'key' ? record.key : request.text.replaceAll(MCP_KEY_PLACEHOLDER, record.key)
     clipboard.writeText(text)
+    scheduleClipboardClear(text)
     return { copied: true }
   })
 

--- a/desktop/windows/src/main/ipc/mcpKey.ts
+++ b/desktop/windows/src/main/ipc/mcpKey.ts
@@ -1,6 +1,7 @@
-import { clipboard, ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { BrowserWindow, clipboard, dialog, ipcMain, type IpcMainInvokeEvent } from 'electron'
 import type {
   McpKeyCopyRequest,
+  McpKeyCopyResult,
   McpKeyMetadata,
   McpKeyRecord,
   McpKeyTestResult
@@ -49,6 +50,28 @@ function normalizeCopyRequest(value: unknown): McpKeyCopyRequest {
     return { kind: 'text', text: request.text }
   }
   throw new Error('Invalid MCP key copy request')
+}
+
+async function confirmMcpKeyCopy(
+  event: IpcMainInvokeEvent,
+  request: McpKeyCopyRequest
+): Promise<boolean> {
+  const parent = BrowserWindow.fromWebContents(event.sender)
+  const label = request.kind === 'key' ? 'raw MCP key' : 'setup text containing your MCP key'
+  const options = {
+    type: 'warning' as const,
+    buttons: ['Copy', 'Cancel'],
+    defaultId: 1,
+    cancelId: 1,
+    title: 'Copy MCP key?',
+    message: `Copy ${label} to the clipboard?`,
+    detail:
+      'Anything on your clipboard may be readable by other apps. Only copy this when you are ready to paste it into a trusted destination.'
+  }
+  const choice = parent
+    ? await dialog.showMessageBox(parent, options)
+    : await dialog.showMessageBox(options)
+  return choice.response === 0
 }
 
 function mcpBaseURL(): string {
@@ -130,13 +153,15 @@ export function registerMcpKeyHandlers(): void {
     return record ? metadataFor(record) : null
   })
 
-  ipcMain.handle('mcpKey:copy', async (event, rawRequest: unknown): Promise<void> => {
+  ipcMain.handle('mcpKey:copy', async (event, rawRequest: unknown): Promise<McpKeyCopyResult> => {
     assertTrustedSender(event)
     const record = loadRequiredMcpKey()
     const request = normalizeCopyRequest(rawRequest)
+    if (!(await confirmMcpKeyCopy(event, request))) return { copied: false, canceled: true }
     const text =
       request.kind === 'key' ? record.key : request.text.replaceAll(MCP_KEY_PLACEHOLDER, record.key)
     clipboard.writeText(text)
+    return { copied: true }
   })
 
   ipcMain.handle('mcpKey:test', async (event): Promise<McpKeyTestResult> => {

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -17,7 +17,6 @@ import type {
   InsightPayload,
   AutomationPlan,
   StepResult,
-  McpKeyRecord,
   McpKeyCopyRequest,
   McpKeyCopyResult
 } from '../shared/types'
@@ -79,7 +78,11 @@ const omi: OmiBridgeApi = {
   googleCalendarFetchNew: () => ipcRenderer.invoke('integrations:google:calendarFetchNew'),
   googleMarkProcessed: (source: GoogleSource, ids: string[]) =>
     ipcRenderer.invoke('integrations:google:markProcessed', source, ids),
-  mcpKeyCreate: (key: McpKeyRecord) => ipcRenderer.invoke('mcpKey:create', key),
+  // NOTE: key creation happens entirely in main (mcpKey:createAndStore). The
+  // renderer passes the Firebase ID token and gets masked metadata back — the
+  // raw MCP key is never returned to renderer code. The only channel the secret
+  // transits is mcpKey:copy, which gates on a native confirmation dialog in main.
+  mcpKeyCreateAndStore: (token: string) => ipcRenderer.invoke('mcpKey:createAndStore', token),
   mcpKeyRead: () => ipcRenderer.invoke('mcpKey:read'),
   mcpKeyCopy: (request: McpKeyCopyRequest) =>
     ipcRenderer.invoke('mcpKey:copy', request) as Promise<McpKeyCopyResult>,

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -16,7 +16,8 @@ import type {
   RewindSettings,
   InsightPayload,
   AutomationPlan,
-  StepResult
+  StepResult,
+  McpKeyRecord
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -76,6 +77,9 @@ const omi: OmiBridgeApi = {
   googleCalendarFetchNew: () => ipcRenderer.invoke('integrations:google:calendarFetchNew'),
   googleMarkProcessed: (source: GoogleSource, ids: string[]) =>
     ipcRenderer.invoke('integrations:google:markProcessed', source, ids),
+  mcpKeyCreate: (key: McpKeyRecord) => ipcRenderer.invoke('mcpKey:create', key),
+  mcpKeyRead: () => ipcRenderer.invoke('mcpKey:read'),
+  mcpKeyDelete: () => ipcRenderer.invoke('mcpKey:delete'),
   memoriesBulkDelete: (args: { baseURL: string; token: string; ids: string[] }) =>
     ipcRenderer.invoke('memories:bulkDelete', args),
   onMemoriesDeleteProgress: (

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -17,7 +17,8 @@ import type {
   InsightPayload,
   AutomationPlan,
   StepResult,
-  McpKeyRecord
+  McpKeyRecord,
+  McpKeyCopyRequest
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -79,6 +80,8 @@ const omi: OmiBridgeApi = {
     ipcRenderer.invoke('integrations:google:markProcessed', source, ids),
   mcpKeyCreate: (key: McpKeyRecord) => ipcRenderer.invoke('mcpKey:create', key),
   mcpKeyRead: () => ipcRenderer.invoke('mcpKey:read'),
+  mcpKeyCopy: (request: McpKeyCopyRequest) => ipcRenderer.invoke('mcpKey:copy', request),
+  mcpKeyTest: () => ipcRenderer.invoke('mcpKey:test'),
   mcpKeyDelete: () => ipcRenderer.invoke('mcpKey:delete'),
   memoriesBulkDelete: (args: { baseURL: string; token: string; ids: string[] }) =>
     ipcRenderer.invoke('memories:bulkDelete', args),

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -18,7 +18,8 @@ import type {
   AutomationPlan,
   StepResult,
   McpKeyRecord,
-  McpKeyCopyRequest
+  McpKeyCopyRequest,
+  McpKeyCopyResult
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -80,7 +81,8 @@ const omi: OmiBridgeApi = {
     ipcRenderer.invoke('integrations:google:markProcessed', source, ids),
   mcpKeyCreate: (key: McpKeyRecord) => ipcRenderer.invoke('mcpKey:create', key),
   mcpKeyRead: () => ipcRenderer.invoke('mcpKey:read'),
-  mcpKeyCopy: (request: McpKeyCopyRequest) => ipcRenderer.invoke('mcpKey:copy', request),
+  mcpKeyCopy: (request: McpKeyCopyRequest) =>
+    ipcRenderer.invoke('mcpKey:copy', request) as Promise<McpKeyCopyResult>,
   mcpKeyTest: () => ipcRenderer.invoke('mcpKey:test'),
   mcpKeyDelete: () => ipcRenderer.invoke('mcpKey:delete'),
   memoriesBulkDelete: (args: { baseURL: string; token: string; ids: string[] }) =>

--- a/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
+++ b/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
@@ -9,23 +9,14 @@ import {
   Server,
   TestTube2
 } from 'lucide-react'
-import type { McpKeyMetadata, McpKeyRecord } from '../../../../shared/types'
-import { createWindowsMcpKey } from '../../lib/apiClient'
+import type { McpKeyMetadata } from '../../../../shared/types'
+import { fetchFirebaseIdToken } from '../../lib/apiClient'
 import { mcpDestinations, type McpDestination } from '../../lib/mcpDestinations'
 
 type CopyState = {
   target: string
   label: string
 } | null
-
-function maskKey(key: string): string {
-  if (key.length <= 10) return '********'
-  return `${key.slice(0, 6)}********${key.slice(-4)}`
-}
-
-function metadataFromRecord(record: McpKeyRecord): McpKeyMetadata {
-  return { id: record.id, name: record.name, maskedKey: maskKey(record.key) }
-}
 
 const MCP_KEY_PLACEHOLDER = 'YOUR_OMI_MCP_KEY'
 
@@ -176,9 +167,11 @@ export function McpConnectorSetup({
     setKeyError(null)
     setTestState({ kind: 'idle', message: '' })
     try {
-      const record = await createWindowsMcpKey()
-      await window.omi.mcpKeyCreate(record)
-      setStoredKey(metadataFromRecord(record))
+      // Main creates + stores the key and returns masked metadata only; the raw
+      // key never enters this renderer.
+      const token = await fetchFirebaseIdToken()
+      const metadata = await window.omi.mcpKeyCreateAndStore(token)
+      setStoredKey(metadata)
       onKeyStateChange?.(true)
     } catch (error) {
       setKeyError((error as Error).message)

--- a/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
+++ b/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Bot,
+  Check,
+  Clipboard,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  KeyRound,
+  Loader2,
+  Server,
+  TestTube2
+} from 'lucide-react'
+import type { McpKeyRecord } from '../../../../shared/types'
+import { createWindowsMcpKey } from '../../lib/apiClient'
+import {
+  mcpDestinations,
+  testHostedMcpConnection,
+  type McpDestination
+} from '../../lib/mcpDestinations'
+
+type CopyState = {
+  target: string
+  label: string
+} | null
+
+function maskKey(key: string): string {
+  if (key.length <= 10) return '********'
+  return `${key.slice(0, 6)}********${key.slice(-4)}`
+}
+
+function CodeBlock({
+  title,
+  value,
+  copyTarget,
+  disabled,
+  secure,
+  revealed,
+  onToggleReveal,
+  onCopy
+}: {
+  title: string
+  value: string
+  copyTarget: string
+  disabled?: boolean
+  secure?: boolean
+  revealed?: boolean
+  onToggleReveal?: () => void
+  onCopy: (value: string, label: string) => void
+}): React.JSX.Element {
+  const displayValue = secure && !revealed ? maskKey(value) : value
+
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-black/25 p-3 ${disabled ? 'opacity-55' : ''}`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-semibold uppercase text-white/45">{title}</span>
+        <div className="flex items-center gap-1.5">
+          {secure && onToggleReveal && (
+            <button
+              onClick={onToggleReveal}
+              className="rounded-lg p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+              title={revealed ? 'Hide key' : 'Show key'}
+              disabled={disabled}
+            >
+              {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </button>
+          )}
+          <button
+            onClick={() => onCopy(copyTarget, title)}
+            className="rounded-lg p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-40"
+            title={`Copy ${title}`}
+            disabled={disabled}
+          >
+            <Clipboard className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+      <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-white/75">
+        {displayValue}
+      </pre>
+    </div>
+  )
+}
+
+function DestinationButton({
+  destination,
+  selected,
+  onSelect
+}: {
+  destination: McpDestination
+  selected: boolean
+  onSelect: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      onClick={onSelect}
+      className={`flex min-h-[9.5rem] flex-col rounded-2xl border p-4 text-left transition-all duration-200 ${
+        selected
+          ? 'border-white/25 bg-white/[0.12] text-white shadow-lg shadow-black/20'
+          : 'border-white/10 bg-white/[0.04] text-white/75 hover:border-white/18 hover:bg-white/[0.07] hover:text-white'
+      }`}
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/10 bg-black/25">
+          <Bot className="h-4 w-4" />
+        </div>
+        {selected && <Check className="h-4 w-4 text-white/70" />}
+      </div>
+      <div className="font-display text-sm font-semibold">{destination.title}</div>
+      <div className="mt-1 text-xs text-white/45">{destination.subtitle}</div>
+      <p className="mt-3 line-clamp-3 text-xs leading-relaxed text-white/55">
+        {destination.description}
+      </p>
+    </button>
+  )
+}
+
+export function McpConnectorSetup(): React.JSX.Element {
+  const [selectedId, setSelectedId] = useState(mcpDestinations[0].id)
+  const [storedKey, setStoredKey] = useState<McpKeyRecord | null>(null)
+  const [loadingKey, setLoadingKey] = useState(true)
+  const [generating, setGenerating] = useState(false)
+  const [showKey, setShowKey] = useState(false)
+  const [copyState, setCopyState] = useState<CopyState>(null)
+  const [testState, setTestState] = useState<{
+    kind: 'idle' | 'running' | 'success' | 'error'
+    message: string
+  }>({
+    kind: 'idle',
+    message: ''
+  })
+  const [keyError, setKeyError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.omi
+      .mcpKeyRead()
+      .then((record) => {
+        if (!cancelled) setStoredKey(record)
+      })
+      .catch((error) => {
+        if (!cancelled) setKeyError((error as Error).message)
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingKey(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const selectedDestination = useMemo(
+    () =>
+      mcpDestinations.find((destination) => destination.id === selectedId) ?? mcpDestinations[0],
+    [selectedId]
+  )
+  const setup = useMemo(
+    () => selectedDestination.setup(storedKey?.key ?? 'YOUR_OMI_MCP_KEY'),
+    [selectedDestination, storedKey?.key]
+  )
+
+  const copy = async (value: string, label: string): Promise<void> => {
+    await navigator.clipboard.writeText(value)
+    setCopyState({ target: value, label })
+    window.setTimeout(() => {
+      setCopyState((current) => (current?.target === value ? null : current))
+    }, 1800)
+  }
+
+  const generateKey = async (): Promise<void> => {
+    if (generating) return
+    setGenerating(true)
+    setKeyError(null)
+    setTestState({ kind: 'idle', message: '' })
+    try {
+      const record = await createWindowsMcpKey()
+      await window.omi.mcpKeyCreate(record)
+      setStoredKey(record)
+      setShowKey(false)
+    } catch (error) {
+      setKeyError((error as Error).message)
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const testConnection = async (): Promise<void> => {
+    if (!storedKey?.key || testState.kind === 'running') return
+    setTestState({ kind: 'running', message: 'Testing hosted MCP...' })
+    try {
+      const result = await testHostedMcpConnection(storedKey.key)
+      setTestState({
+        kind: 'success',
+        message: `Connected. get_memories returned ${result.memoryCount} memor${result.memoryCount === 1 ? 'y' : 'ies'}.`
+      })
+    } catch (error) {
+      setTestState({ kind: 'error', message: (error as Error).message })
+    }
+  }
+
+  const hasKey = Boolean(storedKey?.key)
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase text-white/45">
+            <Server className="h-3.5 w-3.5" />
+            Memory connectors
+          </div>
+          <h2 className="font-display text-lg font-semibold text-white">Connect Omi to AI apps</h2>
+          <p className="mt-1 max-w-2xl text-sm leading-relaxed text-white/55">
+            Give ChatGPT, Claude, Claude Code, Codex, or another agent live access to your Omi
+            memories through hosted MCP.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={generateKey}
+            disabled={loadingKey || generating}
+            className="btn-primary inline-flex items-center gap-2 px-3 py-2 text-xs disabled:opacity-50"
+          >
+            {generating ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <KeyRound className="h-3.5 w-3.5" />
+            )}
+            {hasKey ? 'Regenerate key' : 'Generate key'}
+          </button>
+          <button
+            onClick={testConnection}
+            disabled={!hasKey || testState.kind === 'running'}
+            className="btn-ghost inline-flex items-center gap-2 px-3 py-2 text-xs disabled:opacity-45"
+          >
+            {testState.kind === 'running' ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <TestTube2 className="h-3.5 w-3.5" />
+            )}
+            Test connection
+          </button>
+        </div>
+      </div>
+
+      {keyError && <div className="glass-subtle px-4 py-3 text-sm text-red-200/90">{keyError}</div>}
+      {testState.kind !== 'idle' && (
+        <div
+          className={`glass-subtle px-4 py-3 text-sm ${
+            testState.kind === 'success'
+              ? 'text-emerald-200/90'
+              : testState.kind === 'error'
+                ? 'text-red-200/90'
+                : 'text-white/60'
+          }`}
+        >
+          {testState.message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
+        {mcpDestinations.map((destination) => (
+          <DestinationButton
+            key={destination.id}
+            destination={destination}
+            selected={destination.id === selectedId}
+            onSelect={() => setSelectedId(destination.id)}
+          />
+        ))}
+      </div>
+
+      <div className="surface-card p-5">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="font-display text-base font-semibold text-white/95">
+              {selectedDestination.title} setup
+            </h3>
+            <p className="mt-1 text-sm text-white/55">{selectedDestination.description}</p>
+          </div>
+          {setup.openURL && (
+            <button
+              onClick={() => window.open(setup.openURL, '_blank', 'noopener,noreferrer')}
+              className="btn-ghost inline-flex shrink-0 items-center gap-2 px-3 py-2 text-xs"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              {setup.openTitle ?? `Open ${selectedDestination.title}`}
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div className="space-y-3">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="mb-3 text-xs font-semibold uppercase text-white/45">Steps</div>
+              <ol className="space-y-2">
+                {setup.steps.map((step, index) => (
+                  <li key={step} className="flex gap-3 text-sm leading-relaxed text-white/65">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[11px] font-semibold text-white/70">
+                      {index + 1}
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <CodeBlock
+              title="Server URL"
+              value={setup.serverURL}
+              copyTarget={setup.serverURL}
+              onCopy={copy}
+            />
+            {hasKey ? (
+              <CodeBlock
+                title="Your key"
+                value={storedKey!.key}
+                copyTarget={storedKey!.key}
+                secure
+                revealed={showKey}
+                onToggleReveal={() => setShowKey((visible) => !visible)}
+                onCopy={copy}
+              />
+            ) : (
+              <div className="rounded-2xl border border-white/10 bg-black/25 p-3 text-sm text-white/50">
+                Generate a key to enable secure key copy and destination-specific commands.
+              </div>
+            )}
+            {setup.copyText && (
+              <CodeBlock
+                title={setup.copyTitle ?? 'Setup text'}
+                value={setup.copyText}
+                copyTarget={setup.copyText}
+                disabled={!hasKey}
+                onCopy={copy}
+              />
+            )}
+            {copyState && (
+              <div className="flex items-center gap-2 text-xs text-emerald-200/90">
+                <Check className="h-3.5 w-3.5" />
+                Copied {copyState.label}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
+++ b/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
@@ -117,7 +117,11 @@ function DestinationButton({
   )
 }
 
-export function McpConnectorSetup(): React.JSX.Element {
+export function McpConnectorSetup({
+  onKeyStateChange
+}: {
+  onKeyStateChange?: (hasKey: boolean) => void
+} = {}): React.JSX.Element {
   const [selectedId, setSelectedId] = useState(mcpDestinations[0].id)
   const [storedKey, setStoredKey] = useState<McpKeyRecord | null>(null)
   const [loadingKey, setLoadingKey] = useState(true)
@@ -138,7 +142,10 @@ export function McpConnectorSetup(): React.JSX.Element {
     window.omi
       .mcpKeyRead()
       .then((record) => {
-        if (!cancelled) setStoredKey(record)
+        if (!cancelled) {
+          setStoredKey(record)
+          onKeyStateChange?.(Boolean(record?.key))
+        }
       })
       .catch((error) => {
         if (!cancelled) setKeyError((error as Error).message)
@@ -149,7 +156,7 @@ export function McpConnectorSetup(): React.JSX.Element {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [onKeyStateChange])
 
   const selectedDestination = useMemo(
     () =>
@@ -178,6 +185,7 @@ export function McpConnectorSetup(): React.JSX.Element {
       const record = await createWindowsMcpKey()
       await window.omi.mcpKeyCreate(record)
       setStoredKey(record)
+      onKeyStateChange?.(true)
       setShowKey(false)
     } catch (error) {
       setKeyError((error as Error).message)

--- a/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
+++ b/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
@@ -1,23 +1,17 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Bot,
   Check,
   Clipboard,
   ExternalLink,
-  Eye,
-  EyeOff,
   KeyRound,
   Loader2,
   Server,
   TestTube2
 } from 'lucide-react'
-import type { McpKeyRecord } from '../../../../shared/types'
+import type { McpKeyMetadata, McpKeyRecord } from '../../../../shared/types'
 import { createWindowsMcpKey } from '../../lib/apiClient'
-import {
-  mcpDestinations,
-  testHostedMcpConnection,
-  type McpDestination
-} from '../../lib/mcpDestinations'
+import { mcpDestinations, type McpDestination } from '../../lib/mcpDestinations'
 
 type CopyState = {
   target: string
@@ -29,27 +23,25 @@ function maskKey(key: string): string {
   return `${key.slice(0, 6)}********${key.slice(-4)}`
 }
 
+function metadataFromRecord(record: McpKeyRecord): McpKeyMetadata {
+  return { id: record.id, name: record.name, maskedKey: maskKey(record.key) }
+}
+
+const MCP_KEY_PLACEHOLDER = 'YOUR_OMI_MCP_KEY'
+
 function CodeBlock({
   title,
   value,
   copyTarget,
   disabled,
-  secure,
-  revealed,
-  onToggleReveal,
   onCopy
 }: {
   title: string
   value: string
   copyTarget: string
   disabled?: boolean
-  secure?: boolean
-  revealed?: boolean
-  onToggleReveal?: () => void
   onCopy: (value: string, label: string) => void
 }): React.JSX.Element {
-  const displayValue = secure && !revealed ? maskKey(value) : value
-
   return (
     <div
       className={`rounded-2xl border border-white/10 bg-black/25 p-3 ${disabled ? 'opacity-55' : ''}`}
@@ -57,16 +49,6 @@ function CodeBlock({
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="text-[11px] font-semibold uppercase text-white/45">{title}</span>
         <div className="flex items-center gap-1.5">
-          {secure && onToggleReveal && (
-            <button
-              onClick={onToggleReveal}
-              className="rounded-lg p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white"
-              title={revealed ? 'Hide key' : 'Show key'}
-              disabled={disabled}
-            >
-              {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-            </button>
-          )}
           <button
             onClick={() => onCopy(copyTarget, title)}
             className="rounded-lg p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-40"
@@ -78,7 +60,7 @@ function CodeBlock({
         </div>
       </div>
       <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-white/75">
-        {displayValue}
+        {value}
       </pre>
     </div>
   )
@@ -123,10 +105,10 @@ export function McpConnectorSetup({
   onKeyStateChange?: (hasKey: boolean) => void
 } = {}): React.JSX.Element {
   const [selectedId, setSelectedId] = useState(mcpDestinations[0].id)
-  const [storedKey, setStoredKey] = useState<McpKeyRecord | null>(null)
+  const [storedKey, setStoredKey] = useState<McpKeyMetadata | null>(null)
   const [loadingKey, setLoadingKey] = useState(true)
   const [generating, setGenerating] = useState(false)
-  const [showKey, setShowKey] = useState(false)
+  const testRunId = useRef(0)
   const [copyState, setCopyState] = useState<CopyState>(null)
   const [testState, setTestState] = useState<{
     kind: 'idle' | 'running' | 'success' | 'error'
@@ -144,7 +126,7 @@ export function McpConnectorSetup({
       .then((record) => {
         if (!cancelled) {
           setStoredKey(record)
-          onKeyStateChange?.(Boolean(record?.key))
+          onKeyStateChange?.(Boolean(record))
         }
       })
       .catch((error) => {
@@ -163,13 +145,16 @@ export function McpConnectorSetup({
       mcpDestinations.find((destination) => destination.id === selectedId) ?? mcpDestinations[0],
     [selectedId]
   )
-  const setup = useMemo(
-    () => selectedDestination.setup(storedKey?.key ?? 'YOUR_OMI_MCP_KEY'),
-    [selectedDestination, storedKey?.key]
-  )
+  const setup = useMemo(() => selectedDestination.setup(MCP_KEY_PLACEHOLDER), [selectedDestination])
 
   const copy = async (value: string, label: string): Promise<void> => {
-    await navigator.clipboard.writeText(value)
+    if (value === MCP_KEY_PLACEHOLDER) {
+      await window.omi.mcpKeyCopy({ kind: 'key' })
+    } else if (value.includes(MCP_KEY_PLACEHOLDER)) {
+      await window.omi.mcpKeyCopy({ kind: 'text', text: value })
+    } else {
+      await navigator.clipboard.writeText(value)
+    }
     setCopyState({ target: value, label })
     window.setTimeout(() => {
       setCopyState((current) => (current?.target === value ? null : current))
@@ -177,16 +162,16 @@ export function McpConnectorSetup({
   }
 
   const generateKey = async (): Promise<void> => {
-    if (generating) return
+    if (generating || testState.kind === 'running') return
+    testRunId.current += 1
     setGenerating(true)
     setKeyError(null)
     setTestState({ kind: 'idle', message: '' })
     try {
       const record = await createWindowsMcpKey()
       await window.omi.mcpKeyCreate(record)
-      setStoredKey(record)
+      setStoredKey(metadataFromRecord(record))
       onKeyStateChange?.(true)
-      setShowKey(false)
     } catch (error) {
       setKeyError((error as Error).message)
     } finally {
@@ -195,20 +180,24 @@ export function McpConnectorSetup({
   }
 
   const testConnection = async (): Promise<void> => {
-    if (!storedKey?.key || testState.kind === 'running') return
+    if (!storedKey || testState.kind === 'running') return
+    const runId = testRunId.current + 1
+    testRunId.current = runId
     setTestState({ kind: 'running', message: 'Testing hosted MCP...' })
     try {
-      const result = await testHostedMcpConnection(storedKey.key)
+      const result = await window.omi.mcpKeyTest()
+      if (runId !== testRunId.current) return
       setTestState({
         kind: 'success',
         message: `Connected. get_memories returned ${result.memoryCount} memor${result.memoryCount === 1 ? 'y' : 'ies'}.`
       })
     } catch (error) {
+      if (runId !== testRunId.current) return
       setTestState({ kind: 'error', message: (error as Error).message })
     }
   }
 
-  const hasKey = Boolean(storedKey?.key)
+  const hasKey = Boolean(storedKey)
 
   return (
     <section className="space-y-4">
@@ -227,7 +216,7 @@ export function McpConnectorSetup({
         <div className="flex flex-wrap items-center gap-2">
           <button
             onClick={generateKey}
-            disabled={loadingKey || generating}
+            disabled={loadingKey || generating || testState.kind === 'running'}
             className="btn-primary inline-flex items-center gap-2 px-3 py-2 text-xs disabled:opacity-50"
           >
             {generating ? (
@@ -324,11 +313,8 @@ export function McpConnectorSetup({
             {hasKey ? (
               <CodeBlock
                 title="Your key"
-                value={storedKey!.key}
-                copyTarget={storedKey!.key}
-                secure
-                revealed={showKey}
-                onToggleReveal={() => setShowKey((visible) => !visible)}
+                value={storedKey!.maskedKey}
+                copyTarget={MCP_KEY_PLACEHOLDER}
                 onCopy={copy}
               />
             ) : (

--- a/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
+++ b/desktop/windows/src/renderer/src/components/connectors/McpConnectorSetup.tsx
@@ -148,12 +148,20 @@ export function McpConnectorSetup({
   const setup = useMemo(() => selectedDestination.setup(MCP_KEY_PLACEHOLDER), [selectedDestination])
 
   const copy = async (value: string, label: string): Promise<void> => {
-    if (value === MCP_KEY_PLACEHOLDER) {
-      await window.omi.mcpKeyCopy({ kind: 'key' })
-    } else if (value.includes(MCP_KEY_PLACEHOLDER)) {
-      await window.omi.mcpKeyCopy({ kind: 'text', text: value })
-    } else {
-      await navigator.clipboard.writeText(value)
+    try {
+      setKeyError(null)
+      if (value === MCP_KEY_PLACEHOLDER) {
+        const result = await window.omi.mcpKeyCopy({ kind: 'key' })
+        if (!result.copied) return
+      } else if (value.includes(MCP_KEY_PLACEHOLDER)) {
+        const result = await window.omi.mcpKeyCopy({ kind: 'text', text: value })
+        if (!result.copied) return
+      } else {
+        await navigator.clipboard.writeText(value)
+      }
+    } catch (error) {
+      setKeyError(`Could not copy ${label}: ${(error as Error).message}`)
+      return
     }
     setCopyState({ target: value, label })
     window.setTimeout(() => {

--- a/desktop/windows/src/renderer/src/lib/apiClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.test.ts
@@ -12,30 +12,34 @@ const axiosMock = vi.hoisted(() => {
   return { create, post }
 })
 
+const firebaseMock = vi.hoisted(() => ({
+  auth: {
+    currentUser: null as null | { getIdToken: () => Promise<string> }
+  }
+}))
+
 vi.mock('axios', () => ({
   default: {
     create: axiosMock.create
   }
 }))
 
-vi.mock('./firebase', () => ({
-  auth: {
-    currentUser: null
-  }
-}))
+vi.mock('./firebase', () => firebaseMock)
 
-import { createWindowsMcpKey } from './apiClient'
+import { fetchFirebaseIdToken } from './apiClient'
 
-describe('createWindowsMcpKey', () => {
-  it('posts the Windows MCP key name and returns the key record', async () => {
-    const record = { id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' }
-    axiosMock.post.mockResolvedValueOnce({ data: record })
+describe('fetchFirebaseIdToken', () => {
+  it('rejects when no user is signed in', async () => {
+    firebaseMock.auth.currentUser = null
 
-    await expect(createWindowsMcpKey()).resolves.toEqual(record)
-    expect(axiosMock.post).toHaveBeenCalledWith(
-      '/v1/mcp/keys',
-      { name: 'Omi Windows' },
-      { __noRetry: true }
+    await expect(fetchFirebaseIdToken()).rejects.toThrow(
+      'Sign in to Omi before generating an MCP key.'
     )
+  })
+
+  it('returns the current user token for main-process MCP key creation', async () => {
+    firebaseMock.auth.currentUser = { getIdToken: vi.fn().mockResolvedValue('firebase-token') }
+
+    await expect(fetchFirebaseIdToken()).resolves.toBe('firebase-token')
   })
 })

--- a/desktop/windows/src/renderer/src/lib/apiClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const axiosMock = vi.hoisted(() => {
+  const post = vi.fn()
+  const create = vi.fn(() => ({
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() }
+    },
+    post
+  }))
+  return { create, post }
+})
+
+vi.mock('axios', () => ({
+  default: {
+    create: axiosMock.create
+  }
+}))
+
+vi.mock('./firebase', () => ({
+  auth: {
+    currentUser: null
+  }
+}))
+
+import { createWindowsMcpKey } from './apiClient'
+
+describe('createWindowsMcpKey', () => {
+  it('posts the Windows MCP key name and returns the key record', async () => {
+    const record = { id: 'key_123', name: 'Omi Windows', key: 'omi_live_secret' }
+    axiosMock.post.mockResolvedValueOnce({ data: record })
+
+    await expect(createWindowsMcpKey()).resolves.toEqual(record)
+    expect(axiosMock.post).toHaveBeenCalledWith('/v1/mcp/keys', { name: 'Omi Windows' })
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/apiClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.test.ts
@@ -32,6 +32,10 @@ describe('createWindowsMcpKey', () => {
     axiosMock.post.mockResolvedValueOnce({ data: record })
 
     await expect(createWindowsMcpKey()).resolves.toEqual(record)
-    expect(axiosMock.post).toHaveBeenCalledWith('/v1/mcp/keys', { name: 'Omi Windows' })
+    expect(axiosMock.post).toHaveBeenCalledWith(
+      '/v1/mcp/keys',
+      { name: 'Omi Windows' },
+      { __noRetry: true }
+    )
   })
 })

--- a/desktop/windows/src/renderer/src/lib/apiClient.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.ts
@@ -1,10 +1,5 @@
-import axios, {
-  type AxiosInstance,
-  type AxiosRequestConfig,
-  type InternalAxiosRequestConfig
-} from 'axios'
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
 import { auth } from './firebase'
-import type { McpKeyRecord } from '../../../shared/types'
 
 // Retried statuses: 429 (rate limited) and 503 (transient). Anything else fails
 // fast as before.
@@ -55,8 +50,12 @@ function makeClient(baseURL: string): AxiosInstance {
 export const omiApi = makeClient(import.meta.env.VITE_OMI_API_BASE as string)
 export const desktopApi = makeClient(import.meta.env.VITE_OMI_DESKTOP_API_BASE as string)
 
-export async function createWindowsMcpKey(): Promise<McpKeyRecord> {
-  const config: AxiosRequestConfig & { __noRetry: true } = { __noRetry: true }
-  const response = await omiApi.post<McpKeyRecord>('/v1/mcp/keys', { name: 'Omi Windows' }, config)
-  return response.data
+// The MCP key itself is created and stored in the main process
+// (window.omi.mcpKeyCreateAndStore) so the raw bearer key never reaches
+// renderer code. The renderer only supplies the short-lived Firebase ID token
+// main needs to authenticate the key-creating API call.
+export async function fetchFirebaseIdToken(): Promise<string> {
+  const user = auth.currentUser
+  if (!user) throw new Error('Sign in to Omi before generating an MCP key.')
+  return user.getIdToken()
 }

--- a/desktop/windows/src/renderer/src/lib/apiClient.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
 import { auth } from './firebase'
+import type { McpKeyRecord } from '../../../shared/types'
 
 // Retried statuses: 429 (rate limited) and 503 (transient). Anything else fails
 // fast as before.
@@ -49,3 +50,8 @@ function makeClient(baseURL: string): AxiosInstance {
 
 export const omiApi = makeClient(import.meta.env.VITE_OMI_API_BASE as string)
 export const desktopApi = makeClient(import.meta.env.VITE_OMI_DESKTOP_API_BASE as string)
+
+export async function createWindowsMcpKey(): Promise<McpKeyRecord> {
+  const response = await omiApi.post<McpKeyRecord>('/v1/mcp/keys', { name: 'Omi Windows' })
+  return response.data
+}

--- a/desktop/windows/src/renderer/src/lib/apiClient.ts
+++ b/desktop/windows/src/renderer/src/lib/apiClient.ts
@@ -1,4 +1,8 @@
-import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
+import axios, {
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig
+} from 'axios'
 import { auth } from './firebase'
 import type { McpKeyRecord } from '../../../shared/types'
 
@@ -52,6 +56,7 @@ export const omiApi = makeClient(import.meta.env.VITE_OMI_API_BASE as string)
 export const desktopApi = makeClient(import.meta.env.VITE_OMI_DESKTOP_API_BASE as string)
 
 export async function createWindowsMcpKey(): Promise<McpKeyRecord> {
-  const response = await omiApi.post<McpKeyRecord>('/v1/mcp/keys', { name: 'Omi Windows' })
+  const config: AxiosRequestConfig & { __noRetry: true } = { __noRetry: true }
+  const response = await omiApi.post<McpKeyRecord>('/v1/mcp/keys', { name: 'Omi Windows' }, config)
   return response.data
 }

--- a/desktop/windows/src/renderer/src/lib/mcpDestinations.test.ts
+++ b/desktop/windows/src/renderer/src/lib/mcpDestinations.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildHostedMcpHealthRequest,
+  parseHostedMcpMemoryCount,
+  testHostedMcpConnection
+} from './mcpDestinations'
+
+describe('hosted MCP health check', () => {
+  it('builds the get_memories JSON-RPC request with bearer auth', () => {
+    const { url, init } = buildHostedMcpHealthRequest('omi_secret')
+
+    expect(url).toBe('https://api.omi.me/v1/mcp/sse')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer omi_secret'
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'get_memories',
+        arguments: { limit: 5 }
+      }
+    })
+  })
+
+  it('parses the memory count from MCP text content', () => {
+    expect(
+      parseHostedMcpMemoryCount({
+        result: {
+          content: [
+            { type: 'text', text: JSON.stringify({ memories: [{ id: '1' }, { id: '2' }] }) }
+          ]
+        }
+      })
+    ).toBe(2)
+  })
+
+  it('surfaces JSON-RPC errors without exposing the key', () => {
+    expect(() =>
+      parseHostedMcpMemoryCount({
+        error: { message: 'Invalid or expired key' }
+      })
+    ).toThrow('Hosted MCP failed: Invalid or expired key')
+  })
+
+  it('reports HTTP failures precisely', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(testHostedMcpConnection('omi_secret')).rejects.toThrow(
+      'Hosted MCP returned HTTP 401.'
+    )
+    expect(fetchMock).toHaveBeenCalledOnce()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/mcpDestinations.test.ts
+++ b/desktop/windows/src/renderer/src/lib/mcpDestinations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildHostedMcpHealthRequest,
   parseHostedMcpMemoryCount,
@@ -6,6 +6,11 @@ import {
 } from './mcpDestinations'
 
 describe('hosted MCP health check', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
   it('builds the get_memories JSON-RPC request with bearer auth', () => {
     const { url, init } = buildHostedMcpHealthRequest('omi_secret')
 
@@ -54,7 +59,49 @@ describe('hosted MCP health check', () => {
       'Hosted MCP returned HTTP 401.'
     )
     expect(fetchMock).toHaveBeenCalledOnce()
+  })
 
-    vi.unstubAllGlobals()
+  it('returns memory count on successful hosted MCP checks', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: {
+          content: [{ text: JSON.stringify({ memories: [{ id: 'm1' }, { id: 'm2' }] }) }]
+        }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(testHostedMcpConnection('omi_secret')).resolves.toEqual({ memoryCount: 2 })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.omi.me/v1/mcp/sse',
+      expect.objectContaining({
+        signal: expect.any(AbortSignal)
+      })
+    )
+  })
+
+  it('times out hung hosted MCP checks', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => {
+          const error = new Error('aborted')
+          error.name = 'AbortError'
+          reject(error)
+        })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = expect(testHostedMcpConnection('omi_secret')).rejects.toThrow(
+      'Hosted MCP request timed out.'
+    )
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await result
   })
 })

--- a/desktop/windows/src/renderer/src/lib/mcpDestinations.ts
+++ b/desktop/windows/src/renderer/src/lib/mcpDestinations.ts
@@ -1,0 +1,204 @@
+export type McpDestinationId = 'chatgpt' | 'claude' | 'claude-code' | 'codex' | 'agents'
+
+export type McpSetup = {
+  serverURL: string
+  copyTitle?: string
+  copyText?: string
+  steps: string[]
+  openURL?: string
+  openTitle?: string
+}
+
+export type McpDestination = {
+  id: McpDestinationId
+  title: string
+  subtitle: string
+  description: string
+  setup: (key: string) => McpSetup
+}
+
+export type McpHealthResult = {
+  memoryCount: number
+}
+
+const DEFAULT_OMI_API_BASE = 'https://api.omi.me'
+
+function normalizedApiBase(): string {
+  const raw = (import.meta.env.VITE_OMI_API_BASE as string | undefined) || DEFAULT_OMI_API_BASE
+  return raw.endsWith('/') ? raw : `${raw}/`
+}
+
+export const mcpBaseURL = normalizedApiBase()
+export const mcpServerURL = `${mcpBaseURL}v1/mcp/sse`
+export const mcpAuthorizeURL = `${mcpBaseURL}authorize`
+export const mcpTokenURL = `${mcpBaseURL}token`
+
+export function buildHostedMcpHealthRequest(key: string): { url: string; init: RequestInit } {
+  return {
+    url: mcpServerURL,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'get_memories',
+          arguments: { limit: 5 }
+        }
+      })
+    }
+  }
+}
+
+export function parseHostedMcpMemoryCount(payload: unknown): number {
+  const rpc = payload as {
+    error?: { message?: unknown }
+    result?: { content?: Array<{ text?: unknown }> }
+  }
+  if (rpc.error) {
+    const message = typeof rpc.error.message === 'string' ? rpc.error.message : 'Unknown error'
+    throw new Error(`Hosted MCP failed: ${message}`)
+  }
+
+  const text = rpc.result?.content?.find((item) => typeof item.text === 'string')?.text
+  if (typeof text !== 'string') {
+    throw new Error('Hosted MCP did not return memory data.')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('Hosted MCP returned unreadable memory data.')
+  }
+
+  const memories = (parsed as { memories?: unknown }).memories
+  if (!Array.isArray(memories)) {
+    throw new Error('Hosted MCP did not return memory data.')
+  }
+  return memories.length
+}
+
+export async function testHostedMcpConnection(key: string): Promise<McpHealthResult> {
+  const { url, init } = buildHostedMcpHealthRequest(key)
+  let response: Response
+  try {
+    response = await fetch(url, init)
+  } catch (error) {
+    throw new Error(`Hosted MCP request failed: ${(error as Error).message}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(`Hosted MCP returned HTTP ${response.status}.`)
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new Error('Hosted MCP returned invalid JSON.')
+  }
+
+  return { memoryCount: parseHostedMcpMemoryCount(payload) }
+}
+
+export const mcpDestinations: McpDestination[] = [
+  {
+    id: 'chatgpt',
+    title: 'ChatGPT',
+    subtitle: 'Custom connector',
+    description: 'Connect Omi Memory so ChatGPT can read your memories live.',
+    setup: () => ({
+      serverURL: mcpServerURL,
+      steps: [
+        'Open ChatGPT -> Settings -> Apps -> Advanced, then enable Developer mode.',
+        'Create app -> name it "Omi Memory" and paste the server URL below.',
+        'Authentication: OAuth. In Advanced OAuth settings set Client ID "omi", Client Secret to your key, and token auth method "client_secret_post".',
+        `Auth URL: ${mcpAuthorizeURL} - Token URL: ${mcpTokenURL}`,
+        'Create, then Connect. The connector syncs to ChatGPT desktop and mobile.'
+      ],
+      openURL: 'https://chatgpt.com/',
+      openTitle: 'Open ChatGPT'
+    })
+  },
+  {
+    id: 'claude',
+    title: 'Claude',
+    subtitle: 'Custom connector',
+    description: 'Connect Omi Memory so Claude can read your memories live.',
+    setup: () => ({
+      serverURL: mcpServerURL,
+      steps: [
+        'Open claude.ai -> Settings -> Connectors -> Add custom connector.',
+        'Name it "Omi Memory" and paste the server URL below.',
+        'Under Advanced settings set OAuth Client ID to "omi" and Client Secret to your key below.',
+        'Click Add, then Connect. The connector syncs to Claude desktop and mobile.'
+      ],
+      openURL: 'https://claude.ai/settings/connectors',
+      openTitle: 'Open Claude Connectors'
+    })
+  },
+  {
+    id: 'claude-code',
+    title: 'Claude Code',
+    subtitle: 'Terminal command',
+    description: 'Register Omi as a user-scope MCP server for every Claude Code project.',
+    setup: (key) => ({
+      serverURL: mcpServerURL,
+      copyTitle: 'Copy command',
+      copyText: `claude mcp add --scope user --transport http omi-memory ${mcpServerURL} --header "Authorization: Bearer ${key}"`,
+      steps: [
+        'Run the command below in your terminal.',
+        'It registers Omi at user scope, so every Claude Code project can read your memories.'
+      ]
+    })
+  },
+  {
+    id: 'codex',
+    title: 'Codex',
+    subtitle: 'Config block',
+    description: 'Add Omi Memory to Codex as a hosted MCP server.',
+    setup: (key) => ({
+      serverURL: mcpServerURL,
+      copyTitle: 'Copy config',
+      copyText: `[mcp_servers.omi-memory]
+command = "npx"
+args = ["-y", "mcp-remote", "${mcpServerURL}", "--header", "Authorization: Bearer ${key}"]`,
+      steps: [
+        'Add the block below to ~/.codex/config.toml.',
+        'Restart Codex to load Omi memories over MCP.'
+      ]
+    })
+  },
+  {
+    id: 'agents',
+    title: 'AI Agents',
+    subtitle: 'Generic MCP setup',
+    description: 'Use the server URL and bearer key with any MCP-compatible agent.',
+    setup: (key) => ({
+      serverURL: mcpServerURL,
+      copyTitle: 'Copy JSON',
+      copyText: JSON.stringify(
+        {
+          'omi-memory': {
+            transport: 'http',
+            url: mcpServerURL,
+            headers: { Authorization: `Bearer ${key}` }
+          }
+        },
+        null,
+        2
+      ),
+      steps: [
+        'Create a hosted HTTP MCP server entry named "omi-memory".',
+        'Use the server URL below and set Authorization to Bearer plus your Omi MCP key.',
+        'Test the connection with get_memories and a small limit before relying on it.'
+      ]
+    })
+  }
+]

--- a/desktop/windows/src/renderer/src/lib/mcpDestinations.ts
+++ b/desktop/windows/src/renderer/src/lib/mcpDestinations.ts
@@ -22,6 +22,7 @@ export type McpHealthResult = {
 }
 
 const DEFAULT_OMI_API_BASE = 'https://api.omi.me'
+const HOSTED_MCP_TIMEOUT_MS = 15_000
 
 function normalizedApiBase(): string {
   const raw = (import.meta.env.VITE_OMI_API_BASE as string | undefined) || DEFAULT_OMI_API_BASE
@@ -86,11 +87,18 @@ export function parseHostedMcpMemoryCount(payload: unknown): number {
 
 export async function testHostedMcpConnection(key: string): Promise<McpHealthResult> {
   const { url, init } = buildHostedMcpHealthRequest(key)
+  const controller = new AbortController()
+  const timeout = globalThis.setTimeout(() => controller.abort(), HOSTED_MCP_TIMEOUT_MS)
   let response: Response
   try {
-    response = await fetch(url, init)
+    response = await fetch(url, { ...init, signal: controller.signal })
   } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Hosted MCP request timed out.')
+    }
     throw new Error(`Hosted MCP request failed: ${(error as Error).message}`)
+  } finally {
+    globalThis.clearTimeout(timeout)
   }
 
   if (!response.ok) {

--- a/desktop/windows/src/renderer/src/pages/Apps.tsx
+++ b/desktop/windows/src/renderer/src/pages/Apps.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { LayoutGrid, RefreshCw, Star, Check, Plus, Loader2, Search, SlidersHorizontal, X } from 'lucide-react'
+import {
+  LayoutGrid,
+  RefreshCw,
+  Star,
+  Check,
+  Plus,
+  Loader2,
+  Search,
+  SlidersHorizontal,
+  X
+} from 'lucide-react'
 import { omiApi } from '../lib/apiClient'
 import { PageHeader } from '../components/layout/PageHeader'
 import { EmptyState } from '../components/ui/EmptyState'
+import { McpConnectorSetup } from '../components/connectors/McpConnectorSetup'
 
 type AppEntry = {
   id: string
@@ -27,7 +38,17 @@ function formatCategory(raw: string): string {
     .join(' ')
 }
 
-function AppCard({ app, isOn, isBusy, onToggle }: { app: AppEntry; isOn: boolean; isBusy: boolean; onToggle: (a: AppEntry) => void }): React.JSX.Element {
+function AppCard({
+  app,
+  isOn,
+  isBusy,
+  onToggle
+}: {
+  app: AppEntry
+  isOn: boolean
+  isBusy: boolean
+  onToggle: (a: AppEntry) => void
+}): React.JSX.Element {
   return (
     <div className="surface-card flex flex-col p-5 animate-fade-in">
       <div className="mb-3 flex items-start gap-3">
@@ -47,9 +68,7 @@ function AppCard({ app, isOn, isBusy, onToggle }: { app: AppEntry; isOn: boolean
         )}
         <div className="min-w-0 flex-1">
           <div className="font-display font-semibold text-white/95">{app.name}</div>
-          {app.author && (
-            <div className="text-[11px] text-white/45">{app.author}</div>
-          )}
+          {app.author && <div className="text-[11px] text-white/45">{app.author}</div>}
         </div>
       </div>
       <p className="mb-4 line-clamp-3 flex-1 text-xs leading-relaxed text-white/65">
@@ -279,6 +298,9 @@ export function Apps(): React.JSX.Element {
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-10 lg:py-8">
+        <div className="mx-auto mb-8 max-w-5xl">
+          <McpConnectorSetup />
+        </div>
         {loading && (
           <div className="mx-auto grid max-w-5xl grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -299,9 +321,7 @@ export function Apps(): React.JSX.Element {
             ))}
           </div>
         )}
-        {error && (
-          <div className="glass-subtle mb-5 px-4 py-3 text-sm text-white/60">{error}</div>
-        )}
+        {error && <div className="glass-subtle mb-5 px-4 py-3 text-sm text-white/60">{error}</div>}
         {!loading && !error && (
           <div className="mx-auto max-w-5xl space-y-5">
             <div className="flex items-center gap-2">
@@ -424,22 +444,45 @@ export function Apps(): React.JSX.Element {
 
             {query.trim() ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {categorized.search?.map((a) => <AppCard key={a.id} app={a} isOn={enabled.has(a.id)} isBusy={busy.has(a.id)} onToggle={toggle} />)}
+                {categorized.search?.map((a) => (
+                  <AppCard
+                    key={a.id}
+                    app={a}
+                    isOn={enabled.has(a.id)}
+                    isBusy={busy.has(a.id)}
+                    onToggle={toggle}
+                  />
+                ))}
               </div>
             ) : (
               Object.entries(categorized)
                 .sort(([catA], [catB]) => {
-                  const order = ['Most Popular', 'Featured', 'Integrations', 'Chat Assistants', 'Summary Apps', 'Notifications']
+                  const order = [
+                    'Most Popular',
+                    'Featured',
+                    'Integrations',
+                    'Chat Assistants',
+                    'Summary Apps',
+                    'Notifications'
+                  ]
                   const aIdx = order.indexOf(formatCategory(catA))
                   const bIdx = order.indexOf(formatCategory(catB))
                   return (aIdx === -1 ? Infinity : aIdx) - (bIdx === -1 ? Infinity : bIdx)
                 })
                 .map(([category, categoryApps]) => (
                   <div key={category} className="space-y-3">
-                    <h2 className="text-sm font-semibold text-white/80">{formatCategory(category)}</h2>
+                    <h2 className="text-sm font-semibold text-white/80">
+                      {formatCategory(category)}
+                    </h2>
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                       {categoryApps.map((a) => (
-                        <AppCard key={a.id} app={a} isOn={enabled.has(a.id)} isBusy={busy.has(a.id)} onToggle={toggle} />
+                        <AppCard
+                          key={a.id}
+                          app={a}
+                          isOn={enabled.has(a.id)}
+                          isBusy={busy.has(a.id)}
+                          onToggle={toggle}
+                        />
                       ))}
                     </div>
                   </div>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -253,7 +253,11 @@ export type OmiBridgeApi = {
   googleGmailFetchNew: () => Promise<FetchNewResult<GmailItem>>
   googleCalendarFetchNew: () => Promise<FetchNewResult<CalendarItem>>
   googleMarkProcessed: (source: GoogleSource, ids: string[]) => Promise<void>
-  mcpKeyCreate: (key: McpKeyRecord) => Promise<void>
+  // Hosted MCP key lifecycle (main-process owned). The renderer passes only the
+  // Firebase ID token; main performs the key-creating HTTP call and persists the
+  // key, returning masked metadata. The raw bearer key never crosses IPC to the
+  // renderer — the only way it leaves main is the user-confirmed mcpKeyCopy path.
+  mcpKeyCreateAndStore: (token: string) => Promise<McpKeyMetadata>
   mcpKeyRead: () => Promise<McpKeyMetadata | null>
   mcpKeyCopy: (request: McpKeyCopyRequest) => Promise<McpKeyCopyResult>
   mcpKeyTest: () => Promise<McpKeyTestResult>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -52,6 +52,12 @@ export type ConversationPayload = {
 
 export type ChatMessage = { id?: string; role: 'user' | 'assistant'; content: string }
 
+export type McpKeyRecord = {
+  id: string
+  name: string
+  key: string
+}
+
 // Capture modes a recording session can start in. 'mic' = audio only;
 // 'screen' = mic + screen capture + system audio (both audio streams
 // transcribed independently).
@@ -229,6 +235,9 @@ export type OmiBridgeApi = {
   googleGmailFetchNew: () => Promise<FetchNewResult<GmailItem>>
   googleCalendarFetchNew: () => Promise<FetchNewResult<CalendarItem>>
   googleMarkProcessed: (source: GoogleSource, ids: string[]) => Promise<void>
+  mcpKeyCreate: (key: McpKeyRecord) => Promise<void>
+  mcpKeyRead: () => Promise<McpKeyRecord | null>
+  mcpKeyDelete: () => Promise<void>
   rewindFrames: (from: number, to: number) => Promise<RewindFrame[]>
   rewindDayBounds: () => Promise<{ min: number; max: number } | null>
   rewindSearch: (query: string) => Promise<RewindSearchGroup[]>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -58,6 +58,23 @@ export type McpKeyRecord = {
   key: string
 }
 
+export type McpKeyMetadata = {
+  id: string
+  name: string
+  maskedKey: string
+}
+
+export type McpKeyCopyRequest =
+  | { kind: 'key' }
+  | {
+      kind: 'text'
+      text: string
+    }
+
+export type McpKeyTestResult = {
+  memoryCount: number
+}
+
 // Capture modes a recording session can start in. 'mic' = audio only;
 // 'screen' = mic + screen capture + system audio (both audio streams
 // transcribed independently).
@@ -236,7 +253,9 @@ export type OmiBridgeApi = {
   googleCalendarFetchNew: () => Promise<FetchNewResult<CalendarItem>>
   googleMarkProcessed: (source: GoogleSource, ids: string[]) => Promise<void>
   mcpKeyCreate: (key: McpKeyRecord) => Promise<void>
-  mcpKeyRead: () => Promise<McpKeyRecord | null>
+  mcpKeyRead: () => Promise<McpKeyMetadata | null>
+  mcpKeyCopy: (request: McpKeyCopyRequest) => Promise<void>
+  mcpKeyTest: () => Promise<McpKeyTestResult>
   mcpKeyDelete: () => Promise<void>
   rewindFrames: (from: number, to: number) => Promise<RewindFrame[]>
   rewindDayBounds: () => Promise<{ min: number; max: number } | null>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -70,6 +70,7 @@ export type McpKeyCopyRequest =
       kind: 'text'
       text: string
     }
+export type McpKeyCopyResult = { copied: boolean; canceled?: boolean }
 
 export type McpKeyTestResult = {
   memoryCount: number
@@ -254,7 +255,7 @@ export type OmiBridgeApi = {
   googleMarkProcessed: (source: GoogleSource, ids: string[]) => Promise<void>
   mcpKeyCreate: (key: McpKeyRecord) => Promise<void>
   mcpKeyRead: () => Promise<McpKeyMetadata | null>
-  mcpKeyCopy: (request: McpKeyCopyRequest) => Promise<void>
+  mcpKeyCopy: (request: McpKeyCopyRequest) => Promise<McpKeyCopyResult>
   mcpKeyTest: () => Promise<McpKeyTestResult>
   mcpKeyDelete: () => Promise<void>
   rewindFrames: (from: number, to: number) => Promise<RewindFrame[]>
@@ -362,13 +363,7 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  | 'document'
-  | 'code'
-  | 'image'
-  | 'media'
-  | 'archive'
-  | 'application'
-  | 'other'
+  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -462,14 +457,7 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  | 'project'
-  | 'app'
-  | 'technology'
-  | 'person'
-  | 'org'
-  | 'interest'
-  | 'file_group'
-  | 'card' // background-synthesized natural-language overview served to the chat floor
+  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis


### PR DESCRIPTION
> **Maintainers:** one of several independent Windows split PRs carved out of #8404. Each is small and standalone — **cherry-pick or merge whichever you want, in any order**; they do not depend on each other beyond shared plumbing. Base is v0.11.542 (`84e539a`). Full context: BasedHardware/omi#8404.

---

## Summary

Split **3 of the PR 8404 breakup** (maintainer-requested order pairs this with BYOK: "BYOK/MCP key storage and validation"). Branch: `split/pr8404-mcp-key-storage`.

- Adds the Memory Connectors / hosted MCP setup UI for ChatGPT, Claude, Claude Code, Codex, and generic MCP-compatible agents.
- Keeps key generation/copy/testing actions scoped to the MCP connector UI.

## Scope

- **In scope:** `desktop/windows/src/main/integrations/mcpKeyStore*`, `src/renderer/src/lib/apiClient*`, `src/renderer/src/lib/mcpDestinations*`, the Memory Connectors UI, and shared plumbing (`main/index.ts`, `preload/index.ts`, `shared/types.ts`, `package.json`, `electron-builder.yml`).
- **Out of scope:** BYOK provider keys (separate split), local-agent tools, runtimes.

## Split Overlap & Merge Order

- Split #3 in [SPLIT_MAP.md](../SPLIT_MAP.md), landed with/after `byok`.
- MCP key-store core (`mcpKeyStore`, `mcpDestinations`) is **owned by this split**. Shares only generic plumbing with other splits.

## Windows Desktop Verification Evidence

- **Package check** (`_package-evidence/20260628-083433`): OK — `koffi.node`, `app.asar`, packaged config strings present.
- **Launch smoke** (`_smoke-evidence/20260627-194234`): launch **pass**, title `omi`, unit tests **pass**.
- **Independent unit re-run (2026-07-01, vitest 3.2.6):** `integrations/mcpKeyStore`, `lib/apiClient`, `lib/mcpDestinations` → **9 tests passing**.
- **Feature capture** (`_feature-renderer-evidence/20260628-084516`): loaded `#/apps` and captured the Memory Connectors hosted MCP setup UI from the packaged Windows app.
- **Recorded source checks** (TESTING.md): `npm run test -- src/main/integrations/mcpKeyStore.test.ts src/renderer/src/lib/apiClient.test.ts src/renderer/src/lib/mcpDestinations.test.ts`; `npm run typecheck`; `npm run build`.

## Addresses Maintainer Review Notes (BasedHardware/omi#8404)

- Maintainer split order item **#3** (key storage/validation).
- The prep run did not call raw key read paths and did not generate, reveal, test, or delete an MCP key on the real account.
- Security review should confirm key generation, persistence, clearing, clipboard behavior, status masking, telemetry redaction, and that no raw MCP key leaks into renderer logs or diagnostics.

## Screenshots

Memory Connectors / hosted MCP setup, one capture per destination (recaptured 2026-07-01 via CDP `Page.captureScreenshot`, renderer-only, to cover all five destinations rather than a single view):






## Remaining Checks Before Non-Draft

- Run generate/test/clear on a disposable account or disposable key.
- Redact screenshots before posting if account-specific connector state is visible (see [REDACTION_NOTES.md](../REDACTION_NOTES.md)).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

