### PR TITLE
fix(desktop): Gmail import deadlock on large mailboxes (#8797)

### DIFF
--- a/desktop/macos/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/macos/Desktop/Sources/GmailReaderService.swift
@@ -764,18 +764,56 @@ actor GmailReaderService {
     process.standardOutput = pipe
     process.standardError = errPipe
 
+    // Drain pipes asynchronously to avoid deadlock: the helper prints the full
+    // JSON payload for up to 300 emails to stdout, which can exceed the pipe
+    // buffer. waitUntilExit() blocks if the child blocks in write() on a full
+    // buffer, so read concurrently instead of after exit. (mirrors CalendarReaderService)
+    var outputData = Data()
+    var errData = Data()
+    let outputSem = DispatchSemaphore(value: 0)
+    let errSem = DispatchSemaphore(value: 0)
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+      let d = handle.availableData
+      if d.isEmpty {
+        pipe.fileHandleForReading.readabilityHandler = nil
+        outputSem.signal()
+      } else {
+        outputData.append(d)
+      }
+    }
+    errPipe.fileHandleForReading.readabilityHandler = { handle in
+      let d = handle.availableData
+      if d.isEmpty {
+        errPipe.fileHandleForReading.readabilityHandler = nil
+        errSem.signal()
+      } else {
+        errData.append(d)
+      }
+    }
+
     do {
       try process.run()
+      // Timeout so the import surfaces an actionable error instead of spinning forever.
+      DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(60)) {
+        if process.isRunning { process.terminate() }
+      }
       process.waitUntilExit()
     } catch {
       throw GmailReaderError.networkError("Failed to run Python: \(error.localizedDescription)")
     }
 
-    let output = pipe.fileHandleForReading.readDataToEndOfFile()
-    let errOutput =
-      String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    // Wait for pipe reads to finish (max 5s after process exit)
+    _ = outputSem.wait(timeout: .now() + .seconds(5))
+    _ = errSem.wait(timeout: .now() + .seconds(5))
+
+    let output = outputData
+    let errOutput = String(data: errData, encoding: .utf8) ?? ""
     if !errOutput.isEmpty {
       log("GmailReaderService: Python stderr: \(errOutput.prefix(500))")
+    }
+    if output.isEmpty {
+      throw GmailReaderError.networkError(
+        "Gmail helper produced no output (timed out or exited early)")
     }
 
     guard let json = try? JSONSerialization.jsonObject(with: output) as? [String: Any] else {

--- a/desktop/macos/changelog/unreleased/20260701-gmail-import-deadlock.json
+++ b/desktop/macos/changelog/unreleased/20260701-gmail-import-deadlock.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gmail/Email import hanging forever on 'Importing…' when reading a large mailbox"
+}


### PR DESCRIPTION
## Bug
The macOS Gmail/Email connector hangs indefinitely on `Importing…` / `Connecting to Gmail` and never completes — no counts, no error (#8797, p0).

## Root cause
`GmailReaderService.fetchGmailViaAtomFeedSingle` launched the Python helper, then:
```swift
try process.run()
process.waitUntilExit()
let output = pipe.fileHandleForReading.readDataToEndOfFile()
```
When the helper prints a large JSON payload (up to 300 emails) to stdout, the pipe buffer fills, the child blocks in `write(2)`, and the parent blocks in `waitUntilExit()` — a classic pipe deadlock. The UI spins forever with no timeout/error path.

## Fix
- Drain stdout/stderr **asynchronously** via `readabilityHandler` while the helper runs, then `waitUntilExit()` — the child can never block on a full buffer.
- Add a **60s terminate timeout** so a stuck/slow helper surfaces an actionable error ("produced no output") instead of hanging.
- Mirrors the vetted safe pattern already used in `CalendarReaderService`.

Scope: one file (+ changelog fragment), ~40 lines. Compiles clean (`xcrun swift build -c debug`, Build complete).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

