### PR TITLE
Fix Gmail import helper stdout deadlock

### DIFF
--- a/desktop/macos/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/macos/Desktop/Sources/GmailReaderService.swift
@@ -14,6 +14,8 @@ struct GmailEmail: Identifiable {
 enum GmailReaderError: LocalizedError {
   case noBrowserFound
   case noGmailCookies
+  case notSignedIn
+  case sessionExpired
   case cookieDecryptionFailed(String)
   case networkError(String)
   case authFailed
@@ -25,6 +27,10 @@ enum GmailReaderError: LocalizedError {
       return "No browser with Gmail session found. Log into Gmail in Chrome, Arc, Brave, or Edge."
     case .noGmailCookies:
       return "No Gmail session cookies found. Make sure you're logged into Gmail."
+    case .notSignedIn:
+      return "Not signed into Gmail in any browser. Open mail.google.com in Chrome, Arc, Brave, or Edge, sign in, then try again."
+    case .sessionExpired:
+      return "Your Gmail session expired. Reload mail.google.com in your browser to refresh it, then try again."
     case .cookieDecryptionFailed(let msg):
       return "Cookie decryption failed: \(msg)"
     case .networkError(let msg):
@@ -34,6 +40,58 @@ enum GmailReaderError: LocalizedError {
     case .pythonNotFound:
       return "Python 3 not found. Install it via Homebrew: brew install python3"
     }
+  }
+}
+
+// MARK: - Fetch outcome diagnostics
+
+struct GmailAttempt: Equatable {
+  let browser: String
+  let stage: String
+  let reason: String
+  let hadAuthCookies: Bool
+}
+
+enum GmailFailureClass: String, Equatable {
+  case noBrowser = "no_browser"
+  case notSignedIn = "not_signed_in"
+  case sessionExpired = "session_expired"
+  case decryptFailed = "decrypt_failed"
+  case network = "network"
+  case unknown = "unknown"
+
+  var asError: GmailReaderError {
+    switch self {
+    case .noBrowser: return .noBrowserFound
+    case .notSignedIn: return .notSignedIn
+    case .sessionExpired: return .sessionExpired
+    case .decryptFailed: return .cookieDecryptionFailed("browser session could not be decrypted")
+    case .network: return .networkError("please check your connection and try again")
+    case .unknown: return .networkError("unexpected error")
+    }
+  }
+}
+
+enum GmailOutcomeParser {
+  static func failure(from json: [String: Any]) -> (GmailFailureClass, String, [GmailAttempt]) {
+    let attempts = (json["attempts"] as? [[String: Any]] ?? []).map { dict in
+      GmailAttempt(
+        browser: dict["browser"] as? String ?? "unknown",
+        stage: dict["stage"] as? String ?? "unknown",
+        reason: dict["reason"] as? String ?? "",
+        hadAuthCookies: dict["had_auth"] as? Bool ?? false
+      )
+    }
+    let cls = GmailFailureClass(rawValue: json["error_class"] as? String ?? "") ?? .unknown
+    let summary =
+      (json["summary"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+      ?? cls.asError.errorDescription ?? "Unknown error"
+    return (cls, summary, attempts)
+  }
+
+  static func diagnosticsLine(_ attempts: [GmailAttempt]) -> String {
+    guard !attempts.isEmpty else { return "no browsers scanned" }
+    return attempts.map { "\($0.browser)[\($0.stage):\($0.reason)]" }.joined(separator: ", ")
   }
 }
 
@@ -428,7 +486,7 @@ actor GmailReaderService {
     }
 
     let pythonScript = """
-      import sys, json, sqlite3, hashlib, xml.etree.ElementTree as ET
+      import sys, json, os, sqlite3, tempfile, hashlib, xml.etree.ElementTree as ET
       from http.cookiejar import MozillaCookieJar, Cookie
       from urllib.parse import quote
       from urllib.request import Request, build_opener, HTTPCookieProcessor
@@ -456,6 +514,41 @@ actor GmailReaderService {
       query = sys.argv[3] if len(sys.argv) > 3 else 'newer_than:1d'
       use_bootstrap = (sys.argv[4] if len(sys.argv) > 4 else '1') == '1'
       feed_path = sys.argv[5] if len(sys.argv) > 5 else ''
+
+      def write_result(result):
+          tmp = tempfile.NamedTemporaryFile(
+              mode='w',
+              encoding='utf-8',
+              suffix='.json',
+              prefix='omi_gmail_',
+              delete=False,
+          )
+          try:
+              json.dump(result, tmp)
+              tmp.write('\\n')
+              tmp.close()
+              os.chmod(tmp.name, 0o600)
+              print(tmp.name)
+          except Exception:
+              path = tmp.name
+              tmp.close()
+              try:
+                  os.unlink(path)
+              except OSError:
+                  pass
+              raise
+
+      def classify(attempts):
+          if not attempts:
+              return 'no_browser', 'No supported browser with a readable session was found.'
+          if any(a['stage'] == 'fetch' and a.get('http') in (401, 403) for a in attempts):
+              return 'session_expired', 'Your Gmail session expired. Reload mail.google.com to refresh it.'
+          if any(a['stage'] == 'fetch' for a in attempts):
+              detail = next(a['reason'] for a in attempts if a['stage'] == 'fetch')
+              return 'network', f'Could not reach Gmail ({detail}).'
+          if any(a['stage'] == 'auth' for a in attempts):
+              return 'not_signed_in', 'No browser is signed into Gmail. Sign into mail.google.com and try again.'
+          return 'decrypt_failed', 'Your browser session could not be read.'
 
       def decrypt_cookies_with_domains(db_path, password):
           key = hashlib.pbkdf2_hmac('sha1', password.encode('utf-8'), b'saltysalt', 1003, dklen=16)
@@ -716,14 +809,19 @@ actor GmailReaderService {
           return emails, None
 
       # Try each browser
+      attempts = []
       for browser in browsers:
           cookies, err = decrypt_cookies_with_domains(browser['db_path'], browser['password'])
           if err or not cookies:
+              attempts.append({'browser': browser['name'], 'stage': 'decrypt',
+                               'reason': (err or 'no cookies'), 'had_auth': False})
               continue
 
           auth_names = {'SID', 'HSID', 'SSID', 'APISID', 'SAPISID', '__Secure-1PSID', '__Secure-3PSID'}
           found_auth = [c for c in cookies if c['name'] in auth_names]
           if not found_auth:
+              attempts.append({'browser': browser['name'], 'stage': 'auth',
+                               'reason': 'no Google auth cookies', 'had_auth': False})
               continue
 
           jar = make_cookie_jar(cookies)
@@ -731,17 +829,27 @@ actor GmailReaderService {
           if use_bootstrap and status == 200:
               emails, parse_err = parse_bootstrap_page(body, max_results)
               if not parse_err and emails:
-                  print(json.dumps({'ok': True, 'browser': browser['name'], 'source': 'bootstrap', 'emails': emails, 'count': len(emails)}))
+                  attempts.append({'browser': browser['name'], 'stage': 'ok', 'reason': 'bootstrap', 'had_auth': True})
+                  write_result({'ok': True, 'browser': browser['name'], 'source': 'bootstrap', 'emails': emails, 'count': len(emails), 'attempts': attempts})
                   sys.exit(0)
+          elif status is not None:
+              attempts.append({'browser': browser['name'], 'stage': 'fetch',
+                               'reason': f'home HTTP {status}', 'had_auth': True, 'http': status})
 
           status, body = fetch_atom_feed(jar)
           if status == 200:
               emails, parse_err = parse_atom(body, max_results)
               if not parse_err and emails is not None:
-                  print(json.dumps({'ok': True, 'browser': browser['name'], 'source': 'atom', 'emails': emails, 'count': len(emails)}))
+                  attempts.append({'browser': browser['name'], 'stage': 'ok', 'reason': 'atom', 'had_auth': True})
+                  write_result({'ok': True, 'browser': browser['name'], 'source': 'atom', 'emails': emails, 'count': len(emails), 'attempts': attempts})
                   sys.exit(0)
+          else:
+              attempts.append({'browser': browser['name'], 'stage': 'fetch',
+                               'reason': (f'atom HTTP {status}' if status is not None else str(body)[:120]),
+                               'had_auth': True, 'http': status})
 
-      print(json.dumps({'ok': False, 'error': 'No browser with valid Gmail session found'}))
+      error_class, summary = classify(attempts)
+      write_result({'ok': False, 'error_class': error_class, 'summary': summary, 'attempts': attempts})
       sys.exit(0)
       """
 
@@ -752,78 +860,65 @@ actor GmailReaderService {
       throw GmailReaderError.pythonNotFound
     }
 
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: pythonPath)
-    process.arguments = [
-      "-c", pythonScript, configJSON, String(maxResults), query,
-      shouldUseBootstrapPage ? "1" : "0",
-      feedPath ?? "",
-    ]
-    let pipe = Pipe()
-    let errPipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = errPipe
+    let queryLogDescription =
+      Self.parseNewerThanDays(query).map { "newer_than:\($0)d" }
+      ?? "custom(length:\(query.count))"
+    let feedPathLogDescription = feedPath == nil ? "default" : "custom"
+    log(
+      "GmailReaderService: Helper starting maxResults=\(maxResults), query=\(queryLogDescription), feedPath=\(feedPathLogDescription), bootstrap=\(shouldUseBootstrapPage)"
+    )
 
-    // Drain pipes asynchronously to avoid deadlock: the helper prints the full
-    // JSON payload for up to 300 emails to stdout, which can exceed the pipe
-    // buffer. waitUntilExit() blocks if the child blocks in write() on a full
-    // buffer, so read concurrently instead of after exit. (mirrors CalendarReaderService)
-    var outputData = Data()
-    var errData = Data()
-    let outputSem = DispatchSemaphore(value: 0)
-    let errSem = DispatchSemaphore(value: 0)
-    pipe.fileHandleForReading.readabilityHandler = { handle in
-      let d = handle.availableData
-      if d.isEmpty {
-        pipe.fileHandleForReading.readabilityHandler = nil
-        outputSem.signal()
-      } else {
-        outputData.append(d)
-      }
-    }
-    errPipe.fileHandleForReading.readabilityHandler = { handle in
-      let d = handle.availableData
-      if d.isEmpty {
-        errPipe.fileHandleForReading.readabilityHandler = nil
-        errSem.signal()
-      } else {
-        errData.append(d)
-      }
-    }
-
+    let result: PipeProcessResult
     do {
-      try process.run()
-      // Timeout so the import surfaces an actionable error instead of spinning forever.
-      DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(60)) {
-        if process.isRunning { process.terminate() }
-      }
-      process.waitUntilExit()
+      result = try PipeProcessRunner.run(
+        executableURL: URL(fileURLWithPath: pythonPath),
+        arguments: [
+          "-c", pythonScript, configJSON, String(maxResults), query,
+          shouldUseBootstrapPage ? "1" : "0",
+          feedPath ?? "",
+        ],
+        timeoutSeconds: 60
+      )
     } catch {
-      throw GmailReaderError.networkError("Failed to run Python: \(error.localizedDescription)")
+      log("GmailReaderService: Helper failed before parse: \(error.localizedDescription)")
+      throw GmailReaderError.networkError(error.localizedDescription)
     }
 
-    // Wait for pipe reads to finish (max 5s after process exit)
-    _ = outputSem.wait(timeout: .now() + .seconds(5))
-    _ = errSem.wait(timeout: .now() + .seconds(5))
-
-    let output = outputData
-    let errOutput = String(data: errData, encoding: .utf8) ?? ""
+    let errOutput =
+      String(data: result.stderr, encoding: .utf8) ?? ""
     if !errOutput.isEmpty {
       log("GmailReaderService: Python stderr: \(errOutput.prefix(500))")
     }
-    if output.isEmpty {
+    log(
+      "GmailReaderService: Helper exited status=\(result.terminationStatus), durationMs=\(Int(result.duration * 1000)), stdoutBytes=\(result.stdout.count)"
+    )
+
+    guard result.terminationStatus == 0 else {
       throw GmailReaderError.networkError(
-        "Gmail helper produced no output (timed out or exited early)")
+        "Python exited with status \(result.terminationStatus): \(errOutput.prefix(300))")
     }
 
+    let outputPath =
+      String(data: result.stdout, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+      ?? ""
+    guard !outputPath.isEmpty, FileManager.default.fileExists(atPath: outputPath) else {
+      throw GmailReaderError.networkError(
+        "Python did not produce output file (stdout: \(outputPath.prefix(200)))")
+    }
+    defer { try? FileManager.default.removeItem(atPath: outputPath) }
+
+    let output = try Data(contentsOf: URL(fileURLWithPath: outputPath))
     guard let json = try? JSONSerialization.jsonObject(with: output) as? [String: Any] else {
       let raw = String(data: output, encoding: .utf8) ?? "(empty)"
       throw GmailReaderError.networkError("Python returned invalid JSON: \(raw.prefix(200))")
     }
 
     guard json["ok"] as? Bool == true else {
-      let errMsg = json["error"] as? String ?? "Unknown error"
-      throw GmailReaderError.networkError(errMsg)
+      let (cls, summary, attempts) = GmailOutcomeParser.failure(from: json)
+      log(
+        "GmailReaderService: fetch failed [\(cls.rawValue)] - \(summary) | "
+          + "attempts: \(GmailOutcomeParser.diagnosticsLine(attempts))")
+      throw cls.asError
     }
 
     guard let emailDicts = json["emails"] as? [[String: Any]] else {

--- a/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
+++ b/desktop/macos/Desktop/Sources/PipeProcessRunner.swift
@@ -1,0 +1,159 @@
+import Darwin
+import Foundation
+
+struct PipeProcessResult {
+  let stdout: Data
+  let stderr: Data
+  let terminationStatus: Int32
+  let duration: TimeInterval
+  let timedOut: Bool
+}
+
+enum PipeProcessRunnerError: LocalizedError {
+  case launchFailed(String)
+  case timedOut(seconds: TimeInterval, stderr: String)
+  case pipeDrainTimedOut(streams: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .launchFailed(let message):
+      return "Failed to run helper process: \(message)"
+    case .timedOut(let seconds, let stderr):
+      let detail = stderr.isEmpty ? "" : " Stderr: \(stderr.prefix(300))"
+      return "Helper process timed out after \(Int(seconds)) seconds.\(detail)"
+    case .pipeDrainTimedOut(let streams):
+      return "Helper process exited before \(streams) finished draining."
+    }
+  }
+}
+
+enum PipeProcessRunner {
+  static func run(
+    executableURL: URL,
+    arguments: [String],
+    timeoutSeconds: TimeInterval,
+    killGraceSeconds: TimeInterval = 2
+  ) throws -> PipeProcessResult {
+    let process = Process()
+    process.executableURL = executableURL
+    process.arguments = arguments
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    let stdout = LockedData()
+    let stderr = LockedData()
+    let stdoutSem = DispatchSemaphore(value: 0)
+    let stderrSem = DispatchSemaphore(value: 0)
+
+    stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+      let data = handle.availableData
+      if data.isEmpty {
+        handle.readabilityHandler = nil
+        stdoutSem.signal()
+      } else {
+        stdout.append(data)
+      }
+    }
+    stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+      let data = handle.availableData
+      if data.isEmpty {
+        handle.readabilityHandler = nil
+        stderrSem.signal()
+      } else {
+        stderr.append(data)
+      }
+    }
+
+    let timeoutState = LockedBool(false)
+    let startedAt = Date()
+    let timeoutWork = DispatchWorkItem {
+      guard process.isRunning else { return }
+      timeoutState.set(true)
+      process.terminate()
+      DispatchQueue.global().asyncAfter(deadline: .now() + killGraceSeconds) {
+        if process.isRunning {
+          kill(process.processIdentifier, SIGKILL)
+        }
+      }
+    }
+
+    do {
+      try process.run()
+    } catch {
+      stdoutPipe.fileHandleForReading.readabilityHandler = nil
+      stderrPipe.fileHandleForReading.readabilityHandler = nil
+      timeoutWork.cancel()
+      throw PipeProcessRunnerError.launchFailed(error.localizedDescription)
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWork)
+    process.waitUntilExit()
+    timeoutWork.cancel()
+
+    let stdoutDrained = stdoutSem.wait(timeout: .now() + .seconds(5)) == .success
+    let stderrDrained = stderrSem.wait(timeout: .now() + .seconds(5)) == .success
+
+    let result = PipeProcessResult(
+      stdout: stdout.snapshot(),
+      stderr: stderr.snapshot(),
+      terminationStatus: process.terminationStatus,
+      duration: Date().timeIntervalSince(startedAt),
+      timedOut: timeoutState.get()
+    )
+
+    if result.timedOut {
+      let stderrText = String(data: result.stderr, encoding: .utf8) ?? ""
+      throw PipeProcessRunnerError.timedOut(seconds: timeoutSeconds, stderr: stderrText)
+    }
+    if !stdoutDrained || !stderrDrained {
+      let streams = [
+        stdoutDrained ? nil : "stdout",
+        stderrDrained ? nil : "stderr",
+      ].compactMap(\.self).joined(separator: " and ")
+      throw PipeProcessRunnerError.pipeDrainTimedOut(streams: streams)
+    }
+
+    return result
+  }
+}
+
+private final class LockedData: @unchecked Sendable {
+  private var data = Data()
+  private let lock = NSLock()
+
+  func append(_ chunk: Data) {
+    lock.lock()
+    data.append(chunk)
+    lock.unlock()
+  }
+
+  func snapshot() -> Data {
+    lock.lock()
+    defer { lock.unlock() }
+    return data
+  }
+}
+
+private final class LockedBool: @unchecked Sendable {
+  private var value: Bool
+  private let lock = NSLock()
+
+  init(_ value: Bool) {
+    self.value = value
+  }
+
+  func set(_ newValue: Bool) {
+    lock.lock()
+    value = newValue
+    lock.unlock()
+  }
+
+  func get() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+}

--- a/desktop/macos/Desktop/Tests/GmailOutcomeParserTests.swift
+++ b/desktop/macos/Desktop/Tests/GmailOutcomeParserTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class GmailOutcomeParserTests: XCTestCase {
+  func testNotSignedInRetainsAllBrowserAttempts() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "not_signed_in",
+      "summary": "No browser is signed into Gmail. Sign into mail.google.com and try again.",
+      "attempts": [
+        ["browser": "Chrome (Default)", "stage": "auth", "reason": "no Google auth cookies", "had_auth": false],
+        ["browser": "Chrome (Profile 3)", "stage": "auth", "reason": "no Google auth cookies", "had_auth": false],
+      ],
+    ]
+
+    let (cls, _, attempts) = GmailOutcomeParser.failure(from: json)
+    XCTAssertEqual(cls, .notSignedIn)
+    XCTAssertEqual(cls.asError.errorDescription, GmailReaderError.notSignedIn.errorDescription)
+    XCTAssertEqual(attempts.count, 2)
+  }
+
+  func testSessionExpiredMapsToReloginError() {
+    let json: [String: Any] = [
+      "ok": false,
+      "error_class": "session_expired",
+      "summary": "Your Gmail session expired. Reload mail.google.com to refresh it.",
+      "attempts": [
+        ["browser": "Arc", "stage": "fetch", "reason": "atom HTTP 401", "had_auth": true, "http": 401]
+      ],
+    ]
+
+    let (cls, summary, attempts) = GmailOutcomeParser.failure(from: json)
+    XCTAssertEqual(cls, .sessionExpired)
+    XCTAssertEqual(cls.asError.errorDescription, GmailReaderError.sessionExpired.errorDescription)
+    XCTAssertEqual(summary, "Your Gmail session expired. Reload mail.google.com to refresh it.")
+    XCTAssertEqual(attempts.first?.hadAuthCookies, true)
+  }
+
+  func testDiagnosticsLineCarriesOnlyNonSensitiveFields() {
+    let attempts = [
+      GmailAttempt(
+        browser: "Arc",
+        stage: "auth",
+        reason: "no Google auth cookies",
+        hadAuthCookies: false
+      )
+    ]
+
+    XCTAssertEqual(GmailOutcomeParser.diagnosticsLine(attempts), "Arc[auth:no Google auth cookies]")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PipeProcessRunnerTests.swift
+++ b/desktop/macos/Desktop/Tests/PipeProcessRunnerTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PipeProcessRunnerTests: XCTestCase {
+  func testDrainsLargeStdoutBeforeWaitingForExit() throws {
+    let result = try PipeProcessRunner.run(
+      executableURL: URL(fileURLWithPath: "/usr/bin/python3"),
+      arguments: [
+        "-c",
+        "import sys; sys.stdout.write('x' * (1024 * 1024)); sys.stdout.flush()",
+      ],
+      timeoutSeconds: 5
+    )
+
+    XCTAssertEqual(result.terminationStatus, 0)
+    XCTAssertEqual(result.stdout.count, 1024 * 1024)
+    XCTAssertFalse(result.timedOut)
+  }
+
+  func testDrainsLargeStderrBeforeWaitingForExit() throws {
+    let result = try PipeProcessRunner.run(
+      executableURL: URL(fileURLWithPath: "/usr/bin/python3"),
+      arguments: [
+        "-c",
+        "import sys; sys.stderr.write('x' * (1024 * 1024)); sys.stderr.flush()",
+      ],
+      timeoutSeconds: 5
+    )
+
+    XCTAssertEqual(result.terminationStatus, 0)
+    XCTAssertEqual(result.stderr.count, 1024 * 1024)
+    XCTAssertFalse(result.timedOut)
+  }
+
+  func testTimesOutHungProcessWithActionableError() {
+    XCTAssertThrowsError(
+      try PipeProcessRunner.run(
+        executableURL: URL(fileURLWithPath: "/bin/sh"),
+        arguments: ["-c", "sleep 5"],
+        timeoutSeconds: 0.2,
+        killGraceSeconds: 0.1
+      )
+    ) { error in
+      let message = error.localizedDescription
+      XCTAssertTrue(message.contains("timed out"), message)
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260701-fix-gmail-import-deadlock.json
+++ b/desktop/macos/changelog/unreleased/20260701-fix-gmail-import-deadlock.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Gmail import getting stuck while reading large email histories"
+}

--- a/desktop/macos/docs/connector-checklist.md
+++ b/desktop/macos/docs/connector-checklist.md
@@ -64,9 +64,8 @@ Work top to bottom. Don't skip the probe or the fixture test.
 
 ---
 
-**Known follow-up:** `GmailReaderService.swift` duplicates the exact
-browser-cookie + Python-decrypt + last-writer-wins pattern this checklist fixes
-for calendar. It has the same class of bug and is the next candidate. A shared
+**Known follow-up:** Calendar and Gmail now both classify browser-cookie
+attempts instead of using last-writer-wins diagnostics. A shared
 `BrowserGoogleSession` helper (cookie discovery + decrypt + classify) would let
-both connectors share the hardened path — worth doing once a second consumer
-justifies the extraction.
+both connectors share the hardened path — worth doing once the duplicated shape
+stabilizes.


### PR DESCRIPTION
## Summary
- Fix Gmail import hangs by draining helper stdout/stderr while the Python process runs instead of waiting for process exit before reading pipes.
- Have the Python helper write large Gmail JSON payloads to a restrictive temp file and print only the file path.
- Apply the useful #8805 Calendar pattern to Gmail: aggregate every browser attempt, classify not-signed-in vs expired-session vs network/decrypt failures, and log only sanitized diagnostics instead of last-writer-wins errors.
- Add reusable `PipeProcessRunner` coverage plus Gmail outcome parser tests, and keep the connector checklist aligned with the shared `BrowserGoogleSession` follow-up.

Fixes #8797.

## Root Cause
The Gmail helper could print a large JSON payload directly to stdout. Swift called `waitUntilExit()` before reading stdout, so the child process could block forever once the stdout pipe filled.

## Learnings Applied From #8805
- Gmail now mirrors Calendar's attempt taxonomy so coding agents and users can distinguish missing auth, expired cookies, decrypt failures, and fetch/network errors.
- Diagnostics retain all browser/profile attempts instead of overwriting earlier evidence with the final browser tried.
- The remaining shared abstraction is documented as a future `BrowserGoogleSession` extraction once the duplicated Calendar/Gmail shape stabilizes.

## Verification
- `git diff --check HEAD~1..HEAD`
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'GmailOutcomeParserTests|PipeProcessRunnerTests'` - 6 tests passed
- Named bundle: `OMI_APP_NAME=omi-gmail-deadlock OMI_AUTOMATION_PORT=47937 ./run.sh --yolo`
- Local app automation: `/gmail-read` completed successfully through `com.omi.omi-gmail-deadlock`; result was `emailCount=50`, `memoriesSaved=50`, `memoriesFailed=0`.
- Logs showed helper exit status 0 in 5440ms, bootstrap source, and safe default query logging.
- `git push --force-with-lease origin codex/fix-gmail-import-deadlock` passed pre-push checks, including selected backend tests, OpenAPI contract check, desktop Rust check, desktop tool surface tests, and formatter checks.
- Earlier subagent review completed; P2 findings for raw query logging and insecure temp-file creation were fixed, and pipe-drain timeout behavior was tightened.

## Notes
The branch was rebased over current `origin/main` after #8805 merged, then force-pushed with lease.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/8806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
