### PR TITLE
[WIN] Local STT/TTS (Parakeet/Kokoro)

### DIFF
--- a/desktop/windows/.gitignore
+++ b/desktop/windows/.gitignore
@@ -50,3 +50,4 @@ resources/win-ocr-helper/*.pdb
 src/main/automation/helper/bin/
 src/main/automation/helper/obj/
 resources/win-automation-helper/*.pdb
+resources/koffi/

--- a/desktop/windows/electron-builder.yml
+++ b/desktop/windows/electron-builder.yml
@@ -19,7 +19,17 @@ asarUnpack:
   # koffi loads its native .node at runtime, resolved relative to its own package
   # dir — it must live outside the asar archive or the foreground monitor fails.
   - node_modules/koffi/**
+  # Kokoro local TTS uses Transformers.js + onnxruntime-node. The native binding
+  # and provider DLLs must be unpacked so Electron can dlopen them at runtime.
+  - node_modules/onnxruntime-node/**
+  - node_modules/.pnpm/onnxruntime-node*/node_modules/onnxruntime-node/**
+extraResources:
+  - from: resources/koffi
+    to: koffi
+    filter:
+      - '**/*'
 win:
+  icon: resources/icon.ico
   executableName: omi-windows
   target:
     - target: nsis

--- a/desktop/windows/electron.vite.config.ts
+++ b/desktop/windows/electron.vite.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  main: {},
+  main: {
+    build: {
+      rollupOptions: {
+        external: ['kokoro-js', '@huggingface/transformers', 'onnxruntime-node']
+      }
+    }
+  },
   preload: {},
   renderer: {
     // Pin the dev server to a fixed port so the renderer's origin

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,15 +16,17 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs",
-    "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "npm run build && electron-builder --win --x64",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
+    "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/bench/run.mjs",
-    "bench:anim": "node scripts/bench/anim.mjs"
+    "bench:anim": "node scripts/bench/anim.mjs",
+    "prepare:koffi": "node scripts/ensure-koffi-win32-native.mjs",
+    "verify:win-koffi": "node scripts/verify-win-koffi-native.mjs"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@huggingface/transformers": "^3.8.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-scroll-area": "^1.2.10",
@@ -44,6 +45,7 @@
     "d3-force-3d": "^3.0.6",
     "firebase": "^12.13.0",
     "koffi": "^3.0.2",
+    "kokoro-js": "^1.2.1",
     "lucide-react": "^1.16.0",
     "react-router-dom": "^7.15.1",
     "tailwind-merge": "^3.6.0",

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -16,7 +16,7 @@
     "build": "npm run typecheck && electron-vite build",
     "rebuild:sqlite": "electron-rebuild -f -w better-sqlite3",
     "build:ocr-helper": "powershell -ExecutionPolicy Bypass -File scripts/build-ocr-helper.ps1",
-    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && npm run prepare:koffi",
+    "postinstall": "electron-builder install-app-deps && electron-rebuild -f -w better-sqlite3 && node scripts/ensure-ocr-helper.mjs && node scripts/ensure-koffi-win32-native.mjs",
     "build:unpack": "npm run build && npm run prepare:koffi && electron-builder --win --x64 --dir && npm run verify:win-koffi",
     "build:win": "npm run build && npm run prepare:koffi && electron-builder --win --x64 && npm run verify:win-koffi",
     "build:mac": "electron-vite build && electron-builder --mac",

--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       d3-force-3d:
         specifier: ^3.0.6
         version: 3.0.6
-      electron-updater:
-        specifier: ^6.8.9
-        version: 6.8.9
       firebase:
         specifier: ^12.13.0
         version: 12.14.0
@@ -2197,10 +2194,6 @@ packages:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
     engines: {node: '>=12.0.0'}
 
-  builder-util-runtime@9.7.0:
-    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
-    engines: {node: '>=12.0.0'}
-
   builder-util@26.8.1:
     resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
 
@@ -2506,9 +2499,6 @@ packages:
 
   electron-to-chromium@1.5.366:
     resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
-
-  electron-updater@6.8.9:
-    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
@@ -3257,13 +3247,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.escaperegexp@4.1.2:
-    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
-
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4124,9 +4107,6 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
-
-  tiny-typed-emitter@2.1.0:
-    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -6572,13 +6552,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  builder-util-runtime@9.7.0:
-    dependencies:
-      debug: 4.4.3
-      sax: 1.6.0
-    transitivePeerDependencies:
-      - supports-color
-
   builder-util@26.8.1:
     dependencies:
       7zip-bin: 5.2.0
@@ -6927,19 +6900,6 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.366: {}
-
-  electron-updater@6.8.9:
-    dependencies:
-      builder-util-runtime: 9.7.0
-      fs-extra: 10.1.0
-      js-yaml: 4.2.0
-      lazy-val: 1.0.5
-      lodash.escaperegexp: 4.1.2
-      lodash.isequal: 4.5.0
-      semver: 7.7.4
-      tiny-typed-emitter: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   electron-vite@5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)):
     dependencies:
@@ -7895,10 +7855,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.camelcase@4.3.0: {}
-
-  lodash.escaperegexp@4.1.2: {}
-
-  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8874,8 +8830,6 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
-
-  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/desktop/windows/pnpm-lock.yaml
+++ b/desktop/windows/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.10)
       '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^3.8.1
+        version: 3.8.1
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -56,12 +56,18 @@ importers:
       d3-force-3d:
         specifier: ^3.0.6
         version: 3.0.6
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
       firebase:
         specifier: ^12.13.0
         version: 12.14.0
       koffi:
         specifier: ^3.0.2
         version: 3.0.2
+      kokoro-js:
+        specifier: ^1.2.1
+        version: 1.2.1
       lucide-react:
         specifier: ^1.16.0
         version: 1.17.0(react@19.2.7)
@@ -342,8 +348,8 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -933,11 +939,8 @@ packages:
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
-  '@huggingface/tokenizers@0.1.3':
-    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
-
-  '@huggingface/transformers@4.2.0':
-    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+  '@huggingface/transformers@3.8.1':
+    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2000,10 +2003,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2196,6 +2195,10 @@ packages:
 
   builder-util-runtime@9.5.1:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
     engines: {node: '>=12.0.0'}
 
   builder-util@26.8.1:
@@ -2503,6 +2506,9 @@ packages:
 
   electron-to-chromium@1.5.366:
     resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
+
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
@@ -3225,6 +3231,9 @@ packages:
   koffi@3.0.2:
     resolution: {integrity: sha512-YS4sGzlVMhFNNkKbkB3tcLKJxH9WGP3jHTxi4Eyx+ieMRKVz4K2i+6rebYr9ngHN36jhIW6YXnxkzBeOQ51lsw==}
 
+  kokoro-js@1.2.1:
+    resolution: {integrity: sha512-oq0HZJWis3t8lERkMJh84WLU86dpYD0EuBPtqYnLlQzyFP1OkyBRDcweAqCfhNOpltyN9j/azp1H6uuC47gShw==}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -3248,6 +3257,13 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3460,18 +3476,18 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
 
-  onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
 
-  onnxruntime-node@1.24.3:
-    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+  onnxruntime-node@1.21.0:
+    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
     os: [win32, darwin, linux]
 
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3525,6 +3541,9 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  phonemizer@1.2.1:
+    resolution: {integrity: sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4105,6 +4124,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4719,7 +4741,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4742,7 +4764,7 @@ snapshots:
       dir-compare: 4.2.0
       fs-extra: 11.3.5
       minimatch: 9.0.9
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4757,7 +4779,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5315,14 +5337,11 @@ snapshots:
 
   '@huggingface/jinja@0.5.9': {}
 
-  '@huggingface/tokenizers@0.1.3': {}
-
-  '@huggingface/transformers@4.2.0':
+  '@huggingface/transformers@3.8.1':
     dependencies:
       '@huggingface/jinja': 0.5.9
-      '@huggingface/tokenizers': 0.1.3
-      onnxruntime-node: 1.24.3
-      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      onnxruntime-node: 1.21.0
+      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.5
 
   '@humanfs/core@0.19.2':
@@ -5425,7 +5444,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -6283,8 +6302,7 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xmldom/xmldom@0.9.10':
-    optional: true
+  '@xmldom/xmldom@0.9.10': {}
 
   abbrev@4.0.0: {}
 
@@ -6293,8 +6311,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -6550,6 +6566,13 @@ snapshots:
       ieee754: 1.2.1
 
   builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util-runtime@9.7.0:
     dependencies:
       debug: 4.4.3
       sax: 1.6.0
@@ -6904,6 +6927,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.366: {}
+
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.2.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-vite@5.0.0(vite@7.3.5(@types/node@22.19.19)(jiti@1.21.7)):
     dependencies:
@@ -7834,6 +7870,11 @@ snapshots:
       '@koromix/koffi-win32-ia32': 3.0.2
       '@koromix/koffi-win32-x64': 3.0.2
 
+  kokoro-js@1.2.1:
+    dependencies:
+      '@huggingface/transformers': 3.8.1
+      phonemizer: 1.2.1
+
   lazy-val@1.0.5: {}
 
   levn@0.4.1:
@@ -7854,6 +7895,10 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8052,22 +8097,22 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+  onnxruntime-common@1.21.0: {}
 
-  onnxruntime-common@1.24.3: {}
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
 
-  onnxruntime-node@1.24.3:
+  onnxruntime-node@1.21.0:
     dependencies:
-      adm-zip: 0.5.17
       global-agent: 3.0.0
-      onnxruntime-common: 1.24.3
+      onnxruntime-common: 1.21.0
+      tar: 7.5.16
 
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
       flatbuffers: 25.9.23
       guid-typescript: 1.0.9
       long: 5.3.2
-      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
       protobufjs: 7.6.2
 
@@ -8116,6 +8161,8 @@ snapshots:
 
   pend@1.2.0: {}
 
+  phonemizer@1.2.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -8139,7 +8186,6 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-    optional: true
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8828,6 +8874,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/desktop/windows/pnpm-workspace.yaml
+++ b/desktop/windows/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ allowBuilds:
   onnxruntime-node: true
   protobufjs: true
   sharp: true
+supportedArchitectures:
+  os:
+    - current
+    - win32
+  cpu:
+    - current
+    - x64
+  libc:
+    - current

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -1,0 +1,47 @@
+import { copyFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
+const koffiEntry = requireFromRoot.resolve('koffi')
+const koffiRoot = dirname(koffiEntry)
+const koffiRequire = createRequire(koffiEntry)
+
+const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'))
+const koffiPackage = readJson(join(koffiRoot, 'package.json'))
+
+let nativePackageJson
+let source
+try {
+  const nativeEntry = koffiRequire.resolve('@koromix/koffi-win32-x64')
+  nativePackageJson = join(dirname(nativeEntry), 'package.json')
+  source = join(dirname(nativeEntry), 'win32_x64', 'koffi.node')
+} catch (error) {
+  throw new Error(
+    [
+      'Missing @koromix/koffi-win32-x64.',
+      'Run npm install from desktop/windows on Windows so npm installs win32/x64 optional dependencies.'
+    ].join(' '),
+    { cause: error }
+  )
+}
+
+const nativePackage = readJson(nativePackageJson)
+if (nativePackage.version !== koffiPackage.version) {
+  throw new Error(
+    `Koffi native package version mismatch: koffi=${koffiPackage.version}, @koromix/koffi-win32-x64=${nativePackage.version}`
+  )
+}
+
+const sourceSize = statSync(source).size
+if (sourceSize <= 0) {
+  throw new Error(`Koffi native module is empty: ${source}`)
+}
+
+const targetDir = join(projectRoot, 'resources', 'koffi', 'win32_x64')
+const target = join(targetDir, 'koffi.node')
+mkdirSync(targetDir, { recursive: true })
+copyFileSync(source, target)
+console.log(`[ensure-koffi-win32-native] staged ${target} (${sourceSize} bytes)`)

--- a/desktop/windows/scripts/ensure-koffi-win32-native.mjs
+++ b/desktop/windows/scripts/ensure-koffi-win32-native.mjs
@@ -3,6 +3,11 @@ import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+if (process.platform !== 'win32') {
+  console.log('[ensure-koffi-win32-native] skipped: Windows-only native staging')
+  process.exit(0)
+}
+
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const requireFromRoot = createRequire(join(projectRoot, 'package.json'))
 const koffiEntry = requireFromRoot.resolve('koffi')

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -1,0 +1,43 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageRoots =
+  process.argv.length > 2
+    ? process.argv.slice(2).map((path) => resolve(path))
+    : [join(projectRoot, 'dist', 'win-unpacked')]
+
+const verifyPeFile = (file) => {
+  const stat = statSync(file)
+  if (stat.size <= 0) {
+    throw new Error(`Koffi native module is empty: ${file}`)
+  }
+
+  const fd = openSync(file, 'r')
+  const header = Buffer.alloc(2)
+  try {
+    readSync(fd, header, 0, 2, 0)
+  } finally {
+    closeSync(fd)
+  }
+  if (header.toString('ascii') !== 'MZ') {
+    throw new Error(`Koffi native module is not a Windows binary: ${file}`)
+  }
+  return stat.size
+}
+
+const tried = []
+for (const root of packageRoots) {
+  const file = join(root, 'resources', 'koffi', 'win32_x64', 'koffi.node')
+  tried.push(file)
+  try {
+    const size = verifyPeFile(file)
+    console.log(`[verify-win-koffi-native] found ${file} (${size} bytes)`)
+    process.exit(0)
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+
+throw new Error(`Missing packaged Koffi native module. Checked: ${tried.join(', ')}`)

--- a/desktop/windows/scripts/verify-win-koffi-native.mjs
+++ b/desktop/windows/scripts/verify-win-koffi-native.mjs
@@ -2,6 +2,8 @@ import { closeSync, openSync, readSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+const MIN_PE_SIZE = 1024
+
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const packageRoots =
   process.argv.length > 2
@@ -10,19 +12,28 @@ const packageRoots =
 
 const verifyPeFile = (file) => {
   const stat = statSync(file)
-  if (stat.size <= 0) {
-    throw new Error(`Koffi native module is empty: ${file}`)
+  if (stat.size < MIN_PE_SIZE) {
+    throw new Error(`Koffi native module is too small to be a valid PE file: ${file}`)
   }
 
   const fd = openSync(file, 'r')
-  const header = Buffer.alloc(2)
+  const dosHeader = Buffer.alloc(64)
   try {
-    readSync(fd, header, 0, 2, 0)
+    readSync(fd, dosHeader, 0, dosHeader.length, 0)
+    if (dosHeader.subarray(0, 2).toString('ascii') !== 'MZ') {
+      throw new Error(`Koffi native module is not a Windows binary: ${file}`)
+    }
+    const peOffset = dosHeader.readUInt32LE(0x3c)
+    if (peOffset <= 0 || peOffset + 4 > stat.size) {
+      throw new Error(`Koffi native module has an invalid PE header offset: ${file}`)
+    }
+    const peSignature = Buffer.alloc(4)
+    readSync(fd, peSignature, 0, peSignature.length, peOffset)
+    if (peSignature.toString('binary') !== 'PE\u0000\u0000') {
+      throw new Error(`Koffi native module has an invalid PE signature: ${file}`)
+    }
   } finally {
     closeSync(fd)
-  }
-  if (header.toString('ascii') !== 'MZ') {
-    throw new Error(`Koffi native module is not a Windows binary: ${file}`)
   }
   return stat.size
 }

--- a/desktop/windows/src/main/env.d.ts
+++ b/desktop/windows/src/main/env.d.ts
@@ -26,14 +26,24 @@ declare namespace NodeJS {
     OMI_FORCE_PARAKEET_FAIL?: string
     /** Disable the Windows local Parakeet STT adapter entirely. */
     OMI_LOCAL_STT_DISABLED?: string
-    /** Base URL for the local Parakeet service, e.g. http://127.0.0.1:8765. */
-    OMI_LOCAL_PARAKEET_URL?: string
-    /** Alias for OMI_LOCAL_PARAKEET_URL. */
-    OMI_PARAKEET_URL?: string
     /** Test/dev override for machines where nvidia-smi is unavailable. */
     OMI_LOCAL_STT_ASSUME_NVIDIA?: string
-    /** Allow a healthy Parakeet runtime even when nvidia-smi is absent. */
+    /** Test/dev escape hatch: install CPU Parakeet when nvidia-smi is absent. */
     OMI_LOCAL_STT_ALLOW_NON_NVIDIA?: string
+    /** Test/dev escape hatch: exercise installer logic outside Windows. */
+    OMI_LOCAL_STT_ALLOW_NON_WINDOWS?: string
+    /** Test/dev override for the app-owned Parakeet runtime cache root. */
+    OMI_LOCAL_STT_RUNTIME_ROOT?: string
+    /** Test/dev override for runtime flavor; production auto-selects CUDA on NVIDIA Windows. */
+    OMI_LOCAL_STT_RUNTIME_VARIANT?: 'cuda' | 'cpu'
+    /** Test/dev override for parakeet.cpp release version, e.g. v0.3.2. */
+    OMI_LOCAL_STT_PARAKEET_CPP_VERSION?: string
+    /** Test/dev override for parakeet.cpp release asset base URL. */
+    OMI_LOCAL_STT_RELEASE_BASE?: string
+    /** Test/dev override for the GGUF model filename. */
+    OMI_LOCAL_STT_MODEL_NAME?: string
+    /** Test/dev override for the GGUF model URL. */
+    OMI_LOCAL_STT_MODEL_URL?: string
     /** The desktop-automation bridge (snapshot → plan → approve → execute real
      *  Windows UI actions) is ON by default. Set OMI_AUTOMATION='0' to disable it
      *  (kill-switch for builds that don't want the experimental feature). */

--- a/desktop/windows/src/main/env.d.ts
+++ b/desktop/windows/src/main/env.d.ts
@@ -44,6 +44,18 @@ declare namespace NodeJS {
     OMI_LOCAL_STT_MODEL_NAME?: string
     /** Test/dev override for the GGUF model URL. */
     OMI_LOCAL_STT_MODEL_URL?: string
+    /** Disable the Windows local Kokoro TTS adapter entirely. */
+    OMI_LOCAL_TTS_DISABLED?: string
+    /** Test/dev escape hatch: exercise Kokoro status/synthesis logic outside Windows. */
+    OMI_LOCAL_TTS_ALLOW_NON_WINDOWS?: string
+    /** Test/dev override for the app-owned Kokoro runtime/model cache root. */
+    OMI_LOCAL_TTS_RUNTIME_ROOT?: string
+    /** Test/dev override for the Hugging Face Kokoro ONNX model id. */
+    OMI_LOCAL_TTS_MODEL_ID?: string
+    /** Test/dev override for the Kokoro voice id, e.g. af_heart. */
+    OMI_LOCAL_TTS_VOICE?: string
+    /** Test/dev override for Kokoro ONNX quantization. Defaults to q8. */
+    OMI_LOCAL_TTS_DTYPE?: 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16'
     /** The desktop-automation bridge (snapshot → plan → approve → execute real
      *  Windows UI actions) is ON by default. Set OMI_AUTOMATION='0' to disable it
      *  (kill-switch for builds that don't want the experimental feature). */

--- a/desktop/windows/src/main/env.d.ts
+++ b/desktop/windows/src/main/env.d.ts
@@ -20,6 +20,20 @@ declare namespace NodeJS {
     OMI_PERF_LOG?: string
     /** Override the SQLite file path (used to point at the throwaway bench DB). */
     OMI_DB_PATH?: string
+    /** Force hosted/cloud STT even when a local Parakeet runtime is healthy. */
+    OMI_FORCE_CLOUD_STT?: string
+    /** Test hook mirroring macOS: make local Parakeet report unavailable. */
+    OMI_FORCE_PARAKEET_FAIL?: string
+    /** Disable the Windows local Parakeet STT adapter entirely. */
+    OMI_LOCAL_STT_DISABLED?: string
+    /** Base URL for the local Parakeet service, e.g. http://127.0.0.1:8765. */
+    OMI_LOCAL_PARAKEET_URL?: string
+    /** Alias for OMI_LOCAL_PARAKEET_URL. */
+    OMI_PARAKEET_URL?: string
+    /** Test/dev override for machines where nvidia-smi is unavailable. */
+    OMI_LOCAL_STT_ASSUME_NVIDIA?: string
+    /** Allow a healthy Parakeet runtime even when nvidia-smi is absent. */
+    OMI_LOCAL_STT_ALLOW_NON_NVIDIA?: string
     /** The desktop-automation bridge (snapshot → plan → approve → execute real
      *  Windows UI actions) is ON by default. Set OMI_AUTOMATION='0' to disable it
      *  (kill-switch for builds that don't want the experimental feature). */

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   stopAutomationTargetTracker
 } from './automation/foregroundTarget'
 import { registerScreenSynthHandlers } from './ipc/screenSynth'
+import { registerLocalTtsHandlers } from './ipc/localTts'
 import { startRendererServer, rendererBaseUrl } from './rendererServer'
 import { startRewindCapture } from './rewind/captureService'
 import { startRewindOcr } from './rewind/ocrService'
@@ -286,6 +287,7 @@ app.whenReady().then(async () => {
   registerMemoryExportHandlers()
   registerKgHandlers()
   registerIntegrationsHandlers()
+  registerLocalTtsHandlers()
   registerUsageHandlers()
   registerMemoryCleanupHandlers()
   registerRewindHandlers()

--- a/desktop/windows/src/main/ipc/localTts.ts
+++ b/desktop/windows/src/main/ipc/localTts.ts
@@ -1,0 +1,23 @@
+import { ipcMain } from 'electron'
+import type { LocalTtsSynthesizeRequest } from '../../shared/types'
+import { getManagedKokoroStatus, synthesizeWithManagedKokoro } from '../localTts/kokoroRuntime'
+
+function normalizeSynthesizeRequest(raw: unknown): LocalTtsSynthesizeRequest {
+  if (!raw || typeof raw !== 'object') throw new Error('Invalid local TTS request')
+  const record = raw as Record<string, unknown>
+  if (typeof record.text !== 'string') throw new Error('Text is required for local TTS')
+  return {
+    text: record.text,
+    voice: typeof record.voice === 'string' ? record.voice : undefined,
+    speed: typeof record.speed === 'number' ? record.speed : undefined
+  }
+}
+
+export function registerLocalTtsHandlers(): void {
+  ipcMain.handle('omi-local-tts:status', async () => {
+    return getManagedKokoroStatus()
+  })
+  ipcMain.handle('omi-local-tts:synthesize', async (_e, raw: unknown) => {
+    return synthesizeWithManagedKokoro(normalizeSynthesizeRequest(raw))
+  })
+}

--- a/desktop/windows/src/main/ipc/omiListen.test.ts
+++ b/desktop/windows/src/main/ipc/omiListen.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ListenMessage, ListenStartArgs, LocalSttStatus } from '../../shared/types'
+
+const hoisted = vi.hoisted(() => {
+  const wsInstances: Array<{ url: string }> = []
+
+  class MockWebSocket {
+    static OPEN = 1
+    url: string
+    binaryType = ''
+    readyState = 0
+    handlers = new Map<string, (...args: unknown[]) => void>()
+
+    constructor(url: string) {
+      this.url = url
+      wsInstances.push(this)
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void): void {
+      this.handlers.set(event, handler)
+    }
+
+    close(): void {
+      /* noop */
+    }
+
+    send(): void {
+      /* noop */
+    }
+  }
+
+  return {
+    MockWebSocket,
+    wsInstances,
+    handleRegistrations: new Map<string, (...args: unknown[]) => unknown>(),
+    sentMessages: [] as ListenMessage[],
+    ensureManagedParakeetRuntime: vi.fn(),
+    getLocalSttStatus: vi.fn(),
+    sessionInstances: [] as Array<{ start: ReturnType<typeof vi.fn> }>
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      hoisted.handleRegistrations.set(channel, handler)
+    }),
+    on: vi.fn()
+  },
+  webContents: {
+    fromId: vi.fn(() => ({
+      isDestroyed: () => false,
+      send: (_channel: string, msg: ListenMessage) => {
+        hoisted.sentMessages.push(msg)
+      }
+    }))
+  }
+}))
+
+vi.mock('ws', () => ({ default: hoisted.MockWebSocket }))
+
+vi.mock('../localStt/status', () => ({
+  getLocalSttStatus: hoisted.getLocalSttStatus
+}))
+
+vi.mock('../localStt/parakeetCppRuntime', () => ({
+  ensureManagedParakeetRuntime: hoisted.ensureManagedParakeetRuntime
+}))
+
+vi.mock('../localStt/parakeetCppSession', () => ({
+  ParakeetCppSession: class {
+    start = vi.fn(async () => undefined)
+    stop = vi.fn(async () => undefined)
+    feed = vi.fn()
+
+    constructor() {
+      hoisted.sessionInstances.push(this as unknown as { start: ReturnType<typeof vi.fn> })
+    }
+  }
+}))
+
+import { registerOmiListenHandlers } from './omiListen'
+
+function sttStatus(overrides: {
+  available: boolean
+  canInstall: boolean
+  reason?: string
+}): LocalSttStatus {
+  return {
+    backend: 'parakeet',
+    healthy: overrides.available,
+    available: overrides.available,
+    nvidiaAvailable: true,
+    managed: true,
+    runtime: {
+      kind: 'parakeet.cpp',
+      installState: overrides.available ? 'installed' : 'not_installed',
+      variant: 'cuda',
+      model: 'tdt_ctc-110m-q8_0.gguf',
+      canInstall: overrides.canInstall
+    },
+    reason: overrides.reason,
+    checkedAt: 1
+  }
+}
+
+let nextSession = 1
+
+function startArgs(sttMode: ListenStartArgs['sttMode']): ListenStartArgs {
+  return {
+    sessionId: `test-session-${nextSession++}`,
+    source: 'mic',
+    token: 'not.a.jwt',
+    language: 'en',
+    sttMode
+  }
+}
+
+async function invokeStart(args: ListenStartArgs): Promise<void> {
+  const handler = hoisted.handleRegistrations.get('omi-listen:start')
+  if (!handler) throw new Error('omi-listen:start handler not registered')
+  await handler({ sender: { id: 1 } }, args)
+}
+
+registerOmiListenHandlers()
+
+beforeEach(() => {
+  hoisted.wsInstances.length = 0
+  hoisted.sentMessages.length = 0
+  hoisted.sessionInstances.length = 0
+  hoisted.ensureManagedParakeetRuntime.mockReset()
+  hoisted.getLocalSttStatus.mockReset()
+})
+
+describe('omi-listen start routing', () => {
+  it('auto with an installable-but-not-installed runtime goes straight to cloud without installing', async () => {
+    hoisted.getLocalSttStatus.mockResolvedValue(sttStatus({ available: false, canInstall: true }))
+
+    await invokeStart(startArgs('auto'))
+
+    expect(hoisted.ensureManagedParakeetRuntime).not.toHaveBeenCalled()
+    expect(hoisted.sessionInstances).toHaveLength(0)
+    expect(hoisted.wsInstances).toHaveLength(1)
+    expect(hoisted.wsInstances[0].url).toContain('/v4/listen')
+    expect(hoisted.sentMessages.map((m) => m.kind)).not.toContain('error')
+    const events = hoisted.sentMessages.filter((m) => m.kind === 'event')
+    expect(events).toHaveLength(0)
+  })
+
+  it('missing sttMode defaults to auto and stays on cloud when the runtime is only installable', async () => {
+    hoisted.getLocalSttStatus.mockResolvedValue(sttStatus({ available: false, canInstall: true }))
+
+    await invokeStart(startArgs(undefined))
+
+    expect(hoisted.ensureManagedParakeetRuntime).not.toHaveBeenCalled()
+    expect(hoisted.wsInstances).toHaveLength(1)
+  })
+
+  it('explicit local-parakeet mode may install the runtime on first use', async () => {
+    hoisted.getLocalSttStatus.mockResolvedValue(sttStatus({ available: false, canInstall: true }))
+    hoisted.ensureManagedParakeetRuntime.mockResolvedValue({
+      exePath: 'C:/runtime/bin/parakeet-cli.exe',
+      modelPath: 'C:/runtime/models/tdt.gguf',
+      runtimeRoot: 'C:/runtime',
+      variant: 'cuda',
+      model: 'tdt.gguf',
+      version: 'v0.3.2'
+    })
+
+    await invokeStart(startArgs('local-parakeet'))
+
+    expect(hoisted.ensureManagedParakeetRuntime).toHaveBeenCalledWith({}, { allowInstall: true })
+    expect(hoisted.sessionInstances.length).toBeGreaterThan(0)
+    expect(hoisted.wsInstances).toHaveLength(0)
+    const events = hoisted.sentMessages.filter((m) => m.kind === 'event')
+    expect(events.map((m) => (m.kind === 'event' ? m.event.type : ''))).toContain(
+      'local_stt_installing'
+    )
+  })
+
+  it('auto with an installed runtime uses local STT without permitting installs', async () => {
+    hoisted.getLocalSttStatus.mockResolvedValue(sttStatus({ available: true, canInstall: true }))
+    hoisted.ensureManagedParakeetRuntime.mockResolvedValue({
+      exePath: 'C:/runtime/bin/parakeet-cli.exe',
+      modelPath: 'C:/runtime/models/tdt.gguf',
+      runtimeRoot: 'C:/runtime',
+      variant: 'cuda',
+      model: 'tdt.gguf',
+      version: 'v0.3.2'
+    })
+
+    await invokeStart(startArgs('auto'))
+
+    expect(hoisted.ensureManagedParakeetRuntime).toHaveBeenCalledWith({}, { allowInstall: false })
+    expect(hoisted.sessionInstances.length).toBeGreaterThan(0)
+    expect(hoisted.wsInstances).toHaveLength(0)
+  })
+
+  it('explicit local-parakeet mode fails fatally when the runtime is unsupported', async () => {
+    hoisted.getLocalSttStatus.mockResolvedValue(
+      sttStatus({ available: false, canInstall: false, reason: 'NVIDIA GPU not detected' })
+    )
+
+    await invokeStart(startArgs('local-parakeet'))
+
+    expect(hoisted.ensureManagedParakeetRuntime).not.toHaveBeenCalled()
+    expect(hoisted.wsInstances).toHaveLength(0)
+    const errors = hoisted.sentMessages.filter((m) => m.kind === 'error')
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatchObject({ message: 'NVIDIA GPU not detected', fatal: true })
+  })
+})

--- a/desktop/windows/src/main/ipc/omiListen.ts
+++ b/desktop/windows/src/main/ipc/omiListen.ts
@@ -70,7 +70,11 @@ async function startSession(args: ListenStartArgs, owner: WebContents): Promise<
   const mode = args.sttMode ?? 'auto'
   if (mode === 'local-parakeet' || mode === 'auto') {
     const status = await getLocalSttStatus()
-    if (status.available || status.runtime.canInstall) {
+    // Fail closed: 'auto' may use local Parakeet only when it is already
+    // installed and healthy. Downloading the runtime/model is allowed only for
+    // an explicit Local Parakeet selection — never as a side effect of 'auto'.
+    const allowInstall = mode === 'local-parakeet'
+    if (status.available || (allowInstall && status.runtime.canInstall)) {
       try {
         if (!status.available) {
           emit(owner.id, {
@@ -82,7 +86,7 @@ async function startSession(args: ListenStartArgs, owner: WebContents): Promise<
             }
           })
         }
-        const runtime = await ensureManagedParakeetRuntime()
+        const runtime = await ensureManagedParakeetRuntime({}, { allowInstall })
         await startLocalSession(args, owner, runtime, mode === 'auto')
       } catch (err) {
         const message = err instanceof Error ? err.message : 'local Parakeet STT unavailable'

--- a/desktop/windows/src/main/ipc/omiListen.ts
+++ b/desktop/windows/src/main/ipc/omiListen.ts
@@ -6,7 +6,11 @@ import type {
   ListenMessage,
   ListenStartArgs
 } from '../../shared/types'
-import { ParakeetStreamSession } from '../localStt/parakeetSession'
+import { ParakeetCppSession } from '../localStt/parakeetCppSession'
+import {
+  ensureManagedParakeetRuntime,
+  type ManagedParakeetRuntime
+} from '../localStt/parakeetCppRuntime'
 import { getLocalSttStatus } from '../localStt/status'
 
 function buildEndpoint(language: string): string {
@@ -25,7 +29,7 @@ function buildEndpoint(language: string): string {
 type Session = {
   backend: 'omi' | 'local-parakeet'
   ws?: WebSocket
-  local?: ParakeetStreamSession
+  local?: ParakeetCppSession
   ownerId: number // webContents id for routing replies back
   source: 'mic' | 'system'
   closed: boolean
@@ -66,8 +70,33 @@ async function startSession(args: ListenStartArgs, owner: WebContents): Promise<
   const mode = args.sttMode ?? 'auto'
   if (mode === 'local-parakeet' || mode === 'auto') {
     const status = await getLocalSttStatus()
-    if (status.available) {
-      startLocalSession(args, owner, status.configuredUrl, mode === 'auto')
+    if (status.available || status.runtime.canInstall) {
+      try {
+        if (!status.available) {
+          emit(owner.id, {
+            sessionId: args.sessionId,
+            kind: 'event',
+            event: {
+              type: 'local_stt_installing',
+              raw: { runtime: status.runtime.kind, model: status.runtime.model }
+            }
+          })
+        }
+        const runtime = await ensureManagedParakeetRuntime()
+        await startLocalSession(args, owner, runtime, mode === 'auto')
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'local Parakeet STT unavailable'
+        if (mode === 'auto') {
+          emit(owner.id, {
+            sessionId: args.sessionId,
+            kind: 'event',
+            event: { type: 'local_stt_fallback_cloud', raw: { reason: message } }
+          })
+          startCloudSession(args, owner)
+          return
+        }
+        emit(owner.id, { sessionId: args.sessionId, kind: 'error', message, fatal: true })
+      }
       return
     } else if (mode === 'local-parakeet') {
       emit(owner.id, {
@@ -83,22 +112,23 @@ async function startSession(args: ListenStartArgs, owner: WebContents): Promise<
   startCloudSession(args, owner)
 }
 
-function startLocalSession(
+async function startLocalSession(
   args: ListenStartArgs,
   owner: WebContents,
-  baseUrl: string,
+  runtime: ManagedParakeetRuntime,
   fallbackCloudOnStartupFailure: boolean
-): void {
+): Promise<void> {
   const session: Session = {
     backend: 'local-parakeet',
     ownerId: owner.id,
     source: args.source,
     closed: false
   }
-  const local = new ParakeetStreamSession({
+  const local = new ParakeetCppSession({
     sessionId: args.sessionId,
     source: args.source,
-    baseUrl,
+    language: args.language,
+    runtime,
     handlers: {
       onConnected: () => {
         emit(session.ownerId, {
@@ -123,7 +153,7 @@ function startLocalSession(
   })
   session.local = local
   sessions.set(args.sessionId, session)
-  void local.start().catch((err) => {
+  await local.start().catch((err) => {
     if (session.closed) return
     sessions.delete(args.sessionId)
     session.closed = true

--- a/desktop/windows/src/main/ipc/omiListen.ts
+++ b/desktop/windows/src/main/ipc/omiListen.ts
@@ -6,6 +6,8 @@ import type {
   ListenMessage,
   ListenStartArgs
 } from '../../shared/types'
+import { ParakeetStreamSession } from '../localStt/parakeetSession'
+import { getLocalSttStatus } from '../localStt/status'
 
 function buildEndpoint(language: string): string {
   return (
@@ -21,7 +23,9 @@ function buildEndpoint(language: string): string {
 }
 
 type Session = {
-  ws: WebSocket
+  backend: 'omi' | 'local-parakeet'
+  ws?: WebSocket
+  local?: ParakeetStreamSession
   ownerId: number // webContents id for routing replies back
   source: 'mic' | 'system'
   closed: boolean
@@ -36,13 +40,112 @@ function emit(ownerId: number, msg: ListenMessage): void {
   }
 }
 
-function startSession(args: ListenStartArgs, owner: WebContents): void {
+async function stopSession(sessionId: string): Promise<void> {
+  const s = sessions.get(sessionId)
+  if (!s) return
+  s.closed = true
+  sessions.delete(sessionId)
+  if (s.backend === 'local-parakeet' && s.local) {
+    await s.local.stop()
+    return
+  }
+  try {
+    s.ws?.close()
+  } catch {
+    /* ignore */
+  }
+}
+
+async function startSession(args: ListenStartArgs, owner: WebContents): Promise<void> {
   const existing = sessions.get(args.sessionId)
   if (existing) {
     // Already running — caller bug. Tear the old one down to avoid leaks.
-    try { existing.ws.close() } catch { /* ignore */ }
-    sessions.delete(args.sessionId)
+    await stopSession(args.sessionId)
   }
+
+  const mode = args.sttMode ?? 'auto'
+  if (mode === 'local-parakeet' || mode === 'auto') {
+    const status = await getLocalSttStatus()
+    if (status.available) {
+      startLocalSession(args, owner, status.configuredUrl, mode === 'auto')
+      return
+    } else if (mode === 'local-parakeet') {
+      emit(owner.id, {
+        sessionId: args.sessionId,
+        kind: 'error',
+        message: status.reason ?? 'local Parakeet STT unavailable',
+        fatal: true
+      })
+      return
+    }
+  }
+
+  startCloudSession(args, owner)
+}
+
+function startLocalSession(
+  args: ListenStartArgs,
+  owner: WebContents,
+  baseUrl: string,
+  fallbackCloudOnStartupFailure: boolean
+): void {
+  const session: Session = {
+    backend: 'local-parakeet',
+    ownerId: owner.id,
+    source: args.source,
+    closed: false
+  }
+  const local = new ParakeetStreamSession({
+    sessionId: args.sessionId,
+    source: args.source,
+    baseUrl,
+    handlers: {
+      onConnected: () => {
+        emit(session.ownerId, {
+          sessionId: args.sessionId,
+          kind: 'connected',
+          backend: 'local-parakeet'
+        })
+      },
+      onSegments: (segments) => {
+        emit(session.ownerId, { sessionId: args.sessionId, kind: 'segments', segments })
+      },
+      onError: (message, fatal) => {
+        emit(session.ownerId, { sessionId: args.sessionId, kind: 'error', message, fatal })
+      },
+      onClosed: (code, reason) => {
+        if (session.closed) return
+        session.closed = true
+        sessions.delete(args.sessionId)
+        emit(session.ownerId, { sessionId: args.sessionId, kind: 'closed', code, reason })
+      }
+    }
+  })
+  session.local = local
+  sessions.set(args.sessionId, session)
+  void local.start().catch((err) => {
+    if (session.closed) return
+    sessions.delete(args.sessionId)
+    session.closed = true
+    if (fallbackCloudOnStartupFailure) {
+      emit(session.ownerId, {
+        sessionId: args.sessionId,
+        kind: 'event',
+        event: { type: 'local_stt_fallback_cloud', raw: { reason: (err as Error).message } }
+      })
+      startCloudSession(args, owner)
+      return
+    }
+    emit(session.ownerId, {
+      sessionId: args.sessionId,
+      kind: 'error',
+      message: (err as Error).message,
+      fatal: true
+    })
+  })
+}
+
+function startCloudSession(args: ListenStartArgs, owner: WebContents): void {
   // Decode (not verify) the JWT to derive the uid for the query param; the
   // backend verifies the token from the Authorization header.
   let uid = ''
@@ -63,11 +166,17 @@ function startSession(args: ListenStartArgs, owner: WebContents): void {
     headers: { Authorization: `Bearer ${args.token}` }
   })
   ws.binaryType = 'arraybuffer'
-  const session: Session = { ws, ownerId: owner.id, source: args.source, closed: false }
+  const session: Session = {
+    backend: 'omi',
+    ws,
+    ownerId: owner.id,
+    source: args.source,
+    closed: false
+  }
   sessions.set(args.sessionId, session)
 
   ws.on('open', () => {
-    emit(session.ownerId, { sessionId: args.sessionId, kind: 'connected' })
+    emit(session.ownerId, { sessionId: args.sessionId, kind: 'connected', backend: 'omi' })
   })
 
   ws.on('message', (data, isBinary) => {
@@ -119,24 +228,24 @@ function startSession(args: ListenStartArgs, owner: WebContents): void {
 
 function feedSession(sessionId: string, pcm: ArrayBuffer): void {
   const s = sessions.get(sessionId)
-  if (!s || s.ws.readyState !== WebSocket.OPEN) return
+  if (!s) return
+  if (s.backend === 'local-parakeet') {
+    s.local?.feed(pcm)
+    return
+  }
+  if (s.ws?.readyState !== WebSocket.OPEN) return
   s.ws.send(pcm)
 }
 
-function stopSession(sessionId: string): void {
-  const s = sessions.get(sessionId)
-  if (!s) return
-  s.closed = true
-  sessions.delete(sessionId)
-  try { s.ws.close() } catch { /* ignore */ }
-}
-
 export function registerOmiListenHandlers(): void {
-  ipcMain.handle('omi-listen:start', (e, args: ListenStartArgs) => {
-    startSession(args, e.sender)
+  ipcMain.handle('omi-listen:start', async (e, args: ListenStartArgs) => {
+    await startSession(args, e.sender)
   })
-  ipcMain.handle('omi-listen:stop', (_e, sessionId: string) => {
-    stopSession(sessionId)
+  ipcMain.handle('omi-listen:stop', async (_e, sessionId: string) => {
+    await stopSession(sessionId)
+  })
+  ipcMain.handle('omi-local-stt:status', async () => {
+    return getLocalSttStatus()
   })
   // `on` (not `handle`) — feed is fire-and-forget to keep audio throughput cheap.
   ipcMain.on('omi-listen:feed', (_e, sessionId: string, pcm: ArrayBuffer) => {

--- a/desktop/windows/src/main/localStt/parakeetCppRuntime.test.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppRuntime.test.ts
@@ -64,6 +64,66 @@ describe('managed parakeet.cpp runtime', () => {
     expect(status.runtime.installState).toBe('installed')
   })
 
+  it('rejects without downloading anything when installs are not allowed', async () => {
+    const downloads: string[] = []
+    const deps = {
+      env: {
+        OMI_LOCAL_STT_RELEASE_BASE: 'https://downloads.example/parakeet',
+        OMI_LOCAL_STT_MODEL_URL: 'https://models.example/tdt.gguf'
+      },
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root,
+      detectNvidiaGpu: async () => true,
+      downloadFile: async (url: string): Promise<void> => {
+        downloads.push(url)
+        throw new Error('download must not be attempted when allowInstall is false')
+      },
+      extractZip: async (): Promise<void> => undefined
+    }
+
+    await expect(ensureManagedParakeetRuntime(deps, { allowInstall: false })).rejects.toThrow(
+      /not installed/
+    )
+    expect(downloads).toEqual([])
+
+    // The refusal must not poison the status: nothing was attempted, so the
+    // runtime still reports installable, not an install error.
+    const status = await getManagedParakeetStatus(deps)
+    expect(status.available).toBe(false)
+    expect(status.runtime.installState).toBe('not_installed')
+    expect(status.runtime.canInstall).toBe(true)
+  })
+
+  it('resolves an already-installed runtime even when installs are not allowed', async () => {
+    const deps = {
+      env: {
+        OMI_LOCAL_STT_RELEASE_BASE: 'https://downloads.example/parakeet',
+        OMI_LOCAL_STT_MODEL_URL: 'https://models.example/tdt.gguf'
+      },
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root,
+      detectNvidiaGpu: async () => true,
+      downloadFile: async (): Promise<void> => {
+        throw new Error('download must not be attempted for an installed runtime')
+      },
+      extractZip: async (): Promise<void> => undefined
+    }
+
+    await mkdir(join(root, 'bin'), { recursive: true })
+    await writeFile(join(root, 'bin', 'parakeet-cli.exe'), 'exe')
+    await mkdir(join(root, 'models'), { recursive: true })
+    await writeFile(join(root, 'models', 'tdt_ctc-110m-q8_0.gguf'), 'model')
+
+    const runtime = await ensureManagedParakeetRuntime(deps, { allowInstall: false })
+
+    expect(runtime).toMatchObject({
+      exePath: join(root, 'bin', 'parakeet-cli.exe'),
+      modelPath: join(root, 'models', 'tdt_ctc-110m-q8_0.gguf')
+    })
+  })
+
   it('uses the CPU artifact only when explicitly forced for test/dev', async () => {
     const downloads: string[] = []
     const deps = {

--- a/desktop/windows/src/main/localStt/parakeetCppRuntime.test.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppRuntime.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { tmpdir } from 'os'
+import {
+  ensureManagedParakeetRuntime,
+  getManagedParakeetStatus,
+  resetManagedParakeetRuntimeStateForTests
+} from './parakeetCppRuntime'
+
+let root = ''
+
+beforeEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  root = await mkdtemp(join(tmpdir(), 'omi-parakeet-runtime-'))
+})
+
+afterEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  if (root) await rm(root, { recursive: true, force: true })
+  root = ''
+})
+
+describe('managed parakeet.cpp runtime', () => {
+  it('downloads CUDA runtime assets and the GGUF model into app-owned storage', async () => {
+    const downloads: string[] = []
+    const extracts: string[] = []
+    const deps = {
+      env: {
+        OMI_LOCAL_STT_RELEASE_BASE: 'https://downloads.example/parakeet',
+        OMI_LOCAL_STT_MODEL_URL: 'https://models.example/tdt.gguf'
+      },
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root,
+      detectNvidiaGpu: async () => true,
+      downloadFile: async (url: string, destination: string): Promise<void> => {
+        downloads.push(url)
+        await mkdir(dirname(destination), { recursive: true })
+        await writeFile(destination, 'asset')
+      },
+      extractZip: async (zipPath: string, destination: string): Promise<void> => {
+        extracts.push(zipPath)
+        await mkdir(destination, { recursive: true })
+        await writeFile(join(destination, 'parakeet-cli.exe'), 'exe')
+      }
+    }
+
+    const runtime = await ensureManagedParakeetRuntime(deps)
+    const status = await getManagedParakeetStatus(deps)
+
+    expect(runtime).toMatchObject({
+      variant: 'cuda',
+      exePath: join(root, 'bin', 'parakeet-cli.exe'),
+      modelPath: join(root, 'models', 'tdt_ctc-110m-q8_0.gguf')
+    })
+    expect(downloads).toEqual([
+      'https://downloads.example/parakeet/parakeet-v0.3.2-bin-win-cuda-x64.zip',
+      'https://downloads.example/parakeet/cudart-parakeet-bin-win-cuda-x64.zip',
+      'https://models.example/tdt.gguf'
+    ])
+    expect(extracts).toHaveLength(2)
+    expect(status.available).toBe(true)
+    expect(status.runtime.installState).toBe('installed')
+  })
+
+  it('uses the CPU artifact only when explicitly forced for test/dev', async () => {
+    const downloads: string[] = []
+    const deps = {
+      env: {
+        OMI_LOCAL_STT_RUNTIME_VARIANT: 'cpu',
+        OMI_LOCAL_STT_RELEASE_BASE: 'https://downloads.example/parakeet',
+        OMI_LOCAL_STT_MODEL_URL: 'https://models.example/tdt.gguf'
+      } as NodeJS.ProcessEnv,
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root,
+      detectNvidiaGpu: async () => false,
+      downloadFile: async (url: string, destination: string): Promise<void> => {
+        downloads.push(url)
+        await mkdir(dirname(destination), { recursive: true })
+        await writeFile(destination, 'asset')
+      },
+      extractZip: async (_zipPath: string, destination: string): Promise<void> => {
+        await mkdir(destination, { recursive: true })
+        await writeFile(join(destination, 'parakeet-cli.exe'), 'exe')
+      }
+    }
+
+    const runtime = await ensureManagedParakeetRuntime(deps)
+
+    expect(runtime.variant).toBe('cpu')
+    expect(downloads).toEqual([
+      'https://downloads.example/parakeet/parakeet-v0.3.2-bin-win-cpu-x64.zip',
+      'https://models.example/tdt.gguf'
+    ])
+  })
+})

--- a/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
@@ -157,17 +157,30 @@ export async function getManagedParakeetStatus(deps: RuntimeDeps = {}): Promise<
   }
 }
 
+export type EnsureRuntimeOptions = {
+  /**
+   * When false, resolve an already-installed runtime but never download or
+   * install anything — reject instead. Only an explicit Local Parakeet
+   * selection may install; 'auto' must fail closed to the hosted cloud path.
+   */
+  allowInstall?: boolean
+}
+
 export async function ensureManagedParakeetRuntime(
-  deps: RuntimeDeps = {}
+  deps: RuntimeDeps = {},
+  options: EnsureRuntimeOptions = {}
 ): Promise<ManagedParakeetRuntime> {
   if (installPromise) return installPromise
-  installPromise = installManagedRuntime(deps).finally(() => {
+  installPromise = installManagedRuntime(deps, options.allowInstall ?? true).finally(() => {
     installPromise = null
   })
   return installPromise
 }
 
-async function installManagedRuntime(deps: RuntimeDeps): Promise<ManagedParakeetRuntime> {
+async function installManagedRuntime(
+  deps: RuntimeDeps,
+  allowInstall: boolean
+): Promise<ManagedParakeetRuntime> {
   const selection = await selectRuntime(deps)
   if (!selection.supported || !selection.variant) {
     throw new Error(selection.reason ?? 'local Parakeet runtime is not supported')
@@ -178,6 +191,14 @@ async function installManagedRuntime(deps: RuntimeDeps): Promise<ManagedParakeet
     installError = null
     installState = activeSessions > 0 ? 'running' : 'installed'
     return existing
+  }
+
+  if (!allowInstall) {
+    // Fail closed without touching installState: nothing was attempted, so the
+    // status should keep reporting 'not_installed', not an install error.
+    throw new Error(
+      'local Parakeet runtime is not installed; select Local Parakeet in Settings to install it'
+    )
   }
 
   installState = 'installing'

--- a/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
@@ -1,0 +1,522 @@
+import { spawn } from 'child_process'
+import { createWriteStream } from 'fs'
+import { access, mkdir, readdir, rename, rm } from 'fs/promises'
+import { homedir, tmpdir } from 'os'
+import { basename, dirname, join } from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { LocalSttStatus } from '../../shared/types'
+
+export const PARAKEET_CPP_VERSION = 'v0.3.2'
+export const PARAKEET_CPP_MODEL_NAME = 'tdt_ctc-110m-q8_0.gguf'
+export const PARAKEET_CPP_MODEL_URL =
+  'https://huggingface.co/mudler/parakeet-cpp-gguf/resolve/main/tdt_ctc-110m-q8_0.gguf'
+
+const NVIDIA_TIMEOUT_MS = 1200
+const INSTALL_TIMEOUT_MS = 10 * 60_000
+const EXE_NAME = 'parakeet-cli.exe'
+
+type RuntimeVariant = 'cuda' | 'cpu'
+type RuntimeInstallState = LocalSttStatus['runtime']['installState']
+
+export type ManagedParakeetRuntime = {
+  exePath: string
+  modelPath: string
+  runtimeRoot: string
+  variant: RuntimeVariant
+  model: string
+  version: string
+}
+
+type RuntimeDeps = {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform | string
+  arch?: string
+  detectNvidiaGpu?: () => Promise<boolean | null>
+  downloadFile?: (url: string, destination: string) => Promise<void>
+  extractZip?: (zipPath: string, destination: string) => Promise<void>
+  now?: () => number
+  rootDir?: string
+}
+
+type RuntimeSelection = {
+  supported: boolean
+  reason?: string
+  nvidiaAvailable: boolean | null
+  variant: RuntimeVariant | null
+  runtimeRoot: string
+  binDir: string
+  modelDir: string
+  model: string
+  modelUrl: string
+  version: string
+  releaseBase: string
+}
+
+let installPromise: Promise<ManagedParakeetRuntime> | null = null
+let installState: RuntimeInstallState | null = null
+let installError: string | null = null
+let activeSessions = 0
+
+export function managedParakeetModelName(env: NodeJS.ProcessEnv = process.env): string {
+  return env.OMI_LOCAL_STT_MODEL_NAME || PARAKEET_CPP_MODEL_NAME
+}
+
+export function resetManagedParakeetRuntimeStateForTests(): void {
+  installPromise = null
+  installState = null
+  installError = null
+  activeSessions = 0
+}
+
+export function noteManagedParakeetSessionStarted(): void {
+  activeSessions += 1
+  if (installState === 'installed' || installState === 'starting') installState = 'running'
+}
+
+export function noteManagedParakeetSessionStopped(): void {
+  activeSessions = Math.max(0, activeSessions - 1)
+  if (activeSessions === 0 && installState === 'running') installState = 'installed'
+}
+
+export async function detectNvidiaGpu(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<boolean | null> {
+  if (env.OMI_LOCAL_STT_ASSUME_NVIDIA === '1') return true
+
+  return new Promise((resolve) => {
+    const child = spawn('nvidia-smi', ['-L'], { windowsHide: true })
+    let output = ''
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        /* ignore */
+      }
+      resolve(null)
+    }, NVIDIA_TIMEOUT_MS)
+    timer.unref?.()
+
+    child.stdout.on('data', (data) => {
+      output += data.toString()
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve(null)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve(code === 0 && /GPU/i.test(output))
+    })
+  })
+}
+
+export async function getManagedParakeetStatus(deps: RuntimeDeps = {}): Promise<LocalSttStatus> {
+  const now = deps.now ?? Date.now
+  const checkedAt = now()
+  const selection = await selectRuntime(deps)
+
+  if (!selection.supported) {
+    return {
+      backend: 'parakeet',
+      healthy: false,
+      available: false,
+      nvidiaAvailable: selection.nvidiaAvailable,
+      managed: true,
+      runtime: {
+        kind: 'parakeet.cpp',
+        installState: 'unsupported',
+        variant: selection.variant,
+        model: selection.model,
+        canInstall: false
+      },
+      reason: selection.reason,
+      checkedAt
+    }
+  }
+
+  const runtime = await resolveInstalledRuntime(selection)
+  const installed = runtime != null
+  const state = runtimeInstallState(installed)
+
+  return {
+    backend: 'parakeet',
+    healthy: installed,
+    available: installed,
+    nvidiaAvailable: selection.nvidiaAvailable,
+    managed: true,
+    runtime: {
+      kind: 'parakeet.cpp',
+      installState: state,
+      variant: selection.variant,
+      model: selection.model,
+      canInstall: true
+    },
+    reason: runtimeStatusReason(state),
+    checkedAt
+  }
+}
+
+export async function ensureManagedParakeetRuntime(
+  deps: RuntimeDeps = {}
+): Promise<ManagedParakeetRuntime> {
+  if (installPromise) return installPromise
+  installPromise = installManagedRuntime(deps).finally(() => {
+    installPromise = null
+  })
+  return installPromise
+}
+
+async function installManagedRuntime(deps: RuntimeDeps): Promise<ManagedParakeetRuntime> {
+  const selection = await selectRuntime(deps)
+  if (!selection.supported || !selection.variant) {
+    throw new Error(selection.reason ?? 'local Parakeet runtime is not supported')
+  }
+
+  const existing = await resolveInstalledRuntime(selection)
+  if (existing) {
+    installError = null
+    installState = activeSessions > 0 ? 'running' : 'installed'
+    return existing
+  }
+
+  installState = 'installing'
+  installError = null
+
+  try {
+    await mkdir(selection.binDir, { recursive: true })
+    await mkdir(selection.modelDir, { recursive: true })
+
+    const artifacts = runtimeArtifacts(selection)
+    const archiveDir = join(selection.runtimeRoot, 'archives')
+    await mkdir(archiveDir, { recursive: true })
+
+    for (const artifact of artifacts) {
+      const archivePath = join(archiveDir, basename(new URL(artifact.url).pathname))
+      await ensureDownloaded(artifact.url, archivePath, deps.downloadFile)
+      await extractArchive(archivePath, selection.binDir, deps.extractZip)
+    }
+
+    const exePath = await findParakeetCli(selection.binDir)
+    if (!exePath) throw new Error('installed Parakeet runtime did not include parakeet-cli.exe')
+
+    const modelPath = join(selection.modelDir, selection.model)
+    await ensureDownloaded(selection.modelUrl, modelPath, deps.downloadFile)
+
+    const runtime = {
+      exePath,
+      modelPath,
+      runtimeRoot: selection.runtimeRoot,
+      variant: selection.variant,
+      model: selection.model,
+      version: selection.version
+    } satisfies ManagedParakeetRuntime
+
+    installState = activeSessions > 0 ? 'running' : 'installed'
+    return runtime
+  } catch (err) {
+    installError = err instanceof Error ? err.message : String(err)
+    installState = 'error'
+    throw err
+  }
+}
+
+async function selectRuntime(deps: RuntimeDeps): Promise<RuntimeSelection> {
+  const env = deps.env ?? process.env
+  const platform = deps.platform ?? process.platform
+  const arch = deps.arch ?? process.arch
+  const version = env.OMI_LOCAL_STT_PARAKEET_CPP_VERSION || PARAKEET_CPP_VERSION
+  const model = managedParakeetModelName(env)
+  const releaseBase =
+    env.OMI_LOCAL_STT_RELEASE_BASE ||
+    `https://github.com/mudler/parakeet.cpp/releases/download/${version}`
+  const runtimeRoot = deps.rootDir ?? defaultRuntimeRoot(env, platform, version)
+  const modelDir = join(runtimeRoot, 'models')
+  const binDir = join(runtimeRoot, 'bin')
+  const modelUrl = env.OMI_LOCAL_STT_MODEL_URL || PARAKEET_CPP_MODEL_URL
+  const allowNonWindows = env.OMI_LOCAL_STT_ALLOW_NON_WINDOWS === '1'
+
+  if (platform !== 'win32' && !allowNonWindows) {
+    return {
+      supported: false,
+      reason: 'Local Parakeet install is only available in the Windows app',
+      nvidiaAvailable: null,
+      variant: null,
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  if (arch !== 'x64' && arch !== 'amd64') {
+    return {
+      supported: false,
+      reason: 'Local Parakeet install requires Windows x64',
+      nvidiaAvailable: null,
+      variant: null,
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  const nvidiaAvailable =
+    deps.detectNvidiaGpu != null ? await deps.detectNvidiaGpu() : await detectNvidiaGpu(env)
+  const forcedVariant = env.OMI_LOCAL_STT_RUNTIME_VARIANT
+  const allowNonNvidia = env.OMI_LOCAL_STT_ALLOW_NON_NVIDIA === '1'
+
+  if (forcedVariant === 'cpu') {
+    return {
+      supported: true,
+      nvidiaAvailable,
+      variant: 'cpu',
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  if (forcedVariant === 'cuda') {
+    return {
+      supported: true,
+      nvidiaAvailable,
+      variant: 'cuda',
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  if (nvidiaAvailable === true) {
+    return {
+      supported: true,
+      nvidiaAvailable,
+      variant: 'cuda',
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  if (allowNonNvidia) {
+    return {
+      supported: true,
+      nvidiaAvailable,
+      variant: 'cpu',
+      runtimeRoot,
+      binDir,
+      modelDir,
+      model,
+      modelUrl,
+      version,
+      releaseBase
+    }
+  }
+
+  return {
+    supported: false,
+    reason: 'NVIDIA GPU not detected',
+    nvidiaAvailable,
+    variant: null,
+    runtimeRoot,
+    binDir,
+    modelDir,
+    model,
+    modelUrl,
+    version,
+    releaseBase
+  }
+}
+
+function defaultRuntimeRoot(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform | string,
+  version: string
+): string {
+  if (env.OMI_LOCAL_STT_RUNTIME_ROOT) return env.OMI_LOCAL_STT_RUNTIME_ROOT
+  if (platform === 'win32') {
+    const localAppData = env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+    return join(localAppData, 'Omi for Windows', 'LocalSTT', 'parakeet.cpp', version)
+  }
+  return join(tmpdir(), 'omi-windows-local-stt', 'parakeet.cpp', version)
+}
+
+function runtimeArtifacts(selection: RuntimeSelection): { url: string }[] {
+  if (selection.variant === 'cpu') {
+    return [{ url: `${selection.releaseBase}/parakeet-${selection.version}-bin-win-cpu-x64.zip` }]
+  }
+  return [
+    { url: `${selection.releaseBase}/parakeet-${selection.version}-bin-win-cuda-x64.zip` },
+    { url: `${selection.releaseBase}/cudart-parakeet-bin-win-cuda-x64.zip` }
+  ]
+}
+
+async function resolveInstalledRuntime(
+  selection: RuntimeSelection
+): Promise<ManagedParakeetRuntime | null> {
+  if (!selection.supported || !selection.variant) return null
+  const exePath = await findParakeetCli(selection.binDir)
+  if (!exePath) return null
+  const modelPath = join(selection.modelDir, selection.model)
+  if (!(await fileExists(modelPath))) return null
+  return {
+    exePath,
+    modelPath,
+    runtimeRoot: selection.runtimeRoot,
+    variant: selection.variant,
+    model: selection.model,
+    version: selection.version
+  }
+}
+
+function runtimeInstallState(installed: boolean): RuntimeInstallState {
+  if (installPromise) return 'installing'
+  if (installed) return activeSessions > 0 ? 'running' : 'installed'
+  if (installState === 'error') return 'error'
+  return 'not_installed'
+}
+
+function runtimeStatusReason(state: RuntimeInstallState): string | undefined {
+  if (state === 'installed' || state === 'running') return undefined
+  if (state === 'installing') return 'Installing local Parakeet runtime'
+  if (state === 'error') return installError ?? 'Local Parakeet install failed'
+  return 'Local Parakeet will install on first use'
+}
+
+async function ensureDownloaded(
+  url: string,
+  destination: string,
+  downloadFile = downloadFileDefault
+): Promise<void> {
+  if (await fileExists(destination)) return
+  await mkdir(dirname(destination), { recursive: true })
+  await downloadFile(url, destination)
+}
+
+async function downloadFileDefault(url: string, destination: string): Promise<void> {
+  const part = `${destination}.part`
+  await rm(part, { force: true })
+  const response = await fetch(url)
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to download Parakeet runtime asset (${response.status})`)
+  }
+
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+      createWriteStream(part)
+    )
+    await rename(part, destination)
+  } catch (err) {
+    await rm(part, { force: true })
+    throw err
+  }
+}
+
+async function extractArchive(
+  zipPath: string,
+  destination: string,
+  extractZip = extractZipDefault
+): Promise<void> {
+  await mkdir(destination, { recursive: true })
+  await extractZip(zipPath, destination)
+}
+
+async function extractZipDefault(zipPath: string, destination: string): Promise<void> {
+  await runProcess(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      'Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force',
+      zipPath,
+      destination
+    ],
+    INSTALL_TIMEOUT_MS
+  )
+}
+
+async function findParakeetCli(root: string, depth = 0): Promise<string | null> {
+  if (depth > 5) return null
+  let entries: Array<{ name: string; isFile: () => boolean; isDirectory: () => boolean }>
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch {
+    return null
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(root, entry.name)
+    if (entry.isFile() && entry.name.toLowerCase() === EXE_NAME) return fullPath
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const found = await findParakeetCli(join(root, entry.name), depth + 1)
+    if (found) return found
+  }
+  return null
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function runProcess(command: string, args: string[], timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { windowsHide: true })
+    let stderr = ''
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`${command} timed out`))
+    }, timeoutMs)
+    timer.unref?.()
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error(stderr.trim() || `${command} exited with code ${code ?? 'unknown'}`))
+    })
+  })
+}

--- a/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppRuntime.ts
@@ -71,7 +71,7 @@ export function resetManagedParakeetRuntimeStateForTests(): void {
 
 export function noteManagedParakeetSessionStarted(): void {
   activeSessions += 1
-  if (installState === 'installed' || installState === 'starting') installState = 'running'
+  if (installState === 'installed') installState = 'running'
 }
 
 export function noteManagedParakeetSessionStopped(): void {

--- a/desktop/windows/src/main/localStt/parakeetCppSession.test.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppSession.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { BackendSegment } from '../../shared/types'
+import { parseParakeetCliOutput, ParakeetCppSession, writePcm16Wav } from './parakeetCppSession'
+import { resetManagedParakeetRuntimeStateForTests } from './parakeetCppRuntime'
+
+let root = ''
+
+beforeEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  root = await mkdtemp(join(tmpdir(), 'omi-parakeet-session-'))
+})
+
+afterEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  if (root) await rm(root, { recursive: true, force: true })
+  root = ''
+})
+
+describe('parakeet.cpp CLI session', () => {
+  it('writes PCM16 WAV files with a valid header', async () => {
+    const wav = join(root, 'sample.wav')
+    await writePcm16Wav(wav, Buffer.from(new Int16Array([1, -2, 3]).buffer))
+
+    const bytes = await readFile(wav)
+    expect(bytes.subarray(0, 4).toString('ascii')).toBe('RIFF')
+    expect(bytes.subarray(8, 12).toString('ascii')).toBe('WAVE')
+    expect(bytes.readUInt32LE(40)).toBe(6)
+  })
+
+  it('parses JSON output shapes from parakeet.cpp', () => {
+    expect(
+      parseParakeetCliOutput(
+        JSON.stringify({
+          text: 'hello world',
+          words: [
+            { start: 0.1, end: 0.2 },
+            { start: 0.3, end: 0.8 }
+          ]
+        })
+      )
+    ).toEqual([
+      {
+        text: 'hello world',
+        words: [
+          { start: 0.1, end: 0.2 },
+          { start: 0.3, end: 0.8 }
+        ],
+        start: 0.1,
+        end: 0.8
+      }
+    ])
+
+    expect(parseParakeetCliOutput('plain transcript')).toEqual([{ text: 'plain transcript' }])
+  })
+
+  it('flushes buffered PCM through the CLI and emits backend segments', async () => {
+    const emitted: BackendSegment[][] = []
+    let wavHeader = ''
+    const session = new ParakeetCppSession({
+      sessionId: 'runtime',
+      source: 'mic',
+      language: 'en',
+      drainSeconds: 10,
+      tmpRoot: root,
+      runtime: {
+        exePath: 'parakeet-cli.exe',
+        modelPath: 'model.gguf',
+        runtimeRoot: root,
+        variant: 'cuda',
+        model: 'tdt_ctc-110m-q8_0.gguf',
+        version: 'v0.3.2'
+      },
+      runCli: async (wavPath) => {
+        wavHeader = (await readFile(wavPath)).subarray(0, 4).toString('ascii')
+        return JSON.stringify({
+          text: 'local words',
+          words: [
+            { start: 0.1, end: 0.3 },
+            { start: 0.35, end: 0.9 }
+          ]
+        })
+      },
+      handlers: {
+        onConnected: () => undefined,
+        onSegments: (segments) => emitted.push(segments),
+        onError: (message) => {
+          throw new Error(message)
+        },
+        onClosed: () => undefined
+      }
+    })
+
+    await session.start()
+    session.feed(new Int16Array(16000).buffer)
+    await session.stop()
+
+    expect(wavHeader).toBe('RIFF')
+    expect(emitted).toEqual([
+      [
+        {
+          id: 'local-runtime-1',
+          text: 'local words',
+          speaker: undefined,
+          speaker_id: undefined,
+          is_user: true,
+          person_id: undefined,
+          start: 0.1,
+          end: 0.9
+        }
+      ]
+    ])
+  })
+})

--- a/desktop/windows/src/main/localStt/parakeetCppSession.test.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppSession.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, readFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import type { BackendSegment } from '../../shared/types'
-import { parseParakeetCliOutput, ParakeetCppSession, writePcm16Wav } from './parakeetCppSession'
+import {
+  parseParakeetCliOutput,
+  ParakeetCppSession,
+  safeSessionFilePrefix,
+  writePcm16Wav
+} from './parakeetCppSession'
 import { resetManagedParakeetRuntimeStateForTests } from './parakeetCppRuntime'
 
 let root = ''
@@ -54,6 +59,10 @@ describe('parakeet.cpp CLI session', () => {
     ])
 
     expect(parseParakeetCliOutput('plain transcript')).toEqual([{ text: 'plain transcript' }])
+  })
+
+  it('sanitizes renderer-provided session ids before using them in filenames', () => {
+    expect(safeSessionFilePrefix('../escape.session\\id')).toBe('___escape_session_id')
   })
 
   it('flushes buffered PCM through the CLI and emits backend segments', async () => {

--- a/desktop/windows/src/main/localStt/parakeetCppSession.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppSession.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from 'crypto'
+import { spawn } from 'child_process'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { BackendSegment, ListenSource } from '../../shared/types'
+import { normalizeParakeetSegment } from './parakeetSession'
+import {
+  noteManagedParakeetSessionStarted,
+  noteManagedParakeetSessionStopped,
+  type ManagedParakeetRuntime
+} from './parakeetCppRuntime'
+
+const SAMPLE_RATE = 16000
+const BYTES_PER_SAMPLE = 2
+const DEFAULT_DRAIN_SECONDS = 10
+const MIN_FINAL_SECONDS = 0.25
+const CLI_TIMEOUT_MS = 2 * 60_000
+
+type CliSegment = Record<string, unknown>
+
+type ParakeetCppHandlers = {
+  onConnected: () => void
+  onSegments: (segments: BackendSegment[]) => void
+  onError: (message: string, fatal: boolean) => void
+  onClosed: (code: number, reason: string) => void
+}
+
+type RunCli = (wavPath: string) => Promise<string>
+
+export function writePcm16Wav(path: string, pcm: Buffer, sampleRate = SAMPLE_RATE): Promise<void> {
+  const header = Buffer.alloc(44)
+  const byteRate = sampleRate * BYTES_PER_SAMPLE
+  const blockAlign = BYTES_PER_SAMPLE
+
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + pcm.length, 4)
+  header.write('WAVE', 8)
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20)
+  header.writeUInt16LE(1, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(byteRate, 28)
+  header.writeUInt16LE(blockAlign, 32)
+  header.writeUInt16LE(16, 34)
+  header.write('data', 36)
+  header.writeUInt32LE(pcm.length, 40)
+
+  return writeFile(path, Buffer.concat([header, pcm]))
+}
+
+export function parseParakeetCliOutput(stdout: string): CliSegment[] {
+  const text = stdout.trim()
+  if (!text) return []
+
+  const parsed = parseJsonPayload(text)
+  if (parsed !== null) return cliSegmentsFromPayload(parsed)
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const lineSegments = lines.flatMap((line) => {
+    const payload = parseJsonPayload(line)
+    return payload === null ? [] : cliSegmentsFromPayload(payload)
+  })
+  if (lineSegments.length > 0) return lineSegments
+
+  return [{ text }]
+}
+
+export class ParakeetCppSession {
+  private readonly drainBytes: number
+  private readonly tmpRoot: string
+  private buffers: Buffer[] = []
+  private bufferedBytes = 0
+  private closed = false
+  private sequence = 0
+  private lastEnd = 0
+  private offsetSeconds = 0
+  private timer: NodeJS.Timeout | null = null
+  private drainPromise: Promise<void> = Promise.resolve()
+  private stopPromise: Promise<void> | null = null
+
+  constructor(
+    private readonly args: {
+      sessionId: string
+      source: ListenSource
+      language: string
+      runtime: ManagedParakeetRuntime
+      handlers: ParakeetCppHandlers
+      drainSeconds?: number
+      runCli?: RunCli
+      tmpRoot?: string
+    }
+  ) {
+    this.drainBytes =
+      Math.max(1, args.drainSeconds ?? DEFAULT_DRAIN_SECONDS) * SAMPLE_RATE * BYTES_PER_SAMPLE
+    this.tmpRoot = args.tmpRoot ?? join(tmpdir(), 'omi-local-stt')
+  }
+
+  async start(): Promise<void> {
+    if (this.closed) throw new Error('local Parakeet session already closed')
+    noteManagedParakeetSessionStarted()
+    this.args.handlers.onConnected()
+    this.timer = setInterval(() => {
+      void this.queueDrain(false)
+    }, 1000)
+    this.timer.unref?.()
+  }
+
+  feed(pcm: ArrayBuffer): void {
+    if (this.closed) return
+    const chunk = Buffer.from(new Uint8Array(pcm))
+    if (chunk.length === 0) return
+    this.buffers.push(chunk)
+    this.bufferedBytes += chunk.length
+    if (this.bufferedBytes >= this.drainBytes) {
+      void this.queueDrain(false)
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise
+    this.stopPromise = this.stopInner()
+    return this.stopPromise
+  }
+
+  private async stopInner(): Promise<void> {
+    this.closed = true
+    if (this.timer) clearInterval(this.timer)
+    await this.queueDrain(true)
+    noteManagedParakeetSessionStopped()
+    this.args.handlers.onClosed(1000, 'done')
+  }
+
+  private queueDrain(final: boolean): Promise<void> {
+    const run = async (): Promise<void> => {
+      try {
+        await this.drainAvailable(final)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        this.args.handlers.onError(message, false)
+      }
+    }
+    this.drainPromise = this.drainPromise.then(run, run)
+    return this.drainPromise
+  }
+
+  private async drainAvailable(final: boolean): Promise<void> {
+    while (this.bufferedBytes >= this.drainBytes) {
+      await this.drainChunk(this.drainBytes)
+    }
+
+    if (final && this.bufferedBytes >= MIN_FINAL_SECONDS * SAMPLE_RATE * BYTES_PER_SAMPLE) {
+      await this.drainChunk(this.bufferedBytes)
+    }
+  }
+
+  private async drainChunk(byteCount: number): Promise<void> {
+    const pcm = this.takeBytes(byteCount)
+    const durationSeconds = pcm.length / BYTES_PER_SAMPLE / SAMPLE_RATE
+    const wavPath = join(this.tmpRoot, `${this.args.sessionId}-${randomUUID()}.wav`)
+
+    try {
+      await mkdir(this.tmpRoot, { recursive: true })
+      await writePcm16Wav(wavPath, pcm)
+      const stdout = await (this.args.runCli ?? this.runCli.bind(this))(wavPath)
+      const segments = this.toBackendSegments(parseParakeetCliOutput(stdout), durationSeconds)
+      if (segments.length > 0) this.args.handlers.onSegments(segments)
+    } finally {
+      await rm(wavPath, { force: true })
+      this.offsetSeconds += durationSeconds
+    }
+  }
+
+  private takeBytes(byteCount: number): Buffer {
+    const out = Buffer.alloc(byteCount)
+    let offset = 0
+
+    while (offset < byteCount) {
+      const next = this.buffers[0]
+      const remaining = byteCount - offset
+      if (next.length <= remaining) {
+        next.copy(out, offset)
+        offset += next.length
+        this.buffers.shift()
+      } else {
+        next.copy(out, offset, 0, remaining)
+        this.buffers[0] = next.subarray(remaining)
+        offset += remaining
+      }
+    }
+
+    this.bufferedBytes -= byteCount
+    return out
+  }
+
+  private toBackendSegments(rawSegments: CliSegment[], durationSeconds: number): BackendSegment[] {
+    const segments: BackendSegment[] = []
+    for (const raw of rawSegments) {
+      const start =
+        typeof raw.start === 'number' && Number.isFinite(raw.start)
+          ? this.offsetSeconds + raw.start
+          : this.lastEnd
+      const end =
+        typeof raw.end === 'number' && Number.isFinite(raw.end)
+          ? this.offsetSeconds + raw.end
+          : this.offsetSeconds + durationSeconds
+      const segment = normalizeParakeetSegment({
+        raw: {
+          ...raw,
+          start,
+          end
+        },
+        source: this.args.source,
+        sessionId: this.args.sessionId,
+        sequence: ++this.sequence,
+        fallbackStart: this.lastEnd
+      })
+      if (!segment) continue
+      this.lastEnd = Math.max(this.lastEnd, segment.end)
+      segments.push(segment)
+    }
+    return segments
+  }
+
+  private runCli(wavPath: string): Promise<string> {
+    const cliArgs = [
+      'transcribe',
+      '--model',
+      this.args.runtime.modelPath,
+      '--input',
+      wavPath,
+      '--decoder',
+      'tdt',
+      '--json',
+      '--timestamps'
+    ]
+    if (this.args.language) {
+      cliArgs.push('--lang', this.args.language)
+    }
+    return runProcess(this.args.runtime.exePath, cliArgs, CLI_TIMEOUT_MS)
+  }
+}
+
+function parseJsonPayload(text: string): unknown | null {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function cliSegmentsFromPayload(payload: unknown): CliSegment[] {
+  if (typeof payload === 'string') return [{ text: payload }]
+  if (Array.isArray(payload)) return payload.flatMap(cliSegmentsFromPayload)
+  if (!payload || typeof payload !== 'object') return []
+
+  const record = payload as Record<string, unknown>
+  for (const key of ['segments', 'results', 'transcripts']) {
+    if (Array.isArray(record[key])) return cliSegmentsFromPayload(record[key])
+  }
+
+  const text = firstString(record.text, record.transcript, record.transcription)
+  if (!text) return []
+
+  const words = Array.isArray(record.words) ? record.words : []
+  const wordTimes = words
+    .filter((word): word is Record<string, unknown> => Boolean(word) && typeof word === 'object')
+    .map((word) => ({
+      start: numberValue(word.start ?? word.start_time),
+      end: numberValue(word.end ?? word.end_time)
+    }))
+    .filter((word) => word.start != null || word.end != null)
+
+  const start =
+    numberValue(record.start ?? record.start_time) ??
+    minDefined(wordTimes.map((word) => word.start)) ??
+    undefined
+  const end =
+    numberValue(record.end ?? record.end_time) ??
+    maxDefined(wordTimes.map((word) => word.end)) ??
+    undefined
+
+  return [{ ...record, text, start, end }]
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function minDefined(values: Array<number | null>): number | null {
+  const nums = values.filter((value): value is number => value != null)
+  return nums.length > 0 ? Math.min(...nums) : null
+}
+
+function maxDefined(values: Array<number | null>): number | null {
+  const nums = values.filter((value): value is number => value != null)
+  return nums.length > 0 ? Math.max(...nums) : null
+}
+
+async function runProcess(command: string, args: string[], timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, { windowsHide: true })
+    const stdout: Buffer[] = []
+    let stderr = ''
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`${command} timed out`))
+    }, timeoutMs)
+    timer.unref?.()
+
+    child.stdout.on('data', (data) => {
+      stdout.push(Buffer.from(data))
+    })
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString('utf8'))
+        return
+      }
+      reject(new Error(stderr.trim() || `${command} exited with code ${code ?? 'unknown'}`))
+    })
+  })
+}

--- a/desktop/windows/src/main/localStt/parakeetCppSession.ts
+++ b/desktop/windows/src/main/localStt/parakeetCppSession.ts
@@ -28,6 +28,11 @@ type ParakeetCppHandlers = {
 
 type RunCli = (wavPath: string) => Promise<string>
 
+export function safeSessionFilePrefix(sessionId: string): string {
+  const safe = sessionId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 64)
+  return safe || 'session'
+}
+
 export function writePcm16Wav(path: string, pcm: Buffer, sampleRate = SAMPLE_RATE): Promise<void> {
   const header = Buffer.alloc(44)
   const byteRate = sampleRate * BYTES_PER_SAMPLE
@@ -161,7 +166,10 @@ export class ParakeetCppSession {
   private async drainChunk(byteCount: number): Promise<void> {
     const pcm = this.takeBytes(byteCount)
     const durationSeconds = pcm.length / BYTES_PER_SAMPLE / SAMPLE_RATE
-    const wavPath = join(this.tmpRoot, `${this.args.sessionId}-${randomUUID()}.wav`)
+    const wavPath = join(
+      this.tmpRoot,
+      `${safeSessionFilePrefix(this.args.sessionId)}-${randomUUID()}.wav`
+    )
 
     try {
       await mkdir(this.tmpRoot, { recursive: true })

--- a/desktop/windows/src/main/localStt/parakeetSession.test.ts
+++ b/desktop/windows/src/main/localStt/parakeetSession.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { WebSocketServer } from 'ws'
+import type { AddressInfo } from 'net'
+import type { BackendSegment } from '../../shared/types'
+import { normalizeParakeetSegment, ParakeetStreamSession } from './parakeetSession'
+
+const servers: WebSocketServer[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+        })
+    )
+  )
+})
+
+describe('Parakeet segment normalization', () => {
+  it('maps local mic segments into the shared backend segment shape', () => {
+    const segment = normalizeParakeetSegment({
+      raw: {
+        text: ' hello world ',
+        speaker: 'SPEAKER_2',
+        start: 1.25,
+        end: 2.5,
+        person_id: 'person-1'
+      },
+      source: 'mic',
+      sessionId: 's1',
+      sequence: 3,
+      fallbackStart: 0
+    })
+
+    expect(segment).toEqual({
+      id: 'local-s1-3',
+      text: 'hello world',
+      speaker: 'SPEAKER_2',
+      speaker_id: 2,
+      is_user: true,
+      person_id: 'person-1',
+      start: 1.25,
+      end: 2.5
+    })
+  })
+
+  it('drops empty transcripts and repairs invalid timing', () => {
+    expect(
+      normalizeParakeetSegment({
+        raw: { text: '   ', start: 1, end: 2 },
+        source: 'system',
+        sessionId: 's1',
+        sequence: 1,
+        fallbackStart: 0
+      })
+    ).toBeNull()
+
+    expect(
+      normalizeParakeetSegment({
+        raw: { text: 'tail', start: 4, end: 3 },
+        source: 'system',
+        sessionId: 's1',
+        sequence: 2,
+        fallbackStart: 10
+      })
+    ).toMatchObject({ text: 'tail', is_user: false, start: 4, end: 4.01 })
+  })
+
+  it('streams PCM to a Parakeet-compatible WebSocket and flushes on stop', async () => {
+    const server = new WebSocketServer({ port: 0 })
+    servers.push(server)
+    await new Promise<void>((resolve) => server.once('listening', () => resolve()))
+    const port = (server.address() as AddressInfo).port
+    let sawPcm = false
+    let sawFinalize = false
+
+    server.on('connection', (ws) => {
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) {
+          sawPcm = true
+          return
+        }
+        if (data.toString() === 'finalize') {
+          sawFinalize = true
+          ws.send(JSON.stringify({ text: 'local words', speaker: 'SPEAKER_0', start: 0, end: 1 }))
+          ws.close(1000, 'done')
+        }
+      })
+    })
+
+    const emitted: BackendSegment[][] = []
+    const session = new ParakeetStreamSession({
+      sessionId: 'runtime',
+      source: 'mic',
+      baseUrl: `http://127.0.0.1:${port}`,
+      handlers: {
+        onConnected: () => undefined,
+        onSegments: (segments) => emitted.push(segments),
+        onError: (message) => {
+          throw new Error(message)
+        },
+        onClosed: () => undefined
+      }
+    })
+
+    await session.start()
+    session.feed(new Int16Array([1, 2, 3, 4]).buffer)
+    await session.stop()
+
+    expect(sawPcm).toBe(true)
+    expect(sawFinalize).toBe(true)
+    expect(emitted).toEqual([
+      [
+        {
+          id: 'local-runtime-1',
+          text: 'local words',
+          speaker: 'SPEAKER_0',
+          speaker_id: 0,
+          is_user: true,
+          person_id: undefined,
+          start: 0,
+          end: 1
+        }
+      ]
+    ])
+  })
+})

--- a/desktop/windows/src/main/localStt/parakeetSession.ts
+++ b/desktop/windows/src/main/localStt/parakeetSession.ts
@@ -1,0 +1,207 @@
+import WebSocket from 'ws'
+import type { BackendSegment, ListenSource } from '../../shared/types'
+
+const CONNECT_TIMEOUT_MS = 5000
+const FINALIZE_TIMEOUT_MS = 8000
+
+type ParakeetSegment = Record<string, unknown>
+
+type ParakeetStreamHandlers = {
+  onConnected: () => void
+  onSegments: (segments: BackendSegment[]) => void
+  onError: (message: string, fatal: boolean) => void
+  onClosed: (code: number, reason: string) => void
+}
+
+function parseSpeakerId(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return undefined
+  const match = value.match(/(\d+)/)
+  if (!match) return undefined
+  const parsed = Number(match[1])
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+export function normalizeParakeetSegment(args: {
+  raw: ParakeetSegment
+  source: ListenSource
+  sessionId: string
+  sequence: number
+  fallbackStart: number
+}): BackendSegment | null {
+  const text = typeof args.raw.text === 'string' ? args.raw.text.trim() : ''
+  if (!text) return null
+
+  const start = Math.max(0, num(args.raw.start, args.fallbackStart))
+  const end = Math.max(start + 0.01, num(args.raw.end, start + 0.01))
+  const speakerRaw = args.raw.speaker
+  const speaker =
+    typeof speakerRaw === 'string' && speakerRaw.trim() ? speakerRaw.trim() : undefined
+  const speakerId = parseSpeakerId(args.raw.speaker_id ?? speaker)
+  const personId = typeof args.raw.person_id === 'string' ? args.raw.person_id : undefined
+
+  return {
+    id: `local-${args.sessionId}-${args.sequence}`,
+    text,
+    speaker,
+    speaker_id: speakerId,
+    is_user: args.source === 'mic' ? true : Boolean(args.raw.is_user),
+    person_id: personId,
+    start,
+    end
+  }
+}
+
+function streamUrl(baseUrl: string): string {
+  const wsBase = baseUrl
+    .replace(/^http:/, 'ws:')
+    .replace(/^https:/, 'wss:')
+    .replace(/\/+$/, '')
+  return `${wsBase}/v3/stream?sample_rate=16000`
+}
+
+export class ParakeetStreamSession {
+  private ws: WebSocket | null = null
+  private closed = false
+  private sequence = 0
+  private lastEnd = 0
+  private closePromise: Promise<void> | null = null
+
+  constructor(
+    private readonly args: {
+      sessionId: string
+      source: ListenSource
+      baseUrl: string
+      handlers: ParakeetStreamHandlers
+    }
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.closed) throw new Error('local Parakeet session already closed')
+
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(streamUrl(this.args.baseUrl))
+      this.ws = ws
+      let settled = false
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        this.closed = true
+        try {
+          ws.terminate()
+        } catch {
+          /* ignore */
+        }
+        reject(new Error('local Parakeet connect timeout'))
+      }, CONNECT_TIMEOUT_MS)
+      timer.unref?.()
+
+      const settleFailure = (message: string): void => {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          this.closed = true
+          reject(new Error(message))
+          return
+        }
+        this.args.handlers.onError(message, false)
+      }
+
+      ws.on('open', () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this.args.handlers.onConnected()
+        resolve()
+      })
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) return
+        this.handleMessage(data.toString())
+      })
+      ws.on('error', (err) => settleFailure(err.message))
+      ws.on('close', (code, reasonBuf) => {
+        this.closed = true
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          reject(new Error(`local Parakeet closed before connect (${code})`))
+          return
+        }
+        this.args.handlers.onClosed(code, reasonBuf.toString())
+      })
+    })
+  }
+
+  feed(pcm: ArrayBuffer): void {
+    if (this.closed || this.ws?.readyState !== WebSocket.OPEN) return
+    this.ws.send(Buffer.from(new Uint8Array(pcm)))
+  }
+
+  async stop(): Promise<void> {
+    if (this.closePromise) return this.closePromise
+    this.closePromise = this.stopInner()
+    return this.closePromise
+  }
+
+  private async stopInner(): Promise<void> {
+    const ws = this.ws
+    if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) return
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        try {
+          ws.terminate()
+        } catch {
+          /* ignore */
+        }
+        resolve()
+      }, FINALIZE_TIMEOUT_MS)
+      timer.unref?.()
+
+      ws.once('close', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+
+      try {
+        ws.send('finalize')
+      } catch {
+        try {
+          ws.close()
+        } catch {
+          /* ignore */
+        }
+      }
+    })
+  }
+
+  private handleMessage(text: string): void {
+    let payload: unknown
+    try {
+      payload = JSON.parse(text)
+    } catch {
+      return
+    }
+
+    const raws = Array.isArray(payload) ? payload : [payload]
+    const segments: BackendSegment[] = []
+    for (const raw of raws) {
+      if (!raw || typeof raw !== 'object') continue
+      const segment = normalizeParakeetSegment({
+        raw: raw as ParakeetSegment,
+        source: this.args.source,
+        sessionId: this.args.sessionId,
+        sequence: ++this.sequence,
+        fallbackStart: this.lastEnd
+      })
+      if (!segment) continue
+      this.lastEnd = Math.max(this.lastEnd, segment.end)
+      segments.push(segment)
+    }
+    if (segments.length > 0) this.args.handlers.onSegments(segments)
+  }
+}

--- a/desktop/windows/src/main/localStt/status.test.ts
+++ b/desktop/windows/src/main/localStt/status.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getLocalSttStatus, localParakeetBaseUrl } from './status'
+
+function okFetch(): typeof fetch {
+  return vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ status: 'healthy' }), { status: 200 }))
+}
+
+describe('local STT status', () => {
+  it('uses the configured local Parakeet URL without trailing slashes', () => {
+    expect(localParakeetBaseUrl({ OMI_LOCAL_PARAKEET_URL: 'http://127.0.0.1:9000/' })).toBe(
+      'http://127.0.0.1:9000'
+    )
+  })
+
+  it('is available when health passes and NVIDIA is detected on Windows', async () => {
+    const status = await getLocalSttStatus({
+      env: { OMI_LOCAL_PARAKEET_URL: 'http://127.0.0.1:9000' },
+      platform: 'win32',
+      fetchImpl: okFetch(),
+      detectNvidiaGpu: async () => true,
+      now: () => 123
+    })
+
+    expect(status).toMatchObject({
+      configuredUrl: 'http://127.0.0.1:9000',
+      healthy: true,
+      available: true,
+      nvidiaAvailable: true,
+      checkedAt: 123
+    })
+  })
+
+  it('blocks auto-local on Windows when NVIDIA is missing', async () => {
+    const status = await getLocalSttStatus({
+      env: {},
+      platform: 'win32',
+      fetchImpl: okFetch(),
+      detectNvidiaGpu: async () => false
+    })
+
+    expect(status.available).toBe(false)
+    expect(status.healthy).toBe(true)
+    expect(status.reason).toBe('NVIDIA GPU not detected')
+  })
+
+  it('fails closed when health does not pass', async () => {
+    const status = await getLocalSttStatus({
+      env: {},
+      platform: 'win32',
+      fetchImpl: vi.fn().mockResolvedValue(new Response('', { status: 503 })),
+      detectNvidiaGpu: async () => true
+    })
+
+    expect(status.available).toBe(false)
+    expect(status.healthy).toBe(false)
+    expect(status.reason).toContain('Parakeet runtime is not healthy')
+  })
+})

--- a/desktop/windows/src/main/localStt/status.test.ts
+++ b/desktop/windows/src/main/localStt/status.test.ts
@@ -1,34 +1,76 @@
-import { describe, expect, it, vi } from 'vitest'
-import { getLocalSttStatus, localParakeetBaseUrl } from './status'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { getLocalSttStatus } from './status'
+import { resetManagedParakeetRuntimeStateForTests } from './parakeetCppRuntime'
 
-function okFetch(): typeof fetch {
-  return vi
-    .fn()
-    .mockResolvedValue(new Response(JSON.stringify({ status: 'healthy' }), { status: 200 }))
-}
+let root = ''
+
+beforeEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  root = await mkdtemp(join(tmpdir(), 'omi-local-stt-status-'))
+})
+
+afterEach(async () => {
+  resetManagedParakeetRuntimeStateForTests()
+  if (root) await rm(root, { recursive: true, force: true })
+  root = ''
+})
 
 describe('local STT status', () => {
-  it('uses the configured local Parakeet URL without trailing slashes', () => {
-    expect(localParakeetBaseUrl({ OMI_LOCAL_PARAKEET_URL: 'http://127.0.0.1:9000/' })).toBe(
-      'http://127.0.0.1:9000'
-    )
-  })
-
-  it('is available when health passes and NVIDIA is detected on Windows', async () => {
+  it('ignores externally configured localhost services and reports managed first-use install', async () => {
     const status = await getLocalSttStatus({
-      env: { OMI_LOCAL_PARAKEET_URL: 'http://127.0.0.1:9000' },
+      env: { OMI_LOCAL_PARAKEET_URL: 'http://127.0.0.1:9000' } as NodeJS.ProcessEnv,
       platform: 'win32',
-      fetchImpl: okFetch(),
+      arch: 'x64',
+      rootDir: root,
       detectNvidiaGpu: async () => true,
       now: () => 123
     })
 
     expect(status).toMatchObject({
-      configuredUrl: 'http://127.0.0.1:9000',
+      healthy: false,
+      available: false,
+      nvidiaAvailable: true,
+      managed: true,
+      runtime: {
+        kind: 'parakeet.cpp',
+        installState: 'not_installed',
+        variant: 'cuda',
+        canInstall: true
+      },
+      checkedAt: 123
+    })
+    expect(status.configuredUrl).toBeUndefined()
+    expect(status.healthUrl).toBeUndefined()
+    expect(status.reason).toBe('Local Parakeet will install on first use')
+  })
+
+  it('is available when the app-owned runtime and model are installed', async () => {
+    await mkdir(join(root, 'bin'), { recursive: true })
+    await mkdir(join(root, 'models'), { recursive: true })
+    await writeFile(join(root, 'bin', 'parakeet-cli.exe'), 'exe')
+    await writeFile(join(root, 'models', 'tdt_ctc-110m-q8_0.gguf'), 'model')
+
+    const status = await getLocalSttStatus({
+      env: {},
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root,
+      detectNvidiaGpu: async () => true
+    })
+
+    expect(status).toMatchObject({
       healthy: true,
       available: true,
       nvidiaAvailable: true,
-      checkedAt: 123
+      managed: true,
+      runtime: {
+        installState: 'installed',
+        variant: 'cuda',
+        canInstall: true
+      }
     })
   })
 
@@ -36,25 +78,30 @@ describe('local STT status', () => {
     const status = await getLocalSttStatus({
       env: {},
       platform: 'win32',
-      fetchImpl: okFetch(),
+      arch: 'x64',
+      rootDir: root,
       detectNvidiaGpu: async () => false
     })
 
     expect(status.available).toBe(false)
-    expect(status.healthy).toBe(true)
+    expect(status.healthy).toBe(false)
+    expect(status.runtime.installState).toBe('unsupported')
+    expect(status.runtime.canInstall).toBe(false)
     expect(status.reason).toBe('NVIDIA GPU not detected')
   })
 
-  it('fails closed when health does not pass', async () => {
+  it('fails closed when local STT is disabled', async () => {
     const status = await getLocalSttStatus({
-      env: {},
+      env: { OMI_LOCAL_STT_DISABLED: '1' },
       platform: 'win32',
-      fetchImpl: vi.fn().mockResolvedValue(new Response('', { status: 503 })),
+      arch: 'x64',
+      rootDir: root,
       detectNvidiaGpu: async () => true
     })
 
     expect(status.available).toBe(false)
     expect(status.healthy).toBe(false)
-    expect(status.reason).toContain('Parakeet runtime is not healthy')
+    expect(status.runtime.canInstall).toBe(false)
+    expect(status.reason).toBe('local STT disabled')
   })
 })

--- a/desktop/windows/src/main/localStt/status.ts
+++ b/desktop/windows/src/main/localStt/status.ts
@@ -1,144 +1,57 @@
-import { spawn } from 'child_process'
 import type { LocalSttStatus } from '../../shared/types'
-
-const DEFAULT_PARAKEET_URL = 'http://127.0.0.1:8765'
-const HEALTH_TIMEOUT_MS = 1000
-const NVIDIA_TIMEOUT_MS = 1200
+import {
+  detectNvidiaGpu,
+  getManagedParakeetStatus,
+  managedParakeetModelName,
+  type ManagedParakeetRuntime
+} from './parakeetCppRuntime'
 
 type StatusDeps = {
   env?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform | string
-  fetchImpl?: typeof fetch
+  arch?: string
   detectNvidiaGpu?: () => Promise<boolean | null>
+  downloadFile?: (url: string, destination: string) => Promise<void>
+  extractZip?: (zipPath: string, destination: string) => Promise<void>
   now?: () => number
+  rootDir?: string
 }
 
-export function localParakeetBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
-  return (env.OMI_LOCAL_PARAKEET_URL || env.OMI_PARAKEET_URL || DEFAULT_PARAKEET_URL).replace(
-    /\/+$/,
-    ''
-  )
-}
-
-function timeoutSignal(ms: number): AbortSignal {
-  const controller = new AbortController()
-  setTimeout(() => controller.abort(), ms).unref?.()
-  return controller.signal
-}
-
-export async function detectNvidiaGpu(
-  env: NodeJS.ProcessEnv = process.env
-): Promise<boolean | null> {
-  if (env.OMI_LOCAL_STT_ASSUME_NVIDIA === '1') return true
-
-  return new Promise((resolve) => {
-    const child = spawn('nvidia-smi', ['-L'], { windowsHide: true })
-    let output = ''
-    const timer = setTimeout(() => {
-      try {
-        child.kill()
-      } catch {
-        /* ignore */
-      }
-      resolve(null)
-    }, NVIDIA_TIMEOUT_MS)
-    timer.unref?.()
-
-    child.stdout.on('data', (data) => {
-      output += data.toString()
-    })
-    child.on('error', () => {
-      clearTimeout(timer)
-      resolve(null)
-    })
-    child.on('close', (code) => {
-      clearTimeout(timer)
-      resolve(code === 0 && /GPU/i.test(output))
-    })
-  })
-}
+export { detectNvidiaGpu }
 
 export async function getLocalSttStatus(deps: StatusDeps = {}): Promise<LocalSttStatus> {
   const env = deps.env ?? process.env
-  const platform = deps.platform ?? process.platform
-  const fetchImpl = deps.fetchImpl ?? fetch
   const now = deps.now ?? Date.now
-  const configuredUrl = localParakeetBaseUrl(env)
-  const healthUrl = `${configuredUrl}/health`
   const checkedAt = now()
 
   if (env.OMI_FORCE_CLOUD_STT === '1' || env.OMI_LOCAL_STT_DISABLED === '1') {
-    return {
-      backend: 'parakeet',
-      configuredUrl,
-      healthUrl,
-      healthy: false,
-      available: false,
-      nvidiaAvailable: null,
-      reason: 'local STT disabled',
-      checkedAt
-    }
+    return disabledStatus('local STT disabled', env, checkedAt)
   }
 
   if (env.OMI_FORCE_PARAKEET_FAIL === '1') {
-    return {
-      backend: 'parakeet',
-      configuredUrl,
-      healthUrl,
-      healthy: false,
-      available: false,
-      nvidiaAvailable: null,
-      reason: 'forced local Parakeet failure',
-      checkedAt
-    }
+    return disabledStatus('forced local Parakeet failure', env, checkedAt)
   }
 
-  let healthy = false
-  try {
-    const response = await fetchImpl(healthUrl, { signal: timeoutSignal(HEALTH_TIMEOUT_MS) })
-    healthy = response.ok
-  } catch {
-    healthy = false
-  }
+  return getManagedParakeetStatus(deps)
+}
 
-  if (!healthy) {
-    return {
-      backend: 'parakeet',
-      configuredUrl,
-      healthUrl,
-      healthy: false,
-      available: false,
-      nvidiaAvailable: null,
-      reason: `Parakeet runtime is not healthy at ${configuredUrl}`,
-      checkedAt
-    }
-  }
-
-  const nvidiaAvailable =
-    deps.detectNvidiaGpu != null ? await deps.detectNvidiaGpu() : await detectNvidiaGpu(env)
-  const allowNonNvidia = env.OMI_LOCAL_STT_ALLOW_NON_NVIDIA === '1'
-  const needsNvidia = platform === 'win32'
-
-  if (needsNvidia && !allowNonNvidia && nvidiaAvailable !== true) {
-    return {
-      backend: 'parakeet',
-      configuredUrl,
-      healthUrl,
-      healthy: true,
-      available: false,
-      nvidiaAvailable,
-      reason: 'NVIDIA GPU not detected',
-      checkedAt
-    }
-  }
-
+function disabledStatus(reason: string, env: NodeJS.ProcessEnv, checkedAt: number): LocalSttStatus {
   return {
     backend: 'parakeet',
-    configuredUrl,
-    healthUrl,
-    healthy: true,
-    available: true,
-    nvidiaAvailable,
+    healthy: false,
+    available: false,
+    nvidiaAvailable: null,
+    managed: true,
+    runtime: {
+      kind: 'parakeet.cpp',
+      installState: 'unsupported',
+      variant: null,
+      model: managedParakeetModelName(env),
+      canInstall: false
+    },
+    reason,
     checkedAt
   }
 }
+
+export type { ManagedParakeetRuntime }

--- a/desktop/windows/src/main/localStt/status.ts
+++ b/desktop/windows/src/main/localStt/status.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'child_process'
+import type { LocalSttStatus } from '../../shared/types'
+
+const DEFAULT_PARAKEET_URL = 'http://127.0.0.1:8765'
+const HEALTH_TIMEOUT_MS = 1000
+const NVIDIA_TIMEOUT_MS = 1200
+
+type StatusDeps = {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform | string
+  fetchImpl?: typeof fetch
+  detectNvidiaGpu?: () => Promise<boolean | null>
+  now?: () => number
+}
+
+export function localParakeetBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return (env.OMI_LOCAL_PARAKEET_URL || env.OMI_PARAKEET_URL || DEFAULT_PARAKEET_URL).replace(
+    /\/+$/,
+    ''
+  )
+}
+
+function timeoutSignal(ms: number): AbortSignal {
+  const controller = new AbortController()
+  setTimeout(() => controller.abort(), ms).unref?.()
+  return controller.signal
+}
+
+export async function detectNvidiaGpu(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<boolean | null> {
+  if (env.OMI_LOCAL_STT_ASSUME_NVIDIA === '1') return true
+
+  return new Promise((resolve) => {
+    const child = spawn('nvidia-smi', ['-L'], { windowsHide: true })
+    let output = ''
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        /* ignore */
+      }
+      resolve(null)
+    }, NVIDIA_TIMEOUT_MS)
+    timer.unref?.()
+
+    child.stdout.on('data', (data) => {
+      output += data.toString()
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve(null)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve(code === 0 && /GPU/i.test(output))
+    })
+  })
+}
+
+export async function getLocalSttStatus(deps: StatusDeps = {}): Promise<LocalSttStatus> {
+  const env = deps.env ?? process.env
+  const platform = deps.platform ?? process.platform
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const now = deps.now ?? Date.now
+  const configuredUrl = localParakeetBaseUrl(env)
+  const healthUrl = `${configuredUrl}/health`
+  const checkedAt = now()
+
+  if (env.OMI_FORCE_CLOUD_STT === '1' || env.OMI_LOCAL_STT_DISABLED === '1') {
+    return {
+      backend: 'parakeet',
+      configuredUrl,
+      healthUrl,
+      healthy: false,
+      available: false,
+      nvidiaAvailable: null,
+      reason: 'local STT disabled',
+      checkedAt
+    }
+  }
+
+  if (env.OMI_FORCE_PARAKEET_FAIL === '1') {
+    return {
+      backend: 'parakeet',
+      configuredUrl,
+      healthUrl,
+      healthy: false,
+      available: false,
+      nvidiaAvailable: null,
+      reason: 'forced local Parakeet failure',
+      checkedAt
+    }
+  }
+
+  let healthy = false
+  try {
+    const response = await fetchImpl(healthUrl, { signal: timeoutSignal(HEALTH_TIMEOUT_MS) })
+    healthy = response.ok
+  } catch {
+    healthy = false
+  }
+
+  if (!healthy) {
+    return {
+      backend: 'parakeet',
+      configuredUrl,
+      healthUrl,
+      healthy: false,
+      available: false,
+      nvidiaAvailable: null,
+      reason: `Parakeet runtime is not healthy at ${configuredUrl}`,
+      checkedAt
+    }
+  }
+
+  const nvidiaAvailable =
+    deps.detectNvidiaGpu != null ? await deps.detectNvidiaGpu() : await detectNvidiaGpu(env)
+  const allowNonNvidia = env.OMI_LOCAL_STT_ALLOW_NON_NVIDIA === '1'
+  const needsNvidia = platform === 'win32'
+
+  if (needsNvidia && !allowNonNvidia && nvidiaAvailable !== true) {
+    return {
+      backend: 'parakeet',
+      configuredUrl,
+      healthUrl,
+      healthy: true,
+      available: false,
+      nvidiaAvailable,
+      reason: 'NVIDIA GPU not detected',
+      checkedAt
+    }
+  }
+
+  return {
+    backend: 'parakeet',
+    configuredUrl,
+    healthUrl,
+    healthy: true,
+    available: true,
+    nvidiaAvailable,
+    checkedAt
+  }
+}

--- a/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import {
+  getManagedKokoroStatus,
+  resetManagedKokoroRuntimeStateForTests,
+  synthesizeWithManagedKokoro
+} from './kokoroRuntime'
+
+let root = ''
+
+beforeEach(async () => {
+  resetManagedKokoroRuntimeStateForTests()
+  root = await mkdtemp(join(tmpdir(), 'omi-kokoro-runtime-'))
+})
+
+afterEach(async () => {
+  resetManagedKokoroRuntimeStateForTests()
+  vi.restoreAllMocks()
+  if (root) await rm(root, { recursive: true, force: true })
+  root = ''
+})
+
+describe('managed Kokoro runtime', () => {
+  it('loads Kokoro into app-owned storage and writes synthesized WAV output', async () => {
+    const transformersEnv = {
+      cacheDir: '',
+      allowRemoteModels: false,
+      allowLocalModels: false,
+      useFSCache: false
+    }
+    const fromPretrained = vi.fn(async () => ({
+      generate: vi.fn(async (text: string, options?: { voice?: string; speed?: number }) => ({
+        save: async (filePath: string): Promise<void> => {
+          await mkdir(dirname(filePath), { recursive: true })
+          await writeFile(filePath, `RIFF:${text}:${options?.voice}:${options?.speed}`)
+        }
+      }))
+    }))
+    const deps = {
+      env: { OMI_LOCAL_TTS_ALLOW_NON_WINDOWS: '1' },
+      platform: 'linux',
+      arch: 'x64',
+      rootDir: root,
+      loadTransformers: async () => ({ env: transformersEnv }),
+      loadKokoro: async () => ({ KokoroTTS: { from_pretrained: fromPretrained } })
+    }
+
+    const initialStatus = await getManagedKokoroStatus(deps)
+    const result = await synthesizeWithManagedKokoro(
+      { text: 'Hello from local TTS', voice: 'af_heart', speed: 1.2 },
+      deps
+    )
+    const readyStatus = await getManagedKokoroStatus(deps)
+
+    expect(initialStatus.runtime.installState).toBe('not_installed')
+    expect(transformersEnv.cacheDir).toBe(join(root, 'models'))
+    expect(transformersEnv.allowRemoteModels).toBe(true)
+    expect(transformersEnv.useFSCache).toBe(true)
+    expect(fromPretrained).toHaveBeenCalledWith('onnx-community/Kokoro-82M-v1.0-ONNX', {
+      dtype: 'q8',
+      device: 'cpu'
+    })
+    expect(result.mimeType).toBe('audio/wav')
+    expect(result.audioUrl).toMatch(/^file:/)
+    await expect(readFile(result.audioPath, 'utf8')).resolves.toContain('Hello from local TTS')
+    expect(readyStatus.available).toBe(true)
+    expect(readyStatus.runtime.installState).toBe('installed')
+  })
+
+  it('reports unsupported when disabled and does not offer install', async () => {
+    const status = await getManagedKokoroStatus({
+      env: { OMI_LOCAL_TTS_DISABLED: '1' },
+      platform: 'win32',
+      arch: 'x64',
+      rootDir: root
+    })
+
+    expect(status.available).toBe(false)
+    expect(status.runtime.installState).toBe('unsupported')
+    expect(status.runtime.canInstall).toBe(false)
+    expect(status.reason).toBe('local TTS disabled')
+  })
+
+  it('keeps status in error when synthesis fails', async () => {
+    const deps = {
+      env: { OMI_LOCAL_TTS_ALLOW_NON_WINDOWS: '1' },
+      platform: 'linux',
+      arch: 'x64',
+      rootDir: root,
+      loadTransformers: async () => ({
+        env: {
+          cacheDir: '',
+          allowRemoteModels: false,
+          allowLocalModels: false,
+          useFSCache: false
+        }
+      }),
+      loadKokoro: async () => ({
+        KokoroTTS: {
+          from_pretrained: async () => {
+            throw new Error('model load failed')
+          }
+        }
+      })
+    }
+
+    await expect(synthesizeWithManagedKokoro({ text: 'hello' }, deps)).rejects.toThrow(
+      'model load failed'
+    )
+    const status = await getManagedKokoroStatus(deps)
+
+    expect(status.available).toBe(false)
+    expect(status.runtime.installState).toBe('error')
+    expect(status.reason).toBe('model load failed')
+  })
+})

--- a/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
@@ -31,8 +31,12 @@ describe('managed Kokoro runtime', () => {
       useFSCache: false
     }
     let cacheDirDuringLoad = ''
+    let allowRemoteModelsDuringLoad = false
+    let useFSCacheDuringLoad = false
     const fromPretrained = vi.fn(async () => {
       cacheDirDuringLoad = transformersEnv.cacheDir
+      allowRemoteModelsDuringLoad = transformersEnv.allowRemoteModels
+      useFSCacheDuringLoad = transformersEnv.useFSCache
       return {
         generate: vi.fn(async (text: string, options?: { voice?: string; speed?: number }) => ({
           save: async (filePath: string): Promise<void> => {
@@ -60,6 +64,8 @@ describe('managed Kokoro runtime', () => {
 
     expect(initialStatus.runtime.installState).toBe('not_installed')
     expect(cacheDirDuringLoad).toBe(join(root, 'models'))
+    expect(allowRemoteModelsDuringLoad).toBe(true)
+    expect(useFSCacheDuringLoad).toBe(true)
     expect(transformersEnv.cacheDir).toBe('')
     expect(transformersEnv.allowRemoteModels).toBe(false)
     expect(transformersEnv.useFSCache).toBe(false)

--- a/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.test.ts
@@ -30,14 +30,18 @@ describe('managed Kokoro runtime', () => {
       allowLocalModels: false,
       useFSCache: false
     }
-    const fromPretrained = vi.fn(async () => ({
-      generate: vi.fn(async (text: string, options?: { voice?: string; speed?: number }) => ({
-        save: async (filePath: string): Promise<void> => {
-          await mkdir(dirname(filePath), { recursive: true })
-          await writeFile(filePath, `RIFF:${text}:${options?.voice}:${options?.speed}`)
-        }
-      }))
-    }))
+    let cacheDirDuringLoad = ''
+    const fromPretrained = vi.fn(async () => {
+      cacheDirDuringLoad = transformersEnv.cacheDir
+      return {
+        generate: vi.fn(async (text: string, options?: { voice?: string; speed?: number }) => ({
+          save: async (filePath: string): Promise<void> => {
+            await mkdir(dirname(filePath), { recursive: true })
+            await writeFile(filePath, `RIFF:${text}:${options?.voice}:${options?.speed}`)
+          }
+        }))
+      }
+    })
     const deps = {
       env: { OMI_LOCAL_TTS_ALLOW_NON_WINDOWS: '1' },
       platform: 'linux',
@@ -55,9 +59,10 @@ describe('managed Kokoro runtime', () => {
     const readyStatus = await getManagedKokoroStatus(deps)
 
     expect(initialStatus.runtime.installState).toBe('not_installed')
-    expect(transformersEnv.cacheDir).toBe(join(root, 'models'))
-    expect(transformersEnv.allowRemoteModels).toBe(true)
-    expect(transformersEnv.useFSCache).toBe(true)
+    expect(cacheDirDuringLoad).toBe(join(root, 'models'))
+    expect(transformersEnv.cacheDir).toBe('')
+    expect(transformersEnv.allowRemoteModels).toBe(false)
+    expect(transformersEnv.useFSCache).toBe(false)
     expect(fromPretrained).toHaveBeenCalledWith('onnx-community/Kokoro-82M-v1.0-ONNX', {
       dtype: 'q8',
       device: 'cpu'

--- a/desktop/windows/src/main/localTts/kokoroRuntime.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.ts
@@ -1,0 +1,382 @@
+import { access, mkdir, readdir, rm } from 'fs/promises'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+import { randomUUID } from 'crypto'
+import type {
+  LocalTtsStatus,
+  LocalTtsSynthesizeRequest,
+  LocalTtsSynthesizeResult
+} from '../../shared/types'
+
+export const KOKORO_MODEL_ID = 'onnx-community/Kokoro-82M-v1.0-ONNX'
+export const KOKORO_DEFAULT_VOICE = 'af_heart'
+
+const MAX_TTS_CHARS = 4000
+const AUDIO_RETENTION_MS = 24 * 60 * 60 * 1000
+
+type KokoroInstallState = LocalTtsStatus['runtime']['installState']
+type KokoroDtype = 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16'
+
+type RawAudioLike = {
+  save: (filePath: string) => Promise<void> | void
+}
+
+type KokoroTtsLike = {
+  generate: (text: string, options?: { voice?: string; speed?: number }) => Promise<RawAudioLike>
+}
+
+type KokoroModuleLike = {
+  KokoroTTS: {
+    from_pretrained: (
+      modelId: string,
+      options?: {
+        dtype?: KokoroDtype
+        device?: 'cpu' | 'wasm' | 'webgpu' | null
+        progress_callback?: (progress: unknown) => void
+      }
+    ) => Promise<KokoroTtsLike>
+  }
+}
+
+type TransformersModuleLike = {
+  env: {
+    cacheDir: string
+    allowRemoteModels: boolean
+    allowLocalModels: boolean
+    useFSCache: boolean
+  }
+}
+
+type RuntimeSelection = {
+  supported: boolean
+  reason?: string
+  runtimeRoot: string
+  modelCacheDir: string
+  audioDir: string
+  model: string
+  voice: string
+  dtype: KokoroDtype
+}
+
+type RuntimeDeps = {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform | string
+  arch?: string
+  now?: () => number
+  rootDir?: string
+  loadKokoro?: () => Promise<KokoroModuleLike>
+  loadTransformers?: () => Promise<TransformersModuleLike>
+}
+
+let loadPromise: Promise<KokoroTtsLike> | null = null
+let kokoroTts: KokoroTtsLike | null = null
+let installState: KokoroInstallState | null = null
+let installError: string | null = null
+let activeSyntheses = 0
+let lastCleanupAt = 0
+
+export function resetManagedKokoroRuntimeStateForTests(): void {
+  loadPromise = null
+  kokoroTts = null
+  installState = null
+  installError = null
+  activeSyntheses = 0
+  lastCleanupAt = 0
+}
+
+export async function getManagedKokoroStatus(deps: RuntimeDeps = {}): Promise<LocalTtsStatus> {
+  const now = deps.now ?? Date.now
+  const checkedAt = now()
+  const selection = selectRuntime(deps)
+
+  if (!selection.supported) {
+    return statusFromSelection(selection, 'unsupported', false, checkedAt, selection.reason)
+  }
+
+  const installed = await hasModelCache(selection.modelCacheDir)
+  const loaded = kokoroTts != null
+  const state = runtimeInstallState(installed || loaded)
+
+  return statusFromSelection(
+    selection,
+    state,
+    installed || loaded,
+    checkedAt,
+    runtimeStatusReason(state)
+  )
+}
+
+export async function synthesizeWithManagedKokoro(
+  request: LocalTtsSynthesizeRequest,
+  deps: RuntimeDeps = {}
+): Promise<LocalTtsSynthesizeResult> {
+  const text = normalizeText(request.text)
+  if (!text) throw new Error('Text is required for local TTS')
+
+  const selection = selectRuntime(deps)
+  if (!selection.supported) {
+    throw new Error(selection.reason ?? 'local Kokoro TTS is not supported')
+  }
+
+  const tts = await ensureManagedKokoroRuntime(deps, selection)
+  const voice = normalizeVoice(request.voice, selection.voice)
+  const speed = normalizeSpeed(request.speed)
+  const audioDir = selection.audioDir
+  await mkdir(audioDir, { recursive: true })
+  await cleanupOldAudio(audioDir, deps.now ?? Date.now).catch(() => {
+    /* best effort */
+  })
+
+  const audioPath = join(audioDir, `kokoro-${Date.now()}-${randomUUID()}.wav`)
+  activeSyntheses += 1
+  installState = 'running'
+  try {
+    const audio = await tts.generate(text, { voice, speed })
+    await audio.save(audioPath)
+    return {
+      audioPath,
+      audioUrl: pathToFileURL(audioPath).toString(),
+      mimeType: 'audio/wav'
+    }
+  } catch (err) {
+    installError = err instanceof Error ? err.message : String(err)
+    installState = 'error'
+    throw err
+  } finally {
+    activeSyntheses = Math.max(0, activeSyntheses - 1)
+    if (installState === 'running' && activeSyntheses === 0) installState = 'installed'
+  }
+}
+
+async function ensureManagedKokoroRuntime(
+  deps: RuntimeDeps,
+  selection = selectRuntime(deps)
+): Promise<KokoroTtsLike> {
+  if (kokoroTts) return kokoroTts
+  if (loadPromise) return loadPromise
+  loadPromise = loadManagedRuntime(deps, selection).finally(() => {
+    loadPromise = null
+  })
+  return loadPromise
+}
+
+async function loadManagedRuntime(
+  deps: RuntimeDeps,
+  selection: RuntimeSelection
+): Promise<KokoroTtsLike> {
+  if (!selection.supported) {
+    throw new Error(selection.reason ?? 'local Kokoro TTS is not supported')
+  }
+  installState = 'installing'
+  installError = null
+
+  try {
+    await mkdir(selection.runtimeRoot, { recursive: true })
+    await mkdir(selection.modelCacheDir, { recursive: true })
+
+    const transformers = await loadTransformersModule(deps)
+    transformers.env.cacheDir = selection.modelCacheDir
+    transformers.env.allowRemoteModels = true
+    transformers.env.allowLocalModels = true
+    transformers.env.useFSCache = true
+
+    const kokoro = await loadKokoroModule(deps)
+    const runtime = await kokoro.KokoroTTS.from_pretrained(selection.model, {
+      dtype: selection.dtype,
+      device: 'cpu'
+    })
+    kokoroTts = runtime
+    installState = 'installed'
+    return runtime
+  } catch (err) {
+    installError = err instanceof Error ? err.message : String(err)
+    installState = 'error'
+    throw err
+  }
+}
+
+function selectRuntime(deps: RuntimeDeps): RuntimeSelection {
+  const env = deps.env ?? process.env
+  const platform = deps.platform ?? process.platform
+  const arch = deps.arch ?? process.arch
+  const model = env.OMI_LOCAL_TTS_MODEL_ID || KOKORO_MODEL_ID
+  const voice = env.OMI_LOCAL_TTS_VOICE || KOKORO_DEFAULT_VOICE
+  const dtype = normalizeDtype(env.OMI_LOCAL_TTS_DTYPE)
+  const runtimeRoot = deps.rootDir ?? defaultRuntimeRoot(env, platform)
+  const modelCacheDir = join(runtimeRoot, 'models')
+  const audioDir = join(runtimeRoot, 'audio')
+  const allowNonWindows = env.OMI_LOCAL_TTS_ALLOW_NON_WINDOWS === '1'
+
+  if (env.OMI_LOCAL_TTS_DISABLED === '1') {
+    return unsupported(
+      'local TTS disabled',
+      runtimeRoot,
+      modelCacheDir,
+      audioDir,
+      model,
+      voice,
+      dtype
+    )
+  }
+
+  if (platform !== 'win32' && !allowNonWindows) {
+    return unsupported(
+      'Local Kokoro TTS is only available in the Windows app',
+      runtimeRoot,
+      modelCacheDir,
+      audioDir,
+      model,
+      voice,
+      dtype
+    )
+  }
+
+  if (arch !== 'x64' && arch !== 'amd64') {
+    return unsupported(
+      'Local Kokoro TTS requires Windows x64',
+      runtimeRoot,
+      modelCacheDir,
+      audioDir,
+      model,
+      voice,
+      dtype
+    )
+  }
+
+  return { supported: true, runtimeRoot, modelCacheDir, audioDir, model, voice, dtype }
+}
+
+function unsupported(
+  reason: string,
+  runtimeRoot: string,
+  modelCacheDir: string,
+  audioDir: string,
+  model: string,
+  voice: string,
+  dtype: KokoroDtype
+): RuntimeSelection {
+  return { supported: false, reason, runtimeRoot, modelCacheDir, audioDir, model, voice, dtype }
+}
+
+function defaultRuntimeRoot(env: NodeJS.ProcessEnv, platform: NodeJS.Platform | string): string {
+  if (env.OMI_LOCAL_TTS_RUNTIME_ROOT) return env.OMI_LOCAL_TTS_RUNTIME_ROOT
+  if (platform === 'win32') {
+    const localAppData = env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+    return join(localAppData, 'Omi for Windows', 'LocalTTS', 'kokoro-js')
+  }
+  return join(tmpdir(), 'omi-windows-local-tts', 'kokoro-js')
+}
+
+function statusFromSelection(
+  selection: RuntimeSelection,
+  installState: KokoroInstallState,
+  available: boolean,
+  checkedAt: number,
+  reason?: string
+): LocalTtsStatus {
+  return {
+    backend: 'kokoro',
+    healthy: available,
+    available,
+    managed: true,
+    runtime: {
+      kind: 'kokoro-js',
+      installState,
+      model: selection.model,
+      voice: selection.voice,
+      canInstall: selection.supported
+    },
+    reason,
+    checkedAt
+  }
+}
+
+function runtimeInstallState(installed: boolean): KokoroInstallState {
+  if (loadPromise) return 'installing'
+  if (activeSyntheses > 0) return 'running'
+  if (installed) return 'installed'
+  if (installState === 'error') return 'error'
+  return 'not_installed'
+}
+
+function runtimeStatusReason(state: KokoroInstallState): string | undefined {
+  if (state === 'installed' || state === 'running') return undefined
+  if (state === 'installing') return 'Installing local Kokoro TTS'
+  if (state === 'error') return installError ?? 'Local Kokoro TTS failed'
+  return 'Local Kokoro TTS will install on first spoken reply'
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, MAX_TTS_CHARS)
+}
+
+function normalizeVoice(voice: string | undefined, fallback: string): string {
+  const trimmed = voice?.trim()
+  return trimmed && /^[a-z]{2}_[a-z0-9_-]+$/i.test(trimmed) ? trimmed : fallback
+}
+
+function normalizeSpeed(speed: number | undefined): number {
+  if (typeof speed !== 'number' || !Number.isFinite(speed)) return 1
+  return Math.min(2, Math.max(0.5, speed))
+}
+
+function normalizeDtype(value: string | undefined): KokoroDtype {
+  if (
+    value === 'fp32' ||
+    value === 'fp16' ||
+    value === 'q8' ||
+    value === 'q4' ||
+    value === 'q4f16'
+  ) {
+    return value
+  }
+  return 'q8'
+}
+
+async function hasModelCache(modelCacheDir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(modelCacheDir, { recursive: true, withFileTypes: true })
+    return entries.some((entry) => entry.isFile())
+  } catch {
+    return false
+  }
+}
+
+async function cleanupOldAudio(audioDir: string, now: () => number): Promise<void> {
+  const current = now()
+  if (current - lastCleanupAt < 60 * 60 * 1000) return
+  lastCleanupAt = current
+  const entries = await readdir(audioDir, { withFileTypes: true }).catch(() => [])
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.wav'))
+      .map(async (entry) => {
+        const fullPath = join(audioDir, entry.name)
+        const match = /^kokoro-(\d+)-/.exec(entry.name)
+        const createdAt = match ? Number(match[1]) : current
+        if (current - createdAt > AUDIO_RETENTION_MS && (await exists(fullPath))) {
+          await rm(fullPath, { force: true })
+        }
+      })
+  )
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function loadKokoroModule(deps: RuntimeDeps): Promise<KokoroModuleLike> {
+  if (deps.loadKokoro) return deps.loadKokoro()
+  return import('kokoro-js') as Promise<KokoroModuleLike>
+}
+
+async function loadTransformersModule(deps: RuntimeDeps): Promise<TransformersModuleLike> {
+  if (deps.loadTransformers) return deps.loadTransformers()
+  return import('@huggingface/transformers') as Promise<TransformersModuleLike>
+}

--- a/desktop/windows/src/main/localTts/kokoroRuntime.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.ts
@@ -176,16 +176,20 @@ async function loadManagedRuntime(
     await mkdir(selection.modelCacheDir, { recursive: true })
 
     const transformers = await loadTransformersModule(deps)
-    transformers.env.cacheDir = selection.modelCacheDir
-    transformers.env.allowRemoteModels = true
-    transformers.env.allowLocalModels = true
-    transformers.env.useFSCache = true
-
-    const kokoro = await loadKokoroModule(deps)
-    const runtime = await kokoro.KokoroTTS.from_pretrained(selection.model, {
-      dtype: selection.dtype,
-      device: 'cpu'
-    })
+    const restoreTransformersEnv = configureTransformersEnv(
+      transformers.env,
+      selection.modelCacheDir
+    )
+    let runtime: KokoroTtsLike
+    try {
+      const kokoro = await loadKokoroModule(deps)
+      runtime = await kokoro.KokoroTTS.from_pretrained(selection.model, {
+        dtype: selection.dtype,
+        device: 'cpu'
+      })
+    } finally {
+      restoreTransformersEnv()
+    }
     kokoroTts = runtime
     installState = 'installed'
     return runtime
@@ -346,7 +350,6 @@ async function hasModelCache(modelCacheDir: string): Promise<boolean> {
 async function cleanupOldAudio(audioDir: string, now: () => number): Promise<void> {
   const current = now()
   if (current - lastCleanupAt < 60 * 60 * 1000) return
-  lastCleanupAt = current
   const entries = await readdir(audioDir, { withFileTypes: true }).catch(() => [])
   await Promise.all(
     entries
@@ -360,6 +363,29 @@ async function cleanupOldAudio(audioDir: string, now: () => number): Promise<voi
         }
       })
   )
+  lastCleanupAt = current
+}
+
+function configureTransformersEnv(
+  env: TransformersModuleLike['env'],
+  modelCacheDir: string
+): () => void {
+  const previous = {
+    cacheDir: env.cacheDir,
+    allowRemoteModels: env.allowRemoteModels,
+    allowLocalModels: env.allowLocalModels,
+    useFSCache: env.useFSCache
+  }
+  env.cacheDir = modelCacheDir
+  env.allowRemoteModels = true
+  env.allowLocalModels = true
+  env.useFSCache = true
+  return () => {
+    env.cacheDir = previous.cacheDir
+    env.allowRemoteModels = previous.allowRemoteModels
+    env.allowLocalModels = previous.allowLocalModels
+    env.useFSCache = previous.useFSCache
+  }
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/desktop/windows/src/main/localTts/kokoroRuntime.ts
+++ b/desktop/windows/src/main/localTts/kokoroRuntime.ts
@@ -75,6 +75,7 @@ let installState: KokoroInstallState | null = null
 let installError: string | null = null
 let activeSyntheses = 0
 let lastCleanupAt = 0
+let cleanupPromise: Promise<void> | null = null
 
 export function resetManagedKokoroRuntimeStateForTests(): void {
   loadPromise = null
@@ -83,6 +84,7 @@ export function resetManagedKokoroRuntimeStateForTests(): void {
   installError = null
   activeSyntheses = 0
   lastCleanupAt = 0
+  cleanupPromise = null
 }
 
 export async function getManagedKokoroStatus(deps: RuntimeDeps = {}): Promise<LocalTtsStatus> {
@@ -350,6 +352,15 @@ async function hasModelCache(modelCacheDir: string): Promise<boolean> {
 async function cleanupOldAudio(audioDir: string, now: () => number): Promise<void> {
   const current = now()
   if (current - lastCleanupAt < 60 * 60 * 1000) return
+  if (cleanupPromise) return cleanupPromise
+  lastCleanupAt = current
+  cleanupPromise = cleanupOldAudioInner(audioDir, current).finally(() => {
+    cleanupPromise = null
+  })
+  return cleanupPromise
+}
+
+async function cleanupOldAudioInner(audioDir: string, current: number): Promise<void> {
   const entries = await readdir(audioDir, { withFileTypes: true }).catch(() => [])
   await Promise.all(
     entries
@@ -363,7 +374,6 @@ async function cleanupOldAudio(audioDir: string, now: () => number): Promise<voi
         }
       })
   )
-  lastCleanupAt = current
 }
 
 function configureTransformersEnv(

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   CaptureChoice,
   ListenStartArgs,
   ListenMessage,
+  LocalTtsSynthesizeRequest,
   ExportMemory,
   GoogleSource,
   KnowledgeGraph,
@@ -46,6 +47,9 @@ const omi: OmiBridgeApi = {
     return () => ipcRenderer.removeListener('omi-listen:message', listener)
   },
   localSttStatus: () => ipcRenderer.invoke('omi-local-stt:status'),
+  localTtsStatus: () => ipcRenderer.invoke('omi-local-tts:status'),
+  localTtsSynthesize: (request: LocalTtsSynthesizeRequest) =>
+    ipcRenderer.invoke('omi-local-tts:synthesize', request),
   indexFilesScan: () => ipcRenderer.invoke('fileIndex:scan'),
   indexFilesStatus: () => ipcRenderer.invoke('fileIndex:status'),
   indexFilesApps: (limit?: number) => ipcRenderer.invoke('fileIndex:apps', limit),

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -45,6 +45,7 @@ const omi: OmiBridgeApi = {
     ipcRenderer.on('omi-listen:message', listener)
     return () => ipcRenderer.removeListener('omi-listen:message', listener)
   },
+  localSttStatus: () => ipcRenderer.invoke('omi-local-stt:status'),
   indexFilesScan: () => ipcRenderer.invoke('fileIndex:scan'),
   indexFilesStatus: () => ipcRenderer.invoke('fileIndex:status'),
   indexFilesApps: (limit?: number) => ipcRenderer.invoke('fileIndex:apps', limit),

--- a/desktop/windows/src/renderer/src/components/settings/StatusTile.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/StatusTile.tsx
@@ -1,0 +1,20 @@
+export function StatusTile({
+  label,
+  value,
+  tone = 'neutral'
+}: {
+  label: string
+  value: string
+  tone?: 'good' | 'warn' | 'neutral'
+}): React.JSX.Element {
+  const dot = tone === 'good' ? 'bg-emerald-400' : tone === 'warn' ? 'bg-amber-300' : 'bg-white/30'
+  return (
+    <div className="min-w-0 rounded-lg bg-white/[0.04] px-3 py-2">
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-text-tertiary">
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="mt-1 truncate text-sm text-text-secondary">{value}</div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs.ts
+++ b/desktop/windows/src/renderer/src/components/settings/tabs.ts
@@ -1,5 +1,6 @@
 import {
   Settings as SettingsIcon,
+  AudioLines,
   History,
   ShieldCheck,
   CircleUserRound,
@@ -8,12 +9,20 @@ import {
   type LucideIcon
 } from 'lucide-react'
 
-export type SettingsTabId = 'general' | 'memories' | 'rewind' | 'privacy' | 'account' | 'advanced'
+export type SettingsTabId =
+  | 'general'
+  | 'memories'
+  | 'rewind'
+  | 'transcription'
+  | 'privacy'
+  | 'account'
+  | 'advanced'
 
 export const SETTINGS_TABS: { id: SettingsTabId; label: string; Icon: LucideIcon }[] = [
   { id: 'general', label: 'General', Icon: SettingsIcon },
   { id: 'memories', label: 'Memories', Icon: Brain },
   { id: 'rewind', label: 'Rewind', Icon: History },
+  { id: 'transcription', label: 'Transcription', Icon: AudioLines },
   { id: 'privacy', label: 'Privacy', Icon: ShieldCheck },
   { id: 'account', label: 'Account', Icon: CircleUserRound },
   { id: 'advanced', label: 'Advanced', Icon: SlidersHorizontal }

--- a/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
@@ -32,7 +32,12 @@ function localRuntimeSubtitle(sttMode: SttMode, status: LocalSttStatus | null): 
   if (status.runtime.installState === 'installing' || status.runtime.installState === 'starting') {
     return 'Preparing local Parakeet'
   }
-  if (status.runtime.canInstall) return 'Local Parakeet installs on first use'
+  if (status.runtime.canInstall) {
+    // Auto never downloads the runtime/model; only the explicit choice does.
+    return sttMode === 'local-parakeet'
+      ? 'Local Parakeet installs on first use'
+      : 'Hosted Omi until Local Parakeet is installed'
+  }
   return status.reason ?? 'Local Parakeet unavailable'
 }
 

--- a/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
@@ -101,11 +101,14 @@ export function TranscriptionTab(): React.JSX.Element {
     setPreferences({ sttMode: next })
   }
 
-  const voiceReadiness = realtimeVoiceReadiness({
-    ...getPreferences(),
-    realtimeVoiceEnabled,
-    realtimeVoiceProvider
-  })
+  const voiceReadiness = realtimeVoiceReadiness(
+    {
+      ...getPreferences(),
+      realtimeVoiceEnabled,
+      realtimeVoiceProvider
+    },
+    localTtsStatus
+  )
 
   useEffect(() => {
     let canceled = false

--- a/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useState } from 'react'
+import { Cpu, Languages, Mic, Radio } from 'lucide-react'
+import type {
+  LocalSttStatus,
+  LocalTtsStatus,
+  RealtimeVoiceProvider,
+  SttMode
+} from '../../../../../shared/types'
+import { LANGUAGES, languageLabel } from '../../../lib/languages'
+import { getPreferences, setPreferences } from '../../../lib/preferences'
+import { realtimeVoiceReadiness } from '../../../lib/realtimeVoice'
+import { syncLanguage } from '../../../lib/userProfile'
+import { toast } from '../../../lib/toast'
+import { SettingRow } from '../SettingRow'
+import { StatusTile } from '../StatusTile'
+import { Toggle } from '../Toggle'
+
+function localRuntimeValue(status: LocalSttStatus | null): string {
+  const state = status?.runtime.installState
+  if (!state) return 'Checking'
+  if (state === 'installed' || state === 'running') return 'Installed'
+  if (state === 'installing' || state === 'starting') return 'Installing'
+  if (state === 'not_installed') return 'Installs on first use'
+  if (state === 'unsupported') return 'Unavailable'
+  return 'Needs attention'
+}
+
+function localRuntimeSubtitle(sttMode: SttMode, status: LocalSttStatus | null): string {
+  if (sttMode === 'cloud') return 'Hosted Omi /v4/listen'
+  if (!status) return 'Checking local Parakeet'
+  if (status.available) return 'Local Parakeet ready'
+  if (status.runtime.installState === 'installing' || status.runtime.installState === 'starting') {
+    return 'Preparing local Parakeet'
+  }
+  if (status.runtime.canInstall) return 'Local Parakeet installs on first use'
+  return status.reason ?? 'Local Parakeet unavailable'
+}
+
+function localRuntimeTone(
+  status: LocalSttStatus | null,
+  sttMode: SttMode
+): 'good' | 'warn' | 'neutral' {
+  if (status?.available) return 'good'
+  if (sttMode === 'local-parakeet' || status?.runtime.installState === 'error') return 'warn'
+  return 'neutral'
+}
+
+function localTtsRuntimeValue(status: LocalTtsStatus | null): string {
+  const state = status?.runtime.installState
+  if (!state) return 'Checking'
+  if (state === 'installed' || state === 'running') return 'Ready'
+  if (state === 'installing') return 'Installing'
+  if (state === 'not_installed') return 'Installs on first reply'
+  if (state === 'unsupported') return 'Unavailable'
+  return 'Needs attention'
+}
+
+function localTtsRuntimeTone(
+  status: LocalTtsStatus | null,
+  selected: boolean
+): 'good' | 'warn' | 'neutral' {
+  if (status?.available) return 'good'
+  if (
+    selected &&
+    (!status || !status.runtime.canInstall || status.runtime.installState === 'error')
+  ) {
+    return 'warn'
+  }
+  return 'neutral'
+}
+
+export function TranscriptionTab(): React.JSX.Element {
+  const [language, setLanguage] = useState(getPreferences().language)
+  const [continuousRec, setContinuousRec] = useState<boolean>(
+    () => !!getPreferences().continuousRecording
+  )
+  const [sttMode, setSttMode] = useState<SttMode>(() => getPreferences().sttMode ?? 'auto')
+  const [localSttStatus, setLocalSttStatus] = useState<LocalSttStatus | null>(null)
+  const [realtimeVoiceEnabled, setRealtimeVoiceEnabled] = useState<boolean>(
+    () => !!getPreferences().realtimeVoiceEnabled
+  )
+  const [realtimeVoiceProvider, setRealtimeVoiceProvider] = useState<RealtimeVoiceProvider>(
+    () => getPreferences().realtimeVoiceProvider ?? 'omi-relay'
+  )
+  const [localTtsStatus, setLocalTtsStatus] = useState<LocalTtsStatus | null>(null)
+
+  const toggleContinuous = (): void => {
+    const next = !continuousRec
+    setContinuousRec(next)
+    setPreferences({ continuousRecording: next })
+  }
+
+  const toggleRealtimeVoice = (): void => {
+    const next = !realtimeVoiceEnabled
+    setRealtimeVoiceEnabled(next)
+    setPreferences({ realtimeVoiceEnabled: next })
+  }
+
+  const saveSttMode = (next: SttMode): void => {
+    setSttMode(next)
+    setPreferences({ sttMode: next })
+  }
+
+  const voiceReadiness = realtimeVoiceReadiness({
+    ...getPreferences(),
+    realtimeVoiceEnabled,
+    realtimeVoiceProvider
+  })
+
+  useEffect(() => {
+    let canceled = false
+    const refresh = (): void => {
+      window.omi
+        .localTtsStatus()
+        .then((status) => {
+          if (!canceled) setLocalTtsStatus(status)
+        })
+        .catch(() => {
+          if (!canceled) setLocalTtsStatus(null)
+        })
+    }
+    refresh()
+    const timer = setInterval(refresh, 15000)
+    return () => {
+      canceled = true
+      clearInterval(timer)
+    }
+  }, [])
+
+  useEffect(() => {
+    let canceled = false
+    const refresh = (): void => {
+      window.omi
+        .localSttStatus()
+        .then((status) => {
+          if (!canceled) setLocalSttStatus(status)
+        })
+        .catch(() => {
+          if (!canceled) setLocalSttStatus(null)
+        })
+    }
+    refresh()
+    const timer = setInterval(refresh, 15000)
+    return () => {
+      canceled = true
+      clearInterval(timer)
+    }
+  }, [])
+
+  const saveLanguage = (): void => {
+    setPreferences({ language })
+    void syncLanguage(language).catch(() => toast('Language sync failed', { tone: 'warn' }))
+    toast('Transcription language saved', { tone: 'success' })
+  }
+
+  return (
+    <>
+      <SettingRow
+        icon={Languages}
+        title="Transcription language"
+        subtitle="Language used for continuous recording and voice transcription."
+        keywords="transcription language speech to text stt locale microphone audio"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="glass-subtle min-w-0 flex-1 rounded-lg px-4 py-3 text-sm text-text-secondary focus:outline-none"
+          >
+            {LANGUAGES.map((l) => (
+              <option key={l.code} value={l.code} className="bg-neutral-900">
+                {l.label}
+              </option>
+            ))}
+          </select>
+          <button onClick={saveLanguage} className="btn-ghost">
+            Save · {languageLabel(language)}
+          </button>
+        </div>
+      </SettingRow>
+      <SettingRow
+        icon={Mic}
+        dot={continuousRec ? 'on' : 'off'}
+        title="Continuous recording"
+        subtitle="Always-on microphone. Omi turns what you hear into conversations automatically."
+        keywords="continuous recording microphone audio always-on transcription listen"
+        control={
+          <Toggle on={continuousRec} onChange={toggleContinuous} label="Continuous recording" />
+        }
+      />
+      <SettingRow
+        icon={Cpu}
+        dot={
+          sttMode === 'cloud'
+            ? 'off'
+            : localSttStatus?.available
+              ? 'on'
+              : sttMode === 'local-parakeet'
+                ? 'warn'
+                : 'off'
+        }
+        title="Speech-to-text runtime"
+        subtitle={localRuntimeSubtitle(sttMode, localSttStatus)}
+        keywords="local stt parakeet nvidia cuda offline speech transcription runtime"
+      >
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_180px]">
+          <select
+            value={sttMode}
+            onChange={(e) => saveSttMode(e.target.value as SttMode)}
+            className="glass-subtle min-w-0 rounded-lg px-4 py-3 text-sm text-text-secondary focus:outline-none"
+          >
+            <option value="auto" className="bg-neutral-900">
+              Auto
+            </option>
+            <option value="cloud" className="bg-neutral-900">
+              Hosted Omi
+            </option>
+            <option value="local-parakeet" className="bg-neutral-900">
+              Local Parakeet
+            </option>
+          </select>
+          <StatusTile
+            label="Local STT"
+            value={
+              localSttStatus?.available
+                ? 'Ready'
+                : localSttStatus?.runtime.canInstall
+                  ? 'First-use install'
+                  : 'Unavailable'
+            }
+            tone={localRuntimeTone(localSttStatus, sttMode)}
+          />
+        </div>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <StatusTile
+            label="Local runtime"
+            value={localRuntimeValue(localSttStatus)}
+            tone={localRuntimeTone(localSttStatus, sttMode)}
+          />
+          <StatusTile
+            label="NVIDIA"
+            value={
+              localSttStatus?.nvidiaAvailable == null
+                ? 'Not checked'
+                : localSttStatus.nvidiaAvailable
+                  ? 'Detected'
+                  : 'Not detected'
+            }
+            tone={
+              localSttStatus?.nvidiaAvailable == null
+                ? 'neutral'
+                : localSttStatus.nvidiaAvailable
+                  ? 'good'
+                  : 'warn'
+            }
+          />
+        </div>
+      </SettingRow>
+      <SettingRow
+        icon={Radio}
+        dot={!realtimeVoiceEnabled ? 'off' : voiceReadiness.ready ? 'on' : 'warn'}
+        title="Realtime voice"
+        subtitle={`${voiceReadiness.label} · ${voiceReadiness.keyPath}`}
+        keywords="realtime voice omi local kokoro microphone voice conversation relay"
+        control={
+          <Toggle on={realtimeVoiceEnabled} onChange={toggleRealtimeVoice} label="Realtime voice" />
+        }
+      >
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_180px]">
+          <select
+            value={realtimeVoiceProvider}
+            onChange={(e) => {
+              const provider = e.target.value as RealtimeVoiceProvider
+              setRealtimeVoiceProvider(provider)
+              setPreferences({ realtimeVoiceProvider: provider })
+            }}
+            className="glass-subtle min-w-0 rounded-lg px-4 py-3 text-sm text-text-secondary focus:outline-none"
+          >
+            <option value="omi-relay" className="bg-neutral-900">
+              Omi relay
+            </option>
+            <option value="local-kokoro" className="bg-neutral-900">
+              Local Kokoro
+            </option>
+          </select>
+          <StatusTile
+            label="Voice readiness"
+            value={
+              !realtimeVoiceEnabled
+                ? 'Off'
+                : voiceReadiness.ready
+                  ? 'Ready'
+                  : (voiceReadiness.reason ?? 'Needs setup')
+            }
+            tone={!realtimeVoiceEnabled ? 'neutral' : voiceReadiness.ready ? 'good' : 'warn'}
+          />
+        </div>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <StatusTile
+            label="Local TTS"
+            value={localTtsRuntimeValue(localTtsStatus)}
+            tone={localTtsRuntimeTone(localTtsStatus, realtimeVoiceProvider === 'local-kokoro')}
+          />
+          <StatusTile
+            label="Local voice model"
+            value={localTtsStatus?.runtime.model.includes('Kokoro-82M') ? 'Kokoro-82M' : 'Kokoro'}
+            tone={
+              realtimeVoiceProvider === 'local-kokoro' && localTtsStatus?.runtime.canInstall
+                ? 'good'
+                : 'neutral'
+            }
+          />
+        </div>
+        <div className="mt-3 rounded-lg border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-xs text-white/45">
+          {voiceReadiness.transcriptionPath}
+        </div>
+      </SettingRow>
+    </>
+  )
+}

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -8,6 +8,7 @@ import { callAgentLLM } from '../lib/agentLLM'
 import type { AutomationPlan } from '../../../shared/types'
 import { getPreferences } from '../lib/preferences'
 import { resolveChatId, mergeChatMessages } from '../lib/chatConversation'
+import { speakAssistantText } from '../lib/localTtsPlayback'
 
 export type ChatMsg = { id?: string; role: 'user' | 'assistant'; content: string }
 
@@ -212,6 +213,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       }
       setHistory((h) => [...h, outMsg])
       void persistChat([...baseHistory, userMsg, outMsg])
+      void speakAssistantText(outMsg.content)
       sendingRef.current = false
       return
     }
@@ -224,6 +226,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       }
       setHistory((h) => [...h, errMsg])
       void persistChat([...baseHistory, userMsg, errMsg])
+      void speakAssistantText(errMsg.content)
       sendingRef.current = false
       return
     }
@@ -338,6 +341,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       sendingRef.current = false
       setSending(false)
       await persistChat(buildThread(assistantText))
+      void speakAssistantText(assistantText)
     }
   }
 

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -243,6 +243,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
     let lastPersist = Date.now()
 
     let assistantText = ''
+    let assistantIsError = false
     try {
       const token = await auth.currentUser?.getIdToken()
       // Hybrid pre-step: gather context to PREPEND to the text we send (not what we
@@ -331,6 +332,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
         })
       }
     } catch (e) {
+      assistantIsError = true
       assistantText = `Error: ${(e as Error).message}`
       setHistory((h) => {
         const next = [...h]
@@ -341,7 +343,7 @@ export function useChat(opts?: { surface?: 'main' | 'overlay' }): UseChat {
       sendingRef.current = false
       setSending(false)
       await persistChat(buildThread(assistantText))
-      void speakAssistantText(assistantText)
+      void speakAssistantText(assistantText, { isError: assistantIsError })
     }
   }
 

--- a/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
+++ b/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
@@ -206,7 +206,7 @@ export function usePushToTalk(opts: Options): PushToTalk {
     setFinalizing(false)
     stopAudioViz()
     try {
-      handleRef.current?.stop()
+      void handleRef.current?.stop()
     } catch {
       /* ignore */
     }
@@ -263,7 +263,7 @@ export function usePushToTalk(opts: Options): PushToTalk {
         // Released/superseded before the connection resolved — tear it straight down.
         if (sessionRef.current !== session) {
           try {
-            handle.stop()
+            void handle.stop()
           } catch {
             /* ignore */
           }
@@ -294,13 +294,17 @@ export function usePushToTalk(opts: Options): PushToTalk {
     const releasedAt = Date.now()
 
     const commitNow = (): void => {
+      void commitNowAsync()
+    }
+
+    const commitNowAsync = async (): Promise<void> => {
       if (sessionRef.current !== session) return
       clearPoll()
       finalizingRef.current = false
       setFinalizing(false)
       stopAudioViz()
       try {
-        handleRef.current?.stop()
+        await handleRef.current?.stop()
       } catch {
         /* ignore */
       }
@@ -391,11 +395,14 @@ export function usePushToTalk(opts: Options): PushToTalk {
   // field, so the two never double-handle. Latest start/finish/getDraft are read
   // through refs so the once-registered listeners never call a stale closure.
   const startRecordingRef = useRef(startRecording)
-  startRecordingRef.current = startRecording
   const finishRecordingRef = useRef(finishRecording)
-  finishRecordingRef.current = finishRecording
   const getDraftRef = useRef(opts.getDraft)
-  getDraftRef.current = opts.getDraft
+
+  useEffect(() => {
+    startRecordingRef.current = startRecording
+    finishRecordingRef.current = finishRecording
+    getDraftRef.current = opts.getDraft
+  })
 
   useEffect(() => {
     const inTextField = (): boolean => {
@@ -441,19 +448,19 @@ export function usePushToTalk(opts: Options): PushToTalk {
 
   // Tear everything down if the panel unmounts mid-recording/finalize (e.g. Esc reset).
   useEffect(() => {
+    const session = sessionRef
     return () => {
       if (holdTimerRef.current !== null) clearTimeout(holdTimerRef.current)
       clearPoll()
       stopAudioViz()
       try {
-        handleRef.current?.stop()
+        void handleRef.current?.stop()
       } catch {
         /* ignore */
       }
       handleRef.current = null
-      sessionRef.current++
+      session.current++
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return { recording, finalizing, error, analyserRef, onKeyDown, onKeyUp, cancel }

--- a/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
+++ b/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
@@ -303,11 +303,7 @@ export function usePushToTalk(opts: Options): PushToTalk {
       finalizingRef.current = false
       setFinalizing(false)
       stopAudioViz()
-      try {
-        await handleRef.current?.stop()
-      } catch {
-        /* ignore */
-      }
+      const handle = handleRef.current
       handleRef.current = null
       const text = assembleTranscript(linesRef.current, interimRef.current)
       markConsumed()
@@ -318,6 +314,7 @@ export function usePushToTalk(opts: Options): PushToTalk {
       // quota/1008 or silence) — notify before the text-gated send.
       opts.onCaptureEnd?.()
       if (text) onCommit(text)
+      void handle?.stop().catch(() => undefined)
     }
 
     const check = (): void => {

--- a/desktop/windows/src/renderer/src/hooks/useRecorder.ts
+++ b/desktop/windows/src/renderer/src/hooks/useRecorder.ts
@@ -3,7 +3,9 @@ import { useNavigate } from 'react-router-dom'
 import { useRecording } from './useRecording'
 import { startTranscription, type TranscriptionHandle } from '../lib/transcriptionClient'
 import { invalidateConversationsCache, refreshCloudConversations } from '../lib/pageCache'
-import type { CaptureSource, TranscriptLine } from '../../../shared/types'
+import { getPreferences } from '../lib/preferences'
+import { uploadConversationFromSegments } from '../lib/localSttUpload'
+import type { CaptureSource, TranscriptLine, TranscriptionBackend } from '../../../shared/types'
 
 function linesToString(lines: TranscriptLine[], interim: string): string {
   const parts = lines.map((l) => (l.speaker ? `${l.speaker}: ${l.text}` : l.text))
@@ -39,9 +41,9 @@ export type UseRecorder = {
   systemLines: TranscriptLine[]
   systemInterim: string
   /** Which backend is driving the mic (and system) session, for debug/UI hints.
-   * Always 'omi' once connected (the only transcription backend). */
-  micBackend: 'omi' | null
-  systemBackend: 'omi' | null
+   * 'omi' for hosted /v4/listen or 'local-parakeet' for local STT. */
+  micBackend: TranscriptionBackend | null
+  systemBackend: TranscriptionBackend | null
   screenStream: MediaStream | null
   videoRef: React.RefObject<HTMLVideoElement | null>
   /** Begin a recording session. Pass `system: true` to also transcribe loopback. */
@@ -59,11 +61,15 @@ export function useRecorder(): UseRecorder {
   const [systemLines, setSystemLines] = useState<TranscriptLine[]>([])
   const [systemInterim, setSystemInterim] = useState('')
   const [hasSystem, setHasSystem] = useState(false)
-  const [micBackend, setMicBackend] = useState<'omi' | null>(null)
-  const [systemBackend, setSystemBackend] = useState<'omi' | null>(null)
+  const [micBackend, setMicBackend] = useState<TranscriptionBackend | null>(null)
+  const [systemBackend, setSystemBackend] = useState<TranscriptionBackend | null>(null)
   const [saving, setSaving] = useState(false)
   const micRef = useRef<TranscriptionHandle | null>(null)
   const systemRef = useRef<TranscriptionHandle | null>(null)
+  const micLinesRef = useRef<TranscriptLine[]>([])
+  const systemLinesRef = useRef<TranscriptLine[]>([])
+  const micBackendRef = useRef<TranscriptionBackend | null>(null)
+  const systemBackendRef = useRef<TranscriptionBackend | null>(null)
 
   const [screenStream, setScreenStream] = useState<MediaStream | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
@@ -91,32 +97,44 @@ export function useRecorder(): UseRecorder {
     setSystemInterim('')
     setMicBackend(null)
     setSystemBackend(null)
+    micLinesRef.current = []
+    systemLinesRef.current = []
+    micBackendRef.current = null
+    systemBackendRef.current = null
     setHasSystem(withSystem)
     try {
       micRef.current = await startTranscription('mic', {
         onLine: (line) => {
+          micLinesRef.current = [...micLinesRef.current, line]
           setMicLines((prev) => [...prev, line])
           setMicInterim('')
         },
         onInterim: setMicInterim,
-        onBackend: setMicBackend,
+        onBackend: (backend) => {
+          micBackendRef.current = backend
+          setMicBackend(backend)
+        },
         onError: (e) => console.error('Transcription (mic):', e)
       })
       if (withSystem) {
         systemRef.current = await startTranscription('system', {
           onLine: (line) => {
+            systemLinesRef.current = [...systemLinesRef.current, line]
             setSystemLines((prev) => [...prev, line])
             setSystemInterim('')
           },
           onInterim: setSystemInterim,
-          onBackend: setSystemBackend,
+          onBackend: (backend) => {
+            systemBackendRef.current = backend
+            setSystemBackend(backend)
+          },
           onError: (e) => console.error('Transcription (system):', e)
         })
       }
     } catch (e) {
-      micRef.current?.stop()
+      void micRef.current?.stop()
       micRef.current = null
-      systemRef.current?.stop()
+      void systemRef.current?.stop()
       systemRef.current = null
       const err = e as Error
       const hint =
@@ -167,9 +185,9 @@ export function useRecorder(): UseRecorder {
   }
 
   const stop = async (): Promise<void> => {
-    micRef.current?.stop()
+    await micRef.current?.stop()
     micRef.current = null
-    systemRef.current?.stop()
+    await systemRef.current?.stop()
     systemRef.current = null
     screenStream?.getTracks().forEach((t) => t.stop())
     setScreenStream(null)
@@ -177,6 +195,31 @@ export function useRecorder(): UseRecorder {
 
     const session = stopSession()
     if (!session) return
+
+    const usedLocal =
+      micBackendRef.current === 'local-parakeet' || systemBackendRef.current === 'local-parakeet'
+    if (usedLocal) {
+      const lines = [...micLinesRef.current, ...systemLinesRef.current].sort(
+        (a, b) => (a.start ?? 0) - (b.start ?? 0)
+      )
+      setSaving(true)
+      try {
+        await uploadConversationFromSegments({
+          lines,
+          startedAt: session.startedAt,
+          finishedAt: session.endedAt,
+          language: getPreferences().language
+        })
+        refreshCloudConversations()
+        navigate('/conversations', { replace: true })
+      } catch (e) {
+        console.error('Local STT upload failed:', (e as Error).message)
+        alert(`Save failed: ${(e as Error).message}`)
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
 
     // Mic-only sessions are backend-owned now: the cloud creates a titled
     // conversation from the same stream, so saving a local copy would just be an

--- a/desktop/windows/src/renderer/src/lib/liveMicSession.ts
+++ b/desktop/windows/src/renderer/src/lib/liveMicSession.ts
@@ -6,6 +6,7 @@ import { getPreferences } from './preferences'
 import { uploadConversationFromSegments } from './localSttUpload'
 import { transcriptWordCount } from './retentionRules'
 import { buildLocalGraph } from './kgSynthesis'
+import { toast } from './toast'
 
 // Force a local-KG rebuild so conversation-derived memories reach the brain map,
 // throttled to once per 30 min (the rebuild is two LLM calls). Delayed so the
@@ -98,10 +99,11 @@ export function startLiveMicSession(): LiveMicController {
         startedAt: args.startedAt,
         finishedAt: args.finishedAt,
         language: getPreferences().language
-        })
+      })
         .catch((e) => {
           const message = e instanceof Error ? e.message : String(e)
           console.warn('[local-stt] conversation upload failed:', message)
+          toast('Could not save local transcript', { tone: 'error', body: message })
         })
         .finally(pollForNewConversation)
     } else {

--- a/desktop/windows/src/renderer/src/lib/liveMicSession.ts
+++ b/desktop/windows/src/renderer/src/lib/liveMicSession.ts
@@ -2,6 +2,8 @@ import { startTranscription, type TranscriptionHandle } from './transcriptionCli
 import { liveConversation, isConversationBoundary, onFinalizeRequest } from './liveConversation'
 import { refreshCloudConversations } from './pageCache'
 import { createPendingConversation } from './pendingConversations'
+import { getPreferences } from './preferences'
+import { uploadConversationFromSegments } from './localSttUpload'
 import { transcriptWordCount } from './retentionRules'
 import { buildLocalGraph } from './kgSynthesis'
 
@@ -42,6 +44,9 @@ export function startLiveMicSession(): LiveMicController {
   let handle: TranscriptionHandle | null = null
   let attempt = 0
   let hasSpeech = false
+  let finalizing = false
+  let currentBackend: 'omi' | 'local-parakeet' | null = null
+  let currentStartedAt = Date.now()
   let silenceTimer: ReturnType<typeof setTimeout> | null = null
   const timers: ReturnType<typeof setTimeout>[] = []
 
@@ -79,10 +84,29 @@ export function startLiveMicSession(): LiveMicController {
   // Save the just-spoken transcript as its own conversation: show it in the list
   // instantly (titled client-side), keep it on the live screen flagged "saved",
   // and start a fresh session so capture continues.
-  const saveCurrent = (): void => {
-    createPendingConversation(liveConversation.getSegments())
+  const saveCurrent = (args: {
+    backend: 'omi' | 'local-parakeet' | null
+    startedAt: number
+    finishedAt: number
+  }): void => {
+    const segments = [...liveConversation.getSegments()]
+    createPendingConversation(segments)
     liveConversation.markSaved()
-    pollForNewConversation()
+    if (args.backend === 'local-parakeet') {
+      void uploadConversationFromSegments({
+        lines: segments,
+        startedAt: args.startedAt,
+        finishedAt: args.finishedAt,
+        language: getPreferences().language
+        })
+        .catch((e) => {
+          const message = e instanceof Error ? e.message : String(e)
+          console.warn('[local-stt] conversation upload failed:', message)
+        })
+        .finally(pollForNewConversation)
+    } else {
+      pollForNewConversation()
+    }
     // New conversation-derived memories should reach the brain map without waiting
     // for the next launch; force a throttled KG rebuild (helper above).
     requestKgRebuild()
@@ -91,59 +115,88 @@ export function startLiveMicSession(): LiveMicController {
   // Finalize on the silence timeout or "Save now": end the session (the backend
   // stores it), then restart. No-op if nothing was said since the last finalize.
   const finalize = (): void => {
-    if (cancelled || !hasSpeech) return
+    void finalizeAsync()
+  }
+
+  const finalizeAsync = async (): Promise<void> => {
+    if (cancelled || !hasSpeech || finalizing) return
     // Don't make a conversation out of a trivial blip (< 5 words) — keep
     // listening so it merges into the next real one.
     if (liveWordCount() < 5) {
       armSilence()
       return
     }
+    finalizing = true
     hasSpeech = false
     clearSilence()
-    try { handle?.stop() } catch { /* ignore */ }
+    const backend = currentBackend
+    const startedAt = currentStartedAt
+    try {
+      await handle?.stop()
+    } catch {
+      /* ignore */
+    }
+    const finishedAt = Date.now()
     handle = null
-    saveCurrent()
+    saveCurrent({ backend, startedAt, finishedAt })
     attempt = 0
+    finalizing = false
     startSession()
   }
 
   const startSession = (): void => {
     liveConversation.setStatus('connecting')
-    void startTranscription('mic', {
-      onLine: (line) => {
-        if (cancelled) return
-        liveConversation.setStatus('live')
-        liveConversation.appendLine(line)
-        hasSpeech = true
-        armSilence() // reset the silence countdown on each new utterance
-      },
-      onInterim: () => {},
-      onBackend: () => {
-        if (!cancelled) liveConversation.setStatus('live')
-      },
-      onEvent: (ev) => {
-        if (cancelled) return
-        if (isConversationBoundary(ev)) {
-          // Backend finalized on its own (beat our silence timer). Skip trivial
-          // blips; otherwise keep the transcript shown as saved.
-          clearSilence()
-          hasSpeech = false
-          if (liveWordCount() >= 5) saveCurrent()
-        }
-      },
-      onError: (e) => {
-        if (cancelled) return
-        if (attempt < MAX_ATTEMPTS) {
-          attempt++
-          liveConversation.setStatus('connecting')
-          timers.push(setTimeout(startSession, 800 * attempt))
-        } else {
-          liveConversation.setStatus('error', (e as Error).message)
+    currentBackend = null
+    currentStartedAt = Date.now()
+    void startTranscription(
+      'mic',
+      {
+        onLine: (line) => {
+          if (cancelled) return
+          liveConversation.setStatus('live')
+          liveConversation.appendLine(line)
+          hasSpeech = true
+          armSilence() // reset the silence countdown on each new utterance
+        },
+        onInterim: () => {},
+        onBackend: (backend) => {
+          currentBackend = backend
+          if (!cancelled) liveConversation.setStatus('live')
+        },
+        onEvent: (ev) => {
+          if (cancelled) return
+          if (isConversationBoundary(ev)) {
+            // Backend finalized on its own (beat our silence timer). Skip trivial
+            // blips; otherwise keep the transcript shown as saved.
+            clearSilence()
+            hasSpeech = false
+            if (liveWordCount() >= 5) {
+              saveCurrent({
+                backend: currentBackend,
+                startedAt: currentStartedAt,
+                finishedAt: Date.now()
+              })
+            }
+          }
+        },
+        onError: (e) => {
+          if (cancelled) return
+          if (attempt < MAX_ATTEMPTS) {
+            attempt++
+            liveConversation.setStatus('connecting')
+            timers.push(setTimeout(startSession, 800 * attempt))
+          } else {
+            liveConversation.setStatus('error', (e as Error).message)
+          }
         }
       }
-    }).then((h) => {
+    ).then((h) => {
       if (cancelled) {
-        try { h.stop() } catch { /* ignore */ }
+        try {
+          void h.stop()
+        } catch {
+          /* ignore */
+        }
         return
       }
       handle = h
@@ -163,7 +216,11 @@ export function startLiveMicSession(): LiveMicController {
       clearSilence()
       timers.forEach(clearTimeout)
       unsubFinalize()
-      try { handle?.stop() } catch { /* ignore */ }
+      try {
+        void handle?.stop()
+      } catch {
+        /* ignore */
+      }
       handle = null
       liveConversation.reset()
       refreshCloudConversations()

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildUploadSegments } from './localSttUpload'
+
+vi.mock('./apiClient', () => ({
+  omiApi: { post: vi.fn() }
+}))
+
+describe('local STT upload mapping', () => {
+  it('merges adjacent same-speaker lines and preserves backend timing fields', () => {
+    const segments = buildUploadSegments([
+      {
+        id: 'a',
+        speaker: 'You',
+        text: 'hello',
+        isUser: true,
+        speakerId: 0,
+        start: 0,
+        end: 1
+      },
+      {
+        id: 'b',
+        speaker: 'You',
+        text: 'world',
+        isUser: true,
+        speakerId: 0,
+        start: 1.4,
+        end: 2
+      },
+      {
+        id: 'c',
+        speaker: 'SPEAKER_1',
+        text: 'reply',
+        isUser: false,
+        start: 2.2,
+        end: 3
+      }
+    ])
+
+    expect(segments).toEqual([
+      {
+        text: 'hello world',
+        speaker: 'SPEAKER_0',
+        speaker_id: 0,
+        is_user: true,
+        person_id: undefined,
+        start: 0,
+        end: 2
+      },
+      {
+        text: 'reply',
+        speaker: 'SPEAKER_1',
+        speaker_id: 1,
+        is_user: false,
+        person_id: undefined,
+        start: 2.2,
+        end: 3
+      }
+    ])
+  })
+
+  it('fills missing timing with monotonic fallback durations', () => {
+    const segments = buildUploadSegments([{ text: 'one two three' }, { text: 'next' }])
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0].start).toBe(0)
+    expect(segments[0].end).toBeGreaterThan(1)
+    expect(segments[0].text).toBe('one two three next')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { buildUploadSegments } from './localSttUpload'
+import { buildUploadSegments, LocalSttUploadLimitError } from './localSttUpload'
 
 vi.mock('./apiClient', () => ({
   omiApi: { post: vi.fn() }
@@ -77,6 +77,6 @@ describe('local STT upload mapping', () => {
           end: index * 2 + 1
         }))
       )
-    ).toThrow('Save was stopped to avoid truncating transcript content')
+    ).toThrow(LocalSttUploadLimitError)
   })
 })

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.test.ts
@@ -66,4 +66,17 @@ describe('local STT upload mapping', () => {
     expect(segments[0].end).toBeGreaterThan(1)
     expect(segments[0].text).toBe('one two three next')
   })
+
+  it('fails visibly instead of truncating long transcripts', () => {
+    expect(() =>
+      buildUploadSegments(
+        Array.from({ length: 501 }, (_, index) => ({
+          text: `segment ${index}`,
+          speaker: `SPEAKER_${index}`,
+          start: index * 2,
+          end: index * 2 + 1
+        }))
+      )
+    ).toThrow('Save was stopped to avoid truncating transcript content')
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.ts
@@ -1,0 +1,113 @@
+import { omiApi } from './apiClient'
+import type { TranscriptLine } from '../../../shared/types'
+
+type UploadSegment = {
+  text: string
+  speaker: string
+  speaker_id?: number
+  is_user: boolean
+  person_id?: string
+  start: number
+  end: number
+}
+
+type UploadResponse = {
+  id: string
+  status: string
+  discarded: boolean
+}
+
+function parseSpeakerId(speaker: string | undefined): number | undefined {
+  if (!speaker) return undefined
+  const match = speaker.match(/(\d+)/)
+  if (!match) return undefined
+  const parsed = Number(match[1])
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function fallbackEnd(start: number, text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length
+  return start + Math.max(0.5, words * 0.35)
+}
+
+export function buildUploadSegments(lines: TranscriptLine[]): UploadSegment[] {
+  const raw: UploadSegment[] = []
+  let cursor = 0
+
+  for (const line of lines) {
+    const text = line.text.trim()
+    if (!text) continue
+
+    const start =
+      typeof line.start === 'number' && Number.isFinite(line.start) ? line.start : cursor
+    const end =
+      typeof line.end === 'number' && Number.isFinite(line.end) && line.end > start
+        ? line.end
+        : fallbackEnd(start, text)
+    cursor = Math.max(cursor, end)
+
+    const isUser = line.isUser ?? line.speaker === 'You'
+    const speakerId = line.speakerId ?? parseSpeakerId(line.speaker) ?? (isUser ? 0 : undefined)
+    const speaker =
+      line.speaker && line.speaker !== 'You'
+        ? line.speaker
+        : typeof speakerId === 'number'
+          ? `SPEAKER_${speakerId}`
+          : 'SPEAKER_00'
+
+    raw.push({
+      text,
+      speaker,
+      speaker_id: speakerId,
+      is_user: isUser,
+      person_id: line.personId,
+      start,
+      end
+    })
+  }
+
+  const merged: UploadSegment[] = []
+  for (const segment of raw.sort((a, b) => a.start - b.start)) {
+    const prev = merged[merged.length - 1]
+    if (
+      prev &&
+      prev.speaker === segment.speaker &&
+      prev.speaker_id === segment.speaker_id &&
+      prev.is_user === segment.is_user &&
+      prev.person_id === segment.person_id &&
+      segment.start - prev.end <= 1.0
+    ) {
+      prev.text = `${prev.text} ${segment.text}`.trim()
+      prev.end = Math.max(prev.end, segment.end)
+      continue
+    }
+    merged.push({ ...segment })
+  }
+
+  return merged.slice(0, 500)
+}
+
+export async function uploadConversationFromSegments(args: {
+  lines: TranscriptLine[]
+  startedAt: number
+  finishedAt: number
+  language: string
+}): Promise<UploadResponse | null> {
+  const transcript_segments = buildUploadSegments(args.lines)
+  if (transcript_segments.length === 0) return null
+
+  const latestEnd = Math.max(...transcript_segments.map((s) => s.end))
+  const finishedAt = Math.max(
+    args.finishedAt,
+    args.startedAt + latestEnd * 1000,
+    args.startedAt + 1000
+  )
+  const response = await omiApi.post<UploadResponse>('/v1/conversations/from-segments', {
+    transcript_segments,
+    source: 'desktop',
+    started_at: new Date(args.startedAt).toISOString(),
+    finished_at: new Date(finishedAt).toISOString(),
+    language: args.language
+  })
+  return response.data
+}

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.ts
@@ -17,6 +17,9 @@ type UploadResponse = {
   discarded: boolean
 }
 
+const MAX_UPLOAD_SEGMENTS = 500
+const MAX_RELATIVE_TRANSCRIPT_SECONDS = 24 * 60 * 60
+
 function parseSpeakerId(speaker: string | undefined): number | undefined {
   if (!speaker) return undefined
   const match = speaker.match(/(\d+)/)
@@ -84,7 +87,13 @@ export function buildUploadSegments(lines: TranscriptLine[]): UploadSegment[] {
     merged.push({ ...segment })
   }
 
-  return merged.slice(0, 500)
+  if (merged.length > MAX_UPLOAD_SEGMENTS) {
+    throw new Error(
+      `Transcript has ${merged.length} upload segments; max is ${MAX_UPLOAD_SEGMENTS}. Save was stopped to avoid truncating transcript content.`
+    )
+  }
+
+  return merged
 }
 
 export async function uploadConversationFromSegments(args: {
@@ -97,6 +106,9 @@ export async function uploadConversationFromSegments(args: {
   if (transcript_segments.length === 0) return null
 
   const latestEnd = Math.max(...transcript_segments.map((s) => s.end))
+  if (latestEnd > MAX_RELATIVE_TRANSCRIPT_SECONDS) {
+    throw new Error('Transcript segment times must be seconds relative to recording start')
+  }
   const finishedAt = Math.max(
     args.finishedAt,
     args.startedAt + latestEnd * 1000,

--- a/desktop/windows/src/renderer/src/lib/localSttUpload.ts
+++ b/desktop/windows/src/renderer/src/lib/localSttUpload.ts
@@ -20,6 +20,13 @@ type UploadResponse = {
 const MAX_UPLOAD_SEGMENTS = 500
 const MAX_RELATIVE_TRANSCRIPT_SECONDS = 24 * 60 * 60
 
+export class LocalSttUploadLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LocalSttUploadLimitError'
+  }
+}
+
 function parseSpeakerId(speaker: string | undefined): number | undefined {
   if (!speaker) return undefined
   const match = speaker.match(/(\d+)/)
@@ -88,7 +95,7 @@ export function buildUploadSegments(lines: TranscriptLine[]): UploadSegment[] {
   }
 
   if (merged.length > MAX_UPLOAD_SEGMENTS) {
-    throw new Error(
+    throw new LocalSttUploadLimitError(
       `Transcript has ${merged.length} upload segments; max is ${MAX_UPLOAD_SEGMENTS}. Save was stopped to avoid truncating transcript content.`
     )
   }

--- a/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LocalTtsStatus } from '../../../shared/types'
+import type { Preferences } from './preferences'
+import { speakAssistantText } from './localTtsPlayback'
+
+const enabledPrefs: Preferences = {
+  captionIntervalMs: 2000,
+  showRecordingBadge: true,
+  reduceMotion: false,
+  language: 'en',
+  chatHistoryMode: 'infinite',
+  chatRuntimeMode: 'auto',
+  realtimeVoiceEnabled: true,
+  realtimeVoiceProvider: 'local-kokoro',
+  localTtsVoice: 'af_heart'
+}
+
+const readyStatus: LocalTtsStatus = {
+  backend: 'kokoro',
+  healthy: true,
+  available: true,
+  managed: true,
+  runtime: {
+    kind: 'kokoro-js',
+    installState: 'installed',
+    model: 'onnx-community/Kokoro-82M-v1.0-ONNX',
+    voice: 'af_heart',
+    canInstall: true
+  },
+  checkedAt: 1
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('speakAssistantText', () => {
+  it('skips playback when local Kokoro voice is not selected', async () => {
+    const localTtsStatus = vi.fn(async () => readyStatus)
+    const localTtsSynthesize = vi.fn()
+    ;(globalThis as { window?: unknown }).window = {
+      omi: { localTtsStatus, localTtsSynthesize }
+    }
+
+    const result = await speakAssistantText('hello', {
+      getPrefs: () => ({ ...enabledPrefs, realtimeVoiceProvider: 'omi-relay' })
+    })
+
+    expect(result).toBe('skipped')
+    expect(localTtsStatus).not.toHaveBeenCalled()
+    expect(localTtsSynthesize).not.toHaveBeenCalled()
+  })
+
+  it('synthesizes assistant text and plays the generated local file URL', async () => {
+    const playAudio = vi.fn(async () => undefined)
+    const localTtsStatus = vi.fn(async () => readyStatus)
+    const localTtsSynthesize = vi.fn(async () => ({
+      audioPath: 'C:\\Users\\me\\AppData\\Local\\Omi\\LocalTTS\\audio\\reply.wav',
+      audioUrl: 'file:///C:/Users/me/AppData/Local/Omi/LocalTTS/audio/reply.wav',
+      mimeType: 'audio/wav' as const
+    }))
+    ;(globalThis as { window?: unknown }).window = {
+      omi: { localTtsStatus, localTtsSynthesize }
+    }
+
+    const result = await speakAssistantText(' assistant reply ', {
+      getPrefs: () => enabledPrefs,
+      playAudio
+    })
+
+    expect(result).toBe('played')
+    expect(localTtsSynthesize).toHaveBeenCalledWith({
+      text: 'assistant reply',
+      voice: 'af_heart'
+    })
+    expect(playAudio).toHaveBeenCalledWith(
+      'file:///C:/Users/me/AppData/Local/Omi/LocalTTS/audio/reply.wav'
+    )
+  })
+
+  it('falls back to text-only when local Kokoro is unavailable', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const localTtsSynthesize = vi.fn()
+    ;(globalThis as { window?: unknown }).window = {
+      omi: {
+        localTtsStatus: vi.fn(async () => ({
+          ...readyStatus,
+          healthy: false,
+          available: false,
+          runtime: { ...readyStatus.runtime, installState: 'unsupported', canInstall: false },
+          reason: 'unsupported'
+        })),
+        localTtsSynthesize
+      }
+    }
+
+    const result = await speakAssistantText('assistant reply', {
+      getPrefs: () => enabledPrefs,
+      playAudio: vi.fn()
+    })
+
+    expect(result).toBe('failed')
+    expect(localTtsSynthesize).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
@@ -78,6 +78,42 @@ describe('speakAssistantText', () => {
     )
   })
 
+  it('does not infer error state from assistant text content', async () => {
+    const playAudio = vi.fn(async () => undefined)
+    const localTtsStatus = vi.fn(async () => readyStatus)
+    const localTtsSynthesize = vi.fn(async () => ({
+      audioPath: 'C:\\reply.wav',
+      audioUrl: 'file:///C:/reply.wav',
+      mimeType: 'audio/wav' as const
+    }))
+    ;(globalThis as { window?: unknown }).window = {
+      omi: { localTtsStatus, localTtsSynthesize }
+    }
+
+    await expect(
+      speakAssistantText('Error: this is a legitimate explanation', {
+        getPrefs: () => enabledPrefs,
+        playAudio
+      })
+    ).resolves.toBe('played')
+  })
+
+  it('skips playback when the caller marks the message as an error', async () => {
+    const localTtsStatus = vi.fn(async () => readyStatus)
+    const localTtsSynthesize = vi.fn()
+    ;(globalThis as { window?: unknown }).window = {
+      omi: { localTtsStatus, localTtsSynthesize }
+    }
+
+    await expect(
+      speakAssistantText('assistant failure', {
+        getPrefs: () => enabledPrefs,
+        isError: true
+      })
+    ).resolves.toBe('skipped')
+    expect(localTtsSynthesize).not.toHaveBeenCalled()
+  })
+
   it('falls back to text-only when local Kokoro is unavailable', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const localTtsSynthesize = vi.fn()

--- a/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
+++ b/desktop/windows/src/renderer/src/lib/localTtsPlayback.test.ts
@@ -9,7 +9,6 @@ const enabledPrefs: Preferences = {
   reduceMotion: false,
   language: 'en',
   chatHistoryMode: 'infinite',
-  chatRuntimeMode: 'auto',
   realtimeVoiceEnabled: true,
   realtimeVoiceProvider: 'local-kokoro',
   localTtsVoice: 'af_heart'

--- a/desktop/windows/src/renderer/src/lib/localTtsPlayback.ts
+++ b/desktop/windows/src/renderer/src/lib/localTtsPlayback.ts
@@ -1,0 +1,48 @@
+import type { Preferences } from './preferences'
+import { getPreferences } from './preferences'
+
+type PlaybackResult = 'skipped' | 'played' | 'failed'
+
+type PlaybackDeps = {
+  getPrefs?: () => Preferences
+  playAudio?: (audioUrl: string) => Promise<void>
+}
+
+let activeAudio: HTMLAudioElement | null = null
+
+export async function speakAssistantText(
+  text: string,
+  deps: PlaybackDeps = {}
+): Promise<PlaybackResult> {
+  const cleanText = text.trim()
+  const preferences = deps.getPrefs?.() ?? getPreferences()
+  if (!cleanText || cleanText.startsWith('Error:')) return 'skipped'
+  if (!preferences.realtimeVoiceEnabled || preferences.realtimeVoiceProvider !== 'local-kokoro') {
+    return 'skipped'
+  }
+
+  try {
+    const status = await window.omi.localTtsStatus()
+    if (!status.available && !status.runtime.canInstall) return 'failed'
+    const result = await window.omi.localTtsSynthesize({
+      text: cleanText,
+      voice: preferences.localTtsVoice
+    })
+    await (deps.playAudio ?? playAudioUrl)(result.audioUrl)
+    return 'played'
+  } catch (err) {
+    console.warn('[local-tts] assistant speech failed:', err instanceof Error ? err.message : err)
+    return 'failed'
+  }
+}
+
+async function playAudioUrl(audioUrl: string): Promise<void> {
+  if (typeof Audio === 'undefined') throw new Error('Audio playback is unavailable')
+  if (activeAudio) {
+    activeAudio.pause()
+    activeAudio = null
+  }
+  const audio = new Audio(audioUrl)
+  activeAudio = audio
+  await audio.play()
+}

--- a/desktop/windows/src/renderer/src/lib/localTtsPlayback.ts
+++ b/desktop/windows/src/renderer/src/lib/localTtsPlayback.ts
@@ -6,6 +6,7 @@ type PlaybackResult = 'skipped' | 'played' | 'failed'
 type PlaybackDeps = {
   getPrefs?: () => Preferences
   playAudio?: (audioUrl: string) => Promise<void>
+  isError?: boolean
 }
 
 let activeAudio: HTMLAudioElement | null = null
@@ -16,7 +17,7 @@ export async function speakAssistantText(
 ): Promise<PlaybackResult> {
   const cleanText = text.trim()
   const preferences = deps.getPrefs?.() ?? getPreferences()
-  if (!cleanText || cleanText.startsWith('Error:')) return 'skipped'
+  if (!cleanText || deps.isError) return 'skipped'
   if (!preferences.realtimeVoiceEnabled || preferences.realtimeVoiceProvider !== 'local-kokoro') {
     return 'skipped'
   }

--- a/desktop/windows/src/renderer/src/lib/omiListenClient.ts
+++ b/desktop/windows/src/renderer/src/lib/omiListenClient.ts
@@ -1,10 +1,16 @@
 import { auth } from './firebase'
-import type { BackendSegment, ListenEvent, ListenSource } from '../../../shared/types'
+import type {
+  BackendSegment,
+  ListenEvent,
+  ListenSource,
+  SttMode,
+  TranscriptionBackend
+} from '../../../shared/types'
 import { getPreferences } from './preferences'
 
 export type OmiListenCallbacks = {
-  /** Fires once when the v4/listen WS reaches OPEN. */
-  onConnected: () => void
+  /** Fires once when the selected transcription backend is ready. */
+  onConnected: (backend: TranscriptionBackend) => void
   /** Fires for each batch of finalized segments. */
   onSegments: (segments: BackendSegment[]) => void
   /** Fires for type-tagged status events; renderer just logs. */
@@ -23,7 +29,7 @@ export type OmiListenCallbacks = {
 }
 
 export type OmiListenHandle = {
-  stop: () => void
+  stop: () => Promise<void>
 }
 
 let nextSessionId = 1
@@ -57,7 +63,8 @@ async function getSystemAudioStream(): Promise<MediaStream> {
  */
 export async function startOmiListen(
   source: ListenSource,
-  cb: OmiListenCallbacks
+  cb: OmiListenCallbacks,
+  sttMode: SttMode = getPreferences().sttMode ?? 'auto'
 ): Promise<OmiListenHandle> {
   const user = auth.currentUser
   if (!user) throw new Error('Omi v4/listen requires sign-in.')
@@ -81,7 +88,7 @@ export async function startOmiListen(
     if (msg.sessionId !== sessionId) return
     if (msg.kind === 'connected') {
       connected = true
-      cb.onConnected()
+      cb.onConnected(msg.backend)
     } else if (msg.kind === 'segments') {
       cb.onSegments(msg.segments)
     } else if (msg.kind === 'event') {
@@ -108,7 +115,8 @@ export async function startOmiListen(
       sessionId,
       source,
       token,
-      language: getPreferences().language
+      language: getPreferences().language,
+      sttMode
     })
   } catch (e) {
     unsub()
@@ -149,9 +157,8 @@ export async function startOmiListen(
   processor.connect(audioCtx.destination)
 
   return {
-    stop: (): void => {
+    stop: async (): Promise<void> => {
       stopped = true
-      unsub()
       try {
         processor.disconnect()
       } catch {
@@ -172,7 +179,11 @@ export async function startOmiListen(
       } catch {
         /* ignore */
       }
-      void window.omi.listenStop(sessionId)
+      try {
+        await window.omi.listenStop(sessionId)
+      } finally {
+        unsub()
+      }
     }
   }
 }

--- a/desktop/windows/src/renderer/src/lib/preferences.ts
+++ b/desktop/windows/src/renderer/src/lib/preferences.ts
@@ -36,7 +36,9 @@ export type Preferences = {
   // off (opt-in), so existing users are unaffected until they enable it.
   continuousRecording?: boolean
   // Speech-to-text runtime. 'auto' prefers local Parakeet only when a healthy
-  // supported local runtime is present, otherwise hosted /v4/listen.
+  // local runtime is ALREADY installed, otherwise hosted /v4/listen — it never
+  // downloads/installs the runtime or model. Only the explicit 'local-parakeet'
+  // choice triggers the first-use install.
   sttMode?: SttMode
   // Opt-in realtime voice path. Separate from /v4/listen transcription so
   // continuous recording remains available even when voice is off/unavailable.

--- a/desktop/windows/src/renderer/src/lib/preferences.ts
+++ b/desktop/windows/src/renderer/src/lib/preferences.ts
@@ -2,6 +2,7 @@
 // setters write back to localStorage and notify subscribers so live components
 // can react.
 import { DEFAULT_LANGUAGE } from './languages'
+import type { SttMode } from '../../../shared/types'
 
 const KEY = 'omi-windows-prefs-v1'
 
@@ -34,6 +35,9 @@ export type Preferences = {
   // Set by the onboarding opt-in step; toggled in Settings → Rewind. Undefined =
   // off (opt-in), so existing users are unaffected until they enable it.
   continuousRecording?: boolean
+  // Speech-to-text runtime. 'auto' prefers local Parakeet only when a healthy
+  // supported local runtime is present, otherwise hosted /v4/listen.
+  sttMode?: SttMode
   // Auto-cleanup of empty conversations + junk memories. 'dry-run' (default) logs
   // what it WOULD delete without deleting; 'live' deletes (rate-limited); 'off'
   // disables the sweep. Read with `?? 'dry-run'`.

--- a/desktop/windows/src/renderer/src/lib/preferences.ts
+++ b/desktop/windows/src/renderer/src/lib/preferences.ts
@@ -2,7 +2,7 @@
 // setters write back to localStorage and notify subscribers so live components
 // can react.
 import { DEFAULT_LANGUAGE } from './languages'
-import type { SttMode } from '../../../shared/types'
+import type { RealtimeVoiceProvider, SttMode } from '../../../shared/types'
 
 const KEY = 'omi-windows-prefs-v1'
 
@@ -38,6 +38,11 @@ export type Preferences = {
   // Speech-to-text runtime. 'auto' prefers local Parakeet only when a healthy
   // supported local runtime is present, otherwise hosted /v4/listen.
   sttMode?: SttMode
+  // Opt-in realtime voice path. Separate from /v4/listen transcription so
+  // continuous recording remains available even when voice is off/unavailable.
+  realtimeVoiceEnabled?: boolean
+  realtimeVoiceProvider?: RealtimeVoiceProvider
+  localTtsVoice?: string
   // Auto-cleanup of empty conversations + junk memories. 'dry-run' (default) logs
   // what it WOULD delete without deleting; 'live' deletes (rate-limited); 'off'
   // disables the sweep. Read with `?? 'dry-run'`.

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import type { ByokStatus } from '../../../shared/types'
 import type { Preferences } from './preferences'
 import { realtimeVoiceReadiness } from './realtimeVoice'
 
@@ -9,52 +8,37 @@ const basePreferences: Preferences = {
   reduceMotion: false,
   language: 'en',
   chatHistoryMode: 'infinite',
-  chatRuntimeMode: 'auto',
   realtimeVoiceProvider: 'omi-relay'
-}
-
-const byokStatus: ByokStatus = {
-  activeChatProvider: null,
-  providers: {
-    openai: { provider: 'openai', configured: true },
-    anthropic: { provider: 'anthropic', configured: false },
-    gemini: { provider: 'gemini', configured: false },
-    deepgram: { provider: 'deepgram', configured: false }
-  }
 }
 
 describe('realtimeVoiceReadiness', () => {
   it('keeps voice disabled until the user opts in', () => {
-    const readiness = realtimeVoiceReadiness(basePreferences, byokStatus)
+    const readiness = realtimeVoiceReadiness(basePreferences)
     expect(readiness.enabled).toBe(false)
     expect(readiness.ready).toBe(false)
     expect(readiness.transcriptionPath).toContain('/v4/listen')
   })
 
-  it('uses the OpenAI BYOK key path when selected', () => {
-    const readiness = realtimeVoiceReadiness(
-      {
-        ...basePreferences,
-        realtimeVoiceEnabled: true,
-        realtimeVoiceProvider: 'openai-byok'
-      },
-      byokStatus
-    )
+  it('routes local Kokoro readiness without BYOK state', () => {
+    const readiness = realtimeVoiceReadiness({
+      ...basePreferences,
+      realtimeVoiceEnabled: true,
+      realtimeVoiceProvider: 'local-kokoro'
+    })
+
     expect(readiness.ready).toBe(true)
-    expect(readiness.keyPath).toBe('OpenAI BYOK key')
+    expect(readiness.label).toBe('Local Kokoro')
+    expect(readiness.keyPath).toBe('Local model runtime')
   })
 
-  it('reports a missing OpenAI key without affecting transcription', () => {
-    const readiness = realtimeVoiceReadiness(
-      {
-        ...basePreferences,
-        realtimeVoiceEnabled: true,
-        realtimeVoiceProvider: 'openai-byok'
-      },
-      null
-    )
+  it('reports the relay as unavailable when no relay URL is configured', () => {
+    const readiness = realtimeVoiceReadiness({
+      ...basePreferences,
+      realtimeVoiceEnabled: true,
+      realtimeVoiceProvider: 'omi-relay'
+    })
+
     expect(readiness.ready).toBe(false)
-    expect(readiness.reason).toBe('OpenAI key is not saved')
-    expect(readiness.transcriptionPath).toContain('/v4/listen')
+    expect(readiness.reason).toBe('Realtime relay URL is not configured')
   })
 })

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ByokStatus, LocalTtsStatus } from '../../../shared/types'
+import type { ByokStatus } from '../../../shared/types'
 import type { Preferences } from './preferences'
 import { realtimeVoiceReadiness } from './realtimeVoice'
 
@@ -21,21 +21,6 @@ const byokStatus: ByokStatus = {
     gemini: { provider: 'gemini', configured: false },
     deepgram: { provider: 'deepgram', configured: false }
   }
-}
-
-const localTtsStatus: LocalTtsStatus = {
-  backend: 'kokoro',
-  healthy: false,
-  available: false,
-  managed: true,
-  runtime: {
-    kind: 'kokoro-js',
-    installState: 'not_installed',
-    model: 'onnx-community/Kokoro-82M-v1.0-ONNX',
-    voice: 'af_heart',
-    canInstall: true
-  },
-  checkedAt: 1
 }
 
 describe('realtimeVoiceReadiness', () => {
@@ -70,41 +55,6 @@ describe('realtimeVoiceReadiness', () => {
     )
     expect(readiness.ready).toBe(false)
     expect(readiness.reason).toBe('OpenAI key is not saved')
-    expect(readiness.transcriptionPath).toContain('/v4/listen')
-  })
-
-  it('uses local Kokoro TTS readiness when selected', () => {
-    const readiness = realtimeVoiceReadiness(
-      {
-        ...basePreferences,
-        realtimeVoiceEnabled: true,
-        realtimeVoiceProvider: 'local-kokoro'
-      },
-      byokStatus,
-      localTtsStatus
-    )
-    expect(readiness.ready).toBe(true)
-    expect(readiness.keyPath).toBe('On-device Kokoro-82M')
-    expect(readiness.reason).toBe('Kokoro installs on first spoken reply')
-    expect(readiness.transcriptionPath).toContain('/v4/listen')
-  })
-
-  it('reports local Kokoro unavailable without blocking transcription', () => {
-    const readiness = realtimeVoiceReadiness(
-      {
-        ...basePreferences,
-        realtimeVoiceEnabled: true,
-        realtimeVoiceProvider: 'local-kokoro'
-      },
-      byokStatus,
-      {
-        ...localTtsStatus,
-        runtime: { ...localTtsStatus.runtime, installState: 'unsupported', canInstall: false },
-        reason: 'unsupported'
-      }
-    )
-    expect(readiness.ready).toBe(false)
-    expect(readiness.reason).toBe('unsupported')
     expect(readiness.transcriptionPath).toContain('/v4/listen')
   })
 })

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { LocalTtsStatus } from '../../../shared/types'
 import type { Preferences } from './preferences'
 import { realtimeVoiceReadiness } from './realtimeVoice'
 
@@ -11,6 +12,21 @@ const basePreferences: Preferences = {
   realtimeVoiceProvider: 'omi-relay'
 }
 
+const readyLocalTts: LocalTtsStatus = {
+  backend: 'kokoro',
+  healthy: true,
+  available: true,
+  managed: true,
+  runtime: {
+    kind: 'kokoro-js',
+    installState: 'installed',
+    model: 'onnx-community/Kokoro-82M-v1.0-ONNX',
+    voice: 'af_heart',
+    canInstall: true
+  },
+  checkedAt: 1
+}
+
 describe('realtimeVoiceReadiness', () => {
   it('keeps voice disabled until the user opts in', () => {
     const readiness = realtimeVoiceReadiness(basePreferences)
@@ -20,15 +36,29 @@ describe('realtimeVoiceReadiness', () => {
   })
 
   it('routes local Kokoro readiness without BYOK state', () => {
+    const readiness = realtimeVoiceReadiness(
+      {
+        ...basePreferences,
+        realtimeVoiceEnabled: true,
+        realtimeVoiceProvider: 'local-kokoro'
+      },
+      readyLocalTts
+    )
+
+    expect(readiness.ready).toBe(true)
+    expect(readiness.label).toBe('Local Kokoro')
+    expect(readiness.keyPath).toBe('Local model runtime')
+  })
+
+  it('does not report local Kokoro ready before the runtime is available', () => {
     const readiness = realtimeVoiceReadiness({
       ...basePreferences,
       realtimeVoiceEnabled: true,
       realtimeVoiceProvider: 'local-kokoro'
     })
 
-    expect(readiness.ready).toBe(true)
-    expect(readiness.label).toBe('Local Kokoro')
-    expect(readiness.keyPath).toBe('Local model runtime')
+    expect(readiness.ready).toBe(false)
+    expect(readiness.reason).toBe('Local Kokoro TTS runtime is not ready')
   })
 
   it('reports the relay as unavailable when no relay URL is configured', () => {

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { ByokStatus, LocalTtsStatus } from '../../../shared/types'
+import type { Preferences } from './preferences'
+import { realtimeVoiceReadiness } from './realtimeVoice'
+
+const basePreferences: Preferences = {
+  captionIntervalMs: 2000,
+  showRecordingBadge: true,
+  reduceMotion: false,
+  language: 'en',
+  chatHistoryMode: 'infinite',
+  chatRuntimeMode: 'auto',
+  realtimeVoiceProvider: 'omi-relay'
+}
+
+const byokStatus: ByokStatus = {
+  activeChatProvider: null,
+  providers: {
+    openai: { provider: 'openai', configured: true },
+    anthropic: { provider: 'anthropic', configured: false },
+    gemini: { provider: 'gemini', configured: false },
+    deepgram: { provider: 'deepgram', configured: false }
+  }
+}
+
+const localTtsStatus: LocalTtsStatus = {
+  backend: 'kokoro',
+  healthy: false,
+  available: false,
+  managed: true,
+  runtime: {
+    kind: 'kokoro-js',
+    installState: 'not_installed',
+    model: 'onnx-community/Kokoro-82M-v1.0-ONNX',
+    voice: 'af_heart',
+    canInstall: true
+  },
+  checkedAt: 1
+}
+
+describe('realtimeVoiceReadiness', () => {
+  it('keeps voice disabled until the user opts in', () => {
+    const readiness = realtimeVoiceReadiness(basePreferences, byokStatus)
+    expect(readiness.enabled).toBe(false)
+    expect(readiness.ready).toBe(false)
+    expect(readiness.transcriptionPath).toContain('/v4/listen')
+  })
+
+  it('uses the OpenAI BYOK key path when selected', () => {
+    const readiness = realtimeVoiceReadiness(
+      {
+        ...basePreferences,
+        realtimeVoiceEnabled: true,
+        realtimeVoiceProvider: 'openai-byok'
+      },
+      byokStatus
+    )
+    expect(readiness.ready).toBe(true)
+    expect(readiness.keyPath).toBe('OpenAI BYOK key')
+  })
+
+  it('reports a missing OpenAI key without affecting transcription', () => {
+    const readiness = realtimeVoiceReadiness(
+      {
+        ...basePreferences,
+        realtimeVoiceEnabled: true,
+        realtimeVoiceProvider: 'openai-byok'
+      },
+      null
+    )
+    expect(readiness.ready).toBe(false)
+    expect(readiness.reason).toBe('OpenAI key is not saved')
+    expect(readiness.transcriptionPath).toContain('/v4/listen')
+  })
+
+  it('uses local Kokoro TTS readiness when selected', () => {
+    const readiness = realtimeVoiceReadiness(
+      {
+        ...basePreferences,
+        realtimeVoiceEnabled: true,
+        realtimeVoiceProvider: 'local-kokoro'
+      },
+      byokStatus,
+      localTtsStatus
+    )
+    expect(readiness.ready).toBe(true)
+    expect(readiness.keyPath).toBe('On-device Kokoro-82M')
+    expect(readiness.reason).toBe('Kokoro installs on first spoken reply')
+    expect(readiness.transcriptionPath).toContain('/v4/listen')
+  })
+
+  it('reports local Kokoro unavailable without blocking transcription', () => {
+    const readiness = realtimeVoiceReadiness(
+      {
+        ...basePreferences,
+        realtimeVoiceEnabled: true,
+        realtimeVoiceProvider: 'local-kokoro'
+      },
+      byokStatus,
+      {
+        ...localTtsStatus,
+        runtime: { ...localTtsStatus.runtime, installState: 'unsupported', canInstall: false },
+        reason: 'unsupported'
+      }
+    )
+    expect(readiness.ready).toBe(false)
+    expect(readiness.reason).toBe('unsupported')
+    expect(readiness.transcriptionPath).toContain('/v4/listen')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
@@ -1,7 +1,7 @@
-import type { ByokStatus, LocalTtsStatus, RealtimeVoiceProvider } from '../../../shared/types'
+import type { ByokStatus } from '../../../shared/types'
 import type { Preferences } from './preferences'
 
-export type { RealtimeVoiceProvider } from '../../../shared/types'
+export type RealtimeVoiceProvider = NonNullable<Preferences['realtimeVoiceProvider']>
 
 export type RealtimeVoiceReadiness = {
   enabled: boolean
@@ -15,27 +15,10 @@ export type RealtimeVoiceReadiness = {
 
 export function realtimeVoiceReadiness(
   preferences: Preferences,
-  byokStatus: ByokStatus | null,
-  localTtsStatus: LocalTtsStatus | null = null
+  byokStatus: ByokStatus | null
 ): RealtimeVoiceReadiness {
   const provider = preferences.realtimeVoiceProvider ?? 'omi-relay'
   const enabled = !!preferences.realtimeVoiceEnabled
-  if (provider === 'local-kokoro') {
-    const canRun = !!localTtsStatus?.available || !!localTtsStatus?.runtime.canInstall
-    return {
-      enabled,
-      provider,
-      ready: enabled && canRun,
-      label: 'Local Kokoro',
-      keyPath: 'On-device Kokoro-82M',
-      transcriptionPath: 'Omi /v4/listen remains active for transcription',
-      reason: canRun
-        ? localTtsStatus?.available
-          ? undefined
-          : 'Kokoro installs on first spoken reply'
-        : (localTtsStatus?.reason ?? 'Local Kokoro TTS unavailable')
-    }
-  }
   if (provider === 'openai-byok') {
     const configured = !!byokStatus?.providers.openai.configured
     return {

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
@@ -1,0 +1,61 @@
+import type { ByokStatus, LocalTtsStatus, RealtimeVoiceProvider } from '../../../shared/types'
+import type { Preferences } from './preferences'
+
+export type { RealtimeVoiceProvider } from '../../../shared/types'
+
+export type RealtimeVoiceReadiness = {
+  enabled: boolean
+  provider: RealtimeVoiceProvider
+  ready: boolean
+  label: string
+  keyPath: string
+  transcriptionPath: string
+  reason?: string
+}
+
+export function realtimeVoiceReadiness(
+  preferences: Preferences,
+  byokStatus: ByokStatus | null,
+  localTtsStatus: LocalTtsStatus | null = null
+): RealtimeVoiceReadiness {
+  const provider = preferences.realtimeVoiceProvider ?? 'omi-relay'
+  const enabled = !!preferences.realtimeVoiceEnabled
+  if (provider === 'local-kokoro') {
+    const canRun = !!localTtsStatus?.available || !!localTtsStatus?.runtime.canInstall
+    return {
+      enabled,
+      provider,
+      ready: enabled && canRun,
+      label: 'Local Kokoro',
+      keyPath: 'On-device Kokoro-82M',
+      transcriptionPath: 'Omi /v4/listen remains active for transcription',
+      reason: canRun
+        ? localTtsStatus?.available
+          ? undefined
+          : 'Kokoro installs on first spoken reply'
+        : (localTtsStatus?.reason ?? 'Local Kokoro TTS unavailable')
+    }
+  }
+  if (provider === 'openai-byok') {
+    const configured = !!byokStatus?.providers.openai.configured
+    return {
+      enabled,
+      provider,
+      ready: enabled && configured,
+      label: 'OpenAI Realtime',
+      keyPath: 'OpenAI BYOK key',
+      transcriptionPath: 'Omi /v4/listen remains active for transcription',
+      reason: configured ? undefined : 'OpenAI key is not saved'
+    }
+  }
+  const relayConfigured = !!import.meta.env.VITE_OMI_REALTIME_VOICE_URL
+  return {
+    enabled,
+    provider,
+    ready: enabled && relayConfigured,
+    label: 'Omi realtime relay',
+    keyPath: 'Omi account session',
+    transcriptionPath: 'Omi /v4/listen remains active for transcription',
+    reason: relayConfigured ? undefined : 'Realtime relay URL is not configured'
+  }
+}

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
@@ -1,4 +1,5 @@
 import type { Preferences } from './preferences'
+import type { LocalTtsStatus } from '../../../shared/types'
 
 export type RealtimeVoiceProvider = NonNullable<Preferences['realtimeVoiceProvider']>
 
@@ -13,19 +14,23 @@ export type RealtimeVoiceReadiness = {
 }
 
 export function realtimeVoiceReadiness(
-  preferences: Preferences
+  preferences: Preferences,
+  localTtsStatus?: LocalTtsStatus | null
 ): RealtimeVoiceReadiness {
   const provider = preferences.realtimeVoiceProvider ?? 'omi-relay'
   const enabled = !!preferences.realtimeVoiceEnabled
   if (provider === 'local-kokoro') {
+    const ready = enabled && Boolean(localTtsStatus?.available)
     return {
       enabled,
       provider,
-      ready: enabled,
+      ready,
       label: 'Local Kokoro',
       keyPath: 'Local model runtime',
       transcriptionPath: 'Omi /v4/listen remains active for transcription',
-      reason: undefined
+      reason: ready
+        ? undefined
+        : (localTtsStatus?.reason ?? 'Local Kokoro TTS runtime is not ready')
     }
   }
   const relayConfigured = !!import.meta.env.VITE_OMI_REALTIME_VOICE_URL

--- a/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
+++ b/desktop/windows/src/renderer/src/lib/realtimeVoice.ts
@@ -1,4 +1,3 @@
-import type { ByokStatus } from '../../../shared/types'
 import type { Preferences } from './preferences'
 
 export type RealtimeVoiceProvider = NonNullable<Preferences['realtimeVoiceProvider']>
@@ -14,21 +13,19 @@ export type RealtimeVoiceReadiness = {
 }
 
 export function realtimeVoiceReadiness(
-  preferences: Preferences,
-  byokStatus: ByokStatus | null
+  preferences: Preferences
 ): RealtimeVoiceReadiness {
   const provider = preferences.realtimeVoiceProvider ?? 'omi-relay'
   const enabled = !!preferences.realtimeVoiceEnabled
-  if (provider === 'openai-byok') {
-    const configured = !!byokStatus?.providers.openai.configured
+  if (provider === 'local-kokoro') {
     return {
       enabled,
       provider,
-      ready: enabled && configured,
-      label: 'OpenAI Realtime',
-      keyPath: 'OpenAI BYOK key',
+      ready: enabled,
+      label: 'Local Kokoro',
+      keyPath: 'Local model runtime',
       transcriptionPath: 'Omi /v4/listen remains active for transcription',
-      reason: configured ? undefined : 'OpenAI key is not saved'
+      reason: undefined
     }
   }
   const relayConfigured = !!import.meta.env.VITE_OMI_REALTIME_VOICE_URL

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LocalSttStatus, SttMode } from '../../../shared/types'
+import type { OmiListenCallbacks, OmiListenHandle } from './omiListenClient'
+import { startOmiListen } from './omiListenClient'
+import { getPreferences } from './preferences'
+import { startTranscription } from './transcriptionClient'
+
+vi.mock('./firebase', () => ({ auth: { currentUser: { uid: 'user-1' } } }))
+vi.mock('./omiListenClient', () => ({ startOmiListen: vi.fn() }))
+vi.mock('./preferences', () => ({ getPreferences: vi.fn() }))
+
+const startOmiListenMock = vi.mocked(startOmiListen)
+const getPreferencesMock = vi.mocked(getPreferences)
+
+function sttStatus(overrides: { available: boolean; canInstall: boolean }): LocalSttStatus {
+  return {
+    backend: 'parakeet',
+    healthy: overrides.available,
+    available: overrides.available,
+    nvidiaAvailable: true,
+    managed: true,
+    runtime: {
+      kind: 'parakeet.cpp',
+      installState: overrides.available ? 'installed' : 'not_installed',
+      variant: 'cuda',
+      model: 'tdt_ctc-110m-q8_0.gguf',
+      canInstall: overrides.canInstall
+    },
+    checkedAt: 1
+  }
+}
+
+function setup(args: { sttMode?: SttMode; status: LocalSttStatus }): void {
+  getPreferencesMock.mockReturnValue({
+    captionIntervalMs: 2000,
+    showRecordingBadge: true,
+    reduceMotion: false,
+    language: 'en',
+    chatHistoryMode: 'infinite',
+    sttMode: args.sttMode
+  })
+  ;(globalThis as { window?: unknown }).window = {
+    omi: { localSttStatus: vi.fn(async () => args.status) }
+  }
+  startOmiListenMock.mockImplementation(
+    async (_source, cb: OmiListenCallbacks): Promise<OmiListenHandle> => {
+      const handle = { stop: vi.fn(async () => undefined) }
+      // Fire after the caller's .then() stored the handle, like the real client.
+      setTimeout(() => cb.onConnected('omi'), 0)
+      return handle
+    }
+  )
+}
+
+function attemptedModes(): Array<SttMode | undefined> {
+  return startOmiListenMock.mock.calls.map((call) => call[2])
+}
+
+const callbacks = (): Parameters<typeof startTranscription>[1] => ({
+  onLine: vi.fn(),
+  onInterim: vi.fn(),
+  onBackend: vi.fn(),
+  onError: vi.fn()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('startTranscription backend selection', () => {
+  it('auto with an installable-but-not-installed runtime uses cloud only and never requests local STT', async () => {
+    setup({ sttMode: 'auto', status: sttStatus({ available: false, canInstall: true }) })
+    const cb = callbacks()
+
+    const handle = await startTranscription('mic', cb)
+    await handle.stop()
+
+    expect(attemptedModes()).toEqual(['cloud'])
+    expect(cb.onBackend).toHaveBeenCalledWith('omi')
+    expect(cb.onError).not.toHaveBeenCalled()
+  })
+
+  it('missing sttMode preference behaves like auto and stays on cloud when local is only installable', async () => {
+    setup({ sttMode: undefined, status: sttStatus({ available: false, canInstall: true }) })
+
+    const handle = await startTranscription('mic', callbacks())
+    await handle.stop()
+
+    expect(attemptedModes()).toEqual(['cloud'])
+  })
+
+  it('auto with an installed runtime tries local first, tagged as auto so main cannot install', async () => {
+    setup({ sttMode: 'auto', status: sttStatus({ available: true, canInstall: true }) })
+
+    const handle = await startTranscription('mic', callbacks())
+    await handle.stop()
+
+    expect(attemptedModes()[0]).toBe('auto')
+  })
+
+  it('explicit local-parakeet preference requests local STT with install permitted', async () => {
+    setup({
+      sttMode: 'local-parakeet',
+      status: sttStatus({ available: false, canInstall: true })
+    })
+
+    const handle = await startTranscription('mic', callbacks())
+    await handle.stop()
+
+    expect(attemptedModes()[0]).toBe('local-parakeet')
+  })
+
+  it('cloud preference does not touch local STT when the runtime is not installed', async () => {
+    setup({ sttMode: 'cloud', status: sttStatus({ available: false, canInstall: true }) })
+
+    const handle = await startTranscription('mic', callbacks())
+    await handle.stop()
+
+    expect(attemptedModes()).toEqual(['cloud'])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -76,13 +76,24 @@ const QUOTA_MESSAGE =
   'free Omi transcription quota is used up (1008) — add an Omi subscription or sign in with an entitled account to keep transcribing'
 
 function modeForBackend(backend: TranscriptionBackend): SttMode {
-  return backend === 'local-parakeet' ? 'local-parakeet' : 'cloud'
+  if (backend !== 'local-parakeet') return 'cloud'
+  // Send the user's true preference to main: only an explicit Local Parakeet
+  // selection may trigger a first-use runtime/model install. Any other
+  // preference maps local attempts to 'auto', which main serves only from an
+  // already-installed runtime (falling back to cloud otherwise).
+  return (getPreferences().sttMode ?? 'auto') === 'local-parakeet' ? 'local-parakeet' : 'auto'
 }
 
-async function localSttAvailable(): Promise<boolean> {
+/**
+ * True only when the local Parakeet runtime is already installed and healthy.
+ * Deliberately ignores `runtime.canInstall`: a merely-installable runtime must
+ * not pull automatic modes onto the local path, because that would download
+ * native runtime artifacts and model files without an explicit user choice.
+ */
+async function localSttInstalled(): Promise<boolean> {
   try {
     const status = await window.omi.localSttStatus()
-    return status.available || status.runtime.canInstall
+    return status.available
   } catch {
     return false
   }
@@ -91,10 +102,10 @@ async function localSttAvailable(): Promise<boolean> {
 async function initialBackendOrder(): Promise<TranscriptionBackend[]> {
   const preference = getPreferences().sttMode ?? 'auto'
   if (preference === 'cloud') {
-    return (await localSttAvailable()) ? ['omi', 'local-parakeet'] : ['omi']
+    return (await localSttInstalled()) ? ['omi', 'local-parakeet'] : ['omi']
   }
   if (preference === 'local-parakeet') return ['local-parakeet', 'omi']
-  return (await localSttAvailable()) ? ['local-parakeet', 'omi'] : ['omi']
+  return (await localSttInstalled()) ? ['local-parakeet', 'omi'] : ['omi']
 }
 
 /**
@@ -111,6 +122,10 @@ async function startWithBackend(
 ): Promise<OmiListenHandle | null> {
   if (!auth.currentUser) return null
   let outcome: 'pending' | 'connected' | 'failed' = 'pending'
+  // Main can answer a local-parakeet 'auto' attempt with the cloud backend
+  // (e.g. the installed runtime broke between checks). Track what actually
+  // connected so quota/close handling matches the live backend.
+  let effectiveBackend: TranscriptionBackend = backend
   return new Promise<OmiListenHandle | null>((resolve) => {
     let handle: OmiListenHandle | null = null
     const timeout = setTimeout(
@@ -129,6 +144,7 @@ async function startWithBackend(
         onConnected: (actualBackend) => {
           if (outcome !== 'pending') return
           outcome = 'connected'
+          effectiveBackend = actualBackend
           clearTimeout(timeout)
           cb.onBackend(actualBackend)
           resolve(handle)
@@ -139,7 +155,7 @@ async function startWithBackend(
         },
         onEvent: (ev) => {
           cb.onEvent?.(ev)
-          if (backend !== 'omi' || !isQuotaExhaustedEvent(ev)) return
+          if (effectiveBackend !== 'omi' || !isQuotaExhaustedEvent(ev)) return
           // Free quota is used up — the cloud STT will never emit transcripts.
           if (outcome === 'pending') {
             outcome = 'failed'
@@ -147,18 +163,18 @@ async function startWithBackend(
             void handle?.stop().catch(() => undefined)
             resolve(null)
           } else if (outcome === 'connected') {
-            onLost('Omi free quota exhausted', backend)
+            onLost('Omi free quota exhausted', effectiveBackend)
           }
         },
         onClosed: (code, reason) => {
           if (outcome !== 'connected') return
           const message =
-            backend === 'omi'
+            effectiveBackend === 'omi'
               ? isQuotaClose(code, reason)
                 ? QUOTA_MESSAGE
                 : `Omi /v4/listen closed (${code})${reason ? ` ${reason}` : ''}`
               : `Local Parakeet STT closed (${code})${reason ? ` ${reason}` : ''}`
-          onLost(message, backend)
+          onLost(message, effectiveBackend)
         },
         onError: (err, fatal) => {
           if (outcome === 'pending' && fatal) {
@@ -170,11 +186,11 @@ async function startWithBackend(
             return
           }
           if (outcome === 'connected') {
-            if (backend === 'omi' && isTrialExpiredError(err)) {
-              onLost(QUOTA_MESSAGE, backend)
+            if (effectiveBackend === 'omi' && isTrialExpiredError(err)) {
+              onLost(QUOTA_MESSAGE, effectiveBackend)
               return
             }
-            onLost(err.message, backend)
+            onLost(err.message, effectiveBackend)
           }
         }
       },
@@ -200,10 +216,12 @@ async function startWithBackend(
 }
 
 /**
- * Begin transcribing one audio source. Auto mode uses local Parakeet only when a
- * healthy supported local runtime is present; otherwise it uses Omi /v4/listen.
- * Local model/runtime failure falls back to hosted cloud, and hosted startup/loss
- * can try local once when the runtime is available.
+ * Begin transcribing one audio source. Auto mode uses local Parakeet only when
+ * the local runtime is already installed and healthy; otherwise it uses Omi
+ * /v4/listen and never installs anything. Only the explicit 'local-parakeet'
+ * preference may trigger the first-use runtime/model install. Local
+ * model/runtime failure falls back to hosted cloud, and hosted startup/loss can
+ * try local once when the runtime is already installed.
  */
 export async function startTranscription(
   source: ListenSource,
@@ -220,7 +238,7 @@ export async function startTranscription(
       if (stopped) return
       const fallback: TranscriptionBackend = lostBackend === 'omi' ? 'local-parakeet' : 'omi'
       void (async () => {
-        if (fallback === 'local-parakeet' && !(await localSttAvailable())) {
+        if (fallback === 'local-parakeet' && !(await localSttInstalled())) {
           if (stopped) return
           cb.onError(new Error(`Transcription stopped: ${reason}`))
           return

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -226,7 +226,10 @@ export async function startTranscription(
           return
         }
         const next = await activate(fallback)
-        if (stopped) return
+        if (stopped) {
+          void next?.stop().catch(() => undefined)
+          return
+        }
         if (next) {
           active = next
           return

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -216,27 +216,24 @@ export async function startTranscription(
   const activate = async (backend: TranscriptionBackend): Promise<OmiListenHandle | null> => {
     if (stopped || tried.has(backend)) return null
     tried.add(backend)
-    return startWithBackend(
-      source,
-      backend,
-      cb,
-      (reason, lostBackend) => {
-        if (stopped) return
-        const fallback: TranscriptionBackend = lostBackend === 'omi' ? 'local-parakeet' : 'omi'
-        void (async () => {
-          if (fallback === 'local-parakeet' && !(await localSttAvailable())) {
-            cb.onError(new Error(`Transcription stopped: ${reason}`))
-            return
-          }
-          const next = await activate(fallback)
-          if (next) {
-            active = next
-            return
-          }
+    return startWithBackend(source, backend, cb, (reason, lostBackend) => {
+      if (stopped) return
+      const fallback: TranscriptionBackend = lostBackend === 'omi' ? 'local-parakeet' : 'omi'
+      void (async () => {
+        if (fallback === 'local-parakeet' && !(await localSttAvailable())) {
+          if (stopped) return
           cb.onError(new Error(`Transcription stopped: ${reason}`))
-        })()
-      }
-    )
+          return
+        }
+        const next = await activate(fallback)
+        if (stopped) return
+        if (next) {
+          active = next
+          return
+        }
+        cb.onError(new Error(`Transcription stopped: ${reason}`))
+      })()
+    })
   }
 
   for (const backend of await initialBackendOrder()) {

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../../shared/types'
 
 const CLOUD_CONNECT_TIMEOUT_MS = 3000
-const LOCAL_CONNECT_TIMEOUT_MS = 10000
+const LOCAL_CONNECT_TIMEOUT_MS = 5 * 60_000
 
 export type TranscriptionCallbacks = {
   /** Fires every time a new finalized line is ready. */
@@ -81,7 +81,8 @@ function modeForBackend(backend: TranscriptionBackend): SttMode {
 
 async function localSttAvailable(): Promise<boolean> {
   try {
-    return (await window.omi.localSttStatus()).available
+    const status = await window.omi.localSttStatus()
+    return status.available || status.runtime.canInstall
   } catch {
     return false
   }

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -1,28 +1,32 @@
 import { auth } from './firebase'
 import { startOmiListen, type OmiListenHandle } from './omiListenClient'
-import type { BackendSegment, ListenSource, TranscriptLine } from '../../../shared/types'
+import { getPreferences } from './preferences'
+import type {
+  BackendSegment,
+  ListenSource,
+  SttMode,
+  TranscriptLine,
+  TranscriptionBackend
+} from '../../../shared/types'
 
-const CONNECT_TIMEOUT_MS = 3000
+const CLOUD_CONNECT_TIMEOUT_MS = 3000
+const LOCAL_CONNECT_TIMEOUT_MS = 10000
 
 export type TranscriptionCallbacks = {
-  /** Fires every time a new finalized line is ready (a v4/listen segment). */
+  /** Fires every time a new finalized line is ready. */
   onLine: (line: TranscriptLine) => void
-  /** Reserved for in-progress interim text. The Omi v4/listen path emits only
-   *  finalized segments, so this currently never fires; kept so callers that
-   *  render interim text don't need to change. */
+  /** Reserved for in-progress interim text. The current backends emit finalized segments only. */
   onInterim: (text: string) => void
-  /** Fires once when the session connects. Always 'omi' (the only backend). */
-  onBackend: (backend: 'omi') => void
-  /** Fires when transcription can't start or can't continue: connect failure,
-   *  quota exhausted, or the socket dropped. The session is over when this fires. */
+  /** Fires once when the winning backend connects. */
+  onBackend: (backend: TranscriptionBackend) => void
+  /** Fires when transcription can't start or can't continue. */
   onError: (err: Error) => void
-  /** Fires for every non-segment backend event (e.g. `memory_creating`). Optional;
-   *  quota events are still handled internally regardless. */
+  /** Fires for every non-segment backend event. Optional; quota events are still handled internally. */
   onEvent?: (event: { type: string; raw: Record<string, unknown> }) => void
 }
 
 export type TranscriptionHandle = {
-  stop: () => void
+  stop: () => Promise<void>
 }
 
 function segmentToLine(seg: BackendSegment): TranscriptLine {
@@ -33,7 +37,16 @@ function segmentToLine(seg: BackendSegment): TranscriptLine {
       : typeof seg.speaker_id === 'number'
         ? `Speaker ${seg.speaker_id}`
         : undefined
-  return { id: seg.id, speaker, text: seg.text }
+  return {
+    id: seg.id,
+    speaker,
+    text: seg.text,
+    speakerId: seg.speaker_id,
+    isUser: seg.is_user,
+    personId: seg.person_id,
+    start: seg.start,
+    end: seg.end
+  }
 }
 
 /**
@@ -62,112 +75,115 @@ function isQuotaClose(code: number, reason: string): boolean {
 const QUOTA_MESSAGE =
   'free Omi transcription quota is used up (1008) — add an Omi subscription or sign in with an entitled account to keep transcribing'
 
+function modeForBackend(backend: TranscriptionBackend): SttMode {
+  return backend === 'local-parakeet' ? 'local-parakeet' : 'cloud'
+}
+
+async function localSttAvailable(): Promise<boolean> {
+  try {
+    return (await window.omi.localSttStatus()).available
+  } catch {
+    return false
+  }
+}
+
+async function initialBackendOrder(): Promise<TranscriptionBackend[]> {
+  const preference = getPreferences().sttMode ?? 'auto'
+  if (preference === 'cloud') {
+    return (await localSttAvailable()) ? ['omi', 'local-parakeet'] : ['omi']
+  }
+  if (preference === 'local-parakeet') return ['local-parakeet', 'omi']
+  return (await localSttAvailable()) ? ['local-parakeet', 'omi'] : ['omi']
+}
+
 /**
- * Start an Omi v4/listen session for one source. Resolves the handle once the
- * socket connects, or null on an initial failure (connect timeout, fatal WS
- * error, no signed-in user, or quota exhausted before connect). `onLost` fires
- * when a CONNECTED session can no longer continue (quota exhausted or socket
- * dropped) so the caller can surface an error to the user.
+ * Start one selected backend for one source. Resolves the handle once the
+ * backend connects, or null on an initial failure. `onLost` fires when a
+ * connected session can no longer continue so the owner can try the other
+ * backend or surface an error.
  */
-async function startWithOmi(
+async function startWithBackend(
   source: ListenSource,
+  backend: TranscriptionBackend,
   cb: TranscriptionCallbacks,
-  onLost: (reason: string) => void
+  onLost: (reason: string, backend: TranscriptionBackend) => void
 ): Promise<OmiListenHandle | null> {
   if (!auth.currentUser) return null
-  let outcome: 'pending' | 'omi' | 'failed' = 'pending'
+  let outcome: 'pending' | 'connected' | 'failed' = 'pending'
   return new Promise<OmiListenHandle | null>((resolve) => {
     let handle: OmiListenHandle | null = null
-    const timeout = setTimeout(() => {
-      if (outcome !== 'pending') return
-      outcome = 'failed'
-      try {
-        handle?.stop()
-      } catch {
-        /* ignore */
-      }
-      resolve(null)
-    }, CONNECT_TIMEOUT_MS)
-
-    startOmiListen(source, {
-      onConnected: () => {
+    const timeout = setTimeout(
+      () => {
         if (outcome !== 'pending') return
-        outcome = 'omi'
-        clearTimeout(timeout)
-        cb.onBackend('omi')
-        resolve(handle)
+        outcome = 'failed'
+        void handle?.stop().catch(() => undefined)
+        resolve(null)
       },
-      onSegments: (segs) => {
-        if (outcome !== 'omi') return
-        for (const s of segs) cb.onLine(segmentToLine(s))
-      },
-      onEvent: (ev) => {
-        cb.onEvent?.(ev)
-        if (!isQuotaExhaustedEvent(ev)) return
-        // Free quota is used up — the cloud STT will never emit transcripts.
-        if (outcome === 'pending') {
-          // Never connected as the winner yet: treat as an initial failure.
-          outcome = 'failed'
+      backend === 'local-parakeet' ? LOCAL_CONNECT_TIMEOUT_MS : CLOUD_CONNECT_TIMEOUT_MS
+    )
+
+    startOmiListen(
+      source,
+      {
+        onConnected: (actualBackend) => {
+          if (outcome !== 'pending') return
+          outcome = 'connected'
           clearTimeout(timeout)
-          try {
-            handle?.stop()
-          } catch {
-            /* ignore */
+          cb.onBackend(actualBackend)
+          resolve(handle)
+        },
+        onSegments: (segs) => {
+          if (outcome !== 'connected') return
+          for (const s of segs) cb.onLine(segmentToLine(s))
+        },
+        onEvent: (ev) => {
+          cb.onEvent?.(ev)
+          if (backend !== 'omi' || !isQuotaExhaustedEvent(ev)) return
+          // Free quota is used up — the cloud STT will never emit transcripts.
+          if (outcome === 'pending') {
+            outcome = 'failed'
+            clearTimeout(timeout)
+            void handle?.stop().catch(() => undefined)
+            resolve(null)
+          } else if (outcome === 'connected') {
+            onLost('Omi free quota exhausted', backend)
           }
-          resolve(null)
-        } else if (outcome === 'omi') {
-          // Already connected and committed: tell the caller the session is over.
-          onLost('Omi free quota exhausted')
-        }
-      },
-      onClosed: (code, reason) => {
-        // The Omi socket dropped AFTER connecting (abnormal 1005/1006, clean
-        // 1000, etc.). Omi will emit no more transcripts, so end the session.
-        // (Pre-connect closes arrive via onError and drive the initial failure.)
-        if (outcome !== 'omi') return
-        onLost(
-          isQuotaClose(code, reason)
-            ? QUOTA_MESSAGE
-            : `Omi /v4/listen closed (${code})${reason ? ` ${reason}` : ''}`
-        )
-      },
-      onError: (err, fatal) => {
-        if (outcome === 'pending' && fatal) {
-          outcome = 'failed'
-          clearTimeout(timeout)
-          try {
-            handle?.stop()
-          } catch {
-            /* ignore */
-          }
-          console.warn(`[v4/listen ${source}] initial failure:`, err.message)
-          resolve(null)
-          return
-        }
-        // Only surface post-connect errors when Omi actually connected.
-        if (outcome === 'omi') {
-          // Quota backstop: a 1008 'trial_expired' close (in case the typed
-          // event didn't arrive first). End the session rather than erroring twice.
-          if (isTrialExpiredError(err)) {
-            onLost(QUOTA_MESSAGE)
+        },
+        onClosed: (code, reason) => {
+          if (outcome !== 'connected') return
+          const message =
+            backend === 'omi'
+              ? isQuotaClose(code, reason)
+                ? QUOTA_MESSAGE
+                : `Omi /v4/listen closed (${code})${reason ? ` ${reason}` : ''}`
+              : `Local Parakeet STT closed (${code})${reason ? ` ${reason}` : ''}`
+          onLost(message, backend)
+        },
+        onError: (err, fatal) => {
+          if (outcome === 'pending' && fatal) {
+            outcome = 'failed'
+            clearTimeout(timeout)
+            void handle?.stop().catch(() => undefined)
+            console.warn(`[transcription ${backend} ${source}] initial failure:`, err.message)
+            resolve(null)
             return
           }
-          cb.onError(err)
-        }
-      }
-    })
-      .then((h) => {
-        // startOmiListen resolves as soon as the WS is *created* — long before
-        // it reaches OPEN (~150ms+ away). At that point `outcome` is still
-        // 'pending', so we keep the handle and let onConnected/timeout decide.
-        // Only tear down if we've ALREADY failed; closing here on a still-pending
-        // outcome aborts the handshake mid-connect (ws code 1006).
-        if (outcome === 'failed') {
-          try {
-            h.stop()
-          } catch {
-            /* ignore */
+          if (outcome === 'connected') {
+            if (backend === 'omi' && isTrialExpiredError(err)) {
+              onLost(QUOTA_MESSAGE, backend)
+              return
+            }
+            onLost(err.message, backend)
           }
+        }
+      },
+      modeForBackend(backend)
+    )
+      .then((h) => {
+        // startOmiListen resolves once capture + IPC are set up; the backend
+        // handshake still decides the winner via onConnected/timeout.
+        if (outcome === 'failed') {
+          void h.stop().catch(() => undefined)
         } else {
           handle = h
         }
@@ -176,31 +192,58 @@ async function startWithOmi(
         if (outcome !== 'pending') return
         outcome = 'failed'
         clearTimeout(timeout)
-        console.warn(`[v4/listen ${source}] start threw:`, err)
+        console.warn(`[transcription ${backend} ${source}] start threw:`, err)
         resolve(null)
       })
   })
 }
 
 /**
- * Begin transcribing one audio source via Omi v4/listen. Omi is the only
- * transcription backend: if it can't connect, runs out of free quota, or its
- * socket drops mid-session, the session ends and `onError` fires. (There is no
- * Deepgram fallback.)
+ * Begin transcribing one audio source. Auto mode uses local Parakeet only when a
+ * healthy supported local runtime is present; otherwise it uses Omi /v4/listen.
+ * Local model/runtime failure falls back to hosted cloud, and hosted startup/loss
+ * can try local once when the runtime is available.
  */
 export async function startTranscription(
   source: ListenSource,
   cb: TranscriptionCallbacks
 ): Promise<TranscriptionHandle> {
   let active: OmiListenHandle | null = null
+  let stopped = false
+  const tried = new Set<TranscriptionBackend>()
 
-  const omi = await startWithOmi(source, cb, (reason) => {
-    cb.onError(new Error(`Omi transcription stopped: ${reason}`))
-  })
+  const activate = async (backend: TranscriptionBackend): Promise<OmiListenHandle | null> => {
+    if (stopped || tried.has(backend)) return null
+    tried.add(backend)
+    return startWithBackend(
+      source,
+      backend,
+      cb,
+      (reason, lostBackend) => {
+        if (stopped) return
+        const fallback: TranscriptionBackend = lostBackend === 'omi' ? 'local-parakeet' : 'omi'
+        void (async () => {
+          if (fallback === 'local-parakeet' && !(await localSttAvailable())) {
+            cb.onError(new Error(`Transcription stopped: ${reason}`))
+            return
+          }
+          const next = await activate(fallback)
+          if (next) {
+            active = next
+            return
+          }
+          cb.onError(new Error(`Transcription stopped: ${reason}`))
+        })()
+      }
+    )
+  }
 
-  if (omi) {
-    active = omi
-  } else {
+  for (const backend of await initialBackendOrder()) {
+    active = await activate(backend)
+    if (active) break
+  }
+
+  if (!active) {
     cb.onError(
       new Error(
         auth.currentUser
@@ -211,12 +254,9 @@ export async function startTranscription(
   }
 
   return {
-    stop: (): void => {
-      try {
-        active?.stop()
-      } catch {
-        /* ignore */
-      }
+    stop: async (): Promise<void> => {
+      stopped = true
+      await active?.stop()
     }
   }
 }

--- a/desktop/windows/src/renderer/src/pages/Settings.tsx
+++ b/desktop/windows/src/renderer/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { SettingsTabPanel } from '../components/settings/SettingsTabPanel'
 import { SETTINGS_TABS, type SettingsTabId } from '../components/settings/tabs'
 import { GeneralTab } from '../components/settings/tabs/GeneralTab'
 import { RewindTab } from '../components/settings/tabs/RewindTab'
+import { TranscriptionTab } from '../components/settings/tabs/TranscriptionTab'
 import { PrivacyTab } from '../components/settings/tabs/PrivacyTab'
 import { AccountTab } from '../components/settings/tabs/AccountTab'
 import { AdvancedTab } from '../components/settings/tabs/AdvancedTab'
@@ -17,6 +18,7 @@ import { Memories } from './Memories'
 const TAB_COMPONENTS: Partial<Record<SettingsTabId, () => React.JSX.Element>> = {
   general: GeneralTab,
   rewind: RewindTab,
+  transcription: TranscriptionTab,
   privacy: PrivacyTab,
   account: AccountTab,
   advanced: AdvancedTab

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -147,7 +147,11 @@ export type ListenStartArgs = {
   token: string
   /** BCP-47-ish language code for transcription (e.g. 'en', 'es'). */
   language: string
-  /** 'auto' prefers local Parakeet only when the runtime is healthy and supported. */
+  /**
+   * 'auto' prefers local Parakeet only when the runtime is already installed
+   * and healthy; it never installs. Only the explicit 'local-parakeet' mode may
+   * trigger the first-use runtime/model download.
+   */
   sttMode?: SttMode
 }
 

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -41,6 +41,11 @@ export type TranscriptLine = {
   speaker?: string
   text: string
   interim?: boolean
+  speakerId?: number
+  isUser?: boolean
+  personId?: string
+  start?: number
+  end?: number
 }
 
 export type ConversationPayload = {
@@ -74,6 +79,19 @@ export type LocalConversation = {
 }
 
 export type ListenSource = 'mic' | 'system'
+export type TranscriptionBackend = 'omi' | 'local-parakeet'
+export type SttMode = 'auto' | 'cloud' | 'local-parakeet'
+
+export type LocalSttStatus = {
+  backend: 'parakeet'
+  configuredUrl: string
+  healthUrl: string
+  healthy: boolean
+  available: boolean
+  nvidiaAvailable: boolean | null
+  reason?: string
+  checkedAt: number
+}
 
 export type ListenStartArgs = {
   sessionId: string
@@ -82,10 +100,12 @@ export type ListenStartArgs = {
   token: string
   /** BCP-47-ish language code for transcription (e.g. 'en', 'es'). */
   language: string
+  /** 'auto' prefers local Parakeet only when the runtime is healthy and supported. */
+  sttMode?: SttMode
 }
 
 export type ListenMessage =
-  | { sessionId: string; kind: 'connected' }
+  | { sessionId: string; kind: 'connected'; backend: TranscriptionBackend }
   | { sessionId: string; kind: 'segments'; segments: BackendSegment[] }
   | { sessionId: string; kind: 'event'; event: ListenEvent }
   | { sessionId: string; kind: 'error'; message: string; fatal: boolean }
@@ -161,6 +181,8 @@ export type OmiBridgeApi = {
   listenFeed: (sessionId: string, pcm: ArrayBuffer) => void
   /** Subscribe to status/segment/event messages from every listen session. */
   onListenMessage: (cb: (msg: ListenMessage) => void) => () => void
+  /** Probe the local Parakeet STT runtime used for on-device transcription. */
+  localSttStatus: () => Promise<LocalSttStatus>
   indexFilesScan: () => Promise<FileIndexStatus>
   indexFilesStatus: () => Promise<FileIndexStatus>
   /** Indexed installed apps (Start-Menu shortcuts), newest-modified first. */

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -81,6 +81,7 @@ export type LocalConversation = {
 export type ListenSource = 'mic' | 'system'
 export type TranscriptionBackend = 'omi' | 'local-parakeet'
 export type SttMode = 'auto' | 'cloud' | 'local-parakeet'
+export type RealtimeVoiceProvider = 'omi-relay' | 'openai-byok' | 'local-kokoro'
 
 export type LocalSttStatus = {
   backend: 'parakeet'
@@ -107,6 +108,34 @@ export type LocalSttStatus = {
   }
   reason?: string
   checkedAt: number
+}
+
+export type LocalTtsStatus = {
+  backend: 'kokoro'
+  healthy: boolean
+  available: boolean
+  managed: boolean
+  runtime: {
+    kind: 'kokoro-js'
+    installState: 'unsupported' | 'not_installed' | 'installing' | 'installed' | 'running' | 'error'
+    model: string
+    voice: string
+    canInstall: boolean
+  }
+  reason?: string
+  checkedAt: number
+}
+
+export type LocalTtsSynthesizeRequest = {
+  text: string
+  voice?: string
+  speed?: number
+}
+
+export type LocalTtsSynthesizeResult = {
+  audioPath: string
+  audioUrl: string
+  mimeType: 'audio/wav'
 }
 
 export type ListenStartArgs = {
@@ -199,6 +228,9 @@ export type OmiBridgeApi = {
   onListenMessage: (cb: (msg: ListenMessage) => void) => () => void
   /** Probe the local Parakeet STT runtime used for on-device transcription. */
   localSttStatus: () => Promise<LocalSttStatus>
+  /** Probe the local Kokoro TTS runtime used for on-device assistant speech. */
+  localTtsStatus: () => Promise<LocalTtsStatus>
+  localTtsSynthesize: (request: LocalTtsSynthesizeRequest) => Promise<LocalTtsSynthesizeResult>
   indexFilesScan: () => Promise<FileIndexStatus>
   indexFilesStatus: () => Promise<FileIndexStatus>
   /** Indexed installed apps (Start-Menu shortcuts), newest-modified first. */

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -84,11 +84,27 @@ export type SttMode = 'auto' | 'cloud' | 'local-parakeet'
 
 export type LocalSttStatus = {
   backend: 'parakeet'
-  configuredUrl: string
-  healthUrl: string
+  /** Internal only. Settings must not expose implementation URLs to end users. */
+  configuredUrl?: string
+  healthUrl?: string
   healthy: boolean
   available: boolean
   nvidiaAvailable: boolean | null
+  managed: boolean
+  runtime: {
+    kind: 'parakeet.cpp'
+    installState:
+      | 'unsupported'
+      | 'not_installed'
+      | 'installing'
+      | 'installed'
+      | 'starting'
+      | 'running'
+      | 'error'
+    variant: 'cuda' | 'cpu' | null
+    model: string
+    canInstall: boolean
+  }
   reason?: string
   checkedAt: number
 }

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -81,7 +81,7 @@ export type LocalConversation = {
 export type ListenSource = 'mic' | 'system'
 export type TranscriptionBackend = 'omi' | 'local-parakeet'
 export type SttMode = 'auto' | 'cloud' | 'local-parakeet'
-export type RealtimeVoiceProvider = 'omi-relay' | 'openai-byok' | 'local-kokoro'
+export type RealtimeVoiceProvider = 'omi-relay' | 'local-kokoro'
 
 export type LocalSttStatus = {
   backend: 'parakeet'

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -44,7 +44,9 @@ export type TranscriptLine = {
   speakerId?: number
   isUser?: boolean
   personId?: string
+  /** Seconds relative to the recording/session start, not epoch milliseconds. */
   start?: number
+  /** Seconds relative to the recording/session start, not epoch milliseconds. */
   end?: number
 }
 


### PR DESCRIPTION
> **Maintainers:** one of several independent Windows split PRs carved out of #8404. Each is small and standalone — **cherry-pick or merge whichever you want, in any order**; they do not depend on each other beyond shared plumbing. Base is v0.11.542 (`84e539a`). Full context: BasedHardware/omi#8404.

---

## Summary

Split **6 of the PR 8404 breakup** (maintainer-requested order: "Native STT/TTS/runtime dependency and packaging changes, with provenance/size/license/runtime behavior called out"). Branch: `split/pr8404-local-stt-tts`. Review together with `dependency-security`.

- Adds local Parakeet STT status/session handling and local Kokoro TTS runtime/playback handling.
- Keeps ElevenLabs/cloud voice and BYOK routing outside this split.

## Scope

- **In scope:** `desktop/windows/src/main/localStt/*` (status, parakeetSession, parakeetCppRuntime, parakeetCppSession), `src/main/localTts/*` (kokoroRuntime), `src/renderer/src/lib/localSttUpload*`, `localTtsPlayback*`, `realtimeVoice*`, and shared plumbing.
- **Out of scope:** ElevenLabs/cloud voice, BYOK routing.

## Split Overlap & Merge Order

- Split #6 in [SPLIT_MAP.md](../SPLIT_MAP.md); pair with `dependency-security`.
- `localStt/*` and `localTts/*` are **owned by this split**. Shares plumbing (`main/index.ts`, `preload/index.ts`, `shared/types.ts`, `useChat.ts`, `preferences.ts`, `package.json`, `electron-builder.yml`) with other splits.
- **Adds new runtime dependencies + model downloads** → must be reviewed with `dependency-security` before non-draft.

## Windows Desktop Verification Evidence

- **Package check** (`_package-evidence/20260628-083433`): OK — `koffi.node`, `app.asar`, packaged config strings present.
- **Launch smoke** (`_smoke-evidence/20260627-194234`): launch **pass**, title `omi`, unit tests **pass**.
- **Independent unit re-run (2026-07-01, vitest 3.2.6):** `localStt/status`, `localStt/parakeetSession`, `localStt/parakeetCppRuntime`, `localStt/parakeetCppSession`, `lib/localSttUpload`, `localTts/kokoroRuntime`, `lib/localTtsPlayback`, `lib/realtimeVoice` → **23 tests passing**.
- **Feature capture** (`_feature-renderer-evidence/20260628-084516`): local voice status probe in the packaged app.
  - Parakeet: backend `parakeet`, managed runtime `parakeet.cpp`, install state `not_installed`, CUDA variant, model `tdt_ctc-110m-q8_0.gguf`, `canInstall=true`.
  - Kokoro: backend `kokoro`, managed runtime `kokoro-js`, install state `not_installed`, model `onnx-community/Kokoro-82M-v1.0-ONNX`, voice `af_heart`, `canInstall=true`.
  - No runtime/model download or synthesis was started during prep (opt-in confirmed: both `not_installed`, `canInstall=true`).
- **Recorded source checks** (TESTING.md): `npm run test -- src/main/localStt/status.test.ts src/main/localStt/parakeetSession.test.ts src/main/localStt/parakeetCppRuntime.test.ts src/main/localStt/parakeetCppSession.test.ts src/renderer/src/lib/localSttUpload.test.ts src/main/localTts/kokoroRuntime.test.ts src/renderer/src/lib/localTtsPlayback.test.ts src/renderer/src/lib/realtimeVoice.test.ts`; `npm run build`.

## Addresses Maintainer Review Notes (BasedHardware/omi#8404)

- Maintainer split order item **#5** and blocker **#3** (dependency/runtime pass). Review scope for `dependency-security`: `@huggingface/transformers`, `kokoro-js`, Parakeet runtime/model downloads, managed cache paths, first-use download prompts, model size, license/provenance, native/runtime behavior, offline behavior, telemetry/redaction.

## Screenshots

The **Transcription** settings tab — the controls that make this feature usable: Speech-to-text runtime selector (**Local Parakeet**, NVIDIA detected, first-use install), Realtime voice selector (**Local Kokoro**, Kokoro-82M), continuous-recording toggle, and transcription language:


_This settings tab was added to the split on 2026-07-01 (commits registering `TranscriptionTab` + the `transcription` nav item). See the completeness note below._

## Split Completeness Note

An initial cut of this split shipped the Parakeet/Kokoro **runtime without its settings UI** — the `TranscriptionTab` (Speech-to-text runtime / Realtime voice knobs) had been dropped, leaving no way for a user to enable or select the local runtimes. That tab has since been ported in and validated: it is registered in the settings nav, mapped in `Settings.tsx`, its IPC (`localSttStatus`, `localTtsStatus`) type-checks, `npm run build` passes, and the packaged build renders it (screenshot above).

## Remaining Checks Before Non-Draft

- Run first-use Parakeet download/transcription and Kokoro download/synthesis on a disposable test machine/profile.
- Record model download sizes and cache locations in the `dependency-security` PR.
- Redact screenshots before posting if personal conversation/task history is visible (see [REDACTION_NOTES.md](../REDACTION_NOTES.md)).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

