### PR TITLE
[codex] Tune LLM gateway pilot timeout budgets

### DIFF
--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:c4c393fc3e915b2ecc41d4ef4cce5abd30c6439076814f55e29578eab6232e31
+    artifact_digest: sha256:d387bb7ebde0b4e79583b773111b32e4693808570f7c29470dec68527b595b6e
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -10,7 +10,7 @@ route_artifacts:
       - provider: openai
         model: gpt-4.1-mini
     timeouts:
-      request_ms: 8000
+      request_ms: 30000
     retry:
       max_attempts: 1
     capabilities:
@@ -56,7 +56,7 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:1d46ec82568f2d523da23e1df4b0956cfe876cc6ece9d05dbfb7e0edc7eda74b
+    artifact_digest: sha256:2d073c8787bbff26c9b79492c1eacd1357e2f7a2f6a07e8d603a3b860ea229ce
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # LKG primary must match the legacy `chat_extraction` model (gpt-4.1-mini) so
@@ -68,7 +68,7 @@ route_artifacts:
       model: gpt-4.1-mini
     fallbacks: []
     timeouts:
-      request_ms: 9000
+      request_ms: 30000
     retry:
       max_attempts: 1
     capabilities:

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -228,13 +228,17 @@ def test_gateway_validation_rejects_conversation_structure_defaults_masking_miss
 def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeypatch):
     monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://gateway.test/')
     monkeypatch.setenv('OMI_LLM_GATEWAY_SERVICE_TOKEN', 'service-token')
-    captured = {}
+    captured = {'client_kwargs': None}
+
+    def fake_client(*args, **kwargs):
+        captured['client_kwargs'] = kwargs
+        return FakeGatewayClient(fake_post)
 
     def fake_post(url, *, headers=None, json=None, **kwargs):
         captured.update({'url': url, 'headers': headers, 'json': json})
         return _VALUE_TRUE_RESPONSE
 
-    _mock_gateway_client(monkeypatch, fake_post)
+    monkeypatch.setattr(gateway_client.httpx, 'Client', fake_client)
 
     result = gateway_client.invoke_chat_structured_gateway(
         'classified prompt',
@@ -250,6 +254,27 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
     assert captured['json']['messages'] == [{'role': 'user', 'content': 'classified prompt'}]
     assert captured['json']['response_format']['type'] == 'json_schema'
     assert captured['json']['response_format']['json_schema']['schema']['properties']['value']['type'] == 'boolean'
+    assert captured['client_kwargs'] == {'timeout': gateway_client.CHAT_EXTRACTION_TIMEOUT_SECONDS}
+
+
+def test_chat_structured_gateway_allows_background_timeout_override(monkeypatch):
+    captured = {}
+
+    def fake_client(*args, **kwargs):
+        captured['client_kwargs'] = kwargs
+        return FakeGatewayClient(lambda *args, **kwargs: _VALUE_TRUE_RESPONSE)
+
+    monkeypatch.setattr(gateway_client.httpx, 'Client', fake_client)
+
+    result = gateway_client.invoke_chat_structured_gateway(
+        'classified prompt',
+        chat.RequiresContext,
+        feature='chat_extraction.requires_context',
+        timeout_seconds=gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
+    )
+
+    assert result == chat.RequiresContext(value=True)
+    assert captured['client_kwargs'] == {'timeout': gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS}
 
 
 def test_strict_schema_normalizes_action_item_extraction_for_openai():
@@ -421,8 +446,10 @@ def test_chat_structured_gateway_failure_does_not_log_raw_prompt_or_response(mon
 def test_conversation_discard_gateway_success_returns_without_legacy_llm(monkeypatch):
     captured = {}
 
-    def fake_gateway(prompt, output_model, *, feature):
-        captured.update({'prompt': prompt, 'output_model': output_model, 'feature': feature})
+    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
+        captured.update(
+            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
+        )
         return output_model(discard=True)
 
     monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
@@ -435,6 +462,7 @@ def test_conversation_discard_gateway_success_returns_without_legacy_llm(monkeyp
     assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is True
     assert captured['output_model'] is conversation_processing.DiscardConversation
     assert captured['feature'] == 'conversation_discard.should_discard'
+    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
     assert 'hello there' in captured['prompt']
 
 
@@ -537,8 +565,10 @@ def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
             assert 'submit report by Friday' in values['conversation_context']
             return conversation_processing.ActionItemsExtraction(action_items=[])
 
-    def fake_gateway(prompt, output_model, *, feature):
-        captured.update({'prompt': prompt, 'output_model': output_model, 'feature': feature})
+    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
+        captured.update(
+            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
+        )
         return output_model(action_items=[])
 
     monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
@@ -556,6 +586,7 @@ def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
     assert result == []
     assert captured['output_model'] is conversation_processing.ActionItemsExtraction
     assert captured['feature'] == 'conversation_action_items.extract.shadow'
+    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
     assert 'submit report by Friday' in captured['prompt']
 
 
@@ -594,9 +625,11 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
                 category=CategoryEnum.work,
             )
 
-    def fake_gateway(prompt, output_model, *, feature):
+    def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
         call_order.append('gateway')
-        captured.update({'prompt': prompt, 'output_model': output_model, 'feature': feature})
+        captured.update(
+            {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
+        )
         return output_model(
             title='Weekly Plan',
             overview='Discussed launch tasks for the project.',
@@ -639,6 +672,7 @@ def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_c
     assert call_order == ['legacy', 'gateway']
     assert captured['output_model'] is ConversationStructureExtraction
     assert captured['feature'] == 'conversation_structure.extract.shadow'
+    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
     assert 'return shadow structure' in captured['prompt']
     comparison_labels = [labels for labels, _amount in counter.calls]
     assert {

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -23,6 +23,13 @@ def test_loads_default_gateway_config():
     assert config.feature_bundles['chat_extraction.requires_context'].lane_id == LANE_ID
 
 
+def test_chat_structured_routes_have_background_shadow_timeout_budget():
+    config = load_gateway_config(prod_mode=True)
+
+    assert config.route_artifacts[ACTIVE_ROUTE].timeouts.request_ms >= 30000
+    assert config.route_artifacts[LKG_ROUTE].timeouts.request_ms >= 30000
+
+
 def test_missing_active_route_fails(tmp_path):
     write_config(tmp_path, lane_overrides={'active_route': 'route.missing'})
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -18,7 +18,11 @@ from models.structured import ActionItem, Event, Structured
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction, StructuredExtraction
 from .clients import get_llm, parser
 from utils.byok import has_byok_keys
-from utils.llm.gateway_client import invoke_chat_structured_gateway, record_chat_extraction_gateway_result
+from utils.llm.gateway_client import (
+    BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
+    invoke_chat_structured_gateway,
+    record_chat_extraction_gateway_result,
+)
 from utils.llm.conversation_folder import FolderAssignment, assign_conversation_to_folder, build_folders_context
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
 import logging
@@ -43,11 +47,17 @@ class SpeakerIdMatch(BaseModel):
     speaker_id: int = Field(description="The speaker id assigned to the segment")
 
 
-def _invoke_gateway_unless_byok(prompt: str, output_model: type[BaseModel], *, feature: str) -> BaseModel | None:
+def _invoke_gateway_unless_byok(
+    prompt: str,
+    output_model: type[BaseModel],
+    *,
+    feature: str,
+    timeout_seconds: float = BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS,
+) -> BaseModel | None:
     if has_byok_keys():
         record_chat_extraction_gateway_result(feature=feature, outcome='skipped', reason='byok')
         return None
-    return invoke_chat_structured_gateway(prompt, output_model, feature=feature)
+    return invoke_chat_structured_gateway(prompt, output_model, feature=feature, timeout_seconds=timeout_seconds)
 
 
 def _word_count(text: str) -> int:

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -21,6 +21,7 @@ LLM_GATEWAY_AUTO_LANE_PREFIX = 'omi:auto:'
 CHAT_STRUCTURED_AUTO_LANE_ID = 'omi:auto:chat-structured'
 LLM_GATEWAY_CALLER = 'backend'
 CHAT_EXTRACTION_TIMEOUT_SECONDS = 10.0
+BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
 
 StructuredOutput = TypeVar('StructuredOutput', bound=BaseModel)
 
@@ -47,6 +48,7 @@ def invoke_chat_structured_gateway(
     output_model: type[StructuredOutput],
     *,
     feature: str,
+    timeout_seconds: float = CHAT_EXTRACTION_TIMEOUT_SECONDS,
 ) -> StructuredOutput | None:
     """Call the LLM gateway for chat structured extraction (pilot).
 
@@ -57,7 +59,7 @@ def invoke_chat_structured_gateway(
     code without first offloading via ``run_blocking(llm_executor, ...)``.
     """
     try:
-        with httpx.Client(timeout=CHAT_EXTRACTION_TIMEOUT_SECONDS) as client:
+        with httpx.Client(timeout=timeout_seconds) as client:
             response = client.post(
                 f'{get_llm_gateway_base_url()}/v1/chat/completions',
                 headers=_gateway_headers(),


### PR DESCRIPTION
## Summary
- keeps latency-sensitive chat extraction on the existing 10s backend timeout
- adds an explicit 35s backend timeout budget for conversation background/shadow gateway calls
- raises the chat-structured gateway provider timeout to 30s so background/shadow calls are not cut off by the gateway before the backend budget
- adds tests that lock the latency-sensitive/background timeout split and route timeout budget

## Why
Dev product traffic showed the gateway wiring is working, but background/shadow calls were returning too many `http_502` fallbacks. The likely cause was the 8-9s gateway provider timeout plus 10s backend client timeout being too aggressive for latency-insensitive conversation/action-item shadow work.

This PR should let the dev pilot produce a clearer signal: if failures drop, the prior issue was timeout budget; if failures remain, the logs and metrics should point to a non-timeout gateway/provider/schema problem rather than a known premature cutoff.

## Post-merge dev decision criteria
After auto-deploy to dev, watch sanitized backend events and gateway metrics for the same product paths:
- `conversation_action_items.extract.shadow`
- `conversation_structure.extract.shadow`
- `conversation_discard.should_discard`

Proceed only if:
- gateway product calls continue to arrive from the dev backend
- `fallback reason=http_502`/timeout-like failures drop materially versus the previous sample
- structure shadow comparison events continue firing without raw content in logs
- no user-visible chat latency regression appears, since `chat_extraction.requires_context` still has a 10s backend client timeout

Do not expand if:
- `http_502` remains high after enough product samples
- failures shift to schema/provider errors
- comparison outcomes show obvious quality regressions that need prompt/model work first

## Validation
- `PYTHONPATH=backend pytest backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py backend/tests/unit/test_llm_gateway_config.py -q`
- `PYTHONPATH=backend python3 - <<'PY' ... load_gateway_config(prod_mode=True) ... PY`
- `python3 backend/scripts/scan_async_blockers.py`
- `scripts/pre-push`
- push pre-push hook also passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

