### PR TITLE
Add local workflow contract gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,7 @@ Full RELEASE flow + `gh workflow run gcp_backend.yml -f environment=prod -f bran
 ## Testing
 
 - Run `backend/test-preflight.sh` first to verify tools, packages, and env vars.
+- High-risk backend workflows (checkpoint/resume, retry/idempotency, side-effect fanout, rollout/repair jobs) must be listed in `backend/testing/workflow_contracts.json` with local contract tests; source-only changes must run those tests before PR.
 - OpenAPI contract checks use `backend/scripts/openapi_runner.sh`, which syncs the pinned `backend/openapi-requirements.txt` runner env and prewarms `tiktoken`; CI and `scripts/pre-push` must use this same path.
 - Backend changes: run `backend/test.sh`. App changes: run `app/test.sh`. Run before committing.
 - Backend unit tests need `python3`, `pytest`, packages from `requirements.txt`, `ENCRYPTION_SECRET` (set by test.sh). Integration tests optionally need `OPENAI_API_KEY`, `DEEPGRAM_API_KEY`, `ADMIN_KEY`, Redis, `GOOGLE_APPLICATION_CREDENTIALS`.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -73,6 +73,10 @@ flutter test           # same thing
 flutter test test/unit/  # specific directory
 ```
 
+`bash test.sh` bootstraps missing local generated files with an empty `API_BASE_URL`.
+Set `OMI_APP_TEST_API_BASE_URL=http://127.0.0.1:<port>/` for local backend tests, or
+`OMI_APP_TEST_USE_PROD_API_DEFAULT=1` only when a test intentionally needs the prod API default.
+
 ### Test Patterns
 - Mock singletons (SharedPreferencesUtil, AuthService, FirebaseAuth) since they aren't injectable
 - Test state machine logic via minimal abstractions mirroring production flow
@@ -120,4 +124,3 @@ All API requests include: X-Request-Start-Time, X-App-Platform, X-Device-Id-Hash
 - See `e2e/SKILL.md` for navigation architecture, screen map, widget patterns, and 34 reference flows
 - See `e2e/flows/*.yaml` for individual flow definitions
 - agent-flutter (Marionette) for programmatic UI interaction — see root AGENTS.md for setup
-

--- a/app/test.sh
+++ b/app/test.sh
@@ -36,7 +36,13 @@ if [[ ${#missing_files[@]} -gt 0 ]]; then
   cp setup/prebuilt/GoogleService-Info.plist ios/Config/Prod/
   cp setup/prebuilt/GoogleService-Info.plist macos/Config/Prod/
 
-  echo "API_BASE_URL=https://api.omiapi.com/" > .dev.env
+  if [[ -n "${OMI_APP_TEST_API_BASE_URL:-}" ]]; then
+    echo "API_BASE_URL=${OMI_APP_TEST_API_BASE_URL}" > .dev.env
+  elif [[ "${OMI_APP_TEST_USE_PROD_API_DEFAULT:-}" == "1" ]]; then
+    echo "API_BASE_URL=https://api.omiapi.com/" > .dev.env
+  else
+    echo "API_BASE_URL=" > .dev.env
+  fi
   echo "USE_WEB_AUTH=true" >> .dev.env
   echo "USE_AUTH_CUSTOM_TOKEN=true" >> .dev.env
   echo "STAGING_API_URL=" >> .dev.env

--- a/backend/database/memory_vector_repair_outbox_worker.py
+++ b/backend/database/memory_vector_repair_outbox_worker.py
@@ -22,11 +22,6 @@ VECTOR_REPAIR_OUTBOX_COMPLETED_STATUS = "completed"
 VECTOR_REPAIR_OUTBOX_DEAD_LETTER_STATUS = "dead_letter"
 VECTOR_REPAIR_PURGE_EVENT_TYPE = "vector_repair_purge"
 
-_TERMINAL_OR_LEASED_STATUSES = {
-    VECTOR_REPAIR_OUTBOX_IN_PROGRESS_STATUS,
-    VECTOR_REPAIR_OUTBOX_COMPLETED_STATUS,
-    VECTOR_REPAIR_OUTBOX_DEAD_LETTER_STATUS,
-}
 _DELETE_REASONS = {"missing_authoritative_item"}
 _TOMBSTONE_STATUSES = {"deleted", "tombstoned", "purged", MemoryItemStatus.tombstoned.value}
 _TOMBSTONE_SOURCE_STATES = {SourceState.missing.value, SourceState.tombstoned.value, SourceState.purged.value}
@@ -225,26 +220,40 @@ def lease_vector_repair_purge_outbox_records(
     now_iso = observed_now.isoformat()
     lease_expires_at = (observed_now + timedelta(seconds=lease_seconds)).isoformat()
     collection_path = MemoryCollections(uid=uid).memory_outbox
-    query = (
+    pending_query = (
         db_client.collection(collection_path)
         .where("event_type", "==", VECTOR_REPAIR_PURGE_EVENT_TYPE)
         .where("status", "==", VECTOR_REPAIR_OUTBOX_PENDING_STATUS)
         .where("available_at", "<=", now_iso)
         .limit(limit)
     )
+    expired_lease_query = (
+        db_client.collection(collection_path)
+        .where("event_type", "==", VECTOR_REPAIR_PURGE_EVENT_TYPE)
+        .where("status", "==", VECTOR_REPAIR_OUTBOX_IN_PROGRESS_STATUS)
+        .where("lease_expires_at", "<=", now_iso)
+        .limit(limit)
+    )
 
     leased: List[Dict[str, Any]] = []
-    for snapshot in query.stream():
-        path = getattr(getattr(snapshot, "reference", None), "path", f"{collection_path}/{snapshot.id}")
-        claimed = _claim_vector_repair_purge_outbox_snapshot(
-            db_client=db_client,
-            path=path,
-            worker_id=worker_id,
-            now_iso=now_iso,
-            lease_expires_at=lease_expires_at,
-        )
-        if claimed is not None:
-            leased.append(claimed)
+    seen_paths = set()
+    for query in (pending_query, expired_lease_query):
+        for snapshot in query.stream():
+            if len(leased) >= limit:
+                return leased
+            path = getattr(getattr(snapshot, "reference", None), "path", f"{collection_path}/{snapshot.id}")
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            claimed = _claim_vector_repair_purge_outbox_snapshot(
+                db_client=db_client,
+                path=path,
+                worker_id=worker_id,
+                now_iso=now_iso,
+                lease_expires_at=lease_expires_at,
+            )
+            if claimed is not None:
+                leased.append(claimed)
     return leased
 
 
@@ -351,6 +360,7 @@ def _claim_vector_repair_purge_outbox_snapshot_in_transaction(
     if not _is_claimable_vector_repair_purge_outbox_record(record=record, now_iso=now_iso):
         return None
     record["outbox_path"] = path
+    record["status"] = VECTOR_REPAIR_OUTBOX_PENDING_STATUS
     transaction.update(doc_ref, _lease_patch(worker_id=worker_id, now_iso=now_iso, lease_expires_at=lease_expires_at))
     return record
 
@@ -371,6 +381,7 @@ def _claim_vector_repair_purge_outbox_snapshot_without_transaction(
     if not _is_claimable_vector_repair_purge_outbox_record(record=record, now_iso=now_iso):
         return None
     record["outbox_path"] = path
+    record["status"] = VECTOR_REPAIR_OUTBOX_PENDING_STATUS
     doc_ref.update(_lease_patch(worker_id=worker_id, now_iso=now_iso, lease_expires_at=lease_expires_at))
     return record
 
@@ -378,10 +389,14 @@ def _claim_vector_repair_purge_outbox_snapshot_without_transaction(
 def _is_claimable_vector_repair_purge_outbox_record(*, record: Dict[str, Any], now_iso: str) -> bool:
     if record.get("event_type") != VECTOR_REPAIR_PURGE_EVENT_TYPE:
         return False
-    if record.get("status") != VECTOR_REPAIR_OUTBOX_PENDING_STATUS:
-        return False
-    available_at = record.get("available_at")
-    return isinstance(available_at, str) and available_at <= now_iso
+    status = record.get("status")
+    if status == VECTOR_REPAIR_OUTBOX_PENDING_STATUS:
+        available_at = record.get("available_at")
+        return isinstance(available_at, str) and available_at <= now_iso
+    if status == VECTOR_REPAIR_OUTBOX_IN_PROGRESS_STATUS:
+        lease_expires_at = record.get("lease_expires_at")
+        return isinstance(lease_expires_at, str) and lease_expires_at <= now_iso
+    return False
 
 
 def _lease_patch(*, worker_id: str, now_iso: str, lease_expires_at: str) -> Dict[str, Any]:

--- a/backend/database/projection_repair.py
+++ b/backend/database/projection_repair.py
@@ -8,6 +8,8 @@ projection_repairs_collection = 'projection_repairs'
 PROJECTION_VERSION = 1
 
 DANGEROUS_REASONS = {'retract_fact', 'tombstone_evidence', 'source_tombstoned'}
+TERMINAL_REPAIR_STATUSES = {'repaired', 'dead_letter'}
+PROCESSABLE_REPAIR_STATUSES = ('queued', 'failed')
 
 
 def affected_fact_ids(mutations: List[Dict[str, Any]]) -> List[str]:
@@ -44,8 +46,12 @@ def enqueue_projection_repairs(uid: str, commit: Optional[Dict[str, Any]], *, fi
         reasons = reasons_by_fact.get(fact_id, ['unknown'])
         repair_id = f"{commit.get('commit_id')}:{fact_id}"
         repair_ids.append(repair_id)
+        document_ref = collection_ref.document(repair_id)
+        existing = document_ref.get()
+        if getattr(existing, 'exists', False):
+            continue
         batch.set(
-            collection_ref.document(repair_id),
+            document_ref,
             {
                 'repair_id': repair_id,
                 'fact_id': fact_id,
@@ -68,12 +74,33 @@ def process_projection_repairs(
     fact_loader: Callable[[str], Optional[Dict[str, Any]]],
     repair_func: Callable[[str, Optional[Dict[str, Any]]], str],
     limit: int = 100,
+    firestore_client=None,
+    max_attempts: int = 3,
 ) -> Dict[str, Any]:
-    collection_ref = db.collection(users_collection).document(uid).collection(projection_repairs_collection)
-    queued_docs = collection_ref.where('status', '==', 'queued').limit(limit).stream()
+    if limit < 1:
+        raise ValueError('limit must be positive')
+    if max_attempts < 1:
+        raise ValueError('max_attempts must be positive')
+
+    database = firestore_client or db
+    collection_ref = database.collection(users_collection).document(uid).collection(projection_repairs_collection)
     repaired = []
     failed = []
-    for doc in queued_docs:
+    seen_doc_ids = set()
+    docs = []
+    for status in PROCESSABLE_REPAIR_STATUSES:
+        for doc in collection_ref.where('status', '==', status).limit(limit).stream():
+            doc_id = getattr(doc, 'id', None)
+            if doc_id in seen_doc_ids:
+                continue
+            seen_doc_ids.add(doc_id)
+            docs.append(doc)
+            if len(docs) >= limit:
+                break
+        if len(docs) >= limit:
+            break
+
+    for doc in docs:
         repair = doc.to_dict() or {}
         fact_id = repair.get('fact_id')
         try:
@@ -87,9 +114,12 @@ def process_projection_repairs(
             )
             repaired.append(repair.get('repair_id') or doc.id)
         except Exception as exc:
+            next_attempt_count = int(repair.get('attempt_count') or 0) + 1
+            next_status = 'dead_letter' if next_attempt_count >= max_attempts else 'failed'
             doc.reference.update(
                 {
-                    'status': 'failed',
+                    'status': next_status,
+                    'attempt_count': next_attempt_count,
                     'error': str(exc),
                     'updated_at': datetime.now(timezone.utc),
                 }

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1322,6 +1322,7 @@ async def _run_full_pipeline_background_async(
                         segment_errors.append('Segment timed out after 300s')
                         logger.error(f'sync_v2 bg: segment timed out job={job_id}')
                     elif isinstance(r, Exception):
+                        segment_errors.append(f'Segment failed: {sanitize(str(r))}')
                         logger.error(f'sync_v2 bg: segment error: {r}')
                 try:
                     await run_blocking(

--- a/backend/scripts/check_workflow_contracts.py
+++ b/backend/scripts/check_workflow_contracts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Static checks for high-risk workflow contracts."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+REPO_DIR = BACKEND_DIR.parent
+CONTRACTS_PATH = BACKEND_DIR / "testing" / "workflow_contracts.json"
+
+
+def load_contracts() -> dict[str, Any]:
+    return json.loads(CONTRACTS_PATH.read_text())
+
+
+def normalize_path(path: str) -> str:
+    path = path.strip().replace("\\", "/")
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def path_matches(path: str, pattern: str) -> bool:
+    return PurePosixPath(path).match(pattern)
+
+
+def workflow_sources(contracts: dict[str, Any], changed_paths: list[str] | None = None) -> set[str]:
+    changed = [normalize_path(path) for path in changed_paths or [] if normalize_path(path)]
+    sources: set[str] = set()
+    for workflow in contracts.get("workflows", []):
+        if workflow.get("risk") != "high":
+            continue
+        patterns = workflow.get("sources", [])
+        if changed and not any(any(path_matches(path, pattern) for pattern in patterns) for path in changed):
+            continue
+        for pattern in patterns:
+            if "*" in pattern:
+                sources.update(path.as_posix() for path in REPO_DIR.glob(pattern) if path.is_file())
+            else:
+                source = REPO_DIR / pattern
+                if source.is_file():
+                    sources.add(pattern)
+    return sources
+
+
+def _tuple_arity(node: ast.AST) -> int | None:
+    if not isinstance(node, ast.Subscript):
+        return None
+    root = ast.unparse(node.value)
+    if root not in {"tuple", "Tuple"}:
+        return None
+    if isinstance(node.slice, ast.Tuple):
+        return len(node.slice.elts)
+    return 1
+
+
+def check_no_large_tuple_results(contracts: dict[str, Any], changed_paths: list[str] | None = None) -> list[str]:
+    allowlist = {
+        (entry["path"], entry["function"])
+        for entry in contracts.get("checks", {}).get("no_large_tuple_results", {}).get("allowlist", [])
+    }
+    errors: list[str] = []
+    for rel_path in sorted(workflow_sources(contracts, changed_paths)):
+        source_path = REPO_DIR / rel_path
+        try:
+            tree = ast.parse(source_path.read_text())
+        except SyntaxError as exc:
+            errors.append(f"{rel_path}:{exc.lineno}: cannot parse source: {exc.msg}")
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.returns is None:
+                continue
+            arity = _tuple_arity(node.returns)
+            if arity is None or arity <= 2 or node.name.endswith("_key") or (rel_path, node.name) in allowlist:
+                continue
+            errors.append(
+                f"{rel_path}:{node.lineno}: {node.name} returns a positional tuple with {arity} fields; "
+                "use a named dataclass/model result or add a temporary allowlist entry with a migration reason"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changed-files", help="Only check workflow sources touched by this file list.")
+    args = parser.parse_args()
+
+    changed_paths = None
+    if args.changed_files:
+        changed_paths = Path(args.changed_files).read_text().splitlines()
+
+    contracts = load_contracts()
+    errors = check_no_large_tuple_results(contracts, changed_paths)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print("Workflow contract checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import json
 from pathlib import Path
 from pathlib import PurePosixPath
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 REPO_DIR = BACKEND_DIR.parent
+WORKFLOW_CONTRACTS_PATH = BACKEND_DIR / 'testing' / 'workflow_contracts.json'
 
 FULL_TEST_ROOTS = (
     BACKEND_DIR / 'tests' / 'unit',
@@ -222,6 +224,22 @@ def path_matches(path: str, pattern: str) -> bool:
     return PurePosixPath(path).match(pattern)
 
 
+def load_workflow_contracts() -> list[dict]:
+    if not WORKFLOW_CONTRACTS_PATH.exists():
+        return []
+    return list(json.loads(WORKFLOW_CONTRACTS_PATH.read_text()).get('workflows', []))
+
+
+def workflow_contract_tests_for_path(path: str, all_tests: list[str]) -> set[str]:
+    selected: set[str] = set()
+    for workflow in load_workflow_contracts():
+        sources = tuple(workflow.get('sources') or ())
+        if not any(path_matches(path, source) for source in sources):
+            continue
+        selected.update(test for test in workflow.get('tests') or () if test in all_tests)
+    return selected
+
+
 def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> tuple[list[str], str]:
     changed_paths = [path for path in (normalize_changed_path(path) for path in changed_paths) if path]
     if not changed_paths:
@@ -232,7 +250,10 @@ def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> t
     test_paths = [path for path in backend_paths if path.startswith('backend/tests/') and path.endswith('.py')]
 
     for path in changed_paths:
-        if is_full_run_path(path):
+        selected.update(workflow_contract_tests_for_path(path, all_tests))
+
+    for path in changed_paths:
+        if is_full_run_path(path) and not workflow_contract_tests_for_path(path, all_tests):
             return all_tests, f'{path} requires the full backend unit suite'
 
     for path in test_paths:
@@ -250,7 +271,7 @@ def tests_for_changed_paths(changed_paths: list[str], all_tests: list[str]) -> t
     if not backend_paths:
         return [], 'no backend files changed'
     if selected:
-        return sorted(selected), 'selected backend unit tests from changed paths'
+        return sorted(selected), 'selected backend unit tests from changed paths and workflow contracts'
     return all_tests, 'backend changes did not match a narrow area'
 
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -27,12 +27,23 @@ logger = logging.getLogger(__name__)
 
 
 def purge_derived_user_data(uid: str):
-    """Best-effort purge of a user's derived data outside Firestore."""
+    """Purge a user's derived data outside Firestore.
+
+    Required failures must block the Firestore wipe because those IDs are
+    stored in Firestore and may become unrecoverable after ``delete_user_data``.
+    Best-effort failures are safe to retry independently or leave behind.
+    """
+    result = {'required_failures': [], 'best_effort_failures': []}
+
+    def record_failure(kind: str, operation: str, error: Exception):
+        result[kind].append({'operation': operation, 'error': sanitize(str(error))})
+
     try:
         conversation_ids = get_conversation_ids(uid)
         if conversation_ids:
             delete_conversation_vectors_batch(uid, conversation_ids)
     except Exception as e:
+        record_failure('required_failures', 'conversation_vectors', e)
         logger.error(f'delete_account purge conversation vectors failed for {uid}: {sanitize(str(e))}')
 
     try:
@@ -40,6 +51,7 @@ def purge_derived_user_data(uid: str):
         if conversation_ids:
             delete_transcript_chunk_vectors_batch(uid, conversation_ids)
     except Exception as e:
+        record_failure('required_failures', 'transcript_chunk_vectors', e)
         logger.error(f'delete_account purge transcript chunk vectors failed for {uid}: {sanitize(str(e))}')
 
     try:
@@ -47,6 +59,7 @@ def purge_derived_user_data(uid: str):
         if memory_ids:
             delete_memory_vectors_batch(uid, memory_ids)
     except Exception as e:
+        record_failure('required_failures', 'memory_vectors', e)
         logger.error(f'delete_account purge memory vectors failed for {uid}: {sanitize(str(e))}')
 
     try:
@@ -54,6 +67,7 @@ def purge_derived_user_data(uid: str):
         if action_item_ids:
             delete_action_item_vectors_batch(uid, action_item_ids)
     except Exception as e:
+        record_failure('required_failures', 'action_item_vectors', e)
         logger.error(f'delete_account purge action item vectors failed for {uid}: {sanitize(str(e))}')
 
     try:
@@ -61,17 +75,22 @@ def purge_derived_user_data(uid: str):
         if screen_activity_ids:
             delete_screen_activity_vectors(uid, screen_activity_ids)
     except Exception as e:
+        record_failure('required_failures', 'screen_activity_vectors', e)
         logger.error(f'delete_account purge screen activity vectors failed for {uid}: {sanitize(str(e))}')
 
     try:
         delete_all_conversation_recordings(uid)
     except Exception as e:
+        record_failure('best_effort_failures', 'conversation_recordings', e)
         logger.error(f'delete_account purge recordings failed for {uid}: {sanitize(str(e))}')
 
     try:
         purge_canonical_derived_user_data(uid)
     except Exception as e:
+        record_failure('required_failures', 'canonical_derived_data', e)
         logger.error(f'delete_account purge canonical vectors failed for {uid}: {sanitize(str(e))}')
+
+    return result
 
 
 def background_wipe_user_data(uid: str):
@@ -86,7 +105,11 @@ def background_wipe_user_data(uid: str):
             logger.warning(f'delete_account marker transition to running failed for {uid}: {sanitize(str(e))}')
         # Twilio caller IDs first, while the phone_numbers subcollection still carries twilio_sid metadata.
         delete_user_caller_ids(uid)
-        purge_derived_user_data(uid)
+        purge_result = purge_derived_user_data(uid)
+        required_failures = purge_result.get('required_failures', []) if isinstance(purge_result, dict) else []
+        if required_failures:
+            failed_operations = ', '.join(failure['operation'] for failure in required_failures)
+            raise RuntimeError(f'required derived purge failed: {failed_operations}')
         users_db.delete_user_data(uid)
         logger.info(f'delete_account background wipe complete for {uid}')
     except Exception as e:

--- a/backend/testing/WORKFLOW_CONTRACTS.md
+++ b/backend/testing/WORKFLOW_CONTRACTS.md
@@ -1,0 +1,27 @@
+# Workflow Contracts
+
+High-risk workflows must have local contracts that run from source-only changes.
+
+A workflow is high-risk when correctness depends on checkpoint/resume behavior,
+idempotent retries, side-effect fanout, rollout state, or external service
+repair. Add it to `backend/testing/workflow_contracts.json` with:
+
+- source globs that own the workflow
+- focused contract tests that must run locally before PR
+- invariants the tests own
+- static checks such as `no_large_tuple_results` when useful
+
+Contract tests should cover the smallest deterministic version of:
+
+- first run
+- retry after partial failure
+- completed resume or repair rerun
+- idempotent skip
+- failure accounting for required side effects
+
+Do not report `completed`, `verified`, or `ok` when required side effects failed
+silently. Either make the side effect durable through an outbox or return a
+structured failure that keeps the workflow recoverable.
+
+Remote smoke tests should verify deployed wiring only. Core workflow invariants
+belong in local contract tests.

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -1,0 +1,196 @@
+{
+  "version": 1,
+  "checks": {
+    "no_large_tuple_results": {
+      "description": "High-risk workflow helpers should use named result objects instead of positional tuples with more than two fields.",
+      "allowlist": [
+        {
+          "path": "backend/utils/memory/legacy_backfill.py",
+          "function": "_bucket_counts_and_samples",
+          "reason": "Inventory helper; migrate when touching bucket reporting."
+        },
+        {
+          "path": "backend/utils/memory/legacy_backfill.py",
+          "function": "_sync_backfill_side_effects",
+          "reason": "Legacy contract from issue 8786; covered by backfill contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory/legacy_backfill.py",
+          "function": "_reconcile_backfill_side_effects_for_rows",
+          "reason": "Legacy contract from issue 8786; covered by backfill contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory/legacy_backfill.py",
+          "function": "reconcile_backfill_counts",
+          "reason": "Legacy contract from issue 8786; covered by backfill contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory/short_term_promotion.py",
+          "function": "promote_short_term_item_via_apply",
+          "reason": "Existing promotion apply contract; covered by short-term promotion contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory/short_term_promotion.py",
+          "function": "promote_working_item_to_long_term",
+          "reason": "Existing promotion contract; covered by short-term promotion contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory/product_authorization.py",
+          "function": "resolve_product_memory_authorization",
+          "reason": "Existing authorization contract; migrate separately."
+        },
+        {
+          "path": "backend/utils/memory_ingestion/pipeline.py",
+          "function": "_redact_input",
+          "reason": "Existing pipeline stage contract; covered by memory ingestion contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory_ingestion/pipeline.py",
+          "function": "_positive_secret_signals",
+          "reason": "Existing redaction signal contract; covered by memory ingestion contract tests until migrated."
+        },
+        {
+          "path": "backend/utils/memory_ingestion/pipeline.py",
+          "function": "_compile_mutations",
+          "reason": "Existing mutation compilation contract; covered by memory ingestion contract tests until migrated."
+        }
+      ]
+    }
+  },
+  "workflows": [
+    {
+      "id": "legacy_memory_backfill",
+      "risk": "high",
+      "sources": ["backend/utils/memory/legacy_backfill.py", "backend/scripts/backfill_legacy_memories.py"],
+      "tests": ["tests/unit/test_ws_c_backfill.py"],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "completed checkpoints still reconcile side effects",
+        "partial checkpoints resume idempotently",
+        "legacy/domain timestamps are preserved across operational side effects"
+      ]
+    },
+    {
+      "id": "canonical_memory_fanout",
+      "risk": "high",
+      "sources": ["backend/utils/memory/canonical_memory_adapter.py"],
+      "tests": [
+        "tests/unit/test_ws_i_write_convergence.py",
+        "tests/unit/test_ws_j_delete_privacy.py",
+        "tests/unit/test_canonical_kg_promotion.py"
+      ],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "domain writes use injected stores",
+        "derived keyword/vector/KG fanout is either durable or explicitly recoverable"
+      ]
+    },
+    {
+      "id": "sync_cloud_tasks",
+      "risk": "high",
+      "sources": ["backend/routers/sync.py", "backend/database/sync_jobs.py", "backend/utils/sync/*.py"],
+      "tests": ["tests/unit/test_sync_v2.py", "tests/unit/test_sync_cloud_tasks.py", "tests/unit/test_audio_merge_tasks.py"],
+      "checks": [],
+      "invariants": [
+        "task retries do not double-count usage or completed segments",
+        "segment failures cannot be reported as completed work"
+      ]
+    },
+    {
+      "id": "vector_repair_outbox",
+      "risk": "high",
+      "sources": [
+        "backend/database/memory_vector_repair_outbox.py",
+        "backend/database/memory_vector_repair_outbox_worker.py",
+        "backend/scripts/vector_repair_outbox_worker_entrypoint.py"
+      ],
+      "tests": [
+        "tests/unit/test_vector_repair_outbox_worker.py",
+        "tests/unit/test_vector_repair_outbox_infra.py"
+      ],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "leased work is recoverable after worker death",
+        "completed and dead-lettered work is never reclaimed"
+      ]
+    },
+    {
+      "id": "account_deletion_wipe",
+      "risk": "high",
+      "sources": ["backend/services/users/account_deletion.py", "backend/routers/users.py"],
+      "tests": [
+        "tests/services/users/test_account_deletion.py",
+        "tests/unit/test_claim_deletion_wipe_txn.py",
+        "tests/unit/test_delete_account_purge_storage.py"
+      ],
+      "checks": [],
+      "invariants": [
+        "irreversible auth deletion has a durable recovery marker",
+        "required derived-data purge failures cannot be marked completed"
+      ]
+    },
+    {
+      "id": "projection_repair",
+      "risk": "high",
+      "sources": ["backend/database/projection_repair.py"],
+      "tests": ["tests/unit/test_memory_ledger.py"],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "repair enqueue is idempotent",
+        "repair processing uses injected stores and has retry/dead-letter accounting"
+      ]
+    },
+    {
+      "id": "short_term_lifecycle",
+      "risk": "high",
+      "sources": [
+        "backend/jobs/short_term_lifecycle_worker.py",
+        "backend/utils/memory/short_term_promotion.py",
+        "backend/utils/memory/canonical_short_term_maintenance_cron.py"
+      ],
+      "tests": [
+        "tests/unit/test_short_term_lifecycle_firestore_store.py",
+        "tests/unit/test_ws_b_short_term_lifecycle.py",
+        "tests/unit/test_canonical_short_term_maintenance_cron.py"
+      ],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "promotion and maintenance reruns are idempotent",
+        "derived side-effect failures are accounted for"
+      ]
+    },
+    {
+      "id": "l2_promotion_worker",
+      "risk": "high",
+      "sources": ["backend/jobs/l2_promotion_worker.py", "backend/jobs/l2_promotion_orchestrator.py"],
+      "tests": ["tests/unit/test_l2_promotion_agent_v2.py"],
+      "checks": [],
+      "invariants": [
+        "forward and backfill modes have explicit gates",
+        "per-item failures are reported without corrupting later work"
+      ]
+    },
+    {
+      "id": "webhook_delivery_health",
+      "risk": "high",
+      "sources": ["backend/utils/webhooks.py", "backend/database/webhook_health.py"],
+      "tests": ["tests/unit/test_async_webhooks.py", "tests/unit/test_webhook_auto_disable.py"],
+      "checks": [],
+      "invariants": [
+        "delivery failures are counted durably",
+        "auto-disable state is endpoint-aware and race-safe"
+      ]
+    },
+    {
+      "id": "memory_ingestion_export_runner",
+      "risk": "high",
+      "sources": ["backend/utils/memory_ingestion/export_runner.py", "backend/utils/memory_ingestion/pipeline.py"],
+      "tests": ["tests/unit/test_memory_ingestion_pipeline.py", "tests/unit/test_production_like_memory_model.py"],
+      "checks": ["no_large_tuple_results"],
+      "invariants": [
+        "resume config mismatches fail closed",
+        "failed shards remain visible in run summaries"
+      ]
+    }
+  ]
+}

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -326,7 +326,7 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         account_deletion, 'delete_all_conversation_recordings', lambda uid: calls.append(('recordings', uid))
     )
 
-    account_deletion.purge_derived_user_data('uid1')
+    result = account_deletion.purge_derived_user_data('uid1')
 
     assert calls == [
         ('get_conversations', 'uid1'),
@@ -341,6 +341,7 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         ('delete_screen_vectors', 'uid1', ['s1']),
         ('recordings', 'uid1'),
     ]
+    assert result == {'required_failures': [], 'best_effort_failures': []}
 
 
 def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
@@ -359,7 +360,7 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
         account_deletion, 'delete_all_conversation_recordings', MagicMock(side_effect=Exception('gcs down'))
     )
 
-    account_deletion.purge_derived_user_data('uid1')
+    result = account_deletion.purge_derived_user_data('uid1')
 
     assert account_deletion.get_conversation_ids.call_count == 2
     account_deletion.delete_conversation_vectors_batch.assert_not_called()
@@ -368,6 +369,31 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     account_deletion.delete_action_item_vectors_batch.assert_called_once_with('uid1', ['a1'])
     account_deletion.delete_screen_activity_vectors.assert_called_once_with('uid1', ['s1'])
     account_deletion.delete_all_conversation_recordings.assert_called_once_with('uid1')
+    assert [failure['operation'] for failure in result['required_failures']] == [
+        'conversation_vectors',
+        'transcript_chunk_vectors',
+        'memory_vectors',
+    ]
+    assert [failure['operation'] for failure in result['best_effort_failures']] == ['conversation_recordings']
+
+
+def test_background_wipe_user_data_does_not_complete_when_required_derived_purge_fails(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock())
+    monkeypatch.setattr(
+        account_deletion,
+        'purge_derived_user_data',
+        MagicMock(return_value={'required_failures': [{'operation': 'memory_vectors', 'error': 'down'}]}),
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
+
+    account_deletion.background_wipe_user_data('uid1')
+
+    account_deletion.users_db.delete_user_data.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
 
 
 def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -137,6 +137,7 @@ if "utils.byok" not in sys.modules:
 
 if "utils.llm.gateway_client" not in sys.modules:
     gateway_mod = _stub_module("utils.llm.gateway_client")
+    gateway_mod.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
     gateway_mod.invoke_chat_structured_gateway = MagicMock(return_value=None)
     gateway_mod.record_chat_extraction_gateway_result = MagicMock()
 

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -26,6 +26,8 @@ def write_yaml(path: Path, payload: dict) -> None:
 
 def with_memory_env(payload: str) -> str:
     memory_env = '''\
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED", "value": "true"},
+        {"name": "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE", "value": "1.0"},
         {"name": "MEMORY_MODE", "value": "write"},
         {"name": "MEMORY_ENABLED_USERS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},
         {"name": "MEMORY_V3_GET_ENABLED", "value": "false"},

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -101,6 +101,7 @@ byok_stub.has_byok_keys = MagicMock(return_value=False)
 gateway_stub = _stub_module("utils.llm.gateway_client")
 gateway_stub.invoke_chat_structured_gateway = MagicMock(return_value=None)
 gateway_stub.record_chat_extraction_gateway_result = MagicMock()
+gateway_stub.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS = 35.0
 
 gateway_observability_stub = _stub_module("utils.llm.gateway_observability")
 gateway_observability_stub.record_gateway_shadow_comparison = MagicMock()

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -3,7 +3,8 @@
 Before the fix, _background_wipe_user_data only cleaned Twilio + Firestore, leaving the user's
 Pinecone vectors and GCS conversation recordings behind. The wipe now enumerates IDs (before the
 Firestore delete removes them) and purges Pinecone (conversations/memories/action-items/screen-
-activity) + recordings, each backend isolated so a failure never blocks the Firestore wipe.
+activity) + recordings. Required derived purge failures block the Firestore wipe so deleted
+Firestore IDs do not hide leftover vectors; best-effort recording failures do not block it.
 
 routers/users.py has a heavy import graph, so we install a meta-path finder that auto-stubs the
 database/utils/external namespaces, import routers.users, then drive _background_wipe_user_data
@@ -136,6 +137,12 @@ def _purge_patches(**overrides):
     patchers['delete_user_data'] = patch.object(
         users_service.users_db, 'delete_user_data', create=True, **(overrides.get('delete_user_data') or {})
     )
+    for name in (
+        'mark_user_deletion_wipe_running',
+        'mark_user_deletion_wipe_failed',
+        'mark_user_deletion_wipe_completed',
+    ):
+        patchers[name] = patch.object(users_service.users_db, name, create=True, **(overrides.get(name) or {}))
     started = {name: p.start() for name, p in patchers.items()}
     return patchers, started
 
@@ -176,16 +183,19 @@ def test_id_enumeration_happens_before_firestore_wipe():
     assert order == ['enumerate', 'enumerate', 'wipe'], order
 
 
-def test_pinecone_failure_does_not_block_recordings_or_firestore_wipe():
+def test_pinecone_failure_blocks_firestore_wipe_but_not_best_effort_recordings():
     patchers, m = _purge_patches(delete_conversation_vectors_batch={'side_effect': Exception('pinecone down')})
     try:
         users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
-    # one backend failing must not stop the rest or the Firestore wipe
+    # Required vector purge failure must not stop other derived purges, but it
+    # must block Firestore deletion because Firestore holds the retryable IDs.
     m['delete_memory_vectors_batch'].assert_called_once()
     m['delete_all_conversation_recordings'].assert_called_once_with('uid1')
-    m['delete_user_data'].assert_called_once_with('uid1')
+    m['delete_user_data'].assert_not_called()
+    m['mark_user_deletion_wipe_failed'].assert_called_with('uid1')
+    m['mark_user_deletion_wipe_completed'].assert_not_called()
 
 
 def test_gcs_failure_does_not_block_firestore_wipe():
@@ -198,13 +208,14 @@ def test_gcs_failure_does_not_block_firestore_wipe():
     m['delete_user_data'].assert_called_once_with('uid1')  # and the failure didn't block the wipe
 
 
-def test_enumeration_failure_is_isolated():
+def test_enumeration_failure_blocks_firestore_wipe():
     patchers, m = _purge_patches(get_conversation_ids={'side_effect': Exception('firestore read error')})
     try:
         users_service.background_wipe_user_data('uid1')
     finally:
         _stop(patchers)
-    # conversation enumeration blew up, but the other backends + the wipe still run
+    # conversation enumeration blew up, but the other backends still run
     m['delete_memory_vectors_batch'].assert_called_once_with('uid1', ['m1'])
     m['delete_all_conversation_recordings'].assert_called_once_with('uid1')
-    m['delete_user_data'].assert_called_once_with('uid1')
+    m['delete_user_data'].assert_not_called()
+    m['mark_user_deletion_wipe_failed'].assert_called_with('uid1')

--- a/backend/tests/unit/test_memory_ledger.py
+++ b/backend/tests/unit/test_memory_ledger.py
@@ -288,7 +288,76 @@ def test_append_commit_enqueues_projection_repairs(monkeypatch):
     assert queued == [('uid-1', commit)]
 
 
-def test_process_projection_repairs_applies_queued_vector_repairs(monkeypatch):
+def test_enqueue_projection_repairs_does_not_overwrite_terminal_replay_states():
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    commit = memory_ledger.build_commit(None, [memory_ledger.add_fact({'id': 'm1'})], commit_time=now)
+    repair_id = f"{commit['commit_id']}:m1"
+    path = f"users/uid-1/projection_repairs/{repair_id}"
+
+    class FakeSnapshot:
+        def __init__(self, data):
+            self.exists = data is not None
+            self._data = dict(data) if data is not None else None
+
+        def to_dict(self):
+            return dict(self._data) if self._data is not None else None
+
+    class FakeDocument:
+        def __init__(self, store, path):
+            self._store = store
+            self.path = path
+
+        def collection(self, name):
+            return FakeCollection(self._store, f"{self.path}/{name}")
+
+        def get(self):
+            return FakeSnapshot(self._store.get(self.path))
+
+        def set(self, data):
+            self._store[self.path] = dict(data)
+
+    class FakeCollection:
+        def __init__(self, store, path):
+            self._store = store
+            self.path = path
+
+        def document(self, doc_id):
+            return FakeDocument(self._store, f"{self.path}/{doc_id}")
+
+    class FakeBatch:
+        def __init__(self):
+            self.sets = []
+
+        def set(self, document_ref, data):
+            self.sets.append((document_ref, dict(data)))
+
+        def commit(self):
+            for document_ref, data in self.sets:
+                document_ref.set(data)
+
+    class FakeDB:
+        def __init__(self, initial):
+            self.store = dict(initial)
+            self.last_batch = None
+
+        def collection(self, name):
+            return FakeCollection(self.store, name)
+
+        def batch(self):
+            self.last_batch = FakeBatch()
+            return self.last_batch
+
+    for existing_status in ('queued', 'failed', 'repaired', 'dead_letter'):
+        fake_db = FakeDB({path: {'repair_id': repair_id, 'fact_id': 'm1', 'status': existing_status}})
+
+        repair_ids = projection_repair.enqueue_projection_repairs('uid-1', commit, firestore_client=fake_db)
+
+        assert repair_ids == [repair_id]
+        assert fake_db.last_batch.sets == []
+        assert fake_db.store[path]['status'] == existing_status
+
+
+def test_process_projection_repairs_applies_queued_vector_repairs():
     updates = []
 
     class FakeDoc:
@@ -325,14 +394,75 @@ def test_process_projection_repairs_applies_queued_vector_repairs(monkeypatch):
         def collection(self, value):
             return FakeCollection()
 
-    monkeypatch.setattr(projection_repair, 'db', FakeDB())
-
     result = projection_repair.process_projection_repairs(
         'uid-1',
         fact_loader=lambda fact_id: {'id': fact_id, 'invalid_at': datetime(2026, 6, 1, tzinfo=timezone.utc)},
         repair_func=lambda uid, fact: 'delete' if fact and fact.get('invalid_at') else 'upsert',
+        firestore_client=FakeDB(),
     )
 
     assert result == {'repaired': ['repair1'], 'failed': [], 'processed': 1}
     assert updates[0]['status'] == 'repaired'
     assert updates[0]['repair_action'] == 'delete'
+
+
+def test_process_projection_repairs_records_attempts_and_dead_letters_with_injected_client():
+    updates = []
+
+    class FakeDoc:
+        def __init__(self, repair_id, attempt_count):
+            self.id = repair_id
+            self._repair_id = repair_id
+            self._attempt_count = attempt_count
+
+        @property
+        def reference(self):
+            return self
+
+        def to_dict(self):
+            return {
+                'repair_id': self._repair_id,
+                'fact_id': 'm1',
+                'status': 'queued',
+                'attempt_count': self._attempt_count,
+            }
+
+        def update(self, payload):
+            updates.append((self._repair_id, payload))
+
+    class FakeQuery:
+        def limit(self, value):
+            return self
+
+        def stream(self):
+            return [FakeDoc('retry', 0), FakeDoc('dead', 2)]
+
+    class FakeCollection:
+        def document(self, value):
+            return self
+
+        def collection(self, value):
+            return self
+
+        def where(self, *args):
+            return FakeQuery()
+
+    class FakeDB:
+        def collection(self, value):
+            return FakeCollection()
+
+    result = projection_repair.process_projection_repairs(
+        'uid-1',
+        fact_loader=lambda fact_id: {'id': fact_id},
+        repair_func=lambda uid, fact: (_ for _ in ()).throw(RuntimeError('repair unavailable')),
+        firestore_client=FakeDB(),
+        max_attempts=3,
+    )
+
+    assert result == {'repaired': [], 'failed': ['retry', 'dead'], 'processed': 2}
+    assert updates[0][1]['status'] == 'failed'
+    assert updates[0][1]['attempt_count'] == 1
+    assert updates[0][1]['error'] == 'repair unavailable'
+    assert updates[1][1]['status'] == 'dead_letter'
+    assert updates[1][1]['attempt_count'] == 3
+    assert updates[1][1]['error'] == 'repair unavailable'

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1119,6 +1119,15 @@ class TestAsyncCoordinatorScenarios:
         assert 'isinstance(r, asyncio.TimeoutError)' in seg_early
         assert 'Segment timed out' in seg_early
 
+    def test_generic_segment_task_exception_captured(self):
+        """Generic segment task exceptions must be counted in segment_errors."""
+        body = self._get_bg_func_body()
+        seg_section = body[body.index('seg_results = await asyncio.gather') :]
+        seg_early = seg_section[:800]
+        assert 'elif isinstance(r, Exception):' in seg_early
+        assert 'segment_errors.append' in seg_early
+        assert 'Segment failed:' in seg_early
+
     def test_segment_errors_included_in_result(self):
         """segment_errors must be included in the final result sent to mark_job_completed."""
         body = self._get_bg_func_body()
@@ -1570,6 +1579,42 @@ class TestAsyncCoordinatorBehavioral:
             result = stubs['sync_jobs'].mark_job_completed.call_args[0][1]
             assert result['failed_segments'] == 1
             assert result['total_segments'] == 2
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_generic_segment_task_exception_counts_as_failed_segment(self):
+        """A task-level segment exception must not complete with failed_segments=0."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_one_segment(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg_1700000001.wav')
+
+            module.retrieve_vad_segments = _vad_one_segment
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.users_db.get_user_private_cloud_sync_enabled = MagicMock(return_value=False)
+            module.users_db.get_data_protection_level = MagicMock(return_value=None)
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module._reprocess_merged_conversations = MagicMock()
+            module.record_usage = MagicMock()
+            module.get_timestamp_from_path = MagicMock(return_value=1700000001)
+            module.sanitize = lambda value: value
+            module.process_segment = MagicMock(side_effect=RuntimeError('executor exploded'))
+
+            await module._run_full_pipeline_background_async(
+                'j-generic-segment-error', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job-generic'
+            )
+
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+            result = stubs['sync_jobs'].mark_job_completed.call_args[0][1]
+            assert result['failed_segments'] == 1
+            assert result['total_segments'] == 1
+            assert result['errors'] == ['Segment failed: executor exploded']
         finally:
             self._cleanup(stubs['saved_modules'])
 

--- a/backend/tests/unit/test_vector_repair_outbox_worker.py
+++ b/backend/tests/unit/test_vector_repair_outbox_worker.py
@@ -1,5 +1,14 @@
 from datetime import datetime, timezone
 import json
+import sys
+import types
+
+google_stub = sys.modules.setdefault("google", types.ModuleType("google"))
+cloud_stub = sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+firestore_stub = sys.modules.setdefault("google.cloud.firestore", types.ModuleType("google.cloud.firestore"))
+firestore_stub.transactional = lambda func: func
+google_stub.cloud = cloud_stub
+cloud_stub.firestore = firestore_stub
 
 from database.memory_vector_repair_pinecone_adapter import (
     VECTOR_REPAIR_PINECONE_NAMESPACE,
@@ -126,7 +135,8 @@ class _FakeQuery:
         if op == "==":
             return data.get(field) == value
         if op == "<=":
-            return data.get(field) <= value
+            field_value = data.get(field)
+            return field_value is not None and field_value <= value
         raise AssertionError(f"unexpected op {op}")
 
 
@@ -380,6 +390,81 @@ class TestWorkerCore:
         assert db.store["users/u1/memory_outbox/available"]["status"] == "completed"
         assert db.store["users/u1/memory_outbox/available"]["action"] == "repair"
         assert db.store["users/u1/memory_outbox/available"]["updated_at"] == now.isoformat()
+
+    def test_firestore_reader_reclaims_expired_in_progress_lease_after_expiry_only(self):
+        now = datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc)
+        before_expiry = datetime(2026, 6, 19, 11, 59, tzinfo=timezone.utc)
+        after_expiry = datetime(2026, 6, 19, 12, 1, tzinfo=timezone.utc)
+        path = "users/u1/memory_outbox/expired-lease"
+        db = _FakeFirestore(
+            {
+                path: _record(
+                    record_id="expired-lease",
+                    outbox_path=path,
+                    status="in_progress",
+                    available_at=before_expiry.isoformat(),
+                    lease_owner="old-worker",
+                    lease_expires_at=now.isoformat(),
+                )
+            }
+        )
+
+        not_yet = lease_vector_repair_purge_outbox_records(
+            db_client=db,
+            uid="u1",
+            worker_id="worker-a",
+            limit=10,
+            lease_seconds=30,
+            now=before_expiry,
+        )
+        reclaimed = lease_vector_repair_purge_outbox_records(
+            db_client=db,
+            uid="u1",
+            worker_id="worker-b",
+            limit=10,
+            lease_seconds=30,
+            now=after_expiry,
+        )
+
+        assert not_yet == []
+        assert [record["record_id"] for record in reclaimed] == ["expired-lease"]
+        assert reclaimed[0]["status"] == "pending"
+        assert db.store[path]["status"] == "in_progress"
+        assert db.store[path]["lease_owner"] == "worker-b"
+        assert db.store[path]["leased_at"] == after_expiry.isoformat()
+
+    def test_firestore_reader_never_reclaims_completed_or_dead_letter_records(self):
+        now = datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc)
+        expired = datetime(2026, 6, 19, 11, 0, tzinfo=timezone.utc).isoformat()
+        db = _FakeFirestore(
+            {
+                "users/u1/memory_outbox/completed": _record(
+                    record_id="completed",
+                    status="completed",
+                    available_at=expired,
+                    lease_expires_at=expired,
+                ),
+                "users/u1/memory_outbox/dead": _record(
+                    record_id="dead",
+                    status="dead_letter",
+                    available_at=expired,
+                    lease_expires_at=expired,
+                ),
+            }
+        )
+
+        leased = lease_vector_repair_purge_outbox_records(
+            db_client=db,
+            uid="u1",
+            worker_id="worker-a",
+            limit=10,
+            lease_seconds=30,
+            now=now,
+        )
+
+        assert leased == []
+        assert db.store["users/u1/memory_outbox/completed"]["status"] == "completed"
+        assert db.store["users/u1/memory_outbox/dead"]["status"] == "dead_letter"
 
     def test_firestore_reader_claim_uses_transaction_when_client_supports_it(self):
         now = datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc)

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -1,0 +1,68 @@
+import importlib.util
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _load_script(name: str):
+    path = BACKEND_DIR / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_workflow_contract_sources_select_adjacent_tests():
+    selector = _load_script("select_backend_unit_tests")
+    all_tests = selector.discover_all_tests()
+
+    cases = {
+        "backend/utils/memory/legacy_backfill.py": "tests/unit/test_ws_c_backfill.py",
+        "backend/database/memory_vector_repair_outbox_worker.py": "tests/unit/test_vector_repair_outbox_worker.py",
+        "backend/database/projection_repair.py": "tests/unit/test_memory_ledger.py",
+        "backend/services/users/account_deletion.py": "tests/services/users/test_account_deletion.py",
+        "backend/routers/sync.py": "tests/unit/test_sync_v2.py",
+        "backend/jobs/short_term_lifecycle_worker.py": "tests/unit/test_ws_b_short_term_lifecycle.py",
+        "backend/utils/webhooks.py": "tests/unit/test_async_webhooks.py",
+        "backend/utils/memory_ingestion/export_runner.py": "tests/unit/test_memory_ingestion_pipeline.py",
+    }
+
+    for source_path, expected_test in cases.items():
+        selected, reason = selector.tests_for_changed_paths([source_path], all_tests)
+        assert expected_test in selected, source_path
+        assert reason == "selected backend unit tests from changed paths and workflow contracts"
+
+
+def test_workflow_contracts_static_check_accepts_current_allowlist():
+    checker = _load_script("check_workflow_contracts")
+    contracts = checker.load_contracts()
+
+    assert checker.check_no_large_tuple_results(contracts) == []
+
+
+def test_workflow_contracts_static_check_rejects_unlisted_large_tuple_result(tmp_path, monkeypatch):
+    checker = _load_script("check_workflow_contracts")
+    fake_repo = tmp_path / "repo"
+    fake_repo.mkdir()
+    fake_source = fake_repo / "backend" / "utils" / "memory" / "new_workflow.py"
+    fake_source.parent.mkdir(parents=True)
+    fake_source.write_text("def bad_contract() -> tuple[int, int, int]:\n    return 1, 2, 3\n")
+
+    monkeypatch.setattr(checker, "REPO_DIR", fake_repo)
+    contracts = {
+        "checks": {"no_large_tuple_results": {"allowlist": []}},
+        "workflows": [
+            {
+                "risk": "high",
+                "sources": ["backend/utils/memory/new_workflow.py"],
+                "tests": ["tests/unit/test_new_workflow.py"],
+                "checks": ["no_large_tuple_results"],
+            }
+        ],
+    }
+
+    errors = checker.check_no_large_tuple_results(contracts)
+
+    assert len(errors) == 1
+    assert "bad_contract returns a positional tuple with 3 fields" in errors[0]

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -433,7 +433,7 @@ def test_retract_calls_kg_invalidation_hook(monkeypatch, canonical_db):
     kg_calls = []
     monkeypatch.setattr(
         "utils.memory.canonical_memory_adapter.invalidate_kg_for_memory_retraction",
-        lambda u, ids, **kwargs: kg_calls.append((u, list(ids))),
+        lambda u, ids, **kwargs: kg_calls.append((u, list(ids), kwargs.get("db_client"))),
     )
 
     write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
@@ -441,6 +441,7 @@ def test_retract_calls_kg_invalidation_hook(monkeypatch, canonical_db):
     assert kg_calls
     assert kg_calls[0][0] == uid
     assert payload["id"] in kg_calls[0][1]
+    assert kg_calls[0][2] is canonical_db
 
 
 def test_delete_canonical_memory_calls_kg_invalidation_hook(monkeypatch, canonical_db):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -759,7 +759,7 @@ def retract_conversation_sourced_memories(uid: str, conversation_id: str, *, db_
         retracted_ids.append(item.memory_id)
 
     bumped_control = _bump_source_generation(uid, db_client=client)
-    invalidate_kg_for_memory_retraction(uid, retracted_ids)
+    invalidate_kg_for_memory_retraction(uid, retracted_ids, db_client=client)
 
     return {
         "retracted_memory_ids": retracted_ids,

--- a/desktop/macos/changelog/unreleased/20260702-workflow-contract-harness.json
+++ b/desktop/macos/changelog/unreleased/20260702-workflow-contract-harness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop local test harness validation for development builds."
+}

--- a/desktop/macos/changelog/unreleased/20260702-workflow-contract-harness.json
+++ b/desktop/macos/changelog/unreleased/20260702-workflow-contract-harness.json
@@ -1,3 +1,0 @@
-{
-  "change": "Improved desktop local test harness validation for development builds."
-}

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -22,15 +22,21 @@ chat content. Do not attach or publish a run directory unless you have reviewed 
 
 ## Usage
 
+From the repo root, start the local dev harness and launch a named desktop
+bundle against localhost services:
+
 ```bash
-cd desktop/macos
-OMI_SKIP_STALE_BUNDLE_SCAN=1 OMI_APP_NAME=omi-harness-test OMI_AUTOMATION_PORT=47888 ./run.sh --yolo
+make dev-up
+make desktop-run-local DESKTOP_APP_NAME=omi-harness-test
 ```
 
-In another shell:
+In another shell, run the experience harness from `desktop/macos`. Version 1
+flows are legacy-compatible and require an explicit opt-in:
 
 ```bash
-python3 scripts/omi-harness run e2e/flows/harness-smoke.yaml --lane visual --port 47888
+cd desktop/macos
+python3 scripts/omi-harness run e2e/flows/harness-smoke.yaml \
+  --allow-legacy-flow-version --lane visual
 python3 scripts/omi-harness summarize latest
 python3 scripts/omi-harness latest
 python3 scripts/omi-harness compare <before-run> <after-run> --markdown
@@ -42,7 +48,7 @@ bundle process:
 
 ```bash
 python3 scripts/omi-harness run e2e/flows/ask-omi-chat-power-benchmark.yaml \
-  --port 47888 \
+  --allow-legacy-flow-version \
   --process-match "/Applications/omi-harness-test.app/Contents/MacOS/Omi Computer"
 ```
 
@@ -50,7 +56,7 @@ For `ui` lane AX assertions, pass the named bundle id:
 
 ```bash
 python3 scripts/omi-harness run e2e/flows/harness-smoke.yaml \
-  --lane ui --port 47888 --bundle-id com.omi.omi-harness-test
+  --allow-legacy-flow-version --lane ui --bundle-id com.omi.omi-harness-test
 ```
 
 ## Typed Steps

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -22,6 +22,7 @@ import typing
 
 
 SCHEMA_VERSION = 2
+MIN_COMPATIBLE_FLOW_VERSION = 1
 SCRIPT_DIR = Path(__file__).resolve().parent
 DESKTOP_DIR = SCRIPT_DIR.parent
 DEFAULT_PORT = int(os.environ.get("OMI_AUTOMATION_PORT", "47777"))
@@ -64,6 +65,31 @@ def read_yaml(path: Path) -> dict[str, typing.Any]:
 
     with path.open("r", encoding="utf-8") as handle:
         return yaml.safe_load(handle) or {}
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def validate_flow_schema(flow: dict[str, typing.Any], args: argparse.Namespace) -> int:
+    raw_version = flow.get("version")
+    if isinstance(raw_version, bool) or not isinstance(raw_version, int):
+        raise SystemExit("omi-harness: flow version must be an integer")
+    if raw_version > SCHEMA_VERSION:
+        raise SystemExit(
+            f"omi-harness: flow schema version {raw_version} is newer than supported version {SCHEMA_VERSION}"
+        )
+    if raw_version < MIN_COMPATIBLE_FLOW_VERSION:
+        raise SystemExit(
+            f"omi-harness: flow schema version {raw_version} is older than compatible version "
+            f"{MIN_COMPATIBLE_FLOW_VERSION}"
+        )
+    if raw_version < SCHEMA_VERSION and not getattr(args, "allow_legacy_flow_version", False):
+        raise SystemExit(
+            f"omi-harness: flow schema version {raw_version} requires explicit compatibility; "
+            "pass --allow-legacy-flow-version or set OMI_HARNESS_ALLOW_LEGACY_FLOW_VERSION=1"
+        )
+    return raw_version
 
 
 def write_json(path: Path, data: typing.Any) -> None:
@@ -677,6 +703,7 @@ def unique_run_dir(run_root: Path, timestamp: str, flow_name: str) -> Path:
 def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing.Any]]:
     flow_path = Path(args.flow).resolve()
     flow = read_yaml(flow_path)
+    flow_version = validate_flow_schema(flow, args)
     flow_name = str(flow.get("name") or flow_path.stem)
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     run_root = Path(args.out).resolve()
@@ -710,7 +737,7 @@ def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing
         "schema_version": SCHEMA_VERSION,
         "runner": "omi-harness",
         "runner_version": 2,
-        "flow": {"name": flow_name, "path": str(flow_path), "version": flow.get("version")},
+        "flow": {"name": flow_name, "path": str(flow_path), "version": flow_version},
         "environment": {
             "git_sha": git_sha(),
             "lane": args.lane,
@@ -1008,6 +1035,12 @@ def add_run_args(parser: argparse.ArgumentParser) -> None:
         "--process-match",
         default=os.environ.get("OMI_HARNESS_PROCESS_MATCH"),
         help="unique pgrep pattern for power.sample steps",
+    )
+    parser.add_argument(
+        "--allow-legacy-flow-version",
+        action="store_true",
+        default=env_flag("OMI_HARNESS_ALLOW_LEGACY_FLOW_VERSION"),
+        help="explicitly allow compatible flows older than the current harness schema",
     )
 
 

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -10,6 +10,7 @@ cd "$SCRIPT_DIR"
 bash tests/test-app-config.sh
 bash tests/test-settings-seed.sh
 bash tests/test-cleanup-omi-tcc.sh
+bash tests/test-omi-harness.sh
 echo ""
 
 echo "=== Rust Backend Tests ==="

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HARNESS="$MACOS_DIR/scripts/omi-harness"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+write_flow() {
+  local path="$1" version="$2"
+  cat >"$path" <<YAML
+version: $version
+name: schema-$version
+steps: []
+YAML
+}
+
+write_flow "$TMPDIR/future.yaml" 3
+if "$HARNESS" run "$TMPDIR/future.yaml" --out "$TMPDIR/runs" >/tmp/omi-harness-future.out 2>/tmp/omi-harness-future.err; then
+  fail "future schema unexpectedly succeeded"
+fi
+if ! grep -q "newer than supported version 2" /tmp/omi-harness-future.err; then
+  fail "future schema error did not mention supported version"
+fi
+
+write_flow "$TMPDIR/legacy.yaml" 1
+if "$HARNESS" run "$TMPDIR/legacy.yaml" --out "$TMPDIR/runs" >/tmp/omi-harness-legacy.out 2>/tmp/omi-harness-legacy.err; then
+  fail "legacy schema unexpectedly succeeded without explicit compatibility"
+fi
+if ! grep -q "requires explicit compatibility" /tmp/omi-harness-legacy.err; then
+  fail "legacy schema error did not mention explicit compatibility"
+fi
+
+if "$HARNESS" run "$TMPDIR/legacy.yaml" --allow-legacy-flow-version --out "$TMPDIR/runs" \
+    --port 9 >/tmp/omi-harness-legacy-opt-in.out 2>/tmp/omi-harness-legacy-opt-in.err; then
+  fail "legacy opt-in unexpectedly passed against closed bridge port"
+fi
+if grep -q "requires explicit compatibility" /tmp/omi-harness-legacy-opt-in.err; then
+  fail "legacy opt-in was still rejected by schema compatibility gate"
+fi
+
+echo "omi-harness schema tests passed"

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -16,6 +16,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if ! python3 - <<'PY' >/dev/null 2>&1
+import yaml
+PY
+then
+  echo "omi-harness schema tests skipped: PyYAML is not installed"
+  exit 0
+fi
+
 write_flow() {
   local path="$1" version="$2"
   cat >"$path" <<YAML

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -240,6 +240,19 @@ check_backend_async_blockers_if_needed() {
     --fail-on high_network_io,async_helpers_with_blocking,time_sleep,mixed_await_sync_db,no_await_should_be_def
 }
 
+check_backend_workflow_contracts_if_needed() {
+  if [ "${PRE_PUSH_SKIP_BACKEND_WORKFLOW_CONTRACTS:-}" = "1" ]; then
+    echo "Skipping backend workflow contract checks because PRE_PUSH_SKIP_BACKEND_WORKFLOW_CONTRACTS=1."
+    return
+  fi
+
+  if ! changed_matches 'backend/*.py' 'backend/**/*.py' 'backend/testing/workflow_contracts.json'; then
+    return
+  fi
+
+  python3 backend/scripts/check_workflow_contracts.py --changed-files "$CHANGED_FILES_LIST"
+}
+
 check_backend_unit_tests_if_needed() {
   local selected_count
   local original_selected_count
@@ -450,6 +463,7 @@ fi
 run_step python3 .github/scripts/check-desktop-prod-promotion-policy.py
 run_step check_backend_runtime_env_if_needed
 run_step check_backend_async_blockers_if_needed
+run_step check_backend_workflow_contracts_if_needed
 run_step check_backend_unit_tests_if_needed
 run_step check_openapi_contract_if_needed
 run_step check_workflows_if_needed


### PR DESCRIPTION
## Summary
- Add a local workflow-contract manifest for 10 high-risk backend workflows and wire it into backend test selection plus pre-push static checks.
- Add a static gate for high-risk workflow helpers that prevents new large positional tuple result contracts unless explicitly allowlisted with a migration reason.
- Fix representative footguns found while applying the pattern: recover expired vector repair leases, preserve projection repair retry/dead-letter state, fail account deletion on required derived-data purge failures, count generic sync segment exceptions, and preserve injected stores in canonical KG invalidation.
- Tighten local harness defaults for future agents: app tests no longer silently default to prod API, desktop harness docs point at local dev flow, and desktop harness schema validation rejects incompatible flow files by default.

## Why this shape
Issue #8786 is a symptom of a broader class: risky workflows encode operational contracts in scattered code paths, but agents only discover the right tests after something breaks. This PR makes the contracts named and local:

- `backend/testing/workflow_contracts.json` names the workflow, source files, adjacent tests, static checks, and invariants.
- `backend/scripts/select_backend_unit_tests.py` automatically includes workflow tests when a source changes.
- `scripts/pre-push` runs the static workflow-contract check before backend tests.
- `AGENTS.md` tells future agents to add new high-risk workflows to the manifest with local contract tests.

## Representative workflows covered
- `legacy_memory_backfill`
- `canonical_memory_fanout`
- `sync_cloud_tasks`
- `vector_repair_outbox`
- `account_deletion_wipe`
- `projection_repair`
- `short_term_lifecycle`
- `l2_promotion_worker`
- `webhook_delivery_health`
- `memory_ingestion_export_runner`

## Validation
- `python3 backend/scripts/check_workflow_contracts.py`
- `backend/test-preflight.sh` with `PYTHON=.venv/bin/python`: 17 passed, 8 optional warnings, 0 failed
- focused backend contract tests: account deletion, storage purge, sync v2, vector repair, memory ledger, workflow contracts, privacy fanout, action item/date harness stubs, conversation timezone harness stub
- `backend/test.sh` with `PYTHON=.venv/bin/python BACKEND_PYTEST_XDIST=auto BACKEND_PYTEST_WORKERS=auto`: selected 421 backend unit test files and passed
- desktop harness checks: `bash desktop/macos/tests/test-omi-harness.sh`, `py_compile desktop/macos/scripts/omi-harness`, shell syntax checks
- `scripts/pre-push origin` with `PYTHON=/Users/dazheng/.codex/worktrees/a03d/omi/backend/.venv/bin/python`: passed

## Notes
- Pre-push still reports existing advisory architecture warnings for large/long files in `backend/routers/sync.py`, `backend/tests/unit/test_sync_v2.py`, `backend/tests/unit/test_vector_repair_outbox_worker.py`, and `backend/utils/memory/canonical_memory_adapter.py`; these are warnings, not blocking findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

