### PR TITLE
[codex] Add action-item gateway shadow comparisons

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -115,6 +115,10 @@ env:
     value: "true"
   - name: OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE
     value: "1.0"
+  - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED
+    value: "true"
+  - name: OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE
+    value: "1.0"
   - name: OMI_LLM_GATEWAY_SERVICE_TOKEN
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -18,6 +18,12 @@ environments:
           OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
             value: "1.0"
             category: rollout
+          OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
+            value: "true"
+            category: rollout
+          OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
+            value: "1.0"
+            category: rollout
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret:
               name: dev-omi-backend-secrets
@@ -63,6 +69,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -104,6 +116,12 @@ environments:
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
             MEMORY_MODE:
               value: write
               category: memory_rollout
@@ -143,6 +161,12 @@ environments:
               value: "true"
               category: rollout
             OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE:
+              value: "1.0"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED:
+              value: "true"
+              category: rollout
+            OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE:
               value: "1.0"
               category: rollout
             MEMORY_MODE:

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -543,8 +543,10 @@ def test_conversation_discard_gateway_failure_falls_back_to_legacy_llm(monkeypat
     assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False
 
 
-def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
+def test_action_items_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch, caplog):
     captured = {}
+    counter = FakeCounter()
+    call_order = []
 
     class FakeParser:
         def __init__(self, pydantic_object):
@@ -563,18 +565,121 @@ def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
 
         def invoke(self, values):
             assert 'submit report by Friday' in values['conversation_context']
-            return conversation_processing.ActionItemsExtraction(action_items=[])
+            call_order.append('legacy')
+            return conversation_processing.ActionItemsExtraction(
+                action_items=[
+                    {'description': 'Submit report', 'due_at': datetime(2026, 7, 3, 17, 0, tzinfo=timezone.utc)}
+                ]
+            )
 
     def fake_gateway(prompt, output_model, *, feature, timeout_seconds):
+        call_order.append('gateway')
         captured.update(
             {'prompt': prompt, 'output_model': output_model, 'feature': feature, 'timeout_seconds': timeout_seconds}
         )
-        return output_model(action_items=[])
+        return output_model(action_items=[{'description': 'Submit the report', 'due_at': datetime(2026, 7, 3, 17, 0)}])
 
+    class ImmediateFuture:
+        def result(self):
+            return None
+
+        def add_done_callback(self, callback):
+            callback(self)
+
+    def immediate_submit(fn, *args):
+        fn(*args)
+        return ImmediateFuture()
+
+    monkeypatch.setenv(conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV, 'true')
+    monkeypatch.setenv(conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV, '1.0')
     monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
     monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
     monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
     monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, '_submit_llm_background', immediate_submit)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS', counter)
+
+    with caplog.at_level(logging.INFO, logger='utils.llm.gateway_observability'):
+        result = conversation_processing.extract_action_items(
+            'submit report by Friday',
+            datetime(2026, 7, 1, tzinfo=timezone.utc),
+            'en',
+            'UTC',
+        )
+
+    assert [item.description for item in result] == ['Submit report']
+    assert call_order == ['legacy', 'gateway']
+    assert captured['output_model'] is conversation_processing.ActionItemsExtraction
+    assert captured['feature'] == conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE
+    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
+    assert 'submit report by Friday' in captured['prompt']
+    assert '{started_at_local}' not in captured['prompt']
+    assert '{current_time_local}' not in captured['prompt']
+    assert '{format_instructions}' not in captured['prompt']
+    assert 'return structured output' in captured['prompt']
+    comparison_labels = [labels for labels, _amount in counter.calls]
+    assert {
+        'feature': 'conversation_action_items.extract.shadow',
+        'field': 'count',
+        'outcome': 'exact_match',
+    } in comparison_labels
+    assert {
+        'feature': 'conversation_action_items.extract.shadow',
+        'field': 'description_similarity',
+        'outcome': 'all_high_similarity',
+    } in comparison_labels
+    assert {
+        'feature': 'conversation_action_items.extract.shadow',
+        'field': 'due_at_presence',
+        'outcome': 'exact_match',
+    } in comparison_labels
+    assert {
+        'feature': 'conversation_action_items.extract.shadow',
+        'field': 'due_at_value',
+        'outcome': 'exact_match',
+    } in comparison_labels
+    assert 'llm_gateway_backend_event kind=shadow_comparison' in caplog.text
+    assert 'feature=conversation_action_items.extract.shadow' in caplog.text
+    assert 'Submit report' not in caplog.text
+    assert 'Submit the report' not in caplog.text
+
+
+def test_action_items_gateway_shadow_disabled_skips_submit(monkeypatch):
+    captured = {'gateway_called': False, 'submitted': False}
+    counter = FakeCounter()
+
+    class FakeParser:
+        def __init__(self, pydantic_object):
+            self.pydantic_object = pydantic_object
+
+        def get_format_instructions(self):
+            return 'return structured output'
+
+    class FakePrompt:
+        def __or__(self, other):
+            return FakeChain()
+
+    class FakeChain:
+        def __or__(self, other):
+            return self
+
+        def invoke(self, values):
+            return conversation_processing.ActionItemsExtraction(action_items=[])
+
+    def fake_gateway(*args, **kwargs):
+        captured['gateway_called'] = True
+        return None
+
+    def fake_submit(*args, **kwargs):
+        captured['submitted'] = True
+
+    monkeypatch.delenv(conversation_processing.CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(conversation_processing, 'PydanticOutputParser', FakeParser)
+    monkeypatch.setattr(conversation_processing.ChatPromptTemplate, 'from_messages', lambda messages: FakePrompt())
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: object())
+    monkeypatch.setattr(conversation_processing, 'invoke_chat_structured_gateway', fake_gateway)
+    monkeypatch.setattr(conversation_processing, '_submit_llm_background', fake_submit)
+    monkeypatch.setattr(gateway_observability, 'LLM_GATEWAY_CHAT_EXTRACTION_REQUESTS', counter)
 
     result = conversation_processing.extract_action_items(
         'submit report by Friday',
@@ -584,10 +689,15 @@ def test_action_items_gateway_shadow_keeps_legacy_result(monkeypatch):
     )
 
     assert result == []
-    assert captured['output_model'] is conversation_processing.ActionItemsExtraction
-    assert captured['feature'] == 'conversation_action_items.extract.shadow'
-    assert captured['timeout_seconds'] == gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS
-    assert 'submit report by Friday' in captured['prompt']
+    assert captured == {'gateway_called': False, 'submitted': False}
+    assert (
+        {
+            'feature': 'conversation_action_items.extract.shadow',
+            'outcome': 'skipped',
+            'reason': 'disabled',
+        },
+        1,
+    ) in counter.calls
 
 
 def test_conversation_structure_gateway_shadow_keeps_legacy_result_and_records_comparison(monkeypatch, caplog):

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 CONVERSATION_STRUCTURE_SHADOW_FEATURE = 'conversation_structure.extract.shadow'
 CONVERSATION_STRUCTURE_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED'
 CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE'
+CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE = 'conversation_action_items.extract.shadow'
+CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED'
+CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE'
 
 # =============================================
 #            FOLDER ASSIGNMENT
@@ -79,6 +82,29 @@ def _coerce_structured(response: Structured | StructuredExtraction) -> Structure
     return response
 
 
+def _normalize_action_item_due_dates(
+    action_items: List[ActionItem],
+    *,
+    user_tz,
+    now: datetime,
+    log_past_due_clears: bool,
+) -> List[ActionItem]:
+    for action_item in action_items:
+        if action_item.due_at is None:
+            continue
+        if action_item.due_at.tzinfo is None:
+            action_item.due_at = action_item.due_at.replace(tzinfo=user_tz).astimezone(timezone.utc)
+        else:
+            action_item.due_at = action_item.due_at.astimezone(timezone.utc)
+        if action_item.due_at < now - timedelta(days=1):
+            if log_past_due_clears:
+                logger.warning(
+                    f'Clearing past due_at {action_item.due_at.isoformat()} for action item: {action_item.description}'
+                )
+            action_item.due_at = None
+    return action_items
+
+
 def _record_chat_extraction_comparison(*, feature: str, field: str, outcome: str) -> None:
     record_gateway_shadow_comparison(feature=feature, field=field, outcome=outcome)
 
@@ -100,27 +126,35 @@ def _env_sample_rate(name: str, *, default: float = 0.0) -> float:
         return default
 
 
-def _should_run_conversation_structure_shadow(uid: str, started_at: datetime, conversation_context: str) -> bool:
+def _should_run_gateway_shadow(
+    *,
+    feature: str,
+    enabled_env: str,
+    sample_rate_env: str,
+    sample_id: str,
+    started_at: datetime,
+    conversation_context: str,
+) -> bool:
     if has_byok_keys():
         record_chat_extraction_gateway_result(
-            feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+            feature=feature,
             outcome='skipped',
             reason='byok',
         )
         return False
 
-    if not _env_flag_enabled(CONVERSATION_STRUCTURE_SHADOW_ENABLED_ENV):
+    if not _env_flag_enabled(enabled_env):
         record_chat_extraction_gateway_result(
-            feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+            feature=feature,
             outcome='skipped',
             reason='disabled',
         )
         return False
 
-    sample_rate = _env_sample_rate(CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV, default=1.0)
+    sample_rate = _env_sample_rate(sample_rate_env, default=1.0)
     if sample_rate <= 0:
         record_chat_extraction_gateway_result(
-            feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+            feature=feature,
             outcome='skipped',
             reason='sample_rate_zero',
         )
@@ -128,17 +162,41 @@ def _should_run_conversation_structure_shadow(uid: str, started_at: datetime, co
     if sample_rate >= 1:
         return True
 
-    sample_key = f'{uid}:{started_at.isoformat()}:{len(conversation_context)}'
+    sample_key = f'{sample_id}:{started_at.isoformat()}:{len(conversation_context)}'
     sample_value = int(hashlib.sha256(sample_key.encode('utf-8')).hexdigest()[:8], 16) / 0xFFFFFFFF
     if sample_value < sample_rate:
         return True
 
     record_chat_extraction_gateway_result(
-        feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+        feature=feature,
         outcome='skipped',
         reason='sampled_out',
     )
     return False
+
+
+def _should_run_conversation_structure_shadow(uid: str, started_at: datetime, conversation_context: str) -> bool:
+    return _should_run_gateway_shadow(
+        feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+        enabled_env=CONVERSATION_STRUCTURE_SHADOW_ENABLED_ENV,
+        sample_rate_env=CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV,
+        sample_id=uid,
+        started_at=started_at,
+        conversation_context=conversation_context,
+    )
+
+
+def _should_run_conversation_action_items_shadow(
+    sample_id: str, started_at: datetime, conversation_context: str
+) -> bool:
+    return _should_run_gateway_shadow(
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        enabled_env=CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV,
+        sample_rate_env=CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV,
+        sample_id=sample_id,
+        started_at=started_at,
+        conversation_context=conversation_context,
+    )
 
 
 def _normalized_text(value: object) -> str:
@@ -226,6 +284,95 @@ def _record_conversation_structure_shadow_comparison(
     )
 
 
+def _count_comparison_bucket(legacy_count: int, gateway_count: int) -> str:
+    if legacy_count == gateway_count:
+        return 'exact_match'
+    if gateway_count < legacy_count:
+        return 'gateway_fewer'
+    return 'gateway_more'
+
+
+def _ordered_description_similarity_bucket(legacy_items: List[ActionItem], gateway_items: List[ActionItem]) -> str:
+    if not legacy_items and not gateway_items:
+        return 'both_empty'
+    if not legacy_items:
+        return 'legacy_empty_gateway_present'
+    if not gateway_items:
+        return 'legacy_present_gateway_empty'
+    if len(legacy_items) != len(gateway_items):
+        return 'count_mismatch'
+
+    buckets = [
+        _text_similarity_bucket(left.description, right.description) for left, right in zip(legacy_items, gateway_items)
+    ]
+    if all(bucket == 'exact_match' for bucket in buckets):
+        return 'all_exact_match'
+    if all(bucket in {'exact_match', 'high_similarity'} for bucket in buckets):
+        return 'all_high_similarity'
+    if all(bucket in {'exact_match', 'high_similarity', 'medium_similarity'} for bucket in buckets):
+        return 'all_medium_similarity'
+    return 'low_similarity'
+
+
+def _due_at_presence_bucket(legacy_items: List[ActionItem], gateway_items: List[ActionItem]) -> str:
+    if not legacy_items and not gateway_items:
+        return 'both_empty'
+    if len(legacy_items) != len(gateway_items):
+        return 'count_mismatch'
+    legacy_presence = [item.due_at is not None for item in legacy_items]
+    gateway_presence = [item.due_at is not None for item in gateway_items]
+    return 'exact_match' if legacy_presence == gateway_presence else 'mismatch'
+
+
+def _due_at_value_bucket(legacy_items: List[ActionItem], gateway_items: List[ActionItem]) -> str:
+    if not legacy_items and not gateway_items:
+        return 'both_empty'
+    if len(legacy_items) != len(gateway_items):
+        return 'count_mismatch'
+
+    legacy_due_at = [item.due_at for item in legacy_items]
+    gateway_due_at = [item.due_at for item in gateway_items]
+    if not any(legacy_due_at) and not any(gateway_due_at):
+        return 'no_due_dates'
+    if legacy_due_at == gateway_due_at:
+        return 'exact_match'
+    return 'mismatch'
+
+
+def _record_conversation_action_items_shadow_comparison(
+    gateway_response: ActionItemsExtraction | None,
+    legacy_response: List[ActionItem],
+    *,
+    user_tz,
+    now: datetime,
+) -> None:
+    if gateway_response is None:
+        return
+
+    gateway_items = _coerce_action_items(gateway_response)
+    _normalize_action_item_due_dates(gateway_items, user_tz=user_tz, now=now, log_past_due_clears=False)
+    _record_chat_extraction_comparison(
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        field='count',
+        outcome=_count_comparison_bucket(len(legacy_response), len(gateway_items)),
+    )
+    _record_chat_extraction_comparison(
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        field='description_similarity',
+        outcome=_ordered_description_similarity_bucket(legacy_response, gateway_items),
+    )
+    _record_chat_extraction_comparison(
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        field='due_at_presence',
+        outcome=_due_at_presence_bucket(legacy_response, gateway_items),
+    )
+    _record_chat_extraction_comparison(
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        field='due_at_value',
+        outcome=_due_at_value_bucket(legacy_response, gateway_items),
+    )
+
+
 def _run_conversation_structure_shadow(prompt: str, legacy_response: Structured) -> None:
     gateway_response = _invoke_gateway_unless_byok(
         prompt,
@@ -235,18 +382,34 @@ def _run_conversation_structure_shadow(prompt: str, legacy_response: Structured)
     _record_conversation_structure_shadow_comparison(gateway_response, legacy_response)
 
 
+def _run_conversation_action_items_shadow(
+    prompt: str, legacy_response: List[ActionItem], user_tz, now: datetime
+) -> None:
+    gateway_response = _invoke_gateway_unless_byok(
+        prompt,
+        ActionItemsExtraction,
+        feature=CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+    )
+    _record_conversation_action_items_shadow_comparison(gateway_response, legacy_response, user_tz=user_tz, now=now)
+
+
 def _submit_llm_background(fn, *args):
     from utils.executors import llm_executor, submit_with_context
 
     return submit_with_context(llm_executor, fn, *args)
 
 
-def _submit_conversation_structure_shadow(prompt: str, legacy_response: Structured) -> None:
+def _submit_gateway_shadow(
+    worker_fn,
+    feature: str,
+    log_label: str,
+    *args,
+) -> None:
     try:
-        future = _submit_llm_background(_run_conversation_structure_shadow, prompt, legacy_response)
+        future = _submit_llm_background(worker_fn, *args)
     except Exception:
         record_chat_extraction_gateway_result(
-            feature=CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+            feature=feature,
             outcome='skipped',
             reason='submit_error',
         )
@@ -256,9 +419,33 @@ def _submit_conversation_structure_shadow(prompt: str, legacy_response: Structur
         try:
             completed_future.result()
         except Exception:
-            logger.exception('conversation_structure shadow task failed')
+            logger.exception('%s shadow task failed', log_label)
 
     future.add_done_callback(_log_shadow_failure)
+
+
+def _submit_conversation_structure_shadow(prompt: str, legacy_response: Structured) -> None:
+    _submit_gateway_shadow(
+        _run_conversation_structure_shadow,
+        CONVERSATION_STRUCTURE_SHADOW_FEATURE,
+        'conversation_structure',
+        prompt,
+        legacy_response,
+    )
+
+
+def _submit_conversation_action_items_shadow(
+    prompt: str, legacy_response: List[ActionItem], user_tz, now: datetime
+) -> None:
+    _submit_gateway_shadow(
+        _run_conversation_action_items_shadow,
+        CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE,
+        'conversation_action_items',
+        prompt,
+        legacy_response,
+        user_tz,
+        now,
+    )
 
 
 def should_discard_conversation(
@@ -668,11 +855,7 @@ def extract_action_items(
         'existing_items_context': existing_items_context,
     }
 
-    _invoke_gateway_unless_byok(
-        f'{instructions_text}\n\n{context_message.format(**prompt_values)}',
-        ActionItemsExtraction,
-        feature='conversation_action_items.extract.shadow',
-    )
+    shadow_prompt = f'{instructions_text.format(**prompt_values)}\n\n{context_message.format(**prompt_values)}'
 
     try:
         response = chain.invoke(prompt_values)
@@ -683,18 +866,12 @@ def extract_action_items(
         for action_item in action_items:
             if action_item.created_at is None:
                 action_item.created_at = now
-            # The LLM returns naive LOCAL time; convert to UTC deterministically (and normalize any
-            # tz-aware value), then clear due dates more than 1 day in the past.
-            if action_item.due_at is not None:
-                if action_item.due_at.tzinfo is None:
-                    action_item.due_at = action_item.due_at.replace(tzinfo=user_tz).astimezone(timezone.utc)
-                else:
-                    action_item.due_at = action_item.due_at.astimezone(timezone.utc)
-                if action_item.due_at < now - timedelta(days=1):
-                    logger.warning(
-                        f'Clearing past due_at {action_item.due_at.isoformat()} for action item: {action_item.description}'
-                    )
-                    action_item.due_at = None
+        # The LLM returns naive LOCAL time; convert to UTC deterministically (and normalize any
+        # tz-aware value), then clear due dates more than 1 day in the past.
+        _normalize_action_item_due_dates(action_items, user_tz=user_tz, now=now, log_past_due_clears=True)
+
+        if _should_run_conversation_action_items_shadow('conversation_action_items', started_at, conversation_context):
+            _submit_conversation_action_items_shadow(shadow_prompt, action_items, user_tz, now)
 
         return action_items
 


### PR DESCRIPTION
## Summary
- moves `conversation_action_items.extract.shadow` out of the foreground path and into the LLM background executor after legacy action items are produced
- adds low-cardinality shadow comparison events for action-item count, description similarity, due-date presence, and due-date value
- adds dev-only runtime env controls for action-items shadow sampling across Cloud Run backend services and GKE backend-listen
- keeps prod implicitly disabled unless action-items shadow envs are explicitly configured later

## Why
We need faster, higher-signal dev pilot data without turning gateway expansion into user-visible latency risk. Action items are a good next slice because legacy remains the source of truth, while the gateway can produce structured output that is easy to compare without logging raw user text.

## Post-merge dev checks
After dev deploy, look for sanitized backend observability events:

- `kind=request_result feature=conversation_action_items.extract.shadow outcome=success reason=ok`
- `kind=shadow_comparison feature=conversation_action_items.extract.shadow field=count ...`
- `field=description_similarity`
- `field=due_at_presence`
- `field=due_at_value`

Proceed only if:
- request results are mostly `success ok`, with low `http_502`/`timeout` fallback
- comparison events are present for real product traffic
- no raw action-item descriptions or prompt text appear in logs
- foreground action-item behavior remains unchanged because legacy still returns the product result

Do not expand non-shadow if:
- gateway count frequently differs from legacy
- due-date presence/value mismatches are common
- gateway fallbacks rise again under the larger sample

## Validation
- `PYTHONPATH=backend pytest backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py -q`
- `python3 backend/scripts/validate-backend-runtime-env.py --env dev`
- `python3 backend/scripts/validate-backend-runtime-env.py --env prod`
- `python3 backend/scripts/scan_async_blockers.py`
- `scripts/pre-push`
- push pre-push hook also passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

