### PR TITLE
Always mirror id into MemoryDB memory_id alias

### DIFF
--- a/backend/models/memories.py
+++ b/backend/models/memories.py
@@ -570,10 +570,11 @@ class MemoryDB(Memory):
 
     def __init__(self, **data):
         super().__init__(**data)
-        # Deprecated alias for legacy clients: mirror `id` only. Do not copy
-        # `conversation_id` — that produces id/memory_id conflicts on desktop.
-        if self.memory_id is None:
-            self.memory_id = self.id
+        # Deprecated alias for legacy clients: always mirror `id`. Older code stored
+        # `memory_id = conversation_id` on the doc; serving that stored value makes
+        # desktop's ServerMemory decoder reject the whole memories list, so the alias
+        # must be normalized here rather than trusted from Firestore.
+        self.memory_id = self.id
 
     @property
     def is_active(self) -> bool:

--- a/backend/tests/unit/test_memorydb_memory_id_alias.py
+++ b/backend/tests/unit/test_memorydb_memory_id_alias.py
@@ -1,4 +1,4 @@
-"""MemoryDB ``memory_id`` alias: mirrors ``id`` only, not ``conversation_id``."""
+"""MemoryDB ``memory_id`` alias: always mirrors ``id``, never a stored legacy value."""
 
 import os
 import sys
@@ -60,13 +60,20 @@ def test_legacy_id_only_row_sets_memory_id_from_id():
     assert serialized["memory_id"] == "legacy-mem-only"
 
 
-def test_explicit_memory_id_is_not_overwritten():
+def test_stored_legacy_memory_id_is_normalized_to_id():
+    # Docs written while `memory_id = conversation_id` was live carry a stored
+    # mismatched alias; serving it verbatim makes desktop reject the whole
+    # memories list (ServerMemory throws on id != memory_id).
     memory = MemoryDB(
         **_minimal_payload(
             id="mem_primary",
-            memory_id="mem_explicit",
-            conversation_id="conv_other",
+            memory_id="conv_legacy_ref",
+            conversation_id="conv_legacy_ref",
         )
     )
 
-    assert memory.memory_id == "mem_explicit"
+    assert memory.memory_id == "mem_primary"
+
+    serialized = memory.model_dump(mode="json")
+    assert serialized["memory_id"] == "mem_primary"
+    assert serialized["conversation_id"] == "conv_legacy_ref"


### PR DESCRIPTION
## Problem
Desktop v0.11.582 ships a strict `ServerMemory` decoder that rejects rows where `id != memory_id`. Legacy memory docs (written while the old `self.memory_id = self.conversation_id` mirror was live) store a mismatched `memory_id`, and the backend serves the stored value verbatim — so **one legacy row blanks the user's entire Memories page** (home count 0, "Failed to Load Memories").

Measured blast radius on one long-time account: **5,336 of 17,031** memory docs carry the mismatched stored alias (written 2025-05 → 2026-06-30).

## Fix
Normalize the deprecated alias at serialization: `memory_id` always mirrors `id` instead of trusting the stored Firestore field. No migration needed; fixes every affected user at read time, including clients already on v0.11.582.

Safety: Flutter reads only `conversation_id` (never `memory_id`); desktop expects `memory_id == id`. `conversation_id` is stored separately on these docs, so no linkage is lost.

## Tests
- Updated `test_memorydb_memory_id_alias.py`: stored legacy mismatched alias is normalized to `id` (the old test asserted the buggy passthrough behavior).
- `tests/unit/test_memories_batch.py`, `test_memory_category_auto.py`, alias tests: 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

