### PR TITLE
Harden canonical memory privacy side effects

### DIFF
--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -72,6 +72,7 @@ from utils.memory.canonical_memory_adapter import (
     neutral_vector_id_for_memory,
     purge_canonical_derived_user_data,
     retract_conversation_sourced_memories,
+    update_canonical_memory_visibility,
     write_canonical_extraction_memory,
 )
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
@@ -421,6 +422,29 @@ def test_conversation_delete_cascade_tombstones_canonical_and_emits_vector_purge
     assert purge_record["vector_id"] == neutral_vector_id_for_memory(memory_id)
 
 
+def test_conversation_delete_cascade_deletes_canonical_vector_immediately(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    conversation_id = "conv-cascade-vector"
+    content = "Fact sourced from conversation with vector"
+    payload = _sample_memory_payload(uid=uid, conversation_id=conversation_id, content=content)
+    memory_id = payload["id"]
+
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    deleted_vectors = []
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.delete_canonical_memory_vector",
+        lambda u, mid: deleted_vectors.append((u, mid)),
+    )
+
+    write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+    retract_conversation_sourced_memories(uid, conversation_id, db_client=canonical_db)
+
+    assert deleted_vectors == [(uid, memory_id)]
+
+
 def test_retract_calls_kg_invalidation_hook(monkeypatch, canonical_db):
     uid = "uid-canonical-ws-j"
     conversation_id = "conv-kg"
@@ -454,17 +478,55 @@ def test_delete_canonical_memory_calls_kg_invalidation_hook(monkeypatch, canonic
         lambda **_: _trusted_account_generation(),
     )
     kg_calls = []
+    deleted_vectors = []
     monkeypatch.setattr(
         "utils.memory.canonical_memory_adapter.invalidate_kg_for_memory_retraction",
         lambda u, ids, **kwargs: kg_calls.append((u, list(ids))),
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.delete_canonical_memory_vector",
+        lambda u, mid: deleted_vectors.append((u, mid)),
     )
 
     write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
     delete_canonical_memory(uid, memory_id, db_client=canonical_db)
 
     assert kg_calls == [(uid, [memory_id])]
+    assert deleted_vectors == [(uid, memory_id)]
     tombstoned = canonical_db.docs[f"users/{uid}/memory_items/{memory_id}"]
     assert tombstoned["status"] == MemoryItemStatus.tombstoned.value
+
+
+def test_update_canonical_visibility_resyncs_keyword_and_vector_side_effects(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    conversation_id = "conv-visibility"
+    payload = _sample_memory_payload(uid=uid, conversation_id=conversation_id, content="Visibility side effect")
+    memory_id = payload["id"]
+
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+
+    write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+
+    keyword_syncs = []
+    vector_syncs = []
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.sync_atom_keyword_index_for_item",
+        lambda item, **kwargs: keyword_syncs.append((item.memory_id, item.visibility)) or True,
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.sync_canonical_memory_vector",
+        lambda item, **kwargs: vector_syncs.append((item.memory_id, item.visibility)) or True,
+    )
+
+    updated = update_canonical_memory_visibility(uid, memory_id, "public", db_client=canonical_db)
+
+    assert updated.visibility == "public"
+    assert canonical_db.docs[f"users/{uid}/memory_items/{memory_id}"]["visibility"] == "public"
+    assert keyword_syncs == [(memory_id, "public")]
+    assert vector_syncs == [(memory_id, "public")]
 
 
 def test_delete_all_canonical_memories_batches_kg_invalidation(monkeypatch, canonical_db):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -43,7 +43,7 @@ from models.memory_operations import MemoryOperation, MemoryOperationType
 from models.product_memory import MemoryAccessPolicy, MemoryItemStatus, MemoryLayer, MemoryItem
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.retrieval.hybrid import rrf_rerank
-from utils.memory.canonical_vector_sync import sync_canonical_memory_vector
+from utils.memory.canonical_vector_sync import delete_canonical_memory_vector, sync_canonical_memory_vector
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
 from utils.memory.v3_account_generation_source import read_memory_v3_trusted_account_generation
 
@@ -645,6 +645,8 @@ def update_canonical_memory_visibility(uid: str, memory_id: str, visibility: str
     now = datetime.now(timezone.utc)
     updated = item.model_copy(update={"visibility": visibility, "updated_at": now})
     client.document(f"{MemoryCollections(uid=uid).memory_items}/{memory_id}").set(updated.model_dump(mode="json"))
+    sync_atom_keyword_index_for_item(updated, db_client=client)
+    sync_canonical_memory_vector(updated)
     return updated
 
 
@@ -740,6 +742,7 @@ def _tombstone_memory_item(uid: str, item: MemoryItem, *, db_client, reason: str
     for record in build_vector_repair_purge_outbox_records(uid=uid, candidates=purge_candidates):
         db_client.document(record["outbox_path"]).set(record)
 
+    delete_canonical_memory_vector(uid, item.memory_id)
     delete_atom_keyword_doc(uid, item.memory_id, db_client=db_client)
     purge_stale_review_conflicts_for_memories(uid, [item.memory_id], reason=reason, db_client=db_client)
 


### PR DESCRIPTION
## Summary
- synchronously delete the canonical neutral Pinecone vector when a canonical memory is tombstoned
- keep the durable vector purge outbox path as a retry/backstop
- resync canonical keyword and vector side effects after visibility changes so search metadata follows the authoritative item
- add local privacy/delete regression coverage for immediate vector deletion and visibility side-effect sync

## Context
This is the first focused PR from `.coordination/memory-canonical-hardening-backlog.md` Issue 1: direct canonical mutations and privacy/delete side effects.

Work log:
- owner: side-conversation assistant
- worktree: `/Users/dazheng/.codex/worktrees/memory-issue1-privacy`
- branch: `codex/memory-issue1-privacy-side-effects`

Scope cap:
- This PR does not redesign all canonical mutations around apply/ledger/outbox yet.
- It addresses the highest-risk stale-retrieval slice: delete/retract must not rely only on delayed repair for vector purge, and visibility metadata should not remain stale in derived indexes.

## Tests
- `cd backend && pytest tests/unit/test_ws_j_delete_privacy.py -q`
- `cd backend && pytest tests/unit/test_canonical_memory_vectors.py -q`
- `cd backend && pytest tests/unit/test_ws_m_atom_keyword_index.py -q`
- `cd backend && python -m py_compile utils/memory/canonical_memory_adapter.py tests/unit/test_ws_j_delete_privacy.py`
- pre-push fast checks passed, including selected backend unit tests and OpenAPI contract check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

