### PR TITLE
[WIN] Pi/Omi + Claude chat routing

### DIFF
--- a/desktop/windows/.env.example
+++ b/desktop/windows/.env.example
@@ -12,7 +12,9 @@ VITE_FIREBASE_PROJECT_ID=based-hardware
 VITE_OMI_API_BASE=https://api.omi.me
 VITE_OMI_DESKTOP_API_BASE=https://desktop-backend-hhibjajaja-uc.a.run.app
 
-# Experimental Pi/Omi chat bridge. Leave off to keep the existing /v2/messages chat path.
+# Experimental Pi/Omi chat bridge. Disabled by default (fail closed): chat only
+# routes through the Pi/Omi path when this is explicitly set to a truthy value
+# ('1'/'true'). Leave unset or '0' to keep the existing /v2/messages chat path.
 OMI_WINDOWS_PI_CHAT=0
 
 # PostHog analytics — same project the macOS desktop app reports to. Both have

--- a/desktop/windows/.env.example
+++ b/desktop/windows/.env.example
@@ -12,6 +12,9 @@ VITE_FIREBASE_PROJECT_ID=based-hardware
 VITE_OMI_API_BASE=https://api.omi.me
 VITE_OMI_DESKTOP_API_BASE=https://desktop-backend-hhibjajaja-uc.a.run.app
 
+# Experimental Pi/Omi chat bridge. Leave off to keep the existing /v2/messages chat path.
+OMI_WINDOWS_PI_CHAT=0
+
 # PostHog analytics — same project the macOS desktop app reports to. Both have
 # sensible defaults baked in (the key is a publishable client key), so these only
 # need setting to point at a different PostHog project.

--- a/desktop/windows/.gitignore
+++ b/desktop/windows/.gitignore
@@ -50,3 +50,4 @@ resources/win-ocr-helper/*.pdb
 src/main/automation/helper/bin/
 src/main/automation/helper/obj/
 resources/win-automation-helper/*.pdb
+resources/koffi/

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -19,6 +19,11 @@ asarUnpack:
   # koffi loads its native .node at runtime, resolved relative to its own package
   # dir — it must live outside the asar archive or the foreground monitor fails.
   - node_modules/koffi/**
+extraResources:
+  - from: resources/koffi
+    to: koffi
+    filter:
+      - '**/*'
 win:
   executableName: omi-windows
   target:

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -19,13 +19,13 @@ asarUnpack:
   # koffi loads its native .node at runtime, resolved relative to its own package
   # dir — it must live outside the asar archive or the foreground monitor fails.
   - node_modules/koffi/**
-extraResources:
-  - from: resources/koffi
-    to: koffi
-    filter:
-      - '**/*'
 win:
   executableName: omi-windows
+  extraResources:
+    - from: resources/koffi
+      to: koffi
+      filter:
+        - '**/*'
   target:
     - target: nsis
       arch: [x64]

--- a/desktop/windows/electron.vite.config.ts
+++ b/desktop/windows/electron.vite.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  main: {},
+  main: {
+    build: {
+      externalizeDeps: {
+        exclude: ['@earendil-works/pi-agent-core', '@earendil-works/pi-ai']
+      }
+    }
+  },
   preload: {},
   renderer: {
     // Pin the dev server to a fixed port so the renderer's origin

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -27,6 +27,8 @@
     "bench:anim": "node scripts/bench/anim.mjs"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.79.9",
+    "@earendil-works/pi-ai": "0.79.9",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,15 +16,17 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs",
-    "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "npm run build && electron-builder --win --x64",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
+    "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/bench/run.mjs",
-    "bench:anim": "node scripts/bench/anim.mjs"
+    "bench:anim": "node scripts/bench/anim.mjs",
+    "prepare:koffi": "node scripts/ensure-koffi-win32-native.mjs",
+    "verify:win-koffi": "node scripts/verify-win-koffi-native.mjs"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.79.9",

--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.10)
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -466,9 +463,6 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1063,16 +1057,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@huggingface/jinja@0.5.9':
-    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
-    engines: {node: '>=18'}
-
-  '@huggingface/tokenizers@0.1.3':
-    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
-
-  '@huggingface/transformers@4.2.0':
-    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1092,159 +1076,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2196,10 +2027,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2994,9 +2821,6 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatbuffers@25.9.23:
-    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
-
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -3157,9 +2981,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  guid-typescript@1.0.9:
-    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3731,19 +3552,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
-
-  onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
-
-  onnxruntime-node@1.24.3:
-    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
-    os: [win32, darwin, linux]
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
-
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
@@ -3838,9 +3646,6 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
-
-  platform@1.3.6:
-    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4198,10 +4003,6 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
-
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5308,7 +5109,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5331,7 +5132,7 @@ snapshots:
       dir-compare: 4.2.0
       fs-extra: 11.3.5
       minimatch: 9.0.9
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5344,11 +5145,6 @@ snapshots:
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -5913,18 +5709,6 @@ snapshots:
       protobufjs: 7.6.2
       yargs: 17.7.2
 
-  '@huggingface/jinja@0.5.9': {}
-
-  '@huggingface/tokenizers@0.1.3': {}
-
-  '@huggingface/transformers@4.2.0':
-    dependencies:
-      '@huggingface/jinja': 0.5.9
-      '@huggingface/tokenizers': 0.1.3
-      onnxruntime-node: 1.24.3
-      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
-      sharp: 0.34.5
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5940,102 +5724,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@img/colour@1.1.0': {}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.10.0
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -6957,8 +6645,7 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xmldom/xmldom@0.9.10':
-    optional: true
+  '@xmldom/xmldom@0.9.10': {}
 
   abbrev@4.0.0: {}
 
@@ -6967,8 +6654,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -7186,7 +6871,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  boolean@3.2.0: {}
+  boolean@3.2.0:
+    optional: true
 
   bowser@2.14.1: {}
 
@@ -7491,7 +7177,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  detect-node@2.1.0: {}
+  detect-node@2.1.0:
+    optional: true
 
   didyoumean@1.2.2: {}
 
@@ -7738,7 +7425,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es6-error@4.1.1: {}
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -8057,8 +7745,6 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
-  flatbuffers@25.9.23: {}
-
   flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
@@ -8211,6 +7897,7 @@ snapshots:
       roarr: 2.15.4
       semver: 7.8.1
       serialize-error: 7.0.1
+    optional: true
 
   globals@14.0.0: {}
 
@@ -8253,8 +7940,6 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
-
-  guid-typescript@1.0.9: {}
 
   has-bigints@1.1.0: {}
 
@@ -8541,7 +8226,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1: {}
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -8653,6 +8339,7 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -8820,25 +8507,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
-
-  onnxruntime-common@1.24.3: {}
-
-  onnxruntime-node@1.24.3:
-    dependencies:
-      adm-zip: 0.5.17
-      global-agent: 3.0.0
-      onnxruntime-common: 1.24.3
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    dependencies:
-      flatbuffers: 25.9.23
-      guid-typescript: 1.0.9
-      long: 5.3.2
-      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
-      platform: 1.3.6
-      protobufjs: 7.6.2
-
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
@@ -8908,8 +8576,6 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  platform@1.3.6: {}
-
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.13
@@ -8921,7 +8587,6 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-    optional: true
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9202,6 +8867,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
+    optional: true
 
   rollup@4.61.0:
     dependencies:
@@ -9269,7 +8935,8 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver-compare@1.0.0: {}
+  semver-compare@1.0.0:
+    optional: true
 
   semver@5.7.2: {}
 
@@ -9282,6 +8949,7 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+    optional: true
 
   set-cookie-parser@2.7.2: {}
 
@@ -9306,37 +8974,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
-
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.1
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -9407,7 +9044,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  sprintf-js@1.1.3: {}
+  sprintf-js@1.1.3:
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -9687,7 +9325,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1: {}
+  type-fest@0.13.1:
+    optional: true
 
   typebox@1.1.38: {}
 

--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 0.79.9
+        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 0.79.9
+        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@39.8.10)
@@ -113,7 +119,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.2.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7))
+        version: 5.2.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
@@ -125,7 +131,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7))
+        version: 5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))
       eslint:
         specifier: ^9.39.1
         version: 9.39.4(jiti@1.21.7)
@@ -152,16 +158,16 @@ importers:
         version: 19.2.7(react@19.2.7)
       tailwindcss:
         specifier: ^3.4.19
-        version: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.2.6
-        version: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
+        version: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
 
 packages:
 
@@ -171,6 +177,116 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.22':
+    resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    resolution: {integrity: sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.22':
+    resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1071.0':
+    resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.30':
+    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -271,6 +387,15 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@earendil-works/pi-agent-core@0.79.9':
+    resolution: {integrity: sha512-GsFbPR85nhncKoU9++fTKa11PzwUkAmkrKXo97dBOzi10Td72rVV6vmfxKjwPLHTzRbJMa0byr12YhODZ59yLA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.79.9':
+    resolution: {integrity: sha512-fHmgNMONwCCE7bQAKbcz76sgm3iQuA7km1mpIc4H5xXd9+zhPh/faULz6ARkgjQE0EufHnfZPJY39+lNf8Sa9g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
 
   '@electron-toolkit/eslint-config-prettier@3.0.0':
     resolution: {integrity: sha512-YapmIOVkbYdHLuTa+ad1SAVtcqYL9A/SJsc7cxQokmhcwAwonGevNom37jBf9slXegcZ/Slh01I/JARG1yhNFw==}
@@ -920,6 +1045,15 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@grpc/grpc-js@1.9.16':
     resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
     engines: {node: ^8.13.0 || >=10.10.0}
@@ -1213,10 +1347,21 @@ packages:
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@monogrid/gainmap-js@3.4.0':
     resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
     peerDependencies:
       three: '>= 0.159.0'
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1229,6 +1374,14 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
@@ -1775,6 +1928,46 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@smithy/core@3.25.1':
+    resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.1':
+    resolution: {integrity: sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.1':
+    resolution: {integrity: sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.8.1':
+    resolution: {integrity: sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.1':
+    resolution: {integrity: sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1857,6 +2050,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -2035,6 +2231,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   app-builder-bin@5.0.0-alpha.12:
     resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
 
@@ -2149,6 +2348,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2162,6 +2364,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -2184,6 +2389,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2383,6 +2591,10 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2484,6 +2696,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2690,6 +2905,9 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -2715,6 +2933,13 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2733,6 +2958,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -2788,6 +3017,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -2831,6 +3064,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -2897,6 +3138,14 @@ packages:
 
   glsl-noise@0.0.0:
     resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3192,8 +3441,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3218,6 +3474,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3399,9 +3661,18 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp@12.3.0:
     resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
@@ -3473,6 +3744,18 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3493,13 +3776,24 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3812,6 +4106,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4031,6 +4329,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4155,6 +4456,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4180,6 +4484,9 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4349,6 +4656,10 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
@@ -4425,6 +4736,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
@@ -4443,6 +4758,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4457,6 +4777,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -4505,6 +4830,235 @@ snapshots:
   7zip-bin@5.2.0: {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/eventstream-handler-node': 3.972.22
+      '@aws-sdk/middleware-eventstream': 3.972.18
+      '@aws-sdk/middleware-websocket': 3.972.30
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.25.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-login': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-ini': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/token-providers': 3.1071.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.22':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1071.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.30':
+    dependencies:
+      '@smithy/types': 4.15.0
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4631,6 +5185,41 @@ snapshots:
       ajv-keywords: 3.5.2(ajv@6.15.0)
 
   '@dimforge/rapier3d-compat@0.12.0': {}
+
+  '@earendil-works/pi-agent-core@0.79.9(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.9(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.79.9(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@electron-toolkit/eslint-config-prettier@3.0.0(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3)':
     dependencies:
@@ -5301,6 +5890,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.7.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@grpc/grpc-js@1.9.16':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -5517,10 +6117,24 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@monogrid/gainmap-js@3.4.0(three@0.184.0)':
     dependencies:
       promise-worker-transferable: 1.0.4
       three: 0.184.0
+
+  '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5533,6 +6147,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@pkgr/core@0.3.6': {}
 
@@ -6007,6 +6625,60 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@smithy/core@3.25.1':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -6103,6 +6775,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.19
+
+  '@types/retry@0.12.0': {}
 
   '@types/stats.js@0.17.4': {}
 
@@ -6227,7 +6901,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.7
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -6235,7 +6909,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
+      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6247,13 +6921,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
+      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -6327,6 +7001,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  anynum@1.0.1: {}
 
   app-builder-bin@5.0.0-alpha.12: {}
 
@@ -6496,6 +7172,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
@@ -6509,6 +7187,8 @@ snapshots:
       readable-stream: 3.6.2
 
   boolean@3.2.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.15:
     dependencies:
@@ -6536,6 +7216,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6751,6 +7433,8 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6861,6 +7545,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -6905,7 +7593,7 @@ snapshots:
 
   electron-to-chromium@1.5.366: {}
 
-  electron-vite@5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)):
+  electron-vite@5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
@@ -6913,7 +7601,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
+      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7244,6 +7932,8 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  extend@3.0.2: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -7273,6 +7963,18 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.1
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -7288,6 +7990,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.6.10: {}
 
@@ -7368,6 +8075,10 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@5.3.4: {}
 
   fs-constants@1.0.0: {}
@@ -7420,6 +8131,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -7495,6 +8222,19 @@ snapshots:
       gopd: 1.2.0
 
   glsl-noise@0.0.0: {}
+
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -7786,7 +8526,16 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -7812,6 +8561,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -7980,12 +8740,20 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp@12.3.0:
     dependencies:
@@ -8071,6 +8839,11 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.6.2
 
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8096,11 +8869,20 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
 
+  partial-json@0.1.7: {}
+
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -8155,12 +8937,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.15
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.15
+      yaml: 2.9.0
 
   postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
@@ -8402,6 +9185,8 @@ snapshots:
       lowercase-keys: 2.0.0
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -8708,6 +9493,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -8740,7 +9529,7 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -8759,7 +9548,7 @@ snapshots:
       postcss: 8.5.15
       postcss-import: 15.1.0(postcss@8.5.15)
       postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -8872,6 +9661,8 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
+  ts-algebra@2.0.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -8897,6 +9688,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.13.1: {}
+
+  typebox@1.1.38: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -9001,13 +9794,13 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-node@3.2.4(@types/node@22.19.19)(jiti@1.21.7):
+  vite-node@3.2.4(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
+      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9022,7 +9815,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7):
+  vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9034,12 +9827,13 @@ snapshots:
       '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 1.21.7
+      yaml: 2.9.0
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -9057,8 +9851,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)
-      vite-node: 3.2.4(@types/node@22.19.19)(jiti@1.21.7)
+      vite: 7.3.5(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.19)(jiti@1.21.7)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -9076,6 +9870,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@4.2.4: {}
 
@@ -9161,6 +9957,8 @@ snapshots:
 
   ws@8.21.0: {}
 
+  xml-naming@0.1.0: {}
+
   xmlbuilder@15.1.1: {}
 
   y18n@5.0.8: {}
@@ -9170,6 +9968,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 
@@ -9189,6 +9989,10 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/desktop/windows/pnpm-workspace.yaml
+++ b/desktop/windows/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 allowBuilds:
   '@firebase/util': true
+  # Pure JS SDK; its only install-time script is a no-op echo, so never build it.
+  '@google/genai': false
   better-sqlite3: true
   electron: true
   electron-winstaller: true

--- a/desktop/windows/pnpm-workspace.yaml
+++ b/desktop/windows/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ allowBuilds:
   onnxruntime-node: true
   protobufjs: true
   sharp: true
+supportedArchitectures:
+  os:
+    - current
+    - win32
+  cpu:
+    - current
+    - x64
+  libc:
+    - current

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -1,20 +1,53 @@
-import { copyFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
-const koffiPackageJson = requireFromRoot.resolve('koffi/package.json')
-const koffiRequire = createRequire(koffiPackageJson)
+
+// This stages the Windows x64 native module for packaging. On other platforms
+// the @koromix/koffi-win32-x64 optional dependency is never installed, so skip
+// instead of failing `pnpm install` for macOS/Linux contributors. Set
+// OMI_REQUIRE_KOFFI_WIN32=1 to force the check anywhere (e.g. Windows CI).
+if (process.platform !== 'win32' && process.env.OMI_REQUIRE_KOFFI_WIN32 !== '1') {
+  console.log(
+    `[ensure-koffi-win32-native] skipping on ${process.platform} (only needed for Windows packaging)`
+  )
+  process.exit(0)
+}
 
 const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
+
+// Resolve a package's package.json even when its `exports` map does not expose
+// "./package.json" (koffi's does not — require.resolve('koffi/package.json')
+// throws ERR_PACKAGE_PATH_NOT_EXPORTED). Fall back to resolving the entry
+// point and walking up until the package's own package.json is found.
+const resolvePackageJson = (require, name) => {
+  try {
+    return require.resolve(`${name}/package.json`)
+  } catch (error) {
+    if (error?.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error
+  }
+  let dir = dirname(require.resolve(name))
+  for (;;) {
+    const candidate = join(dir, 'package.json')
+    if (existsSync(candidate) && readJson(candidate).name === name) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) throw new Error(`Cannot locate package.json for ${name}`)
+    dir = parent
+  }
+}
+
+const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
+const koffiPackageJson = resolvePackageJson(requireFromRoot, 'koffi')
+const koffiRequire = createRequire(koffiPackageJson)
+
 const koffiPackage = readJson(koffiPackageJson)
 
 let nativePackageJson
 let source
 try {
-  nativePackageJson = koffiRequire.resolve('@koromix/koffi-win32-x64/package.json')
+  nativePackageJson = resolvePackageJson(koffiRequire, '@koromix/koffi-win32-x64')
   source = join(dirname(nativePackageJson), 'win32_x64', 'koffi.node')
 } catch (error) {
   throw new Error(

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -5,19 +5,18 @@ import { fileURLToPath } from 'node:url'
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
-const koffiEntry = requireFromRoot.resolve('koffi')
-const koffiRoot = dirname(koffiEntry)
-const koffiRequire = createRequire(koffiEntry)
+const koffiPackageJson = requireFromRoot.resolve('koffi/package.json')
+const koffiRoot = dirname(koffiPackageJson)
+const koffiRequire = createRequire(koffiPackageJson)
 
 const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
-const koffiPackage = readJson(join(koffiRoot, 'package.json'))
+const koffiPackage = readJson(koffiPackageJson)
 
 let nativePackageJson
 let source
 try {
-  const nativeEntry = koffiRequire.resolve('@koromix/koffi-win32-x64')
-  nativePackageJson = join(dirname(nativeEntry), 'package.json')
-  source = join(dirname(nativeEntry), 'win32_x64', 'koffi.node')
+  nativePackageJson = koffiRequire.resolve('@koromix/koffi-win32-x64/package.json')
+  source = join(dirname(nativePackageJson), 'win32_x64', 'koffi.node')
 } catch (error) {
   throw new Error(
     [

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -1,0 +1,47 @@
+import { copyFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
+const koffiEntry = requireFromRoot.resolve('koffi')
+const koffiRoot = dirname(koffiEntry)
+const koffiRequire = createRequire(koffiEntry)
+
+const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
+const koffiPackage = readJson(join(koffiRoot, 'package.json'))
+
+let nativePackageJson
+let source
+try {
+  const nativeEntry = koffiRequire.resolve('@koromix/koffi-win32-x64')
+  nativePackageJson = join(dirname(nativeEntry), 'package.json')
+  source = join(dirname(nativeEntry), 'win32_x64', 'koffi.node')
+} catch (error) {
+  throw new Error(
+    [
+      'Missing @koromix/koffi-win32-x64.',
+      'Run npm install from desktop/windows on Windows so npm installs win32/x64 optional dependencies.'
+    ].join(' '),
+    { cause: error }
+  )
+}
+
+const nativePackage = readJson(nativePackageJson)
+if (nativePackage.version !== koffiPackage.version) {
+  throw new Error(
+    `Koffi native package version mismatch: koffi=${koffiPackage.version}, @koromix/koffi-win32-x64=${nativePackage.version}`
+  )
+}
+
+const sourceSize = statSync(source).size
+if (sourceSize <= 0) {
+  throw new Error(`Koffi native module is empty: ${source}`)
+}
+
+const targetDir = join(projectRoot, 'resources', 'koffi', 'win32_x64')
+const target = join(targetDir, 'koffi.node')
+mkdirSync(targetDir, { recursive: true })
+copyFileSync(source, target)
+console.log(`[ensure-koffi-win32-native] staged ${target} (${sourceSize} bytes)`)

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url'
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
 const koffiPackageJson = requireFromRoot.resolve('koffi/package.json')
-const koffiRoot = dirname(koffiPackageJson)
 const koffiRequire = createRequire(koffiPackageJson)
 
 const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -1,0 +1,43 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageRoots =
+  process.argv.length > 2
+    ? process.argv.slice(2).map((path) => resolve(path))
+    : [join(projectRoot, 'dist', 'win-unpacked')]
+
+const verifyPeFile = (file) => {
+  const stat = statSync(file)
+  if (stat.size <= 0) {
+    throw new Error(`Koffi native module is empty: ${file}`)
+  }
+
+  const fd = openSync(file, 'r')
+  const header = Buffer.alloc(2)
+  try {
+    readSync(fd, header, 0, 2, 0)
+  } finally {
+    closeSync(fd)
+  }
+  if (header.toString('ascii') !== 'MZ') {
+    throw new Error(`Koffi native module is not a Windows binary: ${file}`)
+  }
+  return stat.size
+}
+
+const tried = []
+for (const root of packageRoots) {
+  const file = join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node')
+  tried.push(file)
+  try {
+    const size = verifyPeFile(file)
+    console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
+    process.exit(0)
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+
+throw new Error(`Missing packaged Koffi native module. Checked: ${tried.join(', ')}`)

--- a/desktop/windows/src/main/claudeAcp/client.ts
+++ b/desktop/windows/src/main/claudeAcp/client.ts
@@ -1,0 +1,134 @@
+import { spawn } from 'child_process'
+import type { ChatMessage, ClaudeAcpChatResponse, ClaudeAcpStatus } from '../../shared/types'
+
+const DEFAULT_COMMAND = 'claude'
+const DEFAULT_ARGS = ['--print']
+const REQUEST_TIMEOUT_MS = 120000
+
+type SpawnResult = {
+  ok: boolean
+  stdout: string
+  stderr: string
+  exitCode: number | null
+}
+
+function command(): string {
+  return (process.env.OMI_CLAUDE_ACP_COMMAND || DEFAULT_COMMAND).trim() || DEFAULT_COMMAND
+}
+
+function args(): string[] {
+  const raw = process.env.OMI_CLAUDE_ACP_ARGS
+  if (!raw?.trim()) return DEFAULT_ARGS
+  return raw
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+function promptFromMessages(messages: ChatMessage[]): string {
+  const thread = messages
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .map((message) => `${message.role === 'user' ? 'User' : 'Omi'}: ${message.content}`)
+    .join('\n\n')
+  if (!thread.trim()) throw new Error('Claude ACP requires at least one chat message')
+  return [
+    'You are Omi on Windows.',
+    'Answer conversationally and use only the local Claude account/runtime available on this machine.',
+    'Do not assume access to Omi-hosted Anthropic credentials.',
+    '',
+    thread
+  ].join('\n')
+}
+
+function claudeEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (/ANTHROPIC.*API.*KEY|CLAUDE.*API.*KEY|OMI.*ANTHROPIC|VITE.*ANTHROPIC/i.test(key)) {
+      delete env[key]
+    }
+  }
+  return env
+}
+
+function runClaude(
+  extraArgs: string[],
+  input?: string,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<SpawnResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command(), extraArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      env: claudeEnv()
+    })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      child.kill()
+      resolve({
+        ok: false,
+        stdout,
+        stderr: stderr || 'Claude ACP request timed out',
+        exitCode: null
+      })
+    }, timeoutMs)
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+    })
+    child.on('error', (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ ok: false, stdout, stderr: error.message, exitCode: null })
+    })
+    child.on('close', (exitCode) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ ok: exitCode === 0, stdout, stderr, exitCode })
+    })
+    if (input) child.stdin.end(input)
+    else child.stdin.end()
+  })
+}
+
+function statusReason(result: SpawnResult): string | undefined {
+  if (result.ok) return undefined
+  const detail = (result.stderr || result.stdout).trim()
+  if (/ENOENT|not found|not recognized/i.test(detail)) {
+    return 'Claude command was not found'
+  }
+  if (/login|auth|oauth|account|credential/i.test(detail)) {
+    return 'Claude account is not connected'
+  }
+  return detail || 'Claude ACP is unavailable'
+}
+
+export async function getClaudeAcpStatus(): Promise<ClaudeAcpStatus> {
+  const result = await runClaude(['--version'], undefined, 10000)
+  return {
+    configured: result.ok,
+    command: command(),
+    authenticated: result.ok ? null : false,
+    reason: statusReason(result)
+  }
+}
+
+export async function sendClaudeAcpChat(messages: ChatMessage[]): Promise<ClaudeAcpChatResponse> {
+  const prompt = promptFromMessages(messages)
+  const result = await runClaude([...args(), prompt])
+  if (!result.ok) {
+    const reason = statusReason(result)
+    throw new Error(reason ?? 'Claude ACP request failed')
+  }
+  const text = result.stdout.trim()
+  if (!text) throw new Error('Claude ACP returned an empty response')
+  return { text }
+}

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -34,6 +34,7 @@ import {
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
 import { registerLocalAgentHandlers } from './ipc/localAgent'
 import { registerPiChatHandlers } from './ipc/piChat'
+import { registerClaudeAcpHandlers } from './ipc/claudeAcp'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -294,6 +295,7 @@ app.whenReady().then(async () => {
   registerIntegrationsHandlers()
   registerLocalAgentHandlers()
   registerPiChatHandlers()
+  registerClaudeAcpHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   stopAutomationTargetTracker
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
+import { registerLocalAgentHandlers } from './ipc/localAgent'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -290,6 +291,7 @@ app.whenReady().then(async () => {
   registerMemoryExportHandlers()
   registerKgHandlers()
   registerIntegrationsHandlers()
+  registerLocalAgentHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -33,6 +33,7 @@ import {
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
 import { registerLocalAgentHandlers } from './ipc/localAgent'
+import { registerPiChatHandlers } from './ipc/piChat'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -292,6 +293,7 @@ app.whenReady().then(async () => {
   registerKgHandlers()
   registerIntegrationsHandlers()
   registerLocalAgentHandlers()
+  registerPiChatHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -37,6 +37,7 @@ import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
 import { startRewindRetention } from './rewind/retentionRunner'
 import { prewarmPrimarySourceId } from './rewind/sourceId'
+import { startLocalAgentServerIfEnabled, stopLocalAgentServer } from './localAgent/server'
 import { perfMark, flushPerfMarks } from '../shared/perf'
 
 // Default the perf log to the user data dir so marks double as lightweight prod
@@ -205,6 +206,9 @@ app.whenReady().then(async () => {
   }
   // Set app user model id for windows
   electronApp.setAppUserModelId('com.omiwindows.app')
+  void startLocalAgentServerIfEnabled().catch((e) => {
+    console.error('[local-agent] failed to start:', e)
+  })
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
@@ -450,6 +454,7 @@ app.on('window-all-closed', () => {
 app.on('will-quit', () => {
   unregisterOverlayShortcut()
   flushPerfMarks()
+  void stopLocalAgentServer()
   automationBridge.dispose()
   stopAutomationTargetTracker()
 })

--- a/desktop/windows/src/main/ipc/claudeAcp.test.ts
+++ b/desktop/windows/src/main/ipc/claudeAcp.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn()
+  }
+}))
+
+import { normalizeClaudeAcpRequest } from './claudeAcp'
+
+describe('Claude ACP IPC normalization', () => {
+  it('accepts well-formed chat messages', () => {
+    expect(
+      normalizeClaudeAcpRequest({
+        messages: [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi' }
+        ]
+      })
+    ).toEqual({
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi' }
+      ]
+    })
+  })
+
+  it('rejects malformed message entries', () => {
+    expect(() => normalizeClaudeAcpRequest({ messages: [null] })).toThrow(
+      'Claude ACP message must be an object'
+    )
+    expect(() => normalizeClaudeAcpRequest({ messages: [{ role: 'tool', content: 'x' }] })).toThrow(
+      'Claude ACP message role must be user or assistant'
+    )
+  })
+
+  it('caps message count and content length', () => {
+    expect(() =>
+      normalizeClaudeAcpRequest({
+        messages: Array.from({ length: 101 }, () => ({ role: 'user', content: 'x' }))
+      })
+    ).toThrow('at most 100 messages')
+
+    expect(() =>
+      normalizeClaudeAcpRequest({
+        messages: [{ role: 'user', content: 'x'.repeat(20_001) }]
+      })
+    ).toThrow('exceeds 20000 characters')
+  })
+})

--- a/desktop/windows/src/main/ipc/claudeAcp.ts
+++ b/desktop/windows/src/main/ipc/claudeAcp.ts
@@ -1,0 +1,30 @@
+import { ipcMain } from 'electron'
+import type {
+  ClaudeAcpChatRequest,
+  ClaudeAcpChatResponse,
+  ClaudeAcpStatus
+} from '../../shared/types'
+import { getClaudeAcpStatus, sendClaudeAcpChat } from '../claudeAcp/client'
+
+function normalizeRequest(value: unknown): ClaudeAcpChatRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('invalid Claude ACP chat request')
+  }
+  const record = value as Partial<ClaudeAcpChatRequest>
+  if (!Array.isArray(record.messages)) {
+    throw new Error('Claude ACP chat requires messages')
+  }
+  return { messages: record.messages }
+}
+
+export function registerClaudeAcpHandlers(): void {
+  ipcMain.handle('claudeAcp:status', async (): Promise<ClaudeAcpStatus> => {
+    return getClaudeAcpStatus()
+  })
+  ipcMain.handle(
+    'claudeAcp:chatSend',
+    async (_event, rawRequest: unknown): Promise<ClaudeAcpChatResponse> => {
+      return sendClaudeAcpChat(normalizeRequest(rawRequest).messages)
+    }
+  )
+}

--- a/desktop/windows/src/main/ipc/claudeAcp.ts
+++ b/desktop/windows/src/main/ipc/claudeAcp.ts
@@ -1,12 +1,33 @@
 import { ipcMain } from 'electron'
 import type {
+  ChatMessage,
   ClaudeAcpChatRequest,
   ClaudeAcpChatResponse,
   ClaudeAcpStatus
 } from '../../shared/types'
 import { getClaudeAcpStatus, sendClaudeAcpChat } from '../claudeAcp/client'
 
-function normalizeRequest(value: unknown): ClaudeAcpChatRequest {
+const MAX_CLAUDE_MESSAGES = 100
+const MAX_CLAUDE_MESSAGE_CHARS = 20_000
+
+function normalizeMessage(value: unknown): ChatMessage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Claude ACP message must be an object')
+  }
+  const record = value as Partial<ChatMessage>
+  if (record.role !== 'user' && record.role !== 'assistant') {
+    throw new Error('Claude ACP message role must be user or assistant')
+  }
+  if (typeof record.content !== 'string') {
+    throw new Error('Claude ACP message content must be a string')
+  }
+  if (record.content.length > MAX_CLAUDE_MESSAGE_CHARS) {
+    throw new Error(`Claude ACP message content exceeds ${MAX_CLAUDE_MESSAGE_CHARS} characters`)
+  }
+  return { role: record.role, content: record.content }
+}
+
+export function normalizeClaudeAcpRequest(value: unknown): ClaudeAcpChatRequest {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('invalid Claude ACP chat request')
   }
@@ -14,7 +35,13 @@ function normalizeRequest(value: unknown): ClaudeAcpChatRequest {
   if (!Array.isArray(record.messages)) {
     throw new Error('Claude ACP chat requires messages')
   }
-  return { messages: record.messages }
+  if (record.messages.length === 0) {
+    throw new Error('Claude ACP chat requires at least one message')
+  }
+  if (record.messages.length > MAX_CLAUDE_MESSAGES) {
+    throw new Error(`Claude ACP chat accepts at most ${MAX_CLAUDE_MESSAGES} messages`)
+  }
+  return { messages: record.messages.map(normalizeMessage) }
 }
 
 export function registerClaudeAcpHandlers(): void {
@@ -24,7 +51,7 @@ export function registerClaudeAcpHandlers(): void {
   ipcMain.handle(
     'claudeAcp:chatSend',
     async (_event, rawRequest: unknown): Promise<ClaudeAcpChatResponse> => {
-      return sendClaudeAcpChat(normalizeRequest(rawRequest).messages)
+      return sendClaudeAcpChat(normalizeClaudeAcpRequest(rawRequest).messages)
     }
   )
 }

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -991,11 +991,51 @@ export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
   })
 }
 
+export function getRewindFrame(id: number): RewindFrame | null {
+  const row = get().prepare(`SELECT ${REWIND_COLUMNS} FROM rewind_frames WHERE id = ?`).get(id) as
+    | RewindFrame
+    | undefined
+  return row ?? null
+}
+
 export function rewindDayBounds(): { min: number; max: number } | null {
   const row = get()
     .prepare('SELECT MIN(ts) AS min, MAX(ts) AS max FROM rewind_frames')
     .get() as { min: number | null; max: number | null }
   return row.min == null || row.max == null ? null : { min: row.min, max: row.max }
+}
+
+export function rewindStatusStats(): {
+  latestFrameTs: number | null
+  oldestFrameTs: number | null
+  totalFrameCount: number
+  indexedFrameCount: number
+  ocrBacklogCount: number
+} {
+  const row = get()
+    .prepare(
+      `SELECT
+         MIN(ts) AS oldestFrameTs,
+         MAX(ts) AS latestFrameTs,
+         COUNT(*) AS totalFrameCount,
+         SUM(CASE WHEN indexed = 1 THEN 1 ELSE 0 END) AS indexedFrameCount,
+         SUM(CASE WHEN indexed = 0 THEN 1 ELSE 0 END) AS ocrBacklogCount
+       FROM rewind_frames`
+    )
+    .get() as {
+    oldestFrameTs: number | null
+    latestFrameTs: number | null
+    totalFrameCount: number
+    indexedFrameCount: number | null
+    ocrBacklogCount: number | null
+  }
+  return {
+    latestFrameTs: row.latestFrameTs,
+    oldestFrameTs: row.oldestFrameTs,
+    totalFrameCount: row.totalFrameCount,
+    indexedFrameCount: row.indexedFrameCount ?? 0,
+    ocrBacklogCount: row.ocrBacklogCount ?? 0
+  }
 }
 
 /** The single most-recent captured frame (Omi's own windows are never captured),

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -38,6 +38,10 @@ function timed<T>(name: string, fn: () => T): T {
 let db: Database.Database | null = null
 let roDb: Database.Database | null = null
 
+function dbFilePath(): string {
+  return process.env.OMI_DB_PATH ?? join(app.getPath('userData'), 'omi.db')
+}
+
 // Add a column only if it doesn't already exist, so existing databases (which
 // predate the `kind`/`messages` columns) migrate forward without data loss.
 function ensureColumn(d: Database.Database, table: string, col: string, decl: string): void {
@@ -66,7 +70,7 @@ function get(): Database.Database {
   if (db) return db
   // OMI_DB_PATH lets the bench harness point at a throwaway DB so benchmarking
   // never reads or writes the user's real omi.db.
-  const file = process.env.OMI_DB_PATH ?? join(app.getPath('userData'), 'omi.db')
+  const file = dbFilePath()
   db = new Database(file)
   // For the throwaway bench DB only, relax durability so seeding ~7k rows isn't
   // dominated by a per-insert fsync (otherwise it swamps the startup measurement).
@@ -455,7 +459,7 @@ export function getLocalKGStatus(): LocalKGStatus {
 function getReadonly(): Database.Database {
   if (roDb) return roDb
   get() // ensure the db file + schema exist before opening read-only
-  roDb = new Database(join(app.getPath('userData'), 'omi.db'), { readonly: true })
+  roDb = new Database(dbFilePath(), { readonly: true })
   return roDb
 }
 
@@ -469,6 +473,246 @@ export function execSafeSelect(sql: string): KgSqlResult {
     ? Object.keys(rows[0])
     : (stmt.columns().map((c) => c.name) ?? [])
   return { columns, rows }
+}
+
+export type LocalTaskSearchRecord = {
+  source: string
+  id: string
+  backendId: string | null
+  description: string
+  completed: boolean
+  deleted: boolean
+  dueAt: string | number | null
+  createdAt: string | number | null
+  updatedAt: string | number | null
+  priority: string | null
+}
+
+export type LocalTaskSearchResult = {
+  available: boolean
+  reason?: string
+  sources: string[]
+  tasks: LocalTaskSearchRecord[]
+}
+
+type TaskTableSpec = {
+  table: string
+  id: string[]
+  backendId: string[]
+  description: string[]
+  completed: string[]
+  deleted: string[]
+  dueAt: string[]
+  createdAt: string[]
+  updatedAt: string[]
+  priority: string[]
+}
+
+const TASK_TABLE_SPECS: TaskTableSpec[] = [
+  {
+    table: 'action_items',
+    id: ['backendId', 'backend_id', 'id'],
+    backendId: ['backendId', 'backend_id'],
+    description: ['description', 'title', 'text', 'content'],
+    completed: ['completed', 'is_completed'],
+    deleted: ['deleted', 'is_deleted'],
+    dueAt: ['dueAt', 'due_at'],
+    createdAt: ['createdAt', 'created_at'],
+    updatedAt: ['updatedAt', 'updated_at'],
+    priority: ['priority']
+  },
+  {
+    table: 'staged_tasks',
+    id: ['id', 'backendId', 'backend_id'],
+    backendId: ['backendId', 'backend_id'],
+    description: ['description', 'title', 'text', 'content'],
+    completed: ['completed', 'is_completed'],
+    deleted: ['deleted', 'is_deleted'],
+    dueAt: ['dueAt', 'due_at'],
+    createdAt: ['createdAt', 'created_at'],
+    updatedAt: ['updatedAt', 'updated_at'],
+    priority: ['priority']
+  }
+]
+
+type LocalTaskSearchRow = {
+  source: string
+  id: unknown
+  backendId: unknown
+  description: string
+  completed: number
+  deleted: number
+  dueAt: unknown
+  createdAt: unknown
+  updatedAt: unknown
+  priority: unknown
+}
+
+function safeIdent(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) throw new Error(`unsafe identifier: ${name}`)
+  return `"${name}"`
+}
+
+function tableExists(d: Database.Database, table: string): boolean {
+  const row = d
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name=?")
+    .get(table) as { ok: number } | undefined
+  return row?.ok === 1
+}
+
+function tableColumns(d: Database.Database, table: string): Map<string, string> {
+  const rows = d.prepare(`PRAGMA table_info(${safeIdent(table)})`).all() as { name: string }[]
+  const out = new Map<string, string>()
+  for (const row of rows) out.set(row.name.toLowerCase(), row.name)
+  return out
+}
+
+function firstColumn(columns: Map<string, string>, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const column = columns.get(candidate.toLowerCase())
+    if (column) return column
+  }
+  return null
+}
+
+function coalesceColumnExpr(
+  columns: Map<string, string>,
+  candidates: string[],
+  fallbackSql: string
+): string {
+  const matches = candidates
+    .map((candidate) => firstColumn(columns, [candidate]))
+    .filter((column): column is string => column != null)
+  if (matches.length === 0) return fallbackSql
+  return `COALESCE(${matches.map(safeIdent).join(', ')}, ${fallbackSql})`
+}
+
+function booleanColumnExpr(column: string | null): string {
+  if (!column) return '0'
+  const quoted = safeIdent(column)
+  return `CASE WHEN ${quoted} IN (1, '1', 'true', 'TRUE') THEN 1 ELSE 0 END`
+}
+
+function optionalColumnExpr(column: string | null): string {
+  return column ? safeIdent(column) : 'NULL'
+}
+
+function localTaskValue(value: unknown): string | number | null {
+  if (typeof value === 'string' || typeof value === 'number') return value
+  return null
+}
+
+function localTaskString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function localTaskTimestampValue(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value)
+    if (Number.isFinite(numeric)) return numeric
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function mapLocalTaskRow(row: LocalTaskSearchRow): LocalTaskSearchRecord {
+  const fallbackId = `${row.source}:${row.description}:${String(row.createdAt ?? '')}`
+  return {
+    source: row.source,
+    id: String(row.id || row.backendId || fallbackId),
+    backendId: localTaskString(row.backendId),
+    description: row.description,
+    completed: row.completed === 1,
+    deleted: row.deleted === 1,
+    dueAt: localTaskValue(row.dueAt),
+    createdAt: localTaskValue(row.createdAt),
+    updatedAt: localTaskValue(row.updatedAt),
+    priority: localTaskString(row.priority)
+  }
+}
+
+export function searchLocalTasks(
+  query: string,
+  includeCompleted = false,
+  limit = 20
+): LocalTaskSearchResult {
+  const d = getReadonly()
+  const cappedLimit = Math.min(50, Math.max(1, Math.trunc(limit)))
+  const trimmed = query.trim()
+  const tasks: LocalTaskSearchRecord[] = []
+  const sources: string[] = []
+
+  for (const spec of TASK_TABLE_SPECS) {
+    if (!tableExists(d, spec.table)) continue
+    const columns = tableColumns(d, spec.table)
+    const descriptionColumn = firstColumn(columns, spec.description)
+    if (!descriptionColumn) continue
+
+    sources.push(spec.table)
+    const completedColumn = firstColumn(columns, spec.completed)
+    const deletedColumn = firstColumn(columns, spec.deleted)
+    const createdColumn = firstColumn(columns, spec.createdAt)
+    const titleColumn = firstColumn(columns, ['title'])
+    const searchColumns = [...new Set([descriptionColumn, titleColumn].filter(Boolean))] as string[]
+
+    const where: string[] = []
+    const params: unknown[] = []
+    if (deletedColumn) where.push(`${booleanColumnExpr(deletedColumn)} = 0`)
+    if (!includeCompleted && completedColumn)
+      where.push(`${booleanColumnExpr(completedColumn)} = 0`)
+    if (trimmed) {
+      const needles = [
+        trimmed,
+        ...trimmed
+          .split(/\s+/)
+          .map((part) => part.trim())
+          .filter((part) => part.length >= 2 && part !== trimmed)
+      ]
+      const searchParts = needles.map((needle) => {
+        for (let index = 0; index < searchColumns.length; index += 1) params.push(`%${needle}%`)
+        return `(${searchColumns.map((column) => `${safeIdent(column)} LIKE ?`).join(' OR ')})`
+      })
+      where.push(`(${searchParts.join(' OR ')})`)
+    }
+
+    const sql = `
+      SELECT
+        '${spec.table}' AS source,
+        ${coalesceColumnExpr(columns, spec.id, "''")} AS id,
+        ${coalesceColumnExpr(columns, spec.backendId, 'NULL')} AS backendId,
+        ${safeIdent(descriptionColumn)} AS description,
+        ${booleanColumnExpr(completedColumn)} AS completed,
+        ${booleanColumnExpr(deletedColumn)} AS deleted,
+        ${optionalColumnExpr(firstColumn(columns, spec.dueAt))} AS dueAt,
+        ${optionalColumnExpr(createdColumn)} AS createdAt,
+        ${optionalColumnExpr(firstColumn(columns, spec.updatedAt))} AS updatedAt,
+        ${optionalColumnExpr(firstColumn(columns, spec.priority))} AS priority
+      FROM ${safeIdent(spec.table)}
+      ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY ${createdColumn ? safeIdent(createdColumn) : 'rowid'} DESC
+      LIMIT ?
+    `
+    const rows = d.prepare(sql).all(...params, cappedLimit) as LocalTaskSearchRow[]
+    tasks.push(...rows.map(mapLocalTaskRow))
+  }
+
+  if (sources.length === 0) {
+    return {
+      available: false,
+      reason: 'No supported local task tables were found in the Windows main-process database.',
+      sources: [],
+      tasks: []
+    }
+  }
+
+  tasks.sort((a, b) => localTaskTimestampValue(b.createdAt) - localTaskTimestampValue(a.createdAt))
+  return {
+    available: true,
+    sources,
+    tasks: tasks.slice(0, cappedLimit)
+  }
 }
 
 type LocalKGNodeRow = {

--- a/desktop/windows/src/main/ipc/localAgent.ts
+++ b/desktop/windows/src/main/ipc/localAgent.ts
@@ -1,0 +1,35 @@
+import { ipcMain } from 'electron'
+import type { LocalAgentStatus, LocalAgentToolsTestResult } from '../../shared/types'
+import {
+  copyLocalAgentToken,
+  getLocalAgentStatus,
+  rotateLocalAgentAccessToken,
+  setLocalAgentEnabled,
+  setLocalAgentPort,
+  testLocalAgentTools
+} from '../localAgent/control'
+
+export function registerLocalAgentHandlers(): void {
+  ipcMain.handle('localAgent:status', async (): Promise<LocalAgentStatus> => getLocalAgentStatus())
+  ipcMain.handle(
+    'localAgent:setEnabled',
+    async (_e, enabled: boolean): Promise<LocalAgentStatus> =>
+      setLocalAgentEnabled(enabled === true)
+  )
+  ipcMain.handle(
+    'localAgent:setPort',
+    async (_e, port: number): Promise<LocalAgentStatus> => setLocalAgentPort(port)
+  )
+  ipcMain.handle(
+    'localAgent:copyToken',
+    async (): Promise<LocalAgentStatus> => copyLocalAgentToken()
+  )
+  ipcMain.handle(
+    'localAgent:rotateToken',
+    async (): Promise<LocalAgentStatus> => rotateLocalAgentAccessToken()
+  )
+  ipcMain.handle(
+    'localAgent:testTools',
+    async (): Promise<LocalAgentToolsTestResult> => testLocalAgentTools()
+  )
+}

--- a/desktop/windows/src/main/ipc/piChat.ts
+++ b/desktop/windows/src/main/ipc/piChat.ts
@@ -1,0 +1,42 @@
+import { app, ipcMain } from 'electron'
+import type { PiChatRequest, PiChatResponse } from '../../shared/types'
+import type { LocalAgentRuntimeContext } from '../localAgent/tools'
+import { isPiChatEnabled, sendPiChat } from '../pi/chatBridge'
+
+function runtimeContext(): LocalAgentRuntimeContext {
+  return {
+    localUrl: 'omi://local-agent',
+    toolEndpoint: 'omi://local-agent/pi-chat-tool',
+    app: {
+      name: app.getName(),
+      version: app.getVersion(),
+      appId: 'com.omiwindows.app'
+    }
+  }
+}
+
+function normalizeRequest(value: unknown): PiChatRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('invalid Pi/Omi chat request')
+  }
+  const record = value as Partial<PiChatRequest>
+  if (typeof record.token !== 'string') {
+    throw new Error('Pi/Omi chat requires a Firebase ID token')
+  }
+  if (!Array.isArray(record.messages)) {
+    throw new Error('Pi/Omi chat requires messages')
+  }
+  return {
+    token: record.token,
+    messages: record.messages
+  }
+}
+
+export function registerPiChatHandlers(): void {
+  ipcMain.handle('piChat:send', async (_event, rawRequest: unknown): Promise<PiChatResponse> => {
+    if (!isPiChatEnabled()) {
+      throw new Error('Pi/Omi chat is not enabled')
+    }
+    return sendPiChat(normalizeRequest(rawRequest), { runtimeContext: runtimeContext() })
+  })
+}

--- a/desktop/windows/src/main/ipc/piChat.ts
+++ b/desktop/windows/src/main/ipc/piChat.ts
@@ -1,12 +1,5 @@
 import { app, ipcMain } from 'electron'
-import type {
-  PiChatAbortResponse,
-  PiChatRequest,
-  PiChatResponse,
-  PiChatStartResponse,
-  PiChatStreamEvent,
-  PiChatStreamRequest
-} from '../../shared/types'
+import type { PiChatRequest, PiChatResponse } from '../../shared/types'
 import type { LocalAgentRuntimeContext } from '../localAgent/tools'
 import { isPiChatEnabled, sendPiChat } from '../pi/chatBridge'
 
@@ -39,29 +32,6 @@ function normalizeRequest(value: unknown): PiChatRequest {
   }
 }
 
-function normalizeStreamRequest(value: unknown): PiChatStreamRequest {
-  const request = normalizeRequest(value)
-  const sessionId =
-    value && typeof value === 'object' && !Array.isArray(value)
-      ? (value as Partial<PiChatStreamRequest>).sessionId
-      : undefined
-  if (typeof sessionId !== 'string' || !sessionId.trim()) {
-    throw new Error('Pi/Omi chat stream requires a session id')
-  }
-  return {
-    ...request,
-    sessionId: sessionId.trim()
-  }
-}
-
-type ActivePiChatSession = {
-  abort?: () => void
-  aborted: boolean
-  send: (event: PiChatStreamEvent) => void
-}
-
-const activeSessions = new Map<string, ActivePiChatSession>()
-
 export function registerPiChatHandlers(): void {
   ipcMain.handle('piChat:send', async (_event, rawRequest: unknown): Promise<PiChatResponse> => {
     if (!isPiChatEnabled()) {
@@ -69,62 +39,4 @@ export function registerPiChatHandlers(): void {
     }
     return sendPiChat(normalizeRequest(rawRequest), { runtimeContext: runtimeContext() })
   })
-
-  ipcMain.handle(
-    'piChat:start',
-    async (event, rawRequest: unknown): Promise<PiChatStartResponse> => {
-      if (!isPiChatEnabled()) {
-        throw new Error('Pi/Omi chat is not enabled')
-      }
-
-      const request = normalizeStreamRequest(rawRequest)
-      if (activeSessions.has(request.sessionId)) {
-        throw new Error('Pi/Omi chat session is already active')
-      }
-
-      const session: ActivePiChatSession = {
-        aborted: false,
-        send: (streamEvent) => {
-          if (!event.sender.isDestroyed()) event.sender.send('piChat:event', streamEvent)
-        }
-      }
-      activeSessions.set(request.sessionId, session)
-
-      void sendPiChat(request, {
-        runtimeContext: runtimeContext(),
-        onController: (controller) => {
-          session.abort = controller.abort
-          if (session.aborted) controller.abort()
-        },
-        onStreamEvent: (streamEvent) => {
-          session.send({ sessionId: request.sessionId, ...streamEvent })
-        }
-      })
-        .catch((error) => {
-          if (session.aborted) return
-          session.send({
-            sessionId: request.sessionId,
-            type: 'error',
-            message: error instanceof Error ? error.message : String(error)
-          })
-        })
-        .finally(() => {
-          activeSessions.delete(request.sessionId)
-        })
-
-      return { sessionId: request.sessionId }
-    }
-  )
-
-  ipcMain.handle(
-    'piChat:abort',
-    async (_event, sessionId: string): Promise<PiChatAbortResponse> => {
-      const session = activeSessions.get(sessionId)
-      if (!session) return { aborted: false }
-      session.aborted = true
-      session.abort?.()
-      session.send({ sessionId, type: 'aborted' })
-      return { aborted: true }
-    }
-  )
 }

--- a/desktop/windows/src/main/ipc/piChat.ts
+++ b/desktop/windows/src/main/ipc/piChat.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain } from 'electron'
-import type { PiChatRequest, PiChatResponse } from '../../shared/types'
+import type { PiChatRequest, PiChatResponse, PiChatStatus } from '../../shared/types'
 import type { LocalAgentRuntimeContext } from '../localAgent/tools'
 import { isPiChatEnabled, sendPiChat } from '../pi/chatBridge'
 
@@ -33,6 +33,10 @@ function normalizeRequest(value: unknown): PiChatRequest {
 }
 
 export function registerPiChatHandlers(): void {
+  ipcMain.handle('piChat:status', async (): Promise<PiChatStatus> => {
+    return { enabled: isPiChatEnabled() }
+  })
+
   ipcMain.handle('piChat:send', async (_event, rawRequest: unknown): Promise<PiChatResponse> => {
     if (!isPiChatEnabled()) {
       throw new Error('Pi/Omi chat is not enabled')

--- a/desktop/windows/src/main/ipc/piChat.ts
+++ b/desktop/windows/src/main/ipc/piChat.ts
@@ -1,5 +1,12 @@
 import { app, ipcMain } from 'electron'
-import type { PiChatRequest, PiChatResponse } from '../../shared/types'
+import type {
+  PiChatAbortResponse,
+  PiChatRequest,
+  PiChatResponse,
+  PiChatStartResponse,
+  PiChatStreamEvent,
+  PiChatStreamRequest
+} from '../../shared/types'
 import type { LocalAgentRuntimeContext } from '../localAgent/tools'
 import { isPiChatEnabled, sendPiChat } from '../pi/chatBridge'
 
@@ -32,6 +39,29 @@ function normalizeRequest(value: unknown): PiChatRequest {
   }
 }
 
+function normalizeStreamRequest(value: unknown): PiChatStreamRequest {
+  const request = normalizeRequest(value)
+  const sessionId =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Partial<PiChatStreamRequest>).sessionId
+      : undefined
+  if (typeof sessionId !== 'string' || !sessionId.trim()) {
+    throw new Error('Pi/Omi chat stream requires a session id')
+  }
+  return {
+    ...request,
+    sessionId: sessionId.trim()
+  }
+}
+
+type ActivePiChatSession = {
+  abort?: () => void
+  aborted: boolean
+  send: (event: PiChatStreamEvent) => void
+}
+
+const activeSessions = new Map<string, ActivePiChatSession>()
+
 export function registerPiChatHandlers(): void {
   ipcMain.handle('piChat:send', async (_event, rawRequest: unknown): Promise<PiChatResponse> => {
     if (!isPiChatEnabled()) {
@@ -39,4 +69,62 @@ export function registerPiChatHandlers(): void {
     }
     return sendPiChat(normalizeRequest(rawRequest), { runtimeContext: runtimeContext() })
   })
+
+  ipcMain.handle(
+    'piChat:start',
+    async (event, rawRequest: unknown): Promise<PiChatStartResponse> => {
+      if (!isPiChatEnabled()) {
+        throw new Error('Pi/Omi chat is not enabled')
+      }
+
+      const request = normalizeStreamRequest(rawRequest)
+      if (activeSessions.has(request.sessionId)) {
+        throw new Error('Pi/Omi chat session is already active')
+      }
+
+      const session: ActivePiChatSession = {
+        aborted: false,
+        send: (streamEvent) => {
+          if (!event.sender.isDestroyed()) event.sender.send('piChat:event', streamEvent)
+        }
+      }
+      activeSessions.set(request.sessionId, session)
+
+      void sendPiChat(request, {
+        runtimeContext: runtimeContext(),
+        onController: (controller) => {
+          session.abort = controller.abort
+          if (session.aborted) controller.abort()
+        },
+        onStreamEvent: (streamEvent) => {
+          session.send({ sessionId: request.sessionId, ...streamEvent })
+        }
+      })
+        .catch((error) => {
+          if (session.aborted) return
+          session.send({
+            sessionId: request.sessionId,
+            type: 'error',
+            message: error instanceof Error ? error.message : String(error)
+          })
+        })
+        .finally(() => {
+          activeSessions.delete(request.sessionId)
+        })
+
+      return { sessionId: request.sessionId }
+    }
+  )
+
+  ipcMain.handle(
+    'piChat:abort',
+    async (_event, sessionId: string): Promise<PiChatAbortResponse> => {
+      const session = activeSessions.get(sessionId)
+      if (!session) return { aborted: false }
+      session.aborted = true
+      session.abort?.()
+      session.send({ sessionId, type: 'aborted' })
+      return { aborted: true }
+    }
+  )
 }

--- a/desktop/windows/src/main/localAgent/control.test.ts
+++ b/desktop/windows/src/main/localAgent/control.test.ts
@@ -1,0 +1,189 @@
+import { createServer } from 'http'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true,
+  clipboardText: ''
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  clipboard: {
+    writeText: (value: string): void => {
+      electronState.clipboardText = value
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+import {
+  copyLocalAgentToken,
+  getLocalAgentStatus,
+  rotateLocalAgentAccessToken,
+  setLocalAgentEnabled,
+  setLocalAgentPort,
+  testLocalAgentTools
+} from './control'
+import { stopLocalAgentServer } from './server'
+import { loadLocalAgentToken } from './tokenStore'
+import { LOCAL_AGENT_DEFAULT_PORT } from './settings'
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('could not allocate port')))
+        return
+      }
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve(address.port)
+      })
+    })
+  })
+}
+
+async function twoFreePorts(): Promise<[number, number]> {
+  const first = await freePort()
+  let second = await freePort()
+  while (second === first) {
+    second = await freePort()
+  }
+  return [first, second]
+}
+
+async function fetchTools(localUrl: string, token: string): Promise<Response> {
+  return fetch(`${localUrl}/v1/local/tools`, {
+    headers: { authorization: `Bearer ${token}` }
+  })
+}
+
+describe('local agent controls', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-control-'))
+    electronState.encryptionAvailable = true
+    electronState.clipboardText = ''
+  })
+
+  afterEach(async () => {
+    await stopLocalAgentServer()
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('is disabled by default and does not expose a token in status', () => {
+    expect(getLocalAgentStatus()).toEqual({
+      enabled: false,
+      running: false,
+      host: '127.0.0.1',
+      configuredPort: LOCAL_AGENT_DEFAULT_PORT,
+      currentPort: null,
+      localUrl: null,
+      toolEndpoint: null,
+      hasToken: false
+    })
+  })
+
+  it('enables and disables the loopback server from settings', async () => {
+    const port = await freePort()
+    await setLocalAgentPort(port)
+
+    const enabled = await setLocalAgentEnabled(true)
+    expect(enabled).toMatchObject({
+      enabled: true,
+      running: true,
+      host: '127.0.0.1',
+      configuredPort: port,
+      currentPort: port,
+      localUrl: `http://127.0.0.1:${port}`
+    })
+
+    await expect(fetch(`${enabled.localUrl}/health`)).resolves.toMatchObject({ status: 200 })
+
+    const disabled = await setLocalAgentEnabled(false)
+    expect(disabled).toMatchObject({
+      enabled: false,
+      running: false,
+      configuredPort: port,
+      currentPort: null,
+      localUrl: null
+    })
+    await expect(fetch(`${enabled.localUrl}/health`)).rejects.toThrow()
+  })
+
+  it('restarts on a saved port change while enabled', async () => {
+    const [firstPort, secondPort] = await twoFreePorts()
+    await setLocalAgentPort(firstPort)
+    const first = await setLocalAgentEnabled(true)
+
+    const second = await setLocalAgentPort(secondPort)
+
+    expect(second).toMatchObject({
+      enabled: true,
+      running: true,
+      configuredPort: secondPort,
+      currentPort: secondPort,
+      localUrl: `http://127.0.0.1:${secondPort}`
+    })
+    await expect(fetch(`${first.localUrl}/health`)).rejects.toThrow()
+    await expect(fetch(`${second.localUrl}/health`)).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('copies the bearer token without returning it in status', () => {
+    const status = copyLocalAgentToken()
+
+    expect(electronState.clipboardText).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(status.hasToken).toBe(true)
+    expect(status).not.toHaveProperty('token')
+  })
+
+  it('rotates the bearer token and invalidates the old one', async () => {
+    const port = await freePort()
+    await setLocalAgentPort(port)
+    const started = await setLocalAgentEnabled(true)
+    const oldToken = loadLocalAgentToken()
+    if (!oldToken || !started.localUrl) throw new Error('expected started local agent')
+
+    await expect(fetchTools(started.localUrl, oldToken)).resolves.toMatchObject({ status: 200 })
+
+    const rotated = await rotateLocalAgentAccessToken()
+    const newToken = loadLocalAgentToken()
+    if (!newToken || !rotated.localUrl) throw new Error('expected rotated local agent')
+
+    expect(newToken).not.toBe(oldToken)
+    await expect(fetchTools(rotated.localUrl, oldToken)).resolves.toMatchObject({ status: 401 })
+    await expect(fetchTools(rotated.localUrl, newToken)).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('tests the authenticated local tools endpoint', async () => {
+    await expect(testLocalAgentTools()).resolves.toMatchObject({
+      ok: false,
+      error: 'Local agent API is not listening'
+    })
+
+    await setLocalAgentPort(await freePort())
+    await setLocalAgentEnabled(true)
+
+    await expect(testLocalAgentTools()).resolves.toMatchObject({
+      ok: true,
+      status: 200
+    })
+  })
+})

--- a/desktop/windows/src/main/localAgent/control.ts
+++ b/desktop/windows/src/main/localAgent/control.ts
@@ -1,0 +1,99 @@
+import { clipboard } from 'electron'
+import type { LocalAgentStatus, LocalAgentToolsTestResult } from '../../shared/types'
+import { getLocalAgentSettings, setLocalAgentSettings } from './settings'
+import { getLocalAgentServerInfo, startLocalAgentServer, stopLocalAgentServer } from './server'
+import { ensureLocalAgentToken, loadLocalAgentToken, rotateLocalAgentToken } from './tokenStore'
+
+const LOCAL_AGENT_HOST = '127.0.0.1'
+
+function validatePort(port: number): number {
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error('Local agent port must be between 1024 and 65535')
+  }
+  return port
+}
+
+export function getLocalAgentStatus(): LocalAgentStatus {
+  const settings = getLocalAgentSettings()
+  const info = getLocalAgentServerInfo()
+  return {
+    enabled: settings.enabled,
+    running: info !== null,
+    host: info?.host ?? LOCAL_AGENT_HOST,
+    configuredPort: settings.port,
+    currentPort: info?.port ?? null,
+    localUrl: info?.localUrl ?? null,
+    toolEndpoint: info?.toolEndpoint ?? null,
+    hasToken: loadLocalAgentToken() !== null
+  }
+}
+
+export async function setLocalAgentEnabled(enabled: boolean): Promise<LocalAgentStatus> {
+  const settings = setLocalAgentSettings({ ...getLocalAgentSettings(), enabled })
+  if (!enabled) {
+    await stopLocalAgentServer()
+    return getLocalAgentStatus()
+  }
+
+  await startLocalAgentServer({ preferredPort: settings.port })
+  return getLocalAgentStatus()
+}
+
+export async function setLocalAgentPort(port: number): Promise<LocalAgentStatus> {
+  const validatedPort = validatePort(port)
+  const settings = setLocalAgentSettings({ ...getLocalAgentSettings(), port: validatedPort })
+
+  if (settings.enabled) {
+    await stopLocalAgentServer()
+    await startLocalAgentServer({ preferredPort: settings.port })
+  }
+
+  return getLocalAgentStatus()
+}
+
+export function copyLocalAgentToken(): LocalAgentStatus {
+  clipboard.writeText(ensureLocalAgentToken())
+  return getLocalAgentStatus()
+}
+
+export async function rotateLocalAgentAccessToken(): Promise<LocalAgentStatus> {
+  rotateLocalAgentToken()
+  const settings = getLocalAgentSettings()
+
+  if (settings.enabled) {
+    await stopLocalAgentServer()
+    await startLocalAgentServer({ preferredPort: settings.port })
+  }
+
+  return getLocalAgentStatus()
+}
+
+export async function testLocalAgentTools(): Promise<LocalAgentToolsTestResult> {
+  const info = getLocalAgentServerInfo()
+  if (!info) {
+    return { ok: false, error: 'Local agent API is not listening' }
+  }
+
+  const token = loadLocalAgentToken()
+  if (!token) {
+    return { ok: false, error: 'Local agent token is missing' }
+  }
+
+  try {
+    const response = await fetch(`${info.localUrl}/v1/local/tools`, {
+      headers: { authorization: `Bearer ${token}` }
+    })
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` }
+    }
+
+    const body = (await response.json()) as { tools?: unknown[] }
+    const toolCount = Array.isArray(body.tools) ? body.tools.length : 0
+    return { ok: true, status: response.status, toolCount }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Local agent tools test failed'
+    }
+  }
+}

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -100,10 +100,24 @@ describe('local agent server', () => {
     const tools = await fetch(`${info.localUrl}/v1/local/tools`, {
       headers: { authorization: 'Bearer test-token' }
     })
-    await expect(tools.json()).resolves.toEqual({
-      tools: [],
+    const toolsBody = await tools.json()
+    expect(toolsBody).toMatchObject({
+      ok: true,
       toolEndpoint: `${info.localUrl}/v1/local/tool`
     })
+    expect(toolsBody.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'get_local_status',
+        'execute_sql',
+        'search_screen_history',
+        'semantic_search',
+        'get_screenshot',
+        'get_daily_recap',
+        'search_tasks',
+        'complete_task',
+        'delete_task'
+      ])
+    )
 
     const missingAuthToolCall = await fetch(`${info.localUrl}/v1/local/tool`, { method: 'POST' })
     expect(missingAuthToolCall.status).toBe(401)
@@ -114,9 +128,31 @@ describe('local agent server', () => {
         authorization: 'Bearer test-token',
         'content-type': 'application/json'
       },
+      body: JSON.stringify({ name: 'get_local_status', arguments: {} })
+    })
+    expect(toolCall.status).toBe(200)
+    await expect(toolCall.json()).resolves.toMatchObject({
+      ok: true,
+      name: 'get_local_status',
+      result: {
+        ok: true,
+        mode: 'local_omi_windows'
+      }
+    })
+
+    const unknownTool = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
       body: JSON.stringify({ name: 'noop', arguments: {} })
     })
-    expect(toolCall.status).toBe(501)
+    expect(unknownTool.status).toBe(404)
+    await expect(unknownTool.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'unknown_tool' }
+    })
   })
 
   it('falls back from the default port without binding to all interfaces', async () => {

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -1,0 +1,139 @@
+import { createServer, type Server } from 'http'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LOCAL_AGENT_DEFAULT_PORT, setLocalAgentSettings } from './settings'
+import {
+  startLocalAgentServer,
+  startLocalAgentServerIfEnabled,
+  stopLocalAgentServer
+} from './server'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', () => resolve())
+  })
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+}
+
+describe('local agent server', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-'))
+    electronState.encryptionAvailable = true
+  })
+
+  afterEach(async () => {
+    await stopLocalAgentServer()
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('does not start until the local agent setting is enabled', async () => {
+    await expect(startLocalAgentServerIfEnabled()).resolves.toBeNull()
+
+    setLocalAgentSettings({ enabled: true, port: 47820 })
+    const info = await startLocalAgentServerIfEnabled()
+
+    expect(info).toMatchObject({
+      host: '127.0.0.1',
+      port: 47820,
+      localUrl: 'http://127.0.0.1:47820',
+      toolEndpoint: 'http://127.0.0.1:47820/v1/local/tool'
+    })
+  })
+
+  it('serves unauthenticated health metadata on loopback', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47821, token: 'test-token' })
+
+    const response = await fetch(`${info.localUrl}/health`)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      ok: true,
+      app: {
+        name: 'Omi Windows',
+        version: '1.2.3',
+        appId: 'com.omiwindows.app'
+      },
+      localUrl: info.localUrl,
+      toolEndpoint: `${info.localUrl}/v1/local/tool`
+    })
+  })
+
+  it('requires bearer auth for local tool discovery and invocation', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47822, token: 'test-token' })
+
+    const missingAuthTools = await fetch(`${info.localUrl}/v1/local/tools`)
+    expect(missingAuthTools.status).toBe(401)
+
+    const tools = await fetch(`${info.localUrl}/v1/local/tools`, {
+      headers: { authorization: 'Bearer test-token' }
+    })
+    await expect(tools.json()).resolves.toEqual({
+      tools: [],
+      toolEndpoint: `${info.localUrl}/v1/local/tool`
+    })
+
+    const missingAuthToolCall = await fetch(`${info.localUrl}/v1/local/tool`, { method: 'POST' })
+    expect(missingAuthToolCall.status).toBe(401)
+
+    const toolCall = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'noop', arguments: {} })
+    })
+    expect(toolCall.status).toBe(501)
+  })
+
+  it('falls back from the default port without binding to all interfaces', async () => {
+    const occupied = createServer((_req, res) => res.end('occupied'))
+    await listen(occupied, LOCAL_AGENT_DEFAULT_PORT)
+
+    try {
+      const info = await startLocalAgentServer({ token: 'test-token' })
+
+      expect(info).toMatchObject({
+        host: '127.0.0.1',
+        port: LOCAL_AGENT_DEFAULT_PORT + 1,
+        localUrl: `http://127.0.0.1:${LOCAL_AGENT_DEFAULT_PORT + 1}`,
+        toolEndpoint: `http://127.0.0.1:${LOCAL_AGENT_DEFAULT_PORT + 1}/v1/local/tool`
+      })
+    } finally {
+      await close(occupied)
+    }
+  })
+})

--- a/desktop/windows/src/main/localAgent/server.test.ts
+++ b/desktop/windows/src/main/localAgent/server.test.ts
@@ -155,6 +155,25 @@ describe('local agent server', () => {
     })
   })
 
+  it('rejects oversized local tool request bodies', async () => {
+    const info = await startLocalAgentServer({ preferredPort: 47825, token: 'test-token' })
+
+    const response = await fetch(`${info.localUrl}/v1/local/tool`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: 'x'.repeat(1_048_577)
+    })
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'request_body_too_large', max_bytes: 1_048_576 }
+    })
+  })
+
   it('falls back from the default port without binding to all interfaces', async () => {
     const occupied = createServer((_req, res) => res.end('occupied'))
     await listen(occupied, LOCAL_AGENT_DEFAULT_PORT)

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -1,0 +1,205 @@
+import { app } from 'electron'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
+import type { AddressInfo } from 'net'
+import { getLocalAgentSettings, LOCAL_AGENT_DEFAULT_PORT } from './settings'
+import { ensureLocalAgentToken } from './tokenStore'
+
+const LOCAL_AGENT_HOST = '127.0.0.1'
+const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
+const MAX_PORT_ATTEMPTS = 20
+
+export type LocalAgentServerInfo = {
+  host: typeof LOCAL_AGENT_HOST
+  port: number
+  localUrl: string
+  toolEndpoint: string
+}
+
+type AppMetadata = {
+  name: string
+  version: string
+  appId: string
+}
+
+type LocalAgentServerOptions = {
+  preferredPort?: number
+  token?: string
+  appMetadata?: AppMetadata
+  serverFactory?: typeof createServer
+}
+
+let runningServer: Server | null = null
+let runningInfo: LocalAgentServerInfo | null = null
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(payload)
+  })
+  res.end(payload)
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+}
+
+function authorize(req: IncomingMessage, token: string): boolean {
+  const auth = req.headers.authorization
+  return auth === `Bearer ${token}`
+}
+
+function metadata(override?: AppMetadata): AppMetadata {
+  return (
+    override ?? {
+      name: app.getName(),
+      version: app.getVersion(),
+      appId: LOCAL_AGENT_APP_ID
+    }
+  )
+}
+
+function currentInfo(port: number): LocalAgentServerInfo {
+  const localUrl = `http://${LOCAL_AGENT_HOST}:${port}`
+  return {
+    host: LOCAL_AGENT_HOST,
+    port,
+    localUrl,
+    toolEndpoint: `${localUrl}/v1/local/tool`
+  }
+}
+
+function route(
+  req: IncomingMessage,
+  res: ServerResponse,
+  info: LocalAgentServerInfo,
+  token: string,
+  appInfo: AppMetadata
+): void {
+  const method = req.method ?? 'GET'
+  const url = new URL(req.url ?? '/', info.localUrl)
+
+  if (method === 'GET' && url.pathname === '/health') {
+    json(res, 200, {
+      ok: true,
+      app: {
+        name: appInfo.name,
+        version: appInfo.version,
+        appId: appInfo.appId
+      },
+      localUrl: info.localUrl,
+      toolEndpoint: info.toolEndpoint
+    })
+    return
+  }
+
+  if (url.pathname === '/v1/local/tools' || url.pathname === '/v1/local/tool') {
+    if (!authorize(req, token)) {
+      json(res, 401, { error: 'unauthorized' })
+      return
+    }
+
+    if (method === 'GET' && url.pathname === '/v1/local/tools') {
+      json(res, 200, {
+        tools: [],
+        toolEndpoint: info.toolEndpoint
+      })
+      return
+    }
+
+    if (method === 'POST' && url.pathname === '/v1/local/tool') {
+      void readBody(req)
+        .then(() => {
+          json(res, 501, {
+            error: 'no_local_tools_registered',
+            tools: []
+          })
+        })
+        .catch(() => {
+          json(res, 400, { error: 'invalid_request_body' })
+        })
+      return
+    }
+  }
+
+  json(res, 404, { error: 'not_found' })
+}
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off('listening', onListening)
+      reject(error)
+    }
+    const onListening = (): void => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port, LOCAL_AGENT_HOST)
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+}
+
+export async function startLocalAgentServer(
+  options: LocalAgentServerOptions = {}
+): Promise<LocalAgentServerInfo> {
+  if (runningInfo) return runningInfo
+
+  const token = options.token ?? ensureLocalAgentToken()
+  const appInfo = metadata(options.appMetadata)
+  const preferredPort = options.preferredPort ?? LOCAL_AGENT_DEFAULT_PORT
+  const serverFactory = options.serverFactory ?? createServer
+
+  let lastError: unknown = null
+  for (let offset = 0; offset < MAX_PORT_ATTEMPTS; offset += 1) {
+    const port = preferredPort + offset
+    const info = currentInfo(port)
+    const server = serverFactory((req, res) => route(req, res, info, token, appInfo))
+
+    try {
+      await listen(server, port)
+      const address = server.address() as AddressInfo | null
+      if (address?.address !== LOCAL_AGENT_HOST) {
+        await closeServer(server)
+        throw new Error(`local agent server bound unexpected address: ${address?.address}`)
+      }
+      runningServer = server
+      runningInfo = info
+      console.log(`[local-agent] listening on ${info.localUrl}`)
+      return info
+    } catch (e) {
+      lastError = e
+      await closeServer(server).catch(() => undefined)
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('local agent server failed to start')
+}
+
+export async function startLocalAgentServerIfEnabled(): Promise<LocalAgentServerInfo | null> {
+  const settings = getLocalAgentSettings()
+  if (!settings.enabled) return null
+  return startLocalAgentServer({ preferredPort: settings.port })
+}
+
+export async function stopLocalAgentServer(): Promise<void> {
+  const server = runningServer
+  runningServer = null
+  runningInfo = null
+  if (server) await closeServer(server)
+}

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -3,6 +3,12 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from 'net'
 import { getLocalAgentSettings, LOCAL_AGENT_DEFAULT_PORT } from './settings'
 import { ensureLocalAgentToken } from './tokenStore'
+import {
+  errorResponseBody,
+  listLocalAgentTools,
+  runLocalAgentTool,
+  type LocalAgentRuntimeContext
+} from './tools'
 
 const LOCAL_AGENT_HOST = '127.0.0.1'
 const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
@@ -47,6 +53,26 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
     req.on('error', reject)
   })
+}
+
+function parseToolRequest(body: string): { name: string; arguments: unknown } {
+  let payload: unknown
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    throw new Error('invalid_json_body')
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('invalid_json_body')
+  }
+  const record = payload as Record<string, unknown>
+  if (typeof record.name !== 'string' || !record.name.trim()) {
+    throw new Error('missing_tool_name')
+  }
+  return {
+    name: record.name.trim(),
+    arguments: record.arguments ?? {}
+  }
 }
 
 function authorize(req: IncomingMessage, token: string): boolean {
@@ -106,7 +132,8 @@ function route(
 
     if (method === 'GET' && url.pathname === '/v1/local/tools') {
       json(res, 200, {
-        tools: [],
+        ok: true,
+        tools: listLocalAgentTools(),
         toolEndpoint: info.toolEndpoint
       })
       return
@@ -114,14 +141,37 @@ function route(
 
     if (method === 'POST' && url.pathname === '/v1/local/tool') {
       void readBody(req)
-        .then(() => {
-          json(res, 501, {
-            error: 'no_local_tools_registered',
-            tools: []
-          })
+        .then(async (body) => {
+          let request: { name: string; arguments: unknown }
+          try {
+            request = parseToolRequest(body)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'invalid_json_body'
+            json(res, 400, { ok: false, error: { code: message, message } })
+            return
+          }
+
+          try {
+            const context: LocalAgentRuntimeContext = {
+              localUrl: info.localUrl,
+              toolEndpoint: info.toolEndpoint,
+              app: {
+                name: appInfo.name,
+                version: appInfo.version,
+                appId: appInfo.appId
+              }
+            }
+            json(res, 200, await runLocalAgentTool(request.name, request.arguments, context))
+          } catch (error) {
+            const { status, body } = errorResponseBody(error)
+            json(res, status, body)
+          }
         })
         .catch(() => {
-          json(res, 400, { error: 'invalid_request_body' })
+          json(res, 400, {
+            ok: false,
+            error: { code: 'invalid_request_body', message: 'invalid_request_body' }
+          })
         })
       return
     }

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -247,6 +247,10 @@ export async function startLocalAgentServerIfEnabled(): Promise<LocalAgentServer
   return startLocalAgentServer({ preferredPort: settings.port })
 }
 
+export function getLocalAgentServerInfo(): LocalAgentServerInfo | null {
+  return runningInfo
+}
+
 export async function stopLocalAgentServer(): Promise<void> {
   const server = runningServer
   runningServer = null

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -13,6 +13,7 @@ import {
 const LOCAL_AGENT_HOST = '127.0.0.1'
 const LOCAL_AGENT_APP_ID = 'com.omiwindows.app'
 const MAX_PORT_ATTEMPTS = 20
+const MAX_REQUEST_BODY_BYTES = 1_048_576
 
 export type LocalAgentServerInfo = {
   host: typeof LOCAL_AGENT_HOST
@@ -37,6 +38,16 @@ type LocalAgentServerOptions = {
 let runningServer: Server | null = null
 let runningInfo: LocalAgentServerInfo | null = null
 
+class RequestBodyTooLargeError extends Error {
+  readonly code = 'request_body_too_large'
+  readonly status = 413
+
+  constructor() {
+    super(`request body exceeds ${MAX_REQUEST_BODY_BYTES} bytes`)
+    this.name = 'RequestBodyTooLargeError'
+  }
+}
+
 function json(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body)
   res.writeHead(status, {
@@ -49,9 +60,32 @@ function json(res: ServerResponse, status: number, body: unknown): void {
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-    req.on('error', reject)
+    let total = 0
+    let settled = false
+
+    const fail = (error: Error): void => {
+      if (settled) return
+      settled = true
+      chunks.length = 0
+      reject(error)
+    }
+
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return
+      total += chunk.length
+      if (total > MAX_REQUEST_BODY_BYTES) {
+        fail(new RequestBodyTooLargeError())
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      if (!settled) {
+        settled = true
+        resolve(Buffer.concat(chunks).toString('utf8'))
+      }
+    })
+    req.on('error', (error) => fail(error))
   })
 }
 
@@ -167,7 +201,18 @@ function route(
             json(res, status, body)
           }
         })
-        .catch(() => {
+        .catch((error) => {
+          if (error instanceof RequestBodyTooLargeError) {
+            json(res, error.status, {
+              ok: false,
+              error: {
+                code: error.code,
+                message: error.message,
+                max_bytes: MAX_REQUEST_BODY_BYTES
+              }
+            })
+            return
+          }
           json(res, 400, {
             ok: false,
             error: { code: 'invalid_request_body', message: 'invalid_request_body' }

--- a/desktop/windows/src/main/localAgent/server.ts
+++ b/desktop/windows/src/main/localAgent/server.ts
@@ -211,6 +211,7 @@ function route(
                 max_bytes: MAX_REQUEST_BODY_BYTES
               }
             })
+            req.destroy()
             return
           }
           json(res, 400, {

--- a/desktop/windows/src/main/localAgent/settings.ts
+++ b/desktop/windows/src/main/localAgent/settings.ts
@@ -1,0 +1,52 @@
+import { app } from 'electron'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export type LocalAgentSettings = {
+  enabled: boolean
+  port: number
+}
+
+export const LOCAL_AGENT_DEFAULT_PORT = 47778
+
+const DEFAULTS: LocalAgentSettings = {
+  enabled: false,
+  port: LOCAL_AGENT_DEFAULT_PORT
+}
+
+function file(): string {
+  return join(app.getPath('userData'), 'local-agent-settings.json')
+}
+
+function sanitize(raw: Partial<LocalAgentSettings>): LocalAgentSettings {
+  const port =
+    typeof raw.port === 'number' &&
+    Number.isInteger(raw.port) &&
+    raw.port >= 1024 &&
+    raw.port <= 65535
+      ? raw.port
+      : DEFAULTS.port
+
+  return {
+    enabled: raw.enabled === true,
+    port
+  }
+}
+
+export function getLocalAgentSettings(): LocalAgentSettings {
+  try {
+    return sanitize(JSON.parse(readFileSync(file(), 'utf-8')) as Partial<LocalAgentSettings>)
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+export function setLocalAgentSettings(next: LocalAgentSettings): LocalAgentSettings {
+  const value = sanitize(next)
+  try {
+    writeFileSync(file(), JSON.stringify(value), 'utf-8')
+  } catch (e) {
+    console.warn('[local-agent] failed to persist settings:', e)
+  }
+  return value
+}

--- a/desktop/windows/src/main/localAgent/tokenStore.test.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronState = vi.hoisted(() => ({
+  userData: '',
+  encryptionAvailable: true
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: (): boolean => electronState.encryptionAvailable,
+    encryptString: (value: string): Buffer => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer): string => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+import {
+  clearLocalAgentToken,
+  ensureLocalAgentToken,
+  loadLocalAgentToken,
+  saveLocalAgentToken
+} from './tokenStore'
+
+describe('local agent token store', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-token-'))
+    electronState.encryptionAvailable = true
+  })
+
+  afterEach(() => {
+    rmSync(electronState.userData, { recursive: true, force: true })
+  })
+
+  it('stores and loads the bearer token without writing the raw token', () => {
+    saveLocalAgentToken('local_secret_token')
+
+    const rawFile = readFileSync(join(electronState.userData, 'local-agent-token.json'), 'utf8')
+    expect(rawFile).not.toContain('local_secret_token')
+    expect(loadLocalAgentToken()).toBe('local_secret_token')
+  })
+
+  it('creates one token and reuses it on later calls', () => {
+    const first = ensureLocalAgentToken()
+    const second = ensureLocalAgentToken()
+
+    expect(first).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(second).toBe(first)
+  })
+
+  it('deletes the stored token', () => {
+    saveLocalAgentToken('local_secret_token')
+    clearLocalAgentToken()
+
+    expect(loadLocalAgentToken()).toBeNull()
+  })
+
+  it('refuses to save when secure storage is unavailable', () => {
+    electronState.encryptionAvailable = false
+
+    expect(() => saveLocalAgentToken('local_secret_token')).toThrow(
+      'Secure storage is unavailable on this system'
+    )
+  })
+})

--- a/desktop/windows/src/main/localAgent/tokenStore.test.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.test.ts
@@ -26,6 +26,7 @@ import {
   clearLocalAgentToken,
   ensureLocalAgentToken,
   loadLocalAgentToken,
+  rotateLocalAgentToken,
   saveLocalAgentToken
 } from './tokenStore'
 
@@ -53,6 +54,15 @@ describe('local agent token store', () => {
 
     expect(first).toMatch(/^[A-Za-z0-9_-]+$/)
     expect(second).toBe(first)
+  })
+
+  it('rotates and persists a new bearer token', () => {
+    const first = ensureLocalAgentToken()
+    const second = rotateLocalAgentToken()
+
+    expect(second).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(second).not.toBe(first)
+    expect(loadLocalAgentToken()).toBe(second)
   })
 
   it('deletes the stored token', () => {

--- a/desktop/windows/src/main/localAgent/tokenStore.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.ts
@@ -45,6 +45,12 @@ export function ensureLocalAgentToken(): string {
   return token
 }
 
+export function rotateLocalAgentToken(): string {
+  const token = createToken()
+  saveLocalAgentToken(token)
+  return token
+}
+
 export function clearLocalAgentToken(): void {
   try {
     rmSync(file(), { force: true })

--- a/desktop/windows/src/main/localAgent/tokenStore.ts
+++ b/desktop/windows/src/main/localAgent/tokenStore.ts
@@ -1,0 +1,54 @@
+import { app, safeStorage } from 'electron'
+import { randomBytes } from 'crypto'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+type StoredLocalAgentTokenFile = {
+  token: string
+}
+
+function file(): string {
+  return join(app.getPath('userData'), 'local-agent-token.json')
+}
+
+function createToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function saveLocalAgentToken(token: string): void {
+  if (!token) throw new Error('Invalid local agent token')
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('Secure storage is unavailable on this system')
+  }
+  const enc = safeStorage.encryptString(token).toString('base64')
+  writeFileSync(file(), JSON.stringify({ token: enc } satisfies StoredLocalAgentTokenFile), 'utf8')
+}
+
+export function loadLocalAgentToken(): string | null {
+  const f = file()
+  if (!existsSync(f)) return null
+  try {
+    const raw = JSON.parse(readFileSync(f, 'utf8')) as StoredLocalAgentTokenFile
+    if (!raw.token) return null
+    return safeStorage.decryptString(Buffer.from(raw.token, 'base64'))
+  } catch {
+    return null
+  }
+}
+
+export function ensureLocalAgentToken(): string {
+  const existing = loadLocalAgentToken()
+  if (existing) return existing
+
+  const token = createToken()
+  saveLocalAgentToken(token)
+  return token
+}
+
+export function clearLocalAgentToken(): void {
+  try {
+    rmSync(file(), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}

--- a/desktop/windows/src/main/localAgent/tools.test.ts
+++ b/desktop/windows/src/main/localAgent/tools.test.ts
@@ -1,0 +1,249 @@
+import Database from 'better-sqlite3'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LocalConversation, RewindFrame } from '../../shared/types'
+
+const electronState = vi.hoisted(() => ({
+  userData: ''
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: (): string => 'Omi Windows',
+    getVersion: (): string => '1.2.3',
+    getPath: (name: string): string => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`)
+      return electronState.userData
+    }
+  }
+}))
+
+const context = {
+  localUrl: 'http://127.0.0.1:47778',
+  toolEndpoint: 'http://127.0.0.1:47778/v1/local/tool',
+  app: {
+    name: 'Omi Windows',
+    version: '1.2.3',
+    appId: 'com.omiwindows.app'
+  }
+}
+
+async function freshModules(): Promise<{
+  tools: typeof import('./tools')
+  db: typeof import('../ipc/db')
+}> {
+  vi.resetModules()
+  const tools = await import('./tools')
+  const db = await import('../ipc/db')
+  return { tools, db }
+}
+
+function conversation(over: Partial<LocalConversation> = {}): LocalConversation {
+  const now = Date.now()
+  return {
+    id: 'conversation-1',
+    startedAt: now - 1_000,
+    endedAt: now,
+    transcript: 'Discussed the local agent tool registry.',
+    createdAt: now,
+    kind: 'recording',
+    title: 'Local tools',
+    ...over
+  }
+}
+
+function frame(
+  imagePath: string,
+  over: Partial<Omit<RewindFrame, 'id'>> = {}
+): Omit<RewindFrame, 'id'> {
+  return {
+    ts: Date.now(),
+    app: 'Code.exe',
+    windowTitle: 'localAgent tools',
+    processName: 'Code',
+    ocrText: 'first local agent tool set screen history',
+    imagePath,
+    width: 1280,
+    height: 720,
+    indexed: 1,
+    ...over
+  }
+}
+
+describe('local agent tool registry', () => {
+  beforeEach(() => {
+    electronState.userData = mkdtempSync(join(tmpdir(), 'omi-local-agent-tools-'))
+    process.env.OMI_DB_PATH = join(electronState.userData, 'omi.db')
+  })
+
+  afterEach(() => {
+    delete process.env.OMI_DB_PATH
+    vi.resetModules()
+    rmSync(electronState.userData, { recursive: true, force: true })
+    electronState.userData = ''
+  })
+
+  it('lists JSON-schema tool definitions with unavailable destructive task annotations', async () => {
+    const { tools } = await freshModules()
+    const definitions = tools.listLocalAgentTools()
+
+    expect(definitions.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'get_local_status',
+        'execute_sql',
+        'search_screen_history',
+        'semantic_search',
+        'get_screenshot',
+        'get_daily_recap',
+        'search_tasks',
+        'complete_task',
+        'delete_task'
+      ])
+    )
+    expect(definitions.find((tool) => tool.name === 'execute_sql')).toMatchObject({
+      inputSchema: {
+        type: 'object',
+        required: ['query']
+      },
+      annotations: {
+        readOnlyHint: true,
+        readOnlyEnforced: true,
+        mutationStatementsRejected: true
+      }
+    })
+    expect(definitions.find((tool) => tool.name === 'delete_task')).toMatchObject({
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        gated: true,
+        unavailable: true
+      }
+    })
+  })
+
+  it('runs read-only SQL through the guard and rejects mutations', async () => {
+    const { tools, db } = await freshModules()
+    db.insertLocalConversation(conversation())
+
+    const result = await tools.runLocalAgentTool(
+      'execute_sql',
+      { query: 'SELECT id, title FROM local_conversation' },
+      context
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      name: 'execute_sql',
+      result: {
+        columns: ['id', 'title'],
+        row_count: 1,
+        read_only: true,
+        max_rows: 200
+      }
+    })
+    expect((result.result as { rows: Record<string, unknown>[] }).rows[0]).toEqual({
+      id: 'conversation-1',
+      title: 'Local tools'
+    })
+
+    await expect(
+      tools.runLocalAgentTool('execute_sql', { query: 'DELETE FROM local_conversation' }, context)
+    ).rejects.toMatchObject({
+      code: 'sql_rejected_or_failed',
+      status: 400
+    })
+  })
+
+  it('searches Rewind history and returns screenshot image data by frame id', async () => {
+    const { tools, db } = await freshModules()
+    const imagePath = join(electronState.userData, 'rewind', '2026-06-20', 'frame.jpg')
+    mkdirSync(dirname(imagePath), { recursive: true })
+    const imageBytes = Buffer.from([1, 2, 3, 4])
+    writeFileSync(imagePath, imageBytes)
+    const id = db.insertRewindFrame(frame(imagePath))
+
+    const search = await tools.runLocalAgentTool(
+      'search_screen_history',
+      { query: 'agent tool set', days: 1 },
+      context
+    )
+    const searchResult = search.result as {
+      result_count: number
+      results: { representative: { screenshot_id: number } }[]
+    }
+    expect(searchResult.result_count).toBe(1)
+    expect(searchResult.results[0].representative.screenshot_id).toBe(id)
+
+    const screenshot = await tools.runLocalAgentTool(
+      'get_screenshot',
+      { screenshot_id: id },
+      context
+    )
+    expect(screenshot).toMatchObject({
+      ok: true,
+      name: 'get_screenshot',
+      content_type: 'image/jpeg',
+      result: {
+        screenshot_id: id,
+        image_base64: imageBytes.toString('base64'),
+        metadata: {
+          screenshot_id: id,
+          app: 'Code.exe',
+          window_title: 'localAgent tools'
+        }
+      }
+    })
+  })
+
+  it('searches supported local task tables and marks mutations unavailable', async () => {
+    const raw = new Database(process.env.OMI_DB_PATH!)
+    raw.exec(`
+      CREATE TABLE action_items (
+        id TEXT PRIMARY KEY,
+        description TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO action_items (id, description, completed, deleted, created_at)
+      VALUES ('task-1', 'Prepare the local tools demo', 0, 0, ${Date.now()});
+      INSERT INTO action_items (id, description, completed, deleted, created_at)
+      VALUES ('task-2', 'Completed task', 1, 0, ${Date.now() - 1});
+    `)
+    raw.close()
+
+    const { tools } = await freshModules()
+    const result = await tools.runLocalAgentTool(
+      'search_tasks',
+      { query: 'local tools', include_completed: false },
+      context
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      name: 'search_tasks',
+      result: {
+        available: true,
+        sources: ['action_items'],
+        result_count: 1,
+        tasks: [
+          {
+            source: 'action_items',
+            id: 'task-1',
+            description: 'Prepare the local tools demo',
+            completed: false
+          }
+        ]
+      }
+    })
+
+    await expect(
+      tools.runLocalAgentTool('delete_task', { task_id: 'task-1' }, context)
+    ).rejects.toMatchObject({
+      code: 'tool_unavailable',
+      status: 501
+    })
+  })
+})

--- a/desktop/windows/src/main/localAgent/tools.test.ts
+++ b/desktop/windows/src/main/localAgent/tools.test.ts
@@ -184,10 +184,11 @@ describe('local agent tool registry', () => {
     expect(screenshot).toMatchObject({
       ok: true,
       name: 'get_screenshot',
-      content_type: 'image/jpeg',
+      content_type: 'application/json',
       result: {
         screenshot_id: id,
         image_base64: imageBytes.toString('base64'),
+        image_mime_type: 'image/jpeg',
         metadata: {
           screenshot_id: id,
           app: 'Code.exe',

--- a/desktop/windows/src/main/localAgent/tools.ts
+++ b/desktop/windows/src/main/localAgent/tools.ts
@@ -1,0 +1,839 @@
+import {
+  execSafeSelect,
+  getFileIndexStats,
+  getLocalKGStatus,
+  getRewindFrame,
+  listLocalConversations,
+  listRewindFrames,
+  recentInsights,
+  rewindStatusStats,
+  searchLocalTasks,
+  searchRewindFrames
+} from '../ipc/db'
+import { readRewindFrameImage } from '../rewind/frameImage'
+import { rewindRoot } from '../rewind/paths'
+import { groupFrames } from '../rewind/rewindGrouping'
+import { guardSelect } from '../../shared/sqlGuard'
+import type {
+  InsightRecord,
+  LocalConversation,
+  RewindFrame,
+  RewindFrameImageOk,
+  RewindSearchGroup
+} from '../../shared/types'
+
+const MAX_SQL_ROWS = 200
+const MAX_SEARCH_LIMIT = 50
+const DEFAULT_SCREEN_LIMIT = 15
+const DAY_MS = 86_400_000
+const TASK_MUTATION_UNAVAILABLE =
+  'Windows local task mutation is unavailable because tasks are currently backed by the hosted action-items API, not reliable main-process local storage.'
+
+type JsonObject = Record<string, unknown>
+
+type JsonSchemaObject = {
+  type: 'object'
+  properties: Record<string, unknown>
+  required?: string[]
+  additionalProperties?: boolean
+}
+
+export type LocalAgentRuntimeContext = {
+  localUrl: string
+  toolEndpoint: string
+  app: {
+    name: string
+    version: string
+    appId: string
+  }
+}
+
+export type LocalAgentToolDefinition = {
+  name: string
+  description: string
+  inputSchema: JsonSchemaObject
+  annotations: Record<string, unknown>
+}
+
+export type LocalAgentToolResponse = {
+  ok: true
+  name: string
+  content_type: string
+  result: unknown
+}
+
+export class LocalAgentToolError extends Error {
+  readonly code: string
+  readonly status: number
+  readonly details?: unknown
+
+  constructor(code: string, message: string, status = 400, details?: unknown) {
+    super(message)
+    this.name = 'LocalAgentToolError'
+    this.code = code
+    this.status = status
+    this.details = details
+  }
+}
+
+function schema(
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  additionalProperties = false
+): JsonSchemaObject {
+  return {
+    type: 'object',
+    properties,
+    required,
+    additionalProperties
+  }
+}
+
+function annotations(
+  overrides: Partial<LocalAgentToolDefinition['annotations']> = {}
+): LocalAgentToolDefinition['annotations'] {
+  return {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+    ...overrides
+  }
+}
+
+const TOOL_DEFINITIONS: LocalAgentToolDefinition[] = [
+  {
+    name: 'get_local_status',
+    description:
+      'Report local Omi Desktop availability, including Rewind screen-history counts, latest capture time, local knowledge graph status, and unavailable local affordances.',
+    inputSchema: schema({}),
+    annotations: annotations()
+  },
+  {
+    name: 'execute_sql',
+    description:
+      'Run one read-only SELECT or WITH query against the local Omi Windows SQLite database. Mutations and multi-statement SQL are rejected; returned rows are capped.',
+    inputSchema: schema(
+      {
+        query: {
+          type: 'string',
+          description: 'Single read-only SELECT or WITH query to execute.'
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations({
+      readOnlyEnforced: true,
+      maxRows: MAX_SQL_ROWS,
+      mutationStatementsRejected: true
+    })
+  },
+  {
+    name: 'search_screen_history',
+    description:
+      'Search local Rewind screen history using OCR text, app name, and window title. Results include screenshot IDs that can be opened with get_screenshot.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Natural-language or keyword screen-history query.' },
+        days: { type: 'number', description: 'Days to search back. Defaults to 7.' },
+        app_filter: { type: 'string', description: 'Optional app/process/window filter.' },
+        limit: {
+          type: 'number',
+          description: `Maximum result groups to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to ${DEFAULT_SCREEN_LIMIT}.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'semantic_search',
+    description:
+      'Compatibility alias for search_screen_history. On Windows this uses local Rewind OCR/app/window search.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Natural-language or keyword screen-history query.' },
+        days: { type: 'number', description: 'Days to search back. Defaults to 7.' },
+        app_filter: { type: 'string', description: 'Optional app/process/window filter.' },
+        limit: {
+          type: 'number',
+          description: `Maximum result groups to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to ${DEFAULT_SCREEN_LIMIT}.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'get_screenshot',
+    description:
+      'Fetch a local Rewind screenshot image by screenshot_id. Use IDs returned by search_screen_history or execute_sql over rewind_frames.',
+    inputSchema: schema(
+      {
+        screenshot_id: {
+          type: 'number',
+          description: 'Rewind frame ID returned as screenshot_id.'
+        },
+        id: {
+          type: 'number',
+          description: 'Alias for screenshot_id.'
+        }
+      },
+      ['screenshot_id']
+    ),
+    annotations: annotations()
+  },
+  {
+    name: 'get_daily_recap',
+    description:
+      'Get a structured local activity recap for today, yesterday, or a recent range using Rewind frames, local conversations, insights, and locally available tasks.',
+    inputSchema: schema({
+      days_ago: {
+        type: 'number',
+        description: '0=today, 1=yesterday, 7=past week. Defaults to 0.'
+      }
+    }),
+    annotations: annotations()
+  },
+  {
+    name: 'search_tasks',
+    description:
+      'Best-effort search over local task tables if this Windows build has them. Returns an unavailable result when no reliable local task storage exists.',
+    inputSchema: schema(
+      {
+        query: { type: 'string', description: 'Task search query.' },
+        include_completed: {
+          type: 'boolean',
+          description: 'Include completed tasks. Defaults to false.'
+        },
+        limit: {
+          type: 'number',
+          description: `Maximum tasks to return, capped at ${MAX_SEARCH_LIMIT}. Defaults to 10.`
+        }
+      },
+      ['query']
+    ),
+    annotations: annotations({
+      availability: 'best_effort_local_tables'
+    })
+  },
+  {
+    name: 'complete_task',
+    description:
+      'Unavailable on Windows local API until task completion can be backed by reliable local storage and sync semantics.',
+    inputSchema: schema(
+      {
+        task_id: { type: 'string', description: 'Hosted/backend task ID.' }
+      },
+      ['task_id']
+    ),
+    annotations: annotations({
+      readOnlyHint: false,
+      gated: true,
+      unavailable: true,
+      unavailableReason: TASK_MUTATION_UNAVAILABLE
+    })
+  },
+  {
+    name: 'delete_task',
+    description:
+      'Unavailable on Windows local API until destructive task deletion can be backed by reliable local storage and sync semantics.',
+    inputSchema: schema(
+      {
+        task_id: { type: 'string', description: 'Hosted/backend task ID.' }
+      },
+      ['task_id']
+    ),
+    annotations: annotations({
+      readOnlyHint: false,
+      destructiveHint: true,
+      gated: true,
+      unavailable: true,
+      unavailableReason: TASK_MUTATION_UNAVAILABLE
+    })
+  }
+]
+
+const TOOL_NAMES = new Set(TOOL_DEFINITIONS.map((tool) => tool.name))
+
+export function listLocalAgentTools(): LocalAgentToolDefinition[] {
+  return TOOL_DEFINITIONS.map((tool) => ({
+    ...tool,
+    inputSchema: {
+      ...tool.inputSchema,
+      properties: { ...tool.inputSchema.properties },
+      required: [...(tool.inputSchema.required ?? [])]
+    },
+    annotations: { ...tool.annotations }
+  }))
+}
+
+export async function runLocalAgentTool(
+  name: string,
+  rawArguments: unknown,
+  context: LocalAgentRuntimeContext
+): Promise<LocalAgentToolResponse> {
+  if (!TOOL_NAMES.has(name)) {
+    throw new LocalAgentToolError('unknown_tool', `Unknown local tool: ${name}`, 404, { name })
+  }
+  const args = argumentObject(rawArguments)
+
+  switch (name) {
+    case 'get_local_status':
+      return ok(name, getLocalStatus(context))
+    case 'execute_sql':
+      return ok(name, executeSql(args))
+    case 'search_screen_history':
+    case 'semantic_search':
+      return ok(name, searchScreenHistory(args))
+    case 'get_screenshot':
+      return screenshotResponse(name, args)
+    case 'get_daily_recap':
+      return ok(name, getDailyRecap(args))
+    case 'search_tasks':
+      return ok(name, searchTasks(args))
+    case 'complete_task':
+    case 'delete_task':
+      throw new LocalAgentToolError('tool_unavailable', TASK_MUTATION_UNAVAILABLE, 501, { name })
+    default:
+      throw new LocalAgentToolError('unknown_tool', `Unknown local tool: ${name}`, 404, { name })
+  }
+}
+
+export function errorResponseBody(error: unknown): {
+  status: number
+  body: { ok: false; error: { code: string; message: string; details?: unknown } }
+} {
+  if (error instanceof LocalAgentToolError) {
+    return {
+      status: error.status,
+      body: {
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.details === undefined ? {} : { details: error.details })
+        }
+      }
+    }
+  }
+  return {
+    status: 500,
+    body: {
+      ok: false,
+      error: {
+        code: 'tool_execution_failed',
+        message: error instanceof Error ? error.message : 'Local tool execution failed'
+      }
+    }
+  }
+}
+
+function ok(
+  name: string,
+  result: unknown,
+  contentType = 'application/json'
+): LocalAgentToolResponse {
+  return {
+    ok: true,
+    name,
+    content_type: contentType,
+    result
+  }
+}
+
+function argumentObject(rawArguments: unknown): JsonObject {
+  if (rawArguments == null) return {}
+  if (typeof rawArguments === 'object' && !Array.isArray(rawArguments)) {
+    return rawArguments as JsonObject
+  }
+  throw new LocalAgentToolError('invalid_arguments', 'arguments must be a JSON object')
+}
+
+function requiredString(args: JsonObject, key: string, aliases: string[] = []): string {
+  for (const candidate of [key, ...aliases]) {
+    const value = args[candidate]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  throw new LocalAgentToolError('invalid_arguments', `${key} is required`, 400, { key })
+}
+
+function optionalString(args: JsonObject, key: string): string | undefined {
+  const value = args[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function numberArg(
+  args: JsonObject,
+  key: string,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const value = args[key]
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value.trim())
+        : fallback
+  const safe = Number.isFinite(parsed) ? Math.trunc(parsed) : fallback
+  return Math.min(max, Math.max(min, safe))
+}
+
+function booleanArg(args: JsonObject, key: string, fallback: boolean): boolean {
+  const value = args[key]
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') return true
+    if (normalized === 'false') return false
+  }
+  return fallback
+}
+
+function screenshotId(args: JsonObject): number {
+  const value = args.screenshot_id ?? args.id
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value.trim())
+        : NaN
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed
+  throw new LocalAgentToolError('invalid_arguments', 'screenshot_id is required', 400, {
+    key: 'screenshot_id'
+  })
+}
+
+function getLocalStatus(context: LocalAgentRuntimeContext): JsonObject {
+  try {
+    const rewind = rewindStatusStats()
+    const kg = getLocalKGStatus()
+    const fileIndex = getFileIndexStats()
+    return {
+      ok: true,
+      mode: 'local_omi_windows',
+      app: context.app,
+      local_api: context.localUrl,
+      tool_endpoint: context.toolEndpoint,
+      database_available: true,
+      screen_history_available: rewind.totalFrameCount > 0,
+      screenshot_count: rewind.totalFrameCount,
+      indexed_screenshot_count: rewind.indexedFrameCount,
+      ocr_backlog_count: rewind.ocrBacklogCount,
+      oldest_capture_at: iso(rewind.oldestFrameTs),
+      latest_capture_at: iso(rewind.latestFrameTs),
+      knowledge_graph: kg,
+      file_index: fileIndex,
+      local_affordances: [
+        'Rewind screen history and OCR search',
+        'raw screenshot image retrieval by screenshot_id',
+        'local transcription and conversation tables',
+        'read-only SQL over the local Omi Windows database',
+        'daily local activity recaps',
+        'indexed files and local knowledge graph data',
+        'best-effort local task search when task tables exist'
+      ],
+      unavailable_affordances: [
+        {
+          tool: 'complete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        },
+        {
+          tool: 'delete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        }
+      ],
+      recommended_first_tools: [
+        'search_screen_history for Rewind/OCR questions',
+        'get_screenshot after a search result returns a screenshot_id',
+        'get_daily_recap for today/yesterday/this week',
+        'execute_sql for exact read-only local database questions'
+      ]
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      mode: 'local_omi_windows',
+      app: context.app,
+      local_api: context.localUrl,
+      tool_endpoint: context.toolEndpoint,
+      database_available: false,
+      screen_history_available: false,
+      message: error instanceof Error ? error.message : 'Failed to read local Omi status',
+      unavailable_affordances: [
+        {
+          tool: 'complete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        },
+        {
+          tool: 'delete_task',
+          reason: TASK_MUTATION_UNAVAILABLE
+        }
+      ]
+    }
+  }
+}
+
+function executeSql(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query', ['sql'])
+  try {
+    const guarded = guardSelect(query)
+    const result = execSafeSelect(guarded)
+    const rows = result.rows.slice(0, MAX_SQL_ROWS).map(sanitizeRow)
+    return {
+      columns: result.columns,
+      rows,
+      row_count: rows.length,
+      truncated: result.rows.length > rows.length,
+      read_only: true,
+      max_rows: MAX_SQL_ROWS,
+      executed_query: guarded
+    }
+  } catch (error) {
+    throw new LocalAgentToolError(
+      'sql_rejected_or_failed',
+      error instanceof Error ? error.message : 'SQL query failed',
+      400
+    )
+  }
+}
+
+function searchScreenHistory(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query')
+  const days = numberArg(args, 'days', 7, 1, 365)
+  const limit = numberArg(args, 'limit', DEFAULT_SCREEN_LIMIT, 1, MAX_SEARCH_LIMIT)
+  const appFilter = optionalString(args, 'app_filter')
+  const since = Date.now() - days * DAY_MS
+  const candidateLimit = Math.max(limit * 8, 100)
+  const frames = searchRewindFrames(query, candidateLimit)
+    .filter((frame) => frame.ts >= since)
+    .filter((frame) => matchesAppFilter(frame, appFilter))
+  const groups = groupFrames(frames, query).slice(0, limit)
+  const results = groups.map(mapSearchGroup)
+
+  return {
+    query,
+    days,
+    app_filter: appFilter ?? null,
+    limit,
+    result_count: results.length,
+    searched_frame_count: frames.length,
+    source: 'rewind_frames_ocr',
+    results,
+    suggestions:
+      results.length === 0
+        ? [
+            'Try a broader query',
+            'Increase the days window',
+            'Use execute_sql for exact app/window/OCR filters over rewind_frames'
+          ]
+        : []
+  }
+}
+
+async function screenshotResponse(name: string, args: JsonObject): Promise<LocalAgentToolResponse> {
+  const id = screenshotId(args)
+  const result = await readRewindFrameImage(getRewindFrame(id), rewindRoot())
+  if (!result.ok) {
+    throw new LocalAgentToolError('screenshot_not_found', result.message, 404, {
+      screenshot_id: id
+    })
+  }
+
+  return ok(name, mapScreenshot(result), result.imageMimeType)
+}
+
+function getDailyRecap(args: JsonObject): JsonObject {
+  const daysAgo = numberArg(args, 'days_ago', 0, 0, 365)
+  const range = recapRange(daysAgo)
+  const frames = listRewindFrames(range.startTs, range.endTs)
+  const apps = summarizeApps(frames)
+  const conversations = listLocalConversations()
+    .filter(
+      (conversation) =>
+        conversation.startedAt < range.endTs && conversation.endedAt >= range.startTs
+    )
+    .slice(0, 20)
+    .map(mapConversation)
+  const insights = recentInsights(100)
+    .filter((insight) => insight.ts >= range.startTs && insight.ts < range.endTs)
+    .slice(0, 20)
+    .map(mapInsight)
+  const taskSearch = searchLocalTasks('', true, 20)
+  const tasks = taskSearch.tasks.filter((task) => timestampInRange(task.createdAt, range))
+  const text = formatDailyRecap(
+    range.label,
+    apps,
+    conversations,
+    tasks,
+    insights,
+    taskSearch.available
+  )
+
+  return {
+    label: range.label,
+    range: {
+      start_ts: range.startTs,
+      end_ts: range.endTs,
+      start_at: iso(range.startTs),
+      end_at: iso(range.endTs)
+    },
+    apps,
+    conversations,
+    insights,
+    tasks,
+    task_search_available: taskSearch.available,
+    task_search_reason: taskSearch.reason ?? null,
+    text
+  }
+}
+
+function searchTasks(args: JsonObject): JsonObject {
+  const query = requiredString(args, 'query')
+  const includeCompleted = booleanArg(args, 'include_completed', false)
+  const limit = numberArg(args, 'limit', 10, 1, MAX_SEARCH_LIMIT)
+  const result = searchLocalTasks(query, includeCompleted, limit)
+  return {
+    query,
+    include_completed: includeCompleted,
+    limit,
+    available: result.available,
+    reason: result.reason ?? null,
+    sources: result.sources,
+    result_count: result.tasks.length,
+    tasks: result.tasks
+  }
+}
+
+function sanitizeRow(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (Buffer.isBuffer(value)) out[key] = `<${value.length} bytes>`
+    else if (typeof value === 'bigint') out[key] = value.toString()
+    else out[key] = value
+  }
+  return out
+}
+
+function matchesAppFilter(frame: RewindFrame, appFilter?: string): boolean {
+  if (!appFilter) return true
+  const needle = appFilter.toLowerCase()
+  return [frame.app, frame.processName, frame.windowTitle].some((value) =>
+    value.toLowerCase().includes(needle)
+  )
+}
+
+function mapSearchGroup(group: RewindSearchGroup): JsonObject {
+  return {
+    group_id: group.id,
+    app: group.app,
+    window_title: group.windowTitle,
+    start_ts: group.startTs,
+    end_ts: group.endTs,
+    start_at: iso(group.startTs),
+    end_at: iso(group.endTs),
+    match_snippet: group.matchSnippet,
+    representative: mapFrame(group.representative),
+    screenshots: group.frames
+      .filter((frame) => frame.id != null)
+      .slice(0, 10)
+      .map(mapFrame)
+  }
+}
+
+function mapFrame(frame: RewindFrame): JsonObject {
+  return {
+    screenshot_id: frame.id ?? null,
+    ts: frame.ts,
+    timestamp: iso(frame.ts),
+    app: frame.app,
+    window_title: frame.windowTitle,
+    process_name: frame.processName,
+    width: frame.width,
+    height: frame.height,
+    indexed: frame.indexed === 1,
+    ocr_preview: preview(frame.ocrText, 500)
+  }
+}
+
+function mapScreenshot(result: RewindFrameImageOk): JsonObject {
+  const imageBytes = Buffer.byteLength(result.imageBase64, 'base64')
+  return {
+    screenshot_id: result.id,
+    image_base64: result.imageBase64,
+    image_mime_type: result.imageMimeType,
+    metadata: {
+      screenshot_id: result.id,
+      ts: result.ts,
+      timestamp: iso(result.ts),
+      app: result.app,
+      window_title: result.windowTitle,
+      has_ocr: result.ocrPreview.length > 0,
+      ocr_preview: result.ocrPreview,
+      image_mime_type: result.imageMimeType,
+      image_bytes: imageBytes
+    }
+  }
+}
+
+function recapRange(daysAgo: number): { label: string; startTs: number; endTs: number } {
+  const now = Date.now()
+  const today = new Date(now)
+  today.setHours(0, 0, 0, 0)
+  const startToday = today.getTime()
+
+  if (daysAgo === 0) {
+    return { label: 'Today', startTs: startToday, endTs: now }
+  }
+  if (daysAgo === 1) {
+    return { label: 'Yesterday', startTs: startToday - DAY_MS, endTs: startToday }
+  }
+  return {
+    label: `Past ${daysAgo} days`,
+    startTs: startToday - daysAgo * DAY_MS,
+    endTs: now
+  }
+}
+
+function summarizeApps(frames: RewindFrame[]): JsonObject[] {
+  const byApp = new Map<
+    string,
+    {
+      app: string
+      captures: number
+      firstTs: number
+      lastTs: number
+      windowTitles: Set<string>
+    }
+  >()
+  for (const frame of frames) {
+    const app = frame.app || frame.processName || 'Unknown'
+    const current =
+      byApp.get(app) ??
+      ({
+        app,
+        captures: 0,
+        firstTs: frame.ts,
+        lastTs: frame.ts,
+        windowTitles: new Set<string>()
+      } satisfies {
+        app: string
+        captures: number
+        firstTs: number
+        lastTs: number
+        windowTitles: Set<string>
+      })
+    current.captures += 1
+    current.firstTs = Math.min(current.firstTs, frame.ts)
+    current.lastTs = Math.max(current.lastTs, frame.ts)
+    if (frame.windowTitle) current.windowTitles.add(frame.windowTitle)
+    byApp.set(app, current)
+  }
+
+  return [...byApp.values()]
+    .sort((a, b) => b.captures - a.captures)
+    .slice(0, 20)
+    .map((app) => ({
+      app: app.app,
+      captures: app.captures,
+      first_ts: app.firstTs,
+      last_ts: app.lastTs,
+      first_seen_at: iso(app.firstTs),
+      last_seen_at: iso(app.lastTs),
+      sample_window_titles: [...app.windowTitles].slice(0, 5)
+    }))
+}
+
+function mapConversation(conversation: LocalConversation): JsonObject {
+  return {
+    id: conversation.id,
+    title: conversation.title ?? null,
+    kind: conversation.kind ?? 'recording',
+    started_at: iso(conversation.startedAt),
+    ended_at: iso(conversation.endedAt),
+    transcript_preview: preview(conversation.transcript, 500)
+  }
+}
+
+function mapInsight(insight: InsightRecord): JsonObject {
+  return {
+    id: insight.id,
+    ts: insight.ts,
+    timestamp: iso(insight.ts),
+    headline: insight.headline,
+    advice: insight.advice,
+    category: insight.category,
+    source_app: insight.sourceApp,
+    confidence: insight.confidence
+  }
+}
+
+function timestampInRange(value: unknown, range: { startTs: number; endTs: number }): boolean {
+  if (value == null) return true
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number.isFinite(Number(value))
+          ? Number(value)
+          : Date.parse(value)
+        : NaN
+  return Number.isFinite(parsed) ? parsed >= range.startTs && parsed < range.endTs : true
+}
+
+function formatDailyRecap(
+  label: string,
+  apps: JsonObject[],
+  conversations: JsonObject[],
+  tasks: JsonObject[],
+  insights: JsonObject[],
+  taskSearchAvailable: boolean
+): string {
+  const lines = [`# ${label} Recap`, '', `## Apps (${apps.length})`]
+  if (apps.length === 0) {
+    lines.push('No screen activity recorded.')
+  } else {
+    for (const app of apps.slice(0, 10)) {
+      lines.push(`- ${app.app}: ${app.captures} capture(s)`)
+    }
+  }
+
+  lines.push('', `## Conversations (${conversations.length})`)
+  if (conversations.length === 0) {
+    lines.push('No local conversations recorded.')
+  } else {
+    for (const conversation of conversations.slice(0, 10)) {
+      lines.push(`- ${conversation.title ?? conversation.id}: ${conversation.transcript_preview}`)
+    }
+  }
+
+  lines.push('', `## Tasks (${tasks.length})`)
+  if (!taskSearchAvailable) {
+    lines.push('Local task storage is unavailable on this Windows build.')
+  } else if (tasks.length === 0) {
+    lines.push('No local tasks found for this range.')
+  } else {
+    for (const task of tasks.slice(0, 10)) {
+      lines.push(`- ${task.completed ? '[x]' : '[ ]'} ${task.description}`)
+    }
+  }
+
+  lines.push('', `## Insights (${insights.length})`)
+  if (insights.length === 0) {
+    lines.push('No local insights recorded.')
+  } else {
+    for (const insight of insights.slice(0, 10)) {
+      lines.push(`- ${insight.headline}: ${insight.advice}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function preview(text: string, length: number): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, length)
+}
+
+function iso(ts: number | null | undefined): string | null {
+  return typeof ts === 'number' && Number.isFinite(ts) ? new Date(ts).toISOString() : null
+}

--- a/desktop/windows/src/main/localAgent/tools.ts
+++ b/desktop/windows/src/main/localAgent/tools.ts
@@ -541,7 +541,7 @@ async function screenshotResponse(name: string, args: JsonObject): Promise<Local
     })
   }
 
-  return ok(name, mapScreenshot(result), result.imageMimeType)
+  return ok(name, mapScreenshot(result))
 }
 
 function getDailyRecap(args: JsonObject): JsonObject {

--- a/desktop/windows/src/main/pi/chatBridge.test.ts
+++ b/desktop/windows/src/main/pi/chatBridge.test.ts
@@ -3,6 +3,7 @@ import type { LocalAgentRuntimeContext, LocalAgentToolDefinition } from '../loca
 import {
   buildPiChatRequest,
   chatCompletionsUrl,
+  isPiChatEnabled,
   resultToToolContent,
   sendPiChat
 } from './chatBridge'
@@ -74,6 +75,51 @@ const runtimeContext: LocalAgentRuntimeContext = {
     appId: 'com.omiwindows.app'
   }
 }
+
+describe('isPiChatEnabled', () => {
+  it('is disabled by default when neither env var is set (fail closed)', () => {
+    expect(isPiChatEnabled({})).toBe(false)
+  })
+
+  it('stays disabled for explicit off/unknown values', () => {
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: '0' })).toBe(false)
+    expect(isPiChatEnabled({ OMI_PI_CHAT: '0' })).toBe(false)
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: '' })).toBe(false)
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: 'false' })).toBe(false)
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: 'banana' })).toBe(false)
+  })
+
+  it('enables only when a flag is explicitly truthy', () => {
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: '1' })).toBe(true)
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: 'true' })).toBe(true)
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: 'TRUE' })).toBe(true)
+    expect(isPiChatEnabled({ OMI_PI_CHAT: '1' })).toBe(true)
+    expect(isPiChatEnabled({ OMI_PI_CHAT: 'yes' })).toBe(true)
+  })
+
+  it('does not let one truthy flag be vetoed by the other being off', () => {
+    expect(isPiChatEnabled({ OMI_WINDOWS_PI_CHAT: '1', OMI_PI_CHAT: '0' })).toBe(true)
+  })
+
+  it('reads process.env by default and fails closed there too', () => {
+    const saved = {
+      windows: process.env.OMI_WINDOWS_PI_CHAT,
+      generic: process.env.OMI_PI_CHAT
+    }
+    delete process.env.OMI_WINDOWS_PI_CHAT
+    delete process.env.OMI_PI_CHAT
+    try {
+      expect(isPiChatEnabled()).toBe(false)
+      process.env.OMI_WINDOWS_PI_CHAT = '1'
+      expect(isPiChatEnabled()).toBe(true)
+    } finally {
+      if (saved.windows === undefined) delete process.env.OMI_WINDOWS_PI_CHAT
+      else process.env.OMI_WINDOWS_PI_CHAT = saved.windows
+      if (saved.generic === undefined) delete process.env.OMI_PI_CHAT
+      else process.env.OMI_PI_CHAT = saved.generic
+    }
+  })
+})
 
 describe('Pi/Omi chat bridge', () => {
   it('constructs OpenAI-compatible omi-provider requests with only allowed local tools', () => {

--- a/desktop/windows/src/main/pi/chatBridge.test.ts
+++ b/desktop/windows/src/main/pi/chatBridge.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { LocalAgentRuntimeContext, LocalAgentToolDefinition } from '../localAgent/tools'
+import { buildPiChatRequest, chatCompletionsUrl, sendPiChat } from './chatBridge'
+
+const toolDefinitions = vi.hoisted<LocalAgentToolDefinition[]>(() => [
+  {
+    name: 'execute_sql',
+    description: 'Run read-only SQL.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      additionalProperties: false
+    },
+    annotations: {}
+  },
+  {
+    name: 'get_local_status',
+    description: 'Read local status.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    },
+    annotations: {}
+  },
+  {
+    name: 'delete_task',
+    description: 'Unavailable mutation.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: { type: 'string' } },
+      required: ['task_id'],
+      additionalProperties: false
+    },
+    annotations: { destructiveHint: true }
+  }
+])
+
+vi.mock('../localAgent/tools', () => ({
+  listLocalAgentTools: () => toolDefinitions,
+  runLocalAgentTool: vi.fn(),
+  errorResponseBody: (error: unknown) => ({
+    status: 500,
+    body: {
+      ok: false,
+      error: {
+        code: 'tool_execution_failed',
+        message: error instanceof Error ? error.message : 'Local tool failed'
+      }
+    }
+  })
+}))
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body
+  } as Response
+}
+
+const runtimeContext: LocalAgentRuntimeContext = {
+  localUrl: 'omi://local-agent',
+  toolEndpoint: 'omi://local-agent/pi-chat-tool',
+  app: {
+    name: 'Omi Windows',
+    version: '1.2.3',
+    appId: 'com.omiwindows.app'
+  }
+}
+
+describe('Pi/Omi chat bridge', () => {
+  it('constructs OpenAI-compatible omi-provider requests with only allowed local tools', () => {
+    const request = buildPiChatRequest([{ role: 'user', content: 'How many screenshots?' }])
+
+    expect(request).toMatchObject({
+      model: 'omi-sonnet',
+      stream: false,
+      tool_choice: 'auto'
+    })
+    expect(request.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'system' }),
+        { role: 'user', content: 'How many screenshots?' }
+      ])
+    )
+    expect(
+      (request.tools as { function: { name: string } }[]).map((tool) => tool.function.name)
+    ).toEqual(['execute_sql', 'get_local_status'])
+  })
+
+  it('fails closed before network use when the Firebase token is missing', async () => {
+    const fetchImpl = vi.fn()
+
+    await expect(
+      sendPiChat({ token: '   ', messages: [{ role: 'user', content: 'hello' }] }, { fetchImpl })
+    ).rejects.toThrow('Firebase ID token')
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('routes model tool calls through the Windows local tool executor', async () => {
+    const requests: unknown[] = []
+    const fetchImpl = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      requests.push(JSON.parse(String(init.body)))
+      if (requests.length === 1) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'toolu_1',
+                    type: 'function',
+                    function: {
+                      name: 'execute_sql',
+                      arguments: '{"query":"SELECT COUNT(*) AS count FROM rewind_frames"}'
+                    }
+                  }
+                ]
+              },
+              finish_reason: 'tool_calls'
+            }
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 }
+        })
+      }
+      return jsonResponse({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'You have 3 screenshots.'
+            },
+            finish_reason: 'stop'
+          }
+        ],
+        usage: { prompt_tokens: 8, completion_tokens: 5, total_tokens: 13 }
+      })
+    })
+    const runTool = vi.fn().mockResolvedValue({
+      ok: true,
+      name: 'execute_sql',
+      content_type: 'application/json',
+      result: { columns: ['count'], rows: [{ count: 3 }], row_count: 1 }
+    })
+
+    const result = await sendPiChat(
+      {
+        token: 'firebase-token',
+        messages: [{ role: 'user', content: 'How many screenshots do I have?' }]
+      },
+      {
+        fetchImpl,
+        runTool,
+        toolDefinitions: () => toolDefinitions,
+        runtimeContext,
+        desktopApiBaseUrl: 'https://desktop.example.test'
+      }
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      chatCompletionsUrl('https://desktop.example.test'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer firebase-token'
+        })
+      })
+    )
+    expect(runTool).toHaveBeenCalledWith(
+      'execute_sql',
+      { query: 'SELECT COUNT(*) AS count FROM rewind_frames' },
+      runtimeContext
+    )
+    expect(
+      (requests[1] as { messages: { role: string; tool_call_id?: string }[] }).messages
+    ).toEqual(
+      expect.arrayContaining([expect.objectContaining({ role: 'tool', tool_call_id: 'toolu_1' })])
+    )
+    expect(result).toEqual({
+      text: 'You have 3 screenshots.',
+      toolCalls: [{ id: 'toolu_1', name: 'execute_sql' }],
+      usage: { promptTokens: 18, completionTokens: 7, totalTokens: 25 }
+    })
+  })
+
+  it('rejects model tool calls outside the Pi/Omi chat allowlist before execution', async () => {
+    const requests: unknown[] = []
+    const fetchImpl = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      requests.push(JSON.parse(String(init.body)))
+      if (requests.length === 1) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'toolu_delete',
+                    type: 'function',
+                    function: {
+                      name: 'delete_task',
+                      arguments: '{"task_id":"task-1"}'
+                    }
+                  }
+                ]
+              },
+              finish_reason: 'tool_calls'
+            }
+          ],
+          usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 }
+        })
+      }
+      return jsonResponse({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'I cannot delete that task from Pi/Omi chat.'
+            },
+            finish_reason: 'stop'
+          }
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 8, total_tokens: 15 }
+      })
+    })
+    const runTool = vi.fn()
+
+    const result = await sendPiChat(
+      {
+        token: 'firebase-token',
+        messages: [{ role: 'user', content: 'Delete task task-1' }]
+      },
+      {
+        fetchImpl,
+        runTool,
+        toolDefinitions: () => toolDefinitions,
+        runtimeContext,
+        desktopApiBaseUrl: 'https://desktop.example.test'
+      }
+    )
+
+    expect(runTool).not.toHaveBeenCalled()
+    expect(
+      (requests[1] as { messages: { role: string; content?: string }[] }).messages
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'tool',
+          content: expect.stringContaining('Local tool is not available to Pi/Omi chat')
+        })
+      ])
+    )
+    expect(result).toMatchObject({
+      text: 'I cannot delete that task from Pi/Omi chat.',
+      toolCalls: [{ id: 'toolu_delete', name: 'delete_task' }]
+    })
+  })
+})

--- a/desktop/windows/src/main/pi/chatBridge.test.ts
+++ b/desktop/windows/src/main/pi/chatBridge.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { LocalAgentRuntimeContext, LocalAgentToolDefinition } from '../localAgent/tools'
-import { buildPiChatRequest, chatCompletionsUrl, sendPiChat } from './chatBridge'
+import {
+  buildPiChatRequest,
+  chatCompletionsUrl,
+  resultToToolContent,
+  sendPiChat
+} from './chatBridge'
 
 const toolDefinitions = vi.hoisted<LocalAgentToolDefinition[]>(() => [
   {
@@ -100,6 +105,14 @@ describe('Pi/Omi chat bridge', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
+  it('formats non-JSON local tool results defensively', () => {
+    const cyclic: { self?: unknown } = {}
+    cyclic.self = cyclic
+
+    expect(resultToToolContent(undefined)).toBe('null')
+    expect(resultToToolContent(cyclic)).toBe('[object Object]')
+  })
+
   it('routes model tool calls through the Windows local tool executor', async () => {
     const requests: unknown[] = []
     const fetchImpl = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
@@ -186,6 +199,66 @@ describe('Pi/Omi chat bridge', () => {
       toolCalls: [{ id: 'toolu_1', name: 'execute_sql' }],
       usage: { promptTokens: 18, completionTokens: 7, totalTokens: 25 }
     })
+  })
+
+  it('serializes unusual local tool results without crashing chat', async () => {
+    const requests: unknown[] = []
+    const fetchImpl = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      requests.push(JSON.parse(String(init.body)))
+      if (requests.length === 1) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'toolu_undefined',
+                    type: 'function',
+                    function: {
+                      name: 'get_local_status',
+                      arguments: '{}'
+                    }
+                  }
+                ]
+              },
+              finish_reason: 'tool_calls'
+            }
+          ]
+        })
+      }
+      return jsonResponse({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Handled the tool result.'
+            },
+            finish_reason: 'stop'
+          }
+        ]
+      })
+    })
+
+    const result = await sendPiChat(
+      {
+        token: 'firebase-token',
+        messages: [{ role: 'user', content: 'Check local status' }]
+      },
+      {
+        fetchImpl,
+        runTool: vi.fn().mockResolvedValue(undefined),
+        toolDefinitions: () => toolDefinitions,
+        runtimeContext,
+        desktopApiBaseUrl: 'https://desktop.example.test'
+      }
+    )
+
+    expect((requests[1] as { messages: { role: string; content?: string }[] }).messages).toEqual(
+      expect.arrayContaining([expect.objectContaining({ role: 'tool', content: 'null' })])
+    )
+    expect(result.text).toBe('Handled the tool result.')
   })
 
   it('rejects model tool calls outside the Pi/Omi chat allowlist before execution', async () => {

--- a/desktop/windows/src/main/pi/chatBridge.test.ts
+++ b/desktop/windows/src/main/pi/chatBridge.test.ts
@@ -246,13 +246,11 @@ describe('Pi/Omi chat bridge', () => {
     )
 
     expect(runTool).not.toHaveBeenCalled()
-    expect(
-      (requests[1] as { messages: { role: string; content?: string }[] }).messages
-    ).toEqual(
+    expect((requests[1] as { messages: { role: string; content?: string }[] }).messages).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           role: 'tool',
-          content: expect.stringContaining('Local tool is not available to Pi/Omi chat')
+          content: expect.stringContaining('Tool delete_task not found')
         })
       ])
     )

--- a/desktop/windows/src/main/pi/chatBridge.ts
+++ b/desktop/windows/src/main/pi/chatBridge.ts
@@ -119,8 +119,20 @@ export type PiChatSendRequest = {
   skillIds?: string[]
 }
 
-export function isPiChatEnabled(): boolean {
-  return process.env.OMI_WINDOWS_PI_CHAT !== '0' && process.env.OMI_PI_CHAT !== '0'
+const TRUTHY_FLAG_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
+function isTruthyFlag(value: string | undefined): boolean {
+  return value != null && TRUTHY_FLAG_VALUES.has(value.trim().toLowerCase())
+}
+
+/**
+ * Experimental Pi/Omi chat routing is fail-closed: it forwards chat history and
+ * the Firebase ID token to the desktop backend and exposes local tool access to
+ * the agent runtime, so it must stay off unless explicitly enabled via
+ * OMI_WINDOWS_PI_CHAT=1 (or OMI_PI_CHAT=1).
+ */
+export function isPiChatEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyFlag(env.OMI_WINDOWS_PI_CHAT) || isTruthyFlag(env.OMI_PI_CHAT)
 }
 
 function desktopApiBaseUrl(): string {

--- a/desktop/windows/src/main/pi/chatBridge.ts
+++ b/desktop/windows/src/main/pi/chatBridge.ts
@@ -1,0 +1,288 @@
+import type { LocalAgentRuntimeContext, LocalAgentToolDefinition } from '../localAgent/tools'
+import { errorResponseBody, listLocalAgentTools, runLocalAgentTool } from '../localAgent/tools'
+import type { ChatMessage, PiChatResponse, PiChatToolCall, PiChatUsage } from '../../shared/types'
+
+const DEFAULT_DESKTOP_API_BASE = 'https://desktop-backend-hhibjajaja-uc.a.run.app'
+const PI_CHAT_MODEL = 'omi-sonnet'
+const MAX_TOOL_ROUNDS = 6
+
+const PI_CHAT_SYSTEM_PROMPT = [
+  'You are Omi on Windows.',
+  'Answer conversationally and use the provided local Windows tools when they help.',
+  'Local tools can inspect local Omi status, screen history, screenshots, read-only SQL, daily recaps, and best-effort local task tables.',
+  'Do not claim that unavailable or rejected tool actions succeeded.'
+].join('\n')
+
+const PI_CHAT_TOOL_NAMES = new Set([
+  'get_local_status',
+  'execute_sql',
+  'search_screen_history',
+  'semantic_search',
+  'get_screenshot',
+  'get_daily_recap',
+  'search_tasks'
+])
+
+type JsonRecord = Record<string, unknown>
+
+type OpenAiChatMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content?: string | null
+  tool_calls?: OpenAiToolCall[]
+  tool_call_id?: string
+}
+
+type OpenAiTool = {
+  type: 'function'
+  function: {
+    name: string
+    description?: string
+    parameters?: JsonRecord
+  }
+}
+
+type OpenAiToolCall = {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+type OpenAiUsage = {
+  prompt_tokens?: number
+  completion_tokens?: number
+  total_tokens?: number
+}
+
+type OpenAiChatCompletion = {
+  choices?: {
+    message?: {
+      role?: string
+      content?: string | null
+      tool_calls?: OpenAiToolCall[]
+    }
+    finish_reason?: string | null
+  }[]
+  usage?: OpenAiUsage
+}
+
+type FetchLike = typeof fetch
+
+export type PiChatBridgeOptions = {
+  fetchImpl?: FetchLike
+  desktopApiBaseUrl?: string
+  toolDefinitions?: () => LocalAgentToolDefinition[]
+  runTool?: typeof runLocalAgentTool
+  runtimeContext?: LocalAgentRuntimeContext
+}
+
+export type PiChatSendRequest = {
+  token: string
+  messages: ChatMessage[]
+}
+
+export function isPiChatEnabled(): boolean {
+  return process.env.OMI_WINDOWS_PI_CHAT === '1' || process.env.OMI_PI_CHAT === '1'
+}
+
+function desktopApiBaseUrl(): string {
+  return (
+    process.env.OMI_DESKTOP_API_URL ||
+    process.env.VITE_OMI_DESKTOP_API_BASE ||
+    DEFAULT_DESKTOP_API_BASE
+  )
+}
+
+export function chatCompletionsUrl(baseUrl = desktopApiBaseUrl()): string {
+  return `${baseUrl.replace(/\/+$/, '')}/v2/chat/completions`
+}
+
+function usageFrom(raw?: OpenAiUsage): PiChatUsage {
+  return {
+    promptTokens: raw?.prompt_tokens ?? 0,
+    completionTokens: raw?.completion_tokens ?? 0,
+    totalTokens: raw?.total_tokens ?? 0
+  }
+}
+
+function addUsage(a: PiChatUsage, b: PiChatUsage): PiChatUsage {
+  return {
+    promptTokens: a.promptTokens + b.promptTokens,
+    completionTokens: a.completionTokens + b.completionTokens,
+    totalTokens: a.totalTokens + b.totalTokens
+  }
+}
+
+function messagesForPi(messages: ChatMessage[]): OpenAiChatMessage[] {
+  return [
+    { role: 'system', content: PI_CHAT_SYSTEM_PROMPT },
+    ...messages
+      .filter((message) => message.role === 'user' || message.role === 'assistant')
+      .map((message) => ({
+        role: message.role,
+        content: message.content
+      }))
+  ]
+}
+
+function toolsForPi(definitions: LocalAgentToolDefinition[]): OpenAiTool[] {
+  return definitions
+    .filter((tool) => PI_CHAT_TOOL_NAMES.has(tool.name))
+    .map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema
+      }
+    }))
+}
+
+export function buildPiChatRequest(messages: ChatMessage[]): JsonRecord {
+  return {
+    model: PI_CHAT_MODEL,
+    stream: false,
+    messages: messagesForPi(messages),
+    tools: toolsForPi(listLocalAgentTools()),
+    tool_choice: 'auto'
+  }
+}
+
+function parseToolArguments(call: OpenAiToolCall): JsonRecord {
+  const raw = call.function.arguments.trim()
+  if (!raw) return {}
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('tool arguments must be a JSON object')
+  }
+  return parsed as JsonRecord
+}
+
+function resultToToolContent(value: unknown): string {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+function toolErrorContent(error: unknown): string {
+  const { body } = errorResponseBody(error)
+  return `Error: ${body.error.code}: ${body.error.message}`
+}
+
+function defaultRuntimeContext(): LocalAgentRuntimeContext {
+  return {
+    localUrl: 'omi://local-agent',
+    toolEndpoint: 'omi://local-agent/pi-chat-tool',
+    app: {
+      name: 'Omi Windows',
+      version: '1.0.0',
+      appId: 'com.omiwindows.app'
+    }
+  }
+}
+
+async function callChatCompletions(
+  request: JsonRecord,
+  token: string,
+  options: PiChatBridgeOptions
+): Promise<OpenAiChatCompletion> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const response = await fetchImpl(chatCompletionsUrl(options.desktopApiBaseUrl), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(request)
+  })
+  if (!response.ok) {
+    throw new Error(`Pi/Omi chat request failed with HTTP ${response.status}`)
+  }
+  return (await response.json()) as OpenAiChatCompletion
+}
+
+async function executeToolCall(
+  call: OpenAiToolCall,
+  options: PiChatBridgeOptions
+): Promise<OpenAiChatMessage> {
+  const runTool = options.runTool ?? runLocalAgentTool
+  const context = options.runtimeContext ?? defaultRuntimeContext()
+
+  let content = ''
+  try {
+    if (!PI_CHAT_TOOL_NAMES.has(call.function.name)) {
+      throw new Error(`Local tool is not available to Pi/Omi chat: ${call.function.name}`)
+    }
+    const args = parseToolArguments(call)
+    const result = await runTool(call.function.name, args, context)
+    content = resultToToolContent(result)
+  } catch (error) {
+    content = toolErrorContent(error)
+  }
+
+  return {
+    role: 'tool',
+    tool_call_id: call.id,
+    content
+  }
+}
+
+export async function sendPiChat(
+  request: PiChatSendRequest,
+  options: PiChatBridgeOptions = {}
+): Promise<PiChatResponse> {
+  const token = request.token.trim()
+  if (!token) {
+    throw new Error('Pi/Omi chat requires a Firebase ID token')
+  }
+
+  const toolDefinitions = options.toolDefinitions ?? listLocalAgentTools
+  const conversation: OpenAiChatMessage[] = messagesForPi(request.messages)
+  const tools = toolsForPi(toolDefinitions())
+  const toolCalls: PiChatToolCall[] = []
+  let usage: PiChatUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+  let finalText = ''
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+    const body: JsonRecord = {
+      model: PI_CHAT_MODEL,
+      stream: false,
+      messages: conversation,
+      tools,
+      tool_choice: 'auto'
+    }
+    const completion = await callChatCompletions(body, token, options)
+    usage = addUsage(usage, usageFrom(completion.usage))
+    const message = completion.choices?.[0]?.message
+    if (!message) throw new Error('Pi/Omi chat returned no message')
+
+    const assistantText = typeof message.content === 'string' ? message.content : ''
+    const calls = message.tool_calls ?? []
+    if (calls.length === 0) {
+      finalText = assistantText
+      break
+    }
+
+    conversation.push({
+      role: 'assistant',
+      content: assistantText || null,
+      tool_calls: calls
+    })
+
+    for (const call of calls) {
+      toolCalls.push({ id: call.id, name: call.function.name })
+      conversation.push(await executeToolCall(call, options))
+    }
+  }
+
+  if (!finalText && toolCalls.length > 0) {
+    throw new Error('Pi/Omi chat exceeded the local tool-call round limit')
+  }
+
+  return {
+    text: finalText,
+    usage,
+    toolCalls
+  }
+}

--- a/desktop/windows/src/main/pi/chatBridge.ts
+++ b/desktop/windows/src/main/pi/chatBridge.ts
@@ -437,8 +437,17 @@ function truncateForToolResult(text: string): string {
   return `${text.slice(0, MAX_TOOL_RESULT_CHARS)}\n\n[truncated ${text.length - MAX_TOOL_RESULT_CHARS} chars]`
 }
 
-function resultToToolContent(value: unknown): string {
-  const text = typeof value === 'string' ? value : JSON.stringify(value)
+export function resultToToolContent(value: unknown): string {
+  let text: string
+  if (typeof value === 'string') {
+    text = value
+  } else {
+    try {
+      text = JSON.stringify(value) ?? 'null'
+    } catch {
+      text = String(value)
+    }
+  }
   return truncateForToolResult(text)
 }
 

--- a/desktop/windows/src/main/pi/chatBridge.ts
+++ b/desktop/windows/src/main/pi/chatBridge.ts
@@ -1,19 +1,53 @@
+import {
+  Agent,
+  type AgentEvent,
+  type AgentMessage,
+  type AgentTool,
+  type AgentToolResult
+} from '@earendil-works/pi-agent-core/base'
+import {
+  createAssistantMessageEventStream,
+  Type,
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type Context,
+  type Message,
+  type Model,
+  type TextContent,
+  type ToolCall,
+  type ToolResultMessage,
+  type Usage
+} from '@earendil-works/pi-ai/base'
+import type { TSchema } from '@earendil-works/pi-ai/base'
 import type { LocalAgentRuntimeContext, LocalAgentToolDefinition } from '../localAgent/tools'
-import { errorResponseBody, listLocalAgentTools, runLocalAgentTool } from '../localAgent/tools'
+import { listLocalAgentTools, runLocalAgentTool } from '../localAgent/tools'
 import type { ChatMessage, PiChatResponse, PiChatToolCall, PiChatUsage } from '../../shared/types'
 
 const DEFAULT_DESKTOP_API_BASE = 'https://desktop-backend-hhibjajaja-uc.a.run.app'
-const PI_CHAT_MODEL = 'omi-sonnet'
-const MAX_TOOL_ROUNDS = 6
+const PI_MODEL_ID = 'omi-sonnet'
+const PI_MODEL_NAME = 'Omi Sonnet'
+const OMI_PI_API = 'omi-chat-completions'
+const OMI_PI_PROVIDER = 'omi'
+const MAX_TOOL_RESULT_CHARS = 24_000
 
-const PI_CHAT_SYSTEM_PROMPT = [
+const EMPTY_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+}
+
+const BASE_SYSTEM_PROMPT = [
   'You are Omi on Windows.',
+  'You are running through Pi native agent core inside the Electron main process.',
   'Answer conversationally and use the provided local Windows tools when they help.',
   'Local tools can inspect local Omi status, screen history, screenshots, read-only SQL, daily recaps, and best-effort local task tables.',
   'Do not claim that unavailable or rejected tool actions succeeded.'
 ].join('\n')
 
-const PI_CHAT_TOOL_NAMES = new Set([
+const NATIVE_PI_TOOL_NAMES = new Set([
   'get_local_status',
   'execute_sql',
   'search_screen_history',
@@ -24,12 +58,14 @@ const PI_CHAT_TOOL_NAMES = new Set([
 ])
 
 type JsonRecord = Record<string, unknown>
+type FetchLike = typeof fetch
 
 type OpenAiChatMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool'
   content?: string | null
   tool_calls?: OpenAiToolCall[]
   tool_call_id?: string
+  name?: string
 }
 
 type OpenAiTool = {
@@ -68,23 +104,23 @@ type OpenAiChatCompletion = {
   usage?: OpenAiUsage
 }
 
-type FetchLike = typeof fetch
-
 export type PiChatBridgeOptions = {
   fetchImpl?: FetchLike
   desktopApiBaseUrl?: string
   toolDefinitions?: () => LocalAgentToolDefinition[]
   runTool?: typeof runLocalAgentTool
   runtimeContext?: LocalAgentRuntimeContext
+  loadSkillSections?: (ids: string[]) => Promise<string[]>
 }
 
 export type PiChatSendRequest = {
   token: string
   messages: ChatMessage[]
+  skillIds?: string[]
 }
 
 export function isPiChatEnabled(): boolean {
-  return process.env.OMI_WINDOWS_PI_CHAT === '1' || process.env.OMI_PI_CHAT === '1'
+  return process.env.OMI_WINDOWS_PI_CHAT !== '0' && process.env.OMI_PI_CHAT !== '0'
 }
 
 function desktopApiBaseUrl(): string {
@@ -99,15 +135,33 @@ export function chatCompletionsUrl(baseUrl = desktopApiBaseUrl()): string {
   return `${baseUrl.replace(/\/+$/, '')}/v2/chat/completions`
 }
 
-function usageFrom(raw?: OpenAiUsage): PiChatUsage {
+function piModel(baseUrl = desktopApiBaseUrl()): Model<string> {
   return {
-    promptTokens: raw?.prompt_tokens ?? 0,
-    completionTokens: raw?.completion_tokens ?? 0,
-    totalTokens: raw?.total_tokens ?? 0
+    id: PI_MODEL_ID,
+    name: PI_MODEL_NAME,
+    api: OMI_PI_API,
+    provider: OMI_PI_PROVIDER,
+    baseUrl: chatCompletionsUrl(baseUrl),
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192
   }
 }
 
-function addUsage(a: PiChatUsage, b: PiChatUsage): PiChatUsage {
+function usageFrom(raw?: OpenAiUsage): Usage {
+  return {
+    input: raw?.prompt_tokens ?? 0,
+    output: raw?.completion_tokens ?? 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: raw?.total_tokens ?? (raw?.prompt_tokens ?? 0) + (raw?.completion_tokens ?? 0),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+  }
+}
+
+function addResponseUsage(a: PiChatUsage, b: PiChatUsage): PiChatUsage {
   return {
     promptTokens: a.promptTokens + b.promptTokens,
     completionTokens: a.completionTokens + b.completionTokens,
@@ -115,38 +169,100 @@ function addUsage(a: PiChatUsage, b: PiChatUsage): PiChatUsage {
   }
 }
 
-function messagesForPi(messages: ChatMessage[]): OpenAiChatMessage[] {
-  return [
-    { role: 'system', content: PI_CHAT_SYSTEM_PROMPT },
-    ...messages
-      .filter((message) => message.role === 'user' || message.role === 'assistant')
-      .map((message) => ({
-        role: message.role,
-        content: message.content
-      }))
-  ]
+function textBlocksToString(content: readonly { type: string }[]): string {
+  return content
+    .map((block) => {
+      if (block.type === 'text' && 'text' in block) return String(block.text)
+      return ''
+    })
+    .filter(Boolean)
+    .join('\n')
 }
 
-function toolsForPi(definitions: LocalAgentToolDefinition[]): OpenAiTool[] {
-  return definitions
-    .filter((tool) => PI_CHAT_TOOL_NAMES.has(tool.name))
-    .map((tool) => ({
+function messageText(message: AgentMessage | ToolResultMessage): string {
+  if (message.role === 'user') {
+    if (typeof message.content === 'string') return message.content
+    return textBlocksToString(message.content)
+  }
+  if (message.role === 'assistant') {
+    return textBlocksToString(message.content)
+  }
+  if (message.role === 'toolResult' && 'content' in message) {
+    return textBlocksToString(message.content)
+  }
+  return ''
+}
+
+function toolCallsFromAssistant(message: AgentMessage): OpenAiToolCall[] {
+  if (message.role !== 'assistant' || !('content' in message)) return []
+  return message.content
+    .filter((block): block is ToolCall => block.type === 'toolCall')
+    .map((block) => ({
+      id: block.id,
       type: 'function',
       function: {
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.inputSchema
+        name: block.name,
+        arguments: JSON.stringify(block.arguments ?? {})
       }
     }))
 }
 
+function openAiMessagesForContext(context: Context): OpenAiChatMessage[] {
+  const messages: OpenAiChatMessage[] = []
+  if (context.systemPrompt?.trim()) {
+    messages.push({ role: 'system', content: context.systemPrompt.trim() })
+  }
+  for (const message of context.messages) {
+    if (message.role === 'user') {
+      messages.push({ role: 'user', content: messageText(message) })
+      continue
+    }
+    if (message.role === 'assistant') {
+      const toolCalls = toolCallsFromAssistant(message)
+      messages.push({
+        role: 'assistant',
+        content: messageText(message) || null,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {})
+      })
+      continue
+    }
+    messages.push({
+      role: 'tool',
+      tool_call_id: message.toolCallId,
+      name: message.toolName,
+      content: messageText(message)
+    })
+  }
+  return messages
+}
+
+function openAiToolsForContext(context: Context): OpenAiTool[] {
+  return (context.tools ?? []).map((tool) => ({
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters as unknown as JsonRecord
+    }
+  }))
+}
+
 export function buildPiChatRequest(messages: ChatMessage[]): JsonRecord {
+  const context: Context = {
+    systemPrompt: BASE_SYSTEM_PROMPT,
+    messages: messages.map(chatMessageToAgentMessage),
+    tools: nativePiTools()
+  }
+  return buildOmiChatCompletionBody(context)
+}
+
+function buildOmiChatCompletionBody(context: Context): JsonRecord {
+  const tools = openAiToolsForContext(context)
   return {
-    model: PI_CHAT_MODEL,
+    model: PI_MODEL_ID,
     stream: false,
-    messages: messagesForPi(messages),
-    tools: toolsForPi(listLocalAgentTools()),
-    tool_choice: 'auto'
+    messages: openAiMessagesForContext(context),
+    ...(tools.length > 0 ? { tools, tool_choice: 'auto' } : {})
   }
 }
 
@@ -160,20 +276,215 @@ function parseToolArguments(call: OpenAiToolCall): JsonRecord {
   return parsed as JsonRecord
 }
 
-function resultToToolContent(value: unknown): string {
-  if (typeof value === 'string') return value
-  return JSON.stringify(value)
+function stopReason(
+  finishReason?: string | null,
+  hasToolCalls = false
+): AssistantMessage['stopReason'] {
+  if (hasToolCalls || finishReason === 'tool_calls') return 'toolUse'
+  if (finishReason === 'length') return 'length'
+  return 'stop'
 }
 
-function toolErrorContent(error: unknown): string {
-  const { body } = errorResponseBody(error)
-  return `Error: ${body.error.code}: ${body.error.message}`
+function assistantMessageFromCompletion(completion: OpenAiChatCompletion): AssistantMessage {
+  const choice = completion.choices?.[0]
+  const message = choice?.message
+  if (!message) throw new Error('Omi chat returned no message')
+
+  const toolCalls = message.tool_calls ?? []
+  const content: AssistantMessage['content'] = []
+  if (typeof message.content === 'string' && message.content.length > 0) {
+    content.push({ type: 'text', text: message.content })
+  }
+  for (const call of toolCalls) {
+    content.push({
+      type: 'toolCall',
+      id: call.id,
+      name: call.function.name,
+      arguments: parseToolArguments(call)
+    })
+  }
+
+  return {
+    role: 'assistant',
+    content,
+    api: OMI_PI_API,
+    provider: OMI_PI_PROVIDER,
+    model: PI_MODEL_ID,
+    usage: usageFrom(completion.usage),
+    stopReason: stopReason(choice.finish_reason, toolCalls.length > 0),
+    timestamp: Date.now()
+  }
+}
+
+function cloneAssistant(message: AssistantMessage): AssistantMessage {
+  return {
+    ...message,
+    content: message.content.map((block) => ({ ...block }))
+  }
+}
+
+function emitAssistantMessage(
+  stream: AssistantMessageEventStream,
+  message: AssistantMessage
+): void {
+  const partial: AssistantMessage = { ...message, content: [] }
+  stream.push({ type: 'start', partial: cloneAssistant(partial) })
+  message.content.forEach((block, index) => {
+    if (block.type === 'text') {
+      partial.content = [...partial.content, { type: 'text', text: '' }]
+      stream.push({ type: 'text_start', contentIndex: index, partial: cloneAssistant(partial) })
+      ;(partial.content[index] as TextContent).text = block.text
+      stream.push({
+        type: 'text_delta',
+        contentIndex: index,
+        delta: block.text,
+        partial: cloneAssistant(partial)
+      })
+      stream.push({
+        type: 'text_end',
+        contentIndex: index,
+        content: block.text,
+        partial: cloneAssistant(partial)
+      })
+      return
+    }
+    if (block.type !== 'toolCall') return
+    partial.content = [
+      ...partial.content,
+      { type: 'toolCall', id: block.id, name: block.name, arguments: {} }
+    ]
+    stream.push({ type: 'toolcall_start', contentIndex: index, partial: cloneAssistant(partial) })
+    ;(partial.content[index] as ToolCall).arguments = block.arguments
+    stream.push({
+      type: 'toolcall_delta',
+      contentIndex: index,
+      delta: JSON.stringify(block.arguments ?? {}),
+      partial: cloneAssistant(partial)
+    })
+    stream.push({
+      type: 'toolcall_end',
+      contentIndex: index,
+      toolCall: block,
+      partial: cloneAssistant(partial)
+    })
+  })
+  stream.push({
+    type: 'done',
+    reason:
+      message.stopReason === 'toolUse' || message.stopReason === 'length'
+        ? message.stopReason
+        : 'stop',
+    message
+  })
+  stream.end(message)
+}
+
+function errorAssistantMessage(error: unknown): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [],
+    api: OMI_PI_API,
+    provider: OMI_PI_PROVIDER,
+    model: PI_MODEL_ID,
+    usage: EMPTY_USAGE,
+    stopReason: 'error',
+    errorMessage: error instanceof Error ? error.message : String(error),
+    timestamp: Date.now()
+  }
+}
+
+async function callOmiChatCompletions(
+  context: Context,
+  token: string,
+  options: PiChatBridgeOptions
+): Promise<OpenAiChatCompletion> {
+  const response = await (options.fetchImpl ?? fetch)(
+    chatCompletionsUrl(options.desktopApiBaseUrl),
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(buildOmiChatCompletionBody(context))
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`Omi Pi provider request failed with HTTP ${response.status}`)
+  }
+  return (await response.json()) as OpenAiChatCompletion
+}
+
+function createOmiStreamFn(token: string, options: PiChatBridgeOptions) {
+  return (_model: Model<string>, context: Context): AssistantMessageEventStream => {
+    const stream = createAssistantMessageEventStream()
+    void (async () => {
+      try {
+        const completion = await callOmiChatCompletions(context, token, options)
+        emitAssistantMessage(stream, assistantMessageFromCompletion(completion))
+      } catch (error) {
+        const message = errorAssistantMessage(error)
+        stream.push({ type: 'error', reason: 'error', error: message })
+        stream.end(message)
+      }
+    })()
+    return stream
+  }
+}
+
+function truncateForToolResult(text: string): string {
+  if (text.length <= MAX_TOOL_RESULT_CHARS) return text
+  return `${text.slice(0, MAX_TOOL_RESULT_CHARS)}\n\n[truncated ${text.length - MAX_TOOL_RESULT_CHARS} chars]`
+}
+
+function resultToToolContent(value: unknown): string {
+  const text = typeof value === 'string' ? value : JSON.stringify(value)
+  return truncateForToolResult(text)
+}
+
+function prepareToolArgs(args: unknown): Record<string, unknown> {
+  if (args == null) return {}
+  if (typeof args === 'object' && !Array.isArray(args)) return args as Record<string, unknown>
+  throw new Error('tool arguments must be a JSON object')
+}
+
+function nativePiTool(
+  definition: LocalAgentToolDefinition,
+  options: PiChatBridgeOptions
+): AgentTool<TSchema> {
+  const runTool = options.runTool ?? runLocalAgentTool
+  const runtimeContext = options.runtimeContext ?? defaultRuntimeContext()
+  return {
+    name: definition.name,
+    label: definition.name
+      .split('_')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' '),
+    description: definition.description,
+    parameters: Type.Unsafe(definition.inputSchema as unknown as TSchema),
+    prepareArguments: prepareToolArgs,
+    executionMode: 'sequential',
+    execute: async (_toolCallId, params): Promise<AgentToolResult<unknown>> => {
+      const result = await runTool(definition.name, params, runtimeContext)
+      return {
+        content: [{ type: 'text', text: resultToToolContent(result) }],
+        details: result
+      }
+    }
+  }
+}
+
+function nativePiTools(options: PiChatBridgeOptions = {}): AgentTool<TSchema>[] {
+  const toolDefinitions = options.toolDefinitions ?? listLocalAgentTools
+  return toolDefinitions()
+    .filter((tool) => NATIVE_PI_TOOL_NAMES.has(tool.name))
+    .map((tool) => nativePiTool(tool, options))
 }
 
 function defaultRuntimeContext(): LocalAgentRuntimeContext {
   return {
     localUrl: 'omi://local-agent',
-    toolEndpoint: 'omi://local-agent/pi-chat-tool',
+    toolEndpoint: 'omi://native-pi-tool',
     app: {
       name: 'Omi Windows',
       version: '1.0.0',
@@ -182,50 +493,58 @@ function defaultRuntimeContext(): LocalAgentRuntimeContext {
   }
 }
 
-async function callChatCompletions(
-  request: JsonRecord,
-  token: string,
-  options: PiChatBridgeOptions
-): Promise<OpenAiChatCompletion> {
-  const fetchImpl = options.fetchImpl ?? fetch
-  const response = await fetchImpl(chatCompletionsUrl(options.desktopApiBaseUrl), {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${token}`
-    },
-    body: JSON.stringify(request)
-  })
-  if (!response.ok) {
-    throw new Error(`Pi/Omi chat request failed with HTTP ${response.status}`)
+function chatMessageToAgentMessage(message: ChatMessage, index = 0): Message {
+  const timestamp = Date.now() + index
+  if (message.role === 'user') {
+    return {
+      role: 'user',
+      content: [{ type: 'text', text: message.content }],
+      timestamp
+    }
   }
-  return (await response.json()) as OpenAiChatCompletion
+  return {
+    role: 'assistant',
+    content: message.content ? [{ type: 'text', text: message.content }] : [],
+    api: OMI_PI_API,
+    provider: OMI_PI_PROVIDER,
+    model: PI_MODEL_ID,
+    usage: EMPTY_USAGE,
+    stopReason: 'stop',
+    timestamp
+  }
 }
 
-async function executeToolCall(
-  call: OpenAiToolCall,
-  options: PiChatBridgeOptions
-): Promise<OpenAiChatMessage> {
-  const runTool = options.runTool ?? runLocalAgentTool
-  const context = options.runtimeContext ?? defaultRuntimeContext()
+function assistantText(message: AgentMessage): string {
+  return message.role === 'assistant' && 'content' in message ? messageText(message) : ''
+}
 
-  let content = ''
-  try {
-    if (!PI_CHAT_TOOL_NAMES.has(call.function.name)) {
-      throw new Error(`Local tool is not available to Pi/Omi chat: ${call.function.name}`)
-    }
-    const args = parseToolArguments(call)
-    const result = await runTool(call.function.name, args, context)
-    content = resultToToolContent(result)
-  } catch (error) {
-    content = toolErrorContent(error)
+function usageFromAssistant(message: AgentMessage): PiChatUsage {
+  if (message.role !== 'assistant' || !('usage' in message)) {
+    return { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
   }
-
   return {
-    role: 'tool',
-    tool_call_id: call.id,
-    content
+    promptTokens: message.usage.input + message.usage.cacheRead + message.usage.cacheWrite,
+    completionTokens: message.usage.output,
+    totalTokens: message.usage.totalTokens
   }
+}
+
+function systemPromptWithSkills(skillSections: string[]): string {
+  if (skillSections.length === 0) return BASE_SYSTEM_PROMPT
+  return [
+    BASE_SYSTEM_PROMPT,
+    'Use these selected skills as additional operating instructions when relevant:',
+    skillSections.join('\n\n---\n\n')
+  ].join('\n\n')
+}
+
+async function loadSelectedSkillSections(
+  request: PiChatSendRequest,
+  options: PiChatBridgeOptions
+): Promise<string[]> {
+  const ids = request.skillIds?.filter((id) => typeof id === 'string' && id.trim()) ?? []
+  if (ids.length === 0) return []
+  return options.loadSkillSections ? options.loadSkillSections(ids) : []
 }
 
 export async function sendPiChat(
@@ -237,49 +556,44 @@ export async function sendPiChat(
     throw new Error('Pi/Omi chat requires a Firebase ID token')
   }
 
-  const toolDefinitions = options.toolDefinitions ?? listLocalAgentTools
-  const conversation: OpenAiChatMessage[] = messagesForPi(request.messages)
-  const tools = toolsForPi(toolDefinitions())
-  const toolCalls: PiChatToolCall[] = []
-  let usage: PiChatUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+  const skillSections = await loadSelectedSkillSections(request, options)
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: systemPromptWithSkills(skillSections),
+      model: piModel(options.desktopApiBaseUrl),
+      tools: nativePiTools(options),
+      thinkingLevel: 'off'
+    },
+    streamFn: createOmiStreamFn(token, options),
+    toolExecution: 'sequential',
+    transport: 'sse'
+  })
+
   let finalText = ''
+  let usage: PiChatUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+  const toolCalls: PiChatToolCall[] = []
 
-  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
-    const body: JsonRecord = {
-      model: PI_CHAT_MODEL,
-      stream: false,
-      messages: conversation,
-      tools,
-      tool_choice: 'auto'
+  agent.subscribe((event: AgentEvent) => {
+    if (event.type === 'tool_execution_start') {
+      toolCalls.push({ id: event.toolCallId, name: event.toolName })
+      return
     }
-    const completion = await callChatCompletions(body, token, options)
-    usage = addUsage(usage, usageFrom(completion.usage))
-    const message = completion.choices?.[0]?.message
-    if (!message) throw new Error('Pi/Omi chat returned no message')
-
-    const assistantText = typeof message.content === 'string' ? message.content : ''
-    const calls = message.tool_calls ?? []
-    if (calls.length === 0) {
-      finalText = assistantText
-      break
+    if (event.type === 'message_end' && event.message.role === 'assistant') {
+      finalText = assistantText(event.message)
+      usage = addResponseUsage(usage, usageFromAssistant(event.message))
     }
+  })
 
-    conversation.push({
-      role: 'assistant',
-      content: assistantText || null,
-      tool_calls: calls
-    })
-
-    for (const call of calls) {
-      toolCalls.push({ id: call.id, name: call.function.name })
-      conversation.push(await executeToolCall(call, options))
-    }
+  try {
+    await agent.prompt(request.messages.map(chatMessageToAgentMessage))
+  } catch (error) {
+    throw error
   }
 
-  if (!finalText && toolCalls.length > 0) {
-    throw new Error('Pi/Omi chat exceeded the local tool-call round limit')
+  const errorMessage = agent.state.errorMessage
+  if (errorMessage) {
+    throw new Error(errorMessage)
   }
-
   return {
     text: finalText,
     usage,

--- a/desktop/windows/src/main/pi/chatBridge.ts
+++ b/desktop/windows/src/main/pi/chatBridge.ts
@@ -593,11 +593,7 @@ export async function sendPiChat(
     }
   })
 
-  try {
-    await agent.prompt(request.messages.map(chatMessageToAgentMessage))
-  } catch (error) {
-    throw error
-  }
+  await agent.prompt(request.messages.map(chatMessageToAgentMessage))
 
   const errorMessage = agent.state.errorMessage
   if (errorMessage) {

--- a/desktop/windows/src/main/rewind/frameImage.ts
+++ b/desktop/windows/src/main/rewind/frameImage.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'fs/promises'
+import { extname, resolve, sep } from 'path'
+import type { RewindFrame, RewindFrameImageResult } from '../../shared/types'
+
+export function frameImageNotFound(message: string): RewindFrameImageResult {
+  return { ok: false, code: 'not_found', message }
+}
+
+function imageMimeType(imagePath: string): string {
+  const ext = extname(imagePath).toLowerCase()
+  if (ext === '.png') return 'image/png'
+  if (ext === '.webp') return 'image/webp'
+  return 'image/jpeg'
+}
+
+function ocrPreview(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, 240)
+}
+
+export function resolveFrameImagePath(rootPath: string, imagePath: string): string | null {
+  const root = resolve(rootPath)
+  const full = resolve(imagePath)
+  if (full !== root && !full.startsWith(root + sep)) return null
+  return full
+}
+
+export async function readRewindFrameImage(
+  frame: RewindFrame | null,
+  rootPath: string
+): Promise<RewindFrameImageResult> {
+  if (!frame?.id) return frameImageNotFound('Frame not found')
+  const full = resolveFrameImagePath(rootPath, frame.imagePath)
+  if (!full) return frameImageNotFound('Frame image not found')
+  try {
+    const buf = await readFile(full)
+    return {
+      ok: true,
+      id: frame.id,
+      ts: frame.ts,
+      app: frame.app,
+      windowTitle: frame.windowTitle,
+      ocrPreview: ocrPreview(frame.ocrText),
+      imageMimeType: imageMimeType(full),
+      imageBase64: buf.toString('base64')
+    }
+  } catch {
+    return frameImageNotFound('Frame image not found')
+  }
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -76,7 +76,7 @@ const omi: OmiBridgeApi = {
   kgQueryNodes: (q, limit?) => ipcRenderer.invoke('kg:queryNodes', q, limit),
   kgSearchFiles: (q, fileType?, limit?) => ipcRenderer.invoke('kg:searchFiles', q, fileType, limit),
   kgExecuteSql: (sql) => ipcRenderer.invoke('kg:executeSql', sql),
-  piChatEnabled: process.env.OMI_WINDOWS_PI_CHAT === '1' || process.env.OMI_PI_CHAT === '1',
+  piChatStatus: () => ipcRenderer.invoke('piChat:status'),
   piChatSend: (request: PiChatRequest) => ipcRenderer.invoke('piChat:send', request),
   claudeAcpStatus: () => ipcRenderer.invoke('claudeAcp:status'),
   claudeAcpChatSend: (request: ClaudeAcpChatRequest) =>

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -45,6 +45,12 @@ const omi: OmiBridgeApi = {
     ipcRenderer.on('omi-listen:message', listener)
     return () => ipcRenderer.removeListener('omi-listen:message', listener)
   },
+  localAgentStatus: () => ipcRenderer.invoke('localAgent:status'),
+  localAgentSetEnabled: (enabled: boolean) => ipcRenderer.invoke('localAgent:setEnabled', enabled),
+  localAgentSetPort: (port: number) => ipcRenderer.invoke('localAgent:setPort', port),
+  localAgentCopyToken: () => ipcRenderer.invoke('localAgent:copyToken'),
+  localAgentRotateToken: () => ipcRenderer.invoke('localAgent:rotateToken'),
+  localAgentTestTools: () => ipcRenderer.invoke('localAgent:testTools'),
   indexFilesScan: () => ipcRenderer.invoke('fileIndex:scan'),
   indexFilesStatus: () => ipcRenderer.invoke('fileIndex:status'),
   indexFilesApps: (limit?: number) => ipcRenderer.invoke('fileIndex:apps', limit),

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -17,7 +17,8 @@ import type {
   InsightPayload,
   AutomationPlan,
   StepResult,
-  PiChatRequest
+  PiChatRequest,
+  ClaudeAcpChatRequest
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -77,6 +78,9 @@ const omi: OmiBridgeApi = {
   kgExecuteSql: (sql) => ipcRenderer.invoke('kg:executeSql', sql),
   piChatEnabled: process.env.OMI_WINDOWS_PI_CHAT === '1' || process.env.OMI_PI_CHAT === '1',
   piChatSend: (request: PiChatRequest) => ipcRenderer.invoke('piChat:send', request),
+  claudeAcpStatus: () => ipcRenderer.invoke('claudeAcp:status'),
+  claudeAcpChatSend: (request: ClaudeAcpChatRequest) =>
+    ipcRenderer.invoke('claudeAcp:chatSend', request),
   readStickyNotes: () => ipcRenderer.invoke('integrations:stickyNotes:read'),
   googleConnect: () => ipcRenderer.invoke('integrations:google:connect'),
   googleDisconnect: () => ipcRenderer.invoke('integrations:google:disconnect'),

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -16,7 +16,8 @@ import type {
   RewindSettings,
   InsightPayload,
   AutomationPlan,
-  StepResult
+  StepResult,
+  PiChatRequest
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -74,6 +75,8 @@ const omi: OmiBridgeApi = {
   kgQueryNodes: (q, limit?) => ipcRenderer.invoke('kg:queryNodes', q, limit),
   kgSearchFiles: (q, fileType?, limit?) => ipcRenderer.invoke('kg:searchFiles', q, fileType, limit),
   kgExecuteSql: (sql) => ipcRenderer.invoke('kg:executeSql', sql),
+  piChatEnabled: process.env.OMI_WINDOWS_PI_CHAT === '1' || process.env.OMI_PI_CHAT === '1',
+  piChatSend: (request: PiChatRequest) => ipcRenderer.invoke('piChat:send', request),
   readStickyNotes: () => ipcRenderer.invoke('integrations:stickyNotes:read'),
   googleConnect: () => ipcRenderer.invoke('integrations:google:connect'),
   googleDisconnect: () => ipcRenderer.invoke('integrations:google:disconnect'),

--- a/desktop/windows/src/renderer/src/components/settings/tabs.ts
+++ b/desktop/windows/src/renderer/src/components/settings/tabs.ts
@@ -1,5 +1,6 @@
 import {
   Settings as SettingsIcon,
+  BotMessageSquare,
   History,
   ShieldCheck,
   CircleUserRound,
@@ -8,9 +9,17 @@ import {
   type LucideIcon
 } from 'lucide-react'
 
-export type SettingsTabId = 'general' | 'memories' | 'rewind' | 'privacy' | 'account' | 'advanced'
+export type SettingsTabId =
+  | 'ai-chat'
+  | 'general'
+  | 'memories'
+  | 'rewind'
+  | 'privacy'
+  | 'account'
+  | 'advanced'
 
 export const SETTINGS_TABS: { id: SettingsTabId; label: string; Icon: LucideIcon }[] = [
+  { id: 'ai-chat', label: 'AI Chat', Icon: BotMessageSquare },
   { id: 'general', label: 'General', Icon: SettingsIcon },
   { id: 'memories', label: 'Memories', Icon: Brain },
   { id: 'rewind', label: 'Rewind', Icon: History },

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AIChatTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AIChatTab.tsx
@@ -1,11 +1,9 @@
 import { Cpu, RefreshCw } from 'lucide-react'
-import { useState } from 'react'
-import type { ClaudeAcpStatus } from '../../../../../shared/types'
-import { getPreferences, setPreferences } from '../../../lib/preferences'
+import { useEffect, useState } from 'react'
+import type { ClaudeAcpStatus, PiChatStatus } from '../../../../../shared/types'
+import { getPreferences, setPreferences, type ChatRuntimeMode } from '../../../lib/preferences'
 import { toast } from '../../../lib/toast'
 import { SettingRow } from '../SettingRow'
-
-type ChatRuntimeMode = 'auto' | 'omi-hosted' | 'pi' | 'claude-acp'
 
 function claudeStatusText(status: ClaudeAcpStatus | null): string {
   if (!status) return 'Not checked'
@@ -26,8 +24,24 @@ export function AIChatTab(): React.JSX.Element {
   const [chatRuntimeMode, setChatRuntimeMode] = useState<ChatRuntimeMode>(
     () => getPreferences().chatRuntimeMode
   )
+  const [piStatus, setPiStatus] = useState<PiChatStatus | null>(null)
   const [claudeStatus, setClaudeStatus] = useState<ClaudeAcpStatus | null>(null)
   const [claudeBusy, setClaudeBusy] = useState(false)
+
+  useEffect(() => {
+    let canceled = false
+    window.omi
+      .piChatStatus()
+      .then((status) => {
+        if (!canceled) setPiStatus(status)
+      })
+      .catch(() => {
+        if (!canceled) setPiStatus({ enabled: false })
+      })
+    return () => {
+      canceled = true
+    }
+  }, [])
 
   const refreshClaudeStatus = async (): Promise<void> => {
     setClaudeBusy(true)
@@ -92,8 +106,8 @@ export function AIChatTab(): React.JSX.Element {
         </button>
       </div>
       <div className="mt-3 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-xs text-text-tertiary">
-        Pi/Omi routing is {window.omi.piChatEnabled ? 'enabled' : 'disabled'} in this build. Claude
-        routing uses the local Claude command configured on this Windows account.
+        Pi/Omi routing is {piStatus?.enabled ? 'enabled' : piStatus ? 'disabled' : 'checking'} in
+        this build. Claude routing uses the local Claude command configured on this Windows account.
       </div>
     </SettingRow>
   )

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AIChatTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AIChatTab.tsx
@@ -1,0 +1,100 @@
+import { Cpu, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import type { ClaudeAcpStatus } from '../../../../../shared/types'
+import { getPreferences, setPreferences } from '../../../lib/preferences'
+import { toast } from '../../../lib/toast'
+import { SettingRow } from '../SettingRow'
+
+type ChatRuntimeMode = 'auto' | 'omi-hosted' | 'pi' | 'claude-acp'
+
+function claudeStatusText(status: ClaudeAcpStatus | null): string {
+  if (!status) return 'Not checked'
+  if (status.configured) return `Available via ${status.command}`
+  return status.reason ?? 'Not available'
+}
+
+function runtimeSubtitle(chatRuntimeMode: ChatRuntimeMode): string {
+  if (chatRuntimeMode === 'claude-acp') {
+    return 'Use the local Claude account runtime on this Windows machine.'
+  }
+  if (chatRuntimeMode === 'pi') return 'Use the native Pi/Omi agent runtime.'
+  if (chatRuntimeMode === 'omi-hosted') return 'Use Omi hosted chat only.'
+  return 'Use native Pi/Omi when available, otherwise fall back to hosted Omi chat.'
+}
+
+export function AIChatTab(): React.JSX.Element {
+  const [chatRuntimeMode, setChatRuntimeMode] = useState<ChatRuntimeMode>(
+    () => getPreferences().chatRuntimeMode
+  )
+  const [claudeStatus, setClaudeStatus] = useState<ClaudeAcpStatus | null>(null)
+  const [claudeBusy, setClaudeBusy] = useState(false)
+
+  const refreshClaudeStatus = async (): Promise<void> => {
+    setClaudeBusy(true)
+    try {
+      const status = await window.omi.claudeAcpStatus()
+      setClaudeStatus(status)
+      toast(status.configured ? 'Claude account runtime available' : 'Claude account unavailable', {
+        tone: status.configured ? 'success' : 'warn',
+        body: status.reason
+      })
+    } catch (e) {
+      toast('Could not check Claude account', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setClaudeBusy(false)
+    }
+  }
+
+  return (
+    <SettingRow
+      icon={Cpu}
+      title="Chat runtime"
+      subtitle={runtimeSubtitle(chatRuntimeMode)}
+      keywords="ai chat runtime pi omi claude acp local account hosted provider"
+      control={
+        <select
+          value={chatRuntimeMode}
+          onChange={(e) => {
+            const v = e.target.value as ChatRuntimeMode
+            setChatRuntimeMode(v)
+            setPreferences({ chatRuntimeMode: v })
+          }}
+          className="rounded-md bg-white/10 px-2 py-1.5 text-sm text-white focus:outline-none"
+        >
+          <option value="auto" className="bg-neutral-900">
+            Auto
+          </option>
+          <option value="omi-hosted" className="bg-neutral-900">
+            Omi hosted
+          </option>
+          <option value="pi" className="bg-neutral-900">
+            Pi/Omi
+          </option>
+          <option value="claude-acp" className="bg-neutral-900">
+            Claude account
+          </option>
+        </select>
+      }
+    >
+      <div className="grid gap-3 rounded-md border border-white/[0.08] bg-white/[0.03] p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-text-primary">Claude account status</div>
+          <div className="mt-0.5 text-xs text-text-tertiary">{claudeStatusText(claudeStatus)}</div>
+        </div>
+        <button
+          type="button"
+          disabled={claudeBusy}
+          onClick={() => void refreshClaudeStatus()}
+          className="btn-ghost inline-flex min-h-9 items-center gap-1.5 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-4 w-4 ${claudeBusy ? 'animate-spin' : ''}`} />
+          Check
+        </button>
+      </div>
+      <div className="mt-3 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-xs text-text-tertiary">
+        Pi/Omi routing is {window.omi.piChatEnabled ? 'enabled' : 'disabled'} in this build. Claude
+        routing uses the local Claude command configured on this Windows account.
+      </div>
+    </SettingRow>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
@@ -1,17 +1,33 @@
 import { useEffect, useState } from 'react'
-import { Download, Upload, Wrench, FolderSearch, Network, RotateCcw } from 'lucide-react'
+import {
+  Copy,
+  Download,
+  Upload,
+  Wrench,
+  FolderSearch,
+  Network,
+  RotateCcw,
+  KeyRound,
+  RefreshCw
+} from 'lucide-react'
 import { omiApi } from '../../../lib/apiClient'
 import { toast } from '../../../lib/toast'
 import { extractMemories, type MemorySource } from '../../../lib/memoryExtract'
 import { buildLocalGraph } from '../../../lib/kgSynthesis'
-import { summarizeMemories, appIndexMemoryIds, type MemoryBreakdown } from '../../../lib/memoryCleanup'
+import {
+  summarizeMemories,
+  appIndexMemoryIds,
+  type MemoryBreakdown
+} from '../../../lib/memoryCleanup'
 import { useMemories, type Memory } from '../../../hooks/useMemories'
 import { resetOnboarding } from '../../../lib/preferences'
 import { SettingRow } from '../SettingRow'
+import { Toggle } from '../Toggle'
 import { IntegrationsTab } from './IntegrationsTab'
 import type {
   ExportMemory,
   FileIndexStatus,
+  LocalAgentStatus,
   LocalKGStatus,
   MemoryExportResult
 } from '../../../../../shared/types'
@@ -19,11 +35,174 @@ import type {
 export function AdvancedTab(): React.JSX.Element {
   const { memories, refresh } = useMemories()
 
+  // --- Local agent API ---
+  const [localAgent, setLocalAgent] = useState<LocalAgentStatus | null>(null)
+  const [localAgentPort, setLocalAgentPort] = useState('')
+  const [localAgentBusy, setLocalAgentBusy] = useState<
+    '' | 'enable' | 'port' | 'copy-token' | 'rotate-token' | 'test' | 'refresh' | 'copy-url'
+  >('')
+
+  const applyLocalAgentStatus = (status: LocalAgentStatus): void => {
+    setLocalAgent(status)
+    setLocalAgentPort(String(status.configuredPort))
+  }
+
+  const refreshLocalAgent = async (): Promise<void> => {
+    setLocalAgentBusy((current) => current || 'refresh')
+    try {
+      const status = await window.omi.localAgentStatus()
+      applyLocalAgentStatus(status)
+    } catch (e) {
+      toast('Could not read local agent status', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy((current) => (current === 'refresh' ? '' : current))
+    }
+  }
+
+  useEffect(() => {
+    let canceled = false
+    window.omi
+      .localAgentStatus()
+      .then((status) => {
+        if (!canceled) applyLocalAgentStatus(status)
+      })
+      .catch((e) => {
+        if (!canceled) {
+          toast('Could not read local agent status', { tone: 'error', body: (e as Error).message })
+        }
+      })
+    return () => {
+      canceled = true
+    }
+  }, [])
+
+  const setLocalAgentEnabled = async (enabled: boolean): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('enable')
+    try {
+      const status = await window.omi.localAgentSetEnabled(enabled)
+      applyLocalAgentStatus(status)
+      toast(enabled ? 'Local agent API enabled' : 'Local agent API disabled', { tone: 'success' })
+    } catch (e) {
+      toast(enabled ? 'Could not enable local agent API' : 'Could not disable local agent API', {
+        tone: 'error',
+        body: (e as Error).message
+      })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const saveLocalAgentPort = async (): Promise<void> => {
+    if (localAgentBusy) return
+    const port = Number(localAgentPort)
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+      toast('Enter a port between 1024 and 65535', { tone: 'warn' })
+      return
+    }
+
+    setLocalAgentBusy('port')
+    try {
+      const status = await window.omi.localAgentSetPort(port)
+      applyLocalAgentStatus(status)
+      toast('Local agent port saved', {
+        tone: 'success',
+        body: status.running ? `Listening on ${status.localUrl}` : undefined
+      })
+    } catch (e) {
+      toast('Could not save local agent port', { tone: 'error', body: (e as Error).message })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const copyLocalAgentUrl = async (): Promise<void> => {
+    if (!localAgent?.localUrl || localAgentBusy) return
+    setLocalAgentBusy('copy-url')
+    try {
+      await navigator.clipboard.writeText(localAgent.localUrl)
+      toast('Local agent URL copied', { tone: 'success' })
+    } catch (e) {
+      toast('Could not copy local agent URL', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const copyLocalAgentToken = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('copy-token')
+    try {
+      const status = await window.omi.localAgentCopyToken()
+      applyLocalAgentStatus(status)
+      toast('Bearer token copied', { tone: 'success' })
+    } catch (e) {
+      toast('Could not copy bearer token', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const rotateLocalAgentToken = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('rotate-token')
+    try {
+      const status = await window.omi.localAgentRotateToken()
+      applyLocalAgentStatus(status)
+      toast('Bearer token rotated', {
+        tone: 'success',
+        body: status.running ? 'Existing clients must use the new token.' : undefined
+      })
+    } catch (e) {
+      toast('Could not rotate bearer token', { tone: 'error', body: (e as Error).message })
+      await refreshLocalAgent()
+    } finally {
+      setLocalAgentBusy('')
+    }
+  }
+
+  const testLocalAgentTools = async (): Promise<void> => {
+    if (localAgentBusy) return
+    setLocalAgentBusy('test')
+    try {
+      const result = await window.omi.localAgentTestTools()
+      if (result.ok) {
+        toast('Local agent tools reachable', {
+          tone: 'success',
+          body: `${result.toolCount ?? 0} tools available`
+        })
+      } else {
+        toast('Local agent tools test failed', {
+          tone: 'error',
+          body: result.error ?? (result.status ? `HTTP ${result.status}` : undefined)
+        })
+      }
+    } catch (e) {
+      toast('Local agent tools test failed', { tone: 'error', body: (e as Error).message })
+    } finally {
+      setLocalAgentBusy('')
+      void refreshLocalAgent()
+    }
+  }
+
+  const localAgentSubtitle = !localAgent
+    ? 'Loading local API status…'
+    : localAgent.running
+      ? `Listening on ${localAgent.localUrl}`
+      : localAgent.enabled
+        ? 'Enabled, but not currently listening. Refresh status or disable and re-enable.'
+        : 'Disabled by default. Enable to let local agents access Omi through loopback with bearer auth.'
+
   // --- File indexing ---
   const [fileIndex, setFileIndex] = useState<FileIndexStatus | null>(null)
   const [scanning, setScanning] = useState(false)
   useEffect(() => {
-    window.omi.indexFilesStatus().then(setFileIndex).catch(() => setFileIndex(null))
+    window.omi
+      .indexFilesStatus()
+      .then(setFileIndex)
+      .catch(() => setFileIndex(null))
   }, [])
   const rescan = async (): Promise<void> => {
     if (scanning) return
@@ -43,7 +222,10 @@ export function AdvancedTab(): React.JSX.Element {
   const [kgStatus, setKgStatus] = useState<LocalKGStatus | null>(null)
   const [rebuildingKg, setRebuildingKg] = useState(false)
   useEffect(() => {
-    window.omi.kgStatus().then(setKgStatus).catch(() => setKgStatus(null))
+    window.omi
+      .kgStatus()
+      .then(setKgStatus)
+      .catch(() => setKgStatus(null))
   }, [])
   const rebuildKg = async (): Promise<void> => {
     if (rebuildingKg) return
@@ -75,12 +257,17 @@ export function AdvancedTab(): React.JSX.Element {
       const { memories: list, profile: summary } = await extractMemories(dump, source, existing)
       setParsed(list)
       setProfile(summary)
-      if (list.length === 0) toast('No new memories found — they may already be saved', { tone: 'warn' })
+      if (list.length === 0)
+        toast('No new memories found — they may already be saved', { tone: 'warn' })
     } catch (e) {
       console.warn('[memoryImport] AI extraction failed, falling back to split:', e)
       try {
         const norm = (s: string): string =>
-          s.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/g, ' ').trim()
+          s
+            .toLowerCase()
+            .replace(/[^\p{L}\p{N}\s]/gu, '')
+            .replace(/\s+/g, ' ')
+            .trim()
         const have = new Set(existing.map(norm))
         const list = (await window.omi.memoryImportParse(dump)).filter((m) => !have.has(norm(m)))
         setParsed(list)
@@ -134,7 +321,11 @@ export function AdvancedTab(): React.JSX.Element {
   const [notionPage, setNotionPage] = useState('')
   const [exporting, setExporting] = useState(false)
   const toExportMemories = (): ExportMemory[] =>
-    memories.map((m) => ({ content: m.content, category: m.category ?? null, createdAt: m.created_at }))
+    memories.map((m) => ({
+      content: m.content,
+      category: m.category ?? null,
+      createdAt: m.created_at
+    }))
 
   const runExport = async (target: 'obsidian' | 'file' | 'notion'): Promise<void> => {
     if (exporting) return
@@ -159,7 +350,10 @@ export function AdvancedTab(): React.JSX.Element {
           memories: mems
         })
       if (!r.canceled) {
-        toast(`Exported ${r.count} memor${r.count === 1 ? 'y' : 'ies'}`, { tone: 'success', body: r.location })
+        toast(`Exported ${r.count} memor${r.count === 1 ? 'y' : 'ies'}`, {
+          tone: 'success',
+          body: r.location
+        })
       }
     } catch (e) {
       toast('Export failed', { tone: 'error', body: (e as Error).message })
@@ -209,7 +403,12 @@ export function AdvancedTab(): React.JSX.Element {
   const deleteAppIndexMemories = async (): Promise<void> => {
     const ids = appIndexMemoryIds(memAllMemories)
     if (ids.length === 0 || memDeleting) return
-    if (!window.confirm(`Permanently delete ${ids.length} app/file-index memories? This cannot be undone.`)) return
+    if (
+      !window.confirm(
+        `Permanently delete ${ids.length} app/file-index memories? This cannot be undone.`
+      )
+    )
+      return
     setMemDeleting(true)
     setMemDeleteProgress(0)
     const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
@@ -224,13 +423,16 @@ export function AdvancedTab(): React.JSX.Element {
           await omiApi.delete(`/v3/memories/${id}`, { ...({ __noRetry: true } as object) })
           return 'ok'
         } catch (e) {
-          const resp = (e as { response?: { status?: number; headers?: Record<string, string> } }).response
+          const resp = (e as { response?: { status?: number; headers?: Record<string, string> } })
+            .response
           const status = resp?.status
           if (status === 404) return 'gone'
           if (status === 429) {
             paceMs = 1100
             const ra = Number(resp?.headers?.['retry-after'])
-            await sleep(Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000))
+            await sleep(
+              Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000)
+            )
             continue
           }
           if (!firstError) firstError = status ? `HTTP ${status}` : (e as Error).message
@@ -250,7 +452,9 @@ export function AdvancedTab(): React.JSX.Element {
       }
       toast(`Deleted ${deleted} of ${ids.length} memories`, {
         tone: failed ? 'warn' : 'success',
-        body: failed ? `${failed} failed${firstError ? ` — ${firstError}` : ''}. Analyze again to retry.` : undefined
+        body: failed
+          ? `${failed} failed${firstError ? ` — ${firstError}` : ''}. Analyze again to retry.`
+          : undefined
       })
     } catch (e) {
       toast('Delete failed', { tone: 'error', body: (e as Error).message })
@@ -268,6 +472,140 @@ export function AdvancedTab(): React.JSX.Element {
 
   return (
     <>
+      <SettingRow
+        icon={Network}
+        title="Local Agent Access"
+        subtitle={localAgentSubtitle}
+        keywords="local agent api bearer token codex claude chatgpt tools mcp loopback localhost port"
+        dot={!localAgent ? 'off' : localAgent.running ? 'on' : localAgent.enabled ? 'warn' : 'off'}
+        control={
+          <Toggle
+            on={localAgent?.enabled ?? false}
+            onChange={setLocalAgentEnabled}
+            disabled={!localAgent || localAgentBusy !== ''}
+            label="Enable local agent API"
+          />
+        }
+      >
+        <div className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Status</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {!localAgent
+                  ? 'Loading'
+                  : localAgent.running
+                    ? 'Listening'
+                    : localAgent.enabled
+                      ? 'Enabled, stopped'
+                      : 'Disabled'}
+              </div>
+            </div>
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Current port</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {localAgent?.currentPort ?? localAgent?.configuredPort ?? '—'}
+              </div>
+            </div>
+            <div className="glass-subtle rounded-lg px-4 py-3">
+              <div className="text-xs uppercase text-text-tertiary">Host</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">
+                {localAgent?.host ?? '127.0.0.1'}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-xs uppercase text-text-tertiary">Local URL</div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <code className="glass-subtle min-w-0 flex-1 overflow-x-auto rounded-lg px-3 py-2 text-sm text-text-secondary">
+                {localAgent?.localUrl ?? 'Not listening'}
+              </code>
+              <button
+                type="button"
+                onClick={copyLocalAgentUrl}
+                disabled={!localAgent?.localUrl || localAgentBusy !== ''}
+                className="btn-ghost inline-flex items-center justify-center gap-2 disabled:opacity-40"
+              >
+                <Copy className="h-4 w-4" />
+                Copy URL
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <label className="min-w-0 flex-1">
+              <span className="mb-1 block text-xs uppercase text-text-tertiary">Port</span>
+              <input
+                type="number"
+                min={1024}
+                max={65535}
+                value={localAgentPort}
+                onChange={(e) => setLocalAgentPort(e.target.value)}
+                disabled={!localAgent || localAgentBusy !== ''}
+                className="input-field"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={saveLocalAgentPort}
+              disabled={
+                !localAgent ||
+                localAgentBusy !== '' ||
+                localAgentPort === String(localAgent.configuredPort)
+              }
+              className="btn-ghost disabled:opacity-40"
+            >
+              {localAgentBusy === 'port' ? 'Saving…' : 'Save port'}
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={copyLocalAgentToken}
+              disabled={!localAgent || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <Copy className="h-4 w-4" />
+              {localAgentBusy === 'copy-token' ? 'Copying…' : 'Copy token'}
+            </button>
+            <button
+              type="button"
+              onClick={rotateLocalAgentToken}
+              disabled={!localAgent || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <KeyRound className="h-4 w-4" />
+              {localAgentBusy === 'rotate-token' ? 'Rotating…' : 'Rotate token'}
+            </button>
+            <button
+              type="button"
+              onClick={testLocalAgentTools}
+              disabled={!localAgent?.running || localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <Wrench className="h-4 w-4" />
+              {localAgentBusy === 'test' ? 'Testing…' : 'Test local tools'}
+            </button>
+            <button
+              type="button"
+              onClick={refreshLocalAgent}
+              disabled={localAgentBusy !== ''}
+              className="btn-ghost inline-flex items-center gap-2 disabled:opacity-40"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
+          </div>
+
+          <p className="text-sm text-text-tertiary">
+            Bearer auth is required for tools. The token is copied directly to your clipboard and is
+            not displayed here.
+          </p>
+        </div>
+      </SettingRow>
+
       <SettingRow
         icon={Download}
         title="Import memories"
@@ -299,22 +637,36 @@ export function AdvancedTab(): React.JSX.Element {
             className="input-field resize-none"
           />
           <div className="flex items-center gap-2">
-            <button onClick={extractDump} disabled={!dump.trim() || extracting || importing} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={extractDump}
+              disabled={!dump.trim() || extracting || importing}
+              className="btn-ghost disabled:opacity-40"
+            >
               {extracting ? 'Extracting…' : 'Extract memories'}
             </button>
             {parsed && parsed.length > 0 && (
-              <button onClick={importMemories} disabled={importing} className="btn-primary px-4 py-2 disabled:opacity-40">
-                {importing ? 'Importing…' : `Import ${parsed.length} memor${parsed.length === 1 ? 'y' : 'ies'}`}
+              <button
+                onClick={importMemories}
+                disabled={importing}
+                className="btn-primary px-4 py-2 disabled:opacity-40"
+              >
+                {importing
+                  ? 'Importing…'
+                  : `Import ${parsed.length} memor${parsed.length === 1 ? 'y' : 'ies'}`}
               </button>
             )}
           </div>
           {profile && (
-            <p className="glass-subtle rounded-lg px-4 py-3 text-sm italic text-text-tertiary">{profile}</p>
+            <p className="glass-subtle rounded-lg px-4 py-3 text-sm italic text-text-tertiary">
+              {profile}
+            </p>
           )}
           {parsed && parsed.length > 0 && (
             <ul className="glass-subtle max-h-40 overflow-y-auto rounded-lg px-4 py-3 text-sm text-text-tertiary">
               {parsed.map((m, i) => (
-                <li key={i} className="py-0.5">• {m}</li>
+                <li key={i} className="py-0.5">
+                  • {m}
+                </li>
               ))}
             </ul>
           )}
@@ -329,10 +681,18 @@ export function AdvancedTab(): React.JSX.Element {
       >
         <div className="space-y-3">
           <div className="flex flex-wrap gap-2">
-            <button onClick={() => runExport('obsidian')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('obsidian')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               Obsidian vault…
             </button>
-            <button onClick={() => runExport('file')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('file')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               Plain file…
             </button>
           </div>
@@ -352,7 +712,11 @@ export function AdvancedTab(): React.JSX.Element {
               placeholder="Parent page ID"
               className="glass-subtle mb-2 w-full rounded-lg px-4 py-3 text-sm text-text-secondary focus:outline-none"
             />
-            <button onClick={() => runExport('notion')} disabled={exporting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={() => runExport('notion')}
+              disabled={exporting}
+              className="btn-ghost disabled:opacity-40"
+            >
               {exporting ? 'Exporting…' : 'Export to Notion'}
             </button>
           </div>
@@ -367,11 +731,19 @@ export function AdvancedTab(): React.JSX.Element {
       >
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <button onClick={auditMemories} disabled={memAuditing || memDeleting} className="btn-ghost disabled:opacity-40">
+            <button
+              onClick={auditMemories}
+              disabled={memAuditing || memDeleting}
+              className="btn-ghost disabled:opacity-40"
+            >
               {memAuditing ? 'Analyzing…' : 'Analyze memories'}
             </button>
             {memBreakdown && memBreakdown.appIndexCount > 0 && (
-              <button onClick={deleteAppIndexMemories} disabled={memDeleting || memAuditing} className="btn-primary px-4 py-2 disabled:opacity-40">
+              <button
+                onClick={deleteAppIndexMemories}
+                disabled={memDeleting || memAuditing}
+                className="btn-primary px-4 py-2 disabled:opacity-40"
+              >
                 {memDeleting
                   ? `Deleting ${memDeleteProgress}/${memBreakdown.appIndexCount}…`
                   : `Delete ${memBreakdown.appIndexCount} app/file memories`}
@@ -382,12 +754,15 @@ export function AdvancedTab(): React.JSX.Element {
             <div className="glass-subtle rounded-lg px-4 py-3 text-sm text-text-tertiary">
               <p className="mb-2 text-text-secondary">
                 {memBreakdown.total} total memories ·{' '}
-                <span className="text-text-primary">{memBreakdown.appIndexCount}</span> app/file-index matches
+                <span className="text-text-primary">{memBreakdown.appIndexCount}</span>{' '}
+                app/file-index matches
               </p>
               {memBreakdown.appIndexCount > 0 && (
                 <ul className="mb-3 max-h-32 overflow-y-auto">
                   {memBreakdown.appIndexSamples.map((s, i) => (
-                    <li key={i} className="py-0.5">• {s}</li>
+                    <li key={i} className="py-0.5">
+                      • {s}
+                    </li>
                   ))}
                 </ul>
               )}
@@ -396,7 +771,9 @@ export function AdvancedTab(): React.JSX.Element {
                 {memBreakdown.groups.map((g) => (
                   <li key={g.key} className="py-0.5">
                     <span className="text-text-primary">{g.count}</span> — {g.key}
-                    {g.samples[0] ? <span className="opacity-60"> · e.g. “{g.samples[0]}”</span> : null}
+                    {g.samples[0] ? (
+                      <span className="opacity-60"> · e.g. “{g.samples[0]}”</span>
+                    ) : null}
                   </li>
                 ))}
               </ul>
@@ -414,7 +791,9 @@ export function AdvancedTab(): React.JSX.Element {
         subtitle={
           fileIndex
             ? `${fileIndex.filesIndexed.toLocaleString()} items indexed${
-                fileIndex.lastRunAt ? ` · last run ${new Date(fileIndex.lastRunAt).toLocaleString()}` : ''
+                fileIndex.lastRunAt
+                  ? ` · last run ${new Date(fileIndex.lastRunAt).toLocaleString()}`
+                  : ''
               }`
             : 'Indexes file names/metadata locally (contents never read or uploaded).'
         }
@@ -432,13 +811,19 @@ export function AdvancedTab(): React.JSX.Element {
         subtitle={
           kgStatus
             ? `${kgStatus.nodeCount.toLocaleString()} nodes · ${kgStatus.edgeCount.toLocaleString()} relationships${
-                kgStatus.lastBuiltAt ? ` · last built ${new Date(kgStatus.lastBuiltAt).toLocaleString()}` : ''
+                kgStatus.lastBuiltAt
+                  ? ` · last built ${new Date(kgStatus.lastBuiltAt).toLocaleString()}`
+                  : ''
               }`
             : 'A local graph of your projects, tech, people, and apps — used to ground chat answers.'
         }
         keywords="knowledge graph rebuild kg nodes"
         control={
-          <button onClick={rebuildKg} disabled={rebuildingKg} className="btn-ghost disabled:opacity-40">
+          <button
+            onClick={rebuildKg}
+            disabled={rebuildingKg}
+            className="btn-ghost disabled:opacity-40"
+          >
             {rebuildingKg ? 'Rebuilding…' : 'Rebuild now'}
           </button>
         }

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
@@ -38,13 +38,19 @@ export function AdvancedTab(): React.JSX.Element {
   // --- Local agent API ---
   const [localAgent, setLocalAgent] = useState<LocalAgentStatus | null>(null)
   const [localAgentPort, setLocalAgentPort] = useState('')
+  const [localAgentPortDirty, setLocalAgentPortDirty] = useState(false)
   const [localAgentBusy, setLocalAgentBusy] = useState<
     '' | 'enable' | 'port' | 'copy-token' | 'rotate-token' | 'test' | 'refresh' | 'copy-url'
   >('')
 
-  const applyLocalAgentStatus = (status: LocalAgentStatus): void => {
+  const applyLocalAgentStatus = (
+    status: LocalAgentStatus,
+    options: { syncPort?: boolean } = {}
+  ): void => {
     setLocalAgent(status)
-    setLocalAgentPort(String(status.configuredPort))
+    if (options.syncPort || !localAgentPortDirty) {
+      setLocalAgentPort(String(status.configuredPort))
+    }
   }
 
   const refreshLocalAgent = async (): Promise<void> => {
@@ -105,7 +111,8 @@ export function AdvancedTab(): React.JSX.Element {
     setLocalAgentBusy('port')
     try {
       const status = await window.omi.localAgentSetPort(port)
-      applyLocalAgentStatus(status)
+      setLocalAgentPortDirty(false)
+      applyLocalAgentStatus(status, { syncPort: true })
       toast('Local agent port saved', {
         tone: 'success',
         body: status.running ? `Listening on ${status.localUrl}` : undefined
@@ -541,7 +548,11 @@ export function AdvancedTab(): React.JSX.Element {
                 min={1024}
                 max={65535}
                 value={localAgentPort}
-                onChange={(e) => setLocalAgentPort(e.target.value)}
+                onChange={(e) => {
+                  const next = e.target.value
+                  setLocalAgentPort(next)
+                  setLocalAgentPortDirty(next !== String(localAgent?.configuredPort ?? ''))
+                }}
                 disabled={!localAgent || localAgentBusy !== ''}
                 className="input-field"
               />

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -242,6 +242,19 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     let assistantText = ''
     try {
       const token = await auth.currentUser?.getIdToken()
+      if (window.omi.piChatEnabled) {
+        const result = await window.omi.piChatSend({
+          token: token ?? '',
+          messages: [...baseHistory, userMsg]
+        })
+        assistantText = result.text
+        setHistory((h) => {
+          const next = [...h]
+          next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }
+          return next
+        })
+        return
+      }
       // Hybrid pre-step: gather context to PREPEND to the text we send (not what we
       // persist). Both are best-effort ('' on failure) and run concurrently so the
       // send isn't serialized behind them:
@@ -320,7 +333,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       // keyword-less follow-up like "again"). Don't render that raw in the thread.
       if (looksLikeRawPlan(assistantText)) {
         assistantText =
-          "It looks like you want me to do something in an app. Phrase it as a direct command (e.g. \"type report in the search box\") with that app focused, and I'll show you a plan to approve."
+          'It looks like you want me to do something in an app. Phrase it as a direct command (e.g. "type report in the search box") with that app focused, and I\'ll show you a plan to approve.'
         setHistory((h) => {
           const next = [...h]
           next[next.length - 1] = { id: assistantId, role: 'assistant', content: assistantText }

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -245,7 +245,8 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       if (window.omi.piChatEnabled) {
         const result = await window.omi.piChatSend({
           token: token ?? '',
-          messages: [...baseHistory, userMsg]
+          messages: [...baseHistory, userMsg],
+          skillIds: prefs.enabledSkillIds ?? []
         })
         assistantText = result.text
         setHistory((h) => {

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -246,7 +246,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
         const result = await window.omi.piChatSend({
           token: token ?? '',
           messages: [...baseHistory, userMsg],
-          skillIds: prefs.enabledSkillIds ?? []
+          skillIds: getPreferences().enabledSkillIds ?? []
         })
         assistantText = result.text
         setHistory((h) => {

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -242,7 +242,8 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     let assistantText = ''
     try {
       const token = await auth.currentUser?.getIdToken()
-      if (window.omi.piChatEnabled) {
+      const piStatus = await window.omi.piChatStatus()
+      if (piStatus.enabled) {
         const result = await window.omi.piChatSend({
           token: token ?? '',
           messages: [...baseHistory, userMsg],

--- a/desktop/windows/src/renderer/src/lib/preferences.ts
+++ b/desktop/windows/src/renderer/src/lib/preferences.ts
@@ -5,6 +5,8 @@ import { DEFAULT_LANGUAGE } from './languages'
 
 const KEY = 'omi-windows-prefs-v1'
 
+export type ChatRuntimeMode = 'auto' | 'omi-hosted' | 'pi' | 'claude-acp'
+
 export type Preferences = {
   captionIntervalMs: number
   showRecordingBadge: boolean
@@ -18,7 +20,7 @@ export type Preferences = {
   chatHistoryMode: 'per-launch' | 'infinite'
   // Runtime backing chat and agent tasks. 'auto' uses native Pi/Omi first, then
   // Omi hosted if Pi is explicitly disabled; BYOK is handled by its own split.
-  chatRuntimeMode: 'auto' | 'omi-hosted' | 'pi' | 'claude-acp'
+  chatRuntimeMode: ChatRuntimeMode
   // Skills selected in Integrations -> Skills. Optional until the skills UI split lands.
   enabledSkillIds?: string[]
   recordingConsentedAt?: number

--- a/desktop/windows/src/renderer/src/lib/preferences.ts
+++ b/desktop/windows/src/renderer/src/lib/preferences.ts
@@ -16,6 +16,11 @@ export type Preferences = {
   // (default, original behavior); 'infinite' = one ongoing conversation shared
   // by the main window and the overlay.
   chatHistoryMode: 'per-launch' | 'infinite'
+  // Runtime backing chat and agent tasks. 'auto' uses native Pi/Omi first, then
+  // Omi hosted if Pi is explicitly disabled; BYOK is handled by its own split.
+  chatRuntimeMode: 'auto' | 'omi-hosted' | 'pi' | 'claude-acp'
+  // Skills selected in Integrations -> Skills. Optional until the skills UI split lands.
+  enabledSkillIds?: string[]
   recordingConsentedAt?: number
   // The single goal the user picked during onboarding ("Pick one goal"). Stored
   // locally and best-effort synced to the Omi goals backend.
@@ -49,7 +54,8 @@ const defaults: Preferences = {
   // Infinite by default: one ongoing conversation that persists across launches
   // and is accessible from the beginning (the Home thread windows it in as you
   // scroll up). Users can switch back to 'per-launch' in Settings.
-  chatHistoryMode: 'infinite'
+  chatHistoryMode: 'infinite',
+  chatRuntimeMode: 'auto'
 }
 
 function load(): Preferences {

--- a/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
+++ b/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
@@ -90,7 +90,11 @@ async function runWithProvider(run: TaskAgentRun): Promise<void> {
     case 'pi': {
       if (!window.omi.piChatEnabled) throw new Error('Pi/Omi chat is not enabled in this build.')
       const token = await auth.currentUser?.getIdToken()
-      const response = await window.omi.piChatSend({ token: token ?? '', messages })
+      const response = await window.omi.piChatSend({
+        token: token ?? '',
+        messages,
+        skillIds: getPreferences().enabledSkillIds ?? []
+      })
       updateRun(run.id, {
         status: 'completed',
         result: response.text,

--- a/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
+++ b/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import { auth } from './firebase'
+import { getPreferences } from './preferences'
+import { looksLikeAction, planActions } from './actionPlanner'
+import { callAgentLLM } from './agentLLM'
+import type { ChatMessage, PiChatToolCall } from '../../../shared/types'
+
+export type TaskAgentProvider = 'pi' | 'claude-acp'
+export type TaskAgentStatus = 'queued' | 'running' | 'waiting-approval' | 'completed' | 'failed'
+
+export type TaskAgentRun = {
+  id: string
+  prompt: string
+  provider: TaskAgentProvider
+  status: TaskAgentStatus
+  createdAt: number
+  updatedAt: number
+  result?: string
+  error?: string
+  toolCalls: PiChatToolCall[]
+  events: string[]
+}
+
+type StartRequest = {
+  prompt: string
+  provider: TaskAgentProvider
+}
+
+const runs: TaskAgentRun[] = []
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function snapshot(): TaskAgentRun[] {
+  return [...runs].sort((a, b) => b.createdAt - a.createdAt)
+}
+
+function updateRun(id: string, patch: Partial<TaskAgentRun>): void {
+  const run = runs.find((item) => item.id === id)
+  if (!run) return
+  Object.assign(run, patch, { updatedAt: Date.now() })
+  emit()
+}
+
+function addEvent(id: string, event: string): void {
+  const run = runs.find((item) => item.id === id)
+  if (!run) return
+  run.events = [...run.events, event]
+  run.updatedAt = Date.now()
+  emit()
+}
+
+async function maybeRunAutomation(id: string, prompt: string): Promise<boolean> {
+  if (!looksLikeAction(prompt)) return false
+  if (!window.omi.automationEnabled || !getPreferences().automationConsentedAt) {
+    throw new Error('UI automation needs the Privacy setting enabled before an agent task can act.')
+  }
+  addEvent(id, 'Planning UI action')
+  const handle = await window.omi.automationTargetWindow().catch(() => null)
+  const result = await planActions(prompt, {
+    getSnapshot: () => window.omi.automationSnapshot(handle ?? undefined),
+    callLLM: callAgentLLM
+  })
+  if (!result.ok) {
+    if (result.kind === 'chat') return false
+    throw new Error(`Could not build a safe UI plan: ${result.reason}`)
+  }
+  updateRun(id, { status: 'waiting-approval' })
+  addEvent(id, 'Waiting for native approval')
+  const approval = await window.omi.automationConfirmRun(result.plan)
+  if (approval.canceled) {
+    throw new Error('User canceled the UI action.')
+  }
+  if (!approval.ok) {
+    throw new Error(approval.message ?? 'UI action failed.')
+  }
+  updateRun(id, {
+    status: 'completed',
+    result: 'Completed approved UI action.'
+  })
+  addEvent(id, 'Approved UI action completed')
+  return true
+}
+
+async function runWithProvider(run: TaskAgentRun): Promise<void> {
+  const messages: ChatMessage[] = [{ role: 'user', content: run.prompt }]
+  switch (run.provider) {
+    case 'pi': {
+      if (!window.omi.piChatEnabled) throw new Error('Pi/Omi chat is not enabled in this build.')
+      const token = await auth.currentUser?.getIdToken()
+      const response = await window.omi.piChatSend({ token: token ?? '', messages })
+      updateRun(run.id, {
+        status: 'completed',
+        result: response.text,
+        toolCalls: response.toolCalls
+      })
+      addEvent(run.id, `${response.toolCalls.length} local tool call(s)`)
+      return
+    }
+    case 'claude-acp': {
+      const response = await window.omi.claudeAcpChatSend({ messages })
+      updateRun(run.id, { status: 'completed', result: response.text })
+      return
+    }
+  }
+}
+
+async function executeRun(run: TaskAgentRun): Promise<void> {
+  updateRun(run.id, { status: 'running' })
+  addEvent(run.id, `Started with ${run.provider === 'pi' ? 'Pi/Omi' : 'Claude account'}`)
+  try {
+    const handledByAutomation = await maybeRunAutomation(run.id, run.prompt)
+    if (!handledByAutomation) await runWithProvider(run)
+  } catch (e) {
+    updateRun(run.id, {
+      status: 'failed',
+      error: (e as Error).message
+    })
+  }
+}
+
+export function enqueueTaskAgentRun(request: StartRequest): TaskAgentRun {
+  const prompt = request.prompt.trim()
+  if (!prompt) throw new Error('Task prompt is required')
+  const now = Date.now()
+  const run: TaskAgentRun = {
+    id: `agent-task-${crypto.randomUUID()}`,
+    prompt,
+    provider: request.provider,
+    status: 'queued',
+    createdAt: now,
+    updatedAt: now,
+    toolCalls: [],
+    events: []
+  }
+  runs.unshift(run)
+  emit()
+  void executeRun(run)
+  return run
+}
+
+export function subscribeTaskAgentRuns(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getTaskAgentRunsSnapshot(): TaskAgentRun[] {
+  return snapshot()
+}
+
+export function useTaskAgentRuns(): TaskAgentRun[] {
+  const [value, setValue] = useState<TaskAgentRun[]>(() => getTaskAgentRunsSnapshot())
+  useEffect(() => subscribeTaskAgentRuns(() => setValue(getTaskAgentRunsSnapshot())), [])
+  return value
+}

--- a/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
+++ b/desktop/windows/src/renderer/src/lib/taskAgentQueue.ts
@@ -88,7 +88,8 @@ async function runWithProvider(run: TaskAgentRun): Promise<void> {
   const messages: ChatMessage[] = [{ role: 'user', content: run.prompt }]
   switch (run.provider) {
     case 'pi': {
-      if (!window.omi.piChatEnabled) throw new Error('Pi/Omi chat is not enabled in this build.')
+      const piStatus = await window.omi.piChatStatus()
+      if (!piStatus.enabled) throw new Error('Pi/Omi chat is not enabled in this build.')
       const token = await auth.currentUser?.getIdToken()
       const response = await window.omi.piChatSend({
         token: token ?? '',

--- a/desktop/windows/src/renderer/src/pages/Settings.tsx
+++ b/desktop/windows/src/renderer/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { SettingsSearchProvider, useSettingsSearch } from '../components/setting
 import { SettingsTabRail } from '../components/settings/SettingsTabRail'
 import { SettingsTabPanel } from '../components/settings/SettingsTabPanel'
 import { SETTINGS_TABS, type SettingsTabId } from '../components/settings/tabs'
+import { AIChatTab } from '../components/settings/tabs/AIChatTab'
 import { GeneralTab } from '../components/settings/tabs/GeneralTab'
 import { RewindTab } from '../components/settings/tabs/RewindTab'
 import { PrivacyTab } from '../components/settings/tabs/PrivacyTab'
@@ -15,6 +16,7 @@ import { Memories } from './Memories'
 // management UI), so it isn't a simple searchable settings panel — it's handled
 // separately below and is intentionally absent from this map.
 const TAB_COMPONENTS: Partial<Record<SettingsTabId, () => React.JSX.Element>> = {
+  'ai-chat': AIChatTab,
   general: GeneralTab,
   rewind: RewindTab,
   privacy: PrivacyTab,

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -1,11 +1,31 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ListChecks, Check, RefreshCw, Plus, Trash2, Calendar, X, Loader2 } from 'lucide-react'
+import {
+  ListChecks,
+  Check,
+  RefreshCw,
+  Plus,
+  Trash2,
+  Calendar,
+  X,
+  Loader2,
+  Bot,
+  Play,
+  ShieldCheck,
+  Terminal,
+  XCircle
+} from 'lucide-react'
 import { omiApi } from '../lib/apiClient'
 import { PageHeader } from '../components/layout/PageHeader'
 import { TasksGoalsToggle } from '../components/layout/TasksGoalsToggle'
 import { EmptyState } from '../components/ui/EmptyState'
 import { toast } from '../lib/toast'
+import {
+  enqueueTaskAgentRun,
+  useTaskAgentRuns,
+  type TaskAgentProvider,
+  type TaskAgentRun
+} from '../lib/taskAgentQueue'
 
 // First-class action item, as returned by GET /v1/action-items. This is the
 // same source the Omi webapp reads from — so manually-created tasks and due
@@ -140,6 +160,86 @@ const BUCKET_LABEL: Record<Bucket, string> = {
   nodate: 'No due date'
 }
 
+const AGENT_STATUS_CLASS: Record<TaskAgentRun['status'], string> = {
+  queued: 'text-white/45',
+  running: 'text-sky-200/90',
+  'waiting-approval': 'text-amber-200/90',
+  completed: 'text-emerald-200/90',
+  failed: 'text-rose-200/90'
+}
+
+function agentStatusLabel(status: TaskAgentRun['status']): string {
+  switch (status) {
+    case 'queued':
+      return 'Queued'
+    case 'running':
+      return 'Running'
+    case 'waiting-approval':
+      return 'Waiting approval'
+    case 'completed':
+      return 'Completed'
+    case 'failed':
+      return 'Failed'
+  }
+}
+
+function AgentRunRow({ run }: { run: TaskAgentRun }): React.JSX.Element {
+  return (
+    <li className="rounded-md border border-white/[0.08] bg-black/15 p-3">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white/[0.06] text-white/65">
+          {run.status === 'failed' ? (
+            <XCircle className="h-4 w-4 text-rose-200/90" />
+          ) : run.status === 'completed' ? (
+            <Check className="h-4 w-4 text-emerald-200/90" />
+          ) : run.status === 'waiting-approval' ? (
+            <ShieldCheck className="h-4 w-4 text-amber-200/90" />
+          ) : (
+            <Terminal className="h-4 w-4" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`text-xs font-semibold ${AGENT_STATUS_CLASS[run.status]}`}>
+              {agentStatusLabel(run.status)}
+            </span>
+            <span className="text-xs text-white/35">
+              {run.provider === 'pi' ? 'Pi/Omi' : 'Claude account'}
+            </span>
+          </div>
+          <div className="mt-1 line-clamp-2 text-sm text-white/80">{run.prompt}</div>
+          {run.result && (
+            <div className="mt-2 text-xs leading-relaxed text-white/55">{run.result}</div>
+          )}
+          {run.error && (
+            <div className="mt-2 text-xs leading-relaxed text-rose-100/80">{run.error}</div>
+          )}
+          {(run.toolCalls.length > 0 || run.events.length > 0) && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {run.toolCalls.map((call) => (
+                <span
+                  key={call.id}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.04] px-1.5 py-0.5 text-[11px] text-white/45"
+                >
+                  {call.name}
+                </span>
+              ))}
+              {run.events.map((event, i) => (
+                <span
+                  key={`${event}-${i}`}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.04] px-1.5 py-0.5 text-[11px] text-white/45"
+                >
+                  {event}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  )
+}
+
 export function Tasks(): React.JSX.Element {
   const [items, setItems] = useState<ActionItem[]>(cache.items ?? [])
   const [convs, setConvs] = useState<Record<string, ConvMeta>>(cache.convs)
@@ -152,6 +252,9 @@ export function Tasks(): React.JSX.Element {
   const [draft, setDraft] = useState('')
   const [draftDue, setDraftDue] = useState('')
   const [saving, setSaving] = useState(false)
+  const [agentPrompt, setAgentPrompt] = useState('')
+  const [agentProvider, setAgentProvider] = useState<TaskAgentProvider>('pi')
+  const agentRuns = useTaskAgentRuns()
 
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editDraft, setEditDraft] = useState('')
@@ -258,6 +361,16 @@ export function Tasks(): React.JSX.Element {
       toast('Could not create task', { tone: 'error', body: apiError(e) })
     } finally {
       setSaving(false)
+    }
+  }
+
+  const startAgentTask = (): void => {
+    try {
+      enqueueTaskAgentRun({ prompt: agentPrompt, provider: agentProvider })
+      setAgentPrompt('')
+      toast('Agent task queued', { tone: 'success' })
+    } catch (e) {
+      toast('Could not queue agent task', { tone: 'error', body: (e as Error).message })
     }
   }
 
@@ -479,6 +592,53 @@ export function Tasks(): React.JSX.Element {
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-10 lg:py-8">
+        <div className="mx-auto mb-5 max-w-3xl">
+          <div className="surface-card animate-fade-in p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-white/85">
+              <Bot className="h-4 w-4 text-white/55" />
+              Agent queue
+            </div>
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_150px_auto]">
+              <input
+                value={agentPrompt}
+                onChange={(e) => setAgentPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') startAgentTask()
+                }}
+                placeholder="Describe the task for an agent"
+                className="input-field"
+              />
+              <select
+                value={agentProvider}
+                onChange={(e) => setAgentProvider(e.target.value as TaskAgentProvider)}
+                className="rounded-lg border border-white/[0.08] bg-black/20 px-3 text-sm text-white focus:border-white/25 focus:outline-none"
+              >
+                <option value="pi" className="bg-neutral-900">
+                  Pi/Omi
+                </option>
+                <option value="claude-acp" className="bg-neutral-900">
+                  Claude
+                </option>
+              </select>
+              <button
+                onClick={startAgentTask}
+                disabled={!agentPrompt.trim()}
+                className="btn-primary inline-flex items-center gap-2 px-4 py-2 disabled:opacity-40"
+              >
+                <Play className="h-4 w-4" />
+                Run
+              </button>
+            </div>
+            {agentRuns.length > 0 && (
+              <ul className="mt-3 space-y-2">
+                {agentRuns.slice(0, 5).map((run) => (
+                  <AgentRunRow key={run.id} run={run} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
         {composing && (
           <div className="mx-auto mb-5 max-w-3xl">
             <div className="surface-card animate-fade-in p-4">

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -75,6 +75,21 @@ export type PiChatResponse = {
   toolCalls: PiChatToolCall[]
 }
 
+export type ClaudeAcpStatus = {
+  configured: boolean
+  command: string
+  authenticated: boolean | null
+  reason?: string
+}
+
+export type ClaudeAcpChatRequest = {
+  messages: ChatMessage[]
+}
+
+export type ClaudeAcpChatResponse = {
+  text: string
+}
+
 // Capture modes a recording session can start in. 'mic' = audio only;
 // 'screen' = mic + screen capture + system audio (both audio streams
 // transcribed independently).
@@ -266,6 +281,8 @@ export type OmiBridgeApi = {
   /** Opt-in Pi/Omi chat bridge. Normal chat keeps /v2/messages unless this flag is true. */
   piChatEnabled: boolean
   piChatSend: (request: PiChatRequest) => Promise<PiChatResponse>
+  claudeAcpStatus: () => Promise<ClaudeAcpStatus>
+  claudeAcpChatSend: (request: ClaudeAcpChatRequest) => Promise<ClaudeAcpChatResponse>
   // Integrations (3e): read local Windows Sticky Notes for import. The renderer
   // synthesizes the returned note text and writes /v3/memories itself (it holds
   // the auth token).

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -52,6 +52,29 @@ export type ConversationPayload = {
 
 export type ChatMessage = { id?: string; role: 'user' | 'assistant'; content: string }
 
+export type PiChatRequest = {
+  /** Firebase ID token. Main fails closed when this is absent or blank. */
+  token: string
+  messages: ChatMessage[]
+}
+
+export type PiChatUsage = {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+}
+
+export type PiChatToolCall = {
+  id: string
+  name: string
+}
+
+export type PiChatResponse = {
+  text: string
+  usage: PiChatUsage
+  toolCalls: PiChatToolCall[]
+}
+
 // Capture modes a recording session can start in. 'mic' = audio only;
 // 'screen' = mic + screen capture + system audio (both audio streams
 // transcribed independently).
@@ -240,6 +263,9 @@ export type OmiBridgeApi = {
   kgSearchFiles: (q: string, fileType?: string, limit?: number) => Promise<IndexedFileRecord[]>
   /** Run a single read-only SELECT against the local DB (sqlGuard-validated). */
   kgExecuteSql: (sql: string) => Promise<KgSqlResult>
+  /** Opt-in Pi/Omi chat bridge. Normal chat keeps /v2/messages unless this flag is true. */
+  piChatEnabled: boolean
+  piChatSend: (request: PiChatRequest) => Promise<PiChatResponse>
   // Integrations (3e): read local Windows Sticky Notes for import. The renderer
   // synthesizes the returned note text and writes /v3/memories itself (it holds
   // the auth token).

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -619,6 +619,25 @@ export type RewindFrame = {
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
 }
 
+export type RewindFrameImageOk = {
+  ok: true
+  id: number
+  ts: number
+  app: string
+  windowTitle: string
+  ocrPreview: string
+  imageMimeType: string
+  imageBase64: string
+}
+
+export type RewindFrameImageNotFound = {
+  ok: false
+  code: 'not_found'
+  message: string
+}
+
+export type RewindFrameImageResult = RewindFrameImageOk | RewindFrameImageNotFound
+
 export type RewindSearchGroup = {
   id: string
   app: string

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -59,10 +59,6 @@ export type PiChatRequest = {
   skillIds?: string[]
 }
 
-export type PiChatStreamRequest = PiChatRequest & {
-  sessionId: string
-}
-
 export type PiChatUsage = {
   promptTokens: number
   completionTokens: number
@@ -79,31 +75,6 @@ export type PiChatResponse = {
   usage: PiChatUsage
   toolCalls: PiChatToolCall[]
 }
-
-export type PiChatStartResponse = {
-  sessionId: string
-}
-
-export type PiChatAbortResponse = {
-  aborted: boolean
-}
-
-export type PiChatStreamEvent =
-  | { sessionId: string; type: 'started' }
-  | { sessionId: string; type: 'delta'; text: string }
-  | { sessionId: string; type: 'thinking'; text: string }
-  | { sessionId: string; type: 'tool_start'; toolCall: PiChatToolCall; preview?: string }
-  | { sessionId: string; type: 'tool_delta'; toolCall: PiChatToolCall; preview: string }
-  | {
-      sessionId: string
-      type: 'tool_result'
-      toolCall: PiChatToolCall
-      ok: boolean
-      preview: string
-    }
-  | { sessionId: string; type: 'done'; response: PiChatResponse }
-  | { sessionId: string; type: 'error'; message: string }
-  | { sessionId: string; type: 'aborted' }
 
 export type ClaudeAcpStatus = {
   configured: boolean
@@ -311,9 +282,6 @@ export type OmiBridgeApi = {
   /** Opt-in Pi/Omi chat bridge. Normal chat keeps /v2/messages unless this flag is true. */
   piChatEnabled: boolean
   piChatSend: (request: PiChatRequest) => Promise<PiChatResponse>
-  piChatStart: (request: PiChatStreamRequest) => Promise<PiChatStartResponse>
-  piChatAbort: (sessionId: string) => Promise<PiChatAbortResponse>
-  onPiChatEvent: (cb: (event: PiChatStreamEvent) => void) => () => void
   claudeAcpStatus: () => Promise<ClaudeAcpStatus>
   claudeAcpChatSend: (request: ClaudeAcpChatRequest) => Promise<ClaudeAcpChatResponse>
   // Integrations (3e): read local Windows Sticky Notes for import. The renderer

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -59,6 +59,10 @@ export type PiChatRequest = {
   skillIds?: string[]
 }
 
+export type PiChatStreamRequest = PiChatRequest & {
+  sessionId: string
+}
+
 export type PiChatUsage = {
   promptTokens: number
   completionTokens: number
@@ -75,6 +79,31 @@ export type PiChatResponse = {
   usage: PiChatUsage
   toolCalls: PiChatToolCall[]
 }
+
+export type PiChatStartResponse = {
+  sessionId: string
+}
+
+export type PiChatAbortResponse = {
+  aborted: boolean
+}
+
+export type PiChatStreamEvent =
+  | { sessionId: string; type: 'started' }
+  | { sessionId: string; type: 'delta'; text: string }
+  | { sessionId: string; type: 'thinking'; text: string }
+  | { sessionId: string; type: 'tool_start'; toolCall: PiChatToolCall; preview?: string }
+  | { sessionId: string; type: 'tool_delta'; toolCall: PiChatToolCall; preview: string }
+  | {
+      sessionId: string
+      type: 'tool_result'
+      toolCall: PiChatToolCall
+      ok: boolean
+      preview: string
+    }
+  | { sessionId: string; type: 'done'; response: PiChatResponse }
+  | { sessionId: string; type: 'error'; message: string }
+  | { sessionId: string; type: 'aborted' }
 
 export type ClaudeAcpStatus = {
   configured: boolean
@@ -282,6 +311,9 @@ export type OmiBridgeApi = {
   /** Opt-in Pi/Omi chat bridge. Normal chat keeps /v2/messages unless this flag is true. */
   piChatEnabled: boolean
   piChatSend: (request: PiChatRequest) => Promise<PiChatResponse>
+  piChatStart: (request: PiChatStreamRequest) => Promise<PiChatStartResponse>
+  piChatAbort: (sessionId: string) => Promise<PiChatAbortResponse>
+  onPiChatEvent: (cb: (event: PiChatStreamEvent) => void) => () => void
   claudeAcpStatus: () => Promise<ClaudeAcpStatus>
   claudeAcpChatSend: (request: ClaudeAcpChatRequest) => Promise<ClaudeAcpChatResponse>
   // Integrations (3e): read local Windows Sticky Notes for import. The renderer

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -91,6 +91,24 @@ export type ListenMessage =
   | { sessionId: string; kind: 'error'; message: string; fatal: boolean }
   | { sessionId: string; kind: 'closed'; code: number; reason: string }
 
+export type LocalAgentStatus = {
+  enabled: boolean
+  running: boolean
+  host: string
+  configuredPort: number
+  currentPort: number | null
+  localUrl: string | null
+  toolEndpoint: string | null
+  hasToken: boolean
+}
+
+export type LocalAgentToolsTestResult = {
+  ok: boolean
+  status?: number
+  toolCount?: number
+  error?: string
+}
+
 export type OmiOverlayApi = {
   /** Subscribe to summon events; callback fires each time the overlay is shown. Returns an unsubscribe fn. */
   onShown: (cb: () => void) => () => void
@@ -161,6 +179,12 @@ export type OmiBridgeApi = {
   listenFeed: (sessionId: string, pcm: ArrayBuffer) => void
   /** Subscribe to status/segment/event messages from every listen session. */
   onListenMessage: (cb: (msg: ListenMessage) => void) => () => void
+  localAgentStatus: () => Promise<LocalAgentStatus>
+  localAgentSetEnabled: (enabled: boolean) => Promise<LocalAgentStatus>
+  localAgentSetPort: (port: number) => Promise<LocalAgentStatus>
+  localAgentCopyToken: () => Promise<LocalAgentStatus>
+  localAgentRotateToken: () => Promise<LocalAgentStatus>
+  localAgentTestTools: () => Promise<LocalAgentToolsTestResult>
   indexFilesScan: () => Promise<FileIndexStatus>
   indexFilesStatus: () => Promise<FileIndexStatus>
   /** Indexed installed apps (Start-Menu shortcuts), newest-modified first. */

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -76,6 +76,10 @@ export type PiChatResponse = {
   toolCalls: PiChatToolCall[]
 }
 
+export type PiChatStatus = {
+  enabled: boolean
+}
+
 export type ClaudeAcpStatus = {
   configured: boolean
   command: string
@@ -279,8 +283,8 @@ export type OmiBridgeApi = {
   kgSearchFiles: (q: string, fileType?: string, limit?: number) => Promise<IndexedFileRecord[]>
   /** Run a single read-only SELECT against the local DB (sqlGuard-validated). */
   kgExecuteSql: (sql: string) => Promise<KgSqlResult>
-  /** Opt-in Pi/Omi chat bridge. Normal chat keeps /v2/messages unless this flag is true. */
-  piChatEnabled: boolean
+  /** Authoritative Pi/Omi chat bridge status from the main process. */
+  piChatStatus: () => Promise<PiChatStatus>
   piChatSend: (request: PiChatRequest) => Promise<PiChatResponse>
   claudeAcpStatus: () => Promise<ClaudeAcpStatus>
   claudeAcpChatSend: (request: ClaudeAcpChatRequest) => Promise<ClaudeAcpChatResponse>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -56,6 +56,7 @@ export type PiChatRequest = {
   /** Firebase ID token. Main fails closed when this is absent or blank. */
   token: string
   messages: ChatMessage[]
+  skillIds?: string[]
 }
 
 export type PiChatUsage = {


### PR DESCRIPTION
> **Maintainers:** one of several independent Windows split PRs carved out of #8404. Each is small and standalone — **cherry-pick or merge whichever you want, in any order**; they do not depend on each other beyond shared plumbing. Base is v0.11.542 (`84e539a`). Full context: BasedHardware/omi#8404.

---

## Summary

Split **5 of the PR 8404 breakup** (Claude subprocess routing + Pi/Omi chat routing — one of the sensitive surfaces the maintainer called out). Branch: `split/pr8404-pi-claude-routing`.

- Adds Pi/Omi chat routing and Claude ACP (subprocess) routing through the local agent path.
- Keeps Pi routing separate from BYOK and native streaming.

## Scope

- **In scope:** `desktop/windows/src/main/pi/chatBridge.*`, `src/main/ipc/piChat.ts`, `src/main/claudeAcp/*`, `src/main/ipc/claudeAcp.ts`, and the renderer wiring for Pi chat / Claude command status.
- **Explicitly out of scope (by design):** BYOK routing and native streaming.

## Split Overlap & Merge Order — READ THIS

- Split #5 in [SPLIT_MAP.md](../SPLIT_MAP.md). **Land after `local-agent-tools`.**
- **This branch currently also contains the full `local-agent` implementation** (`src/main/localAgent/{server,tokenStore,tools,control}.ts`, `ipc/localAgent.ts`, `AdvancedTab.tsx`), byte-identical to the `local-agent-tools` branch, plus `rewind/frameImage.ts`. That code is **not the subject of this PR** — it rode along because Claude ACP routing goes through the local-agent path and the split was cut from the same integration branch.
  - **Do not review the local-agent code here.** It is authoritatively reviewed in `local-agent-tools` (+ `local-agent-design`).
  - Preferred resolution before non-draft: land `local-agent-tools` first, then rebase this branch so the local-agent files drop out of its diff and this PR narrows to Pi/Claude routing only.
- (This corrects an earlier draft of this note, which incorrectly claimed local-agent surfaces were entirely outside this split.)

## Windows Desktop Verification Evidence

- **Package check** (`_package-evidence/20260628-083433`): OK — `koffi.node`, `app.asar`, packaged config strings present.
- **Launch smoke** (`_smoke-evidence/20260627-194234`): launch **pass**, title `omi`, unit tests **pass**.
- **Independent unit re-run (2026-07-01, vitest 3.2.6):** `pi/chatBridge` → **4 tests passing**.
- **Feature capture** (`_feature-renderer-evidence/20260628-084516`): launched with `OMI_WINDOWS_PI_CHAT=1` and captured the packaged renderer. Status probe: `piChatEnabled=true; claudeAcpStatus.configured=true; claudeAcpStatus.command=claude; claudeAcpStatus.authenticated=null`.
  - Note: the captured home text still shows a stale "Pi/Omi chat is not enabled in this build" string from prior profile state; do not cite that screenshot as proof Pi chat is live. The status probe is the authoritative signal.
- **Recorded source check** (TESTING.md): `npm run build`.

## Addresses Maintainer Review Notes (BasedHardware/omi#8404)

- Covers the "Claude subprocess integration" and "Pi chat routing" surfaces the maintainer listed as needing separate review.
- No Pi/Omi chat send or Claude ACP chat send was performed against the real account during prep.
- Review should verify BYOK routing and native streaming remain outside this split, and that the local-agent code is reviewed in its own split rather than here.

## Screenshots

The **AI Chat** settings tab — the knobs for this feature: **Chat runtime** selector (Pi/Omi ↔ Claude routing) and **Claude account status / Check**:


The per-task routing in action — the Tasks Agent queue, where a task is routed to **Pi/Omi** or **Claude** and run:


_Runtime probe also confirms `piChatEnabled=true`, `claudeAcpStatus.command=claude`._

## Split Completeness Note

An initial cut of this split had the per-task routing selector (Tasks) but not the **AI Chat settings tab** (`AIChatTab` — Chat runtime selector + Claude account status). That tab has since been ported in and validated: registered in the settings nav, mapped in `Settings.tsx`, IPC (`claudeAcpStatus`, `piChatEnabled`) type-checks, `npm run build` passes, and the packaged build renders it (screenshot above).

## Remaining Checks Before Non-Draft

- Rebase after `local-agent-tools` lands so the duplicated local-agent code leaves this diff.
- Send a controlled Pi/Omi test message and a controlled Claude ACP test message in a disposable/test account.
- Redact screenshots before posting if personal task or conversation history is visible (see [REDACTION_NOTES.md](../REDACTION_NOTES.md)).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

