### PR TITLE
[WIN] Local agent tools server

### DIFF
--- a/desktop/windows/.gitignore
+++ b/desktop/windows/.gitignore
@@ -50,3 +50,4 @@ resources/win-ocr-helper/*.pdb
 src/main/automation/helper/bin/
 src/main/automation/helper/obj/
 resources/win-automation-helper/*.pdb
+resources/koffi/

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -19,6 +19,11 @@ asarUnpack:
   # koffi loads its native .node at runtime, resolved relative to its own package
   # dir — it must live outside the asar archive or the foreground monitor fails.
   - node_modules/koffi/**
+extraResources:
+  - from: resources/koffi
+    to: koffi
+    filter:
+      - '**/*'
 win:
   executableName: omi-windows
   target:

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,15 +16,17 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs",
-    "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "npm run build && electron-builder --win --x64",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
+    "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/bench/run.mjs",
-    "bench:anim": "node scripts/bench/anim.mjs"
+    "bench:anim": "node scripts/bench/anim.mjs",
+    "prepare:koffi": "node scripts/ensure-koffi-win32-native.mjs",
+    "verify:win-koffi": "node scripts/verify-win-koffi-native.mjs"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.10)
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -341,9 +338,6 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -929,16 +923,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@huggingface/jinja@0.5.9':
-    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
-    engines: {node: '>=18'}
-
-  '@huggingface/tokenizers@0.1.3':
-    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
-
-  '@huggingface/transformers@4.2.0':
-    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -958,159 +942,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2000,10 +1831,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2765,9 +2592,6 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatbuffers@25.9.23:
-    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
-
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -2908,9 +2732,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  guid-typescript@1.0.9:
-    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3460,19 +3281,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
-
-  onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
-
-  onnxruntime-node@1.24.3:
-    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
-    os: [win32, darwin, linux]
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3544,9 +3352,6 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
-
-  platform@1.3.6:
-    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -3900,10 +3705,6 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
-
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4719,7 +4520,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4742,7 +4543,7 @@ snapshots:
       dir-compare: 4.2.0
       fs-extra: 11.3.5
       minimatch: 9.0.9
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4755,11 +4556,6 @@ snapshots:
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -5313,18 +5109,6 @@ snapshots:
       protobufjs: 7.6.2
       yargs: 17.7.2
 
-  '@huggingface/jinja@0.5.9': {}
-
-  '@huggingface/tokenizers@0.1.3': {}
-
-  '@huggingface/transformers@4.2.0':
-    dependencies:
-      '@huggingface/jinja': 0.5.9
-      '@huggingface/tokenizers': 0.1.3
-      onnxruntime-node: 1.24.3
-      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
-      sharp: 0.34.5
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5340,102 +5124,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@img/colour@1.1.0': {}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.10.0
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -6283,8 +5971,7 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xmldom/xmldom@0.9.10':
-    optional: true
+  '@xmldom/xmldom@0.9.10': {}
 
   abbrev@4.0.0: {}
 
@@ -6293,8 +5980,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -6508,7 +6193,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  boolean@3.2.0: {}
+  boolean@3.2.0:
+    optional: true
 
   brace-expansion@1.1.15:
     dependencies:
@@ -6807,7 +6493,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  detect-node@2.1.0: {}
+  detect-node@2.1.0:
+    optional: true
 
   didyoumean@1.2.2: {}
 
@@ -7050,7 +6737,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es6-error@4.1.1: {}
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -7350,8 +7038,6 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
-  flatbuffers@25.9.23: {}
-
   flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
@@ -7484,6 +7170,7 @@ snapshots:
       roarr: 2.15.4
       semver: 7.8.1
       serialize-error: 7.0.1
+    optional: true
 
   globals@14.0.0: {}
 
@@ -7513,8 +7200,6 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
-
-  guid-typescript@1.0.9: {}
 
   has-bigints@1.1.0: {}
 
@@ -7792,7 +7477,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1: {}
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -7893,6 +7579,7 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -8052,25 +7739,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
-
-  onnxruntime-common@1.24.3: {}
-
-  onnxruntime-node@1.24.3:
-    dependencies:
-      adm-zip: 0.5.17
-      global-agent: 3.0.0
-      onnxruntime-common: 1.24.3
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    dependencies:
-      flatbuffers: 25.9.23
-      guid-typescript: 1.0.9
-      long: 5.3.2
-      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
-      platform: 1.3.6
-      protobufjs: 7.6.2
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8126,8 +7794,6 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  platform@1.3.6: {}
-
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.13
@@ -8139,7 +7805,6 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-    optional: true
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8417,6 +8082,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
+    optional: true
 
   rollup@4.61.0:
     dependencies:
@@ -8484,7 +8150,8 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver-compare@1.0.0: {}
+  semver-compare@1.0.0:
+    optional: true
 
   semver@5.7.2: {}
 
@@ -8497,6 +8164,7 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+    optional: true
 
   set-cookie-parser@2.7.2: {}
 
@@ -8521,37 +8189,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
-
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.1
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -8622,7 +8259,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  sprintf-js@1.1.3: {}
+  sprintf-js@1.1.3:
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -8896,7 +8534,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1: {}
+  type-fest@0.13.1:
+    optional: true
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/desktop/windows/pnpm-workspace.yaml
+++ b/desktop/windows/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ allowBuilds:
   onnxruntime-node: true
   protobufjs: true
   sharp: true
+supportedArchitectures:
+  os:
+    - current
+    - win32
+  cpu:
+    - current
+    - x64
+  libc:
+    - current

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -1,0 +1,47 @@
+import { copyFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
+const koffiEntry = requireFromRoot.resolve('koffi')
+const koffiRoot = dirname(koffiEntry)
+const koffiRequire = createRequire(koffiEntry)
+
+const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
+const koffiPackage = readJson(join(koffiRoot, 'package.json'))
+
+let nativePackageJson
+let source
+try {
+  const nativeEntry = koffiRequire.resolve('@koromix/koffi-win32-x64')
+  nativePackageJson = join(dirname(nativeEntry), 'package.json')
+  source = join(dirname(nativeEntry), 'win32_x64', 'koffi.node')
+} catch (error) {
+  throw new Error(
+    [
+      'Missing @koromix/koffi-win32-x64.',
+      'Run npm install from desktop/windows on Windows so npm installs win32/x64 optional dependencies.'
+    ].join(' '),
+    { cause: error }
+  )
+}
+
+const nativePackage = readJson(nativePackageJson)
+if (nativePackage.version !== koffiPackage.version) {
+  throw new Error(
+    `Koffi native package version mismatch: koffi=${koffiPackage.version}, @koromix/koffi-win32-x64=${nativePackage.version}`
+  )
+}
+
+const sourceSize = statSync(source).size
+if (sourceSize <= 0) {
+  throw new Error(`Koffi native module is empty: ${source}`)
+}
+
+const targetDir = join(projectRoot, 'resources', 'koffi', 'win32_x64')
+const target = join(targetDir, 'koffi.node')
+mkdirSync(targetDir, { recursive: true })
+copyFileSync(source, target)
+console.log(`[ensure-koffi-win32-native] staged ${target} (${sourceSize} bytes)`)

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -1,0 +1,43 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageRoots =
+  process.argv.length > 2
+    ? process.argv.slice(2).map((path) => resolve(path))
+    : [join(projectRoot, 'dist', 'win-unpacked')]
+
+const verifyPeFile = (file) => {
+  const stat = statSync(file)
+  if (stat.size <= 0) {
+    throw new Error(`Koffi native module is empty: ${file}`)
+  }
+
+  const fd = openSync(file, 'r')
+  const header = Buffer.alloc(2)
+  try {
+    readSync(fd, header, 0, 2, 0)
+  } finally {
+    closeSync(fd)
+  }
+  if (header.toString('ascii') !== 'MZ') {
+    throw new Error(`Koffi native module is not a Windows binary: ${file}`)
+  }
+  return stat.size
+}
+
+const tried = []
+for (const root of packageRoots) {
+  const file = join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node')
+  tried.push(file)
+  try {
+    const size = verifyPeFile(file)
+    console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
+    process.exit(0)
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+
+throw new Error(`Missing packaged Koffi native module. Checked: ${tried.join(', ')}`)

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -29,14 +29,39 @@ const verifyPeFile = (file) => {
 
 const tried = []
 for (const root of packageRoots) {
-  const file = join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node')
-  tried.push(file)
-  try {
-    const size = verifyPeFile(file)
-    console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
-    process.exit(0)
-  } catch (error) {
-    if (error.code !== 'ENOENT') throw error
+  const candidates = [
+    join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node'),
+    join(
+      root,
+      'resources',
+      'app.asar.unpacked',
+      'node_modules',
+      'koffi',
+      'build',
+      'koffi',
+      'win32_x64',
+      'koffi.node'
+    ),
+    join(
+      root,
+      'resources',
+      'app.asar.unpacked',
+      'node_modules',
+      '@koromix',
+      'koffi-win32-x64',
+      'win32_x64',
+      'koffi.node'
+    )
+  ]
+  for (const file of candidates) {
+    tried.push(file)
+    try {
+      const size = verifyPeFile(file)
+      console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
+      process.exit(0)
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error
+    }
   }
 }
 

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   stopAutomationTargetTracker
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
+import { registerLocalAgentHandlers } from './ipc/localAgent'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -290,6 +291,7 @@ app.whenReady().then(async () => {
   registerMemoryExportHandlers()
   registerKgHandlers()
   registerIntegrationsHandlers()
+  registerLocalAgentHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -37,6 +37,7 @@ import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
 import { startRewindRetention } from './rewind/retentionRunner'
 import { prewarmPrimarySourceId } from './rewind/sourceId'
+import { startLocalAgentServerIfEnabled, stopLocalAgentServer } from './localAgent/server'
 import { perfMark, flushPerfMarks } from '../shared/perf'
 
 // Default the perf log to the user data dir so marks double as lightweight prod
@@ -205,6 +206,9 @@ app.whenReady().then(async () => {
   }
   // Set app user model id for windows
   electronApp.setAppUserModelId('com.omiwindows.app')
+  void startLocalAgentServerIfEnabled().catch((e) => {
+    console.error('[local-agent] failed to start:', e)
+  })
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
@@ -450,6 +454,7 @@ app.on('window-all-closed', () => {
 app.on('will-quit', () => {
   unregisterOverlayShortcut()
   flushPerfMarks()
+  void stopLocalAgentServer()
   automationBridge.dispose()
   stopAutomationTargetTracker()
 })

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -991,11 +991,51 @@ export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
   })
 }
 
+export function getRewindFrame(id: number): RewindFrame | null {
+  const row = get().prepare(`SELECT ${REWIND_COLUMNS} FROM rewind_frames WHERE id = ?`).get(id) as
+    | RewindFrame
+    | undefined
+  return row ?? null
+}
+
 export function rewindDayBounds(): { min: number; max: number } | null {
   const row = get()
     .prepare('SELECT MIN(ts) AS min, MAX(ts) AS max FROM rewind_frames')
     .get() as { min: number | null; max: number | null }
   return row.min == null || row.max == null ? null : { min: row.min, max: row.max }
+}
+
+export function rewindStatusStats(): {
+  latestFrameTs: number | null
+  oldestFrameTs: number | null
+  totalFrameCount: number
+  indexedFrameCount: number
+  ocrBacklogCount: number
+} {
+  const row = get()
+    .prepare(
+      `SELECT
+         MIN(ts) AS oldestFrameTs,
+         MAX(ts) AS latestFrameTs,
+         COUNT(*) AS totalFrameCount,
+         SUM(CASE WHEN indexed = 1 THEN 1 ELSE 0 END) AS indexedFrameCount,
+         SUM(CASE WHEN indexed = 0 THEN 1 ELSE 0 END) AS ocrBacklogCount
+       FROM rewind_frames`
+    )
+    .get() as {
+    oldestFrameTs: number | null
+    latestFrameTs: number | null
+    totalFrameCount: number
+    indexedFrameCount: number | null
+    ocrBacklogCount: number | null
+  }
+  return {
+    latestFrameTs: row.latestFrameTs,
+    oldestFrameTs: row.oldestFrameTs,
+    totalFrameCount: row.totalFrameCount,
+    indexedFrameCount: row.indexedFrameCount ?? 0,
+    ocrBacklogCount: row.ocrBacklogCount ?? 0
+  }
 }
 
 /** The single most-recent captured frame (Omi's own windows are never captured),

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -38,6 +38,10 @@ function timed<T>(name: string, fn: () => T): T {
 let db: Database.Database | null = null
 let roDb: Database.Database | null = null
 
+function dbFilePath(): string {
+  return process.env.OMI_DB_PATH ?? join(app.getPath('userData'), 'omi.db')
+}
+
 // Add a column only if it doesn't already exist, so existing databases (which
 // predate the `kind`/`messages` columns) migrate forward without data loss.
 function ensureColumn(d: Database.Database, table: string, col: string, decl: string): void {
@@ -66,7 +70,7 @@ function get(): Database.Database {
   if (db) return db
   // OMI_DB_PATH lets the bench harness point at a throwaway DB so benchmarking
   // never reads or writes the user's real omi.db.
-  const file = process.env.OMI_DB_PATH ?? join(app.getPath('userData'), 'omi.db')
+  const file = dbFilePath()
   db = new Database(file)
   // For the throwaway bench DB only, relax durability so seeding ~7k rows isn't
   // dominated by a per-insert fsync (otherwise it swamps the startup measurement).
@@ -455,7 +459,7 @@ export function getLocalKGStatus(): LocalKGStatus {
 function getReadonly(): Database.Database {
   if (roDb) return roDb
   get() // ensure the db file + schema exist before opening read-only
-  roDb = new Database(join(app.getPath('userData'), 'omi.db'), { readonly: true })
+  roDb = new Database(dbFilePath(), { readonly: true })
   return roDb
 }
 
@@ -469,6 +473,246 @@ export function execSafeSelect(sql: string): KgSqlResult {
     ? Object.keys(rows[0])
     : (stmt.columns().map((c) => c.name) ?? [])
   return { columns, rows }
+}
+
+export type LocalTaskSearchRecord = {
+  source: string
+  id: string
+  backendId: string | null
+  description: string
+  completed: boolean
+  deleted: boolean
+  dueAt: string | number | null
+  createdAt: string | number | null
+  updatedAt: string | number | null
+  priority: string | null
+}
+
+export type LocalTaskSearchResult = {
+  available: boolean
+  reason?: string
+  sources: string[]
+  tasks: LocalTaskSearchRecord[]
+}
+
+type TaskTableSpec = {
+  table: string
+  id: string[]
+  backendId: string[]
+  description: string[]
+  completed: string[]
+  deleted: string[]
+  dueAt: string[]
+  createdAt: string[]
+  updatedAt: string[]
+  priority: string[]
+}
+
+const TASK_TABLE_SPECS: TaskTableSpec[] = [
+  {
+    table: 'action_items',
+    id: ['backendId', 'backend_id', 'id'],
+    backendId: ['backendId', 'backend_id'],
+    description: ['description', 'title', 'text', 'content'],
+    completed: ['completed', 'is_completed'],
+    deleted: ['deleted', 'is_deleted'],
+    dueAt: ['dueAt', 'due_at'],
+    createdAt: ['createdAt', 'created_at'],
+    updatedAt: ['updatedAt', 'updated_at'],
+    priority: ['priority']
+  },
+  {
+    table: 'staged_tasks',
+    id: ['id', 'backendId', 'backend_id'],
+    backendId: ['backendId', 'backend_id'],
+    description: ['description', 'title', 'text', 'content'],
+    completed: ['completed', 'is_completed'],
+    deleted: ['deleted', 'is_deleted'],
+    dueAt: ['dueAt', 'due_at'],
+    createdAt: ['createdAt', 'created_at'],
+    updatedAt: ['updatedAt', 'updated_at'],
+    priority: ['priority']
+  }
+]
+
+type LocalTaskSearchRow = {
+  source: string
+  id: unknown
+  backendId: unknown
+  description: string
+  completed: number
+  deleted: number
+  dueAt: unknown
+  createdAt: unknown
+  updatedAt: unknown
+  priority: unknown
+}
+
+function safeIdent(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) throw new Error(`unsafe identifier: ${name}`)
+  return `"${name}"`
+}
+
+function tableExists(d: Database.Database, table: string): boolean {
+  const row = d
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name=?")
+    .get(table) as { ok: number } | undefined
+  return row?.ok === 1
+}
+
+function tableColumns(d: Database.Database, table: string): Map<string, string> {
+  const rows = d.prepare(`PRAGMA table_info(${safeIdent(table)})`).all() as { name: string }[]
+  const out = new Map<string, string>()
+  for (const row of rows) out.set(row.name.toLowerCase(), row.name)
+  return out
+}
+
+function firstColumn(columns: Map<string, string>, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const column = columns.get(candidate.toLowerCase())
+    if (column) return column
+  }
+  return null
+}
+
+function coalesceColumnExpr(
+  columns: Map<string, string>,
+  candidates: string[],
+  fallbackSql: string
+): string {
+  const matches = candidates
+    .map((candidate) => firstColumn(columns, [candidate]))
+    .filter((column): column is string => column != null)
+  if (matches.length === 0) return fallbackSql
+  return `COALESCE(${matches.map(safeIdent).join(', ')}, ${fallbackSql})`
+}
+
+function booleanColumnExpr(column: string | null): string {
+  if (!column) return '0'
+  const quoted = safeIdent(column)
+  return `CASE WHEN ${quoted} IN (1, '1', 'true', 'TRUE') THEN 1 ELSE 0 END`
+}
+
+function optionalColumnExpr(column: string | null): string {
+  return column ? safeIdent(column) : 'NULL'
+}
+
+function localTaskValue(value: unknown): string | number | null {
+  if (typeof value === 'string' || typeof value === 'number') return value
+  return null
+}
+
+function localTaskString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function localTaskTimestampValue(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value)
+    if (Number.isFinite(numeric)) return numeric
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function mapLocalTaskRow(row: LocalTaskSearchRow): LocalTaskSearchRecord {
+  const fallbackId = `${row.source}:${row.description}:${String(row.createdAt ?? '')}`
+  return {
+    source: row.source,
+    id: String(row.id || row.backendId || fallbackId),
+    backendId: localTaskString(row.backendId),
+    description: row.description,
+    completed: row.completed === 1,
+    deleted: row.deleted === 1,
+    dueAt: localTaskValue(row.dueAt),
+    createdAt: localTaskValue(row.createdAt),
+    updatedAt: localTaskValue(row.updatedAt),
+    priority: localTaskString(row.priority)
+  }
+}
+
+export function searchLocalTasks(
+  query: string,
+  includeCompleted = false,
+  limit = 20
+): LocalTaskSearchResult {
+  const d = getReadonly()
+  const cappedLimit = Math.min(50, Math.max(1, Math.trunc(limit)))
+  const trimmed = query.trim()
+  const tasks: LocalTaskSearchRecord[] = []
+  const sources: string[] = []
+
+  for (const spec of TASK_TABLE_SPECS) {
+    if (!tableExists(d, spec.table)) continue
+    const columns = tableColumns(d, spec.table)
+    const descriptionColumn = firstColumn(columns, spec.description)
+    if (!descriptionColumn) continue
+
+    sources.push(spec.table)
+    const completedColumn = firstColumn(columns, spec.completed)
+    const deletedColumn = firstColumn(columns, spec.deleted)
+    const createdColumn = firstColumn(columns, spec.createdAt)
+    const titleColumn = firstColumn(columns, ['title'])
+    const searchColumns = [...new Set([descriptionColumn, titleColumn].filter(Boolean))] as string[]
+
+    const where: string[] = []
+    const params: unknown[] = []
+    if (deletedColumn) where.push(`${booleanColumnExpr(deletedColumn)} = 0`)
+    if (!includeCompleted && completedColumn)
+      where.push(`${booleanColumnExpr(completedColumn)} = 0`)
+    if (trimmed) {
+      const needles = [
+        trimmed,
+        ...trimmed
+          .split(/\s+/)
+          .map((part) => part.trim())
+          .filter((part) => part.length >= 2 && part !== trimmed)
+      ]
+      const searchParts = needles.map((needle) => {
+        for (let index = 0; index < searchColumns.length; index += 1) params.push(`%${needle}%`)
+        return `(${searchColumns.map((column) => `${safeIdent(column)} LIKE ?`).join(' OR ')})`
+      })
+      where.push(`(${searchParts.join(' OR ')})`)
+    }
+
+    const sql = `
+      SELECT
+        '${spec.table}' AS source,
+        ${coalesceColumnExpr(columns, spec.id, "''")} AS id,
+        ${coalesceColumnExpr(columns, spec.backendId, 'NULL')} AS backendId,
+        ${safeIdent(descriptionColumn)} AS description,
+        ${booleanColumnExpr(completedColumn)} AS completed,
+        ${booleanColumnExpr(deletedColumn)} AS deleted,
+        ${optionalColumnExpr(firstColumn(columns, spec.dueAt))} AS dueAt,
+        ${optionalColumnExpr(createdColumn)} AS createdAt,
+        ${optionalColumnExpr(firstColumn(columns, spec.updatedAt))} AS updatedAt,
+        ${optionalColumnExpr(firstColumn(columns, spec.priority))} AS priority
+      FROM ${safeIdent(spec.table)}
+      ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY ${createdColumn ? safeIdent(createdColumn) : 'rowid'} DESC
+      LIMIT ?
+    `
+    const rows = d.prepare(sql).all(...params, cappedLimit) as LocalTaskSearchRow[]
+    tasks.push(...rows.map(mapLocalTaskRow))
+  }
+
+  if (sources.length === 0) {
+    return {
+      available: false,
+      reason: 'No supported local task tables were found in the Windows main-process database.',
+      sources: [],
+      tasks: []
+    }
+  }
+
+  tasks.sort((a, b) => localTaskTimestampValue(b.createdAt) - localTaskTimestampValue(a.createdAt))
+  return {
+    available: true,
+    sources,
+    tasks: tasks.slice(0, cappedLimit)
+  }
 }
 
 type LocalKGNodeRow = {

--- a/desktop/windows/src/main/ipc/localAgent.ts
+++ b/desktop/windows/src/main/ipc/localAgent.ts
@@ -1,0 +1,35 @@
+import { ipcMain } from 'electron'
+import type { LocalAgentStatus, LocalAgentToolsTestResult } from '../../shared/types'
+import {
+  copyLocalAgentToken,
+  getLocalAgentStatus,
+  rotateLocalAgentAccessToken,
+  setLocalAgentEnabled,
+  setLocalAgentPort,
+  testLocalAgentTools
+} from '../localAgent/control'
+
+export function registerLocalAgentHandlers(): void {
+  ipcMain.handle('localAgent:status', async (): Promise<LocalAgentStatus> => getLocalAgentStatus())
+  ipcMain.handle(
+    'localAgent:setEnabled',
+    async (_e, enabled: boolean): Promise<LocalAgentStatus> =>
+      setLocalAgentEnabled(enabled === true)
+  )
+  ipcMain.handle(
+    'localAgent:setPort',
+    async (_e, port: number): Promise<LocalAgentStatus> => setLocalAgentPort(port)
+  )
+  ipcMain.handle(
+    'localAgent:copyToken',
+    async (): Promise<LocalAgentStatus> => copyLocalAgentToken()
+  )
+  ipcMain.handle(
+    'localAgent:rotateToken',
+    async (): Promise<LocalAgentStatus> => rotateLocalAgentAccessToken()
+  )
+  ipcMain.handle(
+    'localAgent:testTools',
+    async (): Promise<LocalAgentToolsTestResult> => testLocalAgentTools()
+  )
+}

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -1,0 +1,189 @@
+import { createServer } from 'http'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true,
+  clipboardText: ''
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  clipboard: {
+    writeText: (value: string): void => {
+      electronState.clipboardText = value
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+import {
+  copyLocalAgentToken,
+  getLocalAgentStatus,
+  rotateLocalAgentAccessToken,
+  setLocalAgentEnabled,
+  setLocalAgentPort,
+  testLocalAgentTools
+} from './control'
+import { stopLocalAgentServer } from './server'
+import { loadLocalAgentToken } from './tokenStore'
+import { LOCAL_AGENT_DEFAULT_PORT } from './settings'
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('could not allocate port')))
+        return
+      }
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve(address.port)
+      })
+    })
+  })
+}
+
+async function twoFreePorts(): Promise<[number, number]> {
+  const first = await freePort()
+  let second = await freePort()
+  while (second === first) {
+    second = await freePort()
+  }
+  return [first, second]
+}
+
+async function fetchTools(localUrl: string, token: string): Promise<Response> {
+  return fetch(`${localUrl}/v1/local/tools`, {
+    headers: { authorization: `Bearer ${token}` }
+  })
+}
+
+describe('local agent controls', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-control-'))
+    electronState.encryptionAvailable = true
+    electronState.clipboardText = ''
+  })
+
+  afterEach(async () => {
+    await stopLocalAgentServer()
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('is disabled by default and does not expose a token in status', () => {
+    expect(getLocalAgentStatus()).toEqual({
+      enabled: false,
+      running: false,
+      host: '127.0.0.1',
+      configuredPort: LOCAL_AGENT_DEFAULT_PORT,
+      currentPort: null,
+      localUrl: null,
+      toolEndpoint: null,
+      hasToken: false
+    })
+  })
+
+  it('enables and disables the loopback server from settings', async () => {
+    const port = await freePort()
+    await setLocalAgentPort(port)
+
+    const enabled = await setLocalAgentEnabled(true)
+    expect(enabled).toMatchObject({
+      enabled: true,
+      running: true,
+      host: '127.0.0.1',
+      configuredPort: port,
+      currentPort: port,
+      localUrl: `http://127.0.0.1:${port}`
+    })
+
+    await expect(fetch(`${enabled.localUrl}/health`)).resolves.toMatchObject({ status: 200 })
+
+    const disabled = await setLocalAgentEnabled(false)
+    expect(disabled).toMatchObject({
+      enabled: false,
+      running: false,
+      configuredPort: port,
+      currentPort: null,
+      localUrl: null
+    })
+    await expect(fetch(`${enabled.localUrl}/health`)).rejects.toThrow()
+  })
+
+  it('restarts on a saved port change while enabled', async () => {
+    const [firstPort, secondPort] = await twoFreePorts()
+    await setLocalAgentPort(firstPort)
+    const first = await setLocalAgentEnabled(true)
+
+    const second = await setLocalAgentPort(secondPort)
+
+    expect(second).toMatchObject({
+      enabled: true,
+      running: true,
+      configuredPort: secondPort,
+      currentPort: secondPort,
+      localUrl: `http://127.0.0.1:${secondPort}`
+    })
+    await expect(fetch(`${first.localUrl}/health`)).rejects.toThrow()
+    await expect(fetch(`${second.localUrl}/health`)).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('copies the bearer token without returning it in status', () => {
+    const status = copyLocalAgentToken()
+
+    expect(electronState.clipboardText).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(status.hasToken).toBe(true)
+    expect(status).not.toHaveProperty('token')
+  })
+
+  it('rotates the bearer token and invalidates the old one', async () => {
+    const port = await freePort()
+    await setLocalAgentPort(port)
+    const started = await setLocalAgentEnabled(true)
+    const oldToken = loadLocalAgentToken()
+    if (!oldToken || !started.localUrl) throw new Error('expected started local agent')
+
+    await expect(fetchTools(started.localUrl, oldToken)).resolves.toMatchObject({ status: 200 })
+
+    const rotated = await rotateLocalAgentAccessToken()
+    const newToken = loadLocalAgentToken()
+    if (!newToken || !rotated.localUrl) throw new Error('expected rotated local agent')
+
+    expect(newToken).not.toBe(oldToken)
+    await expect(fetchTools(rotated.localUrl, oldToken)).resolves.toMatchObject({ status: 401 })
+    await expect(fetchTools(rotated.localUrl, newToken)).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('tests the authenticated local tools endpoint', async () => {
+    await expect(testLocalAgentTools()).resolves.toMatchObject({
+      ok: false,
+      error: 'Local agent API is not listening'
+    })
+
+    await setLocalAgentPort(await freePort())
+    await setLocalAgentEnabled(true)
+
+    await expect(testLocalAgentTools()).resolves.toMatchObject({
+      ok: true,
+      status: 200
+    })
+  })
+})

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'http'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -160,6 +160,18 @@ describe('local agent controls', () => {
 
     vi.advanceTimersByTime(60_000)
     expect(electronState.clipboardText).toBe('')
+  })
+
+  it('does not expose raw token-store errors in status', () => {
+    writeFileSync(join(electronState.userData, 'local-agent-token.json'), '{not-json', 'utf8')
+
+    const status = getLocalAgentStatus()
+
+    expect(status.hasToken).toBe(false)
+    expect(status.tokenError).toBe(
+      'Local agent token is unavailable. Rotate the token to repair local access.'
+    )
+    expect(status.tokenError).not.toContain(electronState.userData)
   })
 
   it('rotates the bearer token and invalidates the old one', async () => {

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -22,7 +22,8 @@ vi.mock('electron', () => ({
   clipboard: {
     writeText: (value: string): void => {
       electronState.clipboardText = value
-    }
+    },
+    readText: (): string => electronState.clipboardText
   },
   safeStorage: {
     isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
@@ -84,6 +85,7 @@ describe('local agent controls', () => {
   })
 
   afterEach(async () => {
+    vi.useRealTimers()
     await stopLocalAgentServer()
     rmSync(electronState.userData, { recursive: true, force: true })
   })
@@ -97,7 +99,8 @@ describe('local agent controls', () => {
       currentPort: null,
       localUrl: null,
       toolEndpoint: null,
-      hasToken: false
+      hasToken: false,
+      tokenError: null
     })
   })
 
@@ -147,11 +150,16 @@ describe('local agent controls', () => {
   })
 
   it('copies the bearer token without returning it in status', () => {
+    vi.useFakeTimers()
     const status = copyLocalAgentToken()
 
     expect(electronState.clipboardText).toMatch(/^[A-Za-z0-9_-]+$/)
     expect(status.hasToken).toBe(true)
+    expect(status.tokenError).toBeNull()
     expect(status).not.toHaveProperty('token')
+
+    vi.advanceTimersByTime(60_000)
+    expect(electronState.clipboardText).toBe('')
   })
 
   it('rotates the bearer token and invalidates the old one', async () => {

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -169,7 +169,7 @@ describe('local agent controls', () => {
 
     expect(status.hasToken).toBe(false)
     expect(status.tokenError).toBe(
-      'Local agent token is unavailable. Rotate the token to repair local access.'
+      'Local agent token is unavailable. Check secure storage and rotate the token if needed.'
     )
     expect(status.tokenError).not.toContain(electronState.userData)
   })

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -86,6 +86,7 @@ describe('local agent controls', () => {
 
   afterEach(async () => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
     await stopLocalAgentServer()
     rmSync(electronState.userData, { recursive: true, force: true })
   })
@@ -174,7 +175,6 @@ describe('local agent controls', () => {
     )
     expect(status.tokenError).not.toContain(electronState.userData)
     expect(warnSpy).toHaveBeenCalledWith('[local-agent] failed to load token:', expect.anything())
-    warnSpy.mockRestore()
   })
 
   it('rotates the bearer token and invalidates the old one', async () => {

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -163,6 +163,7 @@ describe('local agent controls', () => {
   })
 
   it('does not expose raw token-store errors in status', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     writeFileSync(join(electronState.userData, 'local-agent-token.json'), '{not-json', 'utf8')
 
     const status = getLocalAgentStatus()
@@ -172,6 +173,8 @@ describe('local agent controls', () => {
       'Local agent token is unavailable. Check secure storage and rotate the token if needed.'
     )
     expect(status.tokenError).not.toContain(electronState.userData)
+    expect(warnSpy).toHaveBeenCalledWith('[local-agent] failed to load token:', expect.anything())
+    warnSpy.mockRestore()
   })
 
   it('rotates the bearer token and invalidates the old one', async () => {

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -1,0 +1,99 @@
+import { clipboard } from 'electron'
+import type { LocalAgentStatus, LocalAgentToolsTestResult } from '../../shared/types'
+import { getLocalAgentSettings, setLocalAgentSettings } from './settings'
+import { getLocalAgentServerInfo, startLocalAgentServer, stopLocalAgentServer } from './server'
+import { ensureLocalAgentToken, loadLocalAgentToken, rotateLocalAgentToken } from './tokenStore'
+
+const LOCAL_AGENT_HOST = '127.0.0.1'
+
+function validatePort(port: number): number {
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error('Local agent port must be between 1024 and 65535')
+  }
+  return port
+}
+
+export function getLocalAgentStatus(): LocalAgentStatus {
+  const settings = getLocalAgentSettings()
+  const info = getLocalAgentServerInfo()
+  return {
+    enabled: settings.enabled,
+    running: info !== null,
+    host: info?.host ?? LOCAL_AGENT_HOST,
+    configuredPort: settings.port,
+    currentPort: info?.port ?? null,
+    localUrl: info?.localUrl ?? null,
+    toolEndpoint: info?.toolEndpoint ?? null,
+    hasToken: loadLocalAgentToken() !== null
+  }
+}
+
+export async function setLocalAgentEnabled(enabled: boolean): Promise<LocalAgentStatus> {
+  const settings = setLocalAgentSettings({ ...getLocalAgentSettings(), enabled })
+  if (!enabled) {
+    await stopLocalAgentServer()
+    return getLocalAgentStatus()
+  }
+
+  await startLocalAgentServer({ preferredPort: settings.port })
+  return getLocalAgentStatus()
+}
+
+export async function setLocalAgentPort(port: number): Promise<LocalAgentStatus> {
+  const validatedPort = validatePort(port)
+  const settings = setLocalAgentSettings({ ...getLocalAgentSettings(), port: validatedPort })
+
+  if (settings.enabled) {
+    await stopLocalAgentServer()
+    await startLocalAgentServer({ preferredPort: settings.port })
+  }
+
+  return getLocalAgentStatus()
+}
+
+export function copyLocalAgentToken(): LocalAgentStatus {
+  clipboard.writeText(ensureLocalAgentToken())
+  return getLocalAgentStatus()
+}
+
+export async function rotateLocalAgentAccessToken(): Promise<LocalAgentStatus> {
+  rotateLocalAgentToken()
+  const settings = getLocalAgentSettings()
+
+  if (settings.enabled) {
+    await stopLocalAgentServer()
+    await startLocalAgentServer({ preferredPort: settings.port })
+  }
+
+  return getLocalAgentStatus()
+}
+
+export async function testLocalAgentTools(): Promise<LocalAgentToolsTestResult> {
+  const info = getLocalAgentServerInfo()
+  if (!info) {
+    return { ok: false, error: 'Local agent API is not listening' }
+  }
+
+  const token = loadLocalAgentToken()
+  if (!token) {
+    return { ok: false, error: 'Local agent token is missing' }
+  }
+
+  try {
+    const response = await fetch(`${info.localUrl}/v1/local/tools`, {
+      headers: { authorization: `Bearer ${token}` }
+    })
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` }
+    }
+
+    const body = (await response.json()) as { tools?: unknown[] }
+    const toolCount = Array.isArray(body.tools) ? body.tools.length : 0
+    return { ok: true, status: response.status, toolCount }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Local agent tools test failed'
+    }
+  }
+}

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -5,6 +5,9 @@ import { getLocalAgentServerInfo, startLocalAgentServer, stopLocalAgentServer } 
 import { ensureLocalAgentToken, loadLocalAgentToken, rotateLocalAgentToken } from './tokenStore'
 
 const LOCAL_AGENT_HOST = '127.0.0.1'
+const TOKEN_CLIPBOARD_TTL_MS = 60_000
+
+let tokenClipboardClearTimer: NodeJS.Timeout | null = null
 
 function validatePort(port: number): number {
   if (!Number.isInteger(port) || port < 1024 || port > 65535) {
@@ -16,6 +19,13 @@ function validatePort(port: number): number {
 export function getLocalAgentStatus(): LocalAgentStatus {
   const settings = getLocalAgentSettings()
   const info = getLocalAgentServerInfo()
+  let hasToken = false
+  let tokenError: string | null = null
+  try {
+    hasToken = loadLocalAgentToken() !== null
+  } catch (error) {
+    tokenError = error instanceof Error ? error.message : 'Failed to load local agent token'
+  }
   return {
     enabled: settings.enabled,
     running: info !== null,
@@ -24,7 +34,8 @@ export function getLocalAgentStatus(): LocalAgentStatus {
     currentPort: info?.port ?? null,
     localUrl: info?.localUrl ?? null,
     toolEndpoint: info?.toolEndpoint ?? null,
-    hasToken: loadLocalAgentToken() !== null
+    hasToken,
+    tokenError
   }
 }
 
@@ -52,7 +63,15 @@ export async function setLocalAgentPort(port: number): Promise<LocalAgentStatus>
 }
 
 export function copyLocalAgentToken(): LocalAgentStatus {
-  clipboard.writeText(ensureLocalAgentToken())
+  const token = ensureLocalAgentToken()
+  clipboard.writeText(token)
+  if (tokenClipboardClearTimer) clearTimeout(tokenClipboardClearTimer)
+  tokenClipboardClearTimer = setTimeout(() => {
+    if (clipboard.readText() === token) {
+      clipboard.writeText('')
+    }
+    tokenClipboardClearTimer = null
+  }, TOKEN_CLIPBOARD_TTL_MS)
   return getLocalAgentStatus()
 }
 
@@ -74,12 +93,12 @@ export async function testLocalAgentTools(): Promise<LocalAgentToolsTestResult> 
     return { ok: false, error: 'Local agent API is not listening' }
   }
 
-  const token = loadLocalAgentToken()
-  if (!token) {
-    return { ok: false, error: 'Local agent token is missing' }
-  }
-
   try {
+    const token = loadLocalAgentToken()
+    if (!token) {
+      return { ok: false, error: 'Local agent token is missing' }
+    }
+
     const response = await fetch(`${info.localUrl}/v1/local/tools`, {
       headers: { authorization: `Bearer ${token}` }
     })

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -17,7 +17,7 @@ function validatePort(port: number): number {
 }
 
 function tokenStatusError(): string {
-  return 'Local agent token is unavailable. Rotate the token to repair local access.'
+  return 'Local agent token is unavailable. Check secure storage and rotate the token if needed.'
 }
 
 export function getLocalAgentStatus(): LocalAgentStatus {
@@ -76,7 +76,6 @@ export function copyLocalAgentToken(): LocalAgentStatus {
     }
     tokenClipboardClearTimer = null
   }, TOKEN_CLIPBOARD_TTL_MS)
-  tokenClipboardClearTimer.unref?.()
   return getLocalAgentStatus()
 }
 

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -27,7 +27,8 @@ export function getLocalAgentStatus(): LocalAgentStatus {
   let tokenError: string | null = null
   try {
     hasToken = loadLocalAgentToken() !== null
-  } catch {
+  } catch (error) {
+    console.warn('[local-agent] failed to load token:', error)
     tokenError = tokenStatusError()
   }
   return {

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -16,6 +16,10 @@ function validatePort(port: number): number {
   return port
 }
 
+function tokenStatusError(): string {
+  return 'Local agent token is unavailable. Rotate the token to repair local access.'
+}
+
 export function getLocalAgentStatus(): LocalAgentStatus {
   const settings = getLocalAgentSettings()
   const info = getLocalAgentServerInfo()
@@ -23,8 +27,8 @@ export function getLocalAgentStatus(): LocalAgentStatus {
   let tokenError: string | null = null
   try {
     hasToken = loadLocalAgentToken() !== null
-  } catch (error) {
-    tokenError = error instanceof Error ? error.message : 'Failed to load local agent token'
+  } catch {
+    tokenError = tokenStatusError()
   }
   return {
     enabled: settings.enabled,
@@ -72,6 +76,7 @@ export function copyLocalAgentToken(): LocalAgentStatus {
     }
     tokenClipboardClearTimer = null
   }, TOKEN_CLIPBOARD_TTL_MS)
+  tokenClipboardClearTimer.unref?.()
   return getLocalAgentStatus()
 }
 

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -100,10 +100,24 @@ describe('local agent server', () => {
     const tools = await fetch(`${info.localUrl}/v1/local/tools`, {
       headers: { authorization: 'Bearer test-token' }
     })
-    await expect(tools.json()).resolves.toEqual({
-      tools: [],
+    const toolsBody = await tools.json()
+    expect(toolsBody).toMatchObject({
+      ok: true,
       toolEndpoint: `${info.localUrl}/v1/local/tool`
     })
+    expect(toolsBody.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'get_local_status',
+        'execute_sql',
+        'search_screen_history',
+        'semantic_search',
+        'get_screenshot',
+        'get_daily_recap',
+        'search_tasks',
+        'complete_task',
+        'delete_task'
+      ])
+    )
 
     const missingAuthToolCall = await fetch(`${info.localUrl}/v1/local/tool`, { method: 'POST' })
     expect(missingAuthToolCall.status).toBe(401)
@@ -114,9 +128,31 @@ describe('local agent server', () => {
         authorization: 'Bearer test-token',
         'content-type': 'application/json'
       },
+      body: JSON.stringify({ name: 'get_local_status', arguments: {} })
+    })
+    expect(toolCall.status).toBe(200)
+    await expect(toolCall.json()).resolves.toMatchObject({
+      ok: true,
+      name: 'get_local_status',
+      result: {
+        ok: true,
+        mode: 'local_omi_windows'
+      }
+    })
+
+    const unknownTool = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
       body: JSON.stringify({ name: 'noop', arguments: {} })
     })
-    expect(toolCall.status).toBe(501)
+    expect(unknownTool.status).toBe(404)
+    await expect(unknownTool.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'unknown_tool' }
+    })
   })
 
   it('falls back from the default port without binding to all interfaces', async () => {

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -1,0 +1,139 @@
+import { createServer, type Server } from 'http'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LOCAL_AGENT_DEFAULT_PORT, setLocalAgentSettings } from './settings'
+import {
+  startLocalAgentServer,
+  startLocalAgentServerIfEnabled,
+  stopLocalAgentServer
+} from './server'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', () => resolve())
+  })
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+}
+
+describe('local agent server', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-'))
+    electronState.encryptionAvailable = true
+  })
+
+  afterEach(async () => {
+    await stopLocalAgentServer()
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('does not start until the local agent setting is enabled', async () => {
+    await expect(startLocalAgentServerIfEnabled()).resolves.toBeNull()
+
+    setLocalAgentSettings({ enabled: true, port: 47820 })
+    const info = await startLocalAgentServerIfEnabled()
+
+    expect(info).toMatchObject({
+      host: '127.0.0.1',
+      port: 47820,
+      localUrl: 'http://127.0.0.1:47820',
+      toolEndpoint: 'http://127.0.0.1:47820/v1/local/tool'
+    })
+  })
+
+  it('serves unauthenticated health metadata on loopback', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47821, token: 'test-token' })
+
+    const response = await fetch(`${info.localUrl}/health`)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      ok: true,
+      app: {
+        name: 'Omi Windows',
+        version: '1.2.3',
+        appId: 'com.omiwindows.app'
+      },
+      localUrl: info.localUrl,
+      toolEndpoint: `${info.localUrl}/v1/local/tool`
+    })
+  })
+
+  it('requires bearer auth for local tool discovery and invocation', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47822, token: 'test-token' })
+
+    const missingAuthTools = await fetch(`${info.localUrl}/v1/local/tools`)
+    expect(missingAuthTools.status).toBe(401)
+
+    const tools = await fetch(`${info.localUrl}/v1/local/tools`, {
+      headers: { authorization: 'Bearer test-token' }
+    })
+    await expect(tools.json()).resolves.toEqual({
+      tools: [],
+      toolEndpoint: `${info.localUrl}/v1/local/tool`
+    })
+
+    const missingAuthToolCall = await fetch(`${info.localUrl}/v1/local/tool`, { method: 'POST' })
+    expect(missingAuthToolCall.status).toBe(401)
+
+    const toolCall = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'noop', arguments: {} })
+    })
+    expect(toolCall.status).toBe(501)
+  })
+
+  it('falls back from the default port without binding to all interfaces', async () => {
+    const occupied = createServer((_req, res) => res.end('occupied'))
+    await listen(occupied, LOCAL_AGENT_DEFAULT_PORT)
+
+    try {
+      const info = await startLocalAgentServer({ token: 'test-token' })
+
+      expect(info).toMatchObject({
+        host: '127.0.0.1',
+        port: LOCAL_AGENT_DEFAULT_PORT + 1,
+        localUrl: `http://127.0.0.1:${LOCAL_AGENT_DEFAULT_PORT + 1}`,
+        toolEndpoint: `http://127.0.0.1:${LOCAL_AGENT_DEFAULT_PORT + 1}/v1/local/tool`
+      })
+    } finally {
+      await close(occupied)
+    }
+  })
+})

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'http'
 import { mkdtempSync, rmSync } from 'fs'
+import { connect } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -47,6 +48,20 @@ function close(server: Server): Promise<void> {
   })
 }
 
+function rawRequest(port: number, request: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, '127.0.0.1')
+    let response = ''
+    socket.setEncoding('utf8')
+    socket.once('connect', () => socket.write(request))
+    socket.on('data', (chunk) => {
+      response += chunk
+    })
+    socket.once('end', () => resolve(response))
+    socket.once('error', reject)
+  })
+}
+
 describe('local agent server', () => {
   beforeEach(() => {
     electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-'))
@@ -89,6 +104,18 @@ describe('local agent server', () => {
       localUrl: info.localUrl,
       toolEndpoint: `${info.localUrl}/v1/local/tool`
     })
+  })
+
+  it('shares one startup attempt across concurrent callers', async () => {
+    const [first, second] = await Promise.all([
+      startLocalAgentServer({ preferredPort: 47824, token: 'test-token' }),
+      startLocalAgentServer({ preferredPort: 47824, token: 'other-token' })
+    ])
+
+    expect(second).toEqual(first)
+
+    await stopLocalAgentServer()
+    await expect(fetch(`${first.localUrl}/health`)).rejects.toThrow()
   })
 
   it('requires bearer auth for local tool discovery and invocation', async () => {
@@ -153,6 +180,37 @@ describe('local agent server', () => {
       ok: false,
       error: { code: 'unknown_tool' }
     })
+  })
+
+  it('rejects oversized local tool request bodies', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47825, token: 'test-token' })
+
+    const response = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: 'x'.repeat(1_048_577)
+    })
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'request_body_too_large', max_bytes: 1_048_576 }
+    })
+  })
+
+  it('returns 400 for malformed request targets instead of throwing', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47826, token: 'test-token' })
+
+    const response = await rawRequest(
+      info.port,
+      'GET http://[::1/path HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n'
+    )
+
+    expect(response).toContain('400')
+    expect(response).toContain('invalid_request_target')
   })
 
   it('falls back from the default port without binding to all interfaces', async () => {

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -118,6 +118,20 @@ describe('local agent server', () => {
     await expect(fetch(`${first.localUrl}/health`)).rejects.toThrow()
   })
 
+  it('starts a fresh listener when start races with stop', async () => {
+    const firstStart = startLocalAgentServer({ preferredPort: 47827, token: 'test-token' })
+    const stopping = stopLocalAgentServer()
+    const secondStart = startLocalAgentServer({ preferredPort: 47827, token: 'test-token' })
+
+    await stopping
+    const second = await secondStart
+
+    await expect(fetch(`${second.localUrl}/health`)).resolves.toMatchObject({ status: 200 })
+    await expect(firstStart).resolves.toMatchObject({
+      host: '127.0.0.1'
+    })
+  })
+
   it('requires bearer auth for local tool discovery and invocation', async () => {
     const info = await startLocalAgentServer({ preferredPort: 47822, token: 'test-token' })
 

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -1,0 +1,205 @@
+import { app } from 'electron'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
+import type { AddressInfo } from 'net'
+import { getLocalAgentSettings, LOCAL_AGENT_DEFAULT_PORT } from './settings'
+import { ensureLocalAgentToken } from './tokenStore'
+
+const LOCAL_AGENT_HOST = '127.0.0.1'
+const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
+const MAX_PORT_ATTEMPTS = 20
+
+export type LocalAgentServerInfo = {
+  host: typeof LOCAL_AGENT_HOST
+  port: number
+  localUrl: string
+  toolEndpoint: string
+}
+
+type AppMetadata = {
+  name: string
+  version: string
+  appId: string
+}
+
+type LocalAgentServerOptions = {
+  preferredPort?: number
+  token?: string
+  appMetadata?: AppMetadata
+  serverFactory?: typeof createServer
+}
+
+let runningServer: Server | null = null
+let runningInfo: LocalAgentServerInfo | null = null
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(payload)
+  })
+  res.end(payload)
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+}
+
+function authorize(req: IncomingMessage, token: string): boolean {
+  const auth = req.headers.authorization
+  return auth === `Bearer ${token}`
+}
+
+function metadata(override?: AppMetadata): AppMetadata {
+  return (
+    override ?? {
+      name: app.getName(),
+      version: app.getVersion(),
+      appId: LOCAL_AGENT_APP_ID
+    }
+  )
+}
+
+function currentInfo(port: number): LocalAgentServerInfo {
+  const localUrl = `http://${LOCAL_AGENT_HOST}:${port}`
+  return {
+    host: LOCAL_AGENT_HOST,
+    port,
+    localUrl,
+    toolEndpoint: `${localUrl}/v1/local/tool`
+  }
+}
+
+function route(
+  req: IncomingMessage,
+  res: ServerResponse,
+  info: LocalAgentServerInfo,
+  token: string,
+  appInfo: AppMetadata
+): void {
+  const method = req.method ?? 'GET'
+  const url = new URL(req.url ?? '/', info.localUrl)
+
+  if (method === 'GET' && url.pathname === '/health') {
+    json(res, 200, {
+      ok: true,
+      app: {
+        name: appInfo.name,
+        version: appInfo.version,
+        appId: appInfo.appId
+      },
+      localUrl: info.localUrl,
+      toolEndpoint: info.toolEndpoint
+    })
+    return
+  }
+
+  if (url.pathname === '/v1/local/tools' || url.pathname === '/v1/local/tool') {
+    if (!authorize(req, token)) {
+      json(res, 401, { error: 'unauthorized' })
+      return
+    }
+
+    if (method === 'GET' && url.pathname === '/v1/local/tools') {
+      json(res, 200, {
+        tools: [],
+        toolEndpoint: info.toolEndpoint
+      })
+      return
+    }
+
+    if (method === 'POST' && url.pathname === '/v1/local/tool') {
+      void readBody(req)
+        .then(() => {
+          json(res, 501, {
+            error: 'no_local_tools_registered',
+            tools: []
+          })
+        })
+        .catch(() => {
+          json(res, 400, { error: 'invalid_request_body' })
+        })
+      return
+    }
+  }
+
+  json(res, 404, { error: 'not_found' })
+}
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off('listening', onListening)
+      reject(error)
+    }
+    const onListening = (): void => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port, LOCAL_AGENT_HOST)
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+}
+
+export async function startLocalAgentServer(
+  options: LocalAgentServerOptions = {}
+): Promise<LocalAgentServerInfo> {
+  if (runningInfo) return runningInfo
+
+  const token = options.token ?? ensureLocalAgentToken()
+  const appInfo = metadata(options.appMetadata)
+  const preferredPort = options.preferredPort ?? LOCAL_AGENT_DEFAULT_PORT
+  const serverFactory = options.serverFactory ?? createServer
+
+  let lastError: unknown = null
+  for (let offset = 0; offset < MAX_PORT_ATTEMPTS; offset += 1) {
+    const port = preferredPort + offset
+    const info = currentInfo(port)
+    const server = serverFactory((req, res) => route(req, res, info, token, appInfo))
+
+    try {
+      await listen(server, port)
+      const address = server.address() as AddressInfo | null
+      if (address?.address !== LOCAL_AGENT_HOST) {
+        await closeServer(server)
+        throw new Error(`local agent server bound unexpected address: ${address?.address}`)
+      }
+      runningServer = server
+      runningInfo = info
+      console.log(`[local-agent] listening on ${info.localUrl}`)
+      return info
+    } catch (e) {
+      lastError = e
+      await closeServer(server).catch(() => undefined)
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('local agent server failed to start')
+}
+
+export async function startLocalAgentServerIfEnabled(): Promise<LocalAgentServerInfo | null> {
+  const settings = getLocalAgentSettings()
+  if (!settings.enabled) return null
+  return startLocalAgentServer({ preferredPort: settings.port })
+}
+
+export async function stopLocalAgentServer(): Promise<void> {
+  const server = runningServer
+  runningServer = null
+  runningInfo = null
+  if (server) await closeServer(server)
+}

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -3,6 +3,12 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from 'net'
 import { getLocalAgentSettings, LOCAL_AGENT_DEFAULT_PORT } from './settings'
 import { ensureLocalAgentToken } from './tokenStore'
+import {
+  errorResponseBody,
+  listLocalAgentTools,
+  runLocalAgentTool,
+  type LocalAgentRuntimeContext
+} from './tools'
 
 const LOCAL_AGENT_HOST = '127.0.0.1'
 const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
@@ -47,6 +53,26 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
+}
+
+function parseToolRequest(body: string): { name: string; arguments: unknown } {
+  let payload: unknown
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    throw new Error('invalid_json_body')
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('invalid_json_body')
+  }
+  const record = payload as Record<string, unknown>
+  if (typeof record.name !== 'string' || !record.name.trim()) {
+    throw new Error('missing_tool_name')
+  }
+  return {
+    name: record.name.trim(),
+    arguments: record.arguments ?? {}
+  }
 }
 
 function authorize(req: IncomingMessage, token: string): boolean {
@@ -106,7 +132,8 @@ function route(
 
     if (method === 'GET' && url.pathname === '/v1/local/tools') {
       json(res, 200, {
-        tools: [],
+        ok: true,
+        tools: listLocalAgentTools(),
         toolEndpoint: info.toolEndpoint
       })
       return
@@ -114,14 +141,37 @@ function route(
 
     if (method === 'POST' && url.pathname === '/v1/local/tool') {
       void readBody(req)
-        .then(() => {
-          json(res, 501, {
-            error: 'no_local_tools_registered',
-            tools: []
-          })
+        .then(async (body) => {
+          let request: { name: string; arguments: unknown }
+          try {
+            request = parseToolRequest(body)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'invalid_json_body'
+            json(res, 400, { ok: false, error: { code: message, message } })
+            return
+          }
+
+          try {
+            const context: LocalAgentRuntimeContext = {
+              localUrl: info.localUrl,
+              toolEndpoint: info.toolEndpoint,
+              app: {
+                name: appInfo.name,
+                version: appInfo.version,
+                appId: appInfo.appId
+              }
+            }
+            json(res, 200, await runLocalAgentTool(request.name, request.arguments, context))
+          } catch (error) {
+            const { status, body } = errorResponseBody(error)
+            json(res, status, body)
+          }
         })
         .catch(() => {
-          json(res, 400, { error: 'invalid_request_body' })
+          json(res, 400, {
+            ok: false,
+            error: { code: 'invalid_request_body', message: 'invalid_request_body' }
+          })
         })
       return
     }

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -247,6 +247,10 @@ export async function startLocalAgentServerIfEnabled(): Promise<LocalAgentServer
   return startLocalAgentServer({ preferredPort: settings.port })
 }
 
+export function getLocalAgentServerInfo(): LocalAgentServerInfo | null {
+  return runningInfo
+}
+
 export async function stopLocalAgentServer(): Promise<void> {
   const server = runningServer
   runningServer = null

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -13,6 +13,7 @@ import {
 const LOCAL_AGENT_HOST = '127.0.0.1'
 const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
 const MAX_PORT_ATTEMPTS = 20
+const MAX_REQUEST_BODY_BYTES = 1_048_576
 
 export type LocalAgentServerInfo = {
   host: typeof LOCAL_AGENT_HOST
@@ -36,6 +37,17 @@ type LocalAgentServerOptions = {
 
 let runningServer: Server | null = null
 let runningInfo: LocalAgentServerInfo | null = null
+let startupPromise: Promise<LocalAgentServerInfo> | null = null
+
+class RequestBodyTooLargeError extends Error {
+  readonly code = 'request_body_too_large'
+  readonly status = 413
+
+  constructor() {
+    super(`request body exceeds ${MAX_REQUEST_BODY_BYTES} bytes`)
+    this.name = 'RequestBodyTooLargeError'
+  }
+}
 
 function json(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body)
@@ -49,9 +61,32 @@ function json(res: ServerResponse, status: number, body: unknown): void {
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-    req.on('error', reject)
+    let total = 0
+    let settled = false
+
+    const fail = (error: Error): void => {
+      if (settled) return
+      settled = true
+      chunks.length = 0
+      reject(error)
+    }
+
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return
+      total += chunk.length
+      if (total > MAX_REQUEST_BODY_BYTES) {
+        fail(new RequestBodyTooLargeError())
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      if (!settled) {
+        settled = true
+        resolve(Buffer.concat(chunks).toString('utf8'))
+      }
+    })
+    req.on('error', (error) => fail(error))
   })
 }
 
@@ -108,7 +143,16 @@ function route(
   appInfo: AppMetadata
 ): void {
   const method = req.method ?? 'GET'
-  const url = new URL(req.url ?? '/', info.localUrl)
+  let url: URL
+  try {
+    url = new URL(req.url ?? '/', info.localUrl)
+  } catch {
+    json(res, 400, {
+      ok: false,
+      error: { code: 'invalid_request_target', message: 'invalid_request_target' }
+    })
+    return
+  }
 
   if (method === 'GET' && url.pathname === '/health') {
     json(res, 200, {
@@ -167,7 +211,18 @@ function route(
             json(res, status, body)
           }
         })
-        .catch(() => {
+        .catch((error) => {
+          if (error instanceof RequestBodyTooLargeError) {
+            json(res, error.status, {
+              ok: false,
+              error: {
+                code: error.code,
+                message: error.message,
+                max_bytes: MAX_REQUEST_BODY_BYTES
+              }
+            })
+            return
+          }
           json(res, 400, {
             ok: false,
             error: { code: 'invalid_request_body', message: 'invalid_request_body' }
@@ -207,6 +262,18 @@ function closeServer(server: Server): Promise<void> {
 
 export async function startLocalAgentServer(
   options: LocalAgentServerOptions = {}
+): Promise<LocalAgentServerInfo> {
+  if (runningInfo) return runningInfo
+  if (startupPromise) return startupPromise
+
+  startupPromise = startLocalAgentServerInner(options).finally(() => {
+    startupPromise = null
+  })
+  return startupPromise
+}
+
+async function startLocalAgentServerInner(
+  options: LocalAgentServerOptions
 ): Promise<LocalAgentServerInfo> {
   if (runningInfo) return runningInfo
 
@@ -252,6 +319,9 @@ export function getLocalAgentServerInfo(): LocalAgentServerInfo | null {
 }
 
 export async function stopLocalAgentServer(): Promise<void> {
+  if (startupPromise) {
+    await startupPromise.catch(() => undefined)
+  }
   const server = runningServer
   runningServer = null
   runningInfo = null

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -38,6 +38,7 @@ type LocalAgentServerOptions = {
 let runningServer: Server | null = null
 let runningInfo: LocalAgentServerInfo | null = null
 let startupPromise: Promise<LocalAgentServerInfo> | null = null
+let stoppingPromise: Promise<void> | null = null
 
 class RequestBodyTooLargeError extends Error {
   readonly code = 'request_body_too_large'
@@ -221,6 +222,7 @@ function route(
                 max_bytes: MAX_REQUEST_BODY_BYTES
               }
             })
+            req.destroy()
             return
           }
           json(res, 400, {
@@ -263,6 +265,9 @@ function closeServer(server: Server): Promise<void> {
 export async function startLocalAgentServer(
   options: LocalAgentServerOptions = {}
 ): Promise<LocalAgentServerInfo> {
+  if (stoppingPromise) {
+    await stoppingPromise
+  }
   if (runningInfo) return runningInfo
   if (startupPromise) return startupPromise
 
@@ -319,6 +324,14 @@ export function getLocalAgentServerInfo(): LocalAgentServerInfo | null {
 }
 
 export async function stopLocalAgentServer(): Promise<void> {
+  if (stoppingPromise) return stoppingPromise
+  stoppingPromise = stopLocalAgentServerInner().finally(() => {
+    stoppingPromise = null
+  })
+  return stoppingPromise
+}
+
+async function stopLocalAgentServerInner(): Promise<void> {
   if (startupPromise) {
     await startupPromise.catch(() => undefined)
   }

--- a/desktop/windows/src/main/localAgent/settings.ts
+++ b/desktop/windows/src/main/localAgent/settings.ts
@@ -1,0 +1,52 @@
+import { app } from 'electron'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export type LocalAgentSettings = {
+  enabled: boolean
+  port: number
+}
+
+export const LOCAL_AGENT_DEFAULT_PORT = 47778
+
+const DEFAULTS: LocalAgentSettings = {
+  enabled: false,
+  port: LOCAL_AGENT_DEFAULT_PORT
+}
+
+function file(): string {
+  return join(app.getPath('userData'), 'local-agent-settings.json')
+}
+
+function sanitize(raw: Partial<LocalAgentSettings>): LocalAgentSettings {
+  const port =
+    typeof raw.port === 'number' &&
+    Number.isInteger(raw.port) &&
+    raw.port >= 1024 &&
+    raw.port <= 65535
+      ? raw.port
+      : DEFAULTS.port
+
+  return {
+    enabled: raw.enabled === true,
+    port
+  }
+}
+
+export function getLocalAgentSettings(): LocalAgentSettings {
+  try {
+    return sanitize(JSON.parse(readFileSync(file(), 'utf-8')) as Partial<LocalAgentSettings>)
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+export function setLocalAgentSettings(next: LocalAgentSettings): LocalAgentSettings {
+  const value = sanitize(next)
+  try {
+    writeFileSync(file(), JSON.stringify(value), 'utf-8')
+  } catch (e) {
+    console.warn('[local-agent] failed to persist settings:', e)
+  }
+  return value
+}

--- a/desktop/windows/src/main/localAgent/tokenStore.test.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+import {
+  clearLocalAgentToken,
+  ensureLocalAgentToken,
+  loadLocalAgentToken,
+  saveLocalAgentToken
+} from './tokenStore'
+
+describe('local agent token store', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-token-'))
+    electronState.encryptionAvailable = true
+  })
+
+  afterEach(() => {
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('stores and loads the bearer token without writing the raw token', () => {
+    saveLocalAgentToken('local_secret_token')
+
+    const rawFile = readFileSync(join(electronState.userData, 'local-agent-token.json'), 'utf8')
+    expect(rawFile).not.toContain('local_secret_token')
+    expect(loadLocalAgentToken()).toBe('local_secret_token')
+  })
+
+  it('creates one token and reuses it on later calls', () => {
+    const first = ensureLocalAgentToken()
+    const second = ensureLocalAgentToken()
+
+    expect(first).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(second).toBe(first)
+  })
+
+  it('deletes the stored token', () => {
+    saveLocalAgentToken('local_secret_token')
+    clearLocalAgentToken()
+
+    expect(loadLocalAgentToken()).toBeNull()
+  })
+
+  it('refuses to save when secure storage is unavailable', () => {
+    electronState.encryptionAvailable = false
+
+    expect(() => saveLocalAgentToken('local_secret_token')).toThrow(
+      'Secure storage is unavailable on this system'
+    )
+  })
+})

--- a/desktop/windows/src/main/localAgent/tokenStore.test.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.test.ts
@@ -26,6 +26,7 @@ import {
   clearLocalAgentToken,
   ensureLocalAgentToken,
   loadLocalAgentToken,
+  rotateLocalAgentToken,
   saveLocalAgentToken
 } from './tokenStore'
 
@@ -53,6 +54,15 @@ describe('local agent token store', () => {
 
     expect(first).toMatch(/^[A-Za-z0-9_-]+$/)
     expect(second).toBe(first)
+  })
+
+  it('rotates and persists a new bearer token', () => {
+    const first = ensureLocalAgentToken()
+    const second = rotateLocalAgentToken()
+
+    expect(second).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(second).not.toBe(first)
+    expect(loadLocalAgentToken()).toBe(second)
   })
 
   it('deletes the stored token', () => {

--- a/desktop/windows/src/main/localAgent/tokenStore.test.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -26,6 +26,7 @@ import {
   clearLocalAgentToken,
   ensureLocalAgentToken,
   loadLocalAgentToken,
+  LocalAgentTokenStoreError,
   rotateLocalAgentToken,
   saveLocalAgentToken
 } from './tokenStore'
@@ -78,5 +79,12 @@ describe('local agent token store', () => {
     expect(() => saveLocalAgentToken('local_secret_token')).toThrow(
       'Secure storage is unavailable on this system'
     )
+  })
+
+  it('surfaces corrupt stored tokens without rotating them', () => {
+    writeFileSync(join(electronState.userData, 'local-agent-token.json'), '{"token":""}', 'utf8')
+
+    expect(() => loadLocalAgentToken()).toThrow(LocalAgentTokenStoreError)
+    expect(() => ensureLocalAgentToken()).toThrow(LocalAgentTokenStoreError)
   })
 })

--- a/desktop/windows/src/main/localAgent/tokenStore.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.ts
@@ -45,6 +45,12 @@ export function ensureLocalAgentToken(): string {
   return token
 }
 
+export function rotateLocalAgentToken(): string {
+  const token = createToken()
+  saveLocalAgentToken(token)
+  return token
+}
+
 export function clearLocalAgentToken(): void {
   try {
     rmSync(file(), { force: true })

--- a/desktop/windows/src/main/localAgent/tokenStore.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.ts
@@ -1,0 +1,54 @@
+import { app, safeStorage } from 'electron'
+import { randomBytes } from 'crypto'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+type StoredLocalAgentTokenFile = {
+  token: string
+}
+
+function file(): string {
+  return join(app.getPath('userData'), 'local-agent-token.json')
+}
+
+function createToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function saveLocalAgentToken(token: string): void {
+  if (!token) throw new Error('Invalid local agent token')
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('Secure storage is unavailable on this system')
+  }
+  const enc = safeStorage.encryptString(token).toString('base64')
+  writeFileSync(file(), JSON.stringify({ token: enc } satisfies StoredLocalAgentTokenFile), 'utf8')
+}
+
+export function loadLocalAgentToken(): string | null {
+  const f = file()
+  if (!existsSync(f)) return null
+  try {
+    const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredLocalAgentTokenFile
+    if (!raw.token) return null
+    return safeStorage.decryptString(Buffer.from(raw.token, 'base64'))
+  } catch {
+    return null
+  }
+}
+
+export function ensureLocalAgentToken(): string {
+  const existing = loadLocalAgentToken()
+  if (existing) return existing
+
+  const token = createToken()
+  saveLocalAgentToken(token)
+  return token
+}
+
+export function clearLocalAgentToken(): void {
+  try {
+    rmSync(file(), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}

--- a/desktop/windows/src/main/localAgent/tokenStore.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.ts
@@ -7,6 +7,13 @@ type StoredLocalAgentTokenFile = {
   token: string
 }
 
+export class LocalAgentTokenStoreError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LocalAgentTokenStoreError'
+  }
+}
+
 function file(): string {
   return join(app.getPath('userData'), 'local-agent-token.json')
 }
@@ -29,10 +36,15 @@ export function loadLocalAgentToken(): string | null {
   if (!existsSync(f)) return null
   try {
     const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredLocalAgentTokenFile
-    if (!raw.token) return null
-    return safeStorage.decryptString(Buffer.from(raw.token, 'base64'))
-  } catch {
-    return null
+    if (!raw || typeof raw.token !== 'string' || !raw.token) {
+      throw new Error('stored token file is invalid')
+    }
+    const token = safeStorage.decryptString(Buffer.from(raw.token, 'base64'))
+    if (!token) throw new Error('stored token decrypts to an empty value')
+    return token
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown token store error'
+    throw new LocalAgentTokenStoreError(`Failed to load local agent token: ${message}`)
   }
 }
 

--- a/desktop/windows/src/main/localAgent/tools.test.ts
+++ b/desktop/windows/src/main/localAgent/tools.test.ts
@@ -1,0 +1,249 @@
+import Database from 'better-sqlite3'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LocalConversation, RewindFrame } from '../../shared/types'
+
+const electronState = vi.hoisted(() => ({
+  userData: ''
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  }
+}))
+
+const context = {
+  localUrl: 'http://127.0.0.1:47778',
+  toolEndpoint: 'http://127.0.0.1:47778/v1/local/tool',
+  app: {
+    name: 'Omi Windows',
+    version: '1.2.3',
+    appId: 'com.omiwindows.app'
+  }
+}
+
+async function freshModules(): Promise<{
+  tools: typeof import('./tools')
+  db: typeof import('../ipc/db')
+}> {
+  vi.resetModules()
+  const tools = await import('./tools')
+  const db = await import('../ipc/db')
+  return { tools, db }
+}
+
+function conversation(over: Partial<LocalConversation> = {}): LocalConversation {
+  const now = Date.now()
+  return {
+    id: 'conversation-1',
+    startedAt: now - 1_000,
+    endedAt: now,
+    transcript: 'Discussed the local agent tool registry.',
+    createdAt: now,
+    kind: 'recording',
+    title: 'Local tools',
+    ...over
+  }
+}
+
+function frame(
+  imagePath: string,
+  over: Partial<Omit<RewindFrame, 'id'>> = {}
+): Omit<RewindFrame, 'id'> {
+  return {
+    ts: Date.now(),
+    app: 'Code.exe',
+    windowTitle: 'localAgent tools',
+    processName: 'Code',
+    ocrText: 'first local agent tool set screen history',
+    imagePath,
+    width: 1280,
+    height: 720,
+    indexed: 1,
+    ...over
+  }
+}
+
+describe('local agent tool registry', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-tools-'))
+    process.env.OMI_DB_PATH = join(electronState.userData, 'omi.db')
+  })
+
+  afterEach(() => {
+    delete process.env.OMI_DB_PATH
+    vi.resetModules()
+    rmSync(electronState.userData, { recursive: true, force: true })
+    electronState.userData = ''
+  })
+
+  it('lists JSON-schema tool definitions with unavailable destructive task annotations', async () => {
+    const { tools } = await freshModules()
+    const definitions = tools.listLocalAgentTools()
+
+    expect(definitions.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'get_local_status',
+        'execute_sql',
+        'search_screen_history',
+        'semantic_search',
+        'get_screenshot',
+        'get_daily_recap',
+        'search_tasks',
+        'complete_task',
+        'delete_task'
+      ])
+    )
+    expect(definitions.find((tool) => tool.name === 'execute_sql')).toMatchObject({
+      inputSchema: {
+        type: 'object',
+        required: ['query']
+      },
+      annotations: {
+        readOnlyHint: true,
+        readOnlyEnforced: true,
+        mutationStatementsRejected: true
+      }
+    })
+    expect(definitions.find((tool) => tool.name === 'delete_task')).toMatchObject({
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        gated: true,
+        unavailable: true
+      }
+    })
+  })
+
+  it('runs read-only SQL through the guard and rejects mutations', async () => {
+    const { tools, db } = await freshModules()
+    db.insertLocalConversation(conversation())
+
+    const result = await tools.runLocalAgentTool(
+      'execute_sql',
+      { query: 'SELECT id, title FROM local_conversation' },
+      context
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      name: 'execute_sql',
+      result: {
+        columns: ['id', 'title'],
+        row_count: 1,
+        read_only: true,
+        max_rows: 200
+      }
+    })
+    expect((result.result as { rows: Record<string, unknown>[] }).rows[0]).toEqual({
+      id: 'conversation-1',
+      title: 'Local tools'
+    })
+
+    await expect(
+      tools.runLocalAgentTool('execute_sql', { query: 'DELETE FROM local_conversation' }, context)
+    ).rejects.toMatchObject({
+      code: 'sql_rejected_or_failed',
+      status: 400
+    })
+  })
+
+  it('searches Rewind history and returns screenshot image data by frame id', async () => {
+    const { tools, db } = await freshModules()
+    const imagePath = join(electronState.userData, 'rewind', '2026-06-20', 'frame.jpg')
+    mkdirSync(dirname(imagePath), { recursive: true })
+    const imageBytes = Buffer.from([1, 2, 3, 4])
+    writeFileSync(imagePath, imageBytes)
+    const id = db.insertRewindFrame(frame(imagePath))
+
+    const search = await tools.runLocalAgentTool(
+      'search_screen_history',
+      { query: 'agent tool set', days: 1 },
+      context
+    )
+    const searchResult = search.result as {
+      result_count: number
+      results: { representative: { screenshot_id: number } }[]
+    }
+    expect(searchResult.result_count).toBe(1)
+    expect(searchResult.results[0].representative.screenshot_id).toBe(id)
+
+    const screenshot = await tools.runLocalAgentTool(
+      'get_screenshot',
+      { screenshot_id: id },
+      context
+    )
+    expect(screenshot).toMatchObject({
+      ok: true,
+      name: 'get_screenshot',
+      content_type: 'image/jpeg',
+      result: {
+        screenshot_id: id,
+        image_base64: imageBytes.toString('base64'),
+        metadata: {
+          screenshot_id: id,
+          app: 'Code.exe',
+          window_title: 'localAgent tools'
+        }
+      }
+    })
+  })
+
+  it('searches supported local task tables and marks mutations unavailable', async () => {
+    const raw = new Database(process.env.OMI_DB_PATH!)
+    raw.exec(`
+      CREATE TABLE action_items (
+        id TEXT PRIMARY KEY,
+        description TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO action_items (id, description, completed, deleted, created_at)
+      VALUES ('task-1', 'Prepare the local tools demo', 0, 0, ${Date.now()});
+      INSERT INTO action_items (id, description, completed, deleted, created_at)
+      VALUES ('task-2', 'Completed task', 1, 0, ${Date.now() - 1});
+    `)
+    raw.close()
+
+    const { tools } = await freshModules()
+    const result = await tools.runLocalAgentTool(
+      'search_tasks',
+      { query: 'local tools', include_completed: false },
+      context
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      name: 'search_tasks',
+      result: {
+        available: true,
+        sources: ['action_items'],
+        result_count: 1,
+        tasks: [
+          {
+            source: 'action_items',
+            id: 'task-1',
+            description: 'Prepare the local tools demo',
+            completed: false
+          }
+        ]
+      }
+    })
+
+    await expect(
+      tools.runLocalAgentTool('delete_task', { task_id: 'task-1' }, context)
+    ).rejects.toMatchObject({
+      code: 'tool_unavailable',
+      status: 501
+    })
+  })
+})

--- a/desktop/windows/src/main/localAgent/tools.test.ts
+++ b/desktop/windows/src/main/localAgent/tools.test.ts
@@ -121,6 +121,9 @@ describe('local agent tool registry', () => {
         unavailable: true
       }
     })
+    expect(
+      definitions.find((tool) => tool.name === 'get_screenshot')?.inputSchema.required
+    ).toBeUndefined()
   })
 
   it('runs read-only SQL through the guard and rejects mutations', async () => {
@@ -176,11 +179,7 @@ describe('local agent tool registry', () => {
     expect(searchResult.result_count).toBe(1)
     expect(searchResult.results[0].representative.screenshot_id).toBe(id)
 
-    const screenshot = await tools.runLocalAgentTool(
-      'get_screenshot',
-      { screenshot_id: id },
-      context
-    )
+    const screenshot = await tools.runLocalAgentTool('get_screenshot', { id }, context)
     expect(screenshot).toMatchObject({
       ok: true,
       name: 'get_screenshot',

--- a/desktop/windows/src/main/localAgent/tools.ts
+++ b/desktop/windows/src/main/localAgent/tools.ts
@@ -1,0 +1,839 @@
+import {
+  execSafeSelect,
+  getFileIndexStats,
+  getLocalKGStatus,
+  getRewindFrame,
+  listLocalConversations,
+  listRewindFrames,
+  recentInsights,
+  rewindStatusStats,
+  searchLocalTasks,
+  searchRewindFrames
+} from '../ipc/db'
+import { readRewindFrameImage } from '../rewind/frameImage'
+import { rewindRoot } from '../rewind/paths'
+import { groupFrames } from '../rewind/rewindGrouping'
+import { guardSelect } from '../../shared/sqlGuard'
+import type {
+  InsightRecord,
+  LocalConversation,
+  RewindFrame,
+  RewindFrameImageOk,
+  RewindSearchGroup
+} from '../../shared/types'
+
+const MAX_SQL_ROWS = 200
+const MAX_SEARCH_LIMIT = 50
+const DEFAULT_SCREEN_LIMIT = 15
+const DAY_MS = 86_400_000
+const TASK_MUTATION_UNAVAILABLE =
+  'Windows local task mutation is unavailable because tasks are currently backed by the hosted action-items API, not reliable main-process local storage.'
+
+type JsonObject = Record<string, unknown>
+
+type JsonSchemaObject = {
+  type: 'object'
+  properties: Record<string, unknown>
+  required?: string[]
+  additionalProperties?: boolean
+}
+
+export type LocalAgentRuntimeContext = {
+  localUrl: string
+  toolEndpoint: string
+  app: {
+    name: string
+    version: string
+    appId: string
+  }
+}
+
+export type LocalAgentToolDefinition = {
+  name: string
+  description: string
+  inputSchema: JsonSchemaObject
+  annotations: Record<string, unknown>
+}
+
+export type LocalAgentToolResponse = {
+  ok: true
+  name: string
+  content_type: string
+  result: unknown
+}
+
+export class LocalAgentToolError extends Error {
+  readonly code: string
+  readonly status: number
+  readonly details?: unknown
+
+  constructor(code: string, message: string, status = 400, details?: unknown) {
+    super(message)
+    this.name = 'LocalAgentToolError'
+    this.code = code
+    this.status = status
+    this.details = details
+  }
+}
+
+function schema(
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  additionalProperties = false
+): JsonSchemaObject {
+  return {
+    type: 'object',
+    properties,
+    required,
+    additionalProperties
+  }
+}
+
+function annotations(
+  overrides: Partial<LocalAgentToolDefinition['annotations']> = {}
+): LocalAgentToolDefinition['annotations'] {
+  return {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+    ...overrides
+  }
+}
+
+const TOOL_DEFINITIONS: LocalAgentToolDefinition[] = [
+  {
+    name: 'get_local_status',
+    description:
+      'Report local Omi Desktop availability, including Rewind screen-history counts, latest capture time, local knowledge graph status, and unavailable local affordances.',
+    inputSchema: schema({}),
+    annotations: annotations()
+  },
+  {
+    name: 'execute_sql',
+    description:
+      'Run one read-only SELECT or WITH query against the local Omi Windows SQLite database. Mutations and multi-statement SQL are rejected; returned rows are capped.',
+    inputSchema: schema(
+      {
+        query: {
+          type: 'string',
+          description: 'Single read-only SELECT or WITH query to execute.'
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations({
+      readOnlyEnforced: true,
+      maxRows: MAX_SQL_ROWS,
+      mutationStatementsRejected: true
+    })
+  },
+  {
+    name: 'search_screen_history',
+    description:
+      'Search local Rewind screen history using OCR text, app name, and window title. Results include screenshot IDs that can be opened with get_screenshot.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Natural-language or keyword screen-history query.' },
+        days: { type: 'number', description: 'Days to search back. Defaults to 7.' },
+        app_filter: { type: 'string', description: 'Optional app/process/window filter.' },
+        limit: {
+          type: 'number',
+          description: `Maximum result groups to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to ${DEFAULT_SCREEN_LIMIT}.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'semantic_search',
+    description:
+      'Compatibility alias for search_screen_history. On Windows this uses local Rewind OCR/app/window search.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Natural-language or keyword screen-history query.' },
+        days: { type: 'number', description: 'Days to search back. Defaults to 7.' },
+        app_filter: { type: 'string', description: 'Optional app/process/window filter.' },
+        limit: {
+          type: 'number',
+          description: `Maximum result groups to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to ${DEFAULT_SCREEN_LIMIT}.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'get_screenshot',
+    description:
+      'Fetch a local Rewind screenshot image by screenshot_id. Use IDs returned by search_screen_history or execute_sql over rewind_frames.',
+    inputSchema: schema(
+      {
+        screenshot_id: {
+          type: 'number',
+          description: 'Rewind frame ID returned as screenshot_id.'
+        },
+        id: {
+          type: 'number',
+          description: 'Alias for screenshot_id.'
+        }
+      },
+      ['screenshot_id']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'get_daily_recap',
+    description:
+      'Get a structured local activity recap for today, yesterday, or a recent range using Rewind frames, local conversations, insights, and locally available tasks.',
+    inputSchema: schema({
+      days_ago: {
+        type: 'number',
+        description: '0=today, 1=yesterday, 7=past week. Defaults to 0.'
+      }
+    }),
+    annotations: annotations()
+  },
+  {
+    name: 'search_tasks',
+    description:
+      'Best-effort search over local task tables if this Windows build has them. Returns an unavailable result when no reliable local task storage exists.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Task search query.' },
+        include_completed: {
+          type: 'boolean',
+          description: 'Include completed tasks. Defaults to false.'
+        },
+        limit: {
+          type: 'number',
+          description: `Maximum tasks to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to 10.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations({
+      availability: 'best_effort_local_tables'
+    })
+  },
+  {
+    name: 'complete_task',
+    description:
+      'Unavailable on Windows local API until task completion can be backed by reliable local storage and sync semantics.',
+    inputSchema: schema(
+      {
+        task_id: { type: 'string', description: 'Hosted/backend task ID.' }
+      },
+      ['task_id']
+    ),
+    annotations: annotations({
+      readOnlyHint: false,
+      gated: true,
+      unavailable: true,
+      unavailableReason: TASK_MUTATION_UNAVAILABLE
+    })
+  },
+  {
+    name: 'delete_task',
+    description:
+      'Unavailable on Windows local API until destructive task deletion can be backed by reliable local storage and sync semantics.',
+    inputSchema: schema(
+      {
+        task_id: { type: 'string', description: 'Hosted/backend task ID.' }
+      },
+      ['task_id']
+    ),
+    annotations: annotations({
+      readOnlyHint: false,
+      destructiveHint: true,
+      gated: true,
+      unavailable: true,
+      unavailableReason: TASK_MUTATION_UNAVAILABLE
+    })
+  }
+]
+
+const TOOL_NAMES = new Set(TOOL_DEFINITIONS.map((tool) => tool.name))
+
+export function listLocalAgentTools(): LocalAgentToolDefinition[] {
+  return TOOL_DEFINITIONS.map((tool) => ({
+    ...tool,
+    inputSchema: {
+      ...tool.inputSchema,
+      properties: { ...tool.inputSchema.properties },
+      required: [...(tool.inputSchema.required ?? [])]
+    },
+    annotations: { ...tool.annotations }
+  }))
+}
+
+export async function runLocalAgentTool(
+  name: string,
+  rawArguments: unknown,
+  context: LocalAgentRuntimeContext
+): Promise<LocalAgentToolResponse> {
+  if (!TOOL_NAMES.has(name)) {
+    throw new LocalAgentToolError('unknown_tool', `Unknown local tool: ${name}`, 404, { name })
+  }
+  const args = argumentObject(rawArguments)
+
+  switch (name) {
+    case 'get_local_status':
+      return ok(name, getLocalStatus(context))
+    case 'execute_sql':
+      return ok(name, executeSql(args))
+    case 'search_screen_history':
+    case 'semantic_search':
+      return ok(name, searchScreenHistory(args))
+    case 'get_screenshot':
+      return screenshotResponse(name, args)
+    case 'get_daily_recap':
+      return ok(name, getDailyRecap(args))
+    case 'search_tasks':
+      return ok(name, searchTasks(args))
+    case 'complete_task':
+    case 'delete_task':
+      throw new LocalAgentToolError('tool_unavailable', TASK_MUTATION_UNAVAILABLE, 501, { name })
+    default:
+      throw new LocalAgentToolError('unknown_tool', `Unknown local tool: ${name}`, 404, { name })
+  }
+}
+
+export function errorResponseBody(error: unknown): {
+  status: number
+  body: { ok: false; error: { code: string; message: string; details?: unknown } }
+} {
+  if (error instanceof LocalAgentToolError) {
+    return {
+      status: error.status,
+      body: {
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.details === undefined ? {} : { details: error.details })
+        }
+      }
+    }
+  }
+  return {
+    status: 500,
+    body: {
+      ok: false,
+      error: {
+        code: 'tool_execution_failed',
+        message: error instanceof Error ? error.message : 'Local tool execution failed'
+      }
+    }
+  }
+}
+
+function ok(
+  name: string,
+  result: unknown,
+  contentType = 'application/json'
+): LocalAgentToolResponse {
+  return {
+    ok: true,
+    name,
+    content_type: contentType,
+    result
+  }
+}
+
+function argumentObject(rawArguments: unknown): JsonObject {
+  if (rawArguments == null) return {}
+  if (typeof rawArguments === 'object' && !Array.isArray(rawArguments)) {
+    return rawArguments as JsonObject
+  }
+  throw new LocalAgentToolError('invalid_arguments', 'arguments must be a JSON object')
+}
+
+function requiredString(args: JsonObject, key: string, aliases: string[] = []): string {
+  for (const candidate of [key, ...aliases]) {
+    const value = args[candidate]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  throw new LocalAgentToolError('invalid_arguments', `${key} is required`, 400, { key })
+}
+
+function optionalString(args: JsonObject, key: string): string | undefined {
+  const value = args[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function numberArg(
+  args: JsonObject,
+  key: string,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const value = args[key]
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value.trim())
+        : fallback
+  const safe = Number.isFinite(parsed) ? Math.trunc(parsed) : fallback
+  return Math.min(max, Math.max(min, safe))
+}
+
+function booleanArg(args: JsonObject, key: string, fallback: boolean): boolean {
+  const value = args[key]
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') return true
+    if (normalized === 'false') return false
+  }
+  return fallback
+}
+
+function screenshotId(args: JsonObject): number {
+  const value = args.screenshot_id ?? args.id
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value.trim())
+        : NaN
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed
+  throw new LocalAgentToolError('invalid_arguments', 'screenshot_id is required', 400, {
+    key: 'screenshot_id'
+  })
+}
+
+function getLocalStatus(context: LocalAgentRuntimeContext): JsonObject {
+  try {
+    const rewind = rewindStatusStats()
+    const kg = getLocalKGStatus()
+    const fileIndex = getFileIndexStats()
+    return {
+      ok: true,
+      mode: 'local_omi_windows',
+      app: context.app,
+      local_api: context.localUrl,
+      tool_endpoint: context.toolEndpoint,
+      database_available: true,
+      screen_history_available: rewind.totalFrameCount > 0,
+      screenshot_count: rewind.totalFrameCount,
+      indexed_screenshot_count: rewind.indexedFrameCount,
+      ocr_backlog_count: rewind.ocrBacklogCount,
+      oldest_capture_at: iso(rewind.oldestFrameTs),
+      latest_capture_at: iso(rewind.latestFrameTs),
+      knowledge_graph: kg,
+      file_index: fileIndex,
+      local_affordances: [
+        'Rewind screen history and OCR search',
+        'raw screenshot image retrieval by screenshot_id',
+        'local transcription and conversation tables',
+        'read-only SQL over the local Omi Windows database',
+        'daily local activity recaps',
+        'indexed files and local knowledge graph data',
+        'best-effort local task search when task tables exist'
+      ],
+      unavailable_affordances: [
+        {
+          tool: 'complete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        },
+        {
+          tool: 'delete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        }
+      ],
+      recommended_first_tools: [
+        'search_screen_history for Rewind/OCR questions',
+        'get_screenshot after a search result returns a screenshot_id',
+        'get_daily_recap for today/yesterday/this week',
+        'execute_sql for exact read-only local database questions'
+      ]
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      mode: 'local_omi_windows',
+      app: context.app,
+      local_api: context.localUrl,
+      tool_endpoint: context.toolEndpoint,
+      database_available: false,
+      screen_history_available: false,
+      message: error instanceof Error ? error.message : 'Failed to read local Omi status',
+      unavailable_affordances: [
+        {
+          tool: 'complete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        },
+        {
+          tool: 'delete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        }
+      ]
+    }
+  }
+}
+
+function executeSql(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query', ['sql'])
+  try {
+    const guarded = guardSelect(query)
+    const result = execSafeSelect(guarded)
+    const rows = result.rows.slice(0, MAX_SQL_ROWS).map(sanitizeRow)
+    return {
+      columns: result.columns,
+      rows,
+      row_count: rows.length,
+      truncated: result.rows.length > rows.length,
+      read_only: true,
+      max_rows: MAX_SQL_ROWS,
+      executed_query: guarded
+    }
+  } catch (error) {
+    throw new LocalAgentToolError(
+      'sql_rejected_or_failed',
+      error instanceof Error ? error.message : 'SQL query failed',
+      400
+    )
+  }
+}
+
+function searchScreenHistory(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query')
+  const days = numberArg(args, 'days', 7, 1, 365)
+  const limit = numberArg(args, 'limit', DEFAULT_SCREEN_LIMIT, 1, MAX_SEARCH_LIMIT)
+  const appFilter = optionalString(args, 'app_filter')
+  const since = Date.now() - days * DAY_MS
+  const candidateLimit = Math.max(limit * 8, 100)
+  const frames = searchRewindFrames(query, candidateLimit)
+    .filter((frame) => frame.ts >= since)
+    .filter((frame) => matchesAppFilter(frame, appFilter))
+  const groups = groupFrames(frames, query).slice(0, limit)
+  const results = groups.map(mapSearchGroup)
+
+  return {
+    query,
+    days,
+    app_filter: appFilter ?? null,
+    limit,
+    result_count: results.length,
+    searched_frame_count: frames.length,
+    source: 'rewind_frames_ocr',
+    results,
+    suggestions:
+      results.length === 0
+        ? [
+            'Try a broader query',
+            'Increase the days window',
+            'Use execute_sql for exact app/window/OCR filters over rewind_frames'
+          ]
+        : []
+  }
+}
+
+async function screenshotResponse(name: string, args: JsonObject): Promise<LocalAgentToolResponse> {
+  const id = screenshotId(args)
+  const result = await readRewindFrameImage(getRewindFrame(id), rewindRoot())
+  if (!result.ok) {
+    throw new LocalAgentToolError('screenshot_not_found', result.message, 404, {
+      screenshot_id: id
+    })
+  }
+
+  return ok(name, mapScreenshot(result), result.imageMimeType)
+}
+
+function getDailyRecap(args: JsonObject): JsonObject {
+  const daysAgo = numberArg(args, 'days_ago', 0, 0, 365)
+  const range = recapRange(daysAgo)
+  const frames = listRewindFrames(range.startTs, range.endTs)
+  const apps = summarizeApps(frames)
+  const conversations = listLocalConversations()
+    .filter(
+      (conversation) =>
+        conversation.startedAt < range.endTs && conversation.endedAt >= range.startTs
+    )
+    .slice(0, 20)
+    .map(mapConversation)
+  const insights = recentInsights(100)
+    .filter((insight) => insight.ts >= range.startTs && insight.ts < range.endTs)
+    .slice(0, 20)
+    .map(mapInsight)
+  const taskSearch = searchLocalTasks('', true, 20)
+  const tasks = taskSearch.tasks.filter((task) => timestampInRange(task.createdAt, range))
+  const text = formatDailyRecap(
+    range.label,
+    apps,
+    conversations,
+    tasks,
+    insights,
+    taskSearch.available
+  )
+
+  return {
+    label: range.label,
+    range: {
+      start_ts: range.startTs,
+      end_ts: range.endTs,
+      start_at: iso(range.startTs),
+      end_at: iso(range.endTs)
+    },
+    apps,
+    conversations,
+    insights,
+    tasks,
+    task_search_available: taskSearch.available,
+    task_search_reason: taskSearch.reason ?? null,
+    text
+  }
+}
+
+function searchTasks(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query')
+  const includeCompleted = booleanArg(args, 'include_completed', false)
+  const limit = numberArg(args, 'limit', 10, 1, MAX_SEARCH_LIMIT)
+  const result = searchLocalTasks(query, includeCompleted, limit)
+  return {
+    query,
+    include_completed: includeCompleted,
+    limit,
+    available: result.available,
+    reason: result.reason ?? null,
+    sources: result.sources,
+    result_count: result.tasks.length,
+    tasks: result.tasks
+  }
+}
+
+function sanitizeRow(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (Buffer.isBuffer(value)) out[key] = `<${value.length} bytes>`
+    else if (typeof value === 'bigint') out[key] = value.toString()
+    else out[key] = value
+  }
+  return out
+}
+
+function matchesAppFilter(frame: RewindFrame, appFilter?: string): boolean {
+  if (!appFilter) return true
+  const needle = appFilter.toLowerCase()
+  return [frame.app, frame.processName, frame.windowTitle].some((value) =>
+    value.toLowerCase().includes(needle)
+  )
+}
+
+function mapSearchGroup(group: RewindSearchGroup): JsonObject {
+  return {
+    group_id: group.id,
+    app: group.app,
+    window_title: group.windowTitle,
+    start_ts: group.startTs,
+    end_ts: group.endTs,
+    start_at: iso(group.startTs),
+    end_at: iso(group.endTs),
+    match_snippet: group.matchSnippet,
+    representative: mapFrame(group.representative),
+    screenshots: group.frames
+      .filter((frame) => frame.id != null)
+      .slice(0, 10)
+      .map(mapFrame)
+  }
+}
+
+function mapFrame(frame: RewindFrame): JsonObject {
+  return {
+    screenshot_id: frame.id ?? null,
+    ts: frame.ts,
+    timestamp: iso(frame.ts),
+    app: frame.app,
+    window_title: frame.windowTitle,
+    process_name: frame.processName,
+    width: frame.width,
+    height: frame.height,
+    indexed: frame.indexed === 1,
+    ocr_preview: preview(frame.ocrText, 500)
+  }
+}
+
+function mapScreenshot(result: RewindFrameImageOk): JsonObject {
+  const imageBytes = Buffer.byteLength(result.imageBase64, 'base64')
+  return {
+    screenshot_id: result.id,
+    image_base64: result.imageBase64,
+    image_mime_type: result.imageMimeType,
+    metadata: {
+      screenshot_id: result.id,
+      ts: result.ts,
+      timestamp: iso(result.ts),
+      app: result.app,
+      window_title: result.windowTitle,
+      has_ocr: result.ocrPreview.length > 0,
+      ocr_preview: result.ocrPreview,
+      image_mime_type: result.imageMimeType,
+      image_bytes: imageBytes
+    }
+  }
+}
+
+function recapRange(daysAgo: number): { label: string; startTs: number; endTs: number } {
+  const now = Date.now()
+  const today = new Date(now)
+  today.setHours(0, 0, 0, 0)
+  const startToday = today.getTime()
+
+  if (daysAgo === 0) {
+    return { label: 'Today', startTs: startToday, endTs: now }
+  }
+  if (daysAgo === 1) {
+    return { label: 'Yesterday', startTs: startToday - DAY_MS, endTs: startToday }
+  }
+  return {
+    label: `Past ${daysAgo} days`,
+    startTs: startToday - daysAgo * DAY_MS,
+    endTs: now
+  }
+}
+
+function summarizeApps(frames: RewindFrame[]): JsonObject[] {
+  const byApp = new Map<
+    string,
+    {
+      app: string
+      captures: number
+      firstTs: number
+      lastTs: number
+      windowTitles: Set<string>
+    }
+  >()
+  for (const frame of frames) {
+    const app = frame.app || frame.processName || 'Unknown'
+    const current =
+      byApp.get(app) ??
+      ({
+        app,
+        captures: 0,
+        firstTs: frame.ts,
+        lastTs: frame.ts,
+        windowTitles: new Set<string>()
+      } satisfies {
+        app: string
+        captures: number
+        firstTs: number
+        lastTs: number
+        windowTitles: Set<string>
+      })
+    current.captures += 1
+    current.firstTs = Math.min(current.firstTs, frame.ts)
+    current.lastTs = Math.max(current.lastTs, frame.ts)
+    if (frame.windowTitle) current.windowTitles.add(frame.windowTitle)
+    byApp.set(app, current)
+  }
+
+  return [...byApp.values()]
+    .sort((a, b) => b.captures - a.captures)
+    .slice(0, 20)
+    .map((app) => ({
+      app: app.app,
+      captures: app.captures,
+      first_ts: app.firstTs,
+      last_ts: app.lastTs,
+      first_seen_at: iso(app.firstTs),
+      last_seen_at: iso(app.lastTs),
+      sample_window_titles: [...app.windowTitles].slice(0, 5)
+    }))
+}
+
+function mapConversation(conversation: LocalConversation): JsonObject {
+  return {
+    id: conversation.id,
+    title: conversation.title ?? null,
+    kind: conversation.kind ?? 'recording',
+    started_at: iso(conversation.startedAt),
+    ended_at: iso(conversation.endedAt),
+    transcript_preview: preview(conversation.transcript, 500)
+  }
+}
+
+function mapInsight(insight: InsightRecord): JsonObject {
+  return {
+    id: insight.id,
+    ts: insight.ts,
+    timestamp: iso(insight.ts),
+    headline: insight.headline,
+    advice: insight.advice,
+    category: insight.category,
+    source_app: insight.sourceApp,
+    confidence: insight.confidence
+  }
+}
+
+function timestampInRange(value: unknown, range: { startTs: number; endTs: number }): boolean {
+  if (value == null) return true
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number.isFinite(Number(value))
+          ? Number(value)
+          : Date.parse(value)
+        : NaN
+  return Number.isFinite(parsed) ? parsed >= range.startTs && parsed < range.endTs : true
+}
+
+function formatDailyRecap(
+  label: string,
+  apps: JsonObject[],
+  conversations: JsonObject[],
+  tasks: JsonObject[],
+  insights: JsonObject[],
+  taskSearchAvailable: boolean
+): string {
+  const lines = [`# ${label} Recap`, '', `## Apps (${apps.length})`]
+  if (apps.length === 0) {
+    lines.push('No screen activity recorded.')
+  } else {
+    for (const app of apps.slice(0, 10)) {
+      lines.push(`- ${app.app}: ${app.captures} capture(s)`)
+    }
+  }
+
+  lines.push('', `## Conversations (${conversations.length})`)
+  if (conversations.length === 0) {
+    lines.push('No local conversations recorded.')
+  } else {
+    for (const conversation of conversations.slice(0, 10)) {
+      lines.push(`- ${conversation.title ?? conversation.id}: ${conversation.transcript_preview}`)
+    }
+  }
+
+  lines.push('', `## Tasks (${tasks.length})`)
+  if (!taskSearchAvailable) {
+    lines.push('Local task storage is unavailable on this Windows build.')
+  } else if (tasks.length === 0) {
+    lines.push('No local tasks found for this range.')
+  } else {
+    for (const task of tasks.slice(0, 10)) {
+      lines.push(`- ${task.completed ? '[x]' : '[ ]'} ${task.description}`)
+    }
+  }
+
+  lines.push('', `## Insights (${insights.length})`)
+  if (insights.length === 0) {
+    lines.push('No local insights recorded.')
+  } else {
+    for (const insight of insights.slice(0, 10)) {
+      lines.push(`- ${insight.headline}: ${insight.advice}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function preview(text: string, length: number): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, length)
+}
+
+function iso(ts: number | null | undefined): string | null {
+  return typeof ts === 'number' && Number.isFinite(ts) ? new Date(ts).toISOString() : null
+}

--- a/desktop/windows/src/main/localAgent/tools.ts
+++ b/desktop/windows/src/main/localAgent/tools.ts
@@ -84,7 +84,7 @@ function schema(
   return {
     type: 'object',
     properties,
-    required,
+    ...(required.length > 0 ? { required } : {}),
     additionalProperties
   }
 }
@@ -167,19 +167,16 @@ const TOOL_DEFINITIONS: LocalAgentToolDefinition[] = [
     name: 'get_screenshot',
     description:
       'Fetch a local Rewind screenshot image by screenshot_id. Use IDs returned by search_screen_history or execute_sql over rewind_frames.',
-    inputSchema: schema(
-      {
-        screenshot_id: {
-          type: 'number',
-          description: 'Rewind frame ID returned as screenshot_id.'
-        },
-        id: {
-          type: 'number',
-          description: 'Alias for screenshot_id.'
-        }
+    inputSchema: schema({
+      screenshot_id: {
+        type: 'number',
+        description: 'Rewind frame ID returned as screenshot_id.'
       },
-      ['screenshot_id']
-    ),
+      id: {
+        type: 'number',
+        description: 'Alias for screenshot_id.'
+      }
+    }),
     annotations: annotations()
   },
   {
@@ -256,15 +253,18 @@ const TOOL_DEFINITIONS: LocalAgentToolDefinition[] = [
 const TOOL_NAMES = new Set(TOOL_DEFINITIONS.map((tool) => tool.name))
 
 export function listLocalAgentTools(): LocalAgentToolDefinition[] {
-  return TOOL_DEFINITIONS.map((tool) => ({
-    ...tool,
-    inputSchema: {
-      ...tool.inputSchema,
-      properties: { ...tool.inputSchema.properties },
-      required: [...(tool.inputSchema.required ?? [])]
-    },
-    annotations: { ...tool.annotations }
-  }))
+  return TOOL_DEFINITIONS.map((tool) => {
+    const required = tool.inputSchema.required
+    return {
+      ...tool,
+      inputSchema: {
+        ...tool.inputSchema,
+        properties: { ...tool.inputSchema.properties },
+        ...(required ? { required: [...required] } : {})
+      },
+      annotations: { ...tool.annotations }
+    }
+  })
 }
 
 export async function runLocalAgentTool(

--- a/desktop/windows/src/main/rewind/frameImage.ts
+++ b/desktop/windows/src/main/rewind/frameImage.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'fs/promises'
+import { extname, resolve, sep } from 'path'
+import type { RewindFrame, RewindFrameImageResult } from '../../shared/types'
+
+export function frameImageNotFound(message: string): RewindFrameImageResult {
+  return { ok: false, code: 'not_found', message }
+}
+
+function imageMimeType(imagePath: string): string {
+  const ext = extname(imagePath).toLowerCase()
+  if (ext === '.png') return 'image/png'
+  if (ext === '.webp') return 'image/webp'
+  return 'image/jpeg'
+}
+
+function ocrPreview(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, 240)
+}
+
+export function resolveFrameImagePath(rootPath: string, imagePath: string): string | null {
+  const root = resolve(rootPath)
+  const full = resolve(imagePath)
+  if (full !== root && !full.startsWith(root + sep)) return null
+  return full
+}
+
+export async function readRewindFrameImage(
+  frame: RewindFrame | null,
+  rootPath: string
+): Promise<RewindFrameImageResult> {
+  if (!frame?.id) return frameImageNotFound('Frame not found')
+  const full = resolveFrameImagePath(rootPath, frame.imagePath)
+  if (!full) return frameImageNotFound('Frame image not found')
+  try {
+    const buf = await readFile(full)
+    return {
+      ok: true,
+      id: frame.id,
+      ts: frame.ts,
+      app: frame.app,
+      windowTitle: frame.windowTitle,
+      ocrPreview: ocrPreview(frame.ocrText),
+      imageMimeType: imageMimeType(full),
+      imageBase64: buf.toString('base64')
+    }
+  } catch {
+    return frameImageNotFound('Frame image not found')
+  }
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -45,6 +45,12 @@ const omi: OmiBridgeApi = {
     ipcRenderer.on('omi-listen:message', listener)
     return () => ipcRenderer.removeListener('omi-listen:message', listener)
   },
+  localAgentStatus: () => ipcRenderer.invoke('localAgent:status'),
+  localAgentSetEnabled: (enabled: boolean) => ipcRenderer.invoke('localAgent:setEnabled', enabled),
+  localAgentSetPort: (port: number) => ipcRenderer.invoke('localAgent:setPort', port),
+  localAgentCopyToken: () => ipcRenderer.invoke('localAgent:copyToken'),
+  localAgentRotateToken: () => ipcRenderer.invoke('localAgent:rotateToken'),
+  localAgentTestTools: () => ipcRenderer.invoke('localAgent:testTools'),
   indexFilesScan: () => ipcRenderer.invoke('fileIndex:scan'),
   indexFilesStatus: () => ipcRenderer.invoke('fileIndex:status'),
   indexFilesApps: (limit?: number) => ipcRenderer.invoke('fileIndex:apps', limit),

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
@@ -1,17 +1,33 @@
 import { useEffect, useState } from 'react'
-import { Download, Upload, Wrench, FolderSearch, Network, RotateCcw } from 'lucide-react'
+import {
+  Copy,
+  Download,
+  Upload,
+  Wrench,
+  FolderSearch,
+  Network,
+  RotateCcw,
+  KeyRound,
+  RefreshCw
+} from 'lucide-react'
 import { omiApi } from '../../../lib/apiClient'
 import { toast } from '../../../lib/toast'
 import { extractMemories, type MemorySource } from '../../../lib/memoryExtract'
 import { buildLocalGraph } from '../../../lib/kgSynthesis'
-import { summarizeMemories, appIndexMemoryIds, type MemoryBreakdown } from '../../../lib/memoryCleanup'
+import {
+  summarizeMemories,
+  appIndexMemoryIds,
+  type MemoryBreakdown
+} from '../../../lib/memoryCleanup'
 import { useMemories, type Memory } from '../../../hooks/useMemories'
 import { resetOnboarding } from '../../../lib/preferences'
 import { SettingRow } from '../SettingRow'
+import { Toggle } from '../Toggle'
 import { IntegrationsTab } from './IntegrationsTab'
 import type {
   ExportMemory,
   FileIndexStatus,
+  LocalAgentStatus,
   LocalKGStatus,
   MemoryExportResult
 } from '../../../../../shared/types'
@@ -19,11 +35,174 @@ import type {
 export function AdvancedTab(): React.JSX.Element {
   const { memories, refresh } = useMemories()
 
+  // --- Local agent API ---
+  const [localAgent, setLocalAgent] = useState<LocalAgentStatus | null>(null)
+  const [localAgentPort, setLocalAgentPort] = useState('')
+  const [localAgentBusy, setLocalAgentBusy] = useState<
+    '' | 'enable' | 'port' | 'copy-token' | 'rotate-token' | 'test' | 'refresh' | 'copy-url'
+  >('')
+
+  const applyLocalAgentStatus = (status: LocalAgentStatus): void => {
+    setLocalAgent(status)
+    setLocalAgentPort(String(status.configuredPort))
+  }
+
+  const refreshLocalAgent = async (): Promise<void> => {
+    setLocalAgentBusy((current) => current || 'refresh')
+    try {
+      const status = await window.omi.localAgentStatus()
+      applyLocalAgentStatus(status)
+    } catch (e) {
+      toast('Could not read local agent status', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy((current) => (current === 'refresh' ? '' : current))
+    }
+  }
+
+  useEffect(() => {
+    let canceled = false
+    window.omi
+      .localAgentStatus()
+      .then((status) => {
+        if (!canceled) applyLocalAgentStatus(status)
+      })
+      .catch((e) => {
+        if (!canceled) {
+          toast('Could not read local agent status', { tone: 'error', body: (e as Error).message })
+        }
+      })
+    return () => {
+      canceled = true
+    }
+  }, [])
+
+  const setLocalAgentEnabled = async (enabled: boolean): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('enable')
+    try {
+      const status = await window.omi.localAgentSetEnabled(enabled)
+      applyLocalAgentStatus(status)
+      toast(enabled ? 'Local agent API enabled' : 'Local agent API disabled', { tone: 'success' })
+    } catch (e) {
+      toast(enabled ? 'Could not enable local agent API' : 'Could not disable local agent API', {
+        tone: 'error',
+        body: (e as Error).message
+      })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const saveLocalAgentPort = async (): Promise<void> => {
+    if (localAgentBusy) return
+    const port = Number(localAgentPort)
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+      toast('Enter a port between 1024 and 65535', { tone: 'warn' })
+      return
+    }
+
+    setLocalAgentBusy('port')
+    try {
+      const status = await window.omi.localAgentSetPort(port)
+      applyLocalAgentStatus(status)
+      toast('Local agent port saved', {
+        tone: 'success',
+        body: status.running ? `Listening on ${status.localUrl}` : undefined
+      })
+    } catch (e) {
+      toast('Could not save local agent port', { tone: 'error', body: (e as Error).message })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const copyLocalAgentUrl = async (): Promise<void> => {
+    if (!localAgent?.localUrl || localAgentBusy) return
+    setLocalAgentBusy('copy-url')
+    try {
+      await navigator.clipboard.writeText(localAgent.localUrl)
+      toast('Local agent URL copied', { tone: 'success' })
+    } catch (e) {
+      toast('Could not copy local agent URL', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const copyLocalAgentToken = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('copy-token')
+    try {
+      const status = await window.omi.localAgentCopyToken()
+      applyLocalAgentStatus(status)
+      toast('Bearer token copied', { tone: 'success' })
+    } catch (e) {
+      toast('Could not copy bearer token', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const rotateLocalAgentToken = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('rotate-token')
+    try {
+      const status = await window.omi.localAgentRotateToken()
+      applyLocalAgentStatus(status)
+      toast('Bearer token rotated', {
+        tone: 'success',
+        body: status.running ? 'Existing clients must use the new token.' : undefined
+      })
+    } catch (e) {
+      toast('Could not rotate bearer token', { tone: 'error', body: (e as Error).message })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const testLocalAgentTools = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('test')
+    try {
+      const result = await window.omi.localAgentTestTools()
+      if (result.ok) {
+        toast('Local agent tools reachable', {
+          tone: 'success',
+          body: `${result.toolCount ?? 0} tools available`
+        })
+      } else {
+        toast('Local agent tools test failed', {
+          tone: 'error',
+          body: result.error ?? (result.status ? `HTTP ${result.status}` : undefined)
+        })
+      }
+    } catch (e) {
+      toast('Local agent tools test failed', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+      void refreshLocalAgent()
+    }
+  }
+
+  const localAgentSubtitle = !localAgent
+    ? 'Loading local API status…'
+    : localAgent.running
+      ? `Listening on ${localAgent.localUrl}`
+      : localAgent.enabled
+        ? 'Enabled, but not currently listening. Refresh status or disable and re-enable.'
+        : 'Disabled by default. Enable to let local agents access Omi through loopback with bearer auth.'
+
   // --- File indexing ---
   const [fileIndex, setFileIndex] = useState<FileIndexStatus | null>(null)
   const [scanning, setScanning] = useState(false)
   useEffect(() => {
-    window.omi.indexFilesStatus().then(setFileIndex).catch(() => setFileIndex(null))
+    window.omi
+      .indexFilesStatus()
+      .then(setFileIndex)
+      .catch(() => setFileIndex(null))
   }, [])
   const rescan = async (): Promise<void> => {
     if (scanning) return
@@ -43,7 +222,10 @@ export function AdvancedTab(): React.JSX.Element {
   const [kgStatus, setKgStatus] = useState<LocalKGStatus | null>(null)
   const [rebuildingKg, setRebuildingKg] = useState(false)
   useEffect(() => {
-    window.omi.kgStatus().then(setKgStatus).catch(() => setKgStatus(null))
+    window.omi
+      .kgStatus()
+      .then(setKgStatus)
+      .catch(() => setKgStatus(null))
   }, [])
   const rebuildKg = async (): Promise<void> => {
     if (rebuildingKg) return
@@ -75,12 +257,17 @@ export function AdvancedTab(): React.JSX.Element {
       const { memories: list, profile: summary } = await extractMemories(dump, source, existing)
       setParsed(list)
       setProfile(summary)
-      if (list.length === 0) toast('No new memories found — they may already be saved', { tone: 'warn' })
+      if (list.length === 0)
+        toast('No new memories found — they may already be saved', { tone: 'warn' })
     } catch (e) {
       console.warn('[memoryImport] AI extraction failed, falling back to split:', e)
       try {
         const norm = (s: string): string =>
-          s.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/g, ' ').trim()
+          s
+            .toLowerCase()
+            .replace(/[^\p{L}\p{N}\s]/gu, '')
+            .replace(/\s+/g, ' ')
+            .trim()
         const have = new Set(existing.map(norm))
         const list = (await window.omi.memoryImportParse(dump)).filter((m) => !have.has(norm(m)))
         setParsed(list)
@@ -134,7 +321,11 @@ export function AdvancedTab(): React.JSX.Element {
   const [notionPage, setNotionPage] = useState('')
   const [exporting, setExporting] = useState(false)
   const toExportMemories = (): ExportMemory[] =>
-    memories.map((m) => ({ content: m.content, category: m.category ?? null, createdAt: m.created_at }))
+    memories.map((m) => ({
+      content: m.content,
+      category: m.category ?? null,
+      createdAt: m.created_at
+    }))
 
   const runExport = async (target: 'obsidian' | 'file' | 'notion'): Promise<void> => {
     if (exporting) return
@@ -159,7 +350,10 @@ export function AdvancedTab(): React.JSX.Element {
           memories: mems
         })
       if (!r.canceled) {
-        toast(`Exported ${r.count} memor${r.count === 1 ? 'y' : 'ies'}`, { tone: 'success', body: r.location })
+        toast(`Exported ${r.count} memor${r.count === 1 ? 'y' : 'ies'}`, {
+          tone: 'success',
+          body: r.location
+        })
       }
     } catch (e) {
       toast('Export failed', { tone: 'error', body: (e as Error).message })
@@ -209,7 +403,12 @@ export function AdvancedTab(): React.JSX.Element {
   const deleteAppIndexMemories = async (): Promise<void> => {
     const ids = appIndexMemoryIds(memAllMemories)
     if (ids.length === 0 || memDeleting) return
-    if (!window.confirm(`Permanently delete ${ids.length} app/file-index memories? This cannot be undone.`)) return
+    if (
+      !window.confirm(
+        `Permanently delete ${ids.length} app/file-index memories? This cannot be undone.`
+      )
+    )
+      return
     setMemDeleting(true)
     setMemDeleteProgress(0)
     const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
@@ -224,13 +423,16 @@ export function AdvancedTab(): React.JSX.Element {
           await omiApi.delete(`/v3/memories/${id}`, { ...({ __noRetry: true } as object) })
           return 'ok'
         } catch (e) {
-          const resp = (e as { response?: { status?: number; headers?: Record<string, string> } }).response
+          const resp = (e as { response?: { status?: number; headers?: Record<string, string> } })
+            .response
           const status = resp?.status
           if (status === 404) return 'gone'
           if (status === 429) {
             paceMs = 1100
             const ra = Number(resp?.headers?.['retry-after'])
-            await sleep(Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000))
+            await sleep(
+              Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000)
+            )
             continue
           }
           if (!firstError) firstError = status ? `HTTP ${status}` : (e as Error).message
@@ -250,7 +452,9 @@ export function AdvancedTab(): React.JSX.Element {
       }
       toast(`Deleted ${deleted} of ${ids.length} memories`, {
         tone: failed ? 'warn' : 'success',
-        body: failed ? `${failed} failed${firstError ? ` — ${firstError}` : ''}. Analyze again to retry.` : undefined
+        body: failed
+          ? `${failed} failed${firstError ? ` — ${firstError}` : ''}. Analyze again to retry.`
+          : undefined
       })
     } catch (e) {
       toast('Delete failed', { tone: 'error', body: (e as Error).message })
@@ -268,6 +472,140 @@ export function AdvancedTab(): React.JSX.Element {
 
   return (
     <>
+      <SettingRow
+        icon={Network}
+        title="Local Agent Access"
+        subtitle={localAgentSubtitle}
+        keywords="local agent api bearer token codex claude chatgpt tools mcp loopback localhost port"
+        dot={!localAgent ? 'off' : localAgent.running ? 'on' : localAgent.enabled ? 'warn' : 'off'}
+        control={
+          <Toggle
+            on={localAgent?.enabled ?? false}
+            onChange={setLocalAgentEnabled}
+            disabled={!localAgent || localAgentBusy !== ''}
+            label="Enable local agent API"
+          />
+        }
+      >
+        <div className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Status</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {!localAgent
+                  ? 'Loading'
+                  : localAgent.running
+                    ? 'Listening'
+                    : localAgent.enabled
+                      ? 'Enabled, stopped'
+                      : 'Disabled'}
+              </div>
+            </div>
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Current port</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {localAgent?.currentPort ?? localAgent?.configuredPort ?? '—'}
+              </div>
+            </div>
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Host</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {localAgent?.host ?? '127.0.0.1'}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-xs uppercase text-text-tertiary">Local URL</div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <code className="glass-subtle min-w-0 flex-1 overflow-x-auto rounded-lg px-3 py-2 text-sm text-text-secondary">
+                {localAgent?.localUrl ?? 'Not listening'}
+              </code>
+              <button
+                type="button"
+                onClick={copyLocalAgentUrl}
+                disabled={!localAgent?.localUrl || localAgentBusy !== ''}
+                className="btn-ghost inline-flex items-center justify-center gap-2 disabled:opacity-40"
+              >
+                <Copy className="h-4 w-4" />
+                Copy URL
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <label className="min-w-0 flex-1">
+              <span className="mb-1 block text-xs uppercase text-text-tertiary">Port</span>
+              <input
+                type="number"
+                min={1024}
+                max={65535}
+                value={localAgentPort}
+                onChange={(e) => setLocalAgentPort(e.target.value)}
+                disabled={!localAgent || localAgentBusy !== ''}
+                className="input-field"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={saveLocalAgentPort}
+              disabled={
+                !localAgent ||
+                localAgentBusy !== '' ||
+                localAgentPort === String(localAgent.configuredPort)
+              }
+              className="btn-ghost disabled:opacity-40"
+            >
+              {localAgentBusy === 'port' ? 'Saving…' : 'Save port'}
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={copyLocalAgentToken}
+              disabled={!localAgent || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <Copy className="h-4 w-4" />
+              {localAgentBusy === 'copy-token' ? 'Copying…' : 'Copy token'}
+            </button>
+            <button
+              type="button"
+              onClick={rotateLocalAgentToken}
+              disabled={!localAgent || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <KeyRound className="h-4 w-4" />
+              {localAgentBusy === 'rotate-token' ? 'Rotating…' : 'Rotate token'}
+            </button>
+            <button
+              type="button"
+              onClick={testLocalAgentTools}
+              disabled={!localAgent?.running || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <Wrench className="h-4 w-4" />
+              {localAgentBusy === 'test' ? 'Testing…' : 'Test local tools'}
+            </button>
+            <button
+              type="button"
+              onClick={refreshLocalAgent}
+              disabled={localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
+          </div>
+
+          <p className="text-sm text-text-tertiary">
+            Bearer auth is required for tools. The token is copied directly to your clipboard and is
+            not displayed here.
+          </p>
+        </div>
+      </SettingRow>
+
       <SettingRow
         icon={Download}
         title="Import memories"
@@ -299,22 +637,36 @@ export function AdvancedTab(): React.JSX.Element {
             className="input-field resize-none"
           />
           <div className="flex items-center gap-2">
-            <button onClick={extractDump} disabled={!dump.trim() || extracting || importing} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={extractDump}
+              disabled={!dump.trim() || extracting || importing}
+              className="btn-ghost disabled:opacity-40"
+            >
               {extracting ? 'Extracting…' : 'Extract memories'}
             </button>
             {parsed && parsed.length > 0 && (
-              <button onClick={importMemories} disabled={importing} className="btn-primary px-4 py-2 disabled:opacity-40">
-                {importing ? 'Importing…' : `Import ${parsed.length} memor${parsed.length === 1 ? 'y' : 'ies'}`}
+              <button
+                onClick={importMemories}
+                disabled={importing}
+                className="btn-primary px-4 py-2 disabled:opacity-40"
+              >
+                {importing
+                  ? 'Importing…'
+                  : `Import ${parsed.length} memor${parsed.length === 1 ? 'y' : 'ies'}`}
               </button>
             )}
           </div>
           {profile && (
-            <p className="glass-subtle rounded-lg px-4 py-3 text-sm italic text-text-tertiary">{profile}</p>
+            <p className="glass-subtle rounded-lg px-4 py-3 text-sm italic text-text-tertiary">
+              {profile}
+            </p>
           )}
           {parsed && parsed.length > 0 && (
             <ul className="glass-subtle max-h-40 overflow-y-auto rounded-lg px-4 py-3 text-sm text-text-tertiary">
               {parsed.map((m, i) => (
-                <li key={i} className="py-0.5">• {m}</li>
+                <li key={i} className="py-0.5">
+                  • {m}
+                </li>
               ))}
             </ul>
           )}
@@ -329,10 +681,18 @@ export function AdvancedTab(): React.JSX.Element {
       >
         <div className="space-y-3">
           <div className="flex flex-wrap gap-2">
-            <button onClick={() => runExport('obsidian')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('obsidian')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               Obsidian vault…
             </button>
-            <button onClick={() => runExport('file')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('file')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               Plain file…
             </button>
           </div>
@@ -352,7 +712,11 @@ export function AdvancedTab(): React.JSX.Element {
               placeholder="Parent page ID"
               className="glass-subtle mb-2 w-full rounded-lg px-4 py-3 text-sm text-text-secondary focus:outline-none"
             />
-            <button onClick={() => runExport('notion')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('notion')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               {exporting ? 'Exporting…' : 'Export to Notion'}
             </button>
           </div>
@@ -367,11 +731,19 @@ export function AdvancedTab(): React.JSX.Element {
       >
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <button onClick={auditMemories} disabled={memAuditing || memDeleting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={auditMemories}
+              disabled={memAuditing || memDeleting}
+              className="btn-ghost disabled:opacity-40"
+            >
               {memAuditing ? 'Analyzing…' : 'Analyze memories'}
             </button>
             {memBreakdown && memBreakdown.appIndexCount > 0 && (
-              <button onClick={deleteAppIndexMemories} disabled={memDeleting || memAuditing} className="btn-primary px-4 py-2 disabled:opacity-40">
+              <button
+                onClick={deleteAppIndexMemories}
+                disabled={memDeleting || memAuditing}
+                className="btn-primary px-4 py-2 disabled:opacity-40"
+              >
                 {memDeleting
                   ? `Deleting ${memDeleteProgress}/${memBreakdown.appIndexCount}…`
                   : `Delete ${memBreakdown.appIndexCount} app/file memories`}
@@ -382,12 +754,15 @@ export function AdvancedTab(): React.JSX.Element {
             <div className="glass-subtle rounded-lg px-4 py-3 text-sm text-text-tertiary">
               <p className="mb-2 text-text-secondary">
                 {memBreakdown.total} total memories ·{' '}
-                <span className="text-text-primary">{memBreakdown.appIndexCount}</span> app/file-index matches
+                <span className="text-text-primary">{memBreakdown.appIndexCount}</span>{' '}
+                app/file-index matches
               </p>
               {memBreakdown.appIndexCount > 0 && (
                 <ul className="mb-3 max-h-32 overflow-y-auto">
                   {memBreakdown.appIndexSamples.map((s, i) => (
-                    <li key={i} className="py-0.5">• {s}</li>
+                    <li key={i} className="py-0.5">
+                      • {s}
+                    </li>
                   ))}
                 </ul>
               )}
@@ -396,7 +771,9 @@ export function AdvancedTab(): React.JSX.Element {
                 {memBreakdown.groups.map((g) => (
                   <li key={g.key} className="py-0.5">
                     <span className="text-text-primary">{g.count}</span> — {g.key}
-                    {g.samples[0] ? <span className="opacity-60"> · e.g. “{g.samples[0]}”</span> : null}
+                    {g.samples[0] ? (
+                      <span className="opacity-60"> · e.g. “{g.samples[0]}”</span>
+                    ) : null}
                   </li>
                 ))}
               </ul>
@@ -414,7 +791,9 @@ export function AdvancedTab(): React.JSX.Element {
         subtitle={
           fileIndex
             ? `${fileIndex.filesIndexed.toLocaleString()} items indexed${
-                fileIndex.lastRunAt ? ` · last run ${new Date(fileIndex.lastRunAt).toLocaleString()}` : ''
+                fileIndex.lastRunAt
+                  ? ` · last run ${new Date(fileIndex.lastRunAt).toLocaleString()}`
+                  : ''
               }`
             : 'Indexes file names/metadata locally (contents never read or uploaded).'
         }
@@ -432,13 +811,19 @@ export function AdvancedTab(): React.JSX.Element {
         subtitle={
           kgStatus
             ? `${kgStatus.nodeCount.toLocaleString()} nodes · ${kgStatus.edgeCount.toLocaleString()} relationships${
-                kgStatus.lastBuiltAt ? ` · last built ${new Date(kgStatus.lastBuiltAt).toLocaleString()}` : ''
+                kgStatus.lastBuiltAt
+                  ? ` · last built ${new Date(kgStatus.lastBuiltAt).toLocaleString()}`
+                  : ''
               }`
             : 'A local graph of your projects, tech, people, and apps — used to ground chat answers.'
         }
         keywords="knowledge graph rebuild kg nodes"
         control={
-          <button onClick={rebuildKg} disabled={rebuildingKg} className="btn-ghost disabled:opacity-40">
+          <button
+            onClick={rebuildKg}
+            disabled={rebuildingKg}
+            className="btn-ghost disabled:opacity-40"
+          >
             {rebuildingKg ? 'Rebuilding…' : 'Rebuild now'}
           </button>
         }

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
@@ -137,7 +137,10 @@ export function AdvancedTab(): React.JSX.Element {
     try {
       const status = await window.omi.localAgentCopyToken()
       applyLocalAgentStatus(status)
-      toast('Bearer token copied', { tone: 'success' })
+      toast('Bearer token copied', {
+        tone: 'success',
+        body: 'The token will be cleared from the clipboard after 60 seconds if unchanged.'
+      })
     } catch (e) {
       toast('Could not copy bearer token', { tone: 'error', body: (e as Error).message })
     } finally {
@@ -189,11 +192,13 @@ export function AdvancedTab(): React.JSX.Element {
 
   const localAgentSubtitle = !localAgent
     ? 'Loading local API status…'
-    : localAgent.running
-      ? `Listening on ${localAgent.localUrl}`
-      : localAgent.enabled
-        ? 'Enabled, but not currently listening. Refresh status or disable and re-enable.'
-        : 'Disabled by default. Enable to let local agents access Omi through loopback with bearer auth.'
+    : localAgent.tokenError
+      ? localAgent.tokenError
+      : localAgent.running
+        ? `Listening on ${localAgent.localUrl}`
+        : localAgent.enabled
+          ? 'Enabled, but not currently listening. Refresh status or disable and re-enable.'
+          : 'Disabled by default. Enable to let local agents access Omi through loopback with bearer auth.'
 
   // --- File indexing ---
   const [fileIndex, setFileIndex] = useState<FileIndexStatus | null>(null)
@@ -600,8 +605,8 @@ export function AdvancedTab(): React.JSX.Element {
           </div>
 
           <p className="text-sm text-text-tertiary">
-            Bearer auth is required for tools. The token is copied directly to your clipboard and is
-            not displayed here.
+            Bearer auth is required for tools. The token is copied to your clipboard, cleared after
+            60 seconds if unchanged, and not displayed here.
           </p>
         </div>
       </SettingRow>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -619,6 +619,25 @@ export type RewindFrame = {
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
 }
 
+export type RewindFrameImageOk = {
+  ok: true
+  id: number
+  ts: number
+  app: string
+  windowTitle: string
+  ocrPreview: string
+  imageMimeType: string
+  imageBase64: string
+}
+
+export type RewindFrameImageNotFound = {
+  ok: false
+  code: 'not_found'
+  message: string
+}
+
+export type RewindFrameImageResult = RewindFrameImageOk | RewindFrameImageNotFound
+
 export type RewindSearchGroup = {
   id: string
   app: string

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -91,6 +91,24 @@ export type ListenMessage =
   | { sessionId: string; kind: 'error'; message: string; fatal: boolean }
   | { sessionId: string; kind: 'closed'; code: number; reason: string }
 
+export type LocalAgentStatus = {
+  enabled: boolean
+  running: boolean
+  host: string
+  configuredPort: number
+  currentPort: number | null
+  localUrl: string | null
+  toolEndpoint: string | null
+  hasToken: boolean
+}
+
+export type LocalAgentToolsTestResult = {
+  ok: boolean
+  status?: number
+  toolCount?: number
+  error?: string
+}
+
 export type OmiOverlayApi = {
   /** Subscribe to summon events; callback fires each time the overlay is shown. Returns an unsubscribe fn. */
   onShown: (cb: () => void) => () => void
@@ -161,6 +179,12 @@ export type OmiBridgeApi = {
   listenFeed: (sessionId: string, pcm: ArrayBuffer) => void
   /** Subscribe to status/segment/event messages from every listen session. */
   onListenMessage: (cb: (msg: ListenMessage) => void) => () => void
+  localAgentStatus: () => Promise<LocalAgentStatus>
+  localAgentSetEnabled: (enabled: boolean) => Promise<LocalAgentStatus>
+  localAgentSetPort: (port: number) => Promise<LocalAgentStatus>
+  localAgentCopyToken: () => Promise<LocalAgentStatus>
+  localAgentRotateToken: () => Promise<LocalAgentStatus>
+  localAgentTestTools: () => Promise<LocalAgentToolsTestResult>
   indexFilesScan: () => Promise<FileIndexStatus>
   indexFilesStatus: () => Promise<FileIndexStatus>
   /** Indexed installed apps (Start-Menu shortcuts), newest-modified first. */

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -100,6 +100,7 @@ export type LocalAgentStatus = {
   localUrl: string | null
   toolEndpoint: string | null
   hasToken: boolean
+  tokenError: string | null
 }
 
 export type LocalAgentToolsTestResult = {


### PR DESCRIPTION
> **Maintainers:** one of several independent Windows split PRs carved out of #8404. Each is small and standalone — **cherry-pick or merge whichever you want, in any order**; they do not depend on each other beyond shared plumbing. Base is v0.11.542 (`84e539a`). Full context: BasedHardware/omi#8404.

---

## Summary

Split **4 of the PR 8404 breakup** (maintainer-requested order: "Local agent localhost API/tools, with a privacy/security design note"). Branch: `split/pr8404-local-agent-tools`. Review together with `local-agent-design`.

- Adds opt-in localhost access for local agents: bearer-authenticated tool discovery/invocation, safe local-context access, allowlisted read-only SQL, and Rewind screenshot-frame access.
- Defaults to **disabled** and **loopback-only** in the captured Windows state.

## Scope

- **In scope:** `desktop/windows/src/main/localAgent/*` (server, tokenStore, tools, control, settings), `src/main/ipc/localAgent.ts`, the Local Agent Access settings surface (`AdvancedTab.tsx`), and shared plumbing.
- **In scope by dependency:** `src/main/rewind/frameImage.ts` (Rewind frame access for the screenshot tool — owned/reviewed authoritatively in `ui-rewind`).
- **Out of scope:** BYOK provider keys, STT/TTS runtimes, updater.

## Split Overlap & Merge Order

- Split #4 in [SPLIT_MAP.md](../SPLIT_MAP.md); land after `ui-rewind`, review with `local-agent-design`.
- **Authoritative owner of the `localAgent/*` code.** Note: the identical `localAgent/*` server/tokenStore/tools/control code also currently appears in the `pi-claude-routing` branch (byte-identical). Review the local-agent code **here**; `pi-claude-routing` should land after this split or drop the duplicated code.
- Uses `rewind/frameImage.ts` from `ui-rewind`.

## Windows Desktop Verification Evidence

- **Package check** (`_package-evidence/20260628-083433`): OK — `koffi.node`, `app.asar`, packaged config strings present.
- **Launch smoke** (`_smoke-evidence/20260627-194234`): launch **pass**, title `omi`, unit tests **pass**.
- **Independent unit re-run (2026-07-01, vitest 3.2.6):** `localAgent/server`, `localAgent/tokenStore`, `localAgent/tools`, `localAgent/control` → **19 tests passing**. Observed in the run: server binds to `127.0.0.1` only and falls back from the default port without binding to all interfaces; token rotation invalidates the old token; the authenticated tools endpoint requires the bearer.
- **Feature capture** (`_feature-renderer-evidence/20260628-084516`): Local Agent Access settings surface in the packaged app. Status probe: `enabled=false, running=false, host=127.0.0.1, configuredPort=47778, currentPort=null, localUrl=null, toolEndpoint=null, hasToken=false`.
- **Recorded source checks** (TESTING.md): `npm run test -- src/main/localAgent/server.test.ts src/main/localAgent/tokenStore.test.ts src/main/localAgent/tools.test.ts src/main/localAgent/control.test.ts`; `npm run build`.

## Addresses Maintainer Review Notes (BasedHardware/omi#8404)

- Maintainer split order item **#4** and blocker **#4** (privacy/security surface). Pair with `local-agent-design`.
- Captured default is disabled and loopback-only: host `127.0.0.1`, no listener URL, no tool endpoint, no token present.
- No local-agent enable, token copy/rotation, tool test, or bearer-auth request was performed against the real account during prep.
- Review should verify health-endpoint behavior, bearer requirement for tools, token storage/rotation/invalidation, SQL allowlist enforcement, Rewind screenshot path containment, and no sensitive values in logs/telemetry.

## Screenshots


## Remaining Checks Before Non-Draft

- Enable on disposable data and verify `/health`, auth-required tools, token-rotation invalidation, safe SQL allowlist, and Rewind screenshot retrieval end to end.
- Cross-review with `local-agent-design` before non-draft.
- Redact screenshots before posting if personal data is visible (see [REDACTION_NOTES.md](../REDACTION_NOTES.md)).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

