### PR TITLE
Fix brittle Google Calendar connect errors; add integrations philosophy

### DIFF
--- a/desktop/macos/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/macos/Desktop/Sources/CalendarReaderService.swift
@@ -13,30 +13,131 @@ struct CalendarEvent: Identifiable {
   let isAllDay: Bool
 }
 
-enum CalendarReaderError: LocalizedError {
+/// Result of a functional connection probe (philosophy §3/§4). Distinct from a
+/// stored "connected" flag: it reflects what is true *right now*.
+enum CalendarConnectionStatus: Equatable {
+  case connected(verifiedAt: Date)
+  case needsSignIn(message: String)
+  case error(message: String)
+
+  var isConnected: Bool {
+    if case .connected = self { return true }
+    return false
+  }
+}
+
+enum CalendarReaderError: LocalizedError, Equatable {
   case noBrowserFound
-  case noGoogleCookies
+  case notSignedIn
+  case sessionExpired
   case cookieDecryptionFailed(String)
   case networkError(String)
-  case authFailed
   case pythonNotFound
 
   var errorDescription: String? {
     switch self {
     case .noBrowserFound:
-      return "No browser with Google session found. Log into Google in Chrome, Arc, Brave, or Edge."
-    case .noGoogleCookies:
-      return "No Google session cookies found. Make sure you're logged into Google."
+      return "No supported browser found. Open Google Calendar in Chrome, Arc, Brave, or Edge, then try again."
+    case .notSignedIn:
+      return "Not signed into Google in any browser. Open calendar.google.com in Chrome, Arc, Brave, or Edge, sign in, then try again."
+    case .sessionExpired:
+      return "Your Google session expired. Reload calendar.google.com in your browser to refresh it, then try again."
     case .cookieDecryptionFailed(let msg):
-      return "Cookie decryption failed: \(msg)"
+      return "Couldn't read your browser session: \(msg)"
     case .networkError(let msg):
-      return "Network error: \(msg)"
-    case .authFailed:
-      return
-        "Google Calendar authentication failed. Try refreshing your Google session in the browser."
+      return "Couldn't reach Google Calendar: \(msg)"
     case .pythonNotFound:
       return "Python 3 not found. Install it via Homebrew: brew install python3"
     }
+  }
+}
+
+// MARK: - Fetch outcome (pure, testable layer)
+
+/// The classified outcome of a fetch attempt across all browsers/profiles.
+///
+/// Per `docs/integrations-philosophy.md` §2 (observe → recover, never a script)
+/// and §3 (the UI must reflect reality): we aggregate every browser/profile
+/// attempt instead of surfacing whichever one happened to be tried last, then
+/// classify the failure into an actionable error — never the catch-all
+/// "Network error" that a login problem used to render as.
+enum CalendarFetchOutcome: Equatable {
+  case success(events: [[String: Any]], browser: String)
+  case failure(CalendarFailureClass, summary: String, attempts: [CalendarAttempt])
+
+  static func == (lhs: CalendarFetchOutcome, rhs: CalendarFetchOutcome) -> Bool {
+    switch (lhs, rhs) {
+    case let (.success(_, lb), .success(_, rb)):
+      return lb == rb
+    case let (.failure(lc, ls, la), .failure(rc, rs, ra)):
+      return lc == rc && ls == rs && la == ra
+    default:
+      return false
+    }
+  }
+}
+
+/// One browser/profile attempt, carrying only non-sensitive diagnostics — names,
+/// stages, and reasons, never cookie values (philosophy §7: sanitized traces).
+struct CalendarAttempt: Equatable {
+  let browser: String
+  let stage: String  // "decrypt" | "auth" | "fetch" | "ok"
+  let reason: String
+  let hadAuthCookies: Bool
+}
+
+enum CalendarFailureClass: String, Equatable {
+  case noBrowser = "no_browser"
+  case notSignedIn = "not_signed_in"
+  case sessionExpired = "session_expired"
+  case decryptFailed = "decrypt_failed"
+  case network = "network"
+  case unknown = "unknown"
+
+  var asError: CalendarReaderError {
+    switch self {
+    case .noBrowser: return .noBrowserFound
+    case .notSignedIn: return .notSignedIn
+    case .sessionExpired: return .sessionExpired
+    case .decryptFailed: return .cookieDecryptionFailed("browser session could not be decrypted")
+    case .network: return .networkError("please check your connection and try again")
+    case .unknown: return .networkError("unexpected error")
+    }
+  }
+}
+
+/// Parses the structured JSON the Python helper writes into a classified
+/// outcome. Pure and side-effect free so it can be unit-tested against captured
+/// payloads without a browser or Python (philosophy §7: make the surface
+/// testable).
+enum CalendarOutcomeParser {
+  static func parse(_ json: [String: Any]) -> CalendarFetchOutcome {
+    let attempts = (json["attempts"] as? [[String: Any]] ?? []).map { dict in
+      CalendarAttempt(
+        browser: dict["browser"] as? String ?? "unknown",
+        stage: dict["stage"] as? String ?? "unknown",
+        reason: dict["reason"] as? String ?? "",
+        hadAuthCookies: dict["had_auth"] as? Bool ?? false
+      )
+    }
+
+    if json["ok"] as? Bool == true {
+      let events = json["events"] as? [[String: Any]] ?? []
+      let browser = json["browser"] as? String ?? "unknown"
+      return .success(events: events, browser: browser)
+    }
+
+    let cls = CalendarFailureClass(rawValue: json["error_class"] as? String ?? "") ?? .unknown
+    let summary =
+      (json["summary"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+      ?? cls.asError.errorDescription ?? "Unknown error"
+    return .failure(cls, summary: summary, attempts: attempts)
+  }
+
+  /// Human-readable, non-sensitive one-liner for logs and the eval corpus.
+  static func diagnosticsLine(_ attempts: [CalendarAttempt]) -> String {
+    guard !attempts.isEmpty else { return "no browsers scanned" }
+    return attempts.map { "\($0.browser)[\($0.stage):\($0.reason)]" }.joined(separator: ", ")
   }
 }
 
@@ -123,6 +224,31 @@ actor CalendarReaderService {
     let events = try fetchCalendarViaCookies(
       daysBack: daysBack, daysForward: daysForward, maxResults: maxResults)
     return events.sorted { $0.startTime > $1.startTime }
+  }
+
+  /// Lightweight functional probe — does the integration actually work right now?
+  ///
+  /// Per `docs/integrations-philosophy.md` §3/§4, "connected" must mean "verified
+  /// recently against the real surface," never a stored latch. Callers use this
+  /// to render honest status and to drive self-healing, rather than trusting a
+  /// one-time success. It runs the same real fetch path over a tiny window so a
+  /// green result guarantees the whole chain (cookies → auth → API) works.
+  func verifyConnection() async -> CalendarConnectionStatus {
+    do {
+      _ = try fetchCalendarViaCookies(daysBack: 1, daysForward: 1, maxResults: 1)
+      return .connected(verifiedAt: Date())
+    } catch let error as CalendarReaderError {
+      switch error {
+      case .notSignedIn, .noBrowserFound:
+        return .needsSignIn(message: error.errorDescription ?? "Sign into Google to connect.")
+      case .sessionExpired:
+        return .needsSignIn(message: error.errorDescription ?? "Your Google session expired.")
+      default:
+        return .error(message: error.errorDescription ?? "Couldn't verify the connection.")
+      }
+    } catch {
+      return .error(message: error.localizedDescription)
+    }
   }
 
   /// Synthesize profile memories and tasks from calendar events.
@@ -461,6 +587,9 @@ actor CalendarReaderService {
           return "SAPISIDHASH " + timestamp + "_" + hash_val
 
       def fetch_calendar_events(jar, cookies_list, days_back, days_forward, max_results):
+          # Returns (events, error, http_status). http_status lets the caller
+          # distinguish an expired session (401/403) from a transient network
+          # failure so the user gets the right recovery step (philosophy §3).
           # Find SAPISID cookie
           sapisid = None
           for c in cookies_list:
@@ -474,7 +603,7 @@ actor CalendarReaderService {
                       sapisid = c['value']
                       break
           if not sapisid:
-              return None, "No SAPISID cookie found"
+              return None, "No SAPISID cookie found", None
 
           origin = "https://calendar.google.com"
           auth_header = get_sapisidhash(sapisid, origin)
@@ -510,13 +639,12 @@ actor CalendarReaderService {
                   status = resp.getcode()
                   body = resp.read()
                   if status != 200:
-                      return None, f"HTTP {status}"
+                      return None, f"HTTP {status}", status
                   data = json.loads(body)
               except urllib.error.HTTPError as e:
-                  body = e.read().decode('utf-8', errors='replace')[:200] if e.fp else ''
-                  return None, f"HTTP {e.code}: {body}"
+                  return None, f"HTTP {e.code}", e.code
               except Exception as e:
-                  return None, str(e)
+                  return None, str(e), None
 
               items = data.get('items', [])
               all_items.extend(items)
@@ -524,28 +652,54 @@ actor CalendarReaderService {
               if not page_token or not items:
                   break
 
-          return all_items[:max_results], None
+          return all_items[:max_results], None, 200
 
-      last_error = None
+      # Aggregate every browser/profile attempt instead of last-writer-wins, so
+      # we can classify the *most actionable* failure rather than surfacing
+      # whichever profile happened to be tried last (philosophy §2, §3, §7).
+      attempts = []
 
-      # Try each browser
+      def classify(attempts):
+          # No browser produced any readable cookies at all.
+          if not attempts:
+              return 'no_browser', 'No supported browser with a readable session was found.'
+          # Session expired beats "not signed in": if any profile HAD auth
+          # cookies but Google rejected them, telling the user to re-login is the
+          # actionable next step.
+          if any(a['stage'] == 'fetch' and a.get('http') in (401, 403) for a in attempts):
+              return 'session_expired', 'Your Google session expired. Reload calendar.google.com to refresh it.'
+          # Some profile had auth cookies but the fetch failed for another reason.
+          if any(a['stage'] == 'fetch' for a in attempts):
+              detail = next(a['reason'] for a in attempts if a['stage'] == 'fetch')
+              return 'network', f'Could not reach Google Calendar ({detail}).'
+          # Cookies decrypted but no profile was signed into Google.
+          if any(a['stage'] == 'auth' for a in attempts):
+              return 'not_signed_in', 'No browser is signed into Google. Sign into calendar.google.com and try again.'
+          # Everything failed at the decrypt stage.
+          return 'decrypt_failed', 'Your browser session could not be read.'
+
+      # Try each browser/profile
       for browser in browsers:
           cookies, err = decrypt_cookies(browser['db_path'], browser['password'])
           if err or not cookies:
-              last_error = f"{browser['name']}: cookie read failed ({err or 'no cookies'})"
+              attempts.append({'browser': browser['name'], 'stage': 'decrypt',
+                               'reason': (err or 'no cookies'), 'had_auth': False})
               continue
 
           # Check for auth cookies
           auth_names = {'SID', 'HSID', 'SSID', 'APISID', 'SAPISID', '__Secure-1PSID', '__Secure-3PSID'}
           found_auth = [c for c in cookies if c['name'] in auth_names]
           if not found_auth:
-              last_error = f"{browser['name']}: no Google auth cookies"
+              attempts.append({'browser': browser['name'], 'stage': 'auth',
+                               'reason': 'no Google auth cookies', 'had_auth': False})
               continue
 
           jar = make_cookie_jar(cookies)
-          events, fetch_err = fetch_calendar_events(jar, cookies, days_back, days_forward, max_results)
+          events, fetch_err, http_status = fetch_calendar_events(jar, cookies, days_back, days_forward, max_results)
           if fetch_err or events is None:
-              last_error = f"{browser['name']}: {fetch_err or 'unknown fetch error'}"
+              attempts.append({'browser': browser['name'], 'stage': 'fetch',
+                               'reason': (fetch_err or 'unknown fetch error'),
+                               'had_auth': True, 'http': http_status})
               continue
 
           # Format events for output
@@ -569,18 +723,22 @@ actor CalendarReaderService {
                   'is_all_day': 'date' in start and 'dateTime' not in start,
               })
 
+          attempts.append({'browser': browser['name'], 'stage': 'ok', 'reason': 'ok', 'had_auth': True})
           # Write to temp file to avoid pipe buffer truncation with large event lists
           import tempfile
           outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
           with open(outfile, 'w') as f:
-              json.dump({'ok': True, 'browser': browser['name'], 'events': result_events, 'count': len(result_events)}, f)
+              json.dump({'ok': True, 'browser': browser['name'], 'events': result_events,
+                         'count': len(result_events), 'attempts': attempts}, f)
           print(outfile)
           sys.exit(0)
 
+      error_class, summary = classify(attempts)
       import tempfile
       outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
       with open(outfile, 'w') as f:
-          json.dump({'ok': False, 'error': last_error or 'No browser with valid Google session found'}, f)
+          json.dump({'ok': False, 'error_class': error_class, 'summary': summary,
+                     'attempts': attempts}, f)
       print(outfile)
       sys.exit(0)
       """
@@ -664,33 +822,33 @@ actor CalendarReaderService {
       throw CalendarReaderError.networkError("Python returned invalid JSON: \(raw.prefix(200))")
     }
 
-    guard json["ok"] as? Bool == true else {
-      let errMsg = json["error"] as? String ?? "Unknown error"
-      throw CalendarReaderError.networkError(errMsg)
-    }
+    let outcome = CalendarOutcomeParser.parse(json)
+    switch outcome {
+    case let .failure(cls, summary, attempts):
+      // Structured, non-sensitive diagnostics for the eval corpus (philosophy §7).
+      log(
+        "CalendarReaderService: fetch failed [\(cls.rawValue)] — \(summary) | "
+          + "attempts: \(CalendarOutcomeParser.diagnosticsLine(attempts))")
+      throw cls.asError
 
-    guard let eventDicts = json["events"] as? [[String: Any]] else {
-      return []
-    }
+    case let .success(eventDicts, browserName):
+      log("CalendarReaderService: Got \(eventDicts.count) events from \(browserName)")
+      return eventDicts.compactMap { dict -> CalendarEvent? in
+        guard let id = dict["id"] as? String,
+          let summary = dict["summary"] as? String
+        else { return nil }
 
-    let browserName = json["browser"] as? String ?? "unknown"
-    log("CalendarReaderService: Got \(eventDicts.count) events from \(browserName)")
-
-    return eventDicts.compactMap { dict -> CalendarEvent? in
-      guard let id = dict["id"] as? String,
-        let summary = dict["summary"] as? String
-      else { return nil }
-
-      return CalendarEvent(
-        id: id,
-        summary: summary,
-        startTime: dict["start_time"] as? String ?? "",
-        endTime: dict["end_time"] as? String ?? "",
-        attendees: dict["attendees"] as? [String] ?? [],
-        location: dict["location"] as? String ?? "",
-        description: dict["description"] as? String ?? "",
-        isAllDay: dict["is_all_day"] as? Bool ?? false
-      )
+        return CalendarEvent(
+          id: id,
+          summary: summary,
+          startTime: dict["start_time"] as? String ?? "",
+          endTime: dict["end_time"] as? String ?? "",
+          attendees: dict["attendees"] as? [String] ?? [],
+          location: dict["location"] as? String ?? "",
+          description: dict["description"] as? String ?? "",
+          isAllDay: dict["is_all_day"] as? Bool ?? false
+        )
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Tests/CalendarOutcomeParserTests.swift
+++ b/desktop/macos/Desktop/Tests/CalendarOutcomeParserTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Fixture-driven tests for the calendar fetch outcome classifier.
+///
+/// These are the "captured observations as fixtures" the integrations
+/// philosophy (§7) asks for: the JSON payloads below mirror what the Python
+/// cookie helper emits for each real-world failure mode, so we can prove the
+/// classification without a browser, cookies, or Python. When a new failure
+/// shape shows up in the wild, add its payload here.
+final class CalendarOutcomeParserTests: XCTestCase {
+
+  func testSuccessParsesEventsAndBrowser() {
+    let json: [String: Any] = [
+      "ok": true,
+      "browser": "Arc",
+      "events": [["id": "1", "summary": "Standup"]],
+      "attempts": [["browser": "Arc", "stage": "ok", "reason": "ok", "had_auth": true]],
+    ]
+    guard case let .success(events, browser) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected success")
+    }
+    XCTAssertEqual(browser, "Arc")
+    XCTAssertEqual(events.count, 1)
+  }
+
+  /// The exact bug from the screenshot: cookies decrypt fine but no profile is
+  /// signed into Google. This must classify as `notSignedIn` (an actionable
+  /// login prompt), NOT the old catch-all "Network error".
+  func testNotSignedInWhenNoProfileHasAuthCookies() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "not_signed_in",
+      "summary": "No browser is signed into Google. Sign into calendar.google.com and try again.",
+      "attempts": [
+        ["browser": "Chrome (Default)", "stage": "auth", "reason": "no Google auth cookies", "had_auth": false],
+        ["browser": "Chrome (Profile 3)", "stage": "auth", "reason": "no Google auth cookies", "had_auth": false],
+      ],
+    ]
+    guard case let .failure(cls, _, attempts) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .notSignedIn)
+    XCTAssertEqual(cls.asError, .notSignedIn)
+    // Every attempt is retained — not just the last one (no last-writer-wins).
+    XCTAssertEqual(attempts.count, 2)
+  }
+
+  func testSessionExpiredMapsToReloginError() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "session_expired",
+      "summary": "Your Google session expired. Reload calendar.google.com to refresh it.",
+      "attempts": [
+        ["browser": "Chrome (Default)", "stage": "fetch", "reason": "HTTP 401", "had_auth": true, "http": 401]
+      ],
+    ]
+    guard case let .failure(cls, _, _) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .sessionExpired)
+    XCTAssertEqual(cls.asError, .sessionExpired)
+  }
+
+  func testNoBrowserWhenNothingScanned() {
+    let json: [String: Any] = [
+      "ok": false, "error_class": "no_browser",
+      "summary": "No supported browser with a readable session was found.", "attempts": [],
+    ]
+    guard case let .failure(cls, _, attempts) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .noBrowser)
+    XCTAssertTrue(attempts.isEmpty)
+  }
+
+  func testUnknownErrorClassFallsBackGracefully() {
+    let json: [String: Any] = ["ok": false, "error_class": "something_new", "attempts": []]
+    guard case let .failure(cls, summary, _) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    XCTAssertEqual(cls, .unknown)
+    XCTAssertFalse(summary.isEmpty)
+  }
+
+  /// Diagnostics must be safe to log and upload: browser names, stages, and
+  /// reasons only — never a cookie value (philosophy §7 sanitization).
+  func testDiagnosticsLineCarriesOnlyNonSensitiveFields() {
+    let json: [String: Any] = [
+      "ok": false, "error_class": "not_signed_in", "summary": "x",
+      "attempts": [
+        ["browser": "Arc", "stage": "auth", "reason": "no Google auth cookies", "had_auth": false]
+      ],
+    ]
+    guard case let .failure(_, _, attempts) = CalendarOutcomeParser.parse(json) else {
+      return XCTFail("expected failure")
+    }
+    let line = CalendarOutcomeParser.diagnosticsLine(attempts)
+    XCTAssertEqual(line, "Arc[auth:no Google auth cookies]")
+  }
+
+  func testConnectionStatusIsConnectedHelper() {
+    XCTAssertTrue(CalendarConnectionStatus.connected(verifiedAt: Date()).isConnected)
+    XCTAssertFalse(CalendarConnectionStatus.needsSignIn(message: "x").isConnected)
+    XCTAssertFalse(CalendarConnectionStatus.error(message: "x").isConnected)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260701-calendar-connect-clearer-errors.json
+++ b/desktop/macos/changelog/unreleased/20260701-calendar-connect-clearer-errors.json
@@ -1,0 +1,3 @@
+{
+    "change": "Google Calendar now tells you exactly why a connection failed — sign-in needed vs. expired session vs. network — instead of a confusing \"Network error\", and checks all your browser profiles before giving up"
+}

--- a/desktop/macos/docs/connector-checklist.md
+++ b/desktop/macos/docs/connector-checklist.md
@@ -1,0 +1,72 @@
+# Connector Fix Checklist
+
+A short, mechanical checklist for fixing (or adding) a browser-cookie / agent /
+config-file connector. It operationalizes `integrations-philosophy.md`. The
+calendar fix (`CalendarReaderService.swift`) is the worked reference — copy its
+shape.
+
+Work top to bottom. Don't skip the probe or the fixture test.
+
+## 1. Classify the surface
+
+- [ ] Can code write a config file for this? → write it in Swift, idempotently.
+      Do **not** send an agent. (philosophy §1)
+- [ ] Is there an API/CLI? → call it in code.
+- [ ] Only a human UI / browser session? → proceed, but everything below applies.
+
+## 2. Aggregate diagnostics — never last-writer-wins
+
+- [ ] If you loop over candidates (browsers, profiles, accounts), collect a
+      **structured attempt per candidate** — `{who, stage, reason}` — instead of
+      overwriting a single `last_error`. The calendar bug surfaced "Chrome
+      (Profile 3)" only because it was tried last; six other profiles were
+      silently discarded. (philosophy §2)
+- [ ] Classify the *most actionable* failure, not the last one. Prefer
+      "session expired" (had auth, got 401/403) over "not signed in" (an empty
+      profile). See `classify()` in the Python helper.
+
+## 3. Error taxonomy that reflects reality
+
+- [ ] Map failures to distinct, honest cases — `notSignedIn`, `sessionExpired`,
+      `noBrowserFound`, `network`, … — never a catch-all. A login problem must
+      not render as "Network error". (philosophy §3)
+- [ ] Each case's user message says **what to do next** (e.g. "Open
+      calendar.google.com in Chrome and sign in"), not just what failed.
+
+## 4. Pure, testable parsing seam
+
+- [ ] Put the "raw payload → classified outcome" step in a **pure function**
+      (`CalendarOutcomeParser.parse`). No I/O, no Process, no browser.
+- [ ] Add a fixture test with one payload per real failure mode. These are the
+      captured observations the eval flywheel runs on. When a new failure shape
+      appears in the wild, add its payload here. (philosophy §7)
+
+## 5. Functional probe — "connected" means verified now
+
+- [ ] Add a `verifyConnection()` that exercises the **real** path over a tiny
+      window and returns a live status (`connected` / `needsSignIn` / `error`).
+      A green result must guarantee the whole chain works end-to-end.
+      (philosophy §3, §4)
+- [ ] Drive UI status and any "Connected" badge off this probe, never off a
+      stored one-time-success latch.
+
+## 6. Sanitized diagnostics for the corpus
+
+- [ ] Log a structured, **non-sensitive** one-liner of the attempts (names,
+      stages, reasons). Never cookie values, tokens, or response bodies.
+      (philosophy §7)
+
+## 7. Ship hygiene
+
+- [ ] Add a changelog fragment under `desktop/macos/changelog/unreleased/`.
+- [ ] Keep the change scoped to this connector — don't let it reach into a
+      shared god-module that could regress other connectors. (philosophy §8)
+
+---
+
+**Known follow-up:** `GmailReaderService.swift` duplicates the exact
+browser-cookie + Python-decrypt + last-writer-wins pattern this checklist fixes
+for calendar. It has the same class of bug and is the next candidate. A shared
+`BrowserGoogleSession` helper (cookie discovery + decrypt + classify) would let
+both connectors share the hardened path — worth doing once a second consumer
+justifies the extraction.

--- a/desktop/macos/docs/integrations-philosophy.md
+++ b/desktop/macos/docs/integrations-philosophy.md
@@ -1,0 +1,203 @@
+# Integrations Philosophy
+
+**Audience:** any agent (or human) working on Omi's desktop integrations — the
+"Connect data" sources (Gmail, Calendar, Notes, Files, …) and the "Connect your
+AI" connectors (Claude, ChatGPT, Codex, OpenClaw, Hermes, …).
+
+**Status:** load-bearing. Read this before touching `CloudConnectorFormAutomation`,
+`MemoryExportExecutor`, `MemoryExportService`, `MemoryBankConnector`, or any
+`*ReaderService`. If you're about to add a connector, this is the contract.
+
+---
+
+## 0. The one thing to internalize
+
+We integrate with surfaces **we do not own and cannot version**: other apps'
+UIs, other apps' cookie encryption, other apps' config-file formats, and other
+providers' web flows. None of these give us a contract, a deprecation window, or
+an error we can catch. They change without warning, and when they change our
+integration doesn't throw — it silently clicks the wrong button or reads a stale
+cookie.
+
+That is the permanent condition. You cannot fix it by writing better heuristics.
+You can only survive it by building the right **harness** around the agent that
+does the work. **The harness is the product. The automation is disposable.**
+
+Every rule below follows from that sentence.
+
+---
+
+## 1. Code owns contracts. The agent owns only what code can't reach.
+
+If we own the format, a deterministic function writes it — never an agent.
+
+`MemoryBankConnector` already proves the rule. The comment says it plainly:
+
+> "OpenClaw / Hermes have no setup CLI; the agent doesn't reliably perform the
+> file write. Do it deterministically ourselves (idempotent local write)."
+
+MCP client configs (Claude Code, Codex, Cursor, …) are known JSON/TOML files. We
+own that format. Write it in Swift, idempotently, every run. Reserve the agent
+for surfaces with no file and no API — a provider's web "Add connector" dialog.
+
+**Decision rule for a new connector:**
+
+1. Is there a config file we can write? → Write it in code. Done.
+2. Is there an API or CLI? → Call it in code. Done.
+3. Only a human-facing UI? → *Now* an agent may drive it — under the loop in §2.
+
+Every connector you move from category 3 to category 1/2 stops being
+non-deterministic. That is the cheapest reliability you will ever buy. Do it
+before anything clever.
+
+## 2. Agent-driven surfaces run a closed loop, never a script
+
+Fire-and-forget automation breaks on any UI change because it cannot tell that it
+broke. `CloudConnectorFormAutomation` is 1,600 lines of hardcoded clicks and OCR
+anchoring — it is the *least* agentic thing we could have built, and a smarter
+model makes it obsolete rather than better. Do not extend it. Replace its shape.
+
+Every agent-driven flow must run these five beats, and the harness's job is to
+make each a clean tool:
+
+- **Observe** — give the agent the *full* accessibility tree / DOM + screenshot
+  as an observation. Do **not** pre-filter to "find the Add button." Localizing
+  the target is the model's job; doing it for it (badly) is why we have commits
+  like *"Infer Claude Add target from Cancel button."*
+- **Act** — atomic primitives only: `click(x,y)`, `type`, `key`, `scroll`,
+  `navigate`.
+- **Re-observe** — after every action, snapshot again. Acting-then-observing is
+  the single biggest reliability lever we have. It is the thing a script
+  structurally cannot do.
+- **Verify** — let the agent confirm the state actually changed as intended.
+- **Recover** — on mismatch, feed the failure back and let the agent try another
+  approach, bounded to N attempts, then fail loud.
+
+If you find yourself hardcoding *which* element to click or *where* it is on
+screen, stop. That knowledge is volatile; encoding it in Swift means every
+provider redesign becomes a release cycle.
+
+## 3. Never trust the UI. End every flow with a functional probe.
+
+The UI saying "Connected" is not evidence the integration works. A setup is
+complete only when a **real functional call succeeds through the thing you just
+configured.**
+
+We already have the probes: `testHostedMCPMemoryCount()` hits the live MCP
+endpoint and counts memories; `testAgentConnections()` exercises both hosted and
+local. Use them as the completion gate. The agent's screen-reading tells you
+*where to click*; the probe tells you *whether it worked*. Keep those signals
+separate or you will keep shipping false "Connected."
+
+## 4. "Connected" means "verified recently," not "once true."
+
+Today connection state is a one-way latch:
+
+```swift
+func markConnected(dest) { defaults.set(Date()..., forKey: dest.connectedAtKey) }
+hasConnection = exportedCount > 0 || defaults.double(forKey: connectedAtKey) > 0
+```
+
+Once the timestamp is written the source reads "Connected" **forever** — even
+after the cookie expires, the key rotates, or the user deletes the connector on
+the provider side. The user's mental model and reality diverge, and that reads as
+"randomly broken."
+
+Rule: derive status from a recent functional probe (§3) and from
+`CredentialHealthManager`, never from a latch. If it hasn't been verified inside
+the freshness window, it is not "Connected" — it is "needs check."
+
+## 5. Prefer the highest-fidelity perception available
+
+Perception fidelity is reliability. Ranked best to worst:
+
+1. **API response** (a contract) — use if it exists.
+2. **DOM** via a controllable browser (CDP/Playwright) — stable selectors, real
+   element state, `aria` labels.
+3. **Accessibility tree** — structured, but app-dependent.
+4. **Vision/OCR of pixels** — the last resort. "Did OCR read 'Add' or 'Add-on'?"
+
+Provider connector flows are *web pages*. Driving them through OCR of a native
+window is the worst option for the easiest-to-improve surface. When you next
+touch a web-based flow, move it to a browser context so the agent perceives DOM,
+not pixels. Same user session, no new auth — just a vastly richer observation.
+
+## 6. Provider knowledge is data, not binary
+
+Much of our pain is *latency*: a provider moves a button, and the fix needs a
+Swift edit, a clean release build, notarization, and a user update — days, for a
+"the button moved" change. That is backwards.
+
+- The **harness** (perceive/act/verify/probe/recover) is stable → compile it.
+- The **provider knowledge** (how to set up X, what the flow looks like) is
+  volatile → ship it as remotely-updatable config/skills the app fetches.
+
+When a provider redesigns, push a new instruction blob and installed apps
+self-correct on next run. No release cycle for volatile knowledge.
+
+## 7. Build the eval flywheel — this is how the "agents get smarter" bet pays off
+
+A brittle surface with no test is found broken by users while CI stays green. Make
+the surface testable by **capturing observations as fixtures**:
+
+- Every real run records its trace: observations (AX tree / DOM / screenshot),
+  actions, outcome, verified-or-not.
+- Failed runs auto-upload a **sanitized** trace. That is simultaneously the
+  canary (we learn a provider changed *before* users flood in) and the eval
+  corpus.
+- Replay captured traces offline against a candidate model/prompt. "Does the next
+  model still complete all N provider setups?" becomes a CI question answered
+  against real captured snapshots — not a production discovery.
+
+A smarter model only helps if we can feed it the failure data and prove the
+improvement offline. Without this loop, a model upgrade is a coin flip we can't
+measure. With it, every provider UI change becomes: capture new snapshot → add to
+eval set → harness and next model are hardened against it.
+
+**Sanitization is non-negotiable** — traces contain the user's screen. Use
+`sanitize()` / `sanitize_pii()` conventions; strip cookies, tokens, and
+message bodies before anything leaves the machine.
+
+## 8. Self-heal, and isolate blast radius
+
+- **Continuous verifier → auto-reheal.** Run the functional probe on a heartbeat.
+  On failure, don't just flip the badge — spawn the agent to redo setup in the
+  background before the user notices. This is where the agent's adaptability
+  becomes visible: the integration quietly fixes itself.
+- **Per-provider isolation.** One provider's broken flow must be a circuit
+  breaker, not an outage across the whole column. Do not let connectors share a
+  god-module where a Claude change can regress Gmail. (`CloudConnectorFormAutomation`
+  and the oversized `MemoryExportService` are the anti-patterns to break apart,
+  not extend.)
+
+---
+
+## Anti-patterns (do not do these)
+
+- Adding another hardcoded element-anchoring heuristic to
+  `CloudConnectorFormAutomation`. The churn history of that file is the evidence.
+- Gating "Connected" on a timestamp or a one-time success.
+- Sending an agent to do a job a deterministic file write could do.
+- Perceiving a web flow through Vision/OCR when a DOM is available.
+- Compiling volatile provider knowledge into the Swift binary.
+- Shipping a setup flow with no functional probe at the end.
+- Uploading a trace without stripping cookies, tokens, and PII.
+
+## If you only have an hour
+
+1. Move one more connector from "agent does it" to "code writes the file."
+2. Make one connector's status gate on its functional probe instead of the latch.
+
+Both are pure reliability with zero model risk, and they compound.
+
+---
+
+## Why this document exists
+
+We are betting that agents get smarter and that a well-built harness lets them
+"make magic happen." That bet is only sound if we spend our effort on the parts
+we control — the harness, the perception fidelity, the verification loop, the
+eval flywheel — and stop spending it on the parts we don't — other people's UIs.
+A smart agent inside a fire-and-forget script is still brittle. A modest agent
+inside a perceive → act → verify → probe → recover loop, fed by an eval corpus
+and hot-updatable knowledge, is robust. Build the second one.


### PR DESCRIPTION
## Why

The Google Calendar connector fails opaquely. The reported error from the field —

> Network error: Chrome (Profile 3): no Google auth cookies

— is wrong on two counts:

1. **Misclassified.** Not being signed into Google is a *login* problem, not a *network* problem. The old code collapsed every failure into `.networkError`, so the user sees "Network error" and has no idea the real fix is "sign in".
2. **Last-writer-wins diagnostics.** The Python helper looped over every browser/profile and overwrote a single `last_error` each time, so it surfaced whichever profile happened to be tried **last** (an empty "Profile 3") rather than the most informative one — while silently discarding the other six attempts.

This PR is the first worked example of applying the new **integrations philosophy** (added here) to a real connector, and is meant as the template for the rest.

## What changed

**`CalendarReaderService.swift`**
- **Aggregate, don't overwrite** — the Python helper records a structured attempt per browser/profile (`{browser, stage, reason, had_auth}`) and `classify()`s the *most actionable* failure: session-expired (had auth, got 401/403) beats not-signed-in (empty profile) beats decrypt-failed.
- **Honest error taxonomy** — `notSignedIn` / `sessionExpired` / `noBrowserFound` / `network`, each with a next-step message, replacing the catch-all `networkError`.
- **Pure, testable seam** — `CalendarOutcomeParser.parse` turns the raw payload into a classified outcome with no I/O, unit-testable against captured fixtures.
- **Functional probe** — `verifyConnection()` runs the real path over a 1-day window and returns a live `CalendarConnectionStatus`, so "connected" means "verified now" instead of a stored latch.
- **Sanitized diagnostics** — structured log line of names/stages/reasons, never cookie values.

**Docs**
- `docs/integrations-philosophy.md` — the doctrine future integration work references.
- `docs/connector-checklist.md` — the mechanical checklist this fix exemplifies, with the Gmail duplication flagged as the next candidate.

## Verification

- `xcrun swift build -c debug` — clean (exit 0).
- 7 new unit tests in `CalendarOutcomeParserTests` pass (one fixture per real failure mode, including the exact screenshot scenario).
- The embedded Python was extracted and run against real SQLite cookie fixtures: the not-signed-in path returns `error_class: not_signed_in` and the decrypt-failure path aggregates both profiles — no last-writer-wins.

Full end-to-end UI verification requires a real signed-in browser session; the behavior-defining logic (Python classification → Swift error mapping) is exercised end to end here.

## Follow-up

`GmailReaderService.swift` duplicates the same browser-cookie + last-writer-wins pattern and has the same class of bug — next candidate, ideally via a shared `BrowserGoogleSession` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

