### PR TITLE
chore(desktop): add safe TCC cleanup helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ builds-snapshot.md
 
 # Agent planning artifacts (ephemeral; do not commit)
 .cursor/plans/
+.hermes/

--- a/desktop/macos/changelog/unreleased/add-tcc-cleanup-helper.json
+++ b/desktop/macos/changelog/unreleased/add-tcc-cleanup-helper.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Added a safe helper for reviewing and resetting stale macOS privacy permissions from temporary Omi test builds"
+  ]
+}

--- a/desktop/macos/scripts/cleanup-omi-tcc.sh
+++ b/desktop/macos/scripts/cleanup-omi-tcc.sh
@@ -38,7 +38,8 @@ Options:
                    Preserve this Omi bundle ID. May be passed more than once.
   --candidate-prefix BUNDLE_ID_PREFIX
                    Mark matching Omi bundle IDs as reset candidates. May be
-                   passed more than once. Defaults to com.omi.omi-.
+                   passed more than once and is additive with the default
+                   com.omi.omi- prefix.
   --help           Show this help
 USAGE
 }
@@ -147,6 +148,19 @@ def classify_bundle_id(bundle_id):
     if bundle_id.startswith("com.omi."):
         return "review"
     return "other"
+
+
+def classify_tcc_client(client):
+    classification = classify_bundle_id(client)
+    if classification != "other" or not isinstance(client, str):
+        return classification
+
+    path = client.lower()
+    if "/omi.app/" in path or "/omi beta.app/" in path or "/omi dev.app/" in path:
+        return "keep"
+    if "/omi-" in path and ".app/" in path:
+        return "candidate"
+    return classification
 
 
 def read_plist(path):
@@ -296,7 +310,7 @@ def collect_tcc_rows():
         rows = []
         for row in conn.execute(sql):
             item = {key: row[key] for key in selected}
-            item["classification"] = classify_bundle_id(item.get("client"))
+            item["classification"] = classify_tcc_client(item.get("client"))
             if item.get("last_modified") is not None:
                 try:
                     item["last_modified_iso"] = dt.datetime.fromtimestamp(
@@ -343,7 +357,7 @@ def candidate_bundle_ids(inventory):
             bundle_ids.add(domain)
     for item in inventory["tcc"]["rows"]:
         client = item.get("client")
-        if classify_bundle_id(client) == "candidate":
+        if classify_tcc_client(client) == "candidate":
             bundle_ids.add(client)
 
     # Defensive guard: never allow keep IDs or non-candidate com.omi IDs into apply.

--- a/desktop/macos/scripts/cleanup-omi-tcc.sh
+++ b/desktop/macos/scripts/cleanup-omi-tcc.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+# cleanup-omi-tcc.sh — inventory/reset Omi macOS privacy/TCC entries.
+#
+# Default mode is list-only and never mutates TCC, app bundles, or preferences.
+# Apply mode only uses Apple's supported tccutil reset path for candidate
+# bundle IDs; it never edits ~/Library/Application Support/com.apple.TCC/TCC.db.
+#
+# Usage:
+#   scripts/cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json]
+#
+# Keeps by default:
+#   com.omi.computer-macos  (Omi)
+#   com.omi.desktop-dev     (Omi Dev)
+set -euo pipefail
+
+MODE="list"
+OUTPUT="text"
+KEEP_BUNDLE_IDS="com.omi.computer-macos,com.omi.desktop-dev"
+CANDIDATE_PREFIXES="com.omi.omi-"
+
+usage() {
+    cat <<'USAGE'
+Usage: cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json]
+                          [--keep-bundle-id BUNDLE_ID]
+                          [--candidate-prefix BUNDLE_ID_PREFIX] [--help]
+
+List or reset Omi-related macOS app bundle privacy permissions.
+
+Default mode is read-only. Apply mode calls `tccutil reset All <bundle-id>` only
+for candidate bundle IDs and still does not edit the TCC SQLite database,
+preferences, or app bundles.
+
+Options:
+  --list           List inventory only (default)
+  --apply-tccutil  Reset TCC/privacy permissions for candidate bundle IDs
+  --json           Emit deterministic JSON instead of human-readable text
+  --keep-bundle-id BUNDLE_ID
+                   Preserve this Omi bundle ID. May be passed more than once.
+  --candidate-prefix BUNDLE_ID_PREFIX
+                   Mark matching Omi bundle IDs as reset candidates. May be
+                   passed more than once. Defaults to com.omi.omi-.
+  --help           Show this help
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --list)
+            MODE="list"
+            ;;
+        --apply-tccutil|--apply)
+            MODE="apply-tccutil"
+            ;;
+        --json)
+            OUTPUT="json"
+            ;;
+        --keep-bundle-id)
+            if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+                echo "--keep-bundle-id requires a non-empty bundle ID" >&2
+                exit 2
+            fi
+            KEEP_BUNDLE_IDS="${KEEP_BUNDLE_IDS},$2"
+            shift
+            ;;
+        --candidate-prefix)
+            if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+                echo "--candidate-prefix requires a non-empty bundle ID prefix" >&2
+                exit 2
+            fi
+            CANDIDATE_PREFIXES="${CANDIDATE_PREFIXES},$2"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ "$MODE" != "list" ] && [ "$MODE" != "apply-tccutil" ]; then
+    echo "Unsupported mode: $MODE" >&2
+    exit 2
+fi
+
+python3 - "$MODE" "$OUTPUT" "$KEEP_BUNDLE_IDS" "$CANDIDATE_PREFIXES" <<'PY'
+import datetime as dt
+import json
+import os
+import plistlib
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+MODE = sys.argv[1]
+OUTPUT = sys.argv[2]
+KEEP_BUNDLE_IDS = {item for item in sys.argv[3].split(",") if item}
+CANDIDATE_PREFIXES = tuple(item for item in sys.argv[4].split(",") if item)
+HOME = Path(os.environ.get("OMI_TCC_HOME") or Path.home())
+TCC_DB = Path(
+    os.environ.get("OMI_TCC_DB")
+    or HOME / "Library/Application Support/com.apple.TCC/TCC.db"
+)
+APP_ROOTS = [
+    Path(item)
+    for item in (
+        os.environ.get("OMI_TCC_APP_ROOTS")
+        or os.pathsep.join(("/Applications", str(HOME / "Applications")))
+    ).split(os.pathsep)
+    if item
+]
+PREFS_DIR = Path(os.environ.get("OMI_TCC_PREFS_DIR") or HOME / "Library/Preferences")
+
+
+def validate_bundle_id(label, bundle_id):
+    if not bundle_id or bundle_id.strip() != bundle_id or "/" in bundle_id:
+        raise SystemExit(f"Invalid {label}: {bundle_id!r}")
+    if not bundle_id.startswith("com.omi."):
+        raise SystemExit(
+            f"Invalid {label}: {bundle_id!r}; expected an Omi bundle ID starting with 'com.omi.'"
+        )
+
+
+for keep_bundle_id in KEEP_BUNDLE_IDS:
+    validate_bundle_id("keep bundle ID", keep_bundle_id)
+for candidate_prefix in CANDIDATE_PREFIXES:
+    validate_bundle_id("candidate prefix", candidate_prefix)
+
+
+def is_candidate_bundle_id(bundle_id):
+    return isinstance(bundle_id, str) and any(bundle_id.startswith(prefix) for prefix in CANDIDATE_PREFIXES)
+
+
+def classify_bundle_id(bundle_id):
+    if not bundle_id:
+        return "unknown"
+    if bundle_id in KEEP_BUNDLE_IDS:
+        return "keep"
+    if is_candidate_bundle_id(bundle_id):
+        return "candidate"
+    if bundle_id.startswith("com.omi."):
+        return "review"
+    return "other"
+
+
+def read_plist(path):
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def app_info(app_path):
+    info_path = app_path / "Contents/Info.plist"
+    if not info_path.exists():
+        return None
+    try:
+        info = read_plist(info_path)
+    except Exception as exc:
+        return {
+            "path": str(app_path),
+            "error": f"failed to read Info.plist: {exc}",
+        }
+
+    bundle_id = info.get("CFBundleIdentifier")
+    name = (
+        info.get("CFBundleDisplayName")
+        or info.get("CFBundleName")
+        or app_path.stem
+    )
+    if not (
+        bundle_id in KEEP_BUNDLE_IDS
+        or (isinstance(bundle_id, str) and bundle_id.startswith("com.omi."))
+        or name == "Omi"
+        or name == "Omi Dev"
+        or name.startswith("omi-")
+        or app_path.name in {"Omi.app", "Omi Dev.app", "Omi Beta.app"}
+        or app_path.name.startswith("omi-")
+    ):
+        return None
+
+    return {
+        "bundle_id": bundle_id,
+        "classification": classify_bundle_id(bundle_id),
+        "name": name,
+        "path": str(app_path),
+    }
+
+
+def iter_apps(root):
+    if not root.exists():
+        return
+    # Keep the scan bounded and deterministic. Omi dev bundles are installed as
+    # direct children of /Applications by run.sh, but include one nested level for
+    # user-created folders without walking the entire filesystem.
+    try:
+        children = sorted(root.iterdir(), key=lambda p: str(p).lower())
+    except PermissionError:
+        return
+    for child in children:
+        if child.suffix == ".app":
+            yield child
+        elif child.is_dir():
+            try:
+                grandchildren = sorted(child.iterdir(), key=lambda p: str(p).lower())
+            except PermissionError:
+                continue
+            for grandchild in grandchildren:
+                if grandchild.suffix == ".app":
+                    yield grandchild
+
+
+def collect_apps():
+    seen = set()
+    apps = []
+    for root in APP_ROOTS:
+        for app_path in iter_apps(root) or []:
+            resolved_key = str(app_path)
+            if resolved_key in seen:
+                continue
+            seen.add(resolved_key)
+            info = app_info(app_path)
+            if info:
+                apps.append(info)
+    return sorted(apps, key=lambda item: (item.get("classification", ""), item.get("bundle_id") or "", item["path"]))
+
+
+def collect_preferences():
+    prefs = []
+    if not PREFS_DIR.exists():
+        return prefs
+    for path in sorted(PREFS_DIR.glob("com.omi*.plist"), key=lambda p: p.name.lower()):
+        domain = path.name[:-6]
+        prefs.append({
+            "domain": domain,
+            "classification": classify_bundle_id(domain),
+            "path": str(path),
+        })
+    return prefs
+
+
+def sqlite_access_columns(conn):
+    rows = conn.execute("PRAGMA table_info(access)").fetchall()
+    return {row[1] for row in rows}
+
+
+def collect_tcc_rows():
+    result = {
+        "database": str(TCC_DB),
+        "readable": False,
+        "error": None,
+        "rows": [],
+    }
+    if not TCC_DB.exists():
+        result["error"] = "TCC database does not exist"
+        return result
+
+    try:
+        conn = sqlite3.connect(f"file:{TCC_DB}?mode=ro", uri=True)
+    except Exception as exc:
+        result["error"] = str(exc)
+        return result
+
+    try:
+        conn.row_factory = sqlite3.Row
+        columns = sqlite_access_columns(conn)
+        wanted = [
+            "service",
+            "client",
+            "client_type",
+            "auth_value",
+            "auth_reason",
+            "auth_version",
+            "allowed",
+            "prompt_count",
+            "last_modified",
+            "indirect_object_identifier",
+        ]
+        selected = [column for column in wanted if column in columns]
+        if not {"service", "client"}.issubset(columns):
+            result["error"] = "TCC access table does not contain expected service/client columns"
+            return result
+
+        sql = f"""
+            SELECT {', '.join(selected)}
+            FROM access
+            WHERE client LIKE 'com.omi.%'
+               OR client LIKE '%/Omi%.app/%'
+               OR client LIKE '%/omi-%.app/%'
+            ORDER BY client, service
+        """
+        rows = []
+        for row in conn.execute(sql):
+            item = {key: row[key] for key in selected}
+            item["classification"] = classify_bundle_id(item.get("client"))
+            if item.get("last_modified") is not None:
+                try:
+                    item["last_modified_iso"] = dt.datetime.fromtimestamp(
+                        int(item["last_modified"]), tz=dt.timezone.utc
+                    ).isoformat()
+                except Exception:
+                    pass
+            rows.append(item)
+        result["readable"] = True
+        result["rows"] = rows
+        return result
+    except Exception as exc:
+        result["error"] = str(exc)
+        return result
+    finally:
+        conn.close()
+
+
+def grouped_counts(items):
+    counts = {}
+    for item in items:
+        key = item.get("classification", "unknown")
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def status_counts(items):
+    counts = {}
+    for item in items:
+        key = item.get("status", "unknown")
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def candidate_bundle_ids(inventory):
+    bundle_ids = set()
+    for item in inventory["apps"]:
+        bundle_id = item.get("bundle_id")
+        if classify_bundle_id(bundle_id) == "candidate":
+            bundle_ids.add(bundle_id)
+    for item in inventory["preferences"]:
+        domain = item.get("domain")
+        if classify_bundle_id(domain) == "candidate":
+            bundle_ids.add(domain)
+    for item in inventory["tcc"]["rows"]:
+        client = item.get("client")
+        if classify_bundle_id(client) == "candidate":
+            bundle_ids.add(client)
+
+    # Defensive guard: never allow keep IDs or non-candidate com.omi IDs into apply.
+    return sorted(
+        bundle_id
+        for bundle_id in bundle_ids
+        if bundle_id not in KEEP_BUNDLE_IDS and is_candidate_bundle_id(bundle_id)
+    )
+
+
+def installed_candidate_bundle_ids(inventory):
+    # `tccutil reset All <bundle-id>` requires LaunchServices to resolve the
+    # bundle ID. Preference-only stale domains are still listed, but apply mode
+    # skips them to avoid noisy deterministic failures.
+    bundle_ids = set()
+    for item in inventory["apps"]:
+        bundle_id = item.get("bundle_id")
+        if classify_bundle_id(bundle_id) == "candidate":
+            bundle_ids.add(bundle_id)
+    return sorted(bundle_ids)
+
+
+def apply_tccutil(bundle_ids):
+    results = []
+    for bundle_id in bundle_ids:
+        command = ["tccutil", "reset", "All", bundle_id]
+        try:
+            completed = subprocess.run(command, capture_output=True, text=True, check=False)
+            results.append({
+                "bundle_id": bundle_id,
+                "command": command,
+                "returncode": completed.returncode,
+                "stdout": completed.stdout.strip(),
+                "stderr": completed.stderr.strip(),
+                "status": "ok" if completed.returncode == 0 else "failed",
+            })
+        except Exception as exc:
+            results.append({
+                "bundle_id": bundle_id,
+                "command": command,
+                "returncode": None,
+                "stdout": "",
+                "stderr": str(exc),
+                "status": "error",
+            })
+    return results
+
+
+inventory = {
+    "keep_bundle_ids": sorted(KEEP_BUNDLE_IDS),
+    "candidate_prefixes": sorted(CANDIDATE_PREFIXES),
+    "candidate_rule": "bundle_id starts with one of " + json.dumps(sorted(CANDIDATE_PREFIXES)),
+    "apps": collect_apps(),
+    "preferences": collect_preferences(),
+    "tcc": collect_tcc_rows(),
+}
+inventory["summary"] = {
+    "apps": grouped_counts(inventory["apps"]),
+    "preferences": grouped_counts(inventory["preferences"]),
+    "tcc_rows": grouped_counts(inventory["tcc"]["rows"]),
+    "tcc_readable": inventory["tcc"]["readable"],
+}
+inventory["candidate_bundle_ids"] = candidate_bundle_ids(inventory)
+inventory["tccutil_bundle_ids"] = installed_candidate_bundle_ids(inventory)
+
+if MODE == "apply-tccutil":
+    inventory["apply"] = {
+        "mode": MODE,
+        "tool": "tccutil reset All",
+        "results": apply_tccutil(inventory["tccutil_bundle_ids"]),
+    }
+    inventory["apply"]["summary"] = status_counts(inventory["apply"]["results"])
+
+if OUTPUT == "json":
+    print(json.dumps(inventory, indent=2, sort_keys=True))
+    sys.exit(0)
+
+if MODE == "apply-tccutil":
+    print("Omi macOS permissions cleanup apply (tccutil only)")
+    print("==================================================")
+else:
+    print("Omi macOS permissions cleanup inventory (read-only)")
+    print("====================================================")
+print("Keeps:")
+for bundle_id in inventory["keep_bundle_ids"]:
+    print(f"  - {bundle_id}")
+print(f"Candidate rule: {inventory['candidate_rule']}")
+print()
+
+print("Candidate bundle IDs for tccutil reset:")
+if inventory["tccutil_bundle_ids"]:
+    for bundle_id in inventory["tccutil_bundle_ids"]:
+        print(f"  - {bundle_id}")
+else:
+    print("  <none found>")
+skipped = sorted(set(inventory["candidate_bundle_ids"]) - set(inventory["tccutil_bundle_ids"]))
+if skipped:
+    print("Preference-only candidate domains skipped by tccutil apply:")
+    for bundle_id in skipped:
+        print(f"  - {bundle_id}")
+print()
+
+if MODE == "apply-tccutil":
+    print("tccutil reset results:")
+    if inventory["apply"]["results"]:
+        for item in inventory["apply"]["results"]:
+            print(f"  [{item['status']:6}] {item['bundle_id']} rc={item['returncode']}")
+            if item["stdout"]:
+                print(f"           stdout: {item['stdout']}")
+            if item["stderr"]:
+                print(f"           stderr: {item['stderr']}")
+    else:
+        print("  <nothing to reset>")
+    print()
+
+print("Installed app bundles:")
+if inventory["apps"]:
+    for item in inventory["apps"]:
+        bundle_id = item.get("bundle_id") or "<missing bundle id>"
+        print(f"  [{item.get('classification', 'unknown'):9}] {bundle_id:32} {item.get('name', '')} — {item['path']}")
+else:
+    print("  <none found>")
+print()
+
+print("UserDefaults preference domains:")
+if inventory["preferences"]:
+    for item in inventory["preferences"]:
+        print(f"  [{item['classification']:9}] {item['domain']:32} {item['path']}")
+else:
+    print("  <none found>")
+print()
+
+print("TCC/privacy rows:")
+tcc = inventory["tcc"]
+if not tcc["readable"]:
+    print(f"  <not readable> {tcc['database']}")
+    print(f"  Reason: {tcc['error']}")
+    print("  Grant Full Disk Access to the terminal/Hermes host process, then rerun for TCC row details.")
+elif tcc["rows"]:
+    for item in tcc["rows"]:
+        service = item.get("service", "")
+        client = item.get("client", "")
+        auth = item.get("auth_value", item.get("allowed", ""))
+        modified = item.get("last_modified_iso", "")
+        print(f"  [{item['classification']:9}] {client:32} {service:36} auth={auth} {modified}")
+else:
+    print("  <none found>")
+print()
+
+print("Summary:")
+print(json.dumps(inventory["summary"], indent=2, sort_keys=True))
+PY

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -9,6 +9,7 @@ echo "=== Desktop Launcher Script Tests ==="
 cd "$SCRIPT_DIR"
 bash tests/test-app-config.sh
 bash tests/test-settings-seed.sh
+bash tests/test-cleanup-omi-tcc.sh
 echo ""
 
 echo "=== Rust Backend Tests ==="

--- a/desktop/macos/tests/test-cleanup-omi-tcc.sh
+++ b/desktop/macos/tests/test-cleanup-omi-tcc.sh
@@ -78,6 +78,9 @@ conn.executemany(
         ("kTCCServiceScreenCapture", "com.omi.omi-pref-only", 0, 2, 1),
         ("kTCCServiceMicrophone", "com.omi.desktop-dev", 0, 2, 1),
         ("kTCCServiceMicrophone", "com.omi.review-build", 0, 2, 1),
+        ("kTCCServiceMicrophone", "/Applications/Omi.app/Contents/MacOS/Omi", 1, 2, 1),
+        ("kTCCServiceMicrophone", "/Applications/Omi Dev.app/Contents/MacOS/Omi", 1, 2, 1),
+        ("kTCCServiceMicrophone", "/Applications/omi-path-only.app/Contents/MacOS/Omi", 1, 2, 1),
     ],
 )
 conn.commit()
@@ -101,6 +104,10 @@ assert "com.omi.desktop-dev" in data["keep_bundle_ids"]
 assert data["summary"]["apps"].get("keep") == 2, data["summary"]
 assert data["summary"]["apps"].get("candidate") == 1, data["summary"]
 assert data["summary"]["apps"].get("review") == 1, data["summary"]
+tcc_classes = {row["client"]: row["classification"] for row in data["tcc"]["rows"]}
+assert tcc_classes["/Applications/Omi.app/Contents/MacOS/Omi"] == "keep", tcc_classes
+assert tcc_classes["/Applications/Omi Dev.app/Contents/MacOS/Omi"] == "keep", tcc_classes
+assert tcc_classes["/Applications/omi-path-only.app/Contents/MacOS/Omi"] == "candidate", tcc_classes
 PY
 
 cat >"$bin/tccutil" <<'SH'

--- a/desktop/macos/tests/test-cleanup-omi-tcc.sh
+++ b/desktop/macos/tests/test-cleanup-omi-tcc.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$MACOS_DIR/scripts/cleanup-omi-tcc.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+home="$TMPDIR/home"
+apps="$TMPDIR/apps"
+prefs="$home/Library/Preferences"
+tcc_dir="$home/Library/Application Support/com.apple.TCC"
+bin="$TMPDIR/bin"
+mkdir -p "$apps" "$prefs" "$tcc_dir" "$bin"
+
+make_app() {
+  local app_name="$1" bundle_id="$2" display_name="$3"
+  local contents="$apps/$app_name.app/Contents"
+  mkdir -p "$contents"
+  python3 - "$contents/Info.plist" "$bundle_id" "$display_name" <<'PY'
+import plistlib
+import sys
+
+path, bundle_id, display_name = sys.argv[1:]
+with open(path, "wb") as handle:
+    plistlib.dump(
+        {
+            "CFBundleIdentifier": bundle_id,
+            "CFBundleDisplayName": display_name,
+            "CFBundleName": display_name,
+        },
+        handle,
+    )
+PY
+}
+
+make_pref() {
+  local domain="$1"
+  python3 - "$prefs/$domain.plist" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "wb") as handle:
+    plistlib.dump({"fixture": True}, handle)
+PY
+}
+
+make_app "Omi" "com.omi.computer-macos" "Omi"
+make_app "Omi Dev" "com.omi.desktop-dev" "Omi Dev"
+make_app "omi-test-one" "com.omi.omi-test-one" "omi-test-one"
+make_app "omi-review" "com.omi.review-build" "omi-review"
+make_app "Other" "com.example.other" "Other"
+make_pref "com.omi.omi-pref-only"
+make_pref "com.omi.review-pref"
+
+python3 - "$tcc_dir/TCC.db" <<'PY'
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+conn.execute(
+    "CREATE TABLE access (service TEXT, client TEXT, client_type INTEGER, auth_value INTEGER, last_modified INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO access VALUES (?, ?, ?, ?, ?)",
+    [
+        ("kTCCServiceMicrophone", "com.omi.omi-test-one", 0, 2, 1),
+        ("kTCCServiceScreenCapture", "com.omi.omi-pref-only", 0, 2, 1),
+        ("kTCCServiceMicrophone", "com.omi.desktop-dev", 0, 2, 1),
+        ("kTCCServiceMicrophone", "com.omi.review-build", 0, 2, 1),
+    ],
+)
+conn.commit()
+conn.close()
+PY
+
+json_out="$TMPDIR/inventory.json"
+OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" "$SCRIPT" --json >"$json_out"
+
+python3 - "$json_out" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["tcc"]["readable"] is True
+assert data["candidate_prefixes"] == ["com.omi.omi-"]
+assert data["tccutil_bundle_ids"] == ["com.omi.omi-test-one"], data["tccutil_bundle_ids"]
+assert set(data["candidate_bundle_ids"]) == {"com.omi.omi-test-one", "com.omi.omi-pref-only"}
+assert "com.omi.computer-macos" in data["keep_bundle_ids"]
+assert "com.omi.desktop-dev" in data["keep_bundle_ids"]
+assert data["summary"]["apps"].get("keep") == 2, data["summary"]
+assert data["summary"]["apps"].get("candidate") == 1, data["summary"]
+assert data["summary"]["apps"].get("review") == 1, data["summary"]
+PY
+
+cat >"$bin/tccutil" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TCCUTIL_LOG"
+exit 0
+SH
+chmod +x "$bin/tccutil"
+apply_json="$TMPDIR/apply.json"
+TCCUTIL_LOG="$TMPDIR/tccutil.log" \
+PATH="$bin:$PATH" \
+OMI_TCC_HOME="$home" \
+OMI_TCC_APP_ROOTS="$apps" \
+  "$SCRIPT" --apply-tccutil --json >"$apply_json"
+
+python3 - "$apply_json" "$TMPDIR/tccutil.log" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+log = open(sys.argv[2]).read().splitlines()
+assert log == ["reset All com.omi.omi-test-one"], log
+assert data["apply"]["summary"] == {"ok": 1}, data["apply"]
+PY
+
+custom_json="$TMPDIR/custom.json"
+OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" \
+  "$SCRIPT" --json --candidate-prefix com.omi.review- --keep-bundle-id com.omi.review-build >"$custom_json"
+python3 - "$custom_json" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+# Explicit keep wins over a broader candidate prefix.
+assert "com.omi.review-build" in data["keep_bundle_ids"]
+assert data["tccutil_bundle_ids"] == ["com.omi.omi-test-one"], data["tccutil_bundle_ids"]
+PY
+
+if "$SCRIPT" --candidate-prefix org.example. >/tmp/cleanup-omi-tcc-invalid.out 2>/tmp/cleanup-omi-tcc-invalid.err; then
+  fail "invalid non-Omi candidate prefix unexpectedly succeeded"
+fi
+if ! grep -q "expected an Omi bundle ID" /tmp/cleanup-omi-tcc-invalid.err; then
+  fail "invalid candidate prefix did not explain Omi bundle ID requirement"
+fi
+
+echo "cleanup-omi-tcc tests passed"


### PR DESCRIPTION
## Summary
- gitignore local `.hermes/` agent artifacts
- add `desktop/macos/scripts/cleanup-omi-tcc.sh`, a read-only-by-default Omi macOS privacy/TCC inventory helper
- keep prod/dev bundle IDs protected by default, classify temporary `com.omi.omi-*` bundles as reset candidates, and only call Apple's `tccutil reset All <bundle-id>` for installed candidate bundles in apply mode
- add fixture-based tests covering inventory classification, preference-only skip behavior, mocked `tccutil` apply, custom keep/candidate rules, and invalid non-Omi prefixes

## Safety notes
- Default mode only inventories apps, preferences, and readable TCC rows.
- Apply mode does **not** edit `TCC.db`, preferences, or app bundles.
- Apply mode skips preference-only stale domains and never targets `com.omi.computer-macos` or `com.omi.desktop-dev`.
- Candidate matching is configurable but constrained to `com.omi.*` bundle IDs.

## Test plan
- [x] `bash -n desktop/macos/scripts/cleanup-omi-tcc.sh desktop/macos/tests/test-cleanup-omi-tcc.sh desktop/macos/test.sh`
- [x] `bash desktop/macos/tests/test-cleanup-omi-tcc.sh`
- [x] `desktop/macos/scripts/cleanup-omi-tcc.sh --json` against this Mac (read-only; found candidates, TCC DB not readable without Full Disk Access)
- [x] `xcrun swift build -c debug --package-path Desktop`
- [x] `python3 .github/scripts/desktop-changelog.py validate`
- [x] `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD`
- [x] push pre-push checks passed

## Known unrelated local test issue
- `bash desktop/macos/test.sh` got through launcher script tests and Rust backend tests, then timed out during the initial Swift test build attempt. A follow-up direct Swift test run built and started executing tests, then crashed in `MemoryAuthoritativeTierSyncTests` with the existing Firebase default-app-not-configured failure. The debug Swift build itself passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

