### PR TITLE
Make desktop harness schema test self-contained

### DIFF
--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -16,13 +16,26 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if ! python3 - <<'PY' >/dev/null 2>&1
-import yaml
+cat >"$TMPDIR/yaml.py" <<'PY'
+def safe_load(handle):
+    data = {}
+    for raw_line in handle.read().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value == "[]":
+            parsed = []
+        else:
+            try:
+                parsed = int(value)
+            except ValueError:
+                parsed = value
+        data[key.strip()] = parsed
+    return data
 PY
-then
-  echo "omi-harness schema tests skipped: PyYAML is not installed"
-  exit 0
-fi
+export PYTHONPATH="$TMPDIR${PYTHONPATH:+:$PYTHONPATH}"
 
 write_flow() {
   local path="$1" version="$2"


### PR DESCRIPTION
## Summary
- Make `desktop/macos/tests/test-omi-harness.sh` self-contained by providing a tiny test-local YAML parser stub.
- Keeps the schema rejection and legacy opt-in checks exercised even when PyYAML is absent from a clean desktop test environment.

## Validation
- `bash desktop/macos/tests/test-omi-harness.sh`
- `PRE_PUSH_SKIP_DESKTOP_CHANGELOG=1 scripts/pre-push origin`
- push hook passed with desktop Rust/tool-surface checks

## Notes
- Internal-only desktop test harness change; `no-changelog-needed` applies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

