### PR TITLE
Rename home Connect your AI section to "Use omi memory anywhere"

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -569,11 +569,11 @@ struct DashboardPage: View {
     private var destinationStack: some View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 5) {
-                Text("Connect your AI")
+                Text("Use omi memory anywhere")
                     .font(.system(size: 22, weight: .medium, design: .serif))
                     .foregroundStyle(HomePalette.ink)
 
-                Text("Use Omi memory where you already work.")
+                Text("Bring your memories and tasks into the apps you already use")
                     .scaledFont(size: 12, weight: .medium)
                     .foregroundStyle(HomePalette.muted)
                     .fixedSize(horizontal: false, vertical: true)

--- a/desktop/macos/changelog/unreleased/20260701-home-connect-copy.json
+++ b/desktop/macos/changelog/unreleased/20260701-home-connect-copy.json
@@ -1,0 +1,3 @@
+{
+    "change": "Home: renamed the Connect your AI section to \"Use omi memory anywhere\" with a clearer subtitle"
+}


### PR DESCRIPTION
## Summary
- Home page right column: title **Connect your AI** → **Use omi memory anywhere**
- Subtitle **Use Omi memory where you already work.** → **Bring your memories and tasks into the apps you already use**

## Verification
Built and ran a named bundle (`omi-home-copy`) locally; confirmed both strings render on the home page (screenshot attached in workspace, verified via agent-swift text assertions against the live app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

