### PR TITLE
Validate canonical memory item writes

### DIFF
--- a/backend/models/product_memory.py
+++ b/backend/models/product_memory.py
@@ -135,6 +135,13 @@ class MemoryItem(BaseModel):
             raise ValueError("required fields must not be blank")
         return value
 
+    @field_validator("visibility")
+    @classmethod
+    def validate_visibility(cls, value: str) -> str:
+        if value not in {"private", "public", "shared"}:
+            raise ValueError("visibility must be private, public, or shared")
+        return value
+
     @field_validator("version")
     @classmethod
     def validate_version(cls, value: int) -> int:

--- a/backend/tests/unit/test_product_memory_items.py
+++ b/backend/tests/unit/test_product_memory_items.py
@@ -46,6 +46,15 @@ def _item(memory_id: str, **overrides) -> MemoryItem:
     return MemoryItem(**base)
 
 
+def test_memory_item_rejects_unknown_visibility():
+    try:
+        _item('bad-visibility', visibility='friends')
+    except ValueError as exc:
+        assert 'visibility' in str(exc)
+    else:
+        raise AssertionError('expected unknown visibility to be rejected')
+
+
 def test_default_product_memory_reads_include_fresh_short_term_and_exclude_stale_with_lifecycle_audit():
     fresh = _item('fresh-short')
     stale = _item(

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -72,6 +72,7 @@ from utils.memory.canonical_memory_adapter import (
     neutral_vector_id_for_memory,
     purge_canonical_derived_user_data,
     retract_conversation_sourced_memories,
+    update_canonical_memory_visibility,
     write_canonical_extraction_memory,
 )
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
@@ -465,6 +466,26 @@ def test_delete_canonical_memory_calls_kg_invalidation_hook(monkeypatch, canonic
     assert kg_calls == [(uid, [memory_id])]
     tombstoned = canonical_db.docs[f"users/{uid}/memory_items/{memory_id}"]
     assert tombstoned["status"] == MemoryItemStatus.tombstoned.value
+
+
+def test_update_canonical_visibility_validates_before_persisting(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    payload = _sample_memory_payload(uid=uid, conversation_id="conv-invalid-visibility", content="Visibility invariant")
+    memory_id = payload["id"]
+
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+
+    write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+    item_path = f"users/{uid}/memory_items/{memory_id}"
+    before = dict(canonical_db.docs[item_path])
+
+    with pytest.raises(ValueError, match="visibility"):
+        update_canonical_memory_visibility(uid, memory_id, "friends", db_client=canonical_db)
+
+    assert canonical_db.docs[item_path] == before
 
 
 def test_delete_all_canonical_memories_batches_kg_invalidation(monkeypatch, canonical_db):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -436,8 +436,15 @@ def _apply_product_metadata(item: MemoryItem, metadata: Dict[str, Any]) -> Memor
 
 
 def _persist_memory_item(uid: str, item: MemoryItem, *, db_client) -> None:
+    item = MemoryItem.model_validate(item.model_dump(mode="python"))
     path = f"{MemoryCollections(uid=uid).memory_items}/{item.memory_id}"
     db_client.document(path).set(item.model_dump(mode="json"))
+
+
+def _validated_memory_item_copy(item: MemoryItem, updates: Dict[str, Any]) -> MemoryItem:
+    payload = item.model_dump(mode="python")
+    payload.update(updates)
+    return MemoryItem.model_validate(payload)
 
 
 def _evidence_items_from_payload(data: Dict[str, Any]) -> List[MemoryEvidence]:
@@ -616,22 +623,21 @@ def update_canonical_memory_content(uid: str, memory_id: str, content: str, *, d
     if not trimmed:
         raise ValueError("canonical update requires non-empty content")
     now = datetime.now(timezone.utc)
-    updated = item.model_copy(update={"content": trimmed, "updated_at": now, "user_asserted": True})
-    item_path = f"{MemoryCollections(uid=uid).memory_items}/{memory_id}"
-    client.document(item_path).set(updated.model_dump(mode="json"))
+    updated = _validated_memory_item_copy(item, {"content": trimmed, "updated_at": now, "user_asserted": True})
+    _persist_memory_item(uid, updated, db_client=client)
     if (
         updated.tier == MemoryLayer.long_term
         and getattr(updated, "kg_extracted", False)
         and resolve_memory_system(uid, db_client=client) == MemorySystem.CANONICAL
     ):
         invalidate_kg_for_memory_retraction(uid, [memory_id], db_client=client)
-        updated = updated.model_copy(update={"kg_extracted": False})
-        client.document(item_path).set({"kg_extracted": False, "updated_at": now}, merge=True)
+        updated = _validated_memory_item_copy(updated, {"kg_extracted": False, "updated_at": now})
+        _persist_memory_item(uid, updated, db_client=client)
         from utils.memory.canonical_kg_promotion import extract_kg_for_promoted_memory
 
         kg_result = extract_kg_for_promoted_memory(uid, updated, db_client=client)
         if kg_result.success:
-            updated = updated.model_copy(update={"kg_extracted": True})
+            updated = _validated_memory_item_copy(updated, {"kg_extracted": True})
     sync_atom_keyword_index_for_item(updated, db_client=client)
     sync_canonical_memory_vector(updated)
     return updated
@@ -643,8 +649,8 @@ def update_canonical_memory_visibility(uid: str, memory_id: str, visibility: str
     if item is None:
         raise ValueError(f"canonical memory not found: {memory_id}")
     now = datetime.now(timezone.utc)
-    updated = item.model_copy(update={"visibility": visibility, "updated_at": now})
-    client.document(f"{MemoryCollections(uid=uid).memory_items}/{memory_id}").set(updated.model_dump(mode="json"))
+    updated = _validated_memory_item_copy(item, {"visibility": visibility, "updated_at": now})
+    _persist_memory_item(uid, updated, db_client=client)
     return updated
 
 
@@ -657,7 +663,7 @@ def update_canonical_memory_review(uid: str, memory_id: str, value: bool, *, db_
     promotion = dict(item.promotion or {})
     promotion["reviewed"] = True
     promotion["user_review"] = value
-    updated = item.model_copy(update={"promotion": promotion, "updated_at": now})
+    updated = _validated_memory_item_copy(item, {"promotion": promotion, "updated_at": now})
     _persist_memory_item(uid, updated, db_client=client)
     return updated
 
@@ -682,7 +688,7 @@ def update_canonical_memory_product_fields(
     if not metadata:
         return item
     now = datetime.now(timezone.utc)
-    updated = _apply_product_metadata(item, metadata).model_copy(update={"updated_at": now})
+    updated = _validated_memory_item_copy(_apply_product_metadata(item, metadata), {"updated_at": now})
     _persist_memory_item(uid, updated, db_client=client)
     return updated
 
@@ -716,16 +722,17 @@ def _tombstone_memory_item(uid: str, item: MemoryItem, *, db_client, reason: str
         if ev_ref.get().exists:
             ev_ref.set(next_evidence.model_dump(mode="json"))
 
-    updated_item = item.model_copy(
-        update={
+    updated_item = _validated_memory_item_copy(
+        item,
+        {
             "status": MemoryItemStatus.tombstoned,
             "source_state": SourceState.tombstoned,
             "content": None,
             "evidence": tombstoned_evidence,
             "updated_at": now,
-        }
+        },
     )
-    db_client.document(f"{collections.memory_items}/{item.memory_id}").set(updated_item.model_dump(mode="json"))
+    _persist_memory_item(uid, updated_item, db_client=db_client)
 
     purge_candidates = [
         {


### PR DESCRIPTION
## Summary
- add model-level validation for canonical memory visibility values
- add validated copy/persist helpers for canonical memory item mutations in `canonical_memory_adapter`
- route content, visibility, review, product metadata, and tombstone writes through validation before Firestore persistence
- add regression tests proving invalid visibility is rejected and invalid adapter updates do not mutate stored canonical docs

## Context
This is the second focused PR from `.coordination/memory-canonical-hardening-backlog.md` Issue 2: validation-on-write for canonical memory items.

Work log:
- owner: side-conversation assistant
- worktree: `/Users/dazheng/.codex/worktrees/memory-issue2-validation`
- branch: `codex/memory-issue2-validated-writes`

Scope cap:
- This PR does not convert every canonical writer in the repo.
- It hardens the highest-risk adapter mutation/tombstone paths first, so `model_copy(update=...)` cannot silently persist invalid `MemoryItem` state there.

## Tests
- `cd backend && pytest tests/unit/test_product_memory_items.py -q`
- `cd backend && pytest tests/unit/test_ws_j_delete_privacy.py -q`
- `cd backend && pytest tests/unit/test_canonical_kg_promotion.py -q`
- `cd backend && pytest tests/unit/test_memory_service_parity.py -q`
- `cd backend && pytest tests/unit/test_product_memory_read_service.py -q`
- `cd backend && python -m py_compile models/product_memory.py utils/memory/canonical_memory_adapter.py tests/unit/test_product_memory_items.py tests/unit/test_ws_j_delete_privacy.py`
- pre-push fast checks passed, including selected backend unit tests and OpenAPI contract check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

