### PR TITLE
[codex] Fix duplicate chat tool call rows

### DIFF
--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -47,6 +47,10 @@ let package = Package(
         .product(name: "FluidAudio", package: "FluidAudio"),
       ],
       path: "Sources",
+      exclude: [
+        "GoogleService-Info-Dev.plist",
+        "GoogleService-Info-Local.plist",
+      ],
       resources: [
         .process("GoogleService-Info.plist"),
         // Bundles everything under Resources/ (incl. *_logo.png brand marks).

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -330,7 +330,7 @@ class TaskChatState: ObservableObject {
                                 || !messages[currentIndex].contentBlocks.isEmpty
                             )
                         messages[currentIndex].isStreaming = false
-                        completeRemainingToolCalls(messageId: aiMessageId)
+                        completeRemainingToolCalls(messageId: aiMessageId, terminalStatus: .failed)
                         if shouldPersistPartial {
                             persistMessage(messages[currentIndex])
                         }
@@ -374,7 +374,10 @@ class TaskChatState: ObservableObject {
                 } else {
                     Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: error.localizedDescription)
                     messages[index].isStreaming = false
-                    completeRemainingToolCalls(messageId: aiMessageId)
+                    completeRemainingToolCalls(
+                        messageId: aiMessageId,
+                        terminalStatus: failedByUserStop ? .completed : .failed
+                    )
                     persistMessage(messages[index])
                 }
             }
@@ -459,7 +462,7 @@ class TaskChatState: ObservableObject {
            messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: errorText)
             messages[index].isStreaming = false
-            completeRemainingToolCalls(messageId: activeAssistantMessageId)
+            completeRemainingToolCalls(messageId: activeAssistantMessageId, terminalStatus: .failed)
             if persist {
                 persistMessage(messages[index])
             }
@@ -473,7 +476,7 @@ class TaskChatState: ObservableObject {
         }) {
             Self.applyFailureTextIfNeeded(to: &messages[index], errorDescription: errorText)
             messages[index].isStreaming = false
-            completeRemainingToolCalls(messageId: messages[index].id)
+            completeRemainingToolCalls(messageId: messages[index].id, terminalStatus: .failed)
             if persist {
                 persistMessage(messages[index])
             }
@@ -568,62 +571,25 @@ class TaskChatState: ObservableObject {
         }
     }
 
-    // Mirrors ChatProvider.addToolActivity — kept in lockstep.
-    // TODO: DRY these two implementations into a shared helper.
     private func addToolActivity(messageId: String, toolName: String, status: ToolCallStatus, toolUseId: String? = nil, input: [String: Any]? = nil) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
-
-        if status == .running {
-            if let toolUseId = toolUseId, toolInput != nil {
-                for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                    if case .toolCall(let id, let name, let st, let existingTuid, _, let output) = messages[index].contentBlocks[i],
-                       (existingTuid == toolUseId || (existingTuid == nil && name == toolName && st.isInFlight)) {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: st,
-                            toolUseId: toolUseId, input: toolInput, output: output
-                        )
-                        return
-                    }
-                }
-            }
-            messages[index].contentBlocks.append(
-                .toolCall(id: UUID().uuidString, name: toolName, status: .running,
-                          toolUseId: toolUseId, input: toolInput)
-            )
-        } else {
-            for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                if case .toolCall(let id, let name, let st, let existingTuid, let existingInput, let output) = messages[index].contentBlocks[i],
-                   st.isInFlight {
-                    let matches = (toolUseId != nil && existingTuid == toolUseId) || (toolUseId == nil && name == toolName)
-                    if matches {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: .completed,
-                            toolUseId: toolUseId ?? existingTuid,
-                            input: toolInput ?? existingInput,
-                            output: output
-                        )
-                        break
-                    }
-                }
-            }
-        }
+        ToolCallBlockUpdater.applyToolActivity(
+            to: &messages[index].contentBlocks,
+            toolName: toolName,
+            status: status,
+            toolUseId: toolUseId,
+            input: input
+        )
     }
 
     private func addToolResult(messageId: String, toolUseId: String, name: String, output: String) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        for i in messages[index].contentBlocks.indices {
-            if case .toolCall(let id, let blockName, let status, let tuid, let input, _) = messages[index].contentBlocks[i],
-               (tuid == toolUseId || (tuid == nil && blockName == name)) {
-                messages[index].contentBlocks[i] = .toolCall(
-                    id: id, name: blockName, status: status,
-                    toolUseId: toolUseId, input: input, output: output
-                )
-                return
-            }
-        }
+        ToolCallBlockUpdater.applyToolOutput(
+            to: &messages[index].contentBlocks,
+            toolUseId: toolUseId,
+            name: name,
+            output: output
+        )
     }
 
     private func appendThinking(messageId: String, text: String) {
@@ -642,16 +608,11 @@ class TaskChatState: ObservableObject {
     /// Mirrors ChatProvider.completeRemainingToolCalls — matches any
     /// in-flight state (`.running`, `.slow`, `.stalled`) so detector-
     /// promoted blocks resolve when the turn ends.
-    private func completeRemainingToolCalls(messageId: String) {
+    private func completeRemainingToolCalls(messageId: String, terminalStatus: ToolCallStatus = .completed) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-        for i in messages[index].contentBlocks.indices {
-            if case .toolCall(let id, let name, let status, let toolUseId, let input, let output) = messages[index].contentBlocks[i],
-               status.isInFlight {
-                messages[index].contentBlocks[i] = .toolCall(
-                    id: id, name: name, status: .completed,
-                    toolUseId: toolUseId, input: input, output: output
-                )
-            }
-        }
+        ToolCallBlockUpdater.completeRemainingToolCalls(
+            in: &messages[index].contentBlocks,
+            terminalStatus: terminalStatus
+        )
     }
 }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -243,6 +243,219 @@ enum ToolCallStatus: CaseIterable {
     }
 }
 
+/// Canonical mutation rules for visible tool-call blocks.
+/// Adapter streams may emit multiple lifecycle events for one invocation;
+/// the chat transcript keeps exactly one block per `toolUseId`.
+enum ToolCallBlockUpdater {
+    static func applyToolActivity(
+        to blocks: inout [ChatContentBlock],
+        toolName: String,
+        status: ToolCallStatus,
+        toolUseId: String?,
+        input: [String: Any]?
+    ) {
+        let normalizedToolUseId = toolUseId?.isEmpty == false ? toolUseId : nil
+        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
+
+        if status == .running {
+            if let existingIndex = existingToolIndexForStart(
+                in: blocks,
+                toolName: toolName,
+                toolUseId: normalizedToolUseId
+            ) {
+                if case .toolCall(let id, let name, let existingStatus, let existingToolUseId, let existingInput, let output) =
+                    blocks[existingIndex] {
+                    blocks[existingIndex] = .toolCall(
+                        id: id,
+                        name: name,
+                        status: existingStatus,
+                        toolUseId: normalizedToolUseId ?? existingToolUseId,
+                        input: toolInput ?? existingInput,
+                        output: output
+                    )
+                }
+                return
+            }
+
+            blocks.append(
+                .toolCall(
+                    id: UUID().uuidString,
+                    name: toolName,
+                    status: .running,
+                    toolUseId: normalizedToolUseId,
+                    input: toolInput
+                )
+            )
+            return
+        }
+
+        for index in blocks.indices {
+            guard case .toolCall(let id, let name, let existingStatus, let existingToolUseId, let existingInput, let output) =
+                blocks[index],
+                  existingStatus.isInFlight,
+                  toolMatches(
+                    name: name,
+                    toolUseId: existingToolUseId,
+                    requestedName: toolName,
+                    requestedToolUseId: normalizedToolUseId
+                  ) else {
+                continue
+            }
+
+            blocks[index] = .toolCall(
+                id: id,
+                name: name,
+                status: status,
+                toolUseId: normalizedToolUseId ?? existingToolUseId,
+                input: toolInput ?? existingInput,
+                output: output
+            )
+        }
+    }
+
+    static func completeRemainingToolCalls(
+        in blocks: inout [ChatContentBlock],
+        terminalStatus: ToolCallStatus = .completed
+    ) {
+        for index in blocks.indices {
+            if case .toolCall(let id, let name, let status, let toolUseId, let input, let output) = blocks[index],
+               status.isInFlight {
+                blocks[index] = .toolCall(
+                    id: id,
+                    name: name,
+                    status: terminalStatus,
+                    toolUseId: toolUseId,
+                    input: input,
+                    output: output
+                )
+            }
+        }
+    }
+
+    static func applyToolOutput(
+        to blocks: inout [ChatContentBlock],
+        toolUseId: String,
+        name: String,
+        output: String
+    ) {
+        let normalizedToolUseId = toolUseId.isEmpty ? nil : toolUseId
+        for index in blocks.indices {
+            guard case .toolCall(let id, let blockName, let status, let existingToolUseId, let input, _) =
+                blocks[index],
+                  toolMatches(
+                    name: blockName,
+                    toolUseId: existingToolUseId,
+                    requestedName: name,
+                    requestedToolUseId: normalizedToolUseId
+                  ) else {
+                continue
+            }
+
+            blocks[index] = .toolCall(
+                id: id,
+                name: blockName,
+                status: status,
+                toolUseId: normalizedToolUseId ?? existingToolUseId,
+                input: input,
+                output: output
+            )
+        }
+    }
+
+    private static func existingToolIndexForStart(
+        in blocks: [ChatContentBlock],
+        toolName: String,
+        toolUseId: String?
+    ) -> Int? {
+        if let toolUseId {
+            for index in stride(from: blocks.count - 1, through: 0, by: -1) {
+                guard case .toolCall(_, _, _, let existingToolUseId, _, _) = blocks[index] else {
+                    continue
+                }
+                if existingToolUseId == toolUseId {
+                    return index
+                }
+            }
+        }
+
+        for index in stride(from: blocks.count - 1, through: 0, by: -1) {
+            guard case .toolCall(_, let name, let status, let existingToolUseId, _, _) = blocks[index],
+                  status.isInFlight else {
+                continue
+            }
+
+            if existingToolUseId == nil && name == toolName {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private static func toolMatches(
+        name: String,
+        toolUseId: String?,
+        requestedName: String,
+        requestedToolUseId: String?
+    ) -> Bool {
+        if let requestedToolUseId {
+            return toolUseId == requestedToolUseId || (toolUseId == nil && name == requestedName)
+        }
+        return name == requestedName
+    }
+}
+
+final class ChatResponseMetrics: @unchecked Sendable {
+    struct Snapshot {
+        let sqlRowsReturned: Int
+        let sqlQueryCount: Int
+    }
+
+    private let lock = NSLock()
+    private var isFirstResponse = true
+    private var isGenerating = false
+    private var sqlRowsReturned = 0
+    private var sqlQueryCount = 0
+
+    func markFirstOutputIfNeeded() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard isFirstResponse else { return false }
+        isFirstResponse = false
+        return true
+    }
+
+    func markGenerationStartedIfNeeded() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isGenerating else { return false }
+        isGenerating = true
+        return true
+    }
+
+    func recordToolResult(name: String, result: String) {
+        guard name == "execute_sql" else { return }
+        let rowsReturned = Self.sqlRowsReturned(in: result)
+        lock.lock()
+        sqlQueryCount += 1
+        sqlRowsReturned += rowsReturned
+        lock.unlock()
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return Snapshot(sqlRowsReturned: sqlRowsReturned, sqlQueryCount: sqlQueryCount)
+    }
+
+    private static func sqlRowsReturned(in result: String) -> Int {
+        guard let match = result.range(of: #"(\d+) row\(s\)"#, options: .regularExpression) else {
+            return 0
+        }
+        let numStr = result[match].components(separatedBy: " ").first ?? "0"
+        return Int(numStr) ?? 0
+    }
+}
+
 // MARK: - Chat Message Model
 
 /// Metadata about the context and resources used to generate an AI response
@@ -3085,8 +3298,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         let queryStartTime = Date()
         var toolNames: [String] = []
         var toolStartTimes: [String: Date] = [:]
-        var sqlRowsReturned = 0
-        var sqlQueryCount = 0
+        let responseMetrics = ChatResponseMetrics()
         var completedResponseText: String?
 
         // Stall detection.
@@ -3168,22 +3380,18 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
             // Callbacks for agent bridge
             //
-            // QueryTracer: `isFirstResponse` marks TTFT on the very first output of
-            // any kind (text delta OR tool_use start). `isGenerating` brackets the
+            // QueryTracer: responseMetrics marks TTFT on the very first output of
+            // any kind (text delta OR tool_use start). It also brackets the
             // text-streaming window so the `generation` span excludes tool time.
-            var isFirstResponse = true
-            var isGenerating = false
             let currentChatMode = chatMode
             let currentLegacyClientScope = legacyClientScope
             let textDeltaHandler: AgentBridge.TextDeltaHandler = { [weak self] delta in
                 let nowMs = ChatProvider.monotonicNowMs()
-                if isFirstResponse {
-                    isFirstResponse = false
+                if responseMetrics.markFirstOutputIfNeeded() {
                     tracer?.end("ttft")
                     tracer?.markTTFT()
                 }
-                if !isGenerating {
-                    isGenerating = true
+                if responseMetrics.markGenerationStartedIfNeeded() {
                     tracer?.begin("generation")
                 }
                 Task { @MainActor [weak self] in
@@ -3210,15 +3418,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                         toolUseId: callId, name: name, input: inputJson, output: result, durationMs: toolDurMs)
                 }
                 log("OMI tool \(name) executed for callId=\(callId)")
-                // Track SQL query stats for metadata
-                if name == "execute_sql" {
-                    sqlQueryCount += 1
-                    // Parse row count from result (format: "\nN row(s)" at end)
-                    if let match = result.range(of: #"(\d+) row\(s\)"#, options: .regularExpression) {
-                        let numStr = result[match].components(separatedBy: " ").first ?? "0"
-                        sqlRowsReturned += Int(numStr) ?? 0
-                    }
-                }
+                responseMetrics.recordToolResult(name: name, result: result)
                 return result
             }
             let toolActivityHandler: AgentBridge.ToolActivityHandler = { [weak self] name, status, toolUseId, input in
@@ -3237,8 +3437,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 // for TTFT when the model leads with a tool call (no text first).
                 let spanKey = "tool:\(toolUseId ?? name)"
                 if status == "started" {
-                    if isFirstResponse {
-                        isFirstResponse = false
+                    if responseMetrics.markFirstOutputIfNeeded() {
                         tracer?.end("ttft")
                         tracer?.markTTFT()
                     }
@@ -3396,6 +3595,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
                 // Message still in memory — update it in-place
                 messageText = messages[index].text.isEmpty ? queryResult.text : messages[index].text
+                let metricsSnapshot = responseMetrics.snapshot()
                 messages[index].text = messageText
                 messages[index].isStreaming = false
                 messages[index].metadata = MessageMetadata(
@@ -3409,8 +3609,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                     hasScreenshot: imageData != nil,
                     screenshotSizeBytes: imageData?.count,
                     toolNames: toolNames,
-                    sqlRowsReturned: sqlRowsReturned,
-                    sqlQueryCount: sqlQueryCount
+                    sqlRowsReturned: metricsSnapshot.sqlRowsReturned,
+                    sqlQueryCount: metricsSnapshot.sqlQueryCount
                 )
                 completeRemainingToolCalls(messageId: aiMessageId, terminalStatus: .completed)
             } else {
@@ -3517,8 +3717,8 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             }
 
             // Persist the ACP session ID during onboarding so we can resume after app restart
-            if isOnboarding && !queryResult.sessionId.isEmpty {
-                OnboardingChatPersistence.saveSessionId(queryResult.sessionId)
+            if isOnboarding, let adapterSessionId = queryResult.adapterSessionId, !adapterSessionId.isEmpty {
+                OnboardingChatPersistence.saveSessionId(adapterSessionId)
             }
 
             // Analytics: track query completion
@@ -3836,66 +4036,24 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
     private func addToolActivity(messageId: String, toolName: String, status: ToolCallStatus, toolUseId: String? = nil, input: [String: Any]? = nil) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        let toolInput = input.flatMap { ChatContentBlock.toolInputSummary(for: toolName, input: $0) }
-
-        // Detector-promoted .slow / .stalled arrive through the stall
-        // status-update path, not here.
-        if status == .running {
-            // If we have a toolUseId and input, try to update an existing running block (input arrived after start)
-            if let toolUseId = toolUseId, toolInput != nil {
-                for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                    if case .toolCall(let id, let name, let st, let existingTuid, _, let output) = messages[index].contentBlocks[i],
-                       (existingTuid == toolUseId || (existingTuid == nil && name == toolName && st == .running)) {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: st,
-                            toolUseId: toolUseId, input: toolInput, output: output
-                        )
-                        return
-                    }
-                }
-            }
-            // No existing block to update — create a new one
-            messages[index].contentBlocks.append(
-                .toolCall(id: UUID().uuidString, name: toolName, status: .running,
-                          toolUseId: toolUseId, input: toolInput)
-            )
-        } else {
-            // Mark as terminal — find by toolUseId first, fall back to name.
-            // Match any in-flight state so detector-promoted .slow / .stalled
-            // also resolve cleanly when the tool actually finishes.
-            for i in stride(from: messages[index].contentBlocks.count - 1, through: 0, by: -1) {
-                if case .toolCall(let id, let name, let existingStatus, let existingTuid, let existingInput, let output) = messages[index].contentBlocks[i],
-                   existingStatus.isInFlight {
-                    let matches = (toolUseId != nil && existingTuid == toolUseId) || (toolUseId == nil && name == toolName)
-                    if matches {
-                        messages[index].contentBlocks[i] = .toolCall(
-                            id: id, name: name, status: status,
-                            toolUseId: toolUseId ?? existingTuid,
-                            input: toolInput ?? existingInput,
-                            output: output
-                        )
-                        break
-                    }
-                }
-            }
-        }
+        ToolCallBlockUpdater.applyToolActivity(
+            to: &messages[index].contentBlocks,
+            toolName: toolName,
+            status: status,
+            toolUseId: toolUseId,
+            input: input
+        )
     }
 
     /// Add tool result output to an existing tool call block
     private func addToolResult(messageId: String, toolUseId: String, name: String, output: String) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-
-        for i in messages[index].contentBlocks.indices {
-            if case .toolCall(let id, let blockName, let status, let tuid, let input, _) = messages[index].contentBlocks[i],
-               (tuid == toolUseId || (tuid == nil && blockName == name)) {
-                messages[index].contentBlocks[i] = .toolCall(
-                    id: id, name: blockName, status: status,
-                    toolUseId: toolUseId, input: input, output: output
-                )
-                return
-            }
-        }
+        ToolCallBlockUpdater.applyToolOutput(
+            to: &messages[index].contentBlocks,
+            toolUseId: toolUseId,
+            name: name,
+            output: output
+        )
     }
 
     /// Append thinking text to the streaming message via the shared buffer.
@@ -3919,15 +4077,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// so detector-promoted blocks resolve when the turn ends.
     private func completeRemainingToolCalls(messageId: String, terminalStatus: ToolCallStatus = .completed) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-        for i in messages[index].contentBlocks.indices {
-            if case .toolCall(let id, let name, let status, let toolUseId, let input, let output) = messages[index].contentBlocks[i],
-               status.isInFlight {
-                messages[index].contentBlocks[i] = .toolCall(
-                    id: id, name: name, status: terminalStatus,
-                    toolUseId: toolUseId, input: input, output: output
-                )
-            }
-        }
+        ToolCallBlockUpdater.completeRemainingToolCalls(
+            in: &messages[index].contentBlocks,
+            terminalStatus: terminalStatus
+        )
     }
 
     /// Monotonic millisecond timestamp for elapsed-time stall detection.

--- a/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
@@ -144,6 +144,20 @@ final class TaskChatLegacyAcpMigrationTests: XCTestCase {
     XCTAssertFalse(branch.contains("persistMessage(messages[index])"))
   }
 
+  func testTerminalFailureMarksRemainingToolCallsFailed() throws {
+    let source = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift")
+
+    XCTAssertTrue(
+      source.contains("private func completeRemainingToolCalls(messageId: String, terminalStatus: ToolCallStatus = .completed)")
+    )
+    XCTAssertTrue(
+      source.contains("ToolCallBlockUpdater.completeRemainingToolCalls(\n            in: &messages[index].contentBlocks,\n            terminalStatus: terminalStatus\n        )")
+    )
+    XCTAssertTrue(source.contains("completeRemainingToolCalls(messageId: aiMessageId, terminalStatus: .failed)"))
+    XCTAssertTrue(source.contains("terminalStatus: failedByUserStop ? .completed : .failed"))
+    XCTAssertTrue(source.contains("completeRemainingToolCalls(messageId: activeAssistantMessageId, terminalStatus: .failed)"))
+  }
+
   func testActionItemChatSessionIdLegacyMarkerStillUsesTaskId() throws {
     let coordinator = try sourceFile("ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift")
 

--- a/desktop/macos/Desktop/Tests/ToolCallStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/ToolCallStatusTests.swift
@@ -75,4 +75,162 @@ final class ToolCallStatusTests: XCTestCase {
       .failed
     )
   }
+
+  // MARK: - Tool-call content block lifecycle
+
+  func testDuplicateStartForSameToolUseIdUpdatesExistingBlock() {
+    var blocks: [ChatContentBlock] = []
+
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "execute_sql",
+      status: .running,
+      toolUseId: "tool-1",
+      input: ["query": "select 1"]
+    )
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "execute_sql",
+      status: .running,
+      toolUseId: "tool-1",
+      input: nil
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    guard case .toolCall(_, let name, let status, let toolUseId, let input, _) = blocks[0] else {
+      return XCTFail("Expected a tool-call block")
+    }
+    XCTAssertEqual(name, "execute_sql")
+    XCTAssertEqual(status, .running)
+    XCTAssertEqual(toolUseId, "tool-1")
+    XCTAssertEqual(input?.summary, "select 1")
+  }
+
+  func testLateDuplicateStartForCompletedToolUseIdDoesNotReopenSpinner() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "tool-block", name: "execute_sql", status: .completed, toolUseId: "tool-1", input: nil, output: nil)
+    ]
+
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "execute_sql",
+      status: .running,
+      toolUseId: "tool-1",
+      input: ["query": "select 1"]
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    guard case .toolCall(_, _, let status, let toolUseId, let input, _) = blocks[0] else {
+      return XCTFail("Expected a tool-call block")
+    }
+    XCTAssertEqual(status, .completed)
+    XCTAssertEqual(toolUseId, "tool-1")
+    XCTAssertEqual(input?.summary, "select 1")
+  }
+
+  func testDuplicateStartCanAttachLaterToolUseIdToUnidentifiedRunningBlock() {
+    var blocks: [ChatContentBlock] = []
+
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .running,
+      toolUseId: nil,
+      input: nil
+    )
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .running,
+      toolUseId: "tool-2",
+      input: ["command": "pwd"]
+    )
+
+    XCTAssertEqual(blocks.count, 1)
+    guard case .toolCall(_, _, .running, let toolUseId, let input, _) = blocks[0] else {
+      return XCTFail("Expected a running tool-call block")
+    }
+    XCTAssertEqual(toolUseId, "tool-2")
+    XCTAssertEqual(input?.summary, "pwd")
+  }
+
+  func testCompletionMarksAllMatchingDuplicateInFlightBlocks() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "old", name: "execute_sql", status: .running, toolUseId: "tool-3", input: nil, output: nil),
+      .toolCall(id: "new", name: "execute_sql", status: .running, toolUseId: "tool-3", input: nil, output: nil),
+    ]
+
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "execute_sql",
+      status: .completed,
+      toolUseId: "tool-3",
+      input: nil
+    )
+
+    XCTAssertEqual(blocks.count, 2)
+    for block in blocks {
+      guard case .toolCall(_, _, let status, _, _, _) = block else {
+        return XCTFail("Expected only tool-call blocks")
+      }
+      XCTAssertEqual(status, .completed)
+    }
+  }
+
+  func testToolOutputUpdatesAllMatchingDuplicateBlocks() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "old", name: "execute_sql", status: .completed, toolUseId: "tool-3", input: nil, output: nil),
+      .toolCall(id: "new", name: "execute_sql", status: .completed, toolUseId: "tool-3", input: nil, output: nil),
+    ]
+
+    ToolCallBlockUpdater.applyToolOutput(
+      to: &blocks,
+      toolUseId: "tool-3",
+      name: "execute_sql",
+      output: "1 row(s)"
+    )
+
+    for block in blocks {
+      guard case .toolCall(_, _, _, _, _, let output) = block else {
+        return XCTFail("Expected only tool-call blocks")
+      }
+      XCTAssertEqual(output, "1 row(s)")
+    }
+  }
+
+  func testChatResponseMetricsRecordsSqlStatsWithoutCapturedMutableState() {
+    let metrics = ChatResponseMetrics()
+
+    XCTAssertTrue(metrics.markFirstOutputIfNeeded())
+    XCTAssertFalse(metrics.markFirstOutputIfNeeded())
+    XCTAssertTrue(metrics.markGenerationStartedIfNeeded())
+    XCTAssertFalse(metrics.markGenerationStartedIfNeeded())
+
+    metrics.recordToolResult(name: "execute_sql", result: "ok\n3 row(s)")
+    metrics.recordToolResult(name: "Bash", result: "ignored\n9 row(s)")
+
+    let snapshot = metrics.snapshot()
+    XCTAssertEqual(snapshot.sqlQueryCount, 1)
+    XCTAssertEqual(snapshot.sqlRowsReturned, 3)
+  }
+
+  func testIdlessCompletionFallsBackToToolName() {
+    var blocks: [ChatContentBlock] = [
+      .toolCall(id: "known-id", name: "Bash", status: .running, toolUseId: "tool-4", input: nil, output: nil)
+    ]
+
+    ToolCallBlockUpdater.applyToolActivity(
+      to: &blocks,
+      toolName: "Bash",
+      status: .completed,
+      toolUseId: nil,
+      input: nil
+    )
+
+    guard case .toolCall(_, _, let status, let toolUseId, _, _) = blocks[0] else {
+      return XCTFail("Expected a tool-call block")
+    }
+    XCTAssertEqual(status, .completed)
+    XCTAssertEqual(toolUseId, "tool-4")
+  }
 }

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -24,6 +24,11 @@ type ResponseHandler = {
   reject: (err: Error) => void;
 };
 
+type PendingToolActivity = {
+  id: string;
+  name: string;
+};
+
 /**
  * Minimal environment allowlist for user-installed external adapter
  * subprocesses. Only OS-level essentials needed for a CLI tool to function
@@ -411,15 +416,22 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
   ): Promise<AdapterAttemptResult> {
     const adapterSessionId = context.binding.adapterNativeSessionId;
     let fullText = "";
-    const pendingTools: string[] = [];
+    const pendingTools: PendingToolActivity[] = [];
+    let syntheticToolIdCounter = 0;
     const previousHandler = this.notificationHandler;
     let lastProgressAt = Date.now();
     this.notificationHandler = (method, params) => {
       previousHandler?.(method, params);
       if (signal.aborted || method !== "session/update") return;
-      const didProgress = this.translateSessionUpdate(params as Record<string, unknown>, pendingTools, sink, (text) => {
-        fullText += text;
-      });
+      const didProgress = this.translateSessionUpdate(
+        params as Record<string, unknown>,
+        pendingTools,
+        () => `acp-tool-${++syntheticToolIdCounter}`,
+        sink,
+        (text) => {
+          fullText += text;
+        }
+      );
       if (didProgress) {
         lastProgressAt = Date.now();
       }
@@ -632,7 +644,8 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
 
   private translateSessionUpdate(
     params: Record<string, unknown>,
-    pendingTools: string[],
+    pendingTools: PendingToolActivity[],
+    nextSyntheticToolId: () => string,
     sink: AdapterEventSink,
     onText: (text: string) => void
   ): boolean {
@@ -648,8 +661,8 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
         const content = update.content as { type: string; text?: string } | undefined;
         const text = content?.text ?? "";
         if (!text) return false;
-        for (const name of pendingTools.splice(0)) {
-          sink({ type: "tool_activity", name, status: "completed" });
+        for (const tool of pendingTools.splice(0)) {
+          sink({ type: "tool_activity", name: tool.name, status: "completed", toolUseId: tool.id });
         }
         onText(text);
         sink({ type: "text_delta", text });
@@ -667,11 +680,13 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
       }
 
       case "tool_call": {
-        const toolCallId = (update.toolCallId as string) ?? "";
+        const toolCallId = this.resolveToolCallStartId(update, nextSyntheticToolId);
         const title = this.toolTitle(update);
         const status = (update.status as string) ?? "pending";
         if (status === "pending" || status === "in_progress") {
-          pendingTools.push(title);
+          if (!pendingTools.some((tool) => tool.id === toolCallId)) {
+            pendingTools.push({ id: toolCallId, name: title });
+          }
           const rawInput = update.rawInput as Record<string, unknown> | undefined;
           sink({
             type: "tool_activity",
@@ -686,18 +701,18 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
       }
 
       case "tool_call_update": {
-        const toolCallId = (update.toolCallId as string) ?? "";
         const status = (update.status as string) ?? "";
         const title = this.toolTitle(update);
         if (status !== "completed" && status !== "failed" && status !== "cancelled") {
           return false;
         }
-        const idx = pendingTools.indexOf(title);
+        const toolCallId = this.resolveToolCallUpdateId(update, pendingTools, nextSyntheticToolId);
+        const idx = pendingTools.findIndex((tool) => tool.id === toolCallId);
         if (idx >= 0) pendingTools.splice(idx, 1);
         sink({
           type: "tool_activity",
           name: title,
-          status: "completed",
+          status: status === "completed" ? "completed" : "failed",
           toolUseId: toolCallId,
         });
 
@@ -735,6 +750,29 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
         this.log(`Unknown session update type: ${sessionUpdate}`);
         return false;
     }
+  }
+
+  private resolveToolCallStartId(
+    update: Record<string, unknown>,
+    nextSyntheticToolId: () => string
+  ): string {
+    const explicitId = typeof update.toolCallId === "string" ? update.toolCallId.trim() : "";
+    if (explicitId) return explicitId;
+    return nextSyntheticToolId();
+  }
+
+  private resolveToolCallUpdateId(
+    update: Record<string, unknown>,
+    pendingTools: PendingToolActivity[],
+    nextSyntheticToolId: () => string
+  ): string {
+    const explicitId = typeof update.toolCallId === "string" ? update.toolCallId.trim() : "";
+    if (explicitId) return explicitId;
+
+    const title = this.toolTitle(update);
+    const existing = pendingTools.find((tool) => tool.name === title);
+    if (existing) return existing.id;
+    return nextSyntheticToolId();
   }
 
   private toolTitle(update: Record<string, unknown>): string {

--- a/desktop/macos/agent/tests/acp-tool-activity.test.ts
+++ b/desktop/macos/agent/tests/acp-tool-activity.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { AcpRuntimeAdapter } from "../src/adapters/acp.js";
+
+function translateHarness() {
+  const adapter = new AcpRuntimeAdapter({
+    nodeBin: "/node",
+    acpEntry: "/acp-entry.mjs",
+  });
+  const events: Array<any> = [];
+  const pendingTools: Array<any> = [];
+  let syntheticId = 0;
+  const translate = (adapter as any).translateSessionUpdate.bind(adapter);
+  const nextId = () => `synthetic-${++syntheticId}`;
+
+  return {
+    events,
+    pendingTools,
+    translate: (update: Record<string, unknown>) => translate(
+      { update },
+      pendingTools,
+      nextId,
+      (event: any) => events.push(event),
+      () => {}
+    ),
+  };
+}
+
+describe("AcpRuntimeAdapter tool activity translation", () => {
+  it("preserves pending tool ids when text implicitly completes tools", () => {
+    const harness = translateHarness();
+
+    harness.translate({
+      sessionUpdate: "tool_call",
+      toolCallId: "tool-1",
+      status: "pending",
+      title: "Read",
+      rawInput: { path: "README.md" },
+    });
+    harness.translate({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "done" },
+    });
+
+    expect(harness.events).toContainEqual({
+      type: "tool_activity",
+      name: "Read",
+      status: "started",
+      toolUseId: "tool-1",
+      input: { path: "README.md" },
+    });
+    expect(harness.events).toContainEqual({
+      type: "tool_activity",
+      name: "Read",
+      status: "completed",
+      toolUseId: "tool-1",
+    });
+  });
+
+  it("synthesizes stable tool ids when ACP omits toolCallId", () => {
+    const harness = translateHarness();
+
+    harness.translate({
+      sessionUpdate: "tool_call",
+      status: "pending",
+      title: "Bash",
+    });
+    harness.translate({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      title: "Bash",
+    });
+
+    expect(harness.events).toEqual([
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "started",
+        toolUseId: "synthetic-1",
+        input: undefined,
+      },
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "completed",
+        toolUseId: "synthetic-1",
+      },
+    ]);
+  });
+
+  it("does not merge duplicate same-title starts when ACP omits toolCallId", () => {
+    const harness = translateHarness();
+
+    harness.translate({
+      sessionUpdate: "tool_call",
+      status: "pending",
+      title: "Bash",
+      rawInput: { command: "pwd" },
+    });
+    harness.translate({
+      sessionUpdate: "tool_call",
+      status: "pending",
+      title: "Bash",
+      rawInput: { command: "ls" },
+    });
+    harness.translate({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      title: "Bash",
+    });
+    harness.translate({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      title: "Bash",
+    });
+
+    expect(harness.events).toEqual([
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "started",
+        toolUseId: "synthetic-1",
+        input: { command: "pwd" },
+      },
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "started",
+        toolUseId: "synthetic-2",
+        input: { command: "ls" },
+      },
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "completed",
+        toolUseId: "synthetic-1",
+      },
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "completed",
+        toolUseId: "synthetic-2",
+      },
+    ]);
+  });
+
+  it("maps ACP failed and cancelled tool updates to failed activity", () => {
+    const harness = translateHarness();
+
+    harness.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tool-failed",
+      status: "failed",
+      title: "Read",
+    });
+    harness.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tool-cancelled",
+      status: "cancelled",
+      title: "Bash",
+    });
+
+    expect(harness.events).toEqual([
+      {
+        type: "tool_activity",
+        name: "Read",
+        status: "failed",
+        toolUseId: "tool-failed",
+      },
+      {
+        type: "tool_activity",
+        name: "Bash",
+        status: "failed",
+        toolUseId: "tool-cancelled",
+      },
+    ]);
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260702-chat-tool-call-dedupe.json
+++ b/desktop/macos/changelog/unreleased/20260702-chat-tool-call-dedupe.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed duplicate tool-call rows in chat so completed tools no longer leave a second spinner behind"
+}


### PR DESCRIPTION
## Summary
- Deduplicate visible chat tool-call blocks by durable `toolUseId` so repeated lifecycle events update the existing row instead of creating a second spinner.
- Share the tool-call block mutation rules between main chat and task chat, including completion and output attachment.
- Tighten ACP tool activity translation so implicit completions preserve IDs, missing IDs get stable synthetic IDs, and failed/cancelled tool updates surface as failed.
- Move chat response metrics into a lock-backed helper to avoid mutable state captured by sendable callbacks.

## Root Cause
The chat UI stored tool activity as content blocks, but duplicate `started` events for the same invocation were not always matched back to the existing block. A second start without displayable input could append another row, while completion updated only one matching row. That left one row completed and another spinner orphaned.

## Validation
- `npm run build`
- `npm test -- acp-tool-activity.test.ts`
- `xcrun swift test --package-path Desktop --filter ToolCallStatusTests`
- `xcrun swift build -c debug --package-path Desktop`
- `desktop/macos/scripts/test-tool-surfaces.sh` with Node 22 in `PATH`
- pre-push hook passed on push


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

